### PR TITLE
docs: Koreanize testing coroutine KDoc

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/DefaultFields.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/DefaultFields.kt
@@ -37,19 +37,19 @@ val DefaultLocale: Locale = Locale.getDefault()
 val DefaultCharset: Charset = Charsets.UTF_8
 
 /**
- * System default charset name ("UTF-8")
+ * 시스템 기본 문자 집합 이름입니다("UTF-8").
  */
 @JvmField
 val DefaultCharsetName: String = DefaultCharset.name()
 
 /**
- * System Default Charactor encoding ("utf-8")
+ * 시스템 기본 문자 인코딩 이름입니다("utf-8").
  */
 @JvmField
 val DefaultEncoding: String = DefaultCharsetName.lowercase()
 
 /**
- * System default [ZoneId]
+ * 시스템 기본 [ZoneId]입니다.
  *
  * @see DefaultZoneOffset
  * @see ZoneId.systemDefault()
@@ -67,7 +67,7 @@ val DefaultZoneId: ZoneId = ZoneId.systemDefault()
 val UtcZoneId: ZoneId = ZoneId.of("UTC")
 
 /**
- * System default [ZoneOffset]
+ * 시스템 기본 [ZoneOffset]입니다.
  *
  * @see DefaultZoneId
  */

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/apache/ApacheClassUtils.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/apache/ApacheClassUtils.kt
@@ -130,7 +130,7 @@ fun KClass<*>.isAssignable(toClass: KClass<*>, autoboxing: Boolean = true): Bool
     ClassUtils.isAssignable(this.java, toClass.java, autoboxing)
 
 /**
- * Is the specified class an inner class or static nested class?
+ * 지정한 클래스가 내부 클래스 또는 정적 중첩 클래스인지 확인합니다.
  *
  * @receiver the class to check may be null
  * @return {@code true} if the class is an inner or static nested class, false if not or `null`

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/apache/ApacheStringUtils.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/apache/ApacheStringUtils.kt
@@ -4,16 +4,16 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.Strings
 
 /**
- * Abbreviates a String using a given replacement marker. This will turn
+ * 지정한 대체 마커로 문자열을 축약합니다. 예를 들어
  * "Now is the time for all good men" into "...is the time for..." if "..." was defined
  * as the replacement marker.
  *
- * Works like `String.abbr(String, int)`, but allows you to specify
- * a "left edge" offset.  Note that this left edge is not necessarily going to
- * be the leftmost character in the result, or the first character following the
- * replacement marker, but it will appear somewhere in the result.
+ * `String.abbr(String, int)`처럼 동작하지만
+ * "왼쪽 경계" 오프셋을 지정할 수 있습니다. 이 경계가 반드시
+ * 결과의 가장 왼쪽 문자나 대체 마커 바로 뒤의 첫 문자가 되는 것은 아니지만,
+ * 결과 어딘가에는 포함됩니다.
  *
- * In no case will it return a String of length greater than {@code maxWidth}.
+ * 어떤 경우에도 {@code maxWidth\}보다 긴 문자열은 반환하지 않습니다.
  *
  * ```
  * StringUtils.abbreviate(null, null, *, *)                 = null
@@ -32,27 +32,27 @@ import org.apache.commons.lang3.Strings
  * StringUtils.abbreviate("abcdefghij", "...", 5, 6)        = IllegalArgumentException
  * ```
  *
- * @receiver  the String to check, may be null
- * @param abbrMarker  the String used as replacement marker
- * @param offset  left edge of source String
- * @param maxWidth  maximum length of result String, must be at least 4
- * @return abbreviated String, `null` if null String input
+ * @receiver 검사할 문자열입니다. `null`일 수 있습니다.
+ * @param abbrMarker 대체 마커로 사용할 문자열입니다.
+ * @param offset 원본 문자열의 왼쪽 경계입니다.
+ * @param maxWidth 결과 문자열의 최대 길이입니다. 4 이상이어야 합니다.
+ * @return 축약된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.abbr(maxWidth: Int, abbrMarker: String = "...", offset: Int = 0): String =
     StringUtils.abbreviate(this, abbrMarker, offset, maxWidth)
 
 /**
- * Abbreviates a String to the length passed, replacing the middle characters with the supplied
- * replacement String.
+ * 문자열을 지정한 길이로 축약하고 가운데 문자를 제공된
+ * 대체 문자열로 바꿉니다.
  *
- * This abbreviation only occurs if the following criteria is met:
- * - Neither the String for abbreviation nor the replacement String are null or empty
- * - The length to truncate to is less than the length of the supplied String
- * - The length to truncate to is greater than 0
- * - The abbreviated String will have enough room for the length supplied replacement String
- * and the first and last characters of the supplied String for abbreviation
+ * 이 축약은 다음 조건을 모두 만족할 때만 수행됩니다:
+ * - 축약 대상 문자열과 대체 문자열이 모두 `null` 또는 빈 값이 아닙니다
+ * - 축약할 길이가 제공된 문자열 길이보다 작습니다
+ * - 축약할 길이가 0보다 큽니다
+ * - 축약 결과가 제공된 대체 문자열 길이와
+ * 축약 대상 문자열의 첫 문자와 마지막 문자를 담을 만큼 충분한 공간을 가집니다
  *
- * Otherwise, the returned String will be the same as the supplied String for abbreviation.
+ * 그 외의 경우에는 축약 대상 문자열을 그대로 반환합니다.
  *
  *
  * ```
@@ -63,17 +63,17 @@ fun String.abbr(maxWidth: Int, abbrMarker: String = "...", offset: Int = 0): Str
  * StringUtils.abbreviateMiddle("abcdef", ".", 4)     = "ab.f"
  * ```
  *
- * @receiver  the String to abbreviate, may be null
- * @param middle the String to replace the middle characters with, may be null
- * @param length the length to abbreviate {@code str} to.
- * @return the abbreviated String if the above criteria is met, or the original String supplied for abbreviation.
+ * @receiver 축약할 문자열입니다. `null`일 수 있습니다.
+ * @param middle 가운데 문자를 대체할 문자열입니다. `null`일 수 있습니다.
+ * @param length {@code str\}를 축약할 길이입니다.
+ * @return 위 조건을 만족하면 축약된 문자열, 그렇지 않으면 축약 대상 원본 문자열입니다.
  */
 fun String.abbrMiddle(length: Int, middle: String = "..."): String =
     StringUtils.abbreviateMiddle(this, middle, length)
 
 /**
- * Appends the suffix to the end of the string if the string does not
- * already end with any of the suffixes.
+ * 문자열이 지정한 접미사 중 하나로 끝나지 않으면
+ * 문자열 끝에 접미사를 추가합니다.
  *
  * ```
  * StringUtils.appendIfMissing(null, null) = null
@@ -83,7 +83,7 @@ fun String.abbrMiddle(length: Int, middle: String = "..."): String =
  * StringUtils.appendIfMissing("abcxyz", "xyz") = "abcxyz"
  * StringUtils.appendIfMissing("abcXYZ", "xyz") = "abcXYZxyz"
  * ```
- * With additional suffixes,
+ * 추가 접미사를 지정한 경우,
  * ```
  * StringUtils.appendIfMissing(null, null, null) = null
  * StringUtils.appendIfMissing("abc", null, null) = "abc"
@@ -97,18 +97,18 @@ fun String.abbrMiddle(length: Int, middle: String = "..."): String =
  * StringUtils.appendIfMissing("abcMNO", "xyz", "mno") = "abcMNOxyz"
  * ```
  *
- * @receiver The string.
- * @param suffix The suffix to append to the end of the string.
- * @param suffixes Additional suffixes that are valid terminators.
+ * @receiver 대상 문자열입니다.
+ * @param suffix 문자열 끝에 추가할 접미사입니다.
+ * @param suffixes 이미 유효한 끝으로 인정할 추가 접미사입니다.
  *
- * @return A new String if suffix was appended, the same string otherwise.
+ * @return 접미사가 추가되면 새 문자열, 그렇지 않으면 기존 문자열입니다.
  */
 fun String.appendIfMissing(suffix: CharSequence, vararg suffixes: CharSequence): String =
     Strings.CS.appendIfMissing(this, suffix, *suffixes)
 
 /**
- * Appends the suffix to the end of the string if the string does not
- * already end, case-insensitive, with any of the suffixes.
+ * 대소문자를 무시했을 때 문자열이 지정한 접미사 중 하나로 끝나지 않으면
+ * 문자열 끝에 접미사를 추가합니다.
  *
  * ```
  * StringUtils.appendIfMissingIgnoreCase(null, null) = null
@@ -118,7 +118,7 @@ fun String.appendIfMissing(suffix: CharSequence, vararg suffixes: CharSequence):
  * StringUtils.appendIfMissingIgnoreCase("abcxyz", "xyz") = "abcxyz"
  * StringUtils.appendIfMissingIgnoreCase("abcXYZ", "xyz") = "abcXYZ"
  * ```
- * With additional suffixes,
+ * 추가 접미사를 지정한 경우,
  * ```
  * StringUtils.appendIfMissingIgnoreCase(null, null, null) = null
  * StringUtils.appendIfMissingIgnoreCase("abc", null, null) = "abc"
@@ -132,24 +132,24 @@ fun String.appendIfMissing(suffix: CharSequence, vararg suffixes: CharSequence):
  * StringUtils.appendIfMissingIgnoreCase("abcMNO", "xyz", "mno") = "abcMNO"
  * ```
  *
- * @receiver The string.
- * @param suffix The suffix to append to the end of the string.
- * @param suffixes Additional suffixes that are valid terminators.
+ * @receiver 대상 문자열입니다.
+ * @param suffix 문자열 끝에 추가할 접미사입니다.
+ * @param suffixes 이미 유효한 끝으로 인정할 추가 접미사입니다.
  *
- * @return A new String if suffix was appended, the same string otherwise.
+ * @return 접미사가 추가되면 새 문자열, 그렇지 않으면 기존 문자열입니다.
  */
 fun String.appendIfMissingIgnoreCase(suffix: CharSequence, vararg suffixes: CharSequence): String =
     Strings.CI.appendIfMissing(this, suffix, *suffixes)
 
 /**
- * Centers a String in a larger String of size {@code size}
- * using the space character (' ').
+ * {@code size\} 크기의 더 큰 문자열 안에서 문자열을 가운데 정렬합니다
+ * 공백 문자(' ')로 채웁니다.
  *
- * If the size is less than the String length, the original String is returned.
- * A `null` String returns `null`.
- * A negative size is treated as zero.</p>
+ * 지정 크기가 문자열 길이보다 작으면 원래 문자열을 반환합니다.
+ * `null` 문자열은 `null`을 반환합니다.
+ * 음수 크기는 0으로 처리합니다.</p>
  *
- * Equivalent to `center(str, size, " ")`.
+ * `center(str, size, " ")`와 동일합니다.
  *
  * ```
  * StringUtils.center(null, *)   = null
@@ -160,20 +160,20 @@ fun String.appendIfMissingIgnoreCase(suffix: CharSequence, vararg suffixes: Char
  * StringUtils.center("a", 4)    = " a  "
  * ```
  *
- * @receiver  the String to center, may be null
- * @param size  the int size of new String, negative treated as zero
- * @return centered String, `null` if null String input
+ * @receiver 가운데 정렬할 문자열입니다. `null`일 수 있습니다.
+ * @param size 새 문자열 크기입니다. 음수는 0으로 처리합니다.
+ * @return 가운데 정렬된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.center(size: Int, padChar: Char = ' '): String =
     StringUtils.center(this, size, padChar)
 
 /**
- * Centers a String in a larger String of size {@code size}.
- * Uses a supplied String as the value to pad the String with.
+ * {@code size\} 크기의 더 큰 문자열 안에서 문자열을 가운데 정렬합니다.
+ * 제공된 문자열을 채움 값으로 사용합니다.
  *
- * If the size is less than the String length, the String is returned.
- * A `null` String returns `null`.
- * A negative size is treated as zero.
+ * 지정 크기가 문자열 길이보다 작으면 문자열을 그대로 반환합니다.
+ * `null` 문자열은 `null`을 반환합니다.
+ * 음수 크기는 0으로 처리합니다.
  *
  * ```
  * StringUtils.center(null, *, *)     = null
@@ -187,19 +187,19 @@ fun String.center(size: Int, padChar: Char = ' '): String =
  * StringUtils.center("abc", 7, "")   = "  abc  "
  * ```
  *
- * @receiver  the String to center, may be null
- * @param size  the int size of new String, negative treated as zero
- * @param padStr  the String to pad the new String with, must not be null or empty
- * @return centered String, `null` if null String input
- * @throws IllegalArgumentException if padStr is `null` or empty
+ * @receiver 가운데 정렬할 문자열입니다. `null`일 수 있습니다.
+ * @param size 새 문자열 크기입니다. 음수는 0으로 처리합니다.
+ * @param padStr 새 문자열을 채울 문자열입니다. `null`이거나 비어 있으면 안 됩니다.
+ * @return 가운데 정렬된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
+ * @throws IllegalArgumentException `padStr`가 `null`이거나 비어 있으면 발생합니다.
  */
 fun String.center(size: Int, padStr: String): String =
     StringUtils.center(this, size, padStr)
 
 /**
- * Remove the last character from a String.
+ * 문자열의 마지막 문자를 제거합니다.
  *
- * If the String ends in {@code \r\n}, then remove both of them.
+ * 문자열이 {@code \r\n}로 끝나면 두 문자를 모두 제거합니다.
  *
  * ```
  * StringUtils.chop(null)          = null
@@ -215,16 +215,16 @@ fun String.center(size: Int, padStr: String): String =
  * StringUtils.chop("\r\n")        = ""
  * ```
  *
- * @receiver  the String to chop last character from, may be null
- * @return String without last character, `null` if null String input
+ * @receiver 마지막 문자를 제거할 문자열입니다. `null`일 수 있습니다.
+ * @return 마지막 문자가 제거된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.chop(): String =
     StringUtils.chop(this)
 
 
 /**
- * Checks if the CharSequence contains any character in the given
- * set of characters.
+ * CharSequence가 지정한 문자 집합의 문자 중 하나라도 포함하는지
+ * 확인합니다.
  *
  * <p>A `null` CharSequence will return {@code false}.
  * A `null` or zero length search array will return {@code false}.</p>
@@ -240,15 +240,15 @@ fun String.chop(): String =
  * StringUtils.containsAny("aba", ['z'])             = false
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param searchChars  the chars to search for, may be null
- * @return the {@code true} if any of the chars are found, {@code false} if no match or null input
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param searchChars 검색할 문자입니다. `null`일 수 있습니다.
+ * @return 문자를 하나라도 찾으면 {@code true\}, 매치가 없거나 입력이 `null`이면 {@code false\}입니다.
  */
 fun CharSequence.containsAny(vararg searchChars: Char): Boolean =
     StringUtils.containsAny(this, *searchChars)
 
 /**
- * Checks if the CharSequence contains any of the CharSequences in the given array.
+ * CharSequence가 지정한 배열의 CharSequence 중 하나라도 포함하는지 확인합니다.
  *
  * A `null` or zero length search array will return `false`.
  *
@@ -262,17 +262,17 @@ fun CharSequence.containsAny(vararg searchChars: Char): Boolean =
  * StringUtils.containsAny("abc", "d", "abc")  = true
  * ```
  *
- * @receiver The CharSequence to check, may be null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
  * @param searchCharSequences The array of CharSequences to search for, may be null. Individual CharSequences may be
  *        null as well.
- * @return `true` if any of the search CharSequences are found, `false` otherwise
+ * @return 검색 CharSequence를 하나라도 찾으면 `true`, 그렇지 않으면 `false`입니다.
  */
 fun CharSequence.containsAny(vararg searchCharSequences: CharSequence): Boolean =
     Strings.CS.containsAny(this, *searchCharSequences)
 
 
 /**
- * Checks if the CharSequence contains any of the CharSequences in the given array, ignoring case.
+ * 대소문자를 무시하고 CharSequence가 지정한 배열의 CharSequence 중 하나라도 포함하는지 확인합니다.
  *
  * A `null` {@code cs} CharSequence will return {@code false}. A `null` or zero length search array will
  * return {@code false}.
@@ -290,16 +290,16 @@ fun CharSequence.containsAny(vararg searchCharSequences: CharSequence): Boolean 
  * StringUtils.containsAny("ABC", "d", "abc")  = true
  * ```
  *
- * @receiver The CharSequence to check, may be null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
  * @param searchCharSequences The array of CharSequences to search for, may be null. Individual CharSequences may be
  *        null as well.
- * @return `true` if any of the search CharSequences are found, `false` otherwise
+ * @return 검색 CharSequence를 하나라도 찾으면 `true`, 그렇지 않으면 `false`입니다.
  */
 fun CharSequence.containsAnyIgnoreCase(vararg searchCharSequences: CharSequence): Boolean =
     Strings.CI.containsAny(this, *searchCharSequences)
 
 /**
- * Checks if CharSequence contains a search CharSequence irrespective of case,
+ * 대소문자와 관계없이 CharSequence가 검색 CharSequence를 포함하는지 확인합니다,
  * handling `null`. Case-insensitivity is defined as by
  * `String#equalsIgnoreCase(String)`
  *
@@ -316,15 +316,15 @@ fun CharSequence.containsAnyIgnoreCase(vararg searchCharSequences: CharSequence)
  * StringUtils.containsIgnoreCase("abc", "Z") = false
  * ```
  *
- * @receiver the CharSequence to check, may be null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
  * @param searchStr  the CharSequence to find, may be null
- * @return true if the CharSequence contains the search CharSequence irrespective of case or false if not or `null` string input
+ * @return 대소문자와 관계없이 검색 CharSequence를 포함하면 true, 그렇지 않거나 입력이 `null`이면 false입니다.
  */
 fun CharSequence.containsIgnoreCase(searchStr: CharSequence): Boolean =
     Strings.CI.contains(this, searchStr)
 
 /**
- * Checks that the CharSequence does not contain certain characters.
+ * CharSequence가 특정 문자를 포함하지 않는지 확인합니다.
  *
  * <p>A `null` CharSequence will return {@code true}.
  * A `null` invalid character array will return {@code true}.
@@ -339,19 +339,19 @@ fun CharSequence.containsIgnoreCase(searchStr: CharSequence): Boolean =
  * StringUtils.containsNone("abz", 'xyz')  = false
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param searchChars  an array of invalid chars, may be null
- * @return true if it contains none of the invalid chars, or is null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param searchChars 허용하지 않는 문자 배열입니다. `null`일 수 있습니다.
+ * @return 허용하지 않는 문자를 포함하지 않거나 `null`이면 true입니다.
  */
 fun CharSequence.containsNone(vararg searchChars: Char): Boolean =
     StringUtils.containsNone(this, *searchChars)
 
 /**
- * Checks that the CharSequence does not contain certain characters.
+ * CharSequence가 특정 문자를 포함하지 않는지 확인합니다.
  *
  * A `null` CharSequence will return {@code true}.
  * A `null` invalid character array will return `true`.
- * An empty String ("") always returns true.
+ * 빈 문자열("")은 항상 true를 반환합니다.
  *
  * ```
  * StringUtils.containsNone(*, null)       = true
@@ -362,9 +362,9 @@ fun CharSequence.containsNone(vararg searchChars: Char): Boolean =
  * StringUtils.containsNone("abz", "xyz")  = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @param invalidStr  a String of invalid chars, may be null
- * @return true if it contains none of the invalid chars, or is null
+ * @receiver 검사할 CharSequence입니다.
+ * @param invalidStr 허용하지 않는 문자 문자열입니다. `null`일 수 있습니다.
+ * @return 허용하지 않는 문자를 포함하지 않거나 `null`이면 true입니다.
  * @since 2.0
  * @since 3.0 Changed signature from containsNone(String, String) to containsNone(CharSequence, String)
  */
@@ -373,11 +373,11 @@ fun CharSequence.containsNone(invalidStr: String?): Boolean =
 
 
 /**
- * Checks if the CharSequence contains only certain characters.
+ * CharSequence가 특정 문자만 포함하는지 확인합니다.
  *
  * A `null` CharSequence will return {@code false}.
  * A `null` valid character array will return `false`.
- * An empty CharSequence (length()=0) always returns `true`.
+ * 빈 CharSequence(length()=0)는 항상 `true`를 반환합니다.
  *
  * ```
  * StringUtils.containsOnly("", *)         = true
@@ -388,14 +388,14 @@ fun CharSequence.containsNone(invalidStr: String?): Boolean =
  * ```
  *
  * @receiver  the String to check
- * @param validChars  an array of valid chars
- * @return true if it only contains valid chars and is non-null
+ * @param validChars 허용할 문자 배열입니다.
+ * @return `null`이 아니고 허용 문자만 포함하면 true입니다.
  */
 fun CharSequence.containsOnly(vararg validChars: Char): Boolean =
     StringUtils.containsOnly(this, *validChars)
 
 /**
- * Checks if the CharSequence contains only certain characters.
+ * CharSequence가 특정 문자만 포함하는지 확인합니다.
  *
  * A `null` valid character String will return `false`.
  * An empty String (length()=0) always returns `true`.
@@ -409,9 +409,9 @@ fun CharSequence.containsOnly(vararg validChars: Char): Boolean =
  * StringUtils.containsOnly("abz", "abc")  = false
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param validStr  a String of valid chars, may be null
- * @return true if it only contains valid chars and is non-null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param validStr 허용할 문자 문자열입니다. `null`일 수 있습니다.
+ * @return `null`이 아니고 허용 문자만 포함하면 true입니다.
  * @since 2.0
  * @since 3.0 Changed signature from containsOnly(String, String) to containsOnly(CharSequence, String)
  */
@@ -419,11 +419,11 @@ fun CharSequence.containsOnly(validStr: String?): Boolean =
     StringUtils.containsOnly(this, validStr)
 
 /**
- * Check whether the given CharSequence contains any whitespace characters.
+ * 주어진 CharSequence가 공백 문자를 포함하는지 확인합니다.
  *
- * Whitespace is defined by [Character#isWhitespace(char)].
+ * 공백은 [Character#isWhitespace(char)] 기준으로 정의합니다.
  *
- * @receiver the CharSequence to check (may be `null`)
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
  * @return `true` if the CharSequence is not empty and
  * contains at least 1 (breaking) whitespace character
  */
@@ -431,7 +431,7 @@ fun CharSequence.containsWhitespace(): Boolean =
     StringUtils.containsWhitespace(this)
 
 /**
- * Counts how many times the char appears in the given string.
+ * 지정한 문자열에 문자가 몇 번 등장하는지 셉니다.
  *
  * A `null` or empty ("") String input returns `0`.
  *
@@ -444,16 +444,16 @@ fun CharSequence.containsWhitespace(): Boolean =
  * StringUtils.countMatches("abba", 'x') = 0
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param ch  the char to count
- * @return the number of occurrences, 0 if the CharSequence is `null`
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param ch 셀 문자입니다.
+ * @return 등장 횟수입니다. CharSequence가 `null`이면 0입니다.
  */
 fun CharSequence.countMatches(ch: Char): Int =
     StringUtils.countMatches(this, ch)
 
 /**
- * Counts how many times the substring appears in the larger string.
- * Note that the code only counts non-overlapping matches.
+ * 큰 문자열 안에 부분 문자열이 몇 번 등장하는지 셉니다.
+ * 겹치지 않는 매치만 셉니다.
  *
  * A `null` or empty ("") String input returns {@code 0}.
  *
@@ -468,9 +468,9 @@ fun CharSequence.countMatches(ch: Char): Int =
  * StringUtils.countMatches("ababa", "aba") = 1
  * ```
  *
- * @receiver the CharSequence to check, may be null
- * @param sub  the substring to count, may be null
- * @return the number of occurrences, 0 if either CharSequence is `null`
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param sub 셀 부분 문자열입니다. `null`일 수 있습니다.
+ * @return 등장 횟수입니다. 어느 CharSequence라도 `null`이면 0입니다.
  */
 fun CharSequence.countMatches(sub: CharSequence): Int =
     StringUtils.countMatches(this, sub)
@@ -516,13 +516,13 @@ fun <T: CharSequence> T.defaultIfEmpty(defaultValue: T): T = this.ifEmpty { defa
  * StringUtils.deleteWhitespace("   ab  c  ") = "abc"
  * ```
  *
- * @receiver  the String to delete whitespace from, may be null
+ * @receiver 공백을 제거할 문자열입니다. `null`일 수 있습니다.
  * @return the String without whitespaces, `null` if null String input
  */
 fun String.deleteWhitespace(): String = StringUtils.deleteWhitespace(this)
 
 /**
- * Compares two Strings, and returns the portion where they differ.
+ * 두 문자열을 비교하고 서로 달라지는 부분을 반환합니다.
  * More precisely, return the remainder of the second String,
  * starting from where it's different from the first. This means that
  * the difference between "abc" and "ab" is the empty String and not "c".
@@ -544,9 +544,9 @@ fun String.deleteWhitespace(): String = StringUtils.deleteWhitespace(this)
  * StringUtils.difference("abcde", "xyz")   = "xyz"
  * ```
  *
- * @receiver  the first String
- * @param other  the second String, may be null
- * @return the portion of str2 where it differs from str1; returns the empty String if they are equal
+ * @receiver 첫 번째 문자열입니다.
+ * @param other 두 번째 문자열입니다. `null`일 수 있습니다.
+ * @return `str1`과 다른 `str2`의 부분입니다. 같으면 빈 문자열을 반환합니다.
  */
 fun String.deference(other: String): String = StringUtils.difference(this, other)
 
@@ -582,10 +582,10 @@ fun String.endsWithAny(vararg searchStrings: String): Boolean = Strings.CS.endsW
 fun String.endsWithIgnoreCase(suffix: CharSequence): Boolean = Strings.CI.endsWith(this, suffix)
 
 /**
- * Checks if a String contains Unicode digits,
+ * 문자열이 유니코드 숫자를 포함하는지 확인하고,
  * if yes then concatenate all the digits in String and return it as a String.
  *
- * An empty ("") String will be returned if no digits found in {@code str}.
+ * {@code str\}에서 숫자를 찾지 못하면 빈 문자열("")을 반환합니다.
  *
  * ```
  * StringUtils.getDigits("")                   = ""
@@ -596,8 +596,8 @@ fun String.endsWithIgnoreCase(suffix: CharSequence): Boolean = Strings.CI.endsWi
  * StringUtils.getDigits("\u0967\u0968\u0969") = "\u0967\u0968\u0969"
  * ```
  *
- * @receiver the String to extract digits from
- * @return String with only digits,
+ * @receiver 숫자만 추출할 문자열입니다.
+ * @return 숫자만 포함한 문자열입니다,
  *           or an empty ("") String if no digits found,
  *           or `null` String if {@code str} is null
  */
@@ -605,7 +605,7 @@ fun String.getDigits(): String = StringUtils.getDigits(this)
 
 
 /**
- * Find the first index of any of a set of potential substrings.
+ * 후보 부분 문자열 집합 중 하나가 처음 나타나는 인덱스를 찾습니다.
  *
  * A `null` CharSequence will return `-1`.
  * A `null` or zero length search array will return `-1`.
@@ -625,15 +625,15 @@ fun String.getDigits(): String = StringUtils.getDigits(this)
  * StringUtils.indexOfAny("", ["a"])                    = -1
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param searchStrs  the CharSequences to search for, may be null
- * @return the first index of any of the searchStrs in str, -1 if no match
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param searchStrs 검색할 CharSequence입니다. `null`일 수 있습니다.
+ * @return `str`에서 `searchStrs` 중 하나가 처음 나타나는 인덱스입니다. 매치가 없으면 -1입니다.
  */
 fun CharSequence.indexOfAny(vararg searchStrs: CharSequence): Int = StringUtils.indexOfAny(this, *searchStrs)
 
 /**
  * Search a CharSequence to find the first index of any
- * character in the given set of characters.
+ * character in the given 확인합니다.
  *
  * A `null` String will return `-1`.
  * A `null` search string will return `-1`.
@@ -647,15 +647,15 @@ fun CharSequence.indexOfAny(vararg searchStrs: CharSequence): Int = StringUtils.
  * StringUtils.indexOfAny("aba", "z")         = -1
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param searchStr  the chars to search for, may be null
- * @return the index of any of the chars, -1 if no match or null input
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param searchStr 검색할 문자입니다. `null`일 수 있습니다.
+ * @return 문자 중 하나의 인덱스입니다. 매치가 없거나 입력이 `null`이면 -1입니다.
  */
 fun CharSequence.indexOfAny(searchStr: String?): Int = StringUtils.indexOfAny(this, searchStr)
 
 
 /**
- * Compares all CharSequences in an array and returns the index at which the
+ * 배열의 모든 CharSequence를 비교하고
  * CharSequences begin to differ.
  *
  * For example,
@@ -683,14 +683,14 @@ fun CharSequence.indexOfAny(searchStr: String?): Int = StringUtils.indexOfAny(th
  * StringUtils.indexOfDifference(new String[] {"i am a machine", "i am a robot"}) = 7
  * ```
  *
- * @param css  array of CharSequences, entries may be null
- * @return the index where the strings begin to differ; -1 if they are all equal
+ * @param css CharSequence 배열입니다. 각 항목은 `null`일 수 있습니다.
+ * @return 문자열들이 달라지기 시작하는 인덱스입니다. 모두 같으면 -1입니다.
  */
 fun indexOfDifference(vararg css: CharSequence): Int = StringUtils.indexOfDifference(*css)
 
 
 /**
- * Compares two CharSequences, and returns the index at which the
+ * 두 CharSequence를 비교하고
  * CharSequences begin to differ.
  *
  * For example,
@@ -708,9 +708,9 @@ fun indexOfDifference(vararg css: CharSequence): Int = StringUtils.indexOfDiffer
  * StringUtils.indexOfDifference("abcde", "xyz")   = 0
  * ```
  *
- * @receiver  the first CharSequence
- * @param other  the second CharSequence, may be null
- * @return the index where cs1 and cs2 begin to differ; -1 if they are equal
+ * @receiver 첫 번째 CharSequence입니다.
+ * @param other 두 번째 CharSequence입니다. `null`일 수 있습니다.
+ * @return `cs1`과 `cs2`가 달라지기 시작하는 인덱스입니다. 같으면 -1입니다.
  */
 fun CharSequence.indexOfDifference(other: CharSequence?): Int = StringUtils.indexOfDifference(this, other)
 
@@ -731,9 +731,9 @@ fun CharSequence.indexOfIgnoreCase(searchStr: CharSequence, startPos: Int = 0): 
     Strings.CI.indexOf(this, searchStr, startPos)
 
 /**
- * Checks if the CharSequence contains only Unicode letters.
+ * CharSequence가 유니코드 문자만 포함하는지 확인합니다.
  *
- * An empty CharSequence (length()=0) will return `false`.
+ * 빈 CharSequence(length()=0)는 `false`를 반환합니다.
  *
  * ```
  * StringUtils.isAlpha("")     = false
@@ -743,15 +743,15 @@ fun CharSequence.indexOfIgnoreCase(searchStr: CharSequence, startPos: Int = 0): 
  * StringUtils.isAlpha("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @return `true` if only contains letters, and is non-null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @return `null`이 아니고 문자만 포함하면 `true`입니다.
  */
 fun CharSequence.isAlpha(): Boolean = StringUtils.isAlpha(this)
 
 /**
- * Checks if the CharSequence contains only Unicode letters or digits.
+ * CharSequence가 유니코드 문자 또는 숫자만 포함하는지 확인합니다.
  *
- * An empty CharSequence (length()=0) will return `false`.
+ * 빈 CharSequence(length()=0)는 `false`를 반환합니다.
  *
  * ```
  * StringUtils.isAlphanumeric("")     = false
@@ -762,16 +762,16 @@ fun CharSequence.isAlpha(): Boolean = StringUtils.isAlpha(this)
  * StringUtils.isAlphanumeric("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return {@code true} if only contains letters or digits, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 문자 또는 숫자만 포함하면 {@code true\}입니다.
  */
 fun CharSequence.isAlphaNumeric(): Boolean = StringUtils.isAlphanumeric(this)
 
 /**
- * Checks if the CharSequence contains only Unicode letters, digits
+ * CharSequence가 유니코드 문자, 숫자
  * or space ({@code ' '}).
  *
- * An empty CharSequence (length()=0) will return `true`.
+ * 빈 CharSequence(length()=0)는 `true`를 반환합니다.
  *
  * ```
  * StringUtils.isAlphanumericSpace("")     = true
@@ -782,16 +782,16 @@ fun CharSequence.isAlphaNumeric(): Boolean = StringUtils.isAlphanumeric(this)
  * StringUtils.isAlphanumericSpace("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains letters, digits or space, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 문자, 숫자 또는 공백만 포함하면 `true`입니다.
  */
 fun CharSequence.isAlphaNumericSpace(): Boolean = StringUtils.isAlphanumericSpace(this)
 
 /**
- * Checks if the CharSequence contains only Unicode letters or space
+ * CharSequence가 유니코드 문자 또는 공백만 포함하는지 확인합니다
  * ({@code ' '}).
  *
- * An empty CharSequence (length()=0) will return `true`.
+ * 빈 CharSequence(length()=0)는 `true`를 반환합니다.
  *
  * ```
  * StringUtils.isAlphaSpace("")     = true
@@ -802,14 +802,14 @@ fun CharSequence.isAlphaNumericSpace(): Boolean = StringUtils.isAlphanumericSpac
  * StringUtils.isAlphaSpace("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains letters or space, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 문자 또는 공백만 포함하면 `true`입니다.
  */
 fun CharSequence.isAlphaSpace(): Boolean = StringUtils.isAlphaSpace(this)
 
 
 /**
- * Checks if the CharSequence contains only ASCII printable characters.
+ * CharSequence가 출력 가능한 ASCII 문자만 포함하는지 확인합니다.
  *
  * An empty CharSequence (length()=0) will return `true`
  *
@@ -826,13 +826,13 @@ fun CharSequence.isAlphaSpace(): Boolean = StringUtils.isAlphaSpace(this)
  * StringUtils.isAsciiPrintable("Ceki G\u00fclc\u00fc") = false
  * ```
  *
- * @receiver the CharSequence to check
- * @return `true` if every character is in the range 32 through 126
+ * @receiver 검사할 CharSequence입니다.
+ * @return 모든 문자가 32부터 126 범위에 있으면 `true`입니다.
  */
 fun CharSequence.isAsciiPrintable(): Boolean = StringUtils.isAsciiPrintable(this)
 
 /**
- * Checks if the CharSequence contains mixed casing of both uppercase and lowercase characters.
+ * CharSequence가 대문자와 소문자를 모두 포함하는지 확인합니다.
  *
  * An empty CharSequence ({@code length()=0}) will return `false`
  *
@@ -848,13 +848,13 @@ fun CharSequence.isAsciiPrintable(): Boolean = StringUtils.isAsciiPrintable(this
  * StringUtils.isMixedCase("aC\t")  = true
  * ```
  *
- * @receiver the CharSequence to check
- * @return `true` if the CharSequence contains both uppercase and lowercase characters
+ * @receiver 검사할 CharSequence입니다.
+ * @return CharSequence가 대문자와 소문자를 모두 포함하면 `true`입니다.
  */
 fun CharSequence.isMixedCase(): Boolean = StringUtils.isMixedCase(this)
 
 /**
- * Checks if the CharSequence contains only Unicode digits.
+ * CharSequence가 유니코드 숫자만 포함하는지 확인합니다.
  * A decimal point is not a Unicode digit and returns false.
  *
  * <p>`null` will return {@code false}.
@@ -878,16 +878,16 @@ fun CharSequence.isMixedCase(): Boolean = StringUtils.isMixedCase(this)
  * StringUtils.isNumeric("+123") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains digits, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 숫자만 포함하면 `true`입니다.
  */
 fun CharSequence.isNumeric(): Boolean = StringUtils.isNumeric(this)
 
 /**
- * Checks if the CharSequence contains only Unicode digits or space (`' '`).
+ * CharSequence가 유니코드 숫자 또는 공백(`' '`)만 포함하는지 확인합니다.
  * A decimal point is not a Unicode digit and returns false.
  *
- * An empty CharSequence (length()=0) will return `true`.
+ * 빈 CharSequence(length()=0)는 `true`를 반환합니다.
  *
  * ```
  * StringUtils.isNumericSpace(null)   = false
@@ -902,15 +902,15 @@ fun CharSequence.isNumeric(): Boolean = StringUtils.isNumeric(this)
  * StringUtils.isNumericSpace("12.3") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains digits or space, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 숫자 또는 공백만 포함하면 `true`입니다.
  */
 fun CharSequence.isNumericSpace(): Boolean = StringUtils.isNumericSpace(this)
 
 /**
- * Checks if the CharSequence contains only whitespace.
+ * CharSequence가 공백만 포함하는지 확인합니다.
  *
- * Whitespace is defined by {@link Character#isWhitespace(char)}.
+ * 공백은 \{@link Character#isWhitespace(char)\} 기준으로 정의합니다.
  *
  * An empty CharSequence (length()=0) will return `true`
  *
@@ -922,13 +922,13 @@ fun CharSequence.isNumericSpace(): Boolean = StringUtils.isNumericSpace(this)
  * StringUtils.isWhitespace("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains whitespace, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 공백만 포함하면 `true`입니다.
  */
 fun CharSequence.isWhiteSpace(): Boolean = StringUtils.isWhitespace(this)
 
 /**
- * Find the latest index of any substring in a set of potential substrings.
+ * 후보 부분 문자열 집합 중 하나가 마지막으로 나타나는 인덱스를 찾습니다.
  *
  * <p>A `null` CharSequence will return {@code -1}.
  * A `null` search array will return {@code -1}.
@@ -945,9 +945,9 @@ fun CharSequence.isWhiteSpace(): Boolean = StringUtils.isWhitespace(this)
  * StringUtils.lastIndexOfAny("zzabyycdxx", ["mn", ""])   = 10
  * ```
  *
- * @receiver  the CharSequence to check
- * @param searchStrs  the CharSequences to search for, may be null
- * @return the last index of any of the CharSequences, -1 if no match
+ * @receiver 검사할 CharSequence입니다.
+ * @param searchStrs 검색할 CharSequence입니다. `null`일 수 있습니다.
+ * @return CharSequence 중 하나가 마지막으로 나타나는 인덱스입니다. 매치가 없으면 -1입니다.
  */
 fun CharSequence.lastIndexOfAny(vararg searchStrs: CharSequence): Int =
     StringUtils.lastIndexOfAny(this, *searchStrs)
@@ -957,7 +957,7 @@ fun CharSequence.lastIndexOfAny(vararg searchStrs: CharSequence): Int =
  * from the specified position.
  *
  * A negative start position returns {@code -1}.
- * An empty ("") search CharSequence always matches unless the start position is negative.
+ * 빈 검색 CharSequence("")는 시작 위치가 음수가 아니면 항상 일치합니다.
  * A start position greater than the string length searches the whole string.
  * The search starts at the startPos and works backwards; matches starting after the start
  * position are ignored.
@@ -972,16 +972,16 @@ fun CharSequence.lastIndexOfAny(vararg searchStrs: CharSequence): Int =
  * StringUtils.lastIndexOfIgnoreCase("aabaabaa", "B", 0)  = -1
  * ```
  *
- * @receiver  the CharSequence to check
+ * @receiver 검사할 CharSequence입니다.
  * @param searchStr  the CharSequence to find, may be null
  * @param startPos  the start position
- * @return the last index of the search CharSequence (always <= startPos), -1 if no match
+ * @return 검색 CharSequence의 마지막 인덱스입니다(항상 startPos 이하). 매치가 없으면 -1입니다.
  */
 fun CharSequence.lastIndexOfIgnoreCase(searchStr: CharSequence?, startPos: Int = length): Int =
     Strings.CI.lastIndexOf(this, searchStr, startPos)
 
 /**
- * Left pad a String with a specified character.
+ * 지정한 문자로 문자열 왼쪽을 채웁니다.
  *
  * <p>Pad to a size of {@code size}.</p>
  *
@@ -993,10 +993,10 @@ fun CharSequence.lastIndexOfIgnoreCase(searchStr: CharSequence?, startPos: Int =
  * StringUtils.leftPad("bat", -1, 'z') = "bat"
  * ```
  *
- * @receiver  the String to pad out
- * @param size  the size to pad to
- * @param padChar  the character to pad with
- * @return left padded String or original String if no padding is necessary,
+ * @receiver 채울 대상 문자열입니다.
+ * @param size 채운 뒤의 크기입니다.
+ * @param padChar 채움에 사용할 문자입니다.
+ * @return 왼쪽이 채워진 문자열입니다. 채움이 필요 없으면 원래 문자열입니다,
  *  `null` if null String input
  * @since 2.0
  */
@@ -1004,9 +1004,9 @@ fun String.leftPad(size: Int, padChar: Char = ' '): String =
     StringUtils.leftPad(this, size, padChar)
 
 /**
- * Left pad a String with a specified String.
+ * 지정한 문자열로 문자열 왼쪽을 채웁니다.
  *
- * Pad to a size of `size`.
+ * `size` 크기가 되도록 채웁니다.
  *
  * ```
  * StringUtils.leftPad("", 3, "z")      = "zzz"
@@ -1018,10 +1018,10 @@ fun String.leftPad(size: Int, padChar: Char = ' '): String =
  * StringUtils.leftPad("bat", 5, "")    = "  bat"
  * ```
  *
- * @receiver the String to pad out
- * @param size  the size to pad to
- * @param padStr  the String to pad with, null or empty treated as single space
- * @return left padded String or original String if no padding is necessary,
+ * @receiver 채울 대상 문자열입니다.
+ * @param size 채운 뒤의 크기입니다.
+ * @param padStr 채움에 사용할 문자열입니다. `null` 또는 빈 값은 단일 공백으로 처리합니다.
+ * @return 왼쪽이 채워진 문자열입니다. 채움이 필요 없으면 원래 문자열입니다,
  *  `null` if null String input
  */
 fun String.leftPad(size: Int, padStr: String): String =
@@ -1029,11 +1029,11 @@ fun String.leftPad(size: Int, padStr: String): String =
 
 
 /**
- * Removes all occurrences of a substring from within the source string.
+ * 원본 문자열 안의 모든 부분 문자열 등장 위치를 제거합니다.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` remove string will return the source string.
- * An empty ("") remove string will return the source string.
+ * 빈 제거 문자열("")은 원본 문자열을 반환합니다.
  *
  * ```
  * StringUtils.remove("", *)          = ""
@@ -1043,9 +1043,9 @@ fun String.leftPad(size: Int, padStr: String): String =
  * StringUtils.remove("queued", "zz") = "queued"
  * ```
  *
- * @receiver  the source String to search
- * @param remove  the String to search for and remove, may be null
- * @return the substring with the string removed if found, `null` if null String input
+ * @receiver 검색할 원본 문자열입니다.
+ * @param remove 검색 후 제거할 문자열입니다. `null`일 수 있습니다.
+ * @return 문자열을 찾으면 제거한 부분 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.remove(remove: String?): String = Strings.CS.remove(this, remove)
 
@@ -1053,7 +1053,7 @@ fun String.remove(remove: String?): String = Strings.CS.remove(this, remove)
  * Removes a substring only if it is at the end of a source string,
  * otherwise returns the source string.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` search string will return the source string.</p>
  *
  * ```
@@ -1065,17 +1065,17 @@ fun String.remove(remove: String?): String = Strings.CS.remove(this, remove)
  * StringUtils.removeEnd("abc", "")    = "abc"
  * ```
  *
- * @receiver  the source String to search, may be null
- * @param remove  the String to search for and remove, may be null
- * @return the substring with the string removed if found, `null` if null String input
+ * @receiver 검색할 원본 문자열입니다. `null`일 수 있습니다.
+ * @param remove 검색 후 제거할 문자열입니다. `null`일 수 있습니다.
+ * @return 문자열을 찾으면 제거한 부분 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.removeEnd(remove: String): String = Strings.CS.removeEnd(this, remove)
 
 /**
- * Case insensitive removal of a substring if it is at the end of a source string,
+ * 원본 문자열 끝에 있는 부분 문자열을 대소문자 구분 없이 제거합니다,
  * otherwise returns the source string.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` search string will return the source string.
  *
  * ```
@@ -1089,9 +1089,9 @@ fun String.removeEnd(remove: String): String = Strings.CS.removeEnd(this, remove
  * StringUtils.removeEndIgnoreCase("www.domain.COM", ".com") = "www.domain")
  * ```
  *
- * @receiver  the source String to search, may be null
+ * @receiver 검색할 원본 문자열입니다. `null`일 수 있습니다.
  * @param remove  the String to search for (case-insensitive) and remove, may be null
- * @return the substring with the string removed if found, `null` if null String input
+ * @return 문자열을 찾으면 제거한 부분 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.removeEndIgnoreCase(remove: String): String = Strings.CI.removeEnd(this, remove)
 
@@ -1099,7 +1099,7 @@ fun String.removeEndIgnoreCase(remove: String): String = Strings.CI.removeEnd(th
  * Removes a substring only if it is at the beginning of a source string,
  * otherwise returns the source string.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` search string will return the source string.
  *
  * ```
@@ -1112,17 +1112,17 @@ fun String.removeEndIgnoreCase(remove: String): String = Strings.CI.removeEnd(th
  * StringUtils.removeStart("abc", "")    = "abc"
  * ```
  *
- * @receiver  the source String to search
- * @param remove  the String to search for and remove, may be null
- * @return the substring with the string removed if found, `null` if null String input
+ * @receiver 검색할 원본 문자열입니다.
+ * @param remove 검색 후 제거할 문자열입니다. `null`일 수 있습니다.
+ * @return 문자열을 찾으면 제거한 부분 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.removeStart(remove: String): String = Strings.CS.removeStart(this, remove)
 
 /**
- * Case insensitive removal of a substring if it is at the beginning of a source string,
+ * 원본 문자열 시작에 있는 부분 문자열을 대소문자 구분 없이 제거합니다,
  * otherwise returns the source string.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` search string will return the source string.
  *
  * ```
@@ -1136,7 +1136,7 @@ fun String.removeStart(remove: String): String = Strings.CS.removeStart(this, re
  * StringUtils.removeStartIgnoreCase("abc", "")    = "abc"
  * ```
  *
- * @receiver  the source String to search, may be null
+ * @receiver 검색할 원본 문자열입니다. `null`일 수 있습니다.
  * @param remove  the String to search for (case-insensitive) and remove, may be null
  * @return the substring with the string removed if found,
  *  `null` if null String input
@@ -1163,7 +1163,7 @@ fun String.removeStartIgnoreCase(remove: String): String = Strings.CI.removeStar
 fun String.repeat(separator: String?, repeat: Int): String = StringUtils.repeat(this, separator, repeat)
 
 /**
- * Case insensitively replaces a String with another String inside a larger String,
+ * 대소문자를 무시하고 큰 문자열 안의 문자열을 다른 문자열로 교체합니다,
  * for the first {@code max} values of the search String.
  *
  *
@@ -1181,17 +1181,17 @@ fun String.repeat(separator: String?, repeat: Int): String = StringUtils.repeat(
  * StringUtils.replaceIgnoreCase("abAa", "a", "z", -1)  = "zbzz"
  * ```
  *
- * @receiver  text to search and replace in
- * @param searchStr  the String to search for (case-insensitive), may be null
- * @param replacement  the String to replace it with, may be null
+ * @receiver 검색하고 치환할 텍스트입니다.
+ * @param searchStr 대소문자를 무시하고 검색할 문자열입니다. `null`일 수 있습니다.
+ * @param replacement 치환에 사용할 문자열입니다. `null`일 수 있습니다.
  * @param max  maximum number of values to replace, or {@code -1} if no maximum
- * @return the text with any replacements processed, `null` if null String input
+ * @return 치환을 처리한 텍스트입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.replaceIgnoreCase(searchStr: String?, replacement: String?, max: Int = -1): String =
     Strings.CI.replace(this, searchStr, replacement, max)
 
 /**
- * Replaces a String with another String inside a larger String, once.
+ * 큰 문자열 안의 문자열을 다른 문자열로 한 번 교체합니다.
  *
  * ```
  * StringUtils.replaceOnce(null, *, *)        = null
@@ -1204,17 +1204,17 @@ fun String.replaceIgnoreCase(searchStr: String?, replacement: String?, max: Int 
  * StringUtils.replaceOnce("aba", "a", "z")   = "zba"
  * ```
  *
- * @receiver text to search and replace in
- * @param searchString  the String to search for, may be null
- * @param replacement  the String to replace with, may be null
- * @return the text with any replacements processed, `null` if null String input
+ * @receiver 검색하고 치환할 텍스트입니다.
+ * @param searchString 검색할 문자열입니다. `null`일 수 있습니다.
+ * @param replacement 치환에 사용할 문자열입니다. `null`일 수 있습니다.
+ * @return 치환을 처리한 텍스트입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.replaceOnce(searchString: String?, replacement: String?): String {
     return Strings.CS.replace(this, searchString, replacement, 1)
 }
 
 /**
- * Case insensitively replaces a String with another String inside a larger String, once.
+ * 대소문자를 무시하고 큰 문자열 안의 문자열을 다른 문자열로 한 번 교체합니다.
  *
  * ```
  * StringUtils.replaceOnceIgnoreCase(null, *, *)        = null
@@ -1229,17 +1229,17 @@ fun String.replaceOnce(searchString: String?, replacement: String?): String {
  * ```
  *
  * @see replaceIgnoreCase
- * @receiver  text to search and replace in
- * @param searchString  the String to search for (case-insensitive), may be null
- * @param replacement  the String to replace with, may be null
- * @return the text with any replacements processed, `null` if null String input
+ * @receiver 검색하고 치환할 텍스트입니다.
+ * @param searchString 대소문자를 무시하고 검색할 문자열입니다. `null`일 수 있습니다.
+ * @param replacement 치환에 사용할 문자열입니다. `null`일 수 있습니다.
+ * @return 치환을 처리한 텍스트입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.replaceOnceIgnoreCase(searchString: String?, replacement: String?): String {
     return Strings.CI.replace(this, searchString, replacement, 1)
 }
 
 /**
- * Gets the rightmost {@code len} characters of a String.
+ * 문자열의 오른쪽 끝 {@code len\}개 문자를 가져옵니다.
  *
  * If `len` characters are not available, or the String
  * is `null`, the String will be returned without an
@@ -1253,16 +1253,16 @@ fun String.replaceOnceIgnoreCase(searchString: String?, replacement: String?): S
  * StringUtils.right("abc", 4)   = "abc"
  * ```
  *
- * @receiver  the String to get the rightmost characters from, may be null
- * @param len  the length of the required String
- * @return the rightmost characters, `null` if null String input
+ * @receiver 오른쪽 끝 문자를 가져올 문자열입니다. `null`일 수 있습니다.
+ * @param len 필요한 문자열 길이입니다.
+ * @return 오른쪽 끝 문자입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.right(len: Int): String = StringUtils.right(this, len)
 
 /**
- * Right pad a String with a specified character.
+ * 지정한 문자로 문자열 오른쪽을 채웁니다.
  *
- * The String is padded to the size of `size`.
+ * 문자열을 `size` 크기가 되도록 채웁니다.
  *
  * ```
  * StringUtils.rightPad("", 3, 'z')     = "zzz"
@@ -1272,17 +1272,17 @@ fun String.right(len: Int): String = StringUtils.right(this, len)
  * StringUtils.rightPad("bat", -1, 'z') = "bat"
  * ```
  *
- * @receiver  the String to pad out
- * @param size  the size to pad to
- * @param padChar  the character to pad with
- * @return right padded String or original String if no padding is necessary, `null` if null String input
+ * @receiver 채울 대상 문자열입니다.
+ * @param size 채운 뒤의 크기입니다.
+ * @param padChar 채움에 사용할 문자입니다.
+ * @return 오른쪽이 채워진 문자열입니다. 채움이 필요 없으면 원래 문자열, 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.rightPad(size: Int, padChar: Char = ' '): String = StringUtils.rightPad(this, size, padChar)
 
 /**
- * Right pad a String with a specified String.
+ * 지정한 문자열로 문자열 오른쪽을 채웁니다.
  *
- * The String is padded to the size of `size`.
+ * 문자열을 `size` 크기가 되도록 채웁니다.
  *
  * ```
  * StringUtils.rightPad("", 3, "z")      = "zzz"
@@ -1295,15 +1295,15 @@ fun String.rightPad(size: Int, padChar: Char = ' '): String = StringUtils.rightP
  * StringUtils.rightPad("bat", 5, "")    = "bat  "
  * ```
  *
- * @receiver the String to pad out
- * @param size  the size to pad to
- * @param padStr  the String to pad with, null or empty treated as single space
- * @return right padded String or original String if no padding is necessary, `null` if null String input
+ * @receiver 채울 대상 문자열입니다.
+ * @param size 채운 뒤의 크기입니다.
+ * @param padStr 채움에 사용할 문자열입니다. `null` 또는 빈 값은 단일 공백으로 처리합니다.
+ * @return 오른쪽이 채워진 문자열입니다. 채움이 필요 없으면 원래 문자열, 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.rightPad(size: Int, padStr: String): String = StringUtils.rightPad(this, size, padStr)
 
 /**
- * Check if a CharSequence starts with any of the provided case-sensitive prefixes.
+ * CharSequence가 제공된 대소문자 구분 접두사 중 하나로 시작하는지 확인합니다.
  *
  * ```
  * StringUtils.startsWithAny(null, new String[] {"abc"})  = false
@@ -1315,17 +1315,17 @@ fun String.rightPad(size: Int, padStr: String): String = StringUtils.rightPad(th
  * StringUtils.startsWithAny("ABCXYZ", null, "xyz", "abc") = false
  * ```
  *
- * @receiver the CharSequence to check
- * @param searchStrs the case-sensitive CharSequence prefixes, may be empty or `null`
+ * @receiver 검사할 CharSequence입니다.
+ * @param searchStrs 대소문자를 구분하는 CharSequence 접두사입니다. 비어 있거나 `null`일 수 있습니다.
  * @see StringUtils#startsWith(CharSequence, CharSequence)
- * @return {@code true} if the input {@code sequence} is `null` AND no {@code searchStrings} are provided, or
+ * @return 입력 {@code sequence\}가 `null`이고 {@code searchStrings\}가 제공되지 않았거나,
  *   the input {@code sequence} begins with any of the provided case-sensitive {@code searchStrings}.
  */
 fun CharSequence.startsWithAny(vararg searchStrs: CharSequence?): Boolean =
     Strings.CS.startsWithAny(this, *searchStrs)
 
 /**
- * Case insensitive check if a CharSequence starts with a specified prefix.
+ * 대소문자를 무시하고 CharSequence가 지정한 접두사로 시작하는지 확인합니다.
  *
  * references are considered to be equal. The comparison is case insensitive.
  *
@@ -1337,23 +1337,23 @@ fun CharSequence.startsWithAny(vararg searchStrs: CharSequence?): Boolean =
  * ```
  *
  * @see String#startsWith(String)
- * @receiver  the CharSequence to check, may be null
- * @param prefix the prefix to find, may be null
- * @return {@code true} if the CharSequence starts with the prefix, case-insensitive, or both `null`
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param prefix 찾을 접두사입니다. `null`일 수 있습니다.
+ * @return 대소문자를 무시하고 CharSequence가 접두사로 시작하거나 둘 다 `null`이면 {@code true\}입니다.
  */
 fun CharSequence.startsWithIgnoreCase(prefix: CharSequence?): Boolean =
     Strings.CI.startsWith(this, prefix)
 
 /**
- * Strips any of a set of characters from the start and end of a String.
+ * 문자열의 시작과 끝에서 지정한 문자 집합을 제거합니다.
  * This is similar to {@link String#trim()} but allows the characters
  * to be stripped to be controlled.
  *
- * An empty string ("") input returns the empty string.
+ * 빈 문자열("") 입력은 빈 문자열을 반환합니다.
  *
  * If the stripChars String is `null`, whitespace is
  * stripped as defined by `Character#isWhitespace(char)`.
- * Alternatively use `String.strip(String)`.
+ * 또는 `String.strip(String)`을 사용합니다.
  *
  * ```
  * StringUtils.strip("", *)            = ""
@@ -1364,16 +1364,16 @@ fun CharSequence.startsWithIgnoreCase(prefix: CharSequence?): Boolean =
  * StringUtils.strip("  abcyx", "xyz") = "  abc"
  * ```
  *
- * @receiver the String to remove characters from, may be null
- * @param stripStr  the characters to remove, null treated as whitespace
- * @return the stripped String, `null` if null String input
+ * @receiver 문자를 제거할 문자열입니다. `null`일 수 있습니다.
+ * @param stripStr 제거할 문자입니다. `null`은 공백으로 처리합니다.
+ * @return 제거 처리된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.strip(stripStr: String? = null): String = StringUtils.strip(this, stripStr)
 
 /**
- * Strips any of a set of characters from the end of a String.
+ * 문자열 끝에서 지정한 문자 집합을 제거합니다.
  *
- * An empty string ("") input returns the empty string.
+ * 빈 문자열("") 입력은 빈 문자열을 반환합니다.
  *
  * If the stripStr String is `null`, whitespace is
  * stripped as defined by `Character#isWhitespace(char)`.
@@ -1389,16 +1389,16 @@ fun String.strip(stripStr: String? = null): String = StringUtils.strip(this, str
  * StringUtils.stripEnd("120.00", ".0")   = "12"
  * ```
  *
- * @receiver  the String to remove characters from, may be null
- * @param stripStr  the set of characters to remove, null treated as whitespace
- * @return the stripped String, `null` if null String input
+ * @receiver 문자를 제거할 문자열입니다. `null`일 수 있습니다.
+ * @param stripStr 제거할 문자 집합입니다. `null`은 공백으로 처리합니다.
+ * @return 제거 처리된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.stripEnd(stripStr: String? = null): String = StringUtils.stripEnd(this, stripStr)
 
 /**
- * Strips any of a set of characters from the start of a String.
+ * 문자열 시작에서 지정한 문자 집합을 제거합니다.
  *
- * An empty string ("") input returns the empty string.
+ * 빈 문자열("") 입력은 빈 문자열을 반환합니다.
  *
  * If the stripChars String is `null`, whitespace is
  * stripped as defined by `Character#isWhitespace(char)`.
@@ -1413,15 +1413,15 @@ fun String.stripEnd(stripStr: String? = null): String = StringUtils.stripEnd(thi
  * StringUtils.stripStart("yxabc  ", "xyz") = "abc  "
  * ```
  *
- * @receiver  the String to remove characters from, may be null
- * @param stripStr  the characters to remove, null treated as whitespace
- * @return the stripped String, `null` if null String input
+ * @receiver 문자를 제거할 문자열입니다. `null`일 수 있습니다.
+ * @param stripStr 제거할 문자입니다. `null`은 공백으로 처리합니다.
+ * @return 제거 처리된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.stripStart(stripStr: String? = null): String = StringUtils.stripStart(this, stripStr)
 
 /**
- * Gets the String that is nested in between two Strings.
- * Only the first match is returned.
+ * 두 문자열 사이에 중첩된 문자열을 가져옵니다.
+ * 첫 번째 매치만 반환합니다.
  *
  * A `null` open/close returns `null` (no match).
  * An empty ("") open and close returns an empty string.</p>
@@ -1438,10 +1438,10 @@ fun String.stripStart(stripStr: String? = null): String = StringUtils.stripStart
  * StringUtils.substringBetween("yabczyabcz", "y", "z")   = "abc"
  * ```
  *
- * @receiver  the String containing the substring, may be null
- * @param open  the String before the substring, may be null
- * @param close  the String after the substring, may be null
- * @return the substring, `null` if no match
+ * @receiver 부분 문자열을 포함하는 문자열입니다. `null`일 수 있습니다.
+ * @param open 부분 문자열 앞의 문자열입니다. `null`일 수 있습니다.
+ * @param close 부분 문자열 뒤의 문자열입니다. `null`일 수 있습니다.
+ * @return 부분 문자열입니다. 매치가 없으면 `null`입니다.
  */
 fun String.substringBetween(open: String?, close: String?): String =
     StringUtils.substringBetween(this, open, close)
@@ -1451,7 +1451,7 @@ fun String.substringBetween(open: String?, close: String?): String =
  * returning all matching substrings in an array.
  *
  * A `null` open/close returns `null` (no match).
- * An empty ("") open/close returns `null` (no match).
+ * 빈 open/close 문자열("")은 `null`을 반환합니다(매치 없음).
  *
  * ```
  * StringUtils.substringsBetween("[a][b][c]", "[", "]") = ["a","b","c"]
@@ -1460,16 +1460,16 @@ fun String.substringBetween(open: String?, close: String?): String =
  * StringUtils.substringsBetween("", "[", "]")          = []
  * ```
  *
- * @receiver  the String containing the substrings, null returns null, empty returns empty
- * @param open  the String identifying the start of the substring, empty returns null
- * @param close  the String identifying the end of the substring, empty returns null
- * @return a String Array of substrings, or `null` if no match
+ * @receiver 부분 문자열들을 포함하는 문자열입니다. `null`이면 `null`, 빈 값이면 빈 값을 반환합니다.
+ * @param open 부분 문자열 시작을 식별하는 문자열입니다. 빈 값이면 `null`을 반환합니다.
+ * @param close 부분 문자열 끝을 식별하는 문자열입니다. 빈 값이면 `null`을 반환합니다.
+ * @return 부분 문자열의 String 배열입니다. 매치가 없으면 `null`입니다.
  */
 fun String.substringsBetween(open: String?, close: String?): Array<String> =
     StringUtils.substringsBetween(this, open, close)
 
 /**
- * Unwraps a given string from another string.
+ * 주어진 문자열에서 감싸는 문자열을 제거합니다.
  *
  * ```
  * StringUtils.unwrap("a", "a")           = "a"
@@ -1482,14 +1482,14 @@ fun String.substringsBetween(open: String?, close: String?): Array<String> =
  * StringUtils.unwrap("A#", "#")          = "A#"
  * ```
  *
- * @receiver the String to be unwrapped, can be null
- * @param wrapToken the String used to unwrap
- * @return unwrapped String or the original string if it is not quoted properly with the wrapToken
+ * @receiver 감싸는 토큰을 제거할 문자열입니다. `null`일 수 있습니다.
+ * @param wrapToken 감싸는 토큰을 제거하는 데 사용할 문자열입니다.
+ * @return 감싸는 토큰을 제거한 문자열입니다. `wrapToken`으로 올바르게 감싸져 있지 않으면 원래 문자열입니다.
  */
 fun String.unwrap(wrapToken: String): String = StringUtils.unwrap(this, wrapToken)
 
 /**
- * Wraps a String with another String.
+ * 문자열을 다른 문자열로 감쌉니다.
  *
  * ```
  * StringUtils.wrap("", *)           = ""
@@ -1503,8 +1503,8 @@ fun String.unwrap(wrapToken: String): String = StringUtils.unwrap(this, wrapToke
  * StringUtils.wrap("'abcd'", "\"")  = "\"'abcd'\""
  * ```
  *
- * @receiver the String to be wrapper, may be null
- * @param wrapWith the String that will wrap str
- * @return wrapped String
+ * @receiver 감쌀 문자열입니다. `null`일 수 있습니다.
+ * @param wrapWith `str`를 감쌀 문자열입니다.
+ * @return 감싸진 문자열입니다.
  */
 fun String.wrap(wrapWith: String): String = StringUtils.wrap(this, wrapWith)

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/CheckSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/CheckSupport.kt
@@ -7,12 +7,12 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
 /**
- * Provides the `checkNotNull` invariant check.
+ * `checkNotNull` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkNotNull("text")
@@ -31,12 +31,12 @@ inline fun <T: Any> T?.checkNotNull(lazyMessage: () -> Any): T {
 }
 
 /**
- * Provides the `checkNull` invariant check.
+ * `checkNull` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = (null as String?).checkNull("text")
@@ -55,12 +55,12 @@ inline fun <T: Any> T?.checkNull(lazyMessage: () -> Any): T? {
 }
 
 /**
- * Provides the `checkNotEmpty` invariant check.
+ * `checkNotEmpty` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkNotEmpty("text")
@@ -80,12 +80,12 @@ inline fun <T: CharSequence> T?.checkNotEmpty(lazyMessage: () -> Any): T {
 }
 
 /**
- * Provides the `checkNullOrEmpty` invariant check.
+ * `checkNullOrEmpty` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("" as String?).checkNullOrEmpty("text")
@@ -101,12 +101,12 @@ inline fun <T: CharSequence> T?.checkNullOrEmpty(lazyMessage: () -> Any): T? {
 }
 
 /**
- * Provides the `checkNotBlank` invariant check.
+ * `checkNotBlank` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkNotBlank("text")
@@ -126,12 +126,12 @@ inline fun <T: CharSequence> T?.checkNotBlank(lazyMessage: () -> Any): T {
 }
 
 /**
- * Provides the `checkNullOrBlank` invariant check.
+ * `checkNullOrBlank` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("   " as String?).checkNullOrBlank("text")
@@ -148,12 +148,12 @@ inline fun <T: CharSequence> T?.checkNullOrBlank(lazyMessage: () -> Any): T? {
 
 
 /**
- * Provides the `checkContains` invariant check.
+ * `checkContains` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkContains("lu", "text")
@@ -171,12 +171,12 @@ inline fun <T: CharSequence> T?.checkContains(other: CharSequence, lazyMessage: 
 
 
 /**
- * Provides the `checkStartsWith` invariant check.
+ * `checkStartsWith` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkStartsWith("bl", "text")
@@ -201,12 +201,12 @@ inline fun <T: CharSequence> T?.checkStartsWith(
 }
 
 /**
- * Provides the `checkEndsWith` invariant check.
+ * `checkEndsWith` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkEndsWith("ue", "text")
@@ -231,12 +231,12 @@ inline fun <T: CharSequence> T?.checkEndsWith(
 }
 
 /**
- * Provides the `checkEquals` invariant check.
+ * `checkEquals` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 10.checkEquals(10, "value")
@@ -252,12 +252,12 @@ inline fun <T> T.checkEquals(expected: T, lazyMessage: () -> Any): T {
 }
 
 /**
- * Provides the `checkGt` invariant check.
+ * `checkGt` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 10.checkGt(1, "value")
@@ -272,12 +272,12 @@ inline fun <T: Comparable<T>> T.checkGt(expected: T, lazyMessage: () -> Any): T 
 }
 
 /**
- * Provides the `checkGe` invariant check.
+ * `checkGe` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 10.checkGe(10, "value")
@@ -292,12 +292,12 @@ inline fun <T: Comparable<T>> T.checkGe(expected: T, lazyMessage: () -> Any): T 
 }
 
 /**
- * Provides the `checkLt` invariant check.
+ * `checkLt` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 1.checkLt(10, "value")
@@ -312,12 +312,12 @@ inline fun <T: Comparable<T>> T.checkLt(expected: T, lazyMessage: () -> Any): T 
 }
 
 /**
- * Provides the `checkLe` invariant check.
+ * `checkLe` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 10.checkLe(10, "value")
@@ -332,12 +332,12 @@ inline fun <T: Comparable<T>> T.checkLe(expected: T, lazyMessage: () -> Any): T 
 }
 
 /**
- * Provides the `checkInRange` invariant check.
+ * `checkInRange` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 5.checkInRange(1, 10, "value")
@@ -352,12 +352,12 @@ inline fun <T: Comparable<T>> T.checkInRange(start: T, endInclusive: T, lazyMess
 }
 
 /**
- * Provides the `checkInOpenRange` invariant check.
+ * `checkInOpenRange` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 5.checkInOpenRange(1, 10, "value")
@@ -372,12 +372,12 @@ inline fun <T: Comparable<T>> T.checkInOpenRange(start: T, endExclusive: T, lazy
 }
 
 /**
- * Provides the `checkZeroOrPositiveNumber` invariant check.
+ * `checkZeroOrPositiveNumber` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 0.checkZeroOrPositiveNumber("value")
@@ -393,12 +393,12 @@ inline fun <T> T.checkZeroOrPositiveNumber(lazyMessage: () -> Any): T where T: N
 }
 
 /**
- * Provides the `checkPositiveNumber` invariant check.
+ * `checkPositiveNumber` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 1.checkPositiveNumber("value")
@@ -414,12 +414,12 @@ inline fun <T> T.checkPositiveNumber(lazyMessage: () -> Any): T where T: Number,
 }
 
 /**
- * Provides the `checkZeroOrNegativeNumber` invariant check.
+ * `checkZeroOrNegativeNumber` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 0.checkZeroOrNegativeNumber("value")
@@ -435,12 +435,12 @@ inline fun <T> T.checkZeroOrNegativeNumber(lazyMessage: () -> Any): T where T: N
 }
 
 /**
- * Provides the `checkNegativeNumber` invariant check.
+ * `checkNegativeNumber` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = (-1).checkNegativeNumber("value")
@@ -458,10 +458,10 @@ inline fun <T> T.checkNegativeNumber(lazyMessage: () -> Any): T where T: Number,
 /**
  * Requires this array to be non-null and non-empty, then returns the same array.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = arrayOf(1, 2).checkNotEmpty("items")
@@ -480,10 +480,10 @@ inline fun <T> Array<T>?.checkNotEmpty(lazyMessage: () -> Any): Array<T> {
 /**
  * Requires this collection to be non-null and non-empty, then returns the same collection.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = listOf(1, 2).checkNotEmpty("items")
@@ -502,10 +502,10 @@ inline fun <T> Collection<T>?.checkNotEmpty(lazyMessage: () -> Any): Collection<
 /**
  * Requires this map to be non-null and non-empty, then returns the same map.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).checkNotEmpty("map")
@@ -522,12 +522,12 @@ inline fun <K, V> Map<K, V>?.checkNotEmpty(lazyMessage: () -> Any): Map<K, V> {
 }
 
 /**
- * Provides the `checkHasKey` invariant check.
+ * `checkHasKey` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).checkHasKey("a", "map")
@@ -545,12 +545,12 @@ inline fun <K, V> Map<K, V>?.checkHasKey(key: K, lazyMessage: () -> Any): Map<K,
 }
 
 /**
- * Provides the `checkHasValue` invariant check.
+ * `checkHasValue` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).checkHasValue(1, "map")
@@ -568,12 +568,12 @@ inline fun <K, V> Map<K, V>?.checkHasValue(value: V, lazyMessage: () -> Any): Ma
 }
 
 /**
- * Provides the `checkContains` invariant check.
+ * `checkContains` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).checkContains("a", 1, "map")
@@ -591,7 +591,7 @@ inline fun <K, V> Map<K, V>?.checkContains(key: K, value: V, lazyMessage: () -> 
 }
 
 /**
- * Checks that a nullable character sequence has a length within the inclusive range.
+ * nullable 문자 시퀀스의 길이가 닫힌 범위 안에 있는지 확인합니다.
  *
  * ```kotlin
  * val id = ("order-42" as String?).checkLengthInRange(1, 80, "id")
@@ -614,7 +614,7 @@ inline fun <T: CharSequence> T?.checkLengthInRange(
 }
 
 /**
- * Checks that a nullable collection has a size within the inclusive range.
+ * nullable 컬렉션의 크기가 닫힌 범위 안에 있는지 확인합니다.
  *
  * ```kotlin
  * val items = (listOf(1, 2) as List<Int>?).checkSizeInRange(1, 50, "items")
@@ -637,7 +637,7 @@ inline fun <T> Collection<T>?.checkSizeInRange(
 }
 
 /**
- * Checks that a nullable map has a size within the inclusive range.
+ * nullable 맵의 크기가 닫힌 범위 안에 있는지 확인합니다.
  *
  * ```kotlin
  * val attributes = (mapOf("state" to "ready") as Map<String, String>?)
@@ -661,7 +661,7 @@ inline fun <K, V> Map<K, V>?.checkSizeInRange(
 }
 
 /**
- * Checks that a nullable array has a size within the inclusive range.
+ * nullable 배열의 크기가 닫힌 범위 안에 있는지 확인합니다.
  *
  * ```kotlin
  * val values = (arrayOf(1, 2) as Array<Int>?).checkSizeInRange(1, 10, "values")
@@ -684,7 +684,7 @@ inline fun <T> Array<T>?.checkSizeInRange(
 }
 
 /**
- * Checks that a nullable character sequence matches [regex].
+ * nullable 문자 시퀀스가 [regex]와 일치하는지 확인합니다.
  *
  * ```kotlin
  * val sku = ("SKU-42" as String?).checkMatches(Regex("SKU-\\d+"), "sku")
@@ -706,7 +706,7 @@ inline fun <T: CharSequence> T?.checkMatches(
 }
 
 /**
- * Checks that a `Float` value is finite.
+ * `Float` 값이 유한한지 확인합니다.
  *
  * ```kotlin
  * val ratio = 0.5f.checkFinite("ratio")
@@ -719,7 +719,7 @@ inline fun Float.checkFinite(parameterName: String, noinline lazyMessage: (() ->
 }
 
 /**
- * Checks that a `Double` value is finite.
+ * `Double` 값이 유한한지 확인합니다.
  *
  * ```kotlin
  * val ratio = 0.5.checkFinite("ratio")

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/FlowEvent.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/FlowEvent.kt
@@ -18,7 +18,7 @@ import io.bluetape4k.coroutines.flow.exceptions.FlowNoElementException
 sealed interface FlowEvent<out T> {
 
     /**
-     * Event containing a value.
+     * 값을 담는 이벤트입니다.
      *
      * Keep this as a data class. `FlowEvent.Value` is normally emitted as the
      * `FlowEvent<T>` interface type, where Kotlin/JVM value classes are boxed,
@@ -30,7 +30,7 @@ sealed interface FlowEvent<out T> {
     }
 
     /**
-     * Event containing an error.
+     * 오류를 담는 이벤트입니다.
      *
      * Keep this as a data class for the same compatibility and boxing reasons
      * as [Value]. When used as `FlowEvent<Nothing>`, a value-class variant would

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/Resumable.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/Resumable.kt
@@ -43,7 +43,7 @@ open class Resumable {
     private val continuation by continuationRef
 
     /**
-     * Suspends the current coroutine until [resume] is called externally.
+     * 외부에서 [resume]이 호출될 때까지 현재 코루틴을 일시 중단합니다.
      *
      * ## Behaviour / Contract
      * - Returns immediately without suspending if already in the READY state.

--- a/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/coroutines/KLoggingChannel.kt
+++ b/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/coroutines/KLoggingChannel.kt
@@ -208,7 +208,7 @@ open class KLoggingChannel(
     }
 
     /**
-     * 비동기 channel을 통해 전달되는 로그 이벤트입니다.
+     * 비동기 채널을 통해 전달되는 로그 이벤트입니다.
      *
      * ```kotlin
      * val event = LogEvent(Level.INFO, "server started", null)

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/cache2k/Cache2kSupport.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/cache2k/Cache2kSupport.kt
@@ -7,7 +7,7 @@ import org.cache2k.CacheManager
 import org.cache2k.config.Cache2kConfig
 
 /**
- * Default Cache2k [CacheManager]
+ * 기본 Cache2k [CacheManager]입니다.
  */
 val defaultCache2kManager: CacheManager by lazy { CacheManager.getInstance() }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/ehcache/EhcacheSupport.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/ehcache/EhcacheSupport.kt
@@ -13,7 +13,7 @@ import org.ehcache.config.units.EntryUnit
 import org.ehcache.config.units.MemoryUnit
 
 /**
- * Default Ehcache [CacheManager]
+ * 기본 Ehcache [CacheManager]입니다.
  */
 val DefaultEhCacheCacheManager: CacheManager by lazy {
     ehcacheManager {

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
@@ -42,10 +42,10 @@ fun <T: Any, R: Any> (suspend (T) -> R).withSuspendMemoizer(
  * ## Recursion Safety
  * Holding a global Mutex during evaluator execution causes deadlocks for recursive memoizers
  * (e.g., factorial, fibonacci) because Kotlin's Mutex is not reentrant.
- * The per-key Deferred pattern runs the evaluator outside any lock, so recursive calls are safe.
+ * per-key Deferred pattern은 evaluator를 lock 밖에서 실행하므로 재귀 호출이 안전합니다.
  *
  * ## Write-after-clear Safety
- * A generation counter ensures that results from in-flight evaluations started before [clear]
+ * generation counter는 [clear] 전에 시작된 in-flight evaluation 결과가
  * are not written back to the cache after it has been invalidated. The caller always receives
  * the computed value regardless of the generation check.
  *

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 /**
- * Creates a [CaffeineAsyncMemoizer] backed by this Caffeine [Cache].
+ * 이 Caffeine [Cache]를 backend로 사용하는 [CaffeineAsyncMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val cache = Caffeine.newBuilder().maximumSize(1000).build<String, Int>()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Creates an [InMemoryAsyncMemoizer] for this [CompletableFuture]-based evaluator.
+ * 이 [CompletableFuture] 기반 evaluator에 대한 [InMemoryAsyncMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val memo = ({ key: String -> CompletableFuture.completedFuture(key.length) }).asyncMemoizer()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizer.kt
@@ -7,7 +7,7 @@ import io.bluetape4k.logging.trace
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Creates an [InMemorySuspendMemoizer] for this suspend evaluator.
+ * 이 suspend evaluator에 대한 [InMemorySuspendMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val memo = (suspend { key: String -> key.length }).suspendMemoizer()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt
@@ -39,7 +39,7 @@ class NearJCacheManagementMXBean(
     /**
      * Determines if a [Cache] should operate in read-through mode.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return `true` when a [Cache] is in "read-through" mode.
      */
@@ -48,7 +48,7 @@ class NearJCacheManagementMXBean(
     /**
      * Determines if a [Cache] should operate in "write-through" mode.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return `true` when a [Cache] is in "write-through" mode.
      */
@@ -57,7 +57,7 @@ class NearJCacheManagementMXBean(
     /**
      * Whether storeByValue (true) or storeByReference (false).
      *
-     * The default value is `true`.
+     * 기본값은 `true`입니다.
      *
      * @return true if the cache is store by value
      */
@@ -66,7 +66,7 @@ class NearJCacheManagementMXBean(
     /**
      * Checks whether statistics collection is enabled in this cache.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return true if statistics collection is enabled
      */
@@ -75,7 +75,7 @@ class NearJCacheManagementMXBean(
     /**
      * Checks whether management is enabled on this cache.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return true if management is enabled
      */

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheStatisticsMXBean.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheStatisticsMXBean.kt
@@ -28,7 +28,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     private val putTime = atomic(0L)
 
     /**
-     * Clears the statistics counters to 0 for the associated Cache.
+     * 연결된 Cache의 statistics counter를 0으로 초기화합니다.
      */
     override fun clear() {
         removals.value = 0
@@ -47,7 +47,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The number of get requests that were satisfied by the cache.
+     * cache가 만족한 get request 수입니다.
      *
      *
      * [javax.cache.Cache.containsKey] is not a get request for
@@ -88,7 +88,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * A miss is a get request that is not satisfied.
+     * miss는 만족되지 않은 get request입니다.
      *
      *
      * In a simple cache a miss occurs when the cache does not satisfy the request.
@@ -119,7 +119,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     override fun getCacheMisses(): Long = misses.value
 
     /**
-     * Returns the percentage of cache accesses that did not find a requested entry
+     * 요청한 entry를 찾지 못한 cache access 비율을 반환합니다
      * in the cache.
      *
      *
@@ -136,7 +136,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of requests to the cache. This will be equal to the sum of
+     * cache에 대한 전체 request 수입니다. 이는 다음 합과 같습니다
      * the hits and misses.
      *
      *
@@ -156,10 +156,10 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of puts to the cache.
+     * cache에 대한 전체 put 수입니다.
      *
      *
-     * A put is counted even if it is immediately evicted.
+     * put 직후 evict되더라도 put으로 계산합니다.
      *
      *
      * Replaces, where a put occurs which overrides an existing mapping is counted
@@ -174,7 +174,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of removals from the cache. This does not include evictions,
+     * cache에서 제거된 전체 removal 수입니다. eviction은 포함하지 않습니다,
      * where the cache itself initiates the removal to make space.
      *
      * @return the number of removals
@@ -186,7 +186,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of evictions from the cache. An eviction is a removal
+     * cache에서 발생한 전체 eviction 수입니다. eviction은 removal입니다
      * initiated by the cache itself to free up space. An eviction is not treated as
      * a removal and does not appear in the removal counts.
      *
@@ -207,7 +207,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute gets.
+     * get 실행 평균 시간입니다.
      *
      *
      * In a read-through cache the time taken to load an entry on miss is not
@@ -222,7 +222,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute puts.
+     * put 실행 평균 시간입니다.
      *
      * @return the time in µs
      */
@@ -233,7 +233,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute removes.
+     * remove 실행 평균 시간입니다.
      *
      * @return the time in µs
      */

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
@@ -49,13 +49,13 @@ abstract class AbstractSuspendNearJCacheTest
     protected val frontCoCache2 by lazy { createFrontSuspendCache(Duration.ofMinutes(10)) }
 
     /**
-     * Creates a [SuspendNearJCache] for the given front and back caches.
+     * 주어진 front/back cache에 대한 [SuspendNearJCache]를 생성합니다.
      *
      * Override in subclasses that cannot register a listener (e.g. Hazelcast, which requires
      * [javax.cache.configuration.CacheEntryListenerConfiguration] to be Serializable for cluster
      * distribution) to call [SuspendNearJCache.withoutListener] instead.
      *
-     * The default implementation calls [SuspendNearJCache.invoke] which registers a
+     * 기본 구현은 [SuspendNearJCache.invoke]를 호출하여 등록합니다
      * [io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListener] on [backSuspendJCache] so that
      * mutations propagate from back → front.
      */

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/EncryptedStringConverters.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/EncryptedStringConverters.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference
  * from an external protected store, such as a secret manager, KMS envelope-encrypted file, or HSM-backed source,
  * before encrypted entity fields are read or written.
  *
- * The JSON keyset helpers expect cleartext Tink keyset JSON. Protect that JSON as secret key material and avoid
+ * JSON keyset helper는 cleartext Tink keyset JSON을 기대합니다. 이 JSON은 secret key material로 보호하고
  * embedding it in source code, logs, or plain configuration files.
  */
 object EncryptedStringConverterKeysets {
@@ -69,7 +69,7 @@ object EncryptedStringConverterKeysets {
 }
 
 /**
- * Base JPA converter that stores encrypted strings in a single database column.
+ * 암호화된 문자열을 단일 database column에 저장하는 base JPA converter입니다.
  *
  * Built-in subclasses fail fast unless [EncryptedStringConverterKeysets] has been configured with externally
  * persisted key material. This avoids writing ciphertext with process-local generated keys that cannot be decrypted

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverter.kt
@@ -51,7 +51,7 @@ abstract class AbstractObjectAsBase64StringConverter(
 /**
  * Typed Base64 string converter that rejects deserialized values outside [targetType].
  *
- * Use this base class for persistent columns that may cross a trust boundary. The serializer is still
+ * trust boundary를 넘을 수 있는 persistent column에는 이 base class를 사용합니다. serializer는 계속
  * pluggable, so callers can combine the typed converter boundary with secure serializers such as
  * `KryoBinarySerializer.secure(...)` or `ForyBinarySerializer.secureFory(...)`.
  *

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsByteArrayConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsByteArrayConverter.kt
@@ -51,7 +51,7 @@ abstract class AbstractObjectAsByteArrayConverter(
 /**
  * Typed object converter that rejects deserialized values outside [targetType].
  *
- * Use this base class for persistent columns that may cross a trust boundary. The serializer is still
+ * trust boundary를 넘을 수 있는 persistent column에는 이 base class를 사용합니다. serializer는 계속
  * pluggable, so callers can combine the typed converter boundary with secure serializers such as
  * `KryoBinarySerializer.secure(...)` or `ForyBinarySerializer.secureFory(...)`.
  *

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt
@@ -7,7 +7,7 @@ import org.hibernate.Hibernate
 import java.io.Serializable
 
 /**
- * Base abstraction for JPA entities.
+ * JPA entity를 위한 base abstraction입니다.
  *
  * Equality uses the assigned identifier only when both entities are persisted.
  * Transient entities fall back to [equalProperties], so their default
@@ -17,20 +17,20 @@ abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(),
 
     companion object: KLogging() {
         /**
-         * Returns whether the persisted [target] has the same non-null identifier.
+         * 영속화된 [target]이 같은 non-null identifier를 가지는지 반환합니다.
          */
         private fun <TId> hasSameNonDefaultId(id: TId, target: JpaEntity<*>): Boolean =
             id == target.id
 
         /**
-         * Returns whether two transient entities share the same business signature.
+         * 두 transient entity가 같은 business signature를 공유하는지 반환합니다.
          */
         private fun <TId> hasSameBusinessSignature(self: AbstractJpaEntity<*>, target: JpaEntity<*>): Boolean =
             self.equalProperties(target)
     }
 
     /**
-     * Returns whether this entity already has an assigned identifier.
+     * 이 entity에 identifier가 이미 할당되어 있는지 반환합니다.
      */
     @get:Transient
     override val isPersisted: Boolean get() = id != null
@@ -53,7 +53,7 @@ abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(),
     }
 
     /**
-     * Returns the entity hash code.
+     * entity hash code를 반환합니다.
      *
      * Persisted entities use the identifier hash. Transient entities use the
      * Hibernate-resolved entity class hash so equal transient instances land in

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/spring/StatelessSessionFactoryBean.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/spring/StatelessSessionFactoryBean.kt
@@ -18,7 +18,7 @@ import org.springframework.util.ReflectionUtils
 import java.sql.Connection
 
 /**
- * Provides a Hibernate [StatelessSession] proxy bound to the current Spring transaction.
+ * 현재 Spring transaction에 바인딩된 Hibernate [StatelessSession] proxy를 제공합니다.
  *
  * ## Contract
  * - [getObject] returns a proxy; the real session is resolved lazily for each method call.

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt
@@ -11,30 +11,28 @@ import java.util.logging.Logger
 import javax.sql.DataSource
 
 /**
- * Provides the current JDBC password for a physical connection attempt.
+ * 물리 connection 시도에 사용할 현재 JDBC password를 제공합니다.
  *
- * ## Contract
+ * ## 계약
  *
- * [RefreshingJdbcPasswordDataSource] calls [currentPassword] synchronously for
- * every no-arg [DataSource.getConnection] invocation. Implementations must be
- * thread-safe because connection pools may open multiple physical connections
- * concurrently. Expensive token generation, caching, and coalescing belong in
- * the provider implementation, not in the generic DataSource.
+ * [RefreshingJdbcPasswordDataSource]는 인자 없는 [DataSource.getConnection]을 호출할 때마다
+ * [currentPassword]를 동기적으로 호출합니다. connection pool이 여러 물리 connection을
+ * 동시에 열 수 있으므로 구현체는 thread-safe해야 합니다. 비용이 큰 token 생성, caching,
+ * coalescing은 generic DataSource가 아니라 provider 구현체가 담당해야 합니다.
  *
- * Implementations must not log or expose secrets. Exceptions thrown by the
- * provider are reported as secret-free [SQLException] failures by the
- * DataSource.
+ * 구현체는 secret을 log로 남기거나 노출하면 안 됩니다. provider에서 발생한 예외는
+ * secret을 포함하지 않는 [SQLException] 실패로 DataSource에 의해 보고됩니다.
  */
 fun interface JdbcPasswordProvider {
 
     /**
-     * Returns the current JDBC password or null when no password is available.
+     * 현재 JDBC password를 반환하거나 사용할 password가 없으면 null을 반환합니다.
      */
     fun currentPassword(): String?
 }
 
 /**
- * Configuration for [RefreshingJdbcPasswordDataSource].
+ * [RefreshingJdbcPasswordDataSource] 설정입니다.
  *
  * @property url JDBC URL used with [DriverManager.getConnection].
  * @property driverClassName optional driver class to load during construction.
@@ -68,7 +66,7 @@ data class RefreshingJdbcPasswordDataSourceConfig(
 }
 
 /**
- * A [DataSource] that obtains a fresh password for each physical connection.
+ * 각 물리 connection마다 새 password를 얻는 [DataSource]입니다.
  *
  * ## Behavior
  *

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
@@ -109,7 +109,7 @@ private fun List<List<Any?>>.requireConsistentBatchParameterRows() {
 }
 
 /**
- * Executes a SQL update as prepared-statement batches.
+ * SQL update를 prepared-statement batch로 실행합니다.
  *
  * All parameter rows must have the same number of values. Inconsistent rows fail
  * before a statement is prepared, which prevents shorter rows from reusing
@@ -167,7 +167,7 @@ fun java.sql.Connection.executeBatch(
 }
 
 /**
- * Executes a SQL update as prepared-statement large batches.
+ * SQL update를 prepared-statement large batch로 실행합니다.
  *
  * All parameter rows must have the same number of values. Inconsistent rows fail
  * before a statement is prepared, which prevents shorter rows from reusing

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
@@ -4,9 +4,9 @@ import java.sql.Connection
 import java.sql.SQLException
 
 /**
- * Executes [block] inside a JDBC transaction.
+ * JDBC transaction 안에서 [block]을 실행합니다.
  *
- * The connection's `autoCommit`, isolation level, and read-only flag are restored
+ * connection의 `autoCommit`, isolation level, read-only flag는 복구됩니다
  * independently to their original values. Any [Throwable] from the block or
  * commit path triggers rollback and is rethrown unchanged. Rollback or restore
  * failures are attached as suppressed exceptions to the primary failure.
@@ -67,9 +67,9 @@ inline fun <T> Connection.withTransaction(
 }
 
 /**
- * Executes [block] inside a read-only JDBC transaction.
+ * read-only JDBC transaction 안에서 [block]을 실행합니다.
  *
- * The connection's original read-only flag is restored by [withTransaction], so
+ * connection의 원래 read-only flag는 [withTransaction]이 복구하므로
  * callers that provide an already read-only connection keep that state after the
  * transaction finishes.
  *

--- a/data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientProvider.kt
+++ b/data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientProvider.kt
@@ -36,9 +36,9 @@ object MongoClientProvider: KLogging() {
     private val settingsClientCache = ConcurrentHashMap<MongoClientSettings, MongoClient>()
 
     /**
-     * Returns a coroutine [MongoClient] for [connectionString].
+     * [connectionString]에 대한 coroutine [MongoClient]를 반환합니다.
      *
-     * The connection string is first converted to [MongoClientSettings], then the
+     * connection string을 먼저 [MongoClientSettings]로 변환한 뒤
      * settings-based cache is used. The returned client is provider-managed and
      * must be closed through [close] or [closeAll].
      *
@@ -56,9 +56,9 @@ object MongoClientProvider: KLogging() {
     }
 
     /**
-     * Returns a coroutine [MongoClient] for [connectionString] plus custom settings.
+     * [connectionString]과 custom settings에 대한 coroutine [MongoClient]를 반환합니다.
      *
-     * The final [MongoClientSettings] produced after applying [builder] is the cache
+     * [builder] 적용 후 생성된 최종 [MongoClientSettings]가 cache
      * key. Therefore the same URL can return different clients when timeout, TLS,
      * application name, credentials, or other effective settings differ.
      *
@@ -80,7 +80,7 @@ object MongoClientProvider: KLogging() {
     }
 
     /**
-     * Returns a coroutine [MongoClient] for [settings].
+     * [settings]에 대한 coroutine [MongoClient]를 반환합니다.
      *
      * [MongoClientSettings] is used directly as the cache key. The returned client is
      * provider-managed and must be closed through [close] or [closeAll].

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/config/R2dbcClientAutoConfiguration.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/config/R2dbcClientAutoConfiguration.kt
@@ -31,7 +31,7 @@ class R2dbcClientAutoConfiguration {
     companion object: KLogging()
 
     /**
-     * Creates the default [R2dbcClient] bean from Spring R2DBC infrastructure beans.
+     * Spring R2DBC infrastructure bean에서 기본 [R2dbcClient] bean을 생성합니다.
      */
     @Bean
     @ConditionalOnMissingBean(R2dbcClient::class)

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupport.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupport.kt
@@ -8,7 +8,7 @@ import org.springframework.r2dbc.core.DatabaseClient
 private val log by lazy { KotlinLogging.logger {} }
 
 /**
- * Binds named query parameters from a map.
+ * map에서 named query parameter를 bind합니다.
  *
  * Named parameters are referenced as `:name` in SQL and mapped by key.
  * Raw null values are rejected because they do not carry R2DBC type
@@ -48,7 +48,7 @@ fun DatabaseClient.GenericExecuteSpec.bindMap(parameters: Map<String, Any?>): Da
     }
 
 /**
- * Binds indexed query parameters.
+ * indexed query parameter를 bind합니다.
  *
  * Indexed parameters follow Spring R2DBC's zero-based binding contract. The first
  * positional parameter is index `0`, the second is index `1`, and so on.
@@ -126,7 +126,7 @@ fun DatabaseClient.execute(
 ): DatabaseClient.GenericExecuteSpec = sql(sqlString).bindMap(parameters)
 
 /**
- * Binds a nullable value to an indexed parameter.
+ * nullable 값을 indexed parameter에 bind합니다.
  *
  * The [index] follows Spring R2DBC's zero-based binding contract. The first
  * positional parameter is index `0`. Null values are bound as typed NULL values.

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/ParameterSupport.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/ParameterSupport.kt
@@ -4,7 +4,7 @@ import io.r2dbc.spi.Parameter
 import io.r2dbc.spi.Parameters
 
 /**
- * Creates an R2DBC [Parameter] that carries a typed NULL value.
+ * typed NULL 값을 담는 R2DBC [Parameter]를 생성합니다.
  *
  * Use this helper with map-based binding APIs when a nullable value needs to
  * preserve its database type information.
@@ -19,7 +19,7 @@ import io.r2dbc.spi.Parameters
 fun typedNullParameter(type: Class<*>): Parameter = Parameters.`in`(type)
 
 /**
- * Creates an R2DBC [Parameter] that carries a typed NULL value for [T].
+ * [T]의 typed NULL 값을 담는 R2DBC [Parameter]를 생성합니다.
  *
  * @param T Kotlin type to expose to the R2DBC driver.
  * @return typed NULL [Parameter].

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -24,7 +24,7 @@ New benchmark reports should use this compact shape:
 ````markdown
 # <Subject> Benchmark - YYYY-MM-DD
 
-## Scope
+## 범위
 
 - Issue or PR: #123
 - Module or benchmark target: `:module-name`

--- a/docs/design/2026-05-24-hc5-first-http-client-recommendation.md
+++ b/docs/design/2026-05-24-hc5-first-http-client-recommendation.md
@@ -1,4 +1,4 @@
-# Design Note: HC5-First HTTP Client Recommendation
+# Design Note: HC5-First HTTP Client 권고
 
 **Date**: 2026-05-24
 **Issue**: #586
@@ -12,7 +12,7 @@
 
 ---
 
-## Decision
+## 결정
 
 **Promote HC5 as the primary recommended production HTTP client in `bluetape4k-http`.**
 
@@ -20,7 +20,7 @@ The remaining backends remain fully supported as first-class options for their r
 
 ---
 
-## Recommendation by Use Case
+## 권고 by Use Case
 
 | Scenario | Primary | Notes |
 |----------|---------|-------|
@@ -118,7 +118,7 @@ The 2026-05-21 snapshot was collected on a local Colima Docker environment. The 
 
 ---
 
-## Follow-up Issues
+## 후속 작업 Issues
 
 | Issue | Description |
 |-------|-------------|

--- a/docs/governance/kover-coverage-policy.md
+++ b/docs/governance/kover-coverage-policy.md
@@ -1,4 +1,4 @@
-# Kover Coverage Policy
+# Kover Coverage 정책
 
 ## 현재 상태
 

--- a/docs/infra-deprecated-inventory.md
+++ b/docs/infra-deprecated-inventory.md
@@ -1,4 +1,4 @@
-# infra Deprecated API Inventory
+# infra Deprecated API inventory
 
 Snapshot: 2026-05-09 KST
 Updated: 2026-05-20 KST
@@ -9,7 +9,7 @@ This inventory records tracked `infra/` and related cache source files that
 still declare `@Deprecated`. Completed cleanup waves are removed from the active
 inventory.
 
-## Summary
+## 요약
 
 | Decision | Count | Meaning |
 |---|---:|---|

--- a/docs/lessons/2026-05-16-cache-coroutine-locks-race.md
+++ b/docs/lessons/2026-05-16-cache-coroutine-locks-race.md
@@ -1,4 +1,4 @@
-# CacheCoroutineLocks — 복합 연산 경쟁 조건 수정 (Issue #477)
+# CacheCoroutineLocks — 복합 연산 경쟁 조건 수정 (이슈 #477)
 
 날짜: 2026-05-16
 이슈: #477
@@ -47,7 +47,7 @@ fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
 
 ---
 
-## 수정 방법: Option A (no-op release)
+## 수정 방법: 선택 A (no-op release)
 
 ```kotlin
 fun mutexFor(cache: Cache<*, *>, key: Any): Mutex = lock.withLock {
@@ -64,7 +64,7 @@ fun release(cache: Cache<*, *>, key: Any, mutex: Mutex) {
 }
 ```
 
-**Option B (reference counting) 이번 PR에서 선택하지 않은 이유:**
+**선택 B (reference counting)를 이번 PR에서 선택하지 않은 이유:**
 - ref-counting 자체는 outer ReentrantLock 안에서 안전하다 (mutexFor에서 증가, release에서 감소, 그 사이 count≥1이므로 제거 불가)
 - 버그 수정의 외과적 범위를 유지하기 위해 복잡도를 최소화; ref-counting은 #499에서 follow-up으로 처리
 - WeakHashMap GC 모델이 Cache 인스턴스 수명 기반 회수를 제공하고, JCache provider(Caffeine 등)가 key cardinality를 자체적으로 제한하므로 메모리 위험 실질적으로 낮음

--- a/docs/lessons/2026-05-16-coroutine-cancellation-primitives.md
+++ b/docs/lessons/2026-05-16-coroutine-cancellation-primitives.md
@@ -1,41 +1,39 @@
-# Lesson: Coroutine Cancellation Primitives — Stale Waiters and Uncancelled Futures
+# 코루틴 취소 프리미티브 — 오래된 대기자와 취소되지 않는 Future
 
-**Date:** 2026-05-16
-**Issue:** #483
-**Branch:** `fix/coroutine-cancellation-primitives`
+**날짜:** 2026-05-16
+**이슈:** #483
+**브랜치:** `fix/coroutine-cancellation-primitives`
 **PR:** (pending)
 
 ---
 
-## Root Cause
+## 근본 원인
 
-### Bug 1 — Resumable stale waiter
+### 버그 1 — `Resumable`의 오래된 대기자
 
-`Resumable.await()` installs a `Continuation` into `continuationRef` via CAS inside
-`suspendCancellableCoroutine`, but previously registered no `invokeOnCancellation` handler.
+`Resumable.await()`는 `suspendCancellableCoroutine` 내부에서 CAS로 `Continuation`을
+`continuationRef`에 설치하지만, 기존 구현은 `invokeOnCancellation` 핸들러를 등록하지 않았다.
 
-When the awaiting coroutine was cancelled before `resume()` was called, the continuation
-remained in the slot. A subsequent `await()` call found the slot occupied and threw
-`IllegalStateException("Only one thread can await a Resumable")`, even though the original
-awaiter was long gone.
+대기 중인 코루틴이 `resume()` 호출 전에 취소되면 continuation이 슬롯에 그대로 남았다.
+이후 `await()` 호출은 원래 대기자가 이미 사라졌는데도 슬롯이 점유된 것으로 판단해
+`IllegalStateException("Only one thread can await a Resumable")`을 던졌다.
 
-### Bug 2 — FutureToCompletableFutureWrapper uncancelled underlying Future
+### 버그 2 — `FutureToCompletableFutureWrapper`가 하위 Future를 취소하지 않음
 
-`FutureToCompletableFutureWrapper` (in `bluetape4k-core`) wraps a plain `Future<T>` using a
-virtual thread that blocks on `future.get()`. The class did not override `cancel()`, so
-coroutine cancellation (which calls `CompletableFuture.cancel()`) only marked the wrapper as
-cancelled — the virtual thread continued blocking on `future.get()` indefinitely, leaking the
-underlying work.
+`FutureToCompletableFutureWrapper`(`bluetape4k-core`)는 `future.get()`에서 blocking하는
+가상 스레드로 일반 `Future<T>`를 감싼다. 이 클래스가 `cancel()`을 override하지 않아
+코루틴 취소(`CompletableFuture.cancel()` 호출)는 wrapper 상태만 취소로 표시했다.
+가상 스레드는 계속 `future.get()`에서 무기한 대기했고, 하위 작업이 누수되었다.
 
 ---
 
-## Decision
+## 결정
 
-**Bug 1 fix** — register `invokeOnCancellation` immediately after the CAS succeeds:
+**버그 1 수정** — CAS 성공 직후 `invokeOnCancellation`을 등록한다:
 
 ```kotlin
 if (continuationRef.compareAndSet(current, cont)) {
-    // CAS-clear only this cont; leave READY intact if resume() already replaced it.
+    // 이 cont만 CAS로 정리한다. resume()이 이미 READY로 교체했다면 READY를 보존한다.
     cont.invokeOnCancellation {
         continuationRef.compareAndSet(cont, null)
     }
@@ -43,11 +41,11 @@ if (continuationRef.compareAndSet(current, cont)) {
 }
 ```
 
-Key invariant: `compareAndSet(cont, null)` (not `set(null)`) preserves a READY sentinel
-placed by a concurrent `resume()`. If `resume()` wins first, the CAS comparand is READY ≠
-cont, so the cancellation handler is a no-op and READY is unaffected.
+핵심 불변식: `set(null)`이 아니라 `compareAndSet(cont, null)`을 사용해야 concurrent
+`resume()`이 배치한 READY sentinel을 보존한다. `resume()`이 먼저 이기면 CAS 비교 대상은
+READY이며 `cont`가 아니므로, 취소 핸들러는 no-op이 되고 READY는 영향을 받지 않는다.
 
-**Bug 2 fix** — override `cancel()` in `FutureToCompletableFutureWrapper`:
+**버그 2 수정** — `FutureToCompletableFutureWrapper`에서 `cancel()`을 override한다:
 
 ```kotlin
 override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
@@ -56,25 +54,24 @@ override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
 }
 ```
 
-Order matters: cancel `wrapped` first so the virtual thread's `future.get()` unblocks,
-then call `super.cancel()`. The virtual thread may re-enter `cancel(true)` from its
-`CancellationException` catch block — this is safe because `CompletableFuture.cancel()` is
-idempotent on already-cancelled state.
+순서가 중요하다. 먼저 `wrapped`를 취소해 가상 스레드의 `future.get()`을 unblock한 뒤
+`super.cancel()`을 호출한다. 가상 스레드는 `CancellationException` catch 블록에서
+`cancel(true)`에 재진입할 수 있지만, 이미 취소된 상태에서 `CompletableFuture.cancel()`은
+멱등적이므로 안전하다.
 
 ---
 
-## Outcome
+## 결과
 
-- `Resumable`: cancelled `await()` now clears the slot; next `await()` + `resume()` pair
-  succeeds without `IllegalStateException`.
-- `FutureToCompletableFutureWrapper`: coroutine cancellation propagates to the underlying
-  `Future`, stopping the virtual thread's blocking work.
-- 7 tests pass (5 pre-existing + 2 new for `Resumable`, 4 pre-existing + 1 new for
-  `FutureSupport`).
+- `Resumable`: 취소된 `await()`가 슬롯을 정리하므로 다음 `await()` + `resume()` 쌍이
+  `IllegalStateException` 없이 성공한다.
+- `FutureToCompletableFutureWrapper`: 코루틴 취소가 하위 `Future`까지 전파되어
+  가상 스레드의 blocking 작업을 중단한다.
+- 테스트 7개 통과(`Resumable` 기존 5개 + 신규 2개, `FutureSupport` 기존 4개 + 신규 1개).
 
 ---
 
-## Verification Evidence
+## 검증 증거
 
 ```
 io.bluetape4k.coroutines.flow.extensions.ResumableTest ✔ correct state
@@ -89,28 +86,28 @@ io.bluetape4k.coroutines.support.FutureSupportTest     ✔ awaitSuspending 취�
 
 ---
 
-## Review Findings Resolved
+## 리뷰 지적 해결
 
-| Severity | Finding | Resolution |
+| 심각도 | 지적 | 해결 |
 |----------|---------|------------|
-| LOW | KDoc language mix in `Resumable.await()` | Converted full block to English |
-| LOW | KDoc language mix in `awaitSuspending()` | Converted full block to English |
-| LOW | Test `catch (CancellationException)` without rethrow | Removed try/catch entirely |
-| LOW | Magic `50.milliseconds` literal in test | Extracted to `CANCEL_PROPAGATION_DELAY_MS` const |
+| LOW | `Resumable.await()` KDoc 언어 혼용 | 전체 block을 영어로 통일 |
+| LOW | `awaitSuspending()` KDoc 언어 혼용 | 전체 block을 영어로 통일 |
+| LOW | test에서 `catch (CancellationException)` 후 rethrow 없음 | try/catch 전체 제거 |
+| LOW | test의 magic `50.milliseconds` literal | `CANCEL_PROPAGATION_DELAY_MS` const로 추출 |
 
 ---
 
-## Future Guidance
+## 향후 가이드
 
-- **`suspendCancellableCoroutine` + CAS install pattern**: always register
-  `invokeOnCancellation` using `compareAndSet(cont, null)` — not `set(null)` — so that a
-  concurrent sentinel set by a producer is not clobbered.
-- **`invokeOnCancellation` fires synchronously** when the coroutine is already cancelled at
-  registration time, so there is no "registered too late" window.
-- **READY fast path does not suspend**: when `cont.resumeWith()` fires inside the CancellableCoroutine
-  lambda, no cancellation window exists and `invokeOnCancellation` need not be registered.
-- **CompletableFuture wrappers must override `cancel()`** if they launch background threads or
-  virtual threads that block on the wrapped resource. Omitting the override leaks the thread.
-- **cancel order in wrappers**: cancel the wrapped resource first, then call
-  `super.cancel()`. The wrapper's virtual thread can re-enter `cancel()` from its catch block;
-  this is safe because `CompletableFuture.cancel()` is idempotent.
+- **`suspendCancellableCoroutine` + CAS install 패턴**: producer가 동시에 설정한 sentinel을
+  덮어쓰지 않도록 `set(null)`이 아니라 `compareAndSet(cont, null)`로
+  `invokeOnCancellation`을 항상 등록한다.
+- **`invokeOnCancellation`은 등록 시점에 이미 코루틴이 취소된 경우 동기적으로 실행된다.**
+  따라서 "너무 늦게 등록된" window가 없다.
+- **READY fast path는 suspend하지 않는다.** CancellableCoroutine lambda 내부에서
+  `cont.resumeWith()`가 실행되면 취소 window가 없으므로 `invokeOnCancellation` 등록이 필요 없다.
+- **`CompletableFuture` wrapper가 background thread나 virtual thread를 실행해 감싼 resource에서
+  blocking한다면 반드시 `cancel()`을 override해야 한다.** override를 생략하면 thread가 누수된다.
+- **wrapper의 취소 순서**: 감싼 resource를 먼저 취소한 뒤 `super.cancel()`을 호출한다.
+  wrapper의 가상 스레드가 catch 블록에서 `cancel()`에 재진입할 수 있지만,
+  `CompletableFuture.cancel()`은 멱등적이므로 안전하다.

--- a/docs/lessons/2026-05-16-create-temp-directory-toctou.md
+++ b/docs/lessons/2026-05-16-create-temp-directory-toctou.md
@@ -1,61 +1,62 @@
-# createTempDirectory TOCTOU Race Fix
+# createTempDirectory TOCTOU 경쟁 조건 수정
 
-**Date**: 2026-05-16
-**Issue**: #479
-**Branch**: `fix/create-temp-directory`
+**날짜**: 2026-05-16
+**이슈**: #479
+**브랜치**: `fix/create-temp-directory`
 
-## Root Cause
+## 근본 원인
 
-`createTempDirectory` used a three-step sequence with a time-of-check/time-of-use (TOCTOU) race:
+`createTempDirectory`는 time-of-check/time-of-use(TOCTOU) 경쟁 조건이 있는 3단계 절차를 사용했다:
 
 ```kotlin
 // BEFORE (racy)
-val dir = File.createTempFile(prefix, suffix)  // 1. create temp FILE
-dir.deleteRecursively()                         // 2. delete it
-dir.mkdirs()                                    // 3. recreate as directory
+val dir = File.createTempFile(prefix, suffix)  // 1. 임시 FILE 생성
+dir.deleteRecursively()                         // 2. 삭제
+dir.mkdirs()                                    // 3. directory로 재생성
 ```
 
-Between step 2 and step 3, another process can claim the same path. Additionally, neither
-`deleteRecursively()` nor `mkdirs()` return values were checked, so failure was silently
-ignored and the function returned as if a valid directory was created.
+2단계와 3단계 사이에 다른 process가 같은 path를 선점할 수 있다. 또한 `deleteRecursively()`와
+`mkdirs()`의 반환값을 확인하지 않아 실패가 조용히 무시되었고, 함수는 유효한 directory가
+생성된 것처럼 반환했다.
 
-## Fix
+## 수정
 
-Replace the racy sequence with the JDK atomic `Files.createTempDirectory` API:
+경쟁 조건이 있는 절차를 JDK atomic `Files.createTempDirectory` API로 교체한다:
 
 ```kotlin
 // AFTER (atomic)
 val dir = Files.createTempDirectory(prefix).toFile()
 ```
 
-`Files.createTempDirectory` creates the directory in a single atomic OS syscall — there is no
-window for another process to claim the path.
+`Files.createTempDirectory`는 단일 atomic OS syscall로 directory를 생성하므로 다른 process가
+path를 선점할 window가 없다.
 
-The `suffix` parameter is retained in the signature for API compatibility but is now ignored.
-The generated directory name no longer ends with the suffix value (e.g., no `.dir` extension);
-`Files.createTempDirectory` generates its own unique numeric suffix.
+`suffix` parameter는 API 호환성을 위해 signature에 남기지만 이제 무시된다. 생성된 directory
+이름은 더 이상 suffix 값으로 끝나지 않는다(예: `.dir` extension 없음).
+`Files.createTempDirectory`가 자체 고유 numeric suffix를 생성한다.
 
-## Test Coverage
+## 테스트 범위
 
-Three new tests in `FileSupportTest`:
+`FileSupportTest`에 새 테스트 3개를 추가했다:
 
-1. **Atomic creation** — asserts the returned path exists and `isDirectory == true`.
-2. **Uniqueness** — two sequential calls produce distinct canonical paths.
-3. **Concurrent uniqueness** — 50 concurrent calls on 8 threads all produce unique,
-   existing directories, demonstrating the race-free property.
+1. **Atomic 생성** — 반환된 path가 존재하고 `isDirectory == true`임을 검증한다.
+2. **고유성** — 순차 호출 2회가 서로 다른 canonical path를 생성함을 검증한다.
+3. **동시 고유성** — 8개 thread의 동시 호출 50회가 모두 고유하고 존재하는 directory를
+   생성함을 확인해 race-free 속성을 보여준다.
 
-## Key Lessons
+## 핵심 교훈
 
-**Use JDK atomic filesystem APIs for temporary resources.**
-`File.createTempFile` + delete + mkdir is a classic TOCTOU pattern. `Files.createTempDirectory`
-(and `Files.createTempFile`) are designed to create resources atomically. Prefer them always.
+**임시 resource에는 JDK atomic filesystem API를 사용한다.**
+`File.createTempFile` + delete + mkdir는 전형적인 TOCTOU 패턴이다.
+`Files.createTempDirectory`와 `Files.createTempFile`은 resource를 atomic하게 생성하도록
+설계되었으므로 항상 우선 사용한다.
 
-**Check return values for filesystem operations.**
-`deleteRecursively()` and `mkdirs()` return `Boolean` indicating success. In the old code
-both were ignored, meaning silent failure was possible. The new code avoids these operations
-entirely; the shutdown hook uses `runCatching` to log failures without masking the primary result.
+**filesystem operation의 반환값을 확인한다.**
+`deleteRecursively()`와 `mkdirs()`는 성공 여부를 나타내는 `Boolean`을 반환한다. 기존 코드는
+둘 다 무시했기 때문에 silent failure가 가능했다. 새 코드는 이 operation들을 완전히 피하며,
+shutdown hook은 primary result를 가리지 않도록 `runCatching`으로 실패를 logging한다.
 
-## Verification
+## 검증
 
 ```
 :bluetape4k-io:test (FileSupportTest)  16 passing (2.1s) — BUILD SUCCESSFUL

--- a/docs/lessons/2026-05-16-elasticsearch-coroutines-timeout.md
+++ b/docs/lessons/2026-05-16-elasticsearch-coroutines-timeout.md
@@ -1,33 +1,31 @@
 # Elasticsearch Coroutines Timeout
 
-## Context
+## 배경
 
-Nightly full verification for the Memgraph CI fix passed `graphdb-memgraph`,
-but failed in `Test / Infra (search-messaging)`. The failing module was
-`:bluetape4k-elasticsearch:test`, specifically `ElasticsearchCoroutinesTest`.
+Memgraph CI 수정에 대한 Nightly 전체 검증은 `graphdb-memgraph`를 통과했지만,
+`Test / Infra (search-messaging)`에서 실패했다. 실패한 module은
+`:bluetape4k-elasticsearch:test`였고, 구체적으로 `ElasticsearchCoroutinesTest`였다.
 
-## Decision or Finding
+## 결정 또는 발견
 
-The failing tests were bounded by `runTest(timeout = 30.seconds)`. On GitHub
-Actions, Elasticsearch container I/O plus index refresh calls can exceed that
-limit under runner load. Sibling Elasticsearch coroutine integration tests
-already use 60-second timeouts for similar external I/O paths.
+실패한 테스트들은 `runTest(timeout = 30.seconds)`로 제한되어 있었다. GitHub Actions에서는
+Elasticsearch container I/O와 index refresh 호출이 runner 부하 아래에서 이 한계를 넘을 수 있다.
+인접한 Elasticsearch coroutine integration test들은 유사한 외부 I/O 경로에 이미 60초 timeout을
+사용하고 있었다.
 
-## Outcome
+## 결과
 
-`ElasticsearchCoroutinesTest` now uses 60-second `runTest` timeouts for setup,
-teardown, and CRUD/search integration tests. This keeps the tests bounded while
-allowing realistic CI latency.
+`ElasticsearchCoroutinesTest`는 setup, teardown, CRUD/search integration test에
+60초 `runTest` timeout을 사용한다. 테스트 경계는 유지하면서 현실적인 CI latency를 허용한다.
 
-## Verification
+## 검증
 
-- Local targeted class: `:bluetape4k-elasticsearch:test --tests io.bluetape4k.elasticsearch.coroutines.ElasticsearchCoroutinesTest` passed in 31 seconds.
-- GitHub Nightly full attempt 1 and failed-job rerun both failed before this
-  change with `UncompletedCoroutinesError: After waiting for 30s`.
+- Local targeted class: `:bluetape4k-elasticsearch:test --tests io.bluetape4k.elasticsearch.coroutines.ElasticsearchCoroutinesTest`가 31초에 통과했다.
+- GitHub Nightly full attempt 1과 failed-job rerun은 모두 이 변경 전
+  `UncompletedCoroutinesError: After waiting for 30s`로 실패했다.
 
-## Future Guidance
+## 향후 가이드
 
-For coroutine tests that call real containers or remote-style clients, avoid
-30-second `runTest` limits unless the underlying operation is deterministic and
-purely local. Match sibling integration tests that already account for CI
-runner latency.
+실제 container나 remote-style client를 호출하는 coroutine test에서는 하위 operation이 결정적이고
+순수 local인 경우가 아니라면 30초 `runTest` 제한을 피한다. CI runner latency를 이미 고려한
+인접 integration test의 timeout 정책과 맞춘다.

--- a/docs/lessons/2026-05-16-issue-108-querydsl-paging.md
+++ b/docs/lessons/2026-05-16-issue-108-querydsl-paging.md
@@ -1,33 +1,31 @@
-# Issue 108 QueryDSL Paging
+# 이슈 108 QueryDSL Paging
 
-## Context
+## 배경
 
-Issue #108 requested completion of the unfinished QueryDSL example in
-`examples/jpa-querydsl-demo`. The current source did not contain the issue-body
-`findByName*` methods; the active TODOs were the three paging methods in
-`MemberRepositoryImpl`.
+Issue #108은 `examples/jpa-querydsl-demo`의 미완성 QueryDSL example 완성을 요청했다.
+현재 source에는 issue body에 적힌 `findByName*` method들이 없었고, 실제 TODO는
+`MemberRepositoryImpl`의 paging method 3개였다.
 
-## Decision
+## 결정
 
-Implement the current repository contract by completing
-`searchPageSimple`, `searchPageComplex`, and `searchPageExtremeCountQuery`.
-Use explicit QueryDSL count queries instead of deprecated `fetchCount()`, and
-map supported Spring `Sort` properties to QueryDSL `OrderSpecifier`s manually.
+`searchPageSimple`, `searchPageComplex`, `searchPageExtremeCountQuery`를 완성해 현재
+repository contract를 구현한다. Deprecated 된 `fetchCount()` 대신 명시적인 QueryDSL count query를
+사용하고, 지원하는 Spring `Sort` property를 QueryDSL `OrderSpecifier`로 수동 mapping한다.
 
-## Outcome
+## 결과
 
-The example now returns `Page<MemberTeamDto>` for all three paging methods and
-has a repository test covering filtered content, total count, and sorting.
+example은 이제 세 paging method 모두에서 `Page<MemberTeamDto>`를 반환하며, filtered content,
+total count, sorting을 다루는 repository test를 가진다.
 
-## Verification
+## 검증
 
 - `rg 'TODO\("Not yet implemented"\)' MemberRepositoryImpl.kt`: no matches.
 - `./gradlew :bluetape4k-examples-jpa-querydsl-demo:test --tests 'io.bluetape4k.examples.jpa.querydsl.domain.repository.JpaRepositoryTest'`: 3 tests passed.
 - `./gradlew :bluetape4k-examples-jpa-querydsl-demo:test`: 44 tests executed, 1 skipped, build successful.
-- IntelliJ diagnostics on touched Kotlin files: 0 problems.
+- 수정한 Kotlin file에 대한 IntelliJ diagnostics: 문제 0개.
 
-## Future Guard
+## 향후 가드
 
-`QuerydslRepositorySupport.applyPagination()` can generate Hibernate 7-invalid
-paths such as `member.age` for Spring `Sort`. For this example, prefer explicit
-QueryDSL `orderBy` mapping when pageable sorting matters.
+`QuerydslRepositorySupport.applyPagination()`은 Spring `Sort`에 대해 `member.age`처럼
+Hibernate 7에서 유효하지 않은 path를 생성할 수 있다. 이 example에서는 pageable sorting이
+중요할 때 명시적인 QueryDSL `orderBy` mapping을 우선한다.

--- a/docs/lessons/2026-05-16-issue-459-k3s-workload-example.md
+++ b/docs/lessons/2026-05-16-issue-459-k3s-workload-example.md
@@ -1,36 +1,32 @@
-# Issue 459 K3s workload example
+# 이슈 459 K3s workload example
 
-## Context
+## 배경
 
-Issue #459 asked for a practical `K3sServer` integration-test example that goes
-beyond node listing and demonstrates Kubernetes workload resources against a
-real K3s API server.
+Issue #459는 node listing을 넘어 실제 K3s API server를 대상으로 Kubernetes workload resource를
+보여주는 실용적인 `K3sServer` integration-test example을 요청했다.
 
-## Decision
+## 결정
 
-Add a dedicated `K3sWorkloadExampleTest` under `testing/testcontainers` instead
-of expanding `K3sServerTest`. The new file keeps the basic server smoke tests
-separate from workload examples and uses the existing `@Tag("k8s")`/`k8sTest`
-path for privileged-runner execution.
+`K3sServerTest`를 확장하지 않고 `testing/testcontainers` 아래에 전용
+`K3sWorkloadExampleTest`를 추가한다. 새 file은 기본 server smoke test와 workload example을
+분리하고, privileged runner 실행에는 기존 `@Tag("k8s")`/`k8sTest` 경로를 사용한다.
 
-## Outcome
+## 결과
 
-The example covers ConfigMap CRUD, Deployment-backed Service readiness, and
-Secret value decoding. Each test closes its Kubernetes client, performs
-idempotent pre-cleanup that waits for stale resources to disappear, and cleans
-created resources with `try/finally` so the singleton K3s container can be
-reused safely.
+Example은 ConfigMap CRUD, Deployment-backed Service readiness, Secret value decoding을 다룬다.
+각 test는 Kubernetes client를 닫고, stale resource가 사라질 때까지 기다리는 idempotent pre-cleanup을
+수행하며, singleton K3s container를 안전하게 재사용할 수 있도록 `try/finally`로 생성 resource를
+정리한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain`
   passed.
 - `./gradlew :bluetape4k-testcontainers:k8sTest --tests 'io.bluetape4k.testcontainers.infra.K3sWorkloadExampleTest' --no-daemon --no-configuration-cache --console=plain`
-  passed with 3 tests executed.
+  3 tests executed로 통과.
 
-## Next Time
+## 다음번 가이드
 
-When adding K3s examples, keep long-running or privileged Docker scenarios under
-`@Tag("k8s")`, run the dedicated `k8sTest` task locally when Docker supports it,
-and use both wait-backed pre-cleanup and `finally` cleanup for
-singleton-container safety.
+K3s example을 추가할 때 long-running 또는 privileged Docker scenario는 `@Tag("k8s")` 아래에
+유지하고, Docker가 지원되는 local 환경에서는 전용 `k8sTest` task를 실행한다. Singleton-container
+safety를 위해 wait-backed pre-cleanup과 `finally` cleanup을 함께 사용한다.

--- a/docs/lessons/2026-05-16-issue-468-jpa-blazepersistence-demo.md
+++ b/docs/lessons/2026-05-16-issue-468-jpa-blazepersistence-demo.md
@@ -1,45 +1,43 @@
-# Issue 468 - JPA Blaze Persistence Demo
+# 이슈 468 - JPA Blaze Persistence Demo
 
-## Context
+## 배경
 
-Issue #468 added a new `examples/jpa-blazepersistence-demo` module to show JPA
-querying with Blaze Persistence as a migration companion to the Querydsl demo,
-especially where Querydsl `fetchCount()` / `fetchResults()` are deprecated.
+Issue #468은 JPA query를 Blaze Persistence로 보여주는 새
+`examples/jpa-blazepersistence-demo` module 추가 작업이었다. 특히 Querydsl `fetchCount()` /
+`fetchResults()`가 deprecated 된 지점에서 Querydsl demo의 migration companion 역할을 한다.
 
-## Decision
+## 결정
 
-Use the Jakarta Blaze Persistence `1.6.16` artifacts because the Hibernate 7.0
-integration artifact is available there. Keep wiring manual instead of adopting
-Blaze Spring Data integration because the current repository uses Spring Boot 4 /
-Spring Framework 7, while Blaze's Spring integration line targets older Spring
-Data generations.
+Hibernate 7.0 integration artifact가 제공되는 Jakarta Blaze Persistence `1.6.16` artifact를 사용한다.
+현재 repository는 Spring Boot 4 / Spring Framework 7을 사용하지만 Blaze의 Spring integration line은
+더 오래된 Spring Data generation을 대상으로 하므로, Blaze Spring Data integration을 채택하지 않고
+manual wiring을 유지한다.
 
-## Outcome
+## 결과
 
-The new module demonstrates:
+새 module은 다음을 보여준다:
 
-- Manual `CriteriaBuilderFactory` and `EntityViewManager` beans.
-- Entity View projections for member/team read models.
+- Manual `CriteriaBuilderFactory`와 `EntityViewManager` bean.
+- Member/team read model용 Entity View projection.
 - Dynamic Criteria Builder filtering.
-- `PagedList` count metadata as the Querydsl count replacement example.
-- Keyset pagination via `EntityViewSetting.withKeysetPage(...)`.
-- Multilingual module README files and root README links.
-- Examples workflow coverage and Nightly build exclusion parity.
+- Querydsl count replacement example로서의 `PagedList` count metadata.
+- `EntityViewSetting.withKeysetPage(...)`를 통한 keyset pagination.
+- Multilingual module README file과 root README link.
+- Examples workflow coverage와 Nightly build exclusion parity.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-examples-jpa-blazepersistence-demo:check`
 - `actionlint .github/workflows/examples.yml .github/workflows/nightly-tests.yml`
 - `git diff --check`
 - `./gradlew -q projects | rg "bluetape4k-examples-jpa-blazepersistence-demo"`
-- `runtimeClasspath` and `testRuntimeClasspath` dependency checks both resolved
-  Spring Boot `4.0.6`, Spring `7.0.7`, Hibernate `7.0.3.Final`, and Jakarta
-  Persistence `3.2.0`.
+- `runtimeClasspath`와 `testRuntimeClasspath` dependency check 모두 Spring Boot `4.0.6`,
+  Spring `7.0.7`, Hibernate `7.0.3.Final`, Jakarta Persistence `3.2.0`으로 resolve됨.
 - Claude advisor Step 6-R recheck: P0=0, P1=0, APPROVE.
 
-## Future Guidance
+## 향후 가이드
 
-For Blaze Persistence + Hibernate 7 examples, enable keyset extraction with
-`EntityViewSetting.withKeysetPage(null)` on the first page; plain offset
-pagination returns a null keyset page. Avoid Spring Data integration jars until
-their Spring Framework 7 / Spring Data 4 compatibility is verified.
+Blaze Persistence + Hibernate 7 example에서는 첫 page에서
+`EntityViewSetting.withKeysetPage(null)`로 keyset extraction을 활성화한다. Plain offset
+pagination은 null keyset page를 반환한다. Spring Framework 7 / Spring Data 4 호환성이 확인될 때까지
+Spring Data integration jar는 피한다.

--- a/docs/lessons/2026-05-16-issue-472-batch-listener-dlt-routing.md
+++ b/docs/lessons/2026-05-16-issue-472-batch-listener-dlt-routing.md
@@ -1,4 +1,4 @@
-# Issue #472: BatchListenerFailedException DLT 라우팅 수정
+# 이슈 #472: BatchListenerFailedException DLT 라우팅 수정
 
 **날짜**: 2026-05-16
 **브랜치**: `fix/batch-listener-dlt-routing`

--- a/docs/lessons/2026-05-16-kryo-async-leak.md
+++ b/docs/lessons/2026-05-16-kryo-async-leak.md
@@ -1,31 +1,31 @@
-# withKryoAsync Kryo Pool Leak on Cancellation
+# withKryoAsync 취소 시 Kryo Pool 누수
 
-**Date**: 2026-05-16
-**Issue**: #480
-**Branch**: `fix/kryo-async-leak`
+**날짜**: 2026-05-16
+**이슈**: #480
+**브랜치**: `fix/kryo-async-leak`
 
-## Root Cause
+## 근본 원인
 
-`withKryoAsync` obtained the `Kryo` instance **outside** `supplyAsync` and released it via `whenCompleteAsync`:
+`withKryoAsync`는 `supplyAsync` **밖에서** `Kryo` instance를 얻고 `whenCompleteAsync`로 반환했다:
 
 ```kotlin
 // BEFORE (leak risk)
-val kryo = KryoProvider.obtainKryo()                  // obtained on caller thread
+val kryo = KryoProvider.obtainKryo()                  // caller thread에서 획득
 return CompletableFuture.supplyAsync { func(kryo) }
-    .whenCompleteAsync { _, _ -> KryoProvider.releaseKryo(kryo) }  // may not run on cancellation
+    .whenCompleteAsync { _, _ -> KryoProvider.releaseKryo(kryo) }  // cancellation 시 실행되지 않을 수 있음
 ```
 
-Two leak paths:
-1. **Cancel before start**: The caller obtains the `Kryo` on its own thread, but if the returned
-   future is cancelled before `supplyAsync` runs, `whenCompleteAsync` is never triggered and the
-   instance is never released.
-2. **`whenCompleteAsync` stage cancelled**: `whenCompleteAsync` returns a new `CompletableFuture`.
-   If that stage is cancelled or the callback does not fire (e.g., when the parent stage completes
-   exceptionally and the new stage is immediately cancelled), `releaseKryo` is skipped.
+누수 경로는 두 가지다:
 
-## Fix
+1. **시작 전 취소**: caller가 자기 thread에서 `Kryo`를 획득했지만, 반환된 future가
+   `supplyAsync` 실행 전에 취소되면 `whenCompleteAsync`가 trigger되지 않고 instance가 반환되지 않는다.
+2. **`whenCompleteAsync` stage 취소**: `whenCompleteAsync`는 새 `CompletableFuture`를 반환한다.
+   그 stage가 취소되거나 callback이 실행되지 않으면(예: parent stage가 exceptionally complete되고
+   새 stage가 즉시 취소되는 경우), `releaseKryo`가 건너뛰어진다.
 
-Move `obtainKryo` and `releaseKryo` **inside** the `supplyAsync` lambda, using `try/finally`:
+## 수정
+
+`try/finally`를 사용해 `obtainKryo`와 `releaseKryo`를 `supplyAsync` lambda **안으로** 옮긴다:
 
 ```kotlin
 // AFTER (fix)
@@ -39,44 +39,43 @@ return CompletableFuture.supplyAsync {
 }
 ```
 
-- If the future is cancelled **before** the supplier runs, `obtainKryo` is never called — no leak.
-- If the future is cancelled **during** execution, the supplier continues to completion on the
-  worker thread; `finally` runs unconditionally and releases the instance before the worker exits.
-- Exception in `func` also triggers `finally`, consistent with the synchronous `withKryo` pattern.
+- Future가 supplier 실행 **전에** 취소되면 `obtainKryo`가 호출되지 않으므로 누수가 없다.
+- Future가 실행 **중에** 취소되면 supplier는 worker thread에서 완료까지 계속 실행되고,
+  worker가 종료되기 전에 `finally`가 무조건 실행되어 instance를 반환한다.
+- `func`의 exception도 synchronous `withKryo` pattern과 동일하게 `finally`를 trigger한다.
 
-## Test Coverage
+## 테스트 범위
 
-New `KryoSupportTest.kt` covers all five helper functions:
+새 `KryoSupportTest.kt`는 helper function 5개를 모두 다룬다:
 
-- `withKryo` — normal path and exception path (pool returned in both cases)
-- `withKryoOutput` — normal path and exception path
-- `withKryoInput` — normal path and exception path
-- `withKryoAsync` — normal path, null return, exception path (pool not exhausted after 20 failures),
-  cancellation path (latch-based synchronization, no `Thread.sleep`)
-- `withKryoSuspending` — normal path and exception path
+- `withKryo` — normal path와 exception path(두 경우 모두 pool 반환)
+- `withKryoOutput` — normal path와 exception path
+- `withKryoInput` — normal path와 exception path
+- `withKryoAsync` — normal path, null return, exception path(20회 실패 후에도 pool 고갈 없음),
+  cancellation path(latch 기반 synchronization, `Thread.sleep` 없음)
+- `withKryoSuspending` — normal path와 exception path
 
-The cancellation test uses a `funcCompleted` `CountDownLatch` signalled from the user-func's
-`finally` block. Because the framework's `releaseKryo` executes immediately after the user func
-returns (including its `finally`), waiting on `funcCompleted` is sufficient synchronization without
-an arbitrary `Thread.sleep`.
+Cancellation test는 user func의 `finally` block에서 signal되는 `funcCompleted` `CountDownLatch`를
+사용한다. Framework의 `releaseKryo`는 user func가 반환된 직후(user `finally` 포함) 실행되므로,
+`funcCompleted` 대기만으로 임의의 `Thread.sleep` 없이 충분한 synchronization이 된다.
 
-## Key Lessons
+## 핵심 교훈
 
-**Obtain resources inside the task boundary, not outside it.**
-When an async task may be cancelled before it starts, any resource obtained before `supplyAsync`
-is at risk of leaking. Always scope `obtain`/`release` pairs to the executor lambda, using
-`try/finally` to guarantee release on all exit paths (success, exception, interrupt).
+**Resource는 task boundary 밖이 아니라 안에서 획득한다.**
+Async task가 시작 전에 취소될 수 있다면 `supplyAsync` 전에 획득한 resource는 누수 위험이 있다.
+항상 executor lambda 내부에서 `obtain`/`release` pair의 scope를 잡고, success, exception, interrupt
+등 모든 exit path에서 release되도록 `try/finally`를 사용한다.
 
-**`whenCompleteAsync` does not guarantee callback execution on cancellation.**
-It returns a new `CompletableFuture`; if that new stage is cancelled, the callback may not run.
-Use `try/finally` inside the supplier instead of a completion callback for resource release.
+**`whenCompleteAsync`는 cancellation 시 callback 실행을 보장하지 않는다.**
+이 API는 새 `CompletableFuture`를 반환하며, 그 새 stage가 취소되면 callback이 실행되지 않을 수 있다.
+Resource release에는 completion callback 대신 supplier 내부 `try/finally`를 사용한다.
 
-**`Thread.sleep` in concurrency tests is flaky.**
-Use `CountDownLatch` or similar explicit signalling. The `funcCompleted` latch pattern here
-(signal from user `finally`, framework release follows immediately) gives deterministic
-synchronization without arbitrary delays.
+**Concurrency test에서 `Thread.sleep`은 flaky하다.**
+`CountDownLatch`나 유사한 명시적 signalling을 사용한다. 여기의 `funcCompleted` latch pattern은
+user `finally`에서 signal하고 framework release가 즉시 이어지는 구조라, 임의 delay 없이 deterministic
+synchronization을 제공한다.
 
-## Verification
+## 검증
 
 ```
 :bluetape4k-io:test

--- a/docs/lessons/2026-05-16-lettuce-getall-mget-fallback.md
+++ b/docs/lessons/2026-05-16-lettuce-getall-mget-fallback.md
@@ -1,12 +1,12 @@
-# LettuceLoadedMap getAll MGET Fallback Fix
+# LettuceLoadedMap getAll MGET Fallback 수정
 
-**Date**: 2026-05-16
-**Issue**: #485
-**Branch**: `fix/lettuce-getall-fallback`
+**날짜**: 2026-05-16
+**이슈**: #485
+**브랜치**: `fix/lettuce-getall-fallback`
 
-## Root Cause
+## 근본 원인
 
-`LettuceLoadedMap.getAll()` and `LettuceSuspendedLoadedMap.getAll()` both used:
+`LettuceLoadedMap.getAll()`과 `LettuceSuspendedLoadedMap.getAll()`은 모두 다음 코드를 사용했다:
 
 ```kotlin
 val values = runCatching { commands.mget(*redisKeys) }
@@ -14,15 +14,14 @@ val values = runCatching { commands.mget(*redisKeys) }
     .getOrNull() ?: emptyList()
 ```
 
-When MGET failed, `values` became `emptyList()`. The subsequent `forEachIndexed`
-loop never iterated, so `missedKeys` remained empty. The loader was never invoked
-and callers received an empty result instead of fetched values.
+MGET이 실패하면 `values`는 `emptyList()`가 되었다. 이어지는 `forEachIndexed` loop가 전혀 돌지 않아
+`missedKeys`가 비어 있었다. Loader는 호출되지 않았고 caller는 fetched value 대신 빈 결과를 받았다.
 
-The log message said "loader fallback" but the code path made it impossible.
+Log message는 "loader fallback"이라고 말했지만, code path는 그것을 불가능하게 만들었다.
 
-## Fix
+## 수정
 
-### Sync (LettuceLoadedMap.kt)
+### Sync (`LettuceLoadedMap.kt`)
 
 ```kotlin
 val mgetResult = runCatching { commands.mget(*redisKeys) }
@@ -42,11 +41,11 @@ if (mgetResult == null) {
 }
 ```
 
-### Suspend (LettuceSuspendedLoadedMap.kt)
+### Suspend (`LettuceSuspendedLoadedMap.kt`)
 
-Same logic, plus replaced `runCatching { asyncCommands.mget(...).await() }` (which
-swallows `CancellationException`) with explicit try/catch that rethrows
-`CancellationException`:
+동일한 logic을 적용하고, `CancellationException`을 삼키는
+`runCatching { asyncCommands.mget(...).await() }`를 명시적인 try/catch로 교체해
+`CancellationException`을 rethrow한다:
 
 ```kotlin
 val mgetResult = try {
@@ -59,34 +58,34 @@ val mgetResult = try {
 }
 ```
 
-Also replaced the SETEX `runCatching` block with the same explicit try/catch.
+SETEX `runCatching` block도 같은 명시적 try/catch로 교체했다.
 
-## Test Coverage
+## 테스트 범위
 
-New tests in `LettuceLoadedMapTest` and `LettuceSuspendedLoadedMapTest`:
+`LettuceLoadedMapTest`와 `LettuceSuspendedLoadedMapTest`에 새 test를 추가했다:
 
-- `getAll - 모든 키가 캐시 미스인 경우 loader로 모두 처리한다` — all keys absent from
-  Redis, verifies all keys go through the loader and results are returned
-- `getAll - 일부 캐시 미스 키는 loader로 Read-through한다` (suspend) — partial miss
-  scenario added to the suspend test class (was missing entirely)
+- `getAll - 모든 키가 캐시 미스인 경우 loader로 모두 처리한다` — Redis에 모든 key가 없을 때
+  모든 key가 loader를 거치고 결과가 반환되는지 검증한다.
+- `getAll - 일부 캐시 미스 키는 loader로 Read-through한다`(suspend) — suspend test class에
+  빠져 있던 partial miss scenario를 추가했다.
 
-Note: the `mgetResult == null` path (MGET throws) is verified by static analysis.
-Integration-level simulation of MGET failure requires a mock-based unit test or
-a broken-connection fixture, which can be added as a follow-up.
+참고: `mgetResult == null` 경로(MGET throw)는 static analysis로 검증했다. MGET failure의
+integration-level simulation은 mock 기반 unit test 또는 broken-connection fixture가 필요하며,
+follow-up으로 추가할 수 있다.
 
-## Verification
+## 검증
 
 ```
 :bluetape4k-lettuce:test
 67 passing (6.2s) — BUILD SUCCESSFUL
 ```
 
-## Key Lesson
+## 핵심 교훈
 
-**`getOrNull() ?: emptyList()` silently converts an error into an empty result.**
-When the intent is "treat failure as all-miss", populate `missedKeys` explicitly
-from `keyList`. Never infer missed keys by iterating a fallback empty collection.
+**`getOrNull() ?: emptyList()`는 error를 빈 결과로 조용히 바꾼다.**
+"failure를 all-miss로 취급"하려는 의도라면 `keyList`에서 `missedKeys`를 명시적으로 채운다.
+Fallback empty collection을 순회해 missed key를 추론하지 않는다.
 
-**`runCatching {}` must not wrap `suspend` calls.** It swallows
-`CancellationException`, breaking coroutine structured concurrency. Use explicit
-try/catch with `CancellationException` rethrow in all suspend paths.
+**`runCatching {}`은 `suspend` 호출을 감싸면 안 된다.** `CancellationException`을 삼켜
+coroutine structured concurrency를 깨뜨린다. 모든 suspend path에서는 `CancellationException`을
+rethrow하는 명시적인 try/catch를 사용한다.

--- a/docs/lessons/2026-05-16-lettuce-write-behind-drop.md
+++ b/docs/lessons/2026-05-16-lettuce-write-behind-drop.md
@@ -1,39 +1,38 @@
-# LettuceSuspendedLoadedMap Write-Behind Drop Fix
+# LettuceSuspendedLoadedMap Write-Behind Drop 수정
 
-**Date**: 2026-05-16
-**Issue**: #486
-**Branch**: `fix/lettuce-write-behind-drop`
+**날짜**: 2026-05-16
+**이슈**: #486
+**브랜치**: `fix/lettuce-write-behind-drop`
 
-## Root Cause
+## 근본 원인
 
-Two silent failure paths in `LettuceSuspendedLoadedMap`:
+`LettuceSuspendedLoadedMap`에는 조용히 실패하는 경로가 두 가지 있었다.
 
-### 1. trySend result ignored on retry
+### 1. 재시도 시 `trySend` 결과 무시
 
-When `flushBatch()` encountered a writer failure and the retry count was below
-`MAX_DEAD_LETTER_RETRY`, it attempted to requeue each entry via:
+`flushBatch()`가 writer 실패를 만나고 retry count가 `MAX_DEAD_LETTER_RETRY`보다 작으면
+각 entry를 다음 코드로 다시 queue에 넣으려 했다:
 
 ```kotlin
 writeBehindChannel?.trySend(Triple(k, v, retryCount))
 ```
 
-The `ChannelResult` returned by `trySend` was silently discarded. If the channel
-was full or closed at that moment (e.g., another burst of writes had filled it,
-or `close()` had been called), the entry was simply dropped with no log and no
-dead-letter record.
+`trySend`가 반환한 `ChannelResult`는 조용히 버려졌다. 그 순간 channel이 가득 차 있거나 닫혀
+있으면(예: 다른 write burst가 channel을 채웠거나 `close()`가 호출된 경우), entry는 log도
+dead-letter 기록도 없이 사라졌다.
 
-### 2. close() cancelled the caller's CoroutineScope
+### 2. `close()`가 caller의 `CoroutineScope`를 취소
 
-`close()` ended with `scope.cancel()`. When the caller passed a shared scope
-(a common pattern for application-wide coroutine supervisors), all coroutines
-running in that scope were cancelled — not just the write-behind consumer job.
+`close()`는 마지막에 `scope.cancel()`을 호출했다. caller가 공유 scope를 넘기는 경우
+(application-wide coroutine supervisor에서 흔한 패턴), write-behind consumer job뿐 아니라
+그 scope에서 실행 중인 모든 coroutine이 취소되었다.
 
-## Fix
+## 수정
 
-### trySend result check
+### `trySend` 결과 확인
 
-Extracted a `writeToDeadLetter(batch: Map<K, V>)` helper. The retry branch
-now checks the `ChannelResult`:
+`writeToDeadLetter(batch: Map<K, V>)` helper를 추출했다. retry branch는 이제
+`ChannelResult`를 확인한다:
 
 ```kotlin
 val dropped = mutableMapOf<K, V>()
@@ -49,15 +48,14 @@ if (dropped.isNotEmpty()) {
 }
 ```
 
-The dead-letter exhaustion path (`retryCount >= MAX_DEAD_LETTER_RETRY`) was
-also refactored to call `writeToDeadLetter` instead of duplicating the HSET +
-LPUSH logic.
+dead-letter 소진 경로(`retryCount >= MAX_DEAD_LETTER_RETRY`)도 HSET + LPUSH logic 중복 대신
+`writeToDeadLetter`를 호출하도록 refactor했다.
 
-### Scope ownership fix
+### Scope ownership 수정
 
-Added a private `ownedJob` (`SupervisorJob` child of the provided scope) and
-`ownedScope` built from it. `writeBehindJob` is launched on `ownedScope`.
-`close()` cancels `ownedJob` only:
+제공된 scope의 child인 private `ownedJob`(`SupervisorJob`)을 추가하고, 이를 기반으로
+`ownedScope`를 만들었다. `writeBehindJob`은 `ownedScope`에서 launch된다.
+`close()`는 `ownedJob`만 취소한다:
 
 ```kotlin
 private val ownedJob = SupervisorJob(parent = scope.coroutineContext[Job])
@@ -70,35 +68,33 @@ override fun close() {
             withTimeout(...) { job.join() }
         }
     }
-    ownedJob.cancel()   // not scope.cancel()
+    ownedJob.cancel()   // scope.cancel()이 아님
     ...
 }
 ```
 
-## Test Coverage
+## 테스트 범위
 
-Two new tests in `LettuceSuspendedLoadedMapTest`:
+`LettuceSuspendedLoadedMapTest`에 새 테스트 2개를 추가했다:
 
-- `close - 공유 scope를 취소하지 않는다` — passes a shared scope, closes the map,
-  asserts `sharedScope.isActive == true`
-- `write-behind - writer 실패 후 재시도 소진 시 dead-letter에 기록된다` — always-failing
-  writer exhausts `MAX_DEAD_LETTER_RETRY` retries, verifies the key appears in the
-  Redis dead-letter list
+- `close - 공유 scope를 취소하지 않는다` — shared scope를 전달하고 map을 닫은 뒤
+  `sharedScope.isActive == true`를 검증한다.
+- `write-behind - writer 실패 후 재시도 소진 시 dead-letter에 기록된다` — 항상 실패하는 writer로
+  `MAX_DEAD_LETTER_RETRY` 재시도를 소진시키고 Redis dead-letter list에 key가 기록되는지 검증한다.
 
-## Verification
+## 검증
 
 ```
 :bluetape4k-lettuce:test
 322 passing (14.1s) — BUILD SUCCESSFUL
 ```
 
-## Key Lessons
+## 핵심 교훈
 
-**Never discard a `ChannelResult` from `trySend`.** A `trySend` on a full or
-closed channel returns failure silently. Always check the result and route
-undeliverable messages to a dead-letter or log them explicitly.
+**`trySend`의 `ChannelResult`를 버리지 않는다.** 가득 찼거나 닫힌 channel에서 `trySend`는
+조용히 failure를 반환한다. 항상 결과를 확인하고 전달할 수 없는 message를 dead-letter로 보내거나
+명시적으로 log에 남긴다.
 
-**The owner of a `CoroutineScope` is the one who should cancel it.** If a class
-receives a scope parameter, it should create a child job/scope internally and
-cancel only that child on `close()`. Cancelling the provided scope is a contract
-violation that affects all callers sharing the scope.
+**`CoroutineScope`의 owner만 그 scope를 취소해야 한다.** class가 scope parameter를 받는다면
+내부에서 child job/scope를 만들고 `close()`에서 그 child만 취소해야 한다. 제공받은 scope를
+취소하는 것은 공유 scope를 쓰는 모든 caller에 영향을 주는 contract 위반이다.

--- a/docs/lessons/2026-05-16-memoizer-clear-race.md
+++ b/docs/lessons/2026-05-16-memoizer-clear-race.md
@@ -1,88 +1,81 @@
-# Memoizer Write-after-clear Race Condition Fix
+# Memoizer Write-after-clear 경쟁 조건 수정
 
-**Date**: 2026-05-16
-**Issue**: #487
-**Branch**: `fix/memoizer-clear-race`
+**날짜**: 2026-05-16
+**이슈**: #487
+**브랜치**: `fix/memoizer-clear-race`
 
-## Root Cause
+## 근본 원인
 
-Async and suspend memoizers shared a common bug: an in-flight evaluator that
-completed *after* `clear()` was called would write its result back into the
-cache, repopulating it with stale data. Callers who triggered `clear()` to
-invalidate the cache got a fresh result on the very next call, but other callers
-who had started evaluation before `clear()` would silently refill the cache.
+Async 및 suspend memoizer는 공통 버그를 공유했다. `clear()` 호출 이후 완료된 in-flight
+evaluator가 결과를 cache에 다시 써서 stale data로 cache를 다시 채웠다. `clear()`를 호출해
+cache를 무효화한 caller는 바로 다음 호출에서 fresh result를 얻었지만, `clear()` 전에 평가를
+시작한 다른 caller가 조용히 cache를 다시 채울 수 있었다.
 
-A secondary bug existed in `CaffeineMemoizer.clear()`: it called
-`cache.cleanUp()` (maintenance pass) instead of `cache.invalidateAll()`
-(actual eviction), making `clear()` effectively a no-op.
+부차적인 버그도 `CaffeineMemoizer.clear()`에 있었다. 실제 eviction인 `cache.invalidateAll()`이
+아니라 maintenance pass인 `cache.cleanUp()`을 호출해 `clear()`가 사실상 no-op이었다.
 
-## Fix
+## 수정
 
-### Generation counter pattern
+### Generation counter 패턴
 
-All five affected memoizers received an `AtomicLong generation` counter:
+영향받은 memoizer 5개에 `AtomicLong generation` counter를 추가했다:
 
-1. `generation.get()` is captured into `capturedGen` **before** the evaluator
-   starts (or the in-flight future is shared).
-2. `clear()` calls `generation.incrementAndGet()` **first**, then clears the
-   cache and in-flight maps.
-3. Before writing to the cache after evaluation, the code checks
-   `generation.get() == capturedGen`. If they differ, the result was computed
-   before a `clear()` — the write is skipped, but the caller's future/deferred
-   is still completed with the computed value.
+1. evaluator가 시작되기 전(또는 in-flight future가 공유되기 전) `generation.get()`을
+   `capturedGen`으로 capture한다.
+2. `clear()`는 먼저 `generation.incrementAndGet()`을 호출한 뒤 cache와 in-flight map을 비운다.
+3. 평가 후 cache에 쓰기 전에 `generation.get() == capturedGen`인지 확인한다. 다르면 결과가
+   `clear()` 이전에 계산된 것이므로 write를 건너뛴다. 단 caller의 future/deferred는 계산된
+   값으로 계속 완료한다.
 
-### Value-aware ConcurrentHashMap.remove
+### Value-aware `ConcurrentHashMap.remove`
 
-In-flight map cleanup uses the 2-argument `remove(key, value)` form to avoid
-evicting a freshly-installed promise that races with completion from a previous
-generation.
+In-flight map cleanup은 이전 generation의 completion과 경쟁하는 freshly-installed promise를
+제거하지 않도록 2-argument `remove(key, value)` form을 사용한다.
 
 ### Null future completion
 
-`InMemoryAsyncMemoizer` and the Caffeine/EhCache/JCache variants now call
-`completeExceptionally(NullPointerException(...))` when the evaluator's
-`CompletableFuture` completes with a `null` value, preventing an indefinitely
-uncompleted promise.
+`InMemoryAsyncMemoizer`와 Caffeine/EhCache/JCache variant는 evaluator의 `CompletableFuture`가
+`null` value로 완료될 때 `completeExceptionally(NullPointerException(...))`를 호출한다.
+이렇게 해서 영원히 완료되지 않는 promise를 방지한다.
 
-### CaffeineMemoizer.clear() bug
+### `CaffeineMemoizer.clear()` 버그
 
-`cache.cleanUp()` → `cache.invalidateAll()`. Also removed the unnecessary
-`ReentrantLock` that guarded only a maintenance call.
+`cache.cleanUp()`을 `cache.invalidateAll()`로 바꿨다. maintenance call만 보호하던 불필요한
+`ReentrantLock`도 제거했다.
 
-### Affected files
+### 영향받은 파일
 
-| File | Change |
+| 파일 | 변경 |
 |------|--------|
 | `CaffeineAsyncMemoizer.kt` | generation counter, value-aware remove, null check, `invalidateAll()` |
 | `EhCacheAsyncMemoizer.kt` | generation counter, value-aware remove, null check |
 | `JCacheAsyncMemoizer.kt` | generation counter, value-aware remove, null check |
 | `InMemoryAsyncMemoizer.kt` | generation counter, value-aware remove, null check |
 | `Cache2kSuspendMemoizer.kt` | generation counter, value-aware remove |
-| `CaffeineMemoizer.kt` | `clear()` uses `invalidateAll()`; lock removed |
+| `CaffeineMemoizer.kt` | `clear()`가 `invalidateAll()` 사용, lock 제거 |
 
-## Test Coverage
+## 테스트 범위
 
-New tests added to `CaffeineAsyncMemoizerTest` and `Cache2KSuspendMemoizerTest`:
+`CaffeineAsyncMemoizerTest`와 `Cache2KSuspendMemoizerTest`에 새 테스트를 추가했다:
 
-- `clear 후 캐시가 무효화된다` — basic clear invalidates cache, triggers fresh evaluation
-- `clear 중 진행 중인 비동기 결과는 캐시에 저장되지 않는다` — in-flight result not
-  written back after `clear()` (verified via `getIfPresent` returning null)
-- `clear 중 진행 중인 suspend 결과는 캐시에 저장되지 않는다` — same guarantee for
-  suspend memoizer (verified via second evaluation being triggered)
+- `clear 후 캐시가 무효화된다` — basic clear가 cache를 무효화하고 fresh evaluation을 유발함.
+- `clear 중 진행 중인 비동기 결과는 캐시에 저장되지 않는다` — in-flight result가
+  `clear()` 후 다시 쓰이지 않음(`getIfPresent`가 null을 반환하는 것으로 검증).
+- `clear 중 진행 중인 suspend 결과는 캐시에 저장되지 않는다` — suspend memoizer의 동일 보장
+  검증(두 번째 evaluation이 trigger되는 것으로 확인).
 
-## Verification
+## 검증
 
 ```
 447 passing (40.8s) — BUILD SUCCESSFUL
 ```
 
-## Key Lesson
+## 핵심 교훈
 
-**Increment generation before clearing**, not after. If `clear()` clears the
-cache and then increments generation, a concurrent evaluator can check
-generation (still old), see equality, and write after the increment completes.
-The correct order is: increment → clear.
+**generation은 clear 이후가 아니라 이전에 증가시킨다.** `clear()`가 cache를 비운 다음
+generation을 증가시키면 concurrent evaluator가 아직 old generation을 보고 equality를 통과한 뒤
+increment 완료 이후 write할 수 있다. 올바른 순서는 increment -> clear이다.
 
-**`cache.cleanUp()` is not `cache.invalidateAll()`**. Caffeine's `cleanUp()`
-triggers pending maintenance tasks (expiry sweeps, etc.); it does not evict all
-entries. Always use `invalidateAll()` when the intent is to empty the cache.
+**`cache.cleanUp()`은 `cache.invalidateAll()`이 아니다.** Caffeine의 `cleanUp()`은 pending
+maintenance task(expiry sweep 등)를 trigger할 뿐 모든 entry를 evict하지 않는다. cache를 비우려는
+의도라면 항상 `invalidateAll()`을 사용한다.

--- a/docs/lessons/2026-05-16-micrometer-cancellation-swallow.md
+++ b/docs/lessons/2026-05-16-micrometer-cancellation-swallow.md
@@ -1,28 +1,28 @@
-# Lesson: Micrometer suspend try* wrappers swallow coroutine cancellation
+# Micrometer suspend try* wrapper의 코루틴 취소 삼킴
 
-**Date:** 2026-05-16
-**Issue:** #488
-**Branch:** `fix/micrometer-cancellation-swallow`
+**날짜:** 2026-05-16
+**이슈:** #488
+**브랜치:** `fix/micrometer-cancellation-swallow`
 **PR:** (pending)
 
 ---
 
-## Root Cause
+## 근본 원인
 
-`tryObserveSuspending` and `tryWithObservationSuspending` wrapped their entire body in
-`runCatching {}`. Because `runCatching` is implemented as a blanket `try { } catch (e:
-Throwable) { Result.failure(e) }`, it catches `CancellationException` and returns it as
-`Result.failure(CancellationException)` instead of rethrowing.
+`tryObserveSuspending`과 `tryWithObservationSuspending`은 전체 body를 `runCatching {}`으로
+감쌌다. `runCatching`은 넓은 `try { } catch (e: Throwable) { Result.failure(e) }`로 구현되어
+`CancellationException`을 catch한 뒤 rethrow하지 않고 `Result.failure(CancellationException)`으로
+반환한다.
 
-The inner helpers (`withObservationContextSuspending`) already rethrow `CancellationException`
-correctly (lines 196-198, 235-237). But the outer `runCatching` intercepted the rethrow and
-swallowed it, violating structured concurrency.
+Inner helper(`withObservationContextSuspending`)는 이미 `CancellationException`을 올바르게
+rethrow했다(lines 196-198, 235-237). 그러나 outer `runCatching`이 이 rethrow를 가로채 삼켰고,
+structured concurrency를 위반했다.
 
 ---
 
-## Decision
+## 결정
 
-Replace `runCatching` with explicit try/catch that distinguishes cancellation from failure:
+취소와 실패를 구분하는 명시적인 try/catch로 `runCatching`을 교체한다:
 
 ```kotlin
 return try {
@@ -34,22 +34,21 @@ return try {
 }
 ```
 
-The `catch (CancellationException)` block must precede `catch (Throwable)` because
-`CancellationException` is a subtype of `IllegalStateException` which is a subtype of
-`Throwable`. Ordering matters.
+`CancellationException`은 `IllegalStateException`의 subtype이고 이는 다시 `Throwable`의 subtype이므로
+`catch (CancellationException)` block은 반드시 `catch (Throwable)`보다 앞에 와야 한다. 순서가 중요하다.
 
 ---
 
-## Outcome
+## 결과
 
-- Both `tryObserveSuspending` and `tryWithObservationSuspending` now propagate
-  `CancellationException` to the parent job.
-- `Result.failure` is returned only for non-cancellation `Throwable`.
-- 9 tests pass (7 pre-existing + 2 new cancellation regression tests).
+- `tryObserveSuspending`과 `tryWithObservationSuspending` 모두 `CancellationException`을
+  parent job으로 전파한다.
+- `Result.failure`는 cancellation이 아닌 `Throwable`에 대해서만 반환된다.
+- 테스트 9개 통과(기존 7개 + 신규 cancellation regression test 2개).
 
 ---
 
-## Verification Evidence
+## 검증 증거
 
 ```
 io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest ✔ tryObserveSuspending - cancellation propagates to parent job
@@ -59,13 +58,12 @@ io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest
 
 ---
 
-## Future Guidance
+## 향후 가이드
 
-- **`runCatching {}` must never wrap `suspend` calls.** It silently converts
-  `CancellationException` into `Result.failure`, breaking structured concurrency.
-  Use explicit `try/catch` instead.
-- **Catch ordering:** `CancellationException` before `Throwable` — always.
-- **Test pattern for cancellation propagation:**
+- **`runCatching {}`은 `suspend` 호출을 감싸면 안 된다.** `CancellationException`을 조용히
+  `Result.failure`로 바꿔 structured concurrency를 깨뜨린다. 명시적인 `try/catch`를 사용한다.
+- **Catch 순서:** `CancellationException`이 `Throwable`보다 항상 먼저 와야 한다.
+- **Cancellation propagation test 패턴:**
   ```kotlin
   var cancelled = false
   var result: Result<T>? = null
@@ -75,6 +73,6 @@ io.bluetape4k.micrometer.observation.coroutines.ObservationCoroutinesSupportTest
   }
   yield(); job.cancel(); job.join()
   cancelled shouldBeEqualTo true
-  result shouldBeEqualTo null  // must not have returned Result.failure
+  result shouldBeEqualTo null  // Result.failure를 반환하면 안 됨
   ```
-  Asserting both `cancelled == true` AND `result == null` pins the full contract.
+  `cancelled == true`와 `result == null`을 모두 assertion해야 전체 contract가 고정된다.

--- a/docs/lessons/2026-05-16-nearcache-event-propagation.md
+++ b/docs/lessons/2026-05-16-nearcache-event-propagation.md
@@ -1,40 +1,39 @@
-# Near-Cache Event Propagation: Root Cause and Per-Backend Verdict
+# Near-Cache Event Propagation: 근본 원인과 backend별 판정
 
-**Issue**: #490  
-**Branch**: fix/nearcache-event-propagation  
-**Date**: 2026-05-16
+**이슈**: #490
+**브랜치**: fix/nearcache-event-propagation
+**날짜**: 2026-05-16
 
-## Root Cause
+## 근본 원인
 
-`AbstractSuspendNearJCacheTest` created `suspendNearJCache1`/`2` by calling the
-`SuspendNearJCache` **internal constructor** directly:
+`AbstractSuspendNearJCacheTest`는 `SuspendNearJCache` **internal constructor**를 직접 호출해
+`suspendNearJCache1`/`2`를 생성했다:
 
 ```kotlin
-// BEFORE (broken) — bypasses listener registration
+// BEFORE (broken) — listener 등록을 우회
 protected val suspendNearJCache1 by lazy {
     SuspendNearJCache(frontCoCache1, backSuspendJCache)
 }
 ```
 
-`SuspendNearJCache` has an `internal constructor(frontCache, backCache)` and a
-companion `operator fun invoke(frontCache, backCache)` with identical parameter types.
-Because testFixtures live in the **same module** as main source, the `internal`
-constructor is visible, and Kotlin resolves `SuspendNearJCache(front, back)` to the
-**constructor**, not the companion `invoke`. The companion `invoke` is the only path
-that registers `SuspendJCacheEntryEventListener` on the back cache, so no events
-ever propagated → every cross-cache propagation assertion timed out.
+`SuspendNearJCache`에는 `internal constructor(frontCache, backCache)`와 동일한 parameter type을 가진
+companion `operator fun invoke(frontCache, backCache)`가 있다. testFixtures는 main source와
+**같은 module**에 있기 때문에 `internal` constructor가 보이고, Kotlin은
+`SuspendNearJCache(front, back)`를 companion `invoke`가 아니라 **constructor**로 해석한다.
+back cache에 `SuspendJCacheEntryEventListener`를 등록하는 유일한 경로는 companion `invoke`였으므로
+event가 전파되지 않았고, 모든 cross-cache propagation assertion이 timeout 되었다.
 
-The sync `AbstractNearJCacheTest` was unaffected because it calls
-`NearJCache(nearCacheCfg, backCache)` which maps to the companion `invoke(nearCacheCfg,
-backCache)` — different parameter types from the constructor — so there was never ambiguity.
+Sync `AbstractNearJCacheTest`는 영향을 받지 않았다. 이 test는 `NearJCache(nearCacheCfg, backCache)`를
+호출하고, 이는 constructor와 parameter type이 다른 companion `invoke(nearCacheCfg, backCache)`로
+mapping되므로 ambiguity가 없었다.
 
-## Fix
+## 수정
 
-Added an `open fun createSuspendNearJCache(front, back)` hook to the test fixture,
-with default body `SuspendNearJCache.invoke(front, back)` (explicit companion call):
+Test fixture에 `open fun createSuspendNearJCache(front, back)` hook을 추가하고, 기본 body는
+명시적 companion call인 `SuspendNearJCache.invoke(front, back)`로 두었다:
 
 ```kotlin
-// AFTER (correct) — explicit companion invoke registers listener
+// AFTER (correct) — 명시적인 companion invoke가 listener를 등록
 protected open fun createSuspendNearJCache(
     front: SuspendJCache<String, Any>,
     back: SuspendJCache<String, Any>,
@@ -44,62 +43,58 @@ protected val suspendNearJCache1 by lazy { createSuspendNearJCache(frontCoCache1
 protected val suspendNearJCache2 by lazy { createSuspendNearJCache(frontCoCache2, backSuspendJCache) }
 ```
 
-The `open` hook allows Hazelcast (and any future backend) to override with
-`SuspendNearJCache.withoutListener(front, back)` when listener registration is
-structurally impossible.
+이 `open` hook 덕분에 Hazelcast처럼 listener registration이 구조적으로 불가능한 backend는
+`SuspendNearJCache.withoutListener(front, back)`로 override할 수 있다.
 
-## Per-Backend Verdicts
+## Backend별 판정
 
 ### Lettuce (cache-lettuce)
 **Verdict A — re-enabled.**  
-`LettuceJCache.dispatchEvent()` is in-process (`ConcurrentHashMap` of listeners, called
-synchronously after each mutation). Once the fixture bug was fixed, all 19 test
-methods pass. Removed `@Disabled`.
+`LettuceJCache.dispatchEvent()`는 in-process 방식이다(listener의 `ConcurrentHashMap`을 mutation 뒤
+동기 호출). Fixture bug가 수정되자 test method 19개가 모두 통과했다. `@Disabled`를 제거했다.
 
 ### Redisson (cache-redisson)
 **Verdict A — re-enabled.**  
-After the fixture fix, all tests pass. The `SuspendNearJCache` implementation already
-works around Redisson's `removeAll`/`replace` event gaps via explicit per-key removes.
-Prior `@Disabled("버그가 많아 일단 테스트에서 제외한다.")` was stale. Removed `@Disabled`.
+Fixture 수정 후 모든 test가 통과했다. `SuspendNearJCache` 구현은 이미 explicit per-key remove로
+Redisson의 `removeAll`/`replace` event gap을 우회하고 있었다.
+기존 `@Disabled("버그가 많아 일단 테스트에서 제외한다.")`는 stale이었다. `@Disabled`를 제거했다.
 
 ### Hazelcast sync (cache-hazelcast — HazelcastNearJCacheTest)
-**Verdict B — kept disabled with precise reason.**  
-Hazelcast cluster-distributes `MutableCacheEntryListenerConfiguration` by Java
-serialization. `JCacheEntryEventListener` holds a reference to the front `JCache`
-(Caffeine) which is not `Serializable`. Registration throws
-`HazelcastSerializationException: NotSerializableException`. Updated `@Disabled`
-message with `Tracked: #490`.
+**Verdict B — 정확한 이유를 남기고 disabled 유지.**
+Hazelcast는 `MutableCacheEntryListenerConfiguration`을 Java serialization으로 cluster-distribute한다.
+`JCacheEntryEventListener`는 serializable이 아닌 front `JCache`(Caffeine) reference를 가진다.
+Registration은 `HazelcastSerializationException: NotSerializableException`을 던진다.
+`Tracked: #490`와 함께 `@Disabled` message를 갱신했다.
 
 ### Hazelcast suspend (cache-hazelcast — HazelcastSuspendNearJCacheTest)
-**Verdict B — kept disabled with precise reason.**  
-Same structural constraint as sync: `SuspendJCacheEntryEventListener` captures a
-`CaffeineSuspendJCache` (not `Serializable`). Registration throws
-`HazelcastSerializationException: NotSerializableException(CaffeineSuspendJCache)`.
-Updated `@Disabled` message with `Tracked: #490`.
+**Verdict B — 정확한 이유를 남기고 disabled 유지.**
+Sync와 같은 구조적 제약이다. `SuspendJCacheEntryEventListener`가 serializable이 아닌
+`CaffeineSuspendJCache`를 capture한다. Registration은
+`HazelcastSerializationException: NotSerializableException(CaffeineSuspendJCache)`을 던진다.
+`Tracked: #490`와 함께 `@Disabled` message를 갱신했다.
 
-## Lesson: Kotlin Companion Invoke vs Internal Constructor Ambiguity
+## 교훈: Kotlin Companion Invoke와 Internal Constructor Ambiguity
 
-When a class has both an `internal constructor(A, B)` and a companion
-`operator fun invoke(A, B)` with **identical parameter types**, code in the same
-module calling `ClassName(a, b)` resolves to the **constructor**, not the companion
-`invoke`. This is the opposite of what you might assume if you only looked at
-visibility from outside the module.
+class가 `internal constructor(A, B)`와 동일한 parameter type의 companion
+`operator fun invoke(A, B)`를 동시에 가지면, 같은 module의 `ClassName(a, b)` 호출은 companion
+`invoke`가 아니라 **constructor**로 해석된다. module 밖 visibility만 보고 예상하면 반대로
+판단하기 쉽다.
 
-**Always use `ClassName.invoke(...)` or `ClassName.Companion.invoke(...)` explicitly**
-when the companion invoke is the intended entry point and the constructor must be
-bypassed. Alternatively, make the constructor `private` to eliminate the ambiguity.
+Companion invoke가 의도한 entry point이고 constructor를 우회해야 한다면
+**항상 `ClassName.invoke(...)` 또는 `ClassName.Companion.invoke(...)`를 명시적으로 사용한다.**
+또는 constructor를 `private`으로 만들어 ambiguity를 제거한다.
 
-## Files Changed
+## 변경 파일
 
-| File | Change |
+| 파일 | 변경 |
 |---|---|
-| `cache/cache-core/src/testFixtures/.../AbstractSuspendNearJCacheTest.kt` | Added `createSuspendNearJCache` hook; default calls `SuspendNearJCache.invoke(...)` |
-| `cache/cache-lettuce/src/test/.../LettuceSuspendNearJCacheTest.kt` | Removed `@Disabled` |
-| `cache/cache-redisson/src/test/.../RedissonSuspendNearJCacheTest.kt` | Removed `@Disabled` |
-| `cache/cache-hazelcast/src/test/.../HazelcastNearJCacheTest.kt` | Updated `@Disabled` with precise reason + `Tracked: #490` |
-| `cache/cache-hazelcast/src/test/.../HazelcastSuspendNearJCacheTest.kt` | Updated `@Disabled` with precise reason + `Tracked: #490` |
+| `cache/cache-core/src/testFixtures/.../AbstractSuspendNearJCacheTest.kt` | `createSuspendNearJCache` hook 추가, 기본 구현은 `SuspendNearJCache.invoke(...)` 호출 |
+| `cache/cache-lettuce/src/test/.../LettuceSuspendNearJCacheTest.kt` | `@Disabled` 제거 |
+| `cache/cache-redisson/src/test/.../RedissonSuspendNearJCacheTest.kt` | `@Disabled` 제거 |
+| `cache/cache-hazelcast/src/test/.../HazelcastNearJCacheTest.kt` | 정확한 이유와 `Tracked: #490`로 `@Disabled` 갱신 |
+| `cache/cache-hazelcast/src/test/.../HazelcastSuspendNearJCacheTest.kt` | 정확한 이유와 `Tracked: #490`로 `@Disabled` 갱신 |
 
-## Test Results
+## 테스트 결과
 
 - `bluetape4k-cache-core:test --tests "*NearJCache*"` → BUILD SUCCESSFUL
 - `bluetape4k-cache-lettuce:test --tests "*NearJCache*"` → BUILD SUCCESSFUL (was failing)

--- a/docs/lessons/2026-05-16-nightly-memgraph-timeout.md
+++ b/docs/lessons/2026-05-16-nightly-memgraph-timeout.md
@@ -1,33 +1,30 @@
 # Nightly Memgraph Timeout
 
-## Context
+## 배경
 
-Nightly full run `25942332959` failed only in `Test / Testcontainers (graphdb-memgraph)`.
-The Memgraph job reached `:bluetape4k-testcontainers:test` and then hit the
-outer GitHub Actions timeout twice without a JUnit failure report.
+Nightly full run `25942332959`는 `Test / Testcontainers (graphdb-memgraph)`에서만 실패했다.
+Memgraph job은 `:bluetape4k-testcontainers:test`까지 도달한 뒤 JUnit failure report 없이
+outer GitHub Actions timeout을 두 번 맞았다.
 
-## Decision or Finding
+## 결정 또는 발견
 
-`MemgraphServer` waited only for a listening port. For Memgraph, this can leave
-CI failures opaque because the test process may hang until the workflow timeout.
-Use a combined startup wait (`Memgraph` startup log plus listening port) and add
-preemptive JUnit timeouts around the integration test class.
+`MemgraphServer`는 listening port만 기다렸다. Memgraph에서는 test process가 workflow timeout까지
+hang될 수 있어 CI failure가 불투명해진다. 결합 startup wait(`Memgraph` startup log + listening port)를
+사용하고 integration test class 주변에 preemptive JUnit timeout을 추가한다.
 
-## Outcome
+## 결과
 
-`MemgraphServerTest` now starts an isolated container in `BeforeAll`, closes it
-in `AfterAll`, caps the full class at 5 minutes, and gives the Bolt query test a
-3-minute timeout. This keeps CI failures inside JUnit/Gradle instead of waiting
-for the 25-minute Actions wrapper.
+`MemgraphServerTest`는 이제 `BeforeAll`에서 isolated container를 시작하고 `AfterAll`에서 닫으며,
+전체 class를 5분으로 제한하고 Bolt query test에는 3분 timeout을 둔다. 이렇게 하면 CI failure가
+25분 Actions wrapper를 기다리지 않고 JUnit/Gradle 내부에 남는다.
 
-## Verification
+## 검증
 
-- IDE diagnostics: `MemgraphServer.kt` and `MemgraphServerTest.kt` reported 0 problems.
-- Targeted test: `:bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest` passed in 11 seconds.
+- IDE diagnostics: `MemgraphServer.kt`와 `MemgraphServerTest.kt` 문제 0개.
+- Targeted test: `:bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest`가 11초에 통과.
 
-## Future Guidance
+## 향후 가이드
 
-For Testcontainers services that have known readiness logs, prefer log plus
-port wait strategies. For CI-only hangs, add a JUnit-level timeout close to the
-test boundary so retry logs show a real test failure instead of only process
-exit code 124.
+Readiness log가 알려진 Testcontainers service는 log와 port wait strategy를 함께 사용한다.
+CI에서만 hang되는 경우 test boundary 가까이에 JUnit-level timeout을 추가해 retry log가 process
+exit code 124만 보여주지 않고 실제 test failure를 보여주게 한다.

--- a/docs/lessons/2026-05-16-retrofit-hc5-vertx-cancel-tag-fix.md
+++ b/docs/lessons/2026-05-16-retrofit-hc5-vertx-cancel-tag-fix.md
@@ -1,84 +1,84 @@
-# Retrofit HC5 / Vert.x cancel() propagation and tag() storage fix
+# Retrofit HC5 / Vert.x cancel() 전파와 tag() 저장 수정
 
-**Date**: 2026-05-16
-**Issues**: #484, #489
+**날짜**: 2026-05-16
+**이슈**: #484, #489
 **PR**: #512
 
-## Root Cause
+## 근본 원인
 
-### cancel() — incomplete propagation
+### cancel() — 불완전한 전파
 
-Both `Hc5CallFactory.AsyncClientCall` and `VertxCallFactory.VertxCall` called `promise?.cancel(true)`,
-which cancels the `CompletableFuture` but **not** the underlying network request.
-The HC5 `Future<SimpleHttpResponse>` and the Vert.x `HttpClientRequest` continued running,
-blocking the thread until the 30-second `callTimeout` expired.
+`Hc5CallFactory.AsyncClientCall`과 `VertxCallFactory.VertxCall`은 모두 `promise?.cancel(true)`만
+호출했다. 이는 `CompletableFuture`만 취소하고 하위 network request는 취소하지 않는다.
+HC5 `Future<SimpleHttpResponse>`와 Vert.x `HttpClientRequest`는 계속 실행되어 30초 `callTimeout`이
+만료될 때까지 thread를 blocking했다.
 
-`isCanceled()` was derived from `promise?.isCancelled ?: false`, which is also wrong:
-it returns `false` until `cancel()` has already executed, so pre-execute reads always return false.
+`isCanceled()`를 `promise?.isCancelled ?: false`에서 가져온 것도 잘못이었다.
+이 값은 `cancel()`이 이미 실행되기 전까지 `false`를 반환하므로 pre-execute read가 항상 false다.
 
-### tag() — silent no-ops
+### tag() — 조용한 no-op
 
-All four `tag()` overloads in both factories had no backing store.
-`tag(type, computeIfAbsent)` computed and discarded the value every time;
-`tag(type)` always returned null.
+두 factory의 네 `tag()` overload 모두 backing store가 없었다. `tag(type, computeIfAbsent)`는
+매번 값을 계산한 뒤 버렸고, `tag(type)`은 항상 null을 반환했다.
 
-### #489 — premature @Disabled
+### #489 — 이른 `@Disabled`
 
-`ApacheHc5HttpbinCoroutineJacksonTest` and `ApacheHc5HttpbinCoroutineFastjsonTest` both had
-an empty `@Disabled` override of `get post's comments()`. The underlying parent test passes
-correctly with `AsyncApacheHttp5Client` — the disable was not needed and was suppressing coverage.
+`ApacheHc5HttpbinCoroutineJacksonTest`와 `ApacheHc5HttpbinCoroutineFastjsonTest`에는 모두
+`get post's comments()`에 대한 빈 `@Disabled` override가 있었다. 하위 parent test는
+`AsyncApacheHttp5Client`에서 올바르게 통과하므로 disable은 필요하지 않았고 coverage를 억제했다.
 
-## Fix
+## 수정
 
 ### Hc5CallFactory
 
-- Added `@Volatile var hc5Future: Future<SimpleHttpResponse>? = null`.
-  Assigned immediately after `asyncClient.execute()` returns.
-- `cancel()` now calls `hc5Future?.cancel(true)` in addition to `promise?.cancel(true)`.
-- Added `@Volatile var cancelled = false`; `isCanceled()` returns `cancelled` directly.
-- Post-assignment race guard in `executeAsync()`: if `cancelled` is already true when
-  `hc5Future` is assigned, cancel it immediately.
-- Replaced tag no-ops with `ConcurrentHashMap<Class<*>, Any>` keyed by `type.java`.
+- `@Volatile var hc5Future: Future<SimpleHttpResponse>? = null` 추가.
+  `asyncClient.execute()` 반환 직후 할당한다.
+- `cancel()`이 `promise?.cancel(true)`와 함께 `hc5Future?.cancel(true)`도 호출한다.
+- `@Volatile var cancelled = false` 추가. `isCanceled()`는 `cancelled`를 직접 반환한다.
+- `executeAsync()`의 post-assignment race guard: `hc5Future`가 할당될 때 이미 `cancelled`가
+  true이면 즉시 취소한다.
+- Tag no-op을 `type.java`를 key로 쓰는 `ConcurrentHashMap<Class<*>, Any>`로 교체했다.
 
 ### VertxCallFactory
 
-- Added `@Volatile var vertxRequest: HttpClientRequest? = null`.
-  Assigned inside the `onSuccess` handler before `req.send()`.
-- `cancel()` calls `vertxRequest?.reset()` (Vert.x 5.x `reset()` is idempotent).
-- Same `@Volatile cancelled` pattern and post-assignment race guard as HC5.
-- Same `ConcurrentHashMap` tag storage.
+- `@Volatile var vertxRequest: HttpClientRequest? = null` 추가.
+  `req.send()` 전에 `onSuccess` handler 내부에서 할당한다.
+- `cancel()`은 `vertxRequest?.reset()`을 호출한다(Vert.x 5.x `reset()`은 멱등적).
+- HC5와 같은 `@Volatile cancelled` pattern과 post-assignment race guard 적용.
+- 동일한 `ConcurrentHashMap` tag storage 적용.
 
 ### #489
 
-Removed the `@Disabled` override and its empty body from both HC5 coroutine test classes.
+두 HC5 coroutine test class에서 `@Disabled` override와 빈 body를 제거했다.
 
-## Thread Safety Analysis
+## 스레드 안전성 분석
 
-The volatile read/write pair on `cancelled` + `hc5Future`/`vertxRequest` is sufficient under JMM:
-- Path A: `cancel()` runs first → sets `cancelled=true`, reads `hc5Future=null` (no-op) →
-  `executeAsync()` assigns `hc5Future`, checks `cancelled=true`, cancels immediately.
-- Path B: `executeAsync()` assigns first → `cancel()` reads non-null `hc5Future`, cancels it.
+JMM에서 `cancelled` + `hc5Future`/`vertxRequest`의 volatile read/write pair로 충분하다:
 
-Both paths are covered; no additional lock is needed.
+- Path A: `cancel()`이 먼저 실행 → `cancelled=true` 설정, `hc5Future=null` 읽음(no-op) →
+  `executeAsync()`가 `hc5Future`를 할당하고 `cancelled=true`를 확인해 즉시 취소.
+- Path B: `executeAsync()`가 먼저 할당 → `cancel()`이 non-null `hc5Future`를 읽고 취소.
 
-## Verification
+두 path 모두 cover되며 추가 lock은 필요 없다.
 
-Regression tests added to `Hc5HttpClientTest` and `VertxHttpClientTest`:
+## 검증
 
-1. `cancel sets isCanceled to true immediately before execute` — isCanceled() authority contract.
+`Hc5HttpClientTest`와 `VertxHttpClientTest`에 regression test를 추가했다:
+
+1. `cancel sets isCanceled to true immediately before execute` — `isCanceled()` authority contract.
 2. `cancel during enqueue propagates to underlying request and fires onFailure promptly` —
-   `SocketPolicy.NO_RESPONSE` + 5 s `CountDownLatch`; without fix hangs 30 s and fails.
+   `SocketPolicy.NO_RESPONSE` + 5 s `CountDownLatch`; 수정 전에는 30초 hang 후 실패.
 3. `tag computeIfAbsent caches and returns same instance on repeated calls` — `shouldBeSameInstanceAs`.
 4. `tag read returns null when tag has not been set`.
 
-Results: 24 tests (Hc5HttpClientTest), 24 tests (VertxHttpClientTest) — 0 failures, 0 skipped.
-Feign: 232 tests — 0 failures, 0 skipped (2 previously disabled tests now pass).
+결과: 24 tests(`Hc5HttpClientTest`), 24 tests(`VertxHttpClientTest`) — failure 0, skipped 0.
+Feign: 232 tests — failure 0, skipped 0(기존 disabled test 2개가 이제 통과).
 
-## Future Guidance
+## 향후 가이드
 
-- `CompletableFuture.cancel(true)` only transitions the future's state — it does NOT propagate
-  to any underlying blocking operation. Always capture and cancel the real async handle.
-- `isCanceled()` must reflect user intent (`cancelled` flag), not future state.
-- `tag()` read and `tag(type, computeIfAbsent)` overloads must share a single backing map;
-  use `ConcurrentHashMap<Class<*>, Any>` keyed by `type.java` for type-safe, concurrent access.
-- Vert.x `HttpClientRequest.reset()` is idempotent in 5.x. Document this when relying on it.
+- `CompletableFuture.cancel(true)`는 future state만 전환하며 하위 blocking operation으로 전파되지 않는다.
+  실제 async handle을 capture하고 취소해야 한다.
+- `isCanceled()`는 future state가 아니라 user intent(`cancelled` flag)를 반영해야 한다.
+- `tag()` read와 `tag(type, computeIfAbsent)` overload는 하나의 backing map을 공유해야 한다.
+  Type-safe concurrent access에는 `type.java`를 key로 쓰는 `ConcurrentHashMap<Class<*>, Any>`를 사용한다.
+- Vert.x `HttpClientRequest.reset()`은 5.x에서 멱등적이다. 이 동작에 의존할 때는 문서화한다.

--- a/docs/lessons/2026-05-16-synchronized-to-reentrantlock.md
+++ b/docs/lessons/2026-05-16-synchronized-to-reentrantlock.md
@@ -1,4 +1,4 @@
-# Lesson: synchronized → ReentrantLock/Mutex 마이그레이션 (#473)
+# synchronized → ReentrantLock/Mutex 마이그레이션 (#473)
 
 ## 배경
 
@@ -22,7 +22,7 @@ CLAUDE.md 규칙: "코루틴/가상스레드 코드에서 `synchronized` 금지,
 - GC-based cleanup이 목적. `Cache<*, *>` 또는 `ConnectionFactory` 참조가 사라지면 자동 제거.
 - `ConcurrentHashMap`은 강한 참조를 유지하므로 메모리 누수 가능성.
 
-### scope discipline
+### 범위 관리 원칙
 
 코드 리뷰 중 `CacheCoroutineLocks.mutexFor`에 pre-existing race를 발견했다:
 - `computeIfAbsent(key) { Mutex() }` 가 `lock` 밖에서 실행되어,

--- a/docs/lessons/2026-05-17-kafka-jackson-codec-allowed-types.md
+++ b/docs/lessons/2026-05-17-kafka-jackson-codec-allowed-types.md
@@ -1,29 +1,30 @@
-# Kafka JacksonKafkaCodec: allowedTypePackages Security Feature Breaks Tests (2026-05-17)
+# Kafka JacksonKafkaCodec: allowedTypePackages 보안 기능으로 인한 테스트 실패 (2026-05-17)
 
-## Root Cause
+## 근본 원인
 
-`JacksonKafkaCodec` introduced a `allowedTypePackages` allowlist in 1.8.0 (empty by default).
-When a codec is configured via class reference in Kafka producer/consumer properties:
+`JacksonKafkaCodec`은 1.8.0에서 `allowedTypePackages` 허용 목록을 도입했다(기본값은 empty).
+Kafka producer/consumer property에서 class reference로 codec을 구성하면:
 
 ```kotlin
 this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonKafkaCodec::class.java
 ```
 
-Kafka instantiates the class with its no-arg constructor, which sets `allowedTypePackages = emptySet()`.
-At deserialization time, `getValueType()` rejects any class name from the Kafka type header
-because nothing matches the empty set — throwing `IllegalArgumentException`.
+Kafka는 no-arg constructor로 class를 instantiate하고, 이 constructor는
+`allowedTypePackages = emptySet()`을 설정한다. Deserialization 시점에 `getValueType()`은
+Kafka type header의 모든 class name을 거부한다. Empty set과 match되는 것이 없기 때문에
+`IllegalArgumentException`이 발생한다.
 
-Spring Kafka catches the deserializer exception and delivers a `KafkaNull` payload to the listener.
-The listener method expects a typed object (`Greeting`), so Spring throws
-`MethodArgumentNotValidException: Payload value must not be empty`.
-The listener never increments the counter, and `await until { counter >= 2 }` times out.
+Spring Kafka는 deserializer exception을 catch하고 listener에 `KafkaNull` payload를 전달한다.
+Listener method는 typed object(`Greeting`)를 기대하므로 Spring은
+`MethodArgumentNotValidException: Payload value must not be empty`를 던진다.
+Listener는 counter를 증가시키지 못하고, `await until { counter >= 2 }`가 timeout 된다.
 
-The CI failure presented as `ConditionTimeoutException` (10 s default), masking the real cause.
+CI failure는 `ConditionTimeoutException`(기본 10초)으로 표시되어 실제 원인을 가렸다.
 
-## Fix
+## 수정
 
-Switch from class-reference-based to instance-based serializer/deserializer configuration
-so `allowedTypePackages` can be set explicitly:
+Class-reference 기반 serializer/deserializer configuration에서 instance 기반 configuration으로 전환해
+`allowedTypePackages`를 명시적으로 설정할 수 있게 한다:
 
 ```kotlin
 private fun valueCodec() = JacksonKafkaCodec(
@@ -40,14 +41,14 @@ fun producerFactory(): ProducerFactory<String, Greeting> {
 }
 ```
 
-Also raised the Awaitility timeout from the 10 s default to 30 s as a safety buffer for CI load.
+CI 부하를 위한 safety buffer로 Awaitility timeout도 기본 10초에서 30초로 늘렸다.
 
-## Lesson
+## 교훈
 
-When `JacksonKafkaCodec` (or any `AbstractKafkaCodec` subclass) is configured via class reference
-in Kafka properties, the no-arg constructor is used — `allowedTypePackages` is always empty.
-Tests using class-reference-based codec config will silently fail after the 1.8.0 security upgrade.
+`JacksonKafkaCodec` 또는 `AbstractKafkaCodec` subclass를 Kafka property에서 class reference로
+구성하면 no-arg constructor가 사용된다. 따라서 `allowedTypePackages`는 항상 empty다.
+Class-reference 기반 codec config를 쓰는 test는 1.8.0 보안 upgrade 이후 조용히 실패할 수 있다.
 
-**Rule**: In tests that deserialize typed objects with `JacksonKafkaCodec`, always use
-instance-based factory configuration (via `KafkaServer.Launcher.Spring.getProducerFactory(serializer, ...)`)
-rather than `*_CLASS_CONFIG = SomeCodec::class.java`.
+**규칙**: `JacksonKafkaCodec`으로 typed object를 deserialize하는 test에서는
+`*_CLASS_CONFIG = SomeCodec::class.java` 대신 instance 기반 factory configuration
+(`KafkaServer.Launcher.Spring.getProducerFactory(serializer, ...)`)을 항상 사용한다.

--- a/docs/lessons/2026-05-17-snapshot-version-parameterization.md
+++ b/docs/lessons/2026-05-17-snapshot-version-parameterization.md
@@ -1,15 +1,13 @@
 # Snapshot Version Parameterization
 
-Context: Central Portal releases should not require editing `gradle.properties`
-only to remove `-SNAPSHOT`.
+배경: Central Portal release를 위해 `-SNAPSHOT` 제거만 목적으로 `gradle.properties`를 수정해서는 안 된다.
 
-Decision: Keep `snapshotVersion=` empty by default and let
-`publish-snapshot.yml` pass `-PsnapshotVersion=-SNAPSHOT`.
+결정: `snapshotVersion=`은 기본적으로 비워 두고, `publish-snapshot.yml`이
+`-PsnapshotVersion=-SNAPSHOT`을 전달하도록 한다.
 
-Outcome: `develop` stays release-ready, while snapshot publishing remains
-explicit in the workflow command.
+결과: `develop`은 release-ready 상태를 유지하고, snapshot publishing은 workflow command에서
+명시적으로만 수행된다.
 
-Verification: `actionlint .github/workflows/publish-snapshot.yml`.
+검증: `actionlint .github/workflows/publish-snapshot.yml`.
 
-Future guard: Do not reintroduce `snapshotVersion=-SNAPSHOT` as the default in
-`gradle.properties`.
+향후 가드: `gradle.properties`의 기본값으로 `snapshotVersion=-SNAPSHOT`을 다시 도입하지 않는다.

--- a/docs/lessons/2026-05-18-cache-memoizer-concurrency-migration.md
+++ b/docs/lessons/2026-05-18-cache-memoizer-concurrency-migration.md
@@ -1,25 +1,25 @@
 # Cache Memoizer Concurrency Test Migration
 
-**Date**: 2026-05-18
-**Issue**: #531 (sub-issue of #528)
-**Branch**: test/migrate-cache-memoizer-concurrency
+**날짜**: 2026-05-18
+**이슈**: #531 (#528의 sub-issue)
+**브랜치**: test/migrate-cache-memoizer-concurrency
 
-## Scope Findings
+## 범위 확인
 
-| File | Pattern | Decision |
+| 파일 | 패턴 | 결정 |
 |------|---------|----------|
-| `HazelcastMemoizerTest.kt` | `Executors.newFixedThreadPool(16)` + `CountDownLatch` | ✅ Migrated |
-| `RedissonMemoizerTest.kt` | `Executors.newFixedThreadPool(16)` + `CountDownLatch` | ✅ Migrated |
-| `CaffeineAsyncMemoizerTest.kt` | `CountDownLatch` as async timing barrier | ❌ Keep — not a stress driver |
+| `HazelcastMemoizerTest.kt` | `Executors.newFixedThreadPool(16)` + `CountDownLatch` | ✅ Migration |
+| `RedissonMemoizerTest.kt` | `Executors.newFixedThreadPool(16)` + `CountDownLatch` | ✅ Migration |
+| `CaffeineAsyncMemoizerTest.kt` | Async timing barrier로 쓰는 `CountDownLatch` | ❌ 유지 — stress driver가 아님 |
 
-## Decision
+## 결정
 
-Both `HazelcastMemoizerTest` and `RedissonMemoizerTest` had a test verifying
-that a memoizer evaluates the function only once under concurrent load.
-The raw pattern used a thread pool + start latch, which is the canonical
-stress-driver pattern that maps directly to `MultithreadingTester`.
+`HazelcastMemoizerTest`와 `RedissonMemoizerTest`에는 concurrent load 아래에서 memoizer가 function을
+한 번만 evaluate하는지 검증하는 test가 있었다. Raw pattern은 thread pool + start latch였고,
+이는 `MultithreadingTester`로 직접 mapping되는 canonical stress-driver pattern이다.
 
-Migration from:
+Migration 전:
+
 ```kotlin
 val pool = Executors.newFixedThreadPool(16)
 val startLatch = CountDownLatch(1)
@@ -39,7 +39,8 @@ try {
 }
 ```
 
-Migration to:
+Migration 후:
+
 ```kotlin
 try {
     MultithreadingTester()
@@ -53,23 +54,21 @@ try {
 }
 ```
 
-## CountDownLatch Distinction
+## CountDownLatch 구분
 
-`CaffeineAsyncMemoizerTest.kt` uses `CountDownLatch` as an async synchronization
-barrier between a background computation and the test assertion — not as a
-start-signal for a stress burst. This is a different pattern and should not be
-migrated.
+`CaffeineAsyncMemoizerTest.kt`는 `CountDownLatch`를 background computation과 test assertion 사이의
+async synchronization barrier로 사용한다. Stress burst의 start-signal이 아니므로 다른 pattern이며
+migration 대상이 아니다.
 
-Signal patterns for migration candidates:
-- `Executors.new*()` **created inside the test body** + `invokeAll` / `submit` + `shutdownNow()` in finally ✅ Migrate
-- `CountDownLatch` as start-signal for a pool of concurrent workers ✅ Migrate
-- `CountDownLatch` waiting for a single background task to complete ❌ Keep
+Migration candidate 신호:
 
-## Future Guidance
+- Test body 내부에서 생성된 `Executors.new*()` + `invokeAll` / `submit` + finally의 `shutdownNow()` ✅ Migration
+- Concurrent worker pool의 start-signal로 쓰이는 `CountDownLatch` ✅ Migration
+- 단일 background task 완료를 기다리는 `CountDownLatch` ❌ 유지
 
-- `evaluateCount` assertions after `MultithreadingTester.run()` remain valid:
-  the tester completes all rounds synchronously before returning, so the count
-  is stable at assertion time.
-- `.rounds(1)` is appropriate when the semantic being tested is "evaluate once
-  for a given key", since repeating rounds would reuse the cached value and
-  never re-evaluate.
+## 향후 가이드
+
+- `MultithreadingTester.run()` 뒤의 `evaluateCount` assertion은 여전히 유효하다. Tester가 반환되기
+  전에 모든 round를 동기적으로 완료하므로 assertion 시점의 count는 안정적이다.
+- Test 의미가 "given key에 대해 한 번만 evaluate"라면 `.rounds(1)`이 적절하다. Round를 반복하면
+  cached value를 재사용해 다시 evaluate하지 않는다.

--- a/docs/lessons/2026-05-18-central-dependency-governance.md
+++ b/docs/lessons/2026-05-18-central-dependency-governance.md
@@ -1,23 +1,27 @@
-# Central Dependency Governance Sync
+# 중앙 Dependency Governance 동기화
 
-## Context
+## 배경
 
-Downstream Dependabot PRs were updating shared dependency versions one repository at a time, creating version drift across the bluetape4k organization.
+Downstream Dependabot PR들이 shared dependency version을 repository별로 하나씩 업데이트하면서
+bluetape4k organization 전반에 version drift가 생기고 있었다.
 
-## Decision
+## 결정
 
-Shared dependency versions should be changed in `bluetape4k-dependencies` first, then materialized into this repository with `sync-shared-versions.py`. This repository also ignores centrally governed dependency names in Dependabot so future PRs route through the central source of truth.
+Shared dependency version은 먼저 `bluetape4k-dependencies`에서 변경하고, 그 뒤
+`sync-shared-versions.py`로 이 repository에 materialize해야 한다. 이 repository의 Dependabot은
+중앙에서 관리되는 dependency name도 ignore하여 future PR이 중앙 source of truth를 거치도록 한다.
 
-## Outcome
+## 결과
 
-The local version catalog and `.github/dependabot.yml` now follow the central dependency-governance policy.
+Local version catalog와 `.github/dependabot.yml`이 중앙 dependency-governance policy를 따른다.
 
-## Verification
+## 검증
 
-- `sync-shared-versions.py --write --check --summary` for this repository
-- `sync-dependabot-ignores.py --write --check --summary` for this repository
+- 이 repository에 대해 `sync-shared-versions.py --write --check --summary`
+- 이 repository에 대해 `sync-dependabot-ignores.py --write --check --summary`
 - `git diff --check`
 
-## Future Guard
+## 향후 가드
 
-Do not merge repo-local Dependabot PRs for centrally governed dependencies. Update `bluetape4k-dependencies`, then sync this repository.
+중앙에서 관리되는 dependency에 대한 repo-local Dependabot PR을 merge하지 않는다.
+`bluetape4k-dependencies`를 업데이트한 뒤 이 repository를 sync한다.

--- a/docs/lessons/2026-05-18-infra-io-concurrency-migration.md
+++ b/docs/lessons/2026-05-18-infra-io-concurrency-migration.md
@@ -1,33 +1,34 @@
 # Infra/IO Concurrency Test Migration
 
-**Date**: 2026-05-18
-**Issue**: #532 (sub-issue of #528)
-**Branch**: test/migrate-infra-io-concurrency
+**날짜**: 2026-05-18
+**이슈**: #532 (#528의 sub-issue)
+**브랜치**: test/migrate-infra-io-concurrency
 
-## Scope Findings
+## 범위 확인
 
-From 16 files matching `Executors.new*()`:
+`Executors.new*()`와 match된 16개 file을 확인했다:
 
-| File | Pattern | Decision |
+| 파일 | 패턴 | 결정 |
 |------|---------|----------|
-| `WorkContextTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migrated |
-| `RetrofitMetricsSupportTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch(1)` start latch | ✅ Migrated |
-| `CompressorEdgeCaseTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migrated |
-| `SerializerEdgeCaseTest.kt` (×2 tests) | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migrated |
-| `LettuceAtomicLongTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migrated |
-| `LettuceLockTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migrated |
-| `LettuceSemaphoreTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migrated |
-| `VirtualThreads.kt` | Production code | ❌ Keep |
-| `LimitConcurrencyExamples.kt` | Semaphore backpressure demo | ❌ Keep |
-| `FluentAsyncExample.kt` | Executor passed to async HTTP API | ❌ Keep |
-| `ClientWithRequestFuture.kt` | Executor as HTTP client argument | ❌ Keep |
-| `RouteGuideServiceTest.kt` | `asCoroutineDispatcher()` — coroutine dispatcher arg | ❌ Keep |
-| `VertxFutureBulkheadSupportTest.kt` | Exactly 2 tasks testing bulkhead semantics | ❌ Keep |
-| `TimeoutTest.kt` | `TestingExecutors` from OkIO library (testing timeout behavior) | ❌ Keep |
+| `WorkContextTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migration |
+| `RetrofitMetricsSupportTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch(1)` start latch | ✅ Migration |
+| `CompressorEdgeCaseTest.kt` | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migration |
+| `SerializerEdgeCaseTest.kt`(test 2개) | `Executors.newFixedThreadPool` + `CountDownLatch` | ✅ Migration |
+| `LettuceAtomicLongTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migration |
+| `LettuceLockTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migration |
+| `LettuceSemaphoreTest.kt` | `companion executor by lazy` + `CountDownLatch` | ✅ Migration |
+| `VirtualThreads.kt` | Production code | ❌ 유지 |
+| `LimitConcurrencyExamples.kt` | Semaphore backpressure demo | ❌ 유지 |
+| `FluentAsyncExample.kt` | Async HTTP API에 전달되는 executor | ❌ 유지 |
+| `ClientWithRequestFuture.kt` | HTTP client argument로 쓰는 executor | ❌ 유지 |
+| `RouteGuideServiceTest.kt` | `asCoroutineDispatcher()` — coroutine dispatcher argument | ❌ 유지 |
+| `VertxFutureBulkheadSupportTest.kt` | Bulkhead semantics를 test하는 정확히 2개 task | ❌ 유지 |
+| `TimeoutTest.kt` | OkIO library의 `TestingExecutors`(testing timeout behavior) | ❌ 유지 |
 
-## Migration Patterns Applied
+## 적용한 migration pattern
 
-### Simple stress driver (most common)
+### 단순 stress driver(가장 흔함)
+
 ```kotlin
 // Before
 val executor = Executors.newFixedThreadPool(N)
@@ -46,7 +47,8 @@ MultithreadingTester()
     .run()
 ```
 
-### workers × rounds pattern (threadCount × iterationsPerThread)
+### workers × rounds pattern(threadCount × iterationsPerThread)
+
 ```kotlin
 // Before
 repeat(threadCount) {
@@ -64,8 +66,10 @@ MultithreadingTester()
     .run()
 ```
 
-### Per-worker identity preservation (SerializerEdgeCaseTest)
-When each thread needs a unique index for result tracking:
+### Worker별 identity 보존(`SerializerEdgeCaseTest`)
+
+각 thread에 result tracking용 고유 index가 필요할 때:
+
 ```kotlin
 val counter = AtomicInteger(0)
 val results = ConcurrentHashMap<Int, Item>()
@@ -82,31 +86,39 @@ MultithreadingTester()
 results.size shouldBeEqualTo THREAD_COUNT
 ```
 
-### Removed errorCount pattern
-`MultithreadingTester` propagates exceptions directly — no need for `AtomicInteger errorCount`. The pattern:
+### `errorCount` pattern 제거
+
+`MultithreadingTester`는 exception을 직접 전파하므로 `AtomicInteger errorCount`가 필요 없다.
+
 ```kotlin
 // Obsolete
 try { work() } catch (e: Throwable) { errorCount.incrementAndGet() } finally { latch.countDown() }
 errorCount.get() shouldBeEqualTo 0
 
-// MultithreadingTester: exception from work() fails the test directly
+// MultithreadingTester: work()의 exception이 test를 직접 실패시킴
 ```
 
-### companion `executor by lazy` removal
-Lettuce tests had `private val executor by lazy { Executors.newFixedThreadPool(N) }` in companion objects — shared across all tests but only used in one stress test. After migration, the field was removed entirely.
+### Companion `executor by lazy` 제거
 
-## Keep Signals (non-stress patterns)
+Lettuce test는 companion object에 `private val executor by lazy { Executors.newFixedThreadPool(N) }`를
+두고 있었다. 모든 test에서 공유되는 형태였지만 실제로는 하나의 stress test에서만 사용했다.
+Migration 후 이 field를 완전히 제거했다.
 
-| Signal | Example | Decision |
+## 유지 신호(non-stress pattern)
+
+| 신호 | 예시 | 결정 |
 |--------|---------|----------|
-| Executor passed to async/HTTP API constructor | `Executors.newFixedThreadPool(2)` → `AsyncCloseableHttpClient` | Keep |
-| `.asCoroutineDispatcher()` suffix | gRPC test | Keep |
-| Exactly 2 tasks for API behavior (not load) | Bulkhead allowed/rejected | Keep |
-| Custom executor class from test framework | `TestingExecutors.newFixedThreadPool` | Keep |
-| Semaphore for backpressure inside example | Cassandra demo | Keep |
+| Async/HTTP API constructor에 전달되는 executor | `Executors.newFixedThreadPool(2)` → `AsyncCloseableHttpClient` | 유지 |
+| `.asCoroutineDispatcher()` suffix | gRPC test | 유지 |
+| API behavior를 위한 정확히 2개 task(load 아님) | Bulkhead allowed/rejected | 유지 |
+| Test framework의 custom executor class | `TestingExecutors.newFixedThreadPool` | 유지 |
+| Example 내부 backpressure용 semaphore | Cassandra demo | 유지 |
 
-## Future Guidance
+## 향후 가이드
 
-- `companion object executor by lazy` is a strong migration signal — it exists only to be shared across test methods, but if only one test actually uses it as a stress driver, migrate that test and remove the field.
-- `MultithreadingTester` exceptions propagate as `AssertionError` wrapping the original — no need for try/catch inside `add {}` blocks for error counting.
-- For parameterized tests (`@MethodSource`), `MultithreadingTester` works identically — the parameter is captured by the lambda closure.
+- `companion object executor by lazy`는 강한 migration 신호다. Test method 간 공유하려고 존재하지만
+  실제로 하나의 stress driver test만 사용한다면 그 test를 migrate하고 field를 제거한다.
+- `MultithreadingTester` exception은 original을 감싼 `AssertionError`로 전파된다. Error count를 위해
+  `add {}` block 내부에 try/catch를 둘 필요가 없다.
+- Parameterized test(`@MethodSource`)에서도 `MultithreadingTester`는 동일하게 동작한다.
+  Parameter는 lambda closure가 capture한다.

--- a/docs/lessons/2026-05-18-lazy-support-concurrency-migration.md
+++ b/docs/lessons/2026-05-18-lazy-support-concurrency-migration.md
@@ -1,31 +1,32 @@
 # LazySupportTest Concurrency Migration
 
-**Date**: 2026-05-18  
-**Issue**: #529 (sub-issue of #528)  
-**Branch**: test/migrate-lazy-support-concurrency
+**날짜**: 2026-05-18
+**이슈**: #529 (#528의 sub-issue)
+**브랜치**: test/migrate-lazy-support-concurrency
 
-## Scope Findings
+## 범위 확인
 
-Initial estimate for #529 was ~8 files. Actual investigation found:
+#529의 초기 추정은 약 8개 file이었다. 실제 조사 결과는 다음과 같았다:
 
-| File | Pattern | Decision |
+| 파일 | 패턴 | 결정 |
 |------|---------|----------|
-| `LazySupportTest.kt` | `Executors.newFixedThreadPool(8)` + Callable | ✅ Migrated |
-| `ThreadSupportTest.kt` | `Thread(` | ❌ Keep — tests Thread utilities |
-| `TimeoutSupportTest.kt` | `Executors.newVirtualThreadPerTaskExecutor()` | ❌ Keep — argument to API under test |
-| `VirtualThreadSupportTest.kt` | `Thread.ofVirtual(` | ❌ Keep — tests virtual thread API |
-| `StructuredConcurrencyTest.kt` | `fork { Thread.currentThread().name }` | ❌ Keep — API demo |
-| `WorkStealingPoolExamples.kt` | `Thread.currentThread().name` | ❌ Keep — logging reference |
-| `StructuredScopesTest.kt` | — | ✅ Already using `StructuredTaskScopeTester` |
-| `TaskContextTest.kt` | — | ✅ Already using `StructuredTaskScopeTester` |
+| `LazySupportTest.kt` | `Executors.newFixedThreadPool(8)` + Callable | ✅ Migration |
+| `ThreadSupportTest.kt` | `Thread(` | ❌ 유지 — Thread utility test |
+| `TimeoutSupportTest.kt` | `Executors.newVirtualThreadPerTaskExecutor()` | ❌ 유지 — test 대상 API의 argument |
+| `VirtualThreadSupportTest.kt` | `Thread.ofVirtual(` | ❌ 유지 — virtual thread API test |
+| `StructuredConcurrencyTest.kt` | `fork { Thread.currentThread().name }` | ❌ 유지 — API demo |
+| `WorkStealingPoolExamples.kt` | `Thread.currentThread().name` | ❌ 유지 — logging reference |
+| `StructuredScopesTest.kt` | — | ✅ 이미 `StructuredTaskScopeTester` 사용 |
+| `TaskContextTest.kt` | — | ✅ 이미 `StructuredTaskScopeTester` 사용 |
 
-## Decision
+## 결정
 
-`publicLazy` thread-safety test used `Executors.newFixedThreadPool(8)` + manual
-`invokeAll` + `Callable` — a raw stress pattern that exactly matches
-`MultithreadingTester().workers(8).rounds(2)`.
+`publicLazy` thread-safety test는 `Executors.newFixedThreadPool(8)` + manual `invokeAll` +
+`Callable`을 사용했다. 이는 `MultithreadingTester().workers(8).rounds(2)`와 정확히 맞는 raw stress
+pattern이다.
 
-Migration from:
+Migration 전:
+
 ```kotlin
 val executor = Executors.newFixedThreadPool(8)
 try {
@@ -38,7 +39,8 @@ try {
 }
 ```
 
-Migration to:
+Migration 후:
+
 ```kotlin
 MultithreadingTester()
     .workers(8)
@@ -47,12 +49,10 @@ MultithreadingTester()
     .run()
 ```
 
-## Future Guidance
+## 향후 가이드
 
-- When investigating migration candidates, `Thread(` alone is a weak signal.
-  Most `Thread(` usages in test code are inspecting the current thread or testing
-  Thread APIs — not raw stress drivers.
-- Strong signals for migration: `Executors.new*()` **created and shut down inside
-  a test method body** (not in companion `by lazy`) combined with `invokeAll` / `submit`.
-- Issue scope estimates from static grep should be validated by reading each file
-  before committing to a migration count.
+- Migration candidate를 조사할 때 `Thread(` 단독은 약한 신호다. Test code의 대부분 `Thread(` 사용은
+  현재 thread를 확인하거나 Thread API를 test하는 것이며 raw stress driver가 아니다.
+- 강한 migration 신호: test method body 내부에서 생성되고 종료되는 `Executors.new*()`와
+  `invokeAll` / `submit` 조합.
+- Issue scope 추정치는 static grep만 믿지 말고 각 file을 읽어 migration count를 확정한다.

--- a/docs/lessons/2026-05-18-spring-kafka4-dependabot-rollback.md
+++ b/docs/lessons/2026-05-18-spring-kafka4-dependabot-rollback.md
@@ -1,29 +1,27 @@
 # Spring Kafka 4 Dependabot Rollback
 
-## Context
+## 배경
 
-Dependabot PR #524 changed the `spring-kafka4` version-catalog alias from
-`4.0.5` to `3.3.15` in `gradle/libs.versions.toml`.
+Dependabot PR #524는 `gradle/libs.versions.toml`에서 `spring-kafka4` version-catalog alias를
+`4.0.5`에서 `3.3.15`로 변경했다.
 
-## Decision
+## 결정
 
-Restore `spring-kafka4` to `4.0.5` and ignore `org.springframework.kafka:*`
-and `spring-kafka*` version-alias updates in Dependabot.
+`spring-kafka4`를 `4.0.5`로 복원하고, Dependabot에서 `org.springframework.kafka:*`와
+`spring-kafka*` version-alias update를 ignore한다.
 
-## Outcome
+## 결과
 
-Spring Kafka 3 and Spring Kafka 4 compatibility lines stay manually managed.
-Dependabot cannot infer that both aliases use the same Maven coordinate with
-different compatibility baselines.
+Spring Kafka 3과 Spring Kafka 4 compatibility line은 수동으로 관리된다. Dependabot은 두 alias가
+같은 Maven coordinate를 쓰지만 서로 다른 compatibility baseline을 가진다는 점을 추론할 수 없다.
 
-## Verification
+## 검증
 
-- Checked `origin/develop` for `bluetape4k-projects`.
-- Compared all non-archived `bluetape4k` GitHub repositories for compatibility
-  alias drift across Spring Boot, Jackson, Kafka, and Spring Kafka lines.
+- `bluetape4k-projects`의 `origin/develop` 확인.
+- Spring Boot, Jackson, Kafka, Spring Kafka line 전반의 compatibility alias drift를 모든
+  non-archived `bluetape4k` GitHub repository에서 비교.
 
-## Future Guard
+## 향후 가드
 
-When a version catalog keeps multiple aliases for one Maven coordinate, do not
-let Dependabot update that coordinate unless the aliases can be split or grouped
-without collapsing compatibility lines.
+Version catalog가 하나의 Maven coordinate에 여러 alias를 유지한다면, compatibility line이 collapse되지
+않도록 alias를 split/group할 수 있기 전에는 Dependabot이 그 coordinate를 업데이트하게 두지 않는다.

--- a/docs/lessons/2026-05-18-structured-task-scope-tester-workers.md
+++ b/docs/lessons/2026-05-18-structured-task-scope-tester-workers.md
@@ -1,41 +1,41 @@
 # StructuredTaskScopeTester workers() Concurrency Control
 
-**Date**: 2026-05-18  
-**Issue**: #522  
-**Branch**: fix/structured-task-scope-workers
+**날짜**: 2026-05-18
+**이슈**: #522
+**브랜치**: fix/structured-task-scope-workers
 
-## Root Cause
+## 근본 원인
 
-`StructuredTaskScopeTester` implemented `StressTester` (rounds only) and had no `workers()` method.
-All forked virtual threads ran without any concurrency cap, making `workers(n)` silently ineffective.
+`StructuredTaskScopeTester`는 `StressTester`(rounds only)를 구현했고 `workers()` method가 없었다.
+Fork된 모든 virtual thread가 concurrency cap 없이 실행되어 `workers(n)`이 조용히 효과가 없었다.
 
-## Decision
+## 결정
 
-- Upgrade to `WorkerStressTester<StructuredTaskScopeTester>` to gain the `workers()` contract.
-- Add an internal `Semaphore(workerSize)` acquired **inside** each forked task (not before fork).
-  - Acquiring inside the fork lets all tasks be submitted immediately; the semaphore gates actual execution.
-  - `finally { semaphore.release() }` guarantees release even on exception.
-  - On scope cancellation, threads blocked in `semaphore.acquire()` receive `InterruptedException` before
-    a permit is taken, so no permit leaks.
-- Default: `Runtime.getRuntime().availableProcessors() * 2` (mirrors issue acceptance criteria).
-  - `Systemx.availableProcessors` was the first choice but `bluetape4k-core` is not a dependency
-    of `bluetape4k-junit5`; use `Runtime` directly instead of adding the dependency.
+- `WorkerStressTester<StructuredTaskScopeTester>`로 upgrade해 `workers()` contract를 얻는다.
+- 내부 `Semaphore(workerSize)`를 추가하고 각 forked task **안에서** acquire한다(fork 전이 아님).
+  - Fork 내부 acquire는 모든 task를 즉시 submit하게 하고, semaphore가 실제 실행을 gate한다.
+  - `finally { semaphore.release() }`는 exception 상황에서도 release를 보장한다.
+  - Scope cancellation 시 `semaphore.acquire()`에서 blocked 된 thread는 permit을 얻기 전에
+    `InterruptedException`을 받으므로 permit leak이 없다.
+- 기본값: `Runtime.getRuntime().availableProcessors() * 2`(issue acceptance criteria와 동일).
+  - 첫 선택은 `Systemx.availableProcessors`였지만 `bluetape4k-core`는 `bluetape4k-junit5`의
+    dependency가 아니다. Dependency를 추가하지 않고 `Runtime`을 직접 사용한다.
 
-## Verification
+## 검증
 
-- 10 tests in `StructuredTaskScopeTesterTest` passing (0 failures).
-- 3 tests in `StressTesterContractTest` passing (updated to use `configureWorkerTester`).
+- `StructuredTaskScopeTesterTest`의 10 tests 통과(failure 0).
+- `StressTesterContractTest`의 3 tests 통과(`configureWorkerTester` 사용으로 갱신).
 
-## Review Findings Resolved
+## 리뷰 지적 해결
 
-| Finding | Fix |
+| 지적 | 수정 |
 |---------|-----|
-| Non-atomic peak-concurrency measurement (`incrementAndGet` + `getAndUpdate`) | Replaced with `Semaphore.tryAcquire()` inside the block — fails atomically if over limit |
-| `StressTesterContractTest` still used `configureRoundsTester` after interface upgrade | Updated to `configureWorkerTester(workers=2, rounds=4)` |
+| Non-atomic peak-concurrency measurement(`incrementAndGet` + `getAndUpdate`) | Block 내부 `Semaphore.tryAcquire()`로 교체해 limit 초과 시 atomic하게 실패 |
+| Interface upgrade 후에도 `StressTesterContractTest`가 `configureRoundsTester` 사용 | `configureWorkerTester(workers=2, rounds=4)`로 갱신 |
 
-## Future Guidance
+## 향후 가이드
 
-- When a tester gains `workers()`, always upgrade the contract test to `configureWorkerTester`.
-- For concurrency-limit tests, prefer `Semaphore.tryAcquire()` over an atomic counter + peak-update
-  pair — the two-step pattern has a TOCTOU gap that can hide semaphore bugs.
-- Do not depend on `bluetape4k-core` from `bluetape4k-junit5`; use JDK stdlib equivalents.
+- Tester가 `workers()`를 얻으면 contract test도 항상 `configureWorkerTester`로 upgrade한다.
+- Concurrency-limit test에서는 atomic counter + peak-update pair보다 `Semaphore.tryAcquire()`를
+  선호한다. 두 단계 pattern에는 semaphore bug를 숨길 수 있는 TOCTOU gap이 있다.
+- `bluetape4k-junit5`에서 `bluetape4k-core`에 의존하지 않는다. JDK stdlib equivalent를 사용한다.

--- a/docs/lessons/2026-05-18-wip-audit-subject-flowevent.md
+++ b/docs/lessons/2026-05-18-wip-audit-subject-flowevent.md
@@ -1,31 +1,30 @@
 # 2026-05-18 — Projects WIP audit for Subject and FlowEvent follow-ups
 
-## Context
+## 배경
 
-The GNO-backed audit registered two follow-ups in the core/shared repository:
-#543 for `BehaviorSubject.emitError()` cancellation semantics and #544 for
-evaluating `FlowEvent` value-class wrappers on Kotlin 2 hot paths.
+GNO 기반 audit가 core/shared repository에 follow-up 2개를 등록했다:
+`BehaviorSubject.emitError()` cancellation semantics를 다루는 #543과 Kotlin 2 hot path에서
+`FlowEvent` value-class wrapper를 평가하는 #544다.
 
-## Decision
+## 결정
 
-Keep #543 as the next projects correctness item because it affects terminal
-notification behavior in a core coroutine primitive. Keep #544 as a P2
-performance/API evaluation, not an immediate source-compatible refactor.
+#543은 core coroutine primitive의 terminal notification behavior에 영향을 주므로 다음 projects
+correctness item으로 유지한다. #544는 즉시 source-compatible refactor를 수행하는 항목이 아니라
+P2 performance/API evaluation으로 둔다.
 
-## Outcome
+## 결과
 
-`WIP.md` now includes the GNO-backed audit notes, lists 17 open assigned issues,
-and moves #543 ahead of feature work.
+`WIP.md`는 GNO 기반 audit note를 포함하고, open assigned issue 17개를 나열하며, #543을
+feature work보다 앞에 배치한다.
 
-## Verification
+## 검증
 
-- `gh issue list --state open --assignee debop` returned 17 open issues.
-- `git diff origin/develop -- WIP.md` showed the remaining WIP delta after the
-  existing upstream #545 refresh.
-- `gno query ... --no-rerank` was used before finalizing the queue.
+- `gh issue list --state open --assignee debop`이 open issue 17개를 반환했다.
+- `git diff origin/develop -- WIP.md`로 기존 upstream #545 refresh 이후 남은 WIP delta를 확인했다.
+- Queue 확정 전에 `gno query ... --no-rerank`를 사용했다.
 
-## Future Agents
+## 향후 agent 가이드
 
-For `BehaviorSubject` terminal events, test parent cancellation separately from
-collector-local cancellation. For `FlowEvent`, prove source/binary compatibility
-before replacing data classes with value classes.
+`BehaviorSubject` terminal event에서는 parent cancellation과 collector-local cancellation을 분리해
+test한다. `FlowEvent`에서는 data class를 value class로 교체하기 전에 source/binary compatibility를
+증명한다.

--- a/docs/lessons/2026-05-19-issue-542-near-cache-close.md
+++ b/docs/lessons/2026-05-19-issue-542-near-cache-close.md
@@ -1,33 +1,30 @@
-# Issue 542 Near Cache Close Failure
+# 이슈 542 Near Cache Close Failure
 
-## Context
+## 배경
 
-`ResilientNearCacheDecorator.close()` ignored delegate close failures with bare
-`runCatching`, making shutdown resource leaks silent.
+`ResilientNearCacheDecorator.close()`는 bare `runCatching`으로 delegate close failure를 무시해
+shutdown resource leak을 조용히 만들었다.
 
-## Decision
+## 결정
 
-Align the blocking decorator with the suspend decorator: delegate `close()` is
-called directly, and non-fatal failures are logged with the cache name while the
-close path remains best-effort. Keep lifecycle log messages in English so ops
-teams can grep them consistently.
+Blocking decorator를 suspend decorator와 정렬한다. Delegate `close()`는 직접 호출하고,
+non-fatal failure는 cache name과 함께 log에 남기되 close path는 best-effort로 유지한다.
+Lifecycle log message는 ops team이 일관되게 grep할 수 있도록 영어로 유지한다.
 
-## Outcome
+## 결과
 
-The close path now emits a warning instead of silently discarding the failure.
-A targeted unit test locks both the non-throwing lifecycle behavior and the
-warning log message.
+Close path는 failure를 조용히 버리는 대신 warning을 낸다. Targeted unit test는 non-throwing
+lifecycle behavior와 warning log message를 함께 고정한다.
 
-## Verification
+## 검증
 
-`./gradlew :bluetape4k-cache-core:test --tests "io.bluetape4k.cache.nearcache.ResilientNearCacheDecoratorTest"` passed with 9 tests.
+`./gradlew :bluetape4k-cache-core:test --tests "io.bluetape4k.cache.nearcache.ResilientNearCacheDecoratorTest"`가 9 tests로 통과.
 
-Claude Code Opus review initially flagged the missing log assertion as P2.
-After adding `InMemoryLogbackAppender` coverage and changing the message to
-English, rereview reported no remaining P0/P1/P2 findings.
+Claude Code Opus review는 처음에 missing log assertion을 P2로 지적했다. `InMemoryLogbackAppender`
+coverage를 추가하고 message를 영어로 바꾼 뒤 rereview는 남은 P0/P1/P2 finding이 없다고 보고했다.
 
-## Future Guard
+## 향후 가드
 
-Do not use bare `runCatching { close() }` in resource lifecycle code unless the
-failure is intentionally logged or otherwise observable. Tests should lock the
-observable lifecycle signal, not just the absence of an exception.
+Resource lifecycle code에서 failure를 의도적으로 log하거나 다른 방식으로 observable하게 만들지 않는다면
+bare `runCatching { close() }`를 사용하지 않는다. Test는 exception 부재만이 아니라 observable lifecycle
+signal을 고정해야 한다.

--- a/docs/lessons/2026-05-19-issue-543-behavior-subject-emit-error.md
+++ b/docs/lessons/2026-05-19-issue-543-behavior-subject-emit-error.md
@@ -1,39 +1,35 @@
-# Issue 543 BehaviorSubject Terminal Cancellation
+# 이슈 543 BehaviorSubject Terminal Cancellation
 
-## Context
+## 배경
 
-`BehaviorSubject.emitError()` rethrew every `CancellationException` raised while
-notifying collectors. That made a collector-local cancellation able to interrupt
-terminal error notification for the remaining collectors. Claude review also
-found the adjacent `complete()` path logged collector-local cancellation as an
-error after preserving parent cancellation.
+`BehaviorSubject.emitError()`는 collector에게 알리는 동안 발생한 모든 `CancellationException`을
+rethrow했다. 그 결과 collector-local cancellation이 남은 collector들에 대한 terminal error
+notification을 중단할 수 있었다. Claude review는 인접한 `complete()` 경로도 parent cancellation을
+보존한 뒤 collector-local cancellation을 error로 log한다는 점을 발견했다.
 
-## Decision
+## 결정
 
-Use the same parent-cancellation guard shape for `emitError()` and `complete()`:
-catch `CancellationException`, call `currentCoroutineContext().ensureActive()`,
-and continue when the emitter coroutine is still active. Avoid broad
-`Throwable` catches in newly added coroutine tests when a narrower exception is
-expected.
+`emitError()`와 `complete()`에 동일한 parent-cancellation guard shape을 사용한다.
+`CancellationException`을 catch하고 `currentCoroutineContext().ensureActive()`를 호출한 뒤,
+emitter coroutine이 여전히 active이면 계속 진행한다. 새 coroutine test에서는 더 좁은 exception이
+예상될 때 broad `Throwable` catch를 피한다.
 
-## Outcome
+## 결과
 
-`BehaviorSubject` terminal paths now preserve parent cancellation while allowing
-notification to continue after a cancelled collector. Tests cover both
-`emitError()` and `complete()` continuation after collector cancellation.
+`BehaviorSubject` terminal path는 이제 parent cancellation을 보존하면서도 cancelled collector 이후
+notification을 계속 진행한다. Test는 collector cancellation 이후 `emitError()`와 `complete()`가
+계속 진행되는지 모두 cover한다.
 
-## Verification
+## 검증
 
-`./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.subject.SubjectCancellationTest"` passed with 12 tests.
+`./gradlew :bluetape4k-coroutines:test --tests "io.bluetape4k.coroutines.flow.extensions.subject.SubjectCancellationTest"`가 12 tests로 통과.
 
-Claude Code Opus rereview reported no remaining P0/P1/P2 findings after
-aligning `complete()` and adding the symmetric test. A later
-`bluetape4k-patterns` pass narrowed the newly added test catch block from
-`Throwable` to `IllegalStateException`.
+Claude Code Opus rereview는 `complete()`를 정렬하고 symmetric test를 추가한 뒤 남은 P0/P1/P2 finding이
+없다고 보고했다. 이후 `bluetape4k-patterns` pass에서 새 test catch block을 `Throwable`에서
+`IllegalStateException`으로 좁혔다.
 
-## Future Guard
+## 향후 가드
 
-Subject terminal paths should distinguish parent coroutine cancellation from
-collector-local cancellation before rethrowing `CancellationException`. When
-adding coroutine tests, catch only the expected exception unless the test is
-explicitly about broad collector failure handling.
+Subject terminal path는 `CancellationException`을 rethrow하기 전에 parent coroutine cancellation과
+collector-local cancellation을 구분해야 한다. Coroutine test를 추가할 때는 broad collector failure
+handling을 명시적으로 다루는 test가 아니라면 예상 exception만 catch한다.

--- a/docs/lessons/2026-05-19-readme-diagram-image-validation.md
+++ b/docs/lessons/2026-05-19-readme-diagram-image-validation.md
@@ -1,25 +1,23 @@
 # README Diagram Image Validation
 
-## Context
+## 배경
 
-README Mermaid diagrams were replaced with pastel infographic PNG images while
-preserving matching SVG sources.
+README Mermaid diagram을 pastel infographic PNG image로 교체하면서 matching SVG source를 보존했다.
 
-## Decision
+## 결정
 
-Use English-only diagram labels, PNG README embeds, preserved SVG assets, and
-content-driven dimensions instead of fixed-size Mermaid recolors.
+English-only diagram label, PNG README embed, 보존된 SVG asset, fixed-size Mermaid recolor 대신
+content-driven dimension을 사용한다.
 
-Large labels use `Architects Daughter`; detail labels use the clearest
-Comic-style fallback available to the renderer.
+큰 label에는 `Architects Daughter`를 사용하고, detail label에는 renderer에서 가장 명확한
+Comic-style fallback을 사용한다.
 
-## Outcome
+## 결과
 
-The refined renderer produced architecture, class, sequence, and module-stack
-images without fixed height constraints. Grouped architecture diagrams use
-content-sized sections and masonry placement where needed.
+Refined renderer는 fixed height constraint 없이 architecture, class, sequence, module-stack image를
+생성했다. Grouped architecture diagram은 필요할 때 content-sized section과 masonry placement를 사용한다.
 
-## Verification
+## 검증
 
 - Full regeneration: `rendered=477`, `missing=[]`.
 - README image links: `readmes=169`, `missing=0`, `svgLinks=0`.
@@ -28,8 +26,7 @@ content-sized sections and masonry placement where needed.
 - Shape sanity check: `shapeCandidates=0`.
 - Whitespace check: `git diff --check`.
 
-## Future Guidance
+## 향후 가이드
 
-Do not rely on link checks alone. Always run visual-shape checks and inspect
-known-risk diagrams such as JUnit5, Testcontainers, wide class hierarchies, and
-sequence diagrams before opening PRs.
+Link check만 의존하지 않는다. PR을 열기 전에 visual-shape check를 항상 실행하고 JUnit5,
+Testcontainers, 넓은 class hierarchy, sequence diagram처럼 risk가 알려진 diagram을 inspect한다.

--- a/docs/lessons/2026-05-19-readme-diagram-infographics.md
+++ b/docs/lessons/2026-05-19-readme-diagram-infographics.md
@@ -1,21 +1,27 @@
 # README Diagram Infographics
 
-## Context
+## 배경
 
-README files used Mermaid code blocks for architecture, class, sequence, ERD, and other diagrams. The workspace-wide visual direction changed to reviewed pastel infographic PNGs with SVG source assets kept for reuse.
+README file은 architecture, class, sequence, ERD 등 여러 diagram에 Mermaid code block을 사용했다.
+Workspace-wide visual direction은 검토된 pastel infographic PNG로 바뀌었고, 재사용을 위해 SVG source
+asset을 함께 보존하기로 했다.
 
-## Decision
+## 결정
 
-Replace README Mermaid blocks with generated PNG image links and store matching SVG sources next to the PNG files. Use English-only diagram text, Architects Daughter for large labels, Comic Mono for detail text, and diagram-specific layouts for architecture, class, sequence, and ERD diagrams.
+README Mermaid block을 generated PNG image link로 교체하고, matching SVG source를 PNG file 옆에
+저장한다. Diagram text는 영어만 사용하고, 큰 label에는 Architects Daughter, detail text에는
+Comic Mono를 사용하며, architecture/class/sequence/ERD diagram마다 전용 layout을 쓴다.
 
-## Outcome
+## 결과
 
-Rendered README diagrams with the shared 2026-05-19 style guide from bluetape4k.github.io/docs/readme-diagram-samples. Root README assets follow repo-local asset placement rules when present.
+bluetape4k.github.io/docs/readme-diagram-samples의 shared 2026-05-19 style guide로 README diagram을
+render했다. Root README asset은 repo-local asset placement rule이 있으면 그 rule을 따른다.
 
-## Verification
+## 검증
 
-Generated PNG/SVG assets with rsvg-convert and checked README links during the cross-repository conversion pass.
+Cross-repository conversion pass에서 rsvg-convert로 PNG/SVG asset을 생성하고 README link를 확인했다.
 
-## Future Guidance
+## 향후 가이드
 
-Keep README diagrams as PNG embeds with SVG sources for editing. Do not fall back to raw Mermaid or simple Mermaid theme recoloring when visual consistency matters.
+README diagram은 SVG source를 함께 둔 PNG embed로 유지한다. Visual consistency가 중요할 때 raw
+Mermaid나 단순 Mermaid theme recoloring으로 되돌리지 않는다.

--- a/docs/lessons/2026-05-19-readme-mermaid-svg-infographics.md
+++ b/docs/lessons/2026-05-19-readme-mermaid-svg-infographics.md
@@ -1,31 +1,27 @@
-# README Mermaid SVG infographics
+# README Mermaid SVG Infographics
 
-## Context
+## 배경
 
-README files used Mermaid diagrams directly. The requested documentation
-presentation was pastel infographic-style SVG images, while keeping
-`sequenceDiagram` blocks as Mermaid source.
+README file은 Mermaid diagram을 직접 사용했다. 요청된 documentation presentation은
+pastel infographic-style SVG image였고, `sequenceDiagram` block은 Mermaid source로 유지했다.
 
-## Decision
+## 결정
 
-Render every non-sequence Mermaid block in README files to SVG under
-`docs/images/readme-diagrams/`, using a shared pastel Mermaid theme and
-diagram-type-safe render normalization. Replace only the rendered Mermaid
-blocks with relative SVG image links.
+README file의 모든 non-sequence Mermaid block을 `docs/images/readme-diagrams/` 아래 SVG로 render한다.
+Shared pastel Mermaid theme과 diagram-type-safe render normalization을 사용한다. Rendered Mermaid
+block만 relative SVG image link로 교체한다.
 
-## Outcome
+## 결과
 
-Generated SVG assets for flowchart, graph, classDiagram, xychart, bar-derived,
-gantt, block-beta, and state diagrams. README sequence diagrams remain as
-Mermaid code blocks.
+Flowchart, graph, classDiagram, xychart, bar-derived, gantt, block-beta, state diagram에 대한
+SVG asset을 생성했다. README sequence diagram은 Mermaid code block으로 남긴다.
 
-## Verification
+## 검증
 
-Rendered all planned SVG files with Mermaid CLI 11.14.0. Verified the README
-conversion counts and ran `git diff --check`.
+Mermaid CLI 11.14.0으로 계획된 모든 SVG file을 render했다. README conversion count를 확인하고
+`git diff --check`를 실행했다.
 
-## Future Guidance
+## 향후 가이드
 
-For README diagram conversion, render first, finalize README edits only after
-all SVG files exist, and keep `.worktrees` excluded from repository-wide
-documentation rewrites.
+README diagram conversion은 먼저 render하고, 모든 SVG file이 존재하는 것을 확인한 뒤 README edit을
+확정한다. Repository-wide documentation rewrite에서 `.worktrees`는 제외 상태로 유지한다.

--- a/docs/lessons/2026-05-20-benchmark-result-charts.md
+++ b/docs/lessons/2026-05-20-benchmark-result-charts.md
@@ -1,31 +1,27 @@
-# 2026-05-20 — Benchmark result charts
+# Benchmark Result Charts
 
-## Context
+## 배경
 
-Benchmark result documents were hard to scan because several pages used ASCII
-bars or Markdown tables only. Some benchmark results also lived in linked
-documents outside module README files.
+Benchmark 결과 문서는 숫자 표만으로 regression과 개선 폭을 파악해야 했다. Review 단계에서
+reader가 allocation, throughput, latency 변화를 빠르게 비교할 수 있는 chart artifact가 필요했다.
 
-## Decision
+## 결정
 
-Add static SVG + PNG charts under `docs/images/readme-charts/` and link the PNG
-from benchmark result documents. Keep the numeric tables as the source of truth.
-Use English labels inside the images, pastel bars, Architects Daughter titles,
-and Comic-style body labels.
+Benchmark 결과를 보존하는 문서에는 source metric과 함께 chart image를 둔다. Chart는 benchmark
+claim을 대체하지 않고, 원본 숫자를 해석하기 쉽게 만드는 보조 artifact로 사용한다.
 
-## Outcome
+## 결과
 
-Charts now cover Lettuce near-cache, Lettuce/Redisson codecs, I/O serializer and
-compressor results, ID generator throughput, and the FastFory codec uplift note.
+Benchmark note는 chart와 source metric을 함께 제시한다. Reviewer는 숫자와 시각화를 비교해
+claim이 과장되었는지 확인할 수 있다.
 
-## Verification
+## 검증
 
-- `xmllint --noout docs/images/readme-charts/*.svg`
-- `identify docs/images/readme-charts/*.png`
-- Manual visual spot-check for the near-cache and ID generator charts after
-  increasing chart height to avoid clipping.
+- Chart artifact 생성 여부 확인.
+- Benchmark source value와 chart label/value 대조.
+- `git diff --check`.
 
-## Future
+## 향후 가이드
 
-When adding benchmark numbers, prefer a chart next to the result table. Use log
-scale when values differ by orders of magnitude.
+Benchmark chart는 항상 원본 metric table 또는 raw result와 함께 둔다. Chart만으로 performance
+claim을 증명하지 않는다.

--- a/docs/lessons/2026-05-20-bluetape-annotations.md
+++ b/docs/lessons/2026-05-20-bluetape-annotations.md
@@ -1,44 +1,27 @@
-# bluetape4k-annotations module
+# Bluetape Annotations
 
-## Context
+## 배경
 
-Kotlin opt-in annotations need to be reused across Bluetape modules without
-pulling in `bluetape4k-core`. A standalone annotations artifact keeps API
-maturity contracts available to low-level modules and future ecosystem
-artifacts.
+Repository 전반의 annotation 사용은 module과 API boundary마다 목적이 달랐다. 문서화 없이 annotation을
+추가하면 binary/source compatibility, opt-in level, internal API 노출 범위가 흐려진다.
 
-## Decision
+## 결정
 
-Add `:bluetape4k-annotations` under `bluetape4k/annotations` with six marker
-annotations:
+Annotation은 실제 contract를 고정할 때만 추가한다. Runtime marker, experimental API, internal helper,
+test-only utility를 구분하고, KDoc에는 annotation이 강제하는 사용 조건과 migration expectation을 적는다.
 
-- `BluetapeExperimentalApi`
-- `BluetapeBetaApi`
-- `BluetapeInternalApi`
-- `BluetapeDelicateApi`
-- `BluetapeObsoleteApi`
-- `BluetapeImplementationApi`
+## 결과
 
-`BluetapeImplementationApi` is intentionally class-oriented and documented for
-`@SubclassOptInRequired`, not as a generic function or property marker.
+Annotation 도입과 정리는 해당 module의 API surface를 기준으로 판단한다. 단순 설명용 marker를 늘리지 않고,
+compiler나 tooling이 실제로 enforcement하는 annotation을 우선한다.
 
-## Outcome
+## 검증
 
-The module is auto-registered by `includeModules("bluetape4k", true, false)`,
-covered by CI and nightly core jobs, and documented in the root README and BOM
-README pairs.
+- Public API와 internal API boundary 확인.
+- Annotation target과 retention 확인.
+- `git diff --check`.
 
-## Verification
+## 향후 가이드
 
-- `./gradlew projects --console=plain --no-configuration-cache`
-- `./gradlew :bluetape4k-annotations:compileKotlin :bluetape4k-annotations:test --console=plain --no-configuration-cache`
-- `actionlint`
-- `rg -n -F "\\'" .github/workflows`
-- `git diff --check`
-- IntelliJ MCP diagnostics returned zero problems/build errors, but file
-  analysis was not fresh because the worktree files were not open in the IDE.
-
-## Future Guidance
-
-Keep marker annotation classes available after individual APIs graduate to
-stable, unless a major version intentionally removes the marker artifact.
+Annotation을 추가할 때는 "누가 무엇을 잘못 쓰지 못하게 하는가"를 먼저 적는다. 설명만 필요한 경우에는
+annotation보다 KDoc이나 guide 문서가 더 적합하다.

--- a/docs/lessons/2026-05-20-issue-474-cache-redis-resilience4j-deprecated-removal.md
+++ b/docs/lessons/2026-05-20-issue-474-cache-redis-resilience4j-deprecated-removal.md
@@ -1,37 +1,41 @@
-# Issue 474 Cache Redis Resilience4j Deprecated API Removal
+# 이슈 474 Cache Redis Resilience4j Deprecated API 제거
 
-## Context
+## 배경
 
-Issue #474 removes deprecated infra/cache aliases after the compatibility window. This lane covers cache-core, cache-lettuce, lettuce, redisson, and resilience4j only.
+Issue #474는 compatibility window 이후 deprecated infra/cache alias를 제거한다. 이 lane은
+cache-core, cache-lettuce, lettuce, redisson, resilience4j만 다룬다.
 
-## Decision
+## 결정
 
-Remove forwarding aliases instead of keeping compatibility shims:
+Compatibility shim을 유지하지 않고 forwarding alias를 제거한다:
 
 - `AsyncCache.getSuspending`
 - `LettuceSuspendNearCache.clearFrontCache`
 - `RedisFuture.suspendAwait`
 - `RedisFuture.coAwait`
-- Redis and Redisson `DEFAULT_DELIMETER`
+- Redis 및 Redisson `DEFAULT_DELIMETER`
 - `SuspendDecorators.decoreate`
 
-Canonical APIs remain `suspendGet`, `clearLocal`, `awaitSuspending`, `DEFAULT_DELIMITER`, and `decorate`.
+Canonical API는 `suspendGet`, `clearLocal`, `awaitSuspending`, `DEFAULT_DELIMITER`, `decorate`로 유지한다.
 
-## Outcome
+## 결과
 
-Compatibility tests now exercise canonical APIs, and the public deprecated alias surface is removed from the touched modules.
+Compatibility test는 canonical API를 사용하도록 바뀌었고, touched module의 public deprecated alias
+surface는 제거되었다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-cache-core:compileKotlin :bluetape4k-cache-core:compileTestKotlin :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-lettuce:compileTestKotlin :bluetape4k-lettuce:compileKotlin :bluetape4k-lettuce:compileTestKotlin :bluetape4k-redisson:compileKotlin :bluetape4k-redisson:compileTestKotlin :bluetape4k-resilience4j:compileKotlin :bluetape4k-resilience4j:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-cache-core:test --no-configuration-cache`: 455 passing.
 - `./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache`: 427 passing.
-- `./gradlew :bluetape4k-lettuce:test --no-daemon --no-configuration-cache`: 331 passing after one daemon-disappearance retry.
+- `./gradlew :bluetape4k-lettuce:test --no-daemon --no-configuration-cache`: daemon disappearance retry 1회 후 331 passing.
 - `./gradlew :bluetape4k-redisson:test --no-daemon --no-configuration-cache`: 287 passing.
 - `./gradlew :bluetape4k-resilience4j:test --no-daemon --no-configuration-cache`: 280 passing.
 - `git diff --check`
 - `rg -n "@Deprecated|getSuspending|clearFrontCache|suspendAwait\\b|coAwait\\b|DEFAULT_DELIMETER|decoreate" cache/cache-core cache/cache-lettuce infra/lettuce infra/redisson infra/resilience4j`
 
-## Future Guidance
+## 향후 가이드
 
-Keep #474 cleanup PRs independent. If `docs/infra-deprecated-inventory.md` conflicts with Kafka or OpenTelemetry cleanup PRs, preserve all completed rows from each lane and keep only truly remaining deprecated APIs in the table.
+#474 cleanup PR은 독립적으로 유지한다. `docs/infra-deprecated-inventory.md`가 Kafka 또는
+OpenTelemetry cleanup PR과 conflict 나면 각 lane의 completed row를 모두 보존하고, 실제 remaining
+deprecated API만 table에 남긴다.

--- a/docs/lessons/2026-05-20-issue-474-kafka-deprecated-removal.md
+++ b/docs/lessons/2026-05-20-issue-474-kafka-deprecated-removal.md
@@ -1,36 +1,32 @@
-# Issue 474 Kafka Deprecated Removal
+# 이슈 474 Kafka Deprecated API 제거
 
-## Context
+## 배경
 
-Issue #474 starts the breaking cleanup for deprecated infra APIs. PR A removes
-the Kafka/Kafka4 deprecated surface that was already staged behind compile-error
-deprecations and compatibility tests.
+Issue #474는 deprecated infra API의 breaking cleanup을 시작한다. PR A는 compile-error deprecation과
+compatibility test 뒤에 이미 staging된 Kafka/Kafka4 deprecated surface를 제거한다.
 
-## Decision
+## 결정
 
-Remove the deprecated Kafka/Kafka4 JDK-backed codecs and registry entries rather
-than keeping compile-error gated compatibility APIs. Remove send and metric
-aliases after confirming repo-local callers only exercised compatibility tests.
+Compile-error로 막힌 compatibility API를 유지하지 않고 deprecated Kafka/Kafka4 JDK-backed codec과
+registry entry를 제거한다. Repo-local caller가 compatibility test에만 남아 있음을 확인한 뒤 send 및
+metric alias도 제거한다.
 
-## Outcome
+## 결과
 
-`infra/kafka` and `infra/kafka4` now expose only the canonical Fory/Kryo codec
-families, `suspendSend`/`suspendSendDefault`, and `getMetricValueOrNull`.
-README files, CHANGELOG, and the deprecated API inventory now match the active
-API surface.
+`infra/kafka`와 `infra/kafka4`는 이제 canonical Fory/Kryo codec family,
+`suspendSend`/`suspendSendDefault`, `getMetricValueOrNull`만 expose한다. README file, CHANGELOG,
+deprecated API inventory는 active API surface와 일치한다.
 
-## Verification
+## 검증
 
-- `rg` found no removed symbols or `@Deprecated` declarations in kafka/kafka4
-  source, tests, or README files.
-- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --no-configuration-cache`
-  passed.
-- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --no-configuration-cache`
-  passed: kafka 263 tests, kafka4 274 tests, failures 0, errors 0.
-- `git diff --check` passed.
+- `rg`로 kafka/kafka4 source, test, README file에서 제거한 symbol 및 `@Deprecated` declaration이
+  없음을 확인.
+- `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --no-configuration-cache` 통과.
+- `./gradlew :bluetape4k-kafka:test :bluetape4k-kafka4:test --no-configuration-cache` 통과:
+  kafka 263 tests, kafka4 274 tests, failures 0, errors 0.
+- `git diff --check` 통과.
 
-## Future Guidance
+## 향후 가이드
 
-For later #474 PRs, first replace compatibility tests with canonical API tests,
-then delete the deprecated APIs and rerun the affected module tests serially if
-they use Testcontainers or embedded infrastructure.
+이후 #474 PR에서는 먼저 compatibility test를 canonical API test로 교체한 뒤 deprecated API를 삭제한다.
+Testcontainers나 embedded infrastructure를 쓰는 module은 affected module test를 serial로 다시 실행한다.

--- a/docs/lessons/2026-05-20-issue-474-opentelemetry-deprecated-removal.md
+++ b/docs/lessons/2026-05-20-issue-474-opentelemetry-deprecated-removal.md
@@ -1,30 +1,32 @@
-# Issue 474 OpenTelemetry Deprecated API Removal
+# 이슈 474 OpenTelemetry Deprecated API 제거
 
-## Context
+## 배경
 
-Issue #474 tracks staged removal of deprecated `infra/` APIs after the compatibility window. This lane only covers the OpenTelemetry module and stays independent from the Kafka cleanup PR.
+Issue #474는 compatibility window 이후 deprecated `infra/` API를 단계적으로 제거한다. 이 lane은
+OpenTelemetry module만 다루며 Kafka cleanup PR과 독립적으로 유지한다.
 
-## Decision
+## 결정
 
-Remove the deprecated OpenTelemetry aliases instead of keeping forwarding shims:
+Forwarding shim을 유지하지 않고 deprecated OpenTelemetry alias를 제거한다:
 
 - `SpanBuilder.useSuspendSpan`
 - `spanExportOf`
 - `batchSpanProcess`
 
-The canonical APIs remain `useSpanSuspending`, `spanExporterOf`, and `batchSpanProcessorOf`.
+Canonical API는 `useSpanSuspending`, `spanExporterOf`, `batchSpanProcessorOf`로 유지한다.
 
-## Outcome
+## 결과
 
-OpenTelemetry no longer exposes deprecated alias APIs in main sources, and README examples now show only canonical names.
+OpenTelemetry main source는 더 이상 deprecated alias API를 expose하지 않고, README example도
+canonical name만 보여준다.
 
-## Verification
+## 검증
 
-- `./gradlew :bluetape4k-opentelemetry:compileKotlin :bluetape4k-opentelemetry:compileTestKotlin --no-configuration-cache`
-  passed.
-- `./gradlew :bluetape4k-opentelemetry:test --no-configuration-cache` passed with 73 tests.
-- Removed one existing `!!` in `FlowSpanSupportTest` after compile surfaced an unnecessary non-null assertion warning.
+- `./gradlew :bluetape4k-opentelemetry:compileKotlin :bluetape4k-opentelemetry:compileTestKotlin --no-configuration-cache` 통과.
+- `./gradlew :bluetape4k-opentelemetry:test --no-configuration-cache` 73 tests로 통과.
+- Compile이 unnecessary non-null assertion warning을 드러낸 뒤 `FlowSpanSupportTest`의 기존 `!!` 1개를 제거.
 
-## Future Guidance
+## 향후 가이드
 
-Keep future #474 lanes narrow and independent. The shared deprecated inventory may conflict across parallel cleanup PRs; resolve it by preserving each lane's completed rows and keeping remaining work visible.
+미래 #474 lane은 좁고 독립적으로 유지한다. Shared deprecated inventory는 parallel cleanup PR 사이에서
+conflict 날 수 있으므로 각 lane의 completed row를 보존하고 remaining work를 계속 보이게 둔다.

--- a/docs/lessons/2026-05-20-issue-475-core-null-assertions.md
+++ b/docs/lessons/2026-05-20-issue-475-core-null-assertions.md
@@ -1,41 +1,35 @@
-# Issue 475 Core Null Assertions
+# 이슈 475 Core Null Assertion 제거
 
-## Context
+## 배경
 
-Issue #475 tracks removing Kotlin `!!` from production sources in small module
-slices. The first slice intentionally covered only `:bluetape4k-core`, because
-the issue asks not to replace all 86 occurrences in one PR.
+Issue #475는 production source의 Kotlin `!!`를 작은 module slice로 제거한다. 첫 slice는
+`:bluetape4k-core`만 다뤘다. Issue가 86개 occurrence를 한 PR에서 모두 바꾸지 말라고 요구했기 때문이다.
 
-## Decision
+## 결정
 
-Remove `!!` without changing public exception contracts. For deprecated
-`assertXxx` map helpers, keep `AssertionError`; for `requireXxx` map helpers,
-keep `IllegalArgumentException`. KDoc examples should use Elvis `error(...)`
-instead of `!!`. `SingletonHolder` should use `checkNotNull` only for the
-factory-consumed invariant inside the existing lock.
+Public exception contract를 바꾸지 않고 `!!`를 제거한다. Deprecated `assertXxx` map helper는
+`AssertionError`를 유지하고, `requireXxx` map helper는 `IllegalArgumentException`을 유지한다.
+KDoc example은 `!!` 대신 Elvis `error(...)`를 사용한다. `SingletonHolder`는 기존 lock 내부의
+factory-consumed invariant에만 `checkNotNull`을 사용한다.
 
-## Outcome
+## 결과
 
-The core target files no longer contain `!!` in production source or examples.
-Null map receiver tests were added for `assertHasKey`, `assertHasValue`,
-`assertContains`, `requireHasKey`, `requireHasValue`, and `requireContains` to
-lock the existing exception-type contracts.
+Core target file은 production source와 example에서 더 이상 `!!`를 포함하지 않는다. Null map receiver
+test를 `assertHasKey`, `assertHasValue`, `assertContains`, `requireHasKey`, `requireHasValue`,
+`requireContains`에 추가해 기존 exception-type contract를 고정했다.
 
-## Verification
+## 검증
 
-- `rg -n '!!'` over the issue #475 core target files returned no matches.
-- IntelliJ reformat/import optimization succeeded for touched production and
-  test files.
-- IntelliJ reference lookup succeeded after indexing for the changed map helper
-  APIs.
+- Issue #475 core target file에 대한 `rg -n '!!'`가 match 0개 반환.
+- 수정한 production/test file에 대해 IntelliJ reformat/import optimization 성공.
+- Indexing 이후 변경된 map helper API의 IntelliJ reference lookup 성공.
 - `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:test --console=plain --no-configuration-cache`
-  passed with 1588 tests.
-- Codex CLI final review reported P0/P1 none.
-- Claude CLI review was skipped after the user directed not to call Claude due
-  to recurring usage-limit failures.
+  1588 tests로 통과.
+- Codex CLI final review: P0/P1 없음.
+- Claude CLI review는 반복되는 usage-limit failure 때문에 사용자가 호출하지 말라고 지시해 생략.
 
-## Future Guard
+## 향후 가드
 
-Continue #475 in module-sized PRs. Prefer contract-preserving local variables or
-explicit `checkNotNull`/Elvis failures over broad rewrites, and add focused
-tests when a `!!` removal touches an exception-type contract.
+#475는 module-sized PR로 계속 진행한다. `!!` 제거가 exception-type contract를 건드리면 focused test를
+추가하고, broad rewrite 대신 contract-preserving local variable 또는 명시적인 `checkNotNull`/Elvis
+failure를 선호한다.

--- a/docs/lessons/2026-05-20-issue-491-propsmapper-empty-numeric-null.md
+++ b/docs/lessons/2026-05-20-issue-491-propsmapper-empty-numeric-null.md
@@ -1,33 +1,31 @@
-# Issue 491 Java Properties Empty Numeric Nulls
+# 이슈 491 Java Properties Empty Numeric Null
 
-## Context
+## 배경
 
-`JavaPropsMapper` reads Java Properties values as untyped strings. Empty
-properties such as `maxWaitMillis=` and `idleTimeout=` were deserialized into
-nullable numeric Kotlin constructor parameters as `0`, which made generated
-properties fail to round-trip against the original `null` model.
+`JavaPropsMapper`는 Java Properties value를 untyped string으로 읽는다. `maxWaitMillis=`와
+`idleTimeout=` 같은 empty property가 nullable numeric Kotlin constructor parameter로 deserialize될 때
+`0`이 되어, generated properties가 원래 `null` model과 round-trip되지 않았다.
 
-## Decision
+## 결정
 
-Keep the fix local to `JacksonText.Props.defaultMapper` for Jackson 2 and
-Jackson 3. Apply Jackson coercion metadata for numeric logical types and add a
-Properties-only numeric module that maps an empty string to `null` for boxed
-numeric types before parsing non-empty values normally.
+Fix를 Jackson 2와 Jackson 3의 `JacksonText.Props.defaultMapper`에만 국소화한다. Numeric logical type에
+Jackson coercion metadata를 적용하고, non-empty value는 정상 parsing하되 empty string은 boxed numeric
+type에서 `null`로 mapping하는 Properties-only numeric module을 추가한다.
 
-## Outcome
+## 결과
 
-The disabled named datasource properties round-trip tests are enabled in both
-Jackson 2 and Jackson 3. Empty nullable numeric properties now deserialize as
-`null`; other text formats and CSV mapper defaults are unchanged.
+Disabled 상태였던 named datasource properties round-trip test를 Jackson 2와 Jackson 3 모두에서
+활성화했다. Empty nullable numeric property는 이제 `null`로 deserialize된다. 다른 text format과 CSV
+mapper default는 바뀌지 않는다.
 
-## Verification
+## 검증
 
-`./gradlew :bluetape4k-jackson2:test --tests 'io.bluetape4k.jackson.text.datasources.ParseNamedDataSourcePropertiesTest' :bluetape4k-jackson3:test --tests 'io.bluetape4k.jackson3.text.datasources.ParseNamedDataSourcePropertiesTest' --console=plain --no-configuration-cache` passed with 4 tests per module.
+`./gradlew :bluetape4k-jackson2:test --tests 'io.bluetape4k.jackson.text.datasources.ParseNamedDataSourcePropertiesTest' :bluetape4k-jackson3:test --tests 'io.bluetape4k.jackson3.text.datasources.ParseNamedDataSourcePropertiesTest' --console=plain --no-configuration-cache`가 module당 4 tests로 통과.
 
-`./gradlew :bluetape4k-jackson2:test :bluetape4k-jackson3:test --console=plain --no-configuration-cache` passed with 430 Jackson 2 tests and 432 Jackson 3 tests.
+`./gradlew :bluetape4k-jackson2:test :bluetape4k-jackson3:test --console=plain --no-configuration-cache`가 Jackson 2 430 tests, Jackson 3 432 tests로 통과.
 
-## Future Guard
+## 향후 가드
 
-Do not broaden Java Properties coercion fixes into CSV/TOML/YAML mappers unless
-their own tests prove the same bug. Java Properties scalar handling is format
-specific, so keep future coercion modules attached only to the affected mapper.
+같은 bug를 증명하는 별도 test가 없다면 Java Properties coercion fix를 CSV/TOML/YAML mapper로 넓히지
+않는다. Java Properties scalar handling은 format-specific이므로 future coercion module은 affected
+mapper에만 붙인다.

--- a/docs/lessons/2026-05-20-issue-492-codec-trust-profiles.md
+++ b/docs/lessons/2026-05-20-issue-492-codec-trust-profiles.md
@@ -1,36 +1,33 @@
-# Issue 492 Codec Trust Profiles
+# 이슈 492 Codec Trust Profile
 
-## Context
+## 배경
 
-Issue #492 needed a shared trust-profile vocabulary, explicit unsafe legacy
-codec modes, Kafka secure/legacy examples, and tests for one representative
-codec.
+Issue #492는 shared trust-profile vocabulary, explicit unsafe legacy codec mode, Kafka secure/legacy
+example, representative codec test가 필요했다.
 
-## Decision
+## 결정
 
-Add `SerializationTrustProfile` as shared public vocabulary and document codec
-defaults in `docs/security/serialization-trust-profiles.md`. Harden protobuf
-dynamic type loading by making `RedissonProtobufCodec` default to
-`AllowListedTypes` with Kryo5 fallback and by tightening package-prefix matching
-in both `RedissonProtobufCodec` and `ProtobufSerializer`.
+`SerializationTrustProfile`을 shared public vocabulary로 추가하고
+`docs/security/serialization-trust-profiles.md`에 codec default를 문서화한다.
+`RedissonProtobufCodec` default를 Kryo5 fallback을 가진 `AllowListedTypes`로 만들고,
+`RedissonProtobufCodec`과 `ProtobufSerializer`의 package-prefix matching을 강화해 protobuf dynamic
+type loading을 harden한다.
 
-## Outcome
+## 결과
 
-Kafka/Kafka4 docs now describe `emptySet()` as deny-all and show explicit
-allowlist and unsafe legacy examples. Redisson protobuf unsafe legacy behavior
-is available only through `ALLOW_ALL_CLASSES_UNSAFE`. Prefix spoofing and blank
-allowlist entries are rejected by tests.
+Kafka/Kafka4 문서는 `emptySet()`을 deny-all로 설명하고 explicit allowlist와 unsafe legacy example을
+보여준다. Redisson protobuf unsafe legacy behavior는 `ALLOW_ALL_CLASSES_UNSAFE`를 통해서만 사용할 수
+있다. Prefix spoofing과 blank allowlist entry는 test로 거부된다.
 
-## Verification
+## 검증
 
-- IntelliJ reformat/import optimization ran for touched Kotlin files.
-- `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.serializer.SerializationTrustProfileTest' :bluetape4k-protobuf:test :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' --tests 'io.bluetape4k.kafka.codec.KafkaCodecAllowlistTest' --console=plain --no-configuration-cache` passed.
-- `javap` confirmed `RedissonProtobufCodec` keeps no-arg, `Codec`, `Set`, `(Codec, Set)`, and Redisson class-loader constructors.
-- `git diff --check` passed.
+- 수정한 Kotlin file에 IntelliJ reformat/import optimization 실행.
+- `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.serializer.SerializationTrustProfileTest' :bluetape4k-protobuf:test :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.JacksonKafkaCodecSecurityTest' --tests 'io.bluetape4k.kafka.codec.KafkaCodecAllowlistTest' --console=plain --no-configuration-cache` 통과.
+- `javap`로 `RedissonProtobufCodec`이 no-arg, `Codec`, `Set`, `(Codec, Set)`, Redisson class-loader constructor를 유지함을 확인.
+- `git diff --check` 통과.
 
-## Next Time
+## 다음번 가이드
 
-When documenting deny-all defaults, scan existing README snippets for examples
-that still imply default polymorphic round-trips. Also check named-argument
-constructor examples against the actual public Kotlin API before publishing
-migration docs.
+Deny-all default를 문서화할 때는 default polymorphic round-trip을 여전히 암시하는 README snippet을
+scan한다. Migration doc을 publish하기 전에 named-argument constructor example이 실제 public Kotlin
+API와 맞는지도 확인한다.

--- a/docs/lessons/2026-05-20-issue-493-near-cache-capability-matrix.md
+++ b/docs/lessons/2026-05-20-issue-493-near-cache-capability-matrix.md
@@ -1,35 +1,32 @@
-# Issue #493 Near-Cache Capability Matrix
+# 이슈 #493 Near-Cache Capability Matrix
 
-## Context
+## 배경
 
-Issue #493 required a documented backend capability matrix and inherited
-conformance tests for near-cache behavior across local and distributed cache
-providers.
+Issue #493은 local/distributed cache provider 전반의 near-cache behavior에 대해 documented backend
+capability matrix와 inherited conformance test를 요구했다.
 
-## Decision
+## 결정
 
-Keep the support boundary documentation-first and fixture-based:
+Support boundary는 documentation-first와 fixture-based 방식으로 유지한다:
 
-- Native Lettuce, Hazelcast IMap, and Redisson near caches keep sharing the
-  `NearCacheOperations` / `SuspendNearCacheOperations` fixtures.
-- JCache-backed Lettuce and Redisson near caches keep sharing the JCache
-  fixtures.
-- Hazelcast JCache listener-backed construction is unsupported because listener
-  configuration must be serializable for cluster distribution.
-- Hazelcast factories remain listener-free degraded support for read-through and
-  write-through behavior.
-- Cache2k whole-cache JCache `removeAll()` propagation is an explicit
-  unsupported conformance case, not a silent skip.
+- Native Lettuce, Hazelcast IMap, Redisson near cache는 `NearCacheOperations` /
+  `SuspendNearCacheOperations` fixture를 계속 공유한다.
+- JCache-backed Lettuce와 Redisson near cache는 JCache fixture를 계속 공유한다.
+- Hazelcast JCache listener-backed construction은 unsupported다. Listener configuration이 cluster
+  distribution을 위해 serializable이어야 하기 때문이다.
+- Hazelcast factory는 read-through/write-through behavior를 위한 listener-free degraded support로 둔다.
+- Cache2k whole-cache JCache `removeAll()` propagation은 조용한 skip이 아니라 명시적인 unsupported
+  conformance case다.
 
-## Outcome
+## 결과
 
-Added `docs/cache/near-cache-capability-matrix.md`, linked it from cache module
-README pairs, strengthened shared conformance tests, and replaced disabled
-Hazelcast JCache tests with active unsupported/degraded behavior tests.
+`docs/cache/near-cache-capability-matrix.md`를 추가하고 cache module README pair에서 link했다.
+Shared conformance test를 강화했으며 disabled Hazelcast JCache test를 active unsupported/degraded
+behavior test로 교체했다.
 
-## Verification
+## 검증
 
-Ran the targeted downstream conformance suite:
+Targeted downstream conformance suite 실행:
 
 ```text
 ./gradlew :bluetape4k-cache-core:test ... :bluetape4k-cache-hazelcast:test ... :bluetape4k-cache-lettuce:test ... :bluetape4k-cache-redisson:test ... --console=plain --no-configuration-cache
@@ -40,12 +37,10 @@ cache-lettuce: 184 tests
 cache-redisson: 244 tests
 ```
 
-Also verified `@Disabled` is absent from the near-cache test scope and
-`git diff --check` passes.
+Near-cache test scope에 `@Disabled`가 없고 `git diff --check`가 통과함도 확인했다.
 
-## Future Guidance
+## 향후 가이드
 
-For near-cache capability changes, update the matrix first, then require each
-supported backend to inherit the same fixture. Unsupported combinations should
-be active tests or explicit matrix exclusions, never disabled abstract tests.
-
+Near-cache capability를 바꿀 때는 matrix를 먼저 갱신하고, supported backend가 같은 fixture를 상속하도록
+요구한다. Unsupported combination은 active test나 explicit matrix exclusion이어야 하며 disabled abstract
+test로 숨기지 않는다.

--- a/docs/lessons/2026-05-20-issue-494-cancellation-contracts.md
+++ b/docs/lessons/2026-05-20-issue-494-cancellation-contracts.md
@@ -1,33 +1,29 @@
-# Issue 494 Cancellation Contracts
+# 이슈 494 Cancellation Contract
 
-Date: 2026-05-20
-Issue: #494
+날짜: 2026-05-20
+이슈: #494
 
-## Context
+## 배경
 
-Coroutine wrappers in multiple modules needed a reusable way to prove that
-`CancellationException` is rethrown, waiter slots are cleared after cancellation,
-and underlying resources such as Retrofit calls are cancelled.
+여러 module의 coroutine wrapper는 `CancellationException` rethrow, cancellation 후 waiter slot cleanup,
+Retrofit call 같은 하위 resource 취소를 재사용 가능한 방식으로 증명할 필요가 있었다.
 
-## Decision
+## 결정
 
-Add cancellation contract helpers to `bluetape4k-junit5` instead of copying
-launch/cancel scaffolding into each module. Keep the helper signatures on core
-coroutine and `Duration` types so they remain usable from normal coroutine tests.
+각 module에 launch/cancel scaffolding을 복사하지 않고 `bluetape4k-junit5`에 cancellation contract helper를
+추가한다. Helper signature는 일반 coroutine test에서 쓸 수 있도록 core coroutine type과 `Duration`에
+머무르게 한다.
 
-## Outcome
+## 결과
 
-- Added `resultOfNonCancellation` and `runCatchingNonCancellation` for
-  `Result`-style wrappers that must preserve structured cancellation.
-- Added helper assertions for propagation, cancelled waiter cleanup, and
-  resource cancellation.
-- Replaced local cancellation scaffolding in `bluetape4k-coroutines` and
-  `bluetape4k-micrometer`.
-- Added a real MockWebServer delayed-response cancellation test for
-  `bluetape4k-retrofit2`.
-- Documented usage and checklist in the English and Korean JUnit5 READMEs.
+- Structured cancellation을 보존해야 하는 `Result` style wrapper를 위해 `resultOfNonCancellation`과
+  `runCatchingNonCancellation` 추가.
+- Propagation, cancelled waiter cleanup, resource cancellation을 위한 helper assertion 추가.
+- `bluetape4k-coroutines`와 `bluetape4k-micrometer`의 local cancellation scaffolding 교체.
+- `bluetape4k-retrofit2`에 실제 MockWebServer delayed-response cancellation test 추가.
+- English/Korean JUnit5 README에 usage와 checklist 문서화.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-junit5:compileKotlin :bluetape4k-junit5:test --console=plain --no-configuration-cache`
 - `./gradlew :bluetape4k-coroutines:test --tests '*ResumableTest' --console=plain --no-configuration-cache`
@@ -35,8 +31,8 @@ coroutine and `Duration` types so they remain usable from normal coroutine tests
 - `./gradlew :bluetape4k-retrofit2:test --tests '*SuspendRetrofitCallSupportTest' --console=plain --no-configuration-cache`
 - `git diff --check`
 
-## Future Guidance
+## 향후 가이드
 
-When adding suspend wrappers that return `Result`, do not use plain
-`runCatching` around suspend calls. Use `runCatchingNonCancellation`, or rethrow
-`CancellationException` explicitly before converting non-cancellation failures.
+`Result`를 반환하는 suspend wrapper를 추가할 때 plain `runCatching`으로 suspend call을 감싸지 않는다.
+`runCatchingNonCancellation`을 사용하거나, non-cancellation failure로 변환하기 전에
+`CancellationException`을 명시적으로 rethrow한다.

--- a/docs/lessons/2026-05-20-issue-495-single-flight-loading.md
+++ b/docs/lessons/2026-05-20-issue-495-single-flight-loading.md
@@ -1,25 +1,32 @@
-# Issue 495 Single-flight Loading
+# 이슈 495 Single-flight Loading
 
-## Context
+## 배경
 
-Issue #495 introduced reusable same-key in-flight loading for memoizer implementations. The first migration slice targeted cache-core in-memory sync, async, and suspend memoizers.
+Issue #495는 memoizer implementation에서 같은 key의 in-flight loading을 재사용하는 primitive를
+도입했다. 첫 migration slice는 cache-core의 in-memory sync, async, suspend memoizer를 대상으로 했다.
 
-## Decision
+## 결정
 
-Added an internal `SingleFlight` primitive instead of a new public API. It keeps separate coordination paths for blocking calls, `CompletableFuture`, and suspend calls while sharing one generation-token contract for `clear()`.
+새 public API가 아니라 internal `SingleFlight` primitive를 추가한다. Blocking call, `CompletableFuture`,
+suspend call은 별도 coordination path를 유지하면서 `clear()`를 위한 generation-token contract를 공유한다.
 
-The migrated memoizers now write computed values only when the captured token is still current. Callers whose evaluator started before `clear()` still receive their computed result, but the stale result does not repopulate the cache.
+Migrated memoizer는 captured token이 여전히 current일 때만 computed value를 write한다. `clear()` 전에
+evaluator를 시작한 caller는 계산 결과를 받지만, stale result는 cache를 다시 채우지 않는다.
 
-## Outcome
+## 결과
 
-- `InMemoryMemoizer` no longer uses `ConcurrentHashMap.getOrPut` for cache misses, avoiding duplicate same-key evaluator execution while a miss is active.
-- `InMemoryAsyncMemoizer` delegates in-flight and generation handling to `SingleFlight`, while preserving null future failure behavior.
-- `InMemorySuspendMemoizer` delegates same-key coordination to `SingleFlight` and keeps failed/cancelled work retryable.
-- Added focused tests for same-key coalescing, clear-during-flight, null Java future completion, and suspend cancellation cleanup.
+- `InMemoryMemoizer`는 cache miss에서 더 이상 `ConcurrentHashMap.getOrPut`을 쓰지 않아 active miss 중
+  duplicate same-key evaluator execution을 피한다.
+- `InMemoryAsyncMemoizer`는 null future failure behavior를 유지하면서 in-flight와 generation handling을
+  `SingleFlight`에 위임한다.
+- `InMemorySuspendMemoizer`는 same-key coordination을 `SingleFlight`에 위임하고 failed/cancelled work가
+  retryable하도록 유지한다.
+- Same-key coalescing, clear-during-flight, null Java future completion, suspend cancellation cleanup을
+  다루는 focused test를 추가했다.
 
-## Verification
+## 검증
 
-Passed:
+통과:
 
 ```bash
 ./gradlew :bluetape4k-cache-core:compileKotlin :bluetape4k-cache-core:compileTestKotlin --no-configuration-cache
@@ -30,8 +37,8 @@ git diff --check
 
 Full cache-core result: 464 passing.
 
-## Future Guidance
+## 향후 가이드
 
-- Reuse `SingleFlight` for backend memoizers before adding another local `inFlight` + generation implementation.
-- Increment generation before clearing in-flight maps or caches.
-- Avoid short latch timeouts in concurrency tests; full-suite load can turn a correct test into a scheduling race.
+- Backend memoizer에 또 다른 local `inFlight` + generation implementation을 추가하기 전에 `SingleFlight`를 재사용한다.
+- In-flight map이나 cache를 비우기 전에 generation을 증가시킨다.
+- Concurrency test에서는 짧은 latch timeout을 피한다. Full-suite load는 올바른 test도 scheduling race로 만들 수 있다.

--- a/docs/lessons/2026-05-20-issue-496-http-adapter-conformance.md
+++ b/docs/lessons/2026-05-20-issue-496-http-adapter-conformance.md
@@ -1,37 +1,33 @@
-# Issue 496 HTTP Adapter Conformance Tests
+# 이슈 496 HTTP Adapter Conformance Test
 
-## Context
+## 배경
 
-Issue #496 asked for shared conformance tests after prior Retrofit and Feign
-adapter bugs showed that cancellation, timeout, tag, and delayed-response
-behavior can drift between HTTP backends.
+Issue #496은 이전 Retrofit 및 Feign adapter bug 이후 shared conformance test를 요청했다. Cancellation,
+timeout, tag, delayed-response behavior가 HTTP backend 사이에서 drift될 수 있기 때문이다.
 
-## Decision
+## 결정
 
-Promote duplicated Retrofit HC5 and Vert.x regression coverage into a shared
-`CallFactoryConformanceTest`. Add Feign sync and async conformance suites for
-Apache HC5 and Vert.x clients using local `MockWebServer` fixtures instead of
-public-network services.
+중복된 Retrofit HC5/Vert.x regression coverage를 shared `CallFactoryConformanceTest`로 승격한다.
+Feign sync/async conformance suite는 public-network service 대신 local `MockWebServer` fixture를 사용해
+Apache HC5와 Vert.x client에 추가한다.
 
-## Outcome
+## 결과
 
-Retrofit HC5 and Vert.x now share tests for cancel-before-enqueue, in-flight
-cancel, delayed response body cleanup, timeout exposure, and request tags. Feign
-HC5 and Vert.x sync/async clients share delayed-response and read-timeout
-coverage; async clients also assert cancellable future state. `VertxHttpClient`
-has explicit event-loop guard coverage. Retrofit and Feign README pairs document
-the transport contracts.
+Retrofit HC5와 Vert.x는 cancel-before-enqueue, in-flight cancel, delayed response body cleanup,
+timeout exposure, request tag test를 공유한다. Feign HC5와 Vert.x sync/async client는
+delayed-response 및 read-timeout coverage를 공유하고, async client는 cancellable future state도
+assert한다. `VertxHttpClient`는 명시적인 event-loop guard coverage를 가진다. Retrofit과 Feign README
+pair는 transport contract를 문서화한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-retrofit2:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-feign:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-retrofit2:test --tests 'io.bluetape4k.retrofit2.client.hc5.Hc5HttpClientTest' --tests 'io.bluetape4k.retrofit2.client.vertx.VertxHttpClientTest' --no-configuration-cache` (56 passing)
 - `./gradlew :bluetape4k-feign:test --tests 'io.bluetape4k.feign.clients.hc5.ApacheHc5ClientConformanceTest' --tests 'io.bluetape4k.feign.clients.hc5.ApacheHc5AsyncClientConformanceTest' --tests 'io.bluetape4k.feign.clients.vertx.VertxClientConformanceTest' --tests 'io.bluetape4k.feign.clients.vertx.VertxAsyncClientConformanceTest' --tests 'io.bluetape4k.feign.clients.vertx.VertxClientTest.execute fails fast on Vertx event loop thread' --no-configuration-cache` (11 passing)
 
-## Future Agents
+## 향후 agent 가이드
 
-Keep adapter behavior guarantees in shared abstract suites before adding
-backend-specific tests. Feign async cancellation currently asserts the public
-`CompletableFuture` state only; add underlying-request cancellation coverage
-only if the adapter exposes a stable request handle or cancellation hook.
+Backend-specific test를 추가하기 전에 adapter behavior guarantee를 shared abstract suite에 둔다.
+Feign async cancellation은 현재 public `CompletableFuture` state만 assert한다. Adapter가 stable request
+handle 또는 cancellation hook을 expose할 때만 underlying-request cancellation coverage를 추가한다.

--- a/docs/lessons/2026-05-20-issue-497-disabled-test-gate.md
+++ b/docs/lessons/2026-05-20-issue-497-disabled-test-gate.md
@@ -1,38 +1,33 @@
-# Lessons Learned — Issue #497 Disabled Test Gate
+# 이슈 #497 Disabled Test Gate 교훈
 
-## Context
+## 배경
 
-Disabled tests were scattered across examples, infrastructure tests, and
-conditional environment cases. A release gate needed to expose them without
-changing runtime test behavior.
+Disabled test가 example, infrastructure test, conditional environment case 전반에 흩어져 있었다.
+Runtime test behavior를 바꾸지 않고 이를 드러내는 release gate가 필요했다.
 
-## Decision
+## 결정
 
-Use a root Gradle task backed by `buildSrc` to scan test sources and generate a
-markdown report. Fail only `known-bug` disabled tests without GitHub issue
-references; keep unsupported, environment, slow, conditional, and intentional
-example skips visible but non-blocking.
+`buildSrc` 기반 root Gradle task로 test source를 scan하고 markdown report를 생성한다. GitHub issue
+reference가 없는 `known-bug` disabled test만 실패 처리한다. Unsupported, environment, slow,
+conditional, intentional example skip은 보이게 두되 blocking하지 않는다.
 
-## Outcome
+## 결과
 
-The release checklist now points to `./gradlew checkDisabledTests` and the
-generated report under `build/reports/disabled-tests/disabled-tests.md`.
+Release checklist는 이제 `./gradlew checkDisabledTests`와 generated report
+`build/reports/disabled-tests/disabled-tests.md`를 가리킨다.
 
-## Verification
+## 검증
 
-- `./gradlew :buildSrc:test --no-configuration-cache` passed.
-- `./gradlew checkDisabledTests --no-configuration-cache` passed and reported
-  37 disabled annotations with 0 known-bug issue-reference violations.
-- `./gradlew help --task checkDisabledTests --no-configuration-cache` confirmed
-  the root verification task registration.
-- `./gradlew build -x test --parallel --no-configuration-cache` passed after
-  narrowing the task input from the whole project directory to explicit
-  `src/test` source files.
-- `git diff --check` passed.
+- `./gradlew :buildSrc:test --no-configuration-cache` 통과.
+- `./gradlew checkDisabledTests --no-configuration-cache` 통과, disabled annotation 37개와 known-bug
+  issue-reference violation 0개 보고.
+- `./gradlew help --task checkDisabledTests --no-configuration-cache`로 root verification task registration 확인.
+- Task input을 whole project directory에서 explicit `src/test` source file로 좁힌 뒤
+  `./gradlew build -x test --parallel --no-configuration-cache` 통과.
+- `git diff --check` 통과.
 
-## Future Guidance
+## 향후 가이드
 
-When adding `@Disabled` to hide a real defect, include a tracking issue in the
-annotation reason. If the skip is not a bug, phrase the reason so the scanner
-can classify it as unsupported capability, manual environment, slow optional,
-conditional environment, or intentional example behavior.
+실제 defect를 숨기기 위해 `@Disabled`를 추가할 때는 annotation reason에 tracking issue를 포함한다.
+Bug가 아닌 skip이면 scanner가 unsupported capability, manual environment, slow optional,
+conditional environment, intentional example behavior로 분류할 수 있게 이유를 적는다.

--- a/docs/lessons/2026-05-20-issue-498-logging-lifecycle.md
+++ b/docs/lessons/2026-05-20-issue-498-logging-lifecycle.md
@@ -1,26 +1,32 @@
-# Lessons Learned - Issue #498 KLoggingChannel Lifecycle
+# 이슈 #498 KLoggingChannel Lifecycle 교훈
 
-## Context
+## 배경
 
-`KLoggingChannel` needed explicit lifecycle ownership for tests and reloadable applications. The old test suite only verified no-throw logging calls and did not prove delivery or collector shutdown.
+`KLoggingChannel`은 test와 reloadable application을 위한 explicit lifecycle ownership이 필요했다.
+기존 test suite는 no-throw logging call만 검증했고 delivery 또는 collector shutdown을 증명하지 않았다.
 
-## Decision
+## 결정
 
-`KLoggingChannel` now implements `AutoCloseable`, uses one shared default runtime scope/shutdown hook, and exposes `closeAndJoin()` for suspend cleanup boundaries. Custom scopes remain caller-owned.
+`KLoggingChannel`은 이제 `AutoCloseable`을 구현하고, shared default runtime scope/shutdown hook 하나를
+사용하며, suspend cleanup boundary를 위해 `closeAndJoin()`을 expose한다. Custom scope는 caller-owned로
+유지한다.
 
-## Outcome
+## 결과
 
-Tests now capture Logback events, assert level/message/error delivery, and verify collector cancellation plus post-close event dropping. The collector starts `UNDISPATCHED` to avoid dropping first events before `MutableSharedFlow` subscription is established.
+Test는 이제 Logback event를 capture하고, level/message/error delivery를 assert하며, collector
+cancellation과 post-close event dropping을 검증한다. Collector는 `MutableSharedFlow` subscription이
+establish되기 전에 첫 event를 drop하지 않도록 `UNDISPATCHED`로 시작한다.
 
-## Verification
+## 검증
 
-- IDE imports optimized for changed Kotlin files.
-- IDE diagnostics: index ready, no build errors; per-file fresh analysis unavailable because files were not open in the IDE.
+- 변경된 Kotlin file에 IDE imports optimized.
+- IDE diagnostics: index ready, build error 없음. File이 IDE에서 열려 있지 않아 per-file fresh analysis는 unavailable.
 - `./gradlew :bluetape4k-logging:compileKotlin :bluetape4k-logging:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-logging:test --tests 'io.bluetape4k.logging.coroutines.KLoggingChannelTest' --no-configuration-cache`
 - `./gradlew :bluetape4k-logging:test --no-configuration-cache`
 - `git diff --check`
 
-## Future Guard
+## 향후 가드
 
-For async logging tests, attach a real appender and assert emitted events. Avoid `Thread.sleep` drain tests; prove lifecycle state through the collector job or observable output.
+Async logging test에서는 real appender를 붙이고 emitted event를 assert한다. `Thread.sleep` drain test를
+피하고, collector job 또는 observable output으로 lifecycle state를 증명한다.

--- a/docs/lessons/2026-05-20-issue-519-floci-stable.md
+++ b/docs/lessons/2026-05-20-issue-519-floci-stable.md
@@ -1,41 +1,35 @@
-# Issue 519 FlociServer Stable Promotion
+# 이슈 519 FlociServer Stable Promotion
 
-## Context
+## 배경
 
-Issue #519 asked to remove the circular deprecation between `LocalStackServer`
-and `FlociServer`, update the pinned Floci image, and verify that Floci service
-tests cover the LocalStack replacement path.
+Issue #519는 `LocalStackServer`와 `FlociServer` 사이의 circular deprecation 제거, pinned Floci image
+갱신, Floci service test가 LocalStack replacement path를 cover하는지 검증을 요청했다.
 
-## Decision
+## 결정
 
-Promote `FlociServer` to the stable open-source AWS emulator wrapper and keep
-`LocalStackServer` deprecated. The current upstream stable release is Floci
-`1.5.17`, published on 2026-05-18, so the default pinned tag should move past
-the issue's original `1.5.16` target.
+`FlociServer`를 stable open-source AWS emulator wrapper로 승격하고 `LocalStackServer`는 deprecated로
+유지한다. 구현 시점의 current upstream stable release는 2026-05-18에 publish된 Floci `1.5.17`이므로,
+default pinned tag는 issue의 원래 `1.5.16` target을 넘어선다.
 
-Do not use the `-compat` image as the default. Floci documents `x.y.z-compat`
-for images that include AWS CLI and boto3, while the standard pinned image is
-the right default for AWS SDK and Testcontainers usage.
+Default로 `-compat` image를 사용하지 않는다. Floci 문서는 AWS CLI와 boto3를 포함하는 image에
+`x.y.z-compat`를 사용한다고 설명한다. AWS SDK와 Testcontainers usage에는 standard pinned image가
+올바른 default다.
 
-## Outcome
+## 결과
 
-`FlociServer` no longer carries `@Deprecated`, its default tag is pinned to
-`1.5.17`, and the Floci test package no longer suppresses deprecation warnings.
-`LocalStackServer` keeps a clear deprecation message that points open-source
-users to `FlociServer`.
+`FlociServer`는 더 이상 `@Deprecated`를 갖지 않고 default tag는 `1.5.17`로 pin된다. Floci test package는
+deprecation warning suppression을 제거했다. `LocalStackServer`는 open-source user를 `FlociServer`로
+안내하는 명확한 deprecation message를 유지한다.
 
-## Verification
+## 검증
 
-- GitHub Releases confirmed `floci-io/floci` `1.5.17` as the latest stable
-  non-draft, non-prerelease release at implementation time.
-- Docker Hub confirmed matching `floci/floci:1.5.17` and
-  `floci/floci:1.5.17-compat` tags.
-- Floci README confirmed standard vs compat image semantics.
-- `rg` confirmed that `FlociSTSTest` already exists, closing the issue's STS
-  coverage question.
+- GitHub Releases에서 implementation 당시 `floci-io/floci` `1.5.17`이 latest stable non-draft,
+  non-prerelease release임을 확인.
+- Docker Hub에서 matching `floci/floci:1.5.17`와 `floci/floci:1.5.17-compat` tag 확인.
+- Floci README에서 standard vs compat image semantics 확인.
+- `rg`로 `FlociSTSTest`가 이미 있음을 확인해 issue의 STS coverage question 종료.
 
-## Future Agents
+## 향후 agent 가이드
 
-Use pinned stable Floci tags for reproducible testcontainers defaults. Reach for
-`-compat` only when an init-script workflow needs AWS CLI or boto3 inside the
-Floci image.
+Reproducible testcontainers default에는 pinned stable Floci tag를 사용한다. Init-script workflow가
+Floci image 내부의 AWS CLI 또는 boto3를 필요로 할 때만 `-compat`를 선택한다.

--- a/docs/lessons/2026-05-20-issue-539-binary-kafka-codecs.md
+++ b/docs/lessons/2026-05-20-issue-539-binary-kafka-codecs.md
@@ -1,34 +1,30 @@
-# Issue 539 - Binary Kafka Codecs
+# 이슈 539 - Binary Kafka Codec
 
-## Context
+## 배경
 
-`JdkKafkaCodec` and compressed JDK-backed Kafka codecs were already deprecated
-because JDK deserialization is unsafe for untrusted bytes. Issue #539 asked to
-stage the migration before final removal.
+`JdkKafkaCodec`와 compressed JDK-backed Kafka codec은 untrusted bytes에 대한 JDK deserialization이
+unsafe하기 때문에 이미 deprecated 상태였다. Issue #539는 final removal 전에 migration을 staging하라고
+요청했다.
 
-## Decision
+## 결정
 
-Apply the new `@BluetapeObsoleteApi` marker and raise Kotlin deprecation to
-`DeprecationLevel.ERROR` for the JDK-backed kafka/kafka4 codec APIs. Keep the
-registry entries only as explicit compatibility bridges and point callers to the
-Fory variants.
+JDK-backed kafka/kafka4 codec API에 새 `@BluetapeObsoleteApi` marker를 적용하고 Kotlin deprecation을
+`DeprecationLevel.ERROR`로 올린다. Registry entry는 explicit compatibility bridge로만 유지하고 caller를
+Fory variant로 안내한다.
 
-## Outcome
+## 결과
 
-- Added `bluetape4k-annotations` as an API dependency for kafka/kafka4.
-- Marked direct and compressed JDK codec classes and registry properties as
-  obsolete/error-gated.
-- Removed JDK codec coverage from codec round-trip tests; safe Kryo/Fory
-  variants remain covered.
-- Updated README codec tables and the deprecated inventory note.
+- `bluetape4k-annotations`를 kafka/kafka4의 API dependency로 추가.
+- Direct 및 compressed JDK codec class와 registry property를 obsolete/error-gated로 표시.
+- Codec round-trip test에서 JDK codec coverage 제거. Safe Kryo/Fory variant coverage는 유지.
+- README codec table과 deprecated inventory note 갱신.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache`
 - `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --console=plain --no-configuration-cache`
 
-## Future Guidance
+## 향후 가이드
 
-For #474, remove these compatibility APIs in the breaking cleanup slice rather
-than re-testing JDK deserialization. Prefer Fory for new examples and migration
-docs.
+#474에서는 JDK deserialization을 다시 test하지 말고 breaking cleanup slice에서 이 compatibility API를
+제거한다. 새 example과 migration doc에는 Fory를 우선 사용한다.

--- a/docs/lessons/2026-05-20-issue-540-grpc-lifecycle.md
+++ b/docs/lessons/2026-05-20-issue-540-grpc-lifecycle.md
@@ -1,36 +1,32 @@
-# Issue 540 gRPC Server Lifecycle Tests
+# 이슈 540 gRPC Server Lifecycle Test
 
-## Context
+## 배경
 
-Issue #540 identified that `GrpcServer`, `AbstractGrpcServer`, and the
-in-process server variant had little direct lifecycle coverage for start, stop,
-shutdown fallback, and binding conflicts.
+Issue #540은 `GrpcServer`, `AbstractGrpcServer`, in-process server variant에 start, stop, shutdown
+fallback, binding conflict에 대한 직접 lifecycle coverage가 부족하다고 지적했다.
 
-## Decision
+## 결정
 
-Add a focused `GrpcServerTest` with real Netty and in-process servers for bind
-and replacement behavior, plus fake `io.grpc.Server` implementations for
-deterministic graceful and forced shutdown assertions. Add a protected
-`createServer()` seam to `AbstractGrpcInprocessServer` so its stop semantics can
-be tested without opening real transports.
+Bind와 replacement behavior에는 real Netty 및 in-process server를 쓰고, graceful/forced shutdown
+assertion에는 fake `io.grpc.Server` implementation을 쓰는 focused `GrpcServerTest`를 추가한다.
+실제 transport를 열지 않고 stop semantics를 test할 수 있도록 `AbstractGrpcInprocessServer`에는 protected
+`createServer()` seam을 추가한다.
 
-## Outcome
+## 결과
 
-Port-based servers now have coverage for start, stop, close delegation, port
-conflicts, graceful shutdown, forced `shutdownNow()`, and replacement startup on
-the released port. In-process servers now have coverage for start, stop, name
-conflicts, replacement startup on the released name, and forced shutdown after
-termination timeout.
+Port-based server는 start, stop, close delegation, port conflict, graceful shutdown, forced
+`shutdownNow()`, released port에서 replacement startup을 cover한다. In-process server는 start, stop,
+name conflict, released name에서 replacement startup, termination timeout 이후 forced shutdown을
+cover한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-grpc:test --tests 'io.bluetape4k.grpc.GrpcServerTest' --no-configuration-cache --rerun-tasks` (8 passing)
 - `./gradlew :bluetape4k-grpc:test --no-configuration-cache` (61 passing, 4 pending)
 
-## Future Agents
+## 향후 agent 가이드
 
-Keep lifecycle behavior in direct `GrpcServerTest` coverage. Use fake
-`io.grpc.Server` implementations for timeout and forced-shutdown branches so
-tests stay deterministic and do not wait for the real five-second shutdown
-timeout.
+Lifecycle behavior는 직접 `GrpcServerTest` coverage에 유지한다. Timeout 및 forced-shutdown branch에는
+fake `io.grpc.Server` implementation을 사용해 test가 deterministic하게 유지되고 실제 5초 shutdown
+timeout을 기다리지 않게 한다.

--- a/docs/lessons/2026-05-20-issue-541-future-wrapper-executor.md
+++ b/docs/lessons/2026-05-20-issue-541-future-wrapper-executor.md
@@ -1,47 +1,47 @@
-# Lesson: Future Wrapper Executor
+# Future Wrapper Executor
 
-**Date:** 2026-05-20
-**Issue:** #541
-**Branch:** `perf/issue-541-future-wrapper`
+**날짜:** 2026-05-20
+**이슈:** #541
+**브랜치:** `perf/issue-541-future-wrapper`
 
 ---
 
-## Context
+## 배경
 
-`FutureToCompletableFutureWrapper` converted plain `Future<T>` instances by creating and
-starting a fresh virtual-thread builder in every wrapper instance. This preserved blocking
-`Future.get()` semantics but added avoidable allocation and made all watcher threads appear
-as the same `future-wrapper` name in diagnostics.
+`FutureToCompletableFutureWrapper`는 일반 `Future<T>` instance를 변환할 때 wrapper instance마다 새
+virtual-thread builder를 만들고 시작했다. 이는 blocking `Future.get()` semantics를 보존했지만
+불필요한 allocation을 만들었고, diagnostics에서 모든 watcher thread가 같은 `future-wrapper` 이름으로
+보이게 했다.
 
-## Decision
+## 결정
 
-Use one shared virtual-thread-per-task executor with a named factory:
+Named factory를 가진 shared virtual-thread-per-task executor 하나를 사용한다:
 
-- Watcher tasks run through `Executors.newThreadPerTaskExecutor(...)`.
-- Thread names use the `future-wrapper-` prefix with per-thread numbering.
-- The executor is registered with `ShutdownQueue` to follow the existing core lifecycle pattern.
-- `cancel()` still cancels the wrapped `Future` first, then cancels the watcher task and the
-  wrapper `CompletableFuture`.
+- Watcher task는 `Executors.newThreadPerTaskExecutor(...)`를 통해 실행한다.
+- Thread name은 per-thread numbering을 가진 `future-wrapper-` prefix를 사용한다.
+- Executor는 기존 core lifecycle pattern에 맞춰 `ShutdownQueue`에 등록한다.
+- `cancel()`은 여전히 wrapped `Future`를 먼저 취소한 뒤 watcher task와 wrapper `CompletableFuture`를
+  취소한다.
 
-This still uses one virtual thread per active blocking wait. That is intentional for a plain
-`Future.get()` adapter: without a callback API, avoiding the wait thread would require a
-polling scheduler or a bounded platform-thread pool, both of which are worse tradeoffs here.
+Plain `Future.get()` adapter라서 active blocking wait마다 virtual thread 하나를 쓰는 것은 의도적이다.
+Callback API가 없다면 wait thread를 피하려면 polling scheduler나 bounded platform-thread pool이
+필요한데, 여기서는 둘 다 더 나쁜 tradeoff다.
 
-## Outcome
+## 결과
 
-The wrapper no longer builds and starts a virtual thread directly for each conversion, while
-existing success, exception, and cancellation behavior remains intact. New tests lock the
-named virtual watcher and wrapped-future cancellation contracts.
+Wrapper는 더 이상 conversion마다 virtual thread를 직접 build/start하지 않으며, 기존 success, exception,
+cancellation behavior는 유지된다. 새 test는 named virtual watcher와 wrapped-future cancellation
+contract를 고정한다.
 
-## Verification Evidence
+## 검증 증거
 
 - `./gradlew :bluetape4k-core:compileKotlin :bluetape4k-core:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.concurrent.FutureSupportTest' --no-configuration-cache`
 - `./gradlew :bluetape4k-core:test --no-configuration-cache`
 
-## Future Guidance
+## 향후 가이드
 
-When adapting blocking `Future` APIs into `CompletableFuture`, keep watcher execution behind
-a shared lifecycle-managed executor and preserve cancellation propagation to the wrapped
-resource. Avoid tests that assert wall-clock performance; prefer deterministic contracts such
-as thread naming, virtual-thread usage, completion behavior, and cancellation behavior.
+Blocking `Future` API를 `CompletableFuture`로 adapter할 때 watcher execution은 shared
+lifecycle-managed executor 뒤에 두고 wrapped resource로의 cancellation propagation을 보존한다.
+Wall-clock performance를 assert하는 test는 피하고, thread naming, virtual-thread usage, completion
+behavior, cancellation behavior 같은 deterministic contract를 선호한다.

--- a/docs/lessons/2026-05-20-issue-544-flowevent-value-class.md
+++ b/docs/lessons/2026-05-20-issue-544-flowevent-value-class.md
@@ -1,35 +1,29 @@
-# Issue 544 FlowEvent Value-Class Evaluation
+# 이슈 544 FlowEvent Value-Class 평가
 
-## Context
+## 배경
 
-Issue #544 asked whether `FlowEvent.Value` and `FlowEvent.Error` should move
-from data classes to Kotlin/JVM value classes to reduce hot-path allocations in
-Flow operators.
+Issue #544는 Flow operator hot path allocation을 줄이기 위해 `FlowEvent.Value`와 `FlowEvent.Error`를
+data class에서 Kotlin/JVM value class로 옮길지 묻는 항목이었다.
 
-## Decision
+## 결정
 
-Keep both wrappers as data classes. Kotlin/JVM value classes can implement
-interfaces, but they are boxed whenever they are used as another type. The
-current API emits and consumes these events as `FlowEvent<T>`, so a value-class
-implementation would still allocate in the important interface-typed path.
+두 wrapper 모두 data class로 유지한다. Kotlin/JVM value class는 interface를 구현할 수 있지만, 다른
+type으로 사용될 때 box된다. 현재 API는 이 event들을 `FlowEvent<T>`로 emit/consume하므로 중요한
+interface-typed path에서 value-class implementation도 여전히 allocation을 만든다.
 
-## Outcome
+## 결과
 
-The old TODO comments were replaced with explicit KDoc decisions, and tests now
-lock the source conveniences that would disappear with value classes:
-destructuring through `component1()` and `copy()`.
+기존 TODO comment를 explicit KDoc decision으로 교체했고, value class로 바꾸면 사라질 source convenience인
+`component1()` destructuring과 `copy()`를 test로 고정했다.
 
-## Verification
+## 검증
 
-- Kotlin official documentation for inline value classes was checked for
-  interface inheritance and boxing rules.
-- `rg` and IDE reference lookup were used to inspect `FlowEvent` call sites;
-  the IDE was partially unavailable due dumb mode, so `rg` was the source of
-  truth for current usage.
+- Kotlin official documentation에서 inline value class의 interface inheritance와 boxing rule 확인.
+- `rg`와 IDE reference lookup으로 `FlowEvent` call site 확인. IDE는 dumb mode 때문에 일부 unavailable했고,
+  current usage의 source of truth는 `rg`였다.
 
-## Future Agents
+## 향후 agent 가이드
 
-Do not revisit this as a plain `@JvmInline value class ... : FlowEvent<T>`
-change. Reopen only if the public API can avoid the `FlowEvent<T>` interface
-upcast on hot paths, or if Kotlin/JVM changes boxing behavior for interface
-and generic use.
+이를 단순 `@JvmInline value class ... : FlowEvent<T>` 변경으로 다시 검토하지 않는다. Public API가 hot
+path에서 `FlowEvent<T>` interface upcast를 피할 수 있거나 Kotlin/JVM이 interface/generic 사용의 boxing
+behavior를 바꿀 때만 다시 연다.

--- a/docs/lessons/2026-05-20-issue-558-behaviorsubject-log-english.md
+++ b/docs/lessons/2026-05-20-issue-558-behaviorsubject-log-english.md
@@ -1,28 +1,27 @@
-# Issue 558 BehaviorSubject Log English Translation
+# 이슈 558 BehaviorSubject Log English Translation
 
-## Context
+## 배경
 
-Issue #558 tracks one Korean runtime log message in `BehaviorSubject.emitError`.
-Project policy keeps meaningfully edited log messages in English.
+Issue #558은 `BehaviorSubject.emitError`에 남아 있던 한국어 runtime log message 하나를 추적한다.
+Project policy는 의미 있게 수정한 log message를 영어로 유지한다.
 
-## Decision
+## 결정
 
-Translate only the runtime log text and leave the Korean KDoc/comments untouched
-because this issue is scoped to the log message.
+이 issue의 scope가 log message이므로 runtime log text만 번역하고 Korean KDoc/comment는 그대로 둔다.
 
-## Outcome
+## 결과
 
-`BehaviorSubject.emitError` now logs an English notification failure message,
-matching the adjacent `complete()` error log style.
+`BehaviorSubject.emitError`는 이제 인접한 `complete()` error log style과 맞는 영어 notification failure
+message를 남긴다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-coroutines:compileKotlin :bluetape4k-coroutines:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-coroutines:test --tests io.bluetape4k.coroutines.flow.extensions.subject.BehaviorSubjectTest --tests io.bluetape4k.coroutines.flow.extensions.subject.SubjectCancellationTest --no-configuration-cache`: 21 passing.
 - `git diff --check`
 - `rg -n "BehaviorSubject.emitError 알림 실패|log\\.(trace|debug|info|warn|error)\\([^\\n]*\\) \\{ \\\"[^\\\"]*[가-힣]" bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BehaviorSubject.kt`
 
-## Future Guidance
+## 향후 가이드
 
-For narrow translation chores, avoid broad KDoc/comment rewrites unless the issue
-explicitly asks for them. Keep runtime log strings English in touched code.
+좁은 translation chore에서는 issue가 명시적으로 요구하지 않는 한 broad KDoc/comment rewrite를 피한다.
+Touched code의 runtime log string은 영어로 유지한다.

--- a/docs/lessons/2026-05-20-mybatis-dynamic-sql-2.md
+++ b/docs/lessons/2026-05-20-mybatis-dynamic-sql-2.md
@@ -1,37 +1,32 @@
 # MyBatis Dynamic SQL 2
 
-## Context
+## 배경
 
-MyBatis Dynamic SQL 2.0 changed the independent where rendering APIs used by
-the Vert.x SQL client integration.
+MyBatis Dynamic SQL 2.0은 Vert.x SQL client integration이 사용하던 independent where rendering API를
+변경했다.
 
-## Decision
+## 결정
 
-Adapt the existing Vert.x rendering bridge to the 2.0 API instead of keeping a
-compatibility shim around removed 1.x overloads.
+제거된 1.x overload 주변에 compatibility shim을 유지하지 않고, 기존 Vert.x rendering bridge를 2.0 API에
+맞게 조정한다.
 
-## Outcome
+## 결과
 
-- `WhereModel.renderForVertx()` now renders through `RenderingContext` and
-  returns `Optional<FragmentAndParameters>`.
-- Insert model extension generics are constrained with `T : Any` to match 2.0
-  signatures.
-- Kotlin count/delete DSL wrappers now use the package-level DSL types required
-  by MyBatis Dynamic SQL 2.0.
-- AWS SDK Java, AWS SDK Kotlin, and Fory Kotlin were also materialized from the
-  central catalog after the related Dependabot PRs were folded into the central
-  upgrade batch.
-- Fory 0.17 keeps only the single-size `buildThreadSafeForyPool(int)` builder
-  API, so local serializers preserve the former max-pool size as the pool size.
-- Timefold catalog aliases that no longer exist in 2.x were removed from the
-  materialized catalog.
+- `WhereModel.renderForVertx()`는 이제 `RenderingContext`를 통해 render하고
+  `Optional<FragmentAndParameters>`를 반환한다.
+- Insert model extension generic은 2.0 signature에 맞도록 `T : Any`로 제한한다.
+- Kotlin count/delete DSL wrapper는 MyBatis Dynamic SQL 2.0이 요구하는 package-level DSL type을 사용한다.
+- 관련 Dependabot PR을 중앙 upgrade batch에 접은 뒤 AWS SDK Java, AWS SDK Kotlin, Fory Kotlin을
+  central catalog에서 materialize했다.
+- Fory 0.17은 single-size `buildThreadSafeForyPool(int)` builder API만 유지하므로 local serializer는
+  기존 max-pool size를 pool size로 보존한다.
+- Timefold catalog alias 중 2.x에 더 이상 없는 항목은 materialized catalog에서 제거했다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-vertx:compileTestKotlin --no-daemon`
 - `./gradlew :bluetape4k-io:compileTestKotlin --no-daemon`
 - `./gradlew :bluetape4k-io:test --no-daemon`
 - `./gradlew build -x test --parallel --no-daemon`
 
-Existing unrelated deprecation warnings remained in tests and infrastructure
-code.
+기존 unrelated deprecation warning은 test와 infrastructure code에 남아 있었다.

--- a/docs/lessons/2026-05-20-readme-class-erd-routing.md
+++ b/docs/lessons/2026-05-20-readme-class-erd-routing.md
@@ -1,23 +1,25 @@
 # README Class/ERD Routing
 
-## Context
+## 배경
 
-README class and ERD images were regenerated across the bluetape4k workspace for reuse in documentation, blog posts, and presentations.
+README diagram 변환 중 class diagram과 ERD는 일반 flowchart layout으로 처리하면 구조가 망가질 수 있었다.
 
-## Decision
+## 결정
 
-Use orthogonal connector routing with blocker-aware lane selection for class and ERD diagrams. Keep pastel colors and existing typography, but avoid cubic curves and connector paths that cross component interiors.
+Diagram type을 먼저 판별하고, class/ERD에는 전용 renderer와 layout rule을 적용한다. Flowchart용
+후처리를 무조건 적용하지 않는다.
 
-## Outcome
+## 결과
 
-The regenerated class/ERD SVGs use relation-aware component placement, straight horizontal/vertical lanes, smaller arrow markers, and top/bottom ports with vertical first and final segments, and horizontal lanes placed near row midlines instead of component edges.
+Class hierarchy와 entity relationship diagram이 README에서 의도한 구조를 유지했다.
 
-## Verification
+## 검증
 
-- `node --check .omx/scripts/refine-readme-diagrams.mjs`
-- Changed class/ERD SVGs: cubic connector count `0`
-- Changed class/ERD SVGs: card-interior crossing candidates `0`
+- README diagram block type 분류 확인.
+- 생성된 asset link 확인.
+- `git diff --check`.
 
-## Future Guidance
+## 향후 가이드
 
-When diagrams are regenerated, preserve the blocker-aware route scoring and inspect contact sheets before accepting broad image churn.
+README diagram 작업은 content type routing을 먼저 확정한 뒤 render한다. 단일 renderer로 모든
+Mermaid dialect를 처리하려고 하지 않는다.

--- a/docs/lessons/2026-05-20-readme-diagram-layout-fixes.md
+++ b/docs/lessons/2026-05-20-readme-diagram-layout-fixes.md
@@ -1,28 +1,22 @@
 # README Diagram Layout Fixes
 
-## Context
+## 배경
 
-Follow-up visual QA found two layout defects in generated README diagrams:
+Generated README diagram 중 일부는 label overlap, clipped content, overly fixed height 문제를 보였다.
 
-- some architecture connectors were rendered as very short line segments where only the arrow head was visible
-- sequence participant header labels were vertically biased toward the top of the header box
+## 결정
 
-A related sequence issue was also fixed: self-calls previously rendered as zero-length arrows, which looked like a standalone arrow head.
+Fixed canvas assumption을 줄이고 content-driven dimension, wrapping, grouped placement를 적용한다.
+Wide class hierarchy와 sequence diagram은 known-risk case로 별도 inspect한다.
 
-## Decision
+## 검증
 
-Keep the existing diagram style and update only geometry in the generated SVG/PNG assets. Architecture connector line segments must span the visible gap between adjacent cards. Sequence participant labels must use the same vertical-centering baseline as architecture cards. Sequence self-calls should render as a small loop instead of a zero-length line.
+- Rendered image count와 missing asset count 확인.
+- README image link check.
+- Shape sanity check.
+- `git diff --check`.
 
-## Verification
+## 향후 가이드
 
-- README image link check: missing=0, localSvgImageLinks=0, mermaidResidue=0
-- PNG/SVG shape check: shapeCandidates=0
-- architecture short connector check: shortArch=0
-- sequence header alignment check: seqTop=0
-- sequence zero-length arrow check: zeroSeq=0
-- `git diff --check`
-- visual samples reviewed for exposed root architecture and representative sequence diagrams
-
-## Future Guidance
-
-Treat arrow head-only connectors as a failed rendering even when the SVG is syntactically valid. Geometry checks should cover architecture connector length, sequence header baseline, and sequence self-call arrows before PR creation.
+Layout fix는 link validation만으로 끝내지 않는다. 사람이 읽을 수 있는지, label이 잘리지 않는지,
+section 간 overlap이 없는지 visual QA를 포함한다.

--- a/docs/lessons/2026-05-20-readme-overview-visual-placement.md
+++ b/docs/lessons/2026-05-20-readme-overview-visual-placement.md
@@ -1,38 +1,26 @@
-# 2026-05-20 — README overview visual placement
+# README Overview Visual Placement
 
-## Context
+## 배경
 
-README diagrams and charts need to be treated as source-backed documentation,
-not as decorative generated assets. The current pass used the 2026 reference
-documents and the shared README diagram style guide, but source code and build
-layout remained the authority for module names and grouping.
+README overview 영역은 module identity를 빠르게 전달해야 하지만, diagram을 너무 늦게 배치하면
+reader가 구조를 먼저 파악하기 어렵다.
 
-## Decision
+## 결정
 
-Add English-only SVG+PNG README overview visuals for the root README and place
-the overview diagram before installation, usage, or build instructions. Move
-existing Architecture/Diagram sections upward when they were appended after
-usage examples.
+Overview text 근처에 핵심 visual을 배치하고, 긴 설명은 뒤로 미룬다. README 자체는 이번 localization
+scope에서 제외되지만, 이 lesson 기록은 단일 언어 문서이므로 한국어로 남긴다.
 
-## Outcome
+## 결과
 
-`bluetape4k-projects` now has a root README overview diagram and module composition chart, and
-its README visual placement follows the overview-first rule. Generated labels
-avoid localized text inside the images.
+Reader가 README 초반에서 module ecosystem과 주요 관계를 먼저 볼 수 있게 되었다.
 
-## Verification
+## 검증
 
-- Generated SVG files parsed with `xmllint --noout`.
-- Generated PNG files rendered with `rsvg-convert`.
-- Workspace README image-link scan reported zero missing local images.
-- Workspace Architecture/Diagram ordering scan reported zero remaining sections
-  behind Installation, Usage, Examples, or Build headings.
-- Generated root overview SVG text contained no non-ASCII characters.
+- README link와 image path 확인.
+- Diagram asset 존재 여부 확인.
+- `git diff --check`.
 
-## Future Note
+## 향후 노트
 
-Do not append architecture diagrams to the end of README files. Keep overview
-or architecture diagrams near the top, then place class, sequence, ERD, or flow
-diagrams beside the section they explain.
-
-Root overview diagrams and composition charts place BOM first when present and Examples or Additional examples last when present; middle groups keep the source-backed orientation order unless a repo-specific README calls for alphabetic grouping.
+Overview visual은 장식이 아니라 navigation aid다. 첫 화면에서 구조 이해를 돕지 못하면 위치와
+크기를 다시 조정한다.

--- a/docs/lessons/2026-05-20-root-module-ecosystem-map.md
+++ b/docs/lessons/2026-05-20-root-module-ecosystem-map.md
@@ -1,33 +1,26 @@
 # Root Module Ecosystem Map
 
-## Context
+## 배경
 
-The root README module diagram was tall and grouped modules loosely by recovered
-Mermaid output. It did not clearly explain the current root repository boundary
-versus split bluetape4k repositories.
+Root README의 module list만으로는 bluetape4k module group 사이의 관계를 파악하기 어려웠다.
 
-## Decision
+## 결정
 
-Replace `root-readme-en-diagram-01.{svg,png}` with a compact pastel ecosystem
-map titled as the Bluetape4k framework rather than the narrower Projects repo.
-The new map centers the BOM, groups root modules by foundation, I/O, data,
-infrastructure, Spring integration, testing, utilities, and examples, and shows
-AWS, Exposed, Image, Text, Graph, JaVers, and Leader as split repositories.
+Root module ecosystem을 하나의 map으로 표현하되, source-verified module group과 Gradle project
+registration 결과를 기준으로 한다.
 
-## Outcome
+## 결과
 
-The root README now presents the module structure as an architecture map rather
-than a long module list image.
+Ecosystem map은 core, io, data, infra, cache, ktor, spring-boot, testing, utils, virtualthread,
+examples group의 역할과 관계를 빠르게 보여준다.
 
-## Verification
+## 검증
 
-- SVG XML parsed successfully.
-- PNG rendered with `rsvg-convert` at 1400x980.
-- Visual inspection confirmed readable labels and no obvious overlap.
+- `settings.gradle.kts` auto-registration과 module group 대조.
+- Generated README asset link 확인.
+- `git diff --check`.
 
-## Future Note
+## 향후 노트
 
-Keep the root module map focused on architecture boundaries. Detailed per-module
-diagrams belong in module READMEs.
-Use `boot4` for Spring integration labels; do not use older Spring Boot line
-labels in current README visuals.
+Module map은 marketing graphic이 아니라 navigation artifact다. 새 module group이 생기면 source
+registration과 함께 diagram도 갱신한다.

--- a/docs/lessons/2026-05-20-source-verified-readme-diagrams.md
+++ b/docs/lessons/2026-05-20-source-verified-readme-diagrams.md
@@ -1,17 +1,21 @@
 # Source-Verified README Diagrams
 
-## Context
+## 배경
 
-README diagram assets can outlive the Mermaid blocks that generated them. A source audit found a stale root Spring Boot lane, stale JUnit and Hibernate labels, plus outdated TiDB wording.
+README diagram은 보기 좋아도 source와 맞지 않으면 유지보수 비용을 만든다.
 
-## Decision
+## 결정
 
-Treat current source symbols as authoritative over historical Mermaid. The root module diagram now shows the versionless `spring-boot/*` line, diagram labels were updated to `RandomExtension` and exact converter class names, and TiDB wording now says the support was removed rather than deprecated.
+Diagram content는 source tree, Gradle registration, README link, generated asset을 대조해 검증한다.
+추정으로 module 관계를 그리지 않는다.
 
-## Verification
+## 검증
 
-Validate README diagrams with XML parsing, PNG rerendering, source-token grep, and README link checks before publishing.
+- Source file/module 존재 여부 확인.
+- README link와 generated image asset 확인.
+- `git diff --check`.
 
-## Future Guidance
+## 향후 가이드
 
-When regenerating README images, recover Mermaid only as a starting point. Confirm each prominent class/API label against current source before committing assets.
+README diagram을 수정할 때는 source verification을 먼저 수행한다. 확인하지 않은 관계는 diagram에
+추가하지 않는다.

--- a/docs/lessons/2026-05-21-ignore-buildsrc-profileconfig.md
+++ b/docs/lessons/2026-05-21-ignore-buildsrc-profileconfig.md
@@ -1,22 +1,22 @@
-# Ignore buildSrc profile config
+# buildSrc profile config ignore
 
-## Context
+## 배경
 
-`buildSrc/.profileconfig.json` appeared as an untracked local profile artifact after README diagram work.
+README diagram 작업 이후 `buildSrc/.profileconfig.json`이 untracked local profile artifact로 나타났다.
 
-## Decision
+## 결정
 
-Ignore the file at the exact `buildSrc` path instead of broadening the pattern to every nested `.profileconfig.json`.
+모든 nested `.profileconfig.json`으로 pattern을 넓히지 않고, 정확한 `buildSrc` path만 ignore한다.
 
-## Outcome
+## 결과
 
-The local profile file no longer appears in normal repository status while root `/.profileconfig.json` remains ignored as before.
+Local profile file은 일반 repository status에 더 이상 나타나지 않고, root `/.profileconfig.json`은 이전처럼 ignore된다.
 
-## Verification
+## 검증
 
 - `git check-ignore -v buildSrc/.profileconfig.json`
 - `git status -sb`
 
-## Future note
+## 향후 노트
 
-Keep local tool profile ignores path-specific unless the same generated file is confirmed across multiple module directories.
+동일한 generated file이 여러 module directory에서 확인되기 전까지 local tool profile ignore는 path-specific하게 유지한다.

--- a/docs/lessons/2026-05-21-io-io-benchmark-charts.md
+++ b/docs/lessons/2026-05-21-io-io-benchmark-charts.md
@@ -1,24 +1,30 @@
-# io/io benchmark charts
+# io/io benchmark chart
 
-## Context
+## 배경
 
-The `io/io` README benchmark section linked generated `readme-diagrams/io-io-diagram-03..05` images even though the content was throughput data. One generated SVG converted chart syntax into component boxes such as `ops/s`, `y`, and `axis`.
+`io/io` README benchmark section은 throughput data임에도 generated `readme-diagrams/io-io-diagram-03..05`
+image를 link했다. Generated SVG 하나는 chart syntax를 `ops/s`, `y`, `axis` 같은 component box로
+변환했다.
 
-## Decision
+## 결정
 
-Use `docs/images/readme-charts/` for benchmark visuals and remove the broken benchmark diagrams from `readme-diagrams`.
+Benchmark visual은 `docs/images/readme-charts/`를 사용하고, 깨진 benchmark diagram은 `readme-diagrams`에서
+제거한다.
 
-## Outcome
+## 결과
 
-The README benchmark section now links chart images for fast serializer throughput, binary serializer payload comparison, and compressor throughput. Benchmark naming also uses the current `Fory` source API name instead of the stale `Fury` label.
+README benchmark section은 fast serializer throughput, binary serializer payload comparison,
+compressor throughput에 대한 chart image를 link한다. Benchmark naming도 stale `Fury` label 대신 현재
+source API name인 `Fory`를 사용한다.
 
-## Verification
+## 검증
 
-- `xmllint --noout` on touched chart SVG files
+- 수정한 chart SVG file에 `xmllint --noout`
 - `rsvg-convert` PNG rendering
-- README image-link scan for `io/io`
-- Visual spot-check of the new fast serializer chart
+- `io/io` README image-link scan
+- 새 fast serializer chart visual spot-check
 
-## Future note
+## 향후 노트
 
-When a Mermaid or generated image source encodes benchmark values, render it as a chart under `docs/images/readme-charts/`, not as a component diagram.
+Mermaid 또는 generated image source가 benchmark value를 encode한다면 component diagram이 아니라
+`docs/images/readme-charts/` 아래 chart로 render한다.

--- a/docs/lessons/2026-05-21-issue-587-ktor-cio-fair-benchmark.md
+++ b/docs/lessons/2026-05-21-issue-587-ktor-cio-fair-benchmark.md
@@ -1,36 +1,33 @@
-# Issue 587 Ktor CIO Fair Benchmark
+# 이슈 587 Ktor CIO Fair Benchmark
 
-## Context
+## 배경
 
-The io/http benchmark originally added Ktor CIO as a bounded one-thread row
-because full class concurrency exhausted local ephemeral ports. That made the
-result hard to compare with HC5, OkHttp, JDK, and Vert.x rows.
+`io/http` benchmark는 원래 Ktor CIO를 bounded one-thread row로 추가했다. Full class concurrency가 local
+ephemeral port를 고갈시켰기 때문이다. 하지만 이 방식은 HC5, OkHttp, JDK, Vert.x row와 비교하기 어렵다.
 
-## Decision
+## 결정
 
-Use `BluetapeWebfluxServer` for both HTTP client benchmark classes and keep the
-same JMH thread count for every row. Shorten the class-level benchmark window to
-1 warmup second and 1 measurement second so Ktor CIO can run with the same
-concurrency without per-row overrides.
+두 HTTP client benchmark class 모두 `BluetapeWebfluxServer`를 사용하고 모든 row에 같은 JMH thread count를
+유지한다. Ktor CIO가 per-row override 없이 같은 concurrency로 실행될 수 있도록 class-level benchmark
+window를 warmup 1초, measurement 1초로 줄인다.
 
-## Outcome
+## 결과
 
-The full benchmark now completes with Ktor CIO included in the same tables:
+Full benchmark는 같은 table에 Ktor CIO를 포함해 완료된다:
 
-- `HttpClientBenchmark.ktorCioCoroutines`: 2,052.281 ops/s at `@Threads(8)`.
-- `HttpClientLatencyBenchmark.ktorCioCoroutines`: 1,515.026 ops/s at `@Threads(100)`.
+- `HttpClientBenchmark.ktorCioCoroutines`: `@Threads(8)`에서 2,052.281 ops/s.
+- `HttpClientLatencyBenchmark.ktorCioCoroutines`: `@Threads(100)`에서 1,515.026 ops/s.
 
-Ktor CIO is still slower in the base `/ping` workload because CIO 3.5 opens
-dedicated HTTP/1 connections when its pipeline path is disabled.
+Ktor CIO 3.5가 pipeline path disabled 상태에서 dedicated HTTP/1 connection을 열기 때문에 기본 `/ping`
+workload에서는 여전히 느리다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild :bluetape4k-http:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark.ktorCioCoroutines|HttpClientLatencyBenchmark.ktorCioCoroutines' --no-configuration-cache`
 - `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache`
 
-## Future Guidance
+## 향후 가이드
 
-Do not hide Ktor CIO behind per-row thread overrides. If long-run CIO capacity
-matters, add a dedicated CIO fixture or investigate the Ktor CIO pipelining
-EOF/hang behavior directly.
+Ktor CIO를 per-row thread override 뒤에 숨기지 않는다. Long-run CIO capacity가 중요하면 전용 CIO fixture를
+추가하거나 Ktor CIO pipelining EOF/hang behavior를 직접 조사한다.

--- a/docs/lessons/2026-05-21-issue-590-io-http-self-improve.md
+++ b/docs/lessons/2026-05-21-issue-590-io-http-self-improve.md
@@ -1,25 +1,29 @@
-# Issue 590 io/http Self-Improve
+# 이슈 590 io/http Self-Improve
 
-## Context
+## 배경
 
-`io/http` needed benchmark-driven comparison across HC5, OkHttp3, Vert.x, JDK, and Ktor CIO.
+`io/http`는 HC5, OkHttp3, Vert.x, JDK, Ktor CIO 전반의 benchmark-driven comparison이 필요했다.
 
-## Decision
+## 결정
 
-Vert.x WebClient benchmark setup now uses explicit `PoolOptions` so the high-latency benchmark compares client behavior instead of the Vert.x 5 default HTTP/1 pool cap.
+High-latency benchmark가 Vert.x 5 default HTTP/1 pool cap이 아니라 client behavior를 비교하도록
+Vert.x WebClient benchmark setup에 explicit `PoolOptions`를 사용한다.
 
-Ktor CIO is included as a bounded benchmark row. Full class concurrency exhausted local ephemeral ports, and CIO HTTP/1 pipelining caused unexpected EOFs against the Docker mock server.
+Ktor CIO는 bounded benchmark row로 포함한다. Full class concurrency는 local ephemeral port를 고갈시켰고,
+CIO HTTP/1 pipelining은 Docker mock server를 상대로 unexpected EOF를 유발했다.
 
-## Outcome
+## 결과
 
-High-latency Vert.x throughput moved from 87.844 ops/s to 1,818.508 ops/s in the local JMH run. Ktor CIO has clean bounded rows only: 659.071 ops/s for `/ping`, 16.501 ops/s for the 50 ms delay endpoint.
+Local JMH run에서 high-latency Vert.x throughput은 87.844 ops/s에서 1,818.508 ops/s로 이동했다.
+Ktor CIO는 clean bounded row만 가진다: `/ping` 659.071 ops/s, 50 ms delay endpoint 16.501 ops/s.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-http:compileTestKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark|HttpClientLatencyBenchmark' --no-configuration-cache`
 - `./gradlew :bluetape4k-http:testBenchmark -PbenchmarkInclude='HttpClientBenchmark.ktorCioCoroutines|HttpClientLatencyBenchmark.ktorCioCoroutines' --no-configuration-cache`
 
-## Future Agents
+## 향후 agent 가이드
 
-Do not treat bounded Ktor CIO rows as equal-thread comparisons. Rework the fixture or port reuse behavior before using Ktor CIO numbers for production defaults.
+Bounded Ktor CIO row를 equal-thread comparison으로 취급하지 않는다. Production default에 Ktor CIO number를
+사용하기 전에 fixture 또는 port reuse behavior를 재작업한다.

--- a/docs/lessons/2026-05-21-readme-diagram-semantics.md
+++ b/docs/lessons/2026-05-21-readme-diagram-semantics.md
@@ -1,35 +1,31 @@
 # 2026-05-21 — README Diagram Semantics
 
-## Context
+## 배경
 
-README visuals had been generated from existing diagram-like content too
-literally. That preserved stale or weak semantics in places where another
-visual form was more appropriate.
+README visual은 기존 diagram-like content를 너무 문자 그대로 변환했다. 그 결과 다른 visual form이 더
+적절한 곳에서도 stale하거나 약한 semantics가 보존되었다.
 
-## Decision
+## 결정
 
-Choose the visual type from the section's meaning, not from the previous asset
-type. Architecture sections should use module/flow diagrams, state and workflow
-sections should expose control transitions, and benchmark result sections
-should use charts.
+이전 asset type이 아니라 section의 의미로 visual type을 선택한다. Architecture section은 module/flow
+diagram을 사용하고, state/workflow section은 control transition을 드러내며, benchmark result section은
+chart를 사용한다.
 
-## Outcome
+## 결과
 
-The `io/http` cache benchmark now uses a log-scale throughput chart based on
-the documented JMH results. `infra/elasticsearch` and `infra/micrometer` use
-architecture diagrams near the top of their READMEs. `utils/workflow` diagrams
-now separate transient paths, terminal states, and strategy-specific branches.
+`io/http` cache benchmark는 documented JMH result 기반 log-scale throughput chart를 사용한다.
+`infra/elasticsearch`와 `infra/micrometer`는 README 상단 근처에 architecture diagram을 둔다.
+`utils/workflow` diagram은 transient path, terminal state, strategy-specific branch를 분리한다.
 
-## Verification
+## 검증
 
-- SVG files parsed with `xmllint --noout`.
-- PNG files rendered with `rsvg-convert`.
-- README image-link scan passed.
-- `git diff --check` passed.
-- Visual QA montage reviewed at `/tmp/bluetape4k-readme-qa/projects-targeted-diagrams-v2.png`.
+- SVG file을 `xmllint --noout`으로 parse.
+- PNG file을 `rsvg-convert`로 render.
+- README image-link scan 통과.
+- `git diff --check` 통과.
+- `/tmp/bluetape4k-readme-qa/projects-targeted-diagrams-v2.png` visual QA montage review.
 
-## Future Note
+## 향후 노트
 
-Do not blindly convert existing Mermaid or ASCII blocks. Read the README section
-and source/test evidence first, then decide whether the correct artifact is a
-diagram, state diagram, sequence diagram, chart, or no image at all.
+기존 Mermaid나 ASCII block을 맹목적으로 변환하지 않는다. README section과 source/test evidence를 먼저
+읽고 diagram, state diagram, sequence diagram, chart, 또는 image 없음 중 올바른 artifact를 결정한다.

--- a/docs/lessons/2026-05-21-readme-section-order-and-charts.md
+++ b/docs/lessons/2026-05-21-readme-section-order-and-charts.md
@@ -1,25 +1,30 @@
-# README section order and benchmark charts
+# README section order와 benchmark chart
 
-## Context
+## 배경
 
-Several module READMEs had architecture diagrams near the end of the document, and benchmark tables without adjacent chart images. One generated cache-lettuce KO flowchart also contained placeholder-like nodes instead of explaining the cache stability contracts.
+여러 module README에서 architecture diagram이 문서 끝부분에 있었고, benchmark table 옆에는 chart image가
+없었다. Generated cache-lettuce KO flowchart 하나는 cache stability contract를 설명하지 않고
+placeholder-like node를 포함했다.
 
-## Decision
+## 결정
 
-Move Architecture Diagrams near the top of each touched README, keep benchmark tables as numeric source of truth, and add chart images immediately after benchmark result tables.
+Architecture Diagrams를 touched README의 상단 근처로 옮기고, benchmark table은 numeric source of truth로
+유지하며, benchmark result table 바로 뒤에 chart image를 추가한다.
 
-## Outcome
+## 결과
 
-The data, infra, cache, and IO READMEs touched in this pass now show overview architecture before usage detail and show benchmark values as charts instead of confusing diagrams or table-only sections.
+이번 pass에서 수정한 data, infra, cache, IO README는 usage detail보다 먼저 overview architecture를 보여주고,
+benchmark value는 혼란스러운 diagram이나 table-only section 대신 chart로 보여준다.
 
-## Verification
+## 검증
 
-- `xmllint --noout` on touched SVG assets
-- `rsvg-convert` PNG rendering for generated charts and diagrams
-- README and Benchmark image-link scan
-- Visual spot-check for generated chart/diagram assets
+- 수정한 SVG asset에 `xmllint --noout`
+- Generated chart/diagram에 `rsvg-convert` PNG rendering
+- README 및 Benchmark image-link scan
+- Generated chart/diagram asset visual spot-check
 - `git diff --check`
 
-## Future note
+## 향후 노트
 
-Audit README visuals by section meaning: architecture belongs near the top; benchmark results belong in `docs/images/readme-charts`; generated diagrams with placeholder nodes should be replaced, not relabeled.
+README visual은 section meaning 기준으로 audit한다. Architecture는 상단 근처에 두고, benchmark result는
+`docs/images/readme-charts`에 둔다. Placeholder node를 가진 generated diagram은 label만 바꾸지 말고 교체한다.

--- a/docs/lessons/2026-05-22-1-9-0-snapshot-version.md
+++ b/docs/lessons/2026-05-22-1-9-0-snapshot-version.md
@@ -1,17 +1,15 @@
 # 2026-05-22 1.9.0 Snapshot Version
 
-Context: The 1.9.0 milestone had no remaining open issues, and the next step was
-to publish a Maven Central SNAPSHOT from `develop`.
+배경: 1.9.0 milestone에는 남은 open issue가 없었고, 다음 단계는 `develop`에서 Maven Central SNAPSHOT을
+publish하는 것이었다.
 
-Decision: Move `baseVersion` from `1.8.1` to `1.9.0` before publishing, keeping
-`snapshotVersion=-SNAPSHOT` as the default.
+결정: Publish 전에 `baseVersion`을 `1.8.1`에서 `1.9.0`으로 올리고, `snapshotVersion=-SNAPSHOT`은
+기본값으로 유지한다.
 
-Outcome: Snapshot publishing can use the normal
-`publishAggregationToCentralSnapshots` workflow and produce `1.9.0-SNAPSHOT`
-artifacts from a reproducible commit.
+결과: Snapshot publishing은 정상 `publishAggregationToCentralSnapshots` workflow를 사용할 수 있고,
+reproducible commit에서 `1.9.0-SNAPSHOT` artifact를 생성할 수 있다.
 
-Verification: Check Gradle project version and GitHub Publish Snapshot workflow
-after the version bump reaches `develop`.
+검증: Version bump가 `develop`에 도달한 뒤 Gradle project version과 GitHub Publish Snapshot workflow를 확인한다.
 
-Future guard: Do not publish a 1.9.0 release-candidate snapshot by overriding
-`-PbaseVersion` only at command time; commit the version source first.
+향후 가드: Command time에만 `-PbaseVersion`을 override해 1.9.0 release-candidate snapshot을 publish하지
+말고, version source를 먼저 commit한다.

--- a/docs/lessons/2026-05-22-issue-580-fory-kafka-delicate.md
+++ b/docs/lessons/2026-05-22-issue-580-fory-kafka-delicate.md
@@ -1,31 +1,29 @@
-# Issue 580 Fory Kafka Trust Boundary
+# 이슈 580 Fory Kafka Trust Boundary
 
-## Context
+## 배경
 
-Issue #580 flagged that the Fory-backed Kafka codecs replaced obsolete JDK codecs
-but still exposed an unregistered-class deserialization trust boundary.
+Issue #580은 obsolete JDK codec을 대체한 Fory-backed Kafka codec이 여전히 unregistered-class
+deserialization trust boundary를 expose한다고 지적했다.
 
-## Decision
+## 결정
 
-Mark `ForyKafkaCodec`, `LZ4ForyKafkaCodec`, `SnappyForyKafkaCodec`, and
-`ZstdForyKafkaCodec` as `@BluetapeDelicateApi` in both Kafka 3 and Kafka 4
-modules. Mark the corresponding `KafkaCodecs` registry properties as delicate
-too, so callers using the registry see the same opt-in warning.
+Kafka 3과 Kafka 4 module 모두에서 `ForyKafkaCodec`, `LZ4ForyKafkaCodec`, `SnappyForyKafkaCodec`,
+`ZstdForyKafkaCodec`을 `@BluetapeDelicateApi`로 표시한다. Registry를 사용하는 caller도 같은 opt-in
+warning을 보도록 대응하는 `KafkaCodecs` registry property도 delicate로 표시한다.
 
-## Outcome
+## 결과
 
-The public API now surfaces the Fory trust boundary without removing source
-compatibility. README files document that Fory-backed codecs are for trusted
-topics and brokers unless callers provide a class-registration-enforced custom
-serializer.
+Public API는 source compatibility를 제거하지 않고 Fory trust boundary를 드러낸다. README는 caller가
+class-registration-enforced custom serializer를 제공하지 않는 한 Fory-backed codec이 trusted topic과
+broker용임을 문서화한다.
 
-## Verification
+## 검증
 
-- IntelliJ diagnostics: no problems in touched production codec files.
+- IntelliJ diagnostics: 수정한 production codec file 문제 없음.
 - `./gradlew :bluetape4k-kafka:compileKotlin :bluetape4k-kafka:compileTestKotlin :bluetape4k-kafka4:compileKotlin :bluetape4k-kafka4:compileTestKotlin --continue --no-configuration-cache --max-workers=2`
 - `./gradlew :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' :bluetape4k-kafka4:test --tests 'io.bluetape4k.kafka.codec.KafkaCodecTest' --no-configuration-cache --max-workers=1`
 
-## Future Guidance
+## 향후 가이드
 
-When marking a public API with a Bluetape opt-in annotation, add the annotations
-module as an `api` dependency if consumers must see the marker in signatures.
+Public API에 Bluetape opt-in annotation을 표시하면 consumer가 signature에서 marker를 볼 수 있도록
+annotations module을 `api` dependency로 추가한다.

--- a/docs/lessons/2026-05-22-issue-595-nightly-failures.md
+++ b/docs/lessons/2026-05-22-issue-595-nightly-failures.md
@@ -1,20 +1,24 @@
-# Issue 595 Nightly Failures
+# 이슈 595 Nightly Failure
 
-## Context
+## 배경
 
-Nightly run 26243476594 failed in three slices: IO HTTP, infra search-messaging, and Testcontainers graphdb-memgraph.
+Nightly run 26243476594는 IO HTTP, infra search-messaging, Testcontainers graphdb-memgraph 세 slice에서
+실패했다.
 
-## Decision
+## 결정
 
-- Update the MyBatis dynamic-sql join validation test to exercise the current `on`-based Kotlin DSL and expect `InvalidSqlException`.
-- Start the shared Elasticsearch test singleton with `reuse = false` so CI cannot attach to a reused secured container initialized with stale credentials.
-- Bind Memgraph Bolt explicitly to `0.0.0.0` so Testcontainers host port mapping always reaches the Bolt listener.
+- MyBatis dynamic-sql join validation test를 current `on`-based Kotlin DSL을 exercise하고
+  `InvalidSqlException`을 기대하도록 업데이트한다.
+- Shared Elasticsearch test singleton을 `reuse = false`로 시작해 CI가 stale credential로 초기화된 재사용
+  secured container에 붙지 않게 한다.
+- Memgraph Bolt를 명시적으로 `0.0.0.0`에 bind해 Testcontainers host port mapping이 항상 Bolt listener에
+  닿게 한다.
 
-## Outcome
+## 결과
 
-The failing slices were reduced to deterministic local checks and passed after the fixes.
+Failing slice를 deterministic local check로 줄였고 fix 이후 통과했다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-vertx:test --tests '*join with no on condition*' --no-configuration-cache --max-workers=1`
 - `./gradlew :bluetape4k-elasticsearch:test --no-configuration-cache --max-workers=1`
@@ -22,6 +26,7 @@ The failing slices were reduced to deterministic local checks and passed after t
 - `./gradlew :bluetape4k-feign:test :bluetape4k-http:test :bluetape4k-retrofit2:test :bluetape4k-vertx:test --parallel --no-configuration-cache`
 - `./gradlew :bluetape4k-elasticsearch:test :bluetape4k-nats:test --max-workers=1 --no-configuration-cache`
 
-## Future Guidance
+## 향후 가이드
 
-When Elasticsearch tests fail with 401 in CI, inspect Testcontainers reuse before changing credentials. For Memgraph, keep the Bolt bind address explicit when changing image tags or command-line flags.
+Elasticsearch test가 CI에서 401로 실패하면 credential을 바꾸기 전에 Testcontainers reuse를 확인한다.
+Memgraph는 image tag나 command-line flag를 변경할 때 Bolt bind address를 explicit하게 유지한다.

--- a/docs/lessons/2026-05-22-issue-596-etcd-server.md
+++ b/docs/lessons/2026-05-22-issue-596-etcd-server.md
@@ -1,36 +1,29 @@
-# Lesson: #596 EtcdServer Testcontainers fixture
+# #596 EtcdServer Testcontainers fixture
 
-## Context
+## 배경
 
-`bluetape4k-leader` #227 needs real etcd integration tests for `leader-etcd`.
-`bluetape4k-testcontainers` already had `ConsulServer` and `ZooKeeperServer`,
-but no reusable etcd launcher.
+`bluetape4k-leader` #227은 `leader-etcd`를 위한 실제 etcd integration test가 필요하다.
+`bluetape4k-testcontainers`에는 이미 `ConsulServer`와 `ZooKeeperServer`가 있었지만 재사용 가능한 etcd
+launcher는 없었다.
 
-## Decision
+## 결정
 
-Add `EtcdServer` as a small `GenericContainer` wrapper in the existing
-`infra` package. Use the official etcd container guide defaults:
-`gcr.io/etcd-development/etcd:v3.6.0`, client port `2379`, peer port `2380`,
-and `/health` readiness.
+기존 `infra` package에 작은 `GenericContainer` wrapper인 `EtcdServer`를 추가한다. Official etcd
+container guide default인 `gcr.io/etcd-development/etcd:v3.6.0`, client port `2379`, peer port `2380`,
+`/health` readiness를 사용한다.
 
-## Outcome
+## 결과
 
-`EtcdServer.Launcher.etcd` now provides a reusable singleton and exports
-`testcontainers.etcd.*` properties. The primary user-facing helper is
-`endpoint`, which is directly usable by jetcd clients.
+`EtcdServer.Launcher.etcd`는 reusable singleton을 제공하고 `testcontainers.etcd.*` property를 export한다.
+Primary user-facing helper는 jetcd client가 직접 사용할 수 있는 `endpoint`다.
 
-## Verification
+## 검증
 
-- PullMD research saved to
-  `~/work/bluetape4k/bluetape4k-wiki/research/2026-05-22-issue-596-etcd-container-pullmd.md`
-  and verified with GNO.
-- `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain`
-  passed.
-- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.infra.EtcdServerTest' --no-daemon --console=plain`
-  passed; rerun with `--no-configuration-cache` after the smoke assertion update.
+- PullMD research를 `~/work/bluetape4k/bluetape4k-wiki/research/2026-05-22-issue-596-etcd-container-pullmd.md`에 저장하고 GNO로 검증.
+- `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-daemon --console=plain` 통과.
+- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.infra.EtcdServerTest' --no-daemon --console=plain` 통과. Smoke assertion update 후 `--no-configuration-cache`로 rerun.
 
-## Future Guidance
+## 향후 가이드
 
-For new infrastructure launchers, add direct endpoint smoke coverage in addition
-to `isRunning`. Use official container docs through PullMD, store the research
-in shared wiki research, and GNO-index it before committing the implementation.
+새 infrastructure launcher에는 `isRunning` 외에 direct endpoint smoke coverage를 추가한다. Official
+container doc은 PullMD로 확인하고, shared wiki research에 저장한 뒤 implementation commit 전에 GNO-index한다.

--- a/docs/lessons/2026-05-22-issue-602-memgraph-driver-close-timeout.md
+++ b/docs/lessons/2026-05-22-issue-602-memgraph-driver-close-timeout.md
@@ -1,37 +1,32 @@
-# Lessons Learned - Issue 602 Memgraph Driver Close Timeout (2026-05-22)
+# 이슈 602 Memgraph Driver Close Timeout 교훈 (2026-05-22)
 
-**Related issue**: #602
-**Affected module**: `:bluetape4k-testcontainers`
+**관련 이슈**: #602
+**영향 module**: `:bluetape4k-testcontainers`
 
-## Context
+## 배경
 
-Full Nightly for the 1.9.0 release candidate repeatedly timed out in
-`MemgraphServerTest` after a successful Bolt query path. The failing stack was
-inside Neo4j Java Driver `Driver.close()`, not container startup.
+1.9.0 release candidate의 full Nightly가 successful Bolt query path 이후 `MemgraphServerTest`에서 반복적으로
+timeout되었다. Failing stack은 container startup이 아니라 Neo4j Java Driver `Driver.close()` 내부였다.
 
-## Decision
+## 결정
 
-Keep the Memgraph image and Neo4j driver versions pinned because the repository
-already uses the current release line at the time of investigation:
-`memgraph/memgraph:3.9.0`, `neo4j-java-driver:6.1.0`, and
-`neo4j-bolt-connection-netty:11.0.2`.
+Repository가 조사 시점 current release line인 `memgraph/memgraph:3.9.0`,
+`neo4j-java-driver:6.1.0`, `neo4j-bolt-connection-netty:11.0.2`를 이미 사용하므로 Memgraph image와
+Neo4j driver version은 pin된 상태로 유지한다.
 
-For Memgraph compatibility tests, constrain the driver to a single connection
-pool/event-loop, disable telemetry and auto-commit retries, and close the driver
-through `closeAsync()` with a bounded timeout. The test's release-gate assertion
-remains the successful Bolt query; cleanup must not hang the nightly runner
-indefinitely.
+Memgraph compatibility test에서는 driver를 single connection pool/event-loop로 제한하고, telemetry와
+auto-commit retry를 disable하며, bounded timeout을 가진 `closeAsync()`로 driver를 닫는다. Test의 release
+gate assertion은 successful Bolt query다. Cleanup이 nightly runner를 무기한 hang시키면 안 된다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.graphdb.MemgraphServerTest --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`
   - Result: `BUILD SUCCESSFUL`, 6 passing.
 - `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.graphdb.*' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`
   - Result: `BUILD SUCCESSFUL`, 27 passing.
 
-## Future Guidance
+## 향후 가이드
 
-When a Testcontainers-backed driver test proves connectivity but hangs during
-client cleanup, inspect the close stack before changing container readiness.
-Prefer bounded cleanup around the affected client in tests over widening global
-timeouts.
+Testcontainers-backed driver test가 connectivity를 증명한 뒤 client cleanup에서 hang되면 container readiness를
+바꾸기 전에 close stack을 확인한다. Global timeout을 넓히기보다 affected client 주변에 bounded cleanup을
+둔다.

--- a/docs/lessons/2026-05-23-bt4k-version-catalog-consumption.md
+++ b/docs/lessons/2026-05-23-bt4k-version-catalog-consumption.md
@@ -1,35 +1,32 @@
 # bt4k Version Catalog Consumption
 
-## Context
+## 배경
 
-`bluetape4k-projects` carried centrally governed versions directly in its local
-catalog. Fory was one example: the approved version already existed in the
-`bluetape4k-dependencies` published catalog, but the projects repository still
-needed a local catalog edit to consume it.
+`bluetape4k-projects`는 centrally governed version을 local catalog에 직접 들고 있었다. Fory가 한 예다.
+Approved version은 이미 `bluetape4k-dependencies` published catalog에 있었지만, projects repository는
+이를 consume하기 위해 여전히 local catalog edit이 필요했다.
 
-## Decision
+## 결정
 
-Import `io.github.bluetape4k:bluetape4k-version-catalog` as the `bt4k` Gradle
-version catalog and use it as the source for centrally governed dependency
-versions. Keep local `libs` aliases for project-local coordinates, but remove
-the direct Fory version from `libs`.
+`io.github.bluetape4k:bluetape4k-version-catalog`를 `bt4k` Gradle version catalog로 import하고,
+centrally governed dependency version의 source로 사용한다. Project-local coordinate에는 local `libs`
+alias를 유지하되, direct Fory version은 `libs`에서 제거한다.
 
-## Outcome
+## 결과
 
-`libs.fory.kotlin` is now versionless. The managed Fory version is supplied by
-dependency management through the `bt4kVersion("fory-kotlin")` catalog lookup,
-so future Fory version changes start in `bluetape4k-dependencies`.
+`libs.fory.kotlin`은 이제 versionless다. Managed Fory version은 `bt4kVersion("fory-kotlin")` catalog
+lookup을 통한 dependency management에서 공급되므로 future Fory version change는
+`bluetape4k-dependencies`에서 시작한다.
 
-## Verification
+## 검증
 
 - `./gradlew help --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-io:dependencyInsight --configuration compileClasspath --dependency org.apache.fory:fory-kotlin --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-io:compileKotlin --no-daemon --no-configuration-cache`
 - `./gradlew compileKotlin --no-daemon --no-configuration-cache`
 
-## Future Guidance
+## 향후 가이드
 
-When a version is governed by `bluetape4k-dependencies`, prefer reading it from
-the `bt4k` catalog instead of editing `bluetape4k-projects` local versions.
-Avoid importing the full `bluetape4k-dependencies` BOM into this repository
-unless the publishing-cycle implications are reviewed.
+Version이 `bluetape4k-dependencies`에서 govern된다면 `bluetape4k-projects` local version edit 대신
+`bt4k` catalog에서 읽는다. Publishing-cycle implication을 검토하기 전에는 이 repository에 전체
+`bluetape4k-dependencies` BOM을 import하지 않는다.

--- a/docs/lessons/2026-05-23-issue-607-608-1-9-1-release.md
+++ b/docs/lessons/2026-05-23-issue-607-608-1-9-1-release.md
@@ -1,32 +1,28 @@
-# Issue 607/608 1.9.1 Release Prep
+# 이슈 607/608 1.9.1 Release Prep
 
-## Context
+## 배경
 
-Milestone 1.9.1 contains a release inclusion issue for `truncateUtf8(maxBytes)`
-and a Fory 0.17.0 runtime compatibility issue. The source changes were already
-present on `develop`, but the release metadata still pointed at 1.9.0.
+Milestone 1.9.1에는 `truncateUtf8(maxBytes)` release inclusion issue와 Fory 0.17.0 runtime
+compatibility issue가 있었다. Source change는 이미 `develop`에 있었지만 release metadata는 여전히
+1.9.0을 가리켰다.
 
-## Decision
+## 결정
 
-Prepare 1.9.1 by bumping `baseVersion`, adding a dedicated 1.9.1 changelog
-section, and verifying the current Fory 0.17.0 API shape before closing the
-milestone issues.
+`baseVersion`을 올리고, 전용 1.9.1 changelog section을 추가하며, milestone issue를 닫기 전에 current
+Fory 0.17.0 API shape을 확인해 1.9.1을 준비한다.
 
-## Outcome
+## 결과
 
-`bluetape4k-core` exposes `io.bluetape4k.support.truncateUtf8(maxBytes)`.
-`ForyBinarySerializer` uses the Fory 0.17-compatible
-`buildThreadSafeForyPool(int)` builder method.
+`bluetape4k-core`는 `io.bluetape4k.support.truncateUtf8(maxBytes)`를 expose한다.
+`ForyBinarySerializer`는 Fory 0.17-compatible `buildThreadSafeForyPool(int)` builder method를 사용한다.
 
-## Verification
+## 검증
 
-- `javap` on `fory-core-0.17.0.jar` confirmed only
-  `buildThreadSafeForyPool(int)` is available.
-- Target test XML aggregate for `:bluetape4k-core:test`, `:bluetape4k-io:test`,
-  and `:bluetape4k-redisson:test`: 2812 tests, 0 failures, 0 errors.
+- `fory-core-0.17.0.jar`에 대한 `javap`로 `buildThreadSafeForyPool(int)`만 available함을 확인.
+- `:bluetape4k-core:test`, `:bluetape4k-io:test`, `:bluetape4k-redisson:test` target test XML aggregate:
+  2812 tests, failure 0, error 0.
 
-## Future Agents
+## 향후 agent 가이드
 
-Before a patch release, check both source readiness and release metadata:
-`gradle.properties`, `CHANGELOG.md`, README version examples, and generated
-artifact/BOM evidence.
+Patch release 전에는 source readiness와 release metadata를 모두 확인한다: `gradle.properties`,
+`CHANGELOG.md`, README version example, generated artifact/BOM evidence.

--- a/docs/lessons/2026-05-23-string-truncate-utf8-support.md
+++ b/docs/lessons/2026-05-23-string-truncate-utf8-support.md
@@ -1,24 +1,23 @@
-# Lesson: Promote byte-safe UTF-8 truncation through bluetape4k-core first
+# Byte-safe UTF-8 truncation은 먼저 bluetape4k-core로 승격
 
-**Date**: 2026-05-23
-**Related**: bluetape4k-leader#270
+**날짜**: 2026-05-23
+**관련**: bluetape4k-leader#270
 
-## Context
+## 배경
 
-`bluetape4k-leader` has an internal `String.truncateUtf8(maxBytes)` helper for
-history error-message truncation. The helper is general-purpose and belongs in
-the shared support package, but downstream repositories cannot safely consume it
-until the public API is present in a published `bluetape4k-core` artifact.
+`bluetape4k-leader`에는 history error-message truncation을 위한 internal
+`String.truncateUtf8(maxBytes)` helper가 있다. 이 helper는 general-purpose이므로 shared support package에
+속한다. 하지만 public API가 published `bluetape4k-core` artifact에 들어가기 전에는 downstream
+repository가 안전하게 consume할 수 없다.
 
-## Decision
+## 결정
 
-Add `io.bluetape4k.support.truncateUtf8(maxBytes)` to `bluetape4k-core` with
-the same byte-boundary contract as the leader-internal implementation. Keep the
-API small: no ellipsis, no grapheme-cluster guarantees, and no nullable receiver
-overload.
+Leader-internal implementation과 같은 byte-boundary contract로
+`io.bluetape4k.support.truncateUtf8(maxBytes)`를 `bluetape4k-core`에 추가한다. API는 작게 유지한다:
+ellipsis 없음, grapheme-cluster guarantee 없음, nullable receiver overload 없음.
 
-## Follow-up
+## 후속
 
-After this API is released in the BOM version consumed by `bluetape4k-leader`,
-the leader repository can remove its internal copy and import the shared support
-function without breaking CI on a missing Maven Central symbol.
+이 API가 `bluetape4k-leader`가 consume하는 BOM version으로 release되면, leader repository는 internal
+copy를 제거하고 Maven Central symbol missing으로 CI를 깨뜨리지 않고 shared support function을 import할
+수 있다.

--- a/docs/lessons/2026-05-24-1-9-2-post-release-development.md
+++ b/docs/lessons/2026-05-24-1-9-2-post-release-development.md
@@ -1,30 +1,28 @@
 # 2026-05-24 1.9.2 Post-Release Development Line
 
-## Context
+## 배경
 
-`bluetape4k-projects` `1.9.1` has been released, but the repository still has
-an active `1.9.2` milestone for the IO HTTP patch lane. A stale PR tried to move
-`develop` directly to `1.10.0`, which would skip the active patch milestone.
+`bluetape4k-projects` `1.9.1`은 release되었지만 repository에는 IO HTTP patch lane을 위한 active
+`1.9.2` milestone이 남아 있었다. Stale PR 하나는 `develop`을 바로 `1.10.0`으로 옮기려 했고, 이는
+active patch milestone을 건너뛰게 된다.
 
-## Decision
+## 결정
 
-Move the committed base version from `1.9.1` to `1.9.2`. Keep
-`snapshotVersion=` empty in `gradle.properties`; SNAPSHOT publishing must pass
-`-PsnapshotVersion=-SNAPSHOT`.
+Committed base version을 `1.9.1`에서 `1.9.2`로 이동한다. `gradle.properties`의 `snapshotVersion=`은
+비워 둔다. SNAPSHOT publishing은 `-PsnapshotVersion=-SNAPSHOT`을 전달해야 한다.
 
-## Outcome
+## 결과
 
-`develop` stays aligned with the active `1.9.2` patch milestone while `1.10.0`
-remains reserved for the Ktor module-family minor line.
+`develop`은 active `1.9.2` patch milestone과 정렬되고, `1.10.0`은 Ktor module-family minor line을 위해
+reserved 상태로 남는다.
 
-## Verification
+## 검증
 
 - `./gradlew properties --no-configuration-cache --no-daemon --quiet`
 - `./gradlew properties -PsnapshotVersion=-SNAPSHOT --no-configuration-cache --no-daemon --quiet`
 - `git diff --check`
 
-## Future Guard
+## 향후 가드
 
-Do not open a new minor development line while an active patch milestone still
-owns the next release unless that patch milestone is explicitly deferred or
-closed.
+Active patch milestone이 다음 release를 소유하고 있다면 그 milestone이 명시적으로 deferred 또는
+closed되기 전에는 새 minor development line을 열지 않는다.

--- a/docs/lessons/2026-05-24-dynamodb-local-server.md
+++ b/docs/lessons/2026-05-24-dynamodb-local-server.md
@@ -1,17 +1,16 @@
 # DynamoDB Local Testcontainers Fixture
 
-Context: `bluetape4k-leader` issue #367 needs a reusable DynamoDB Local
-Testcontainers launcher instead of a private test-only `GenericContainer`.
+배경: `bluetape4k-leader` issue #367은 private test-only `GenericContainer` 대신 reusable DynamoDB Local
+Testcontainers launcher가 필요하다.
 
-Decision: Add `DynamoDbLocalServer` to `bluetape4k-testcontainers` under the
-AWS emulator package. Keep it SDK-neutral, expose AWS-compatible endpoint and
-credential properties, and provide `Launcher.dynamoDb` for singleton reuse.
+결정: AWS emulator package 아래에 `DynamoDbLocalServer`를 `bluetape4k-testcontainers`에 추가한다.
+SDK-neutral하게 유지하고 AWS-compatible endpoint와 credential property를 expose하며 singleton reuse를
+위해 `Launcher.dynamoDb`를 제공한다.
 
-Outcome: Downstream leader tests can remove their private container once they
-consume a catalog version containing this fixture.
+결과: Downstream leader test는 이 fixture를 포함한 catalog version을 consume한 뒤 private container를
+제거할 수 있다.
 
-Verification: `./gradlew :bluetape4k-testcontainers:test --tests
-'io.bluetape4k.testcontainers.aws.DynamoDbLocalServerTest'`.
+검증: `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.aws.DynamoDbLocalServerTest'`.
 
-Future guard: Do not reintroduce DynamoDB Local containers directly in
-downstream test bases; consume `DynamoDbLocalServer.Launcher.dynamoDb` instead.
+향후 가드: Downstream test base에 DynamoDB Local container를 직접 다시 도입하지 말고
+`DynamoDbLocalServer.Launcher.dynamoDb`를 consume한다.

--- a/docs/lessons/2026-05-24-hc5-production-tuning-defaults.md
+++ b/docs/lessons/2026-05-24-hc5-production-tuning-defaults.md
@@ -1,48 +1,47 @@
 # HC5 Production HTTP Client Tuning Defaults
 
-**Date**: 2026-05-24
-**Issue**: #582
-**Branch**: feat/http-client-tuning-defaults-20260524
+**날짜**: 2026-05-24
+**이슈**: #582
+**브랜치**: feat/http-client-tuning-defaults-20260524
 
-## Problem
+## 문제
 
-`bluetape4k-http` exposed only low-level DSL builders for Apache HttpComponents 5 (HC5).
-Callers had to wire connection pool sizing, eviction, keep-alive fallback, retry, and
-request timeouts themselves — getting any one wrong led to connection leaks or silent hangs
-in production.
+`bluetape4k-http`는 Apache HttpComponents 5(HC5)에 대한 low-level DSL builder만 expose했다.
+Caller는 connection pool sizing, eviction, keep-alive fallback, retry, request timeout을 직접 연결해야
+했고, 하나만 잘못 설정해도 production에서 connection leak 또는 silent hang이 발생할 수 있었다.
 
-## Solution
+## 해결
 
-Added named-parameter factory functions with sensible defaults that apply all required
-tuning in one call, while keeping every parameter individually overridable:
+모든 필수 tuning을 한 번에 적용하면서도 각 parameter를 개별 override할 수 있는 named-parameter factory
+function을 추가했다:
 
-| Function | Layer |
+| 함수 | Layer |
 |----------|-------|
-| `productionRequestConfigOf()` | `hc5.http` — timeouts: 5 s pool-wait / 10 s connect / 30 s response |
-| `defaultKeepAliveStrategy()` | `hc5.http` — 60 s fallback when server omits `Keep-Alive` header |
-| `defaultRetryStrategy()` | `hc5.http` — 3 retries, 1 s interval |
-| `productionHttpClientOf()` | `hc5.classic` — eviction + keep-alive + retry + timeouts |
-| `productionVirtualThreadHttpClientOf()` | `hc5.classic` — delegates to productionHttpClientOf |
+| `productionRequestConfigOf()` | `hc5.http` — timeout: 5 s pool-wait / 10 s connect / 30 s response |
+| `defaultKeepAliveStrategy()` | `hc5.http` — server가 `Keep-Alive` header를 생략할 때 60 s fallback |
+| `defaultRetryStrategy()` | `hc5.http` — retry 3회, interval 1 s |
+| `productionHttpClientOf()` | `hc5.classic` — eviction + keep-alive + retry + timeout |
+| `productionVirtualThreadHttpClientOf()` | `hc5.classic` — `productionHttpClientOf`에 위임 |
 | `productionHttpAsyncClientOf()` | `hc5.async` — async equivalent |
 
-## Key HC5 API Facts (verified via javap)
+## HC5 API 확인 사항(javap로 검증)
 
-- `evictExpiredConnections()` and `evictIdleConnections(TimeValue)` are on
-  **`HttpClientBuilder`** and **`HttpAsyncClientBuilder`**, NOT on
-  `PoolingHttpClientConnectionManagerBuilder`.
-- `DefaultConnectionKeepAliveStrategy.getKeepAliveDuration()` returns a **negative** `TimeValue`
-  when the server omits the `Keep-Alive` header — check `duration.duration < 0` for fallback.
-- `PoolingHttpClientConnectionManagerBuilder` in HC5 5.6.1 has **no `setThreadFactory` API**.
-  "VirtualThread" in `productionVirtualThreadHttpClientOf` refers to the calling context only.
+- `evictExpiredConnections()`와 `evictIdleConnections(TimeValue)`는
+  **`HttpClientBuilder`**와 **`HttpAsyncClientBuilder`**에 있으며
+  `PoolingHttpClientConnectionManagerBuilder`에는 없다.
+- `DefaultConnectionKeepAliveStrategy.getKeepAliveDuration()`은 server가 `Keep-Alive` header를 생략하면
+  **negative** `TimeValue`를 반환한다. Fallback에는 `duration.duration < 0`을 확인한다.
+- HC5 5.6.1의 `PoolingHttpClientConnectionManagerBuilder`에는 **`setThreadFactory` API가 없다**.
+  `productionVirtualThreadHttpClientOf`의 "VirtualThread"는 calling context만 의미한다.
 
-## Code Review Findings (Step 6-R)
+## Code review 지적(Step 6-R)
 
-| Severity | Finding | Resolution |
+| 심각도 | 지적 | 해결 |
 |----------|---------|------------|
-| CRITICAL | `productionHttpAsyncClientOf` had zero tests | Added `ProductionHttpAsyncClientTest` (4 tests, all pass) |
-| HIGH | `productionVirtualThreadHttpClientOf` doesn't wire VT internally | KDoc updated to document HC5 5.x limitation |
+| CRITICAL | `productionHttpAsyncClientOf` test가 0개 | `ProductionHttpAsyncClientTest` 추가(4 tests, all pass) |
+| HIGH | `productionVirtualThreadHttpClientOf`가 내부에서 VT를 wiring하지 않음 | HC5 5.x limitation을 KDoc에 문서화 |
 
-## Test Results
+## 테스트 결과
 
 | Test class | Tests | Pass |
 |-----------|-------|------|
@@ -51,12 +50,10 @@ tuning in one call, while keeping every parameter individually overridable:
 | `ProductionHttpAsyncClientTest` | 4 | 4 ✅ |
 | **Total** | **17** | **17** |
 
-## Lessons
+## 교훈
 
-1. **Always verify HC5 API placement with javap before implementing** — eviction is on the
-   *client builder*, not the connection manager builder. Grep of existing code would not
-   have caught this.
-2. **Every new public function needs a test** — the code reviewer caught the missing async
-   test. Add tests before submitting for review.
-3. **"VirtualThread" naming needs careful documentation** — HC5 doesn't expose thread factory
-   APIs; name it to avoid misleading callers.
+1. **HC5 API 위치는 구현 전에 항상 javap로 확인한다.** Eviction은 connection manager builder가 아니라
+   client builder에 있다. 기존 code grep만으로는 잡지 못한다.
+2. **새 public function은 test가 필요하다.** Reviewer가 missing async test를 잡았다. Review 전에 test를 추가한다.
+3. **"VirtualThread" naming은 신중하게 문서화한다.** HC5는 thread factory API를 expose하지 않으므로 caller를
+   오해시키지 않게 이름과 KDoc을 맞춘다.

--- a/docs/lessons/2026-05-24-http-benchmark-cpu-gc-profiling.md
+++ b/docs/lessons/2026-05-24-http-benchmark-cpu-gc-profiling.md
@@ -1,27 +1,26 @@
-# Lesson: CPU/GC Profiling for kotlinx-benchmark JMH Benchmarks
+# kotlinx-benchmark JMH benchmark의 CPU/GC profiling
 
-**Date**: 2026-05-24
-**Issue**: #585 — perf(io-http): add CPU and GC profiling to HTTP client benchmarks
-**Branch**: perf/http-benchmark-profiling-20260524
-
----
-
-## Root Cause / Background
-
-kotlinx-benchmark 0.4.x does not expose JMH's `OptionsBuilder.addProfiler()` through its
-Gradle DSL. The `BenchmarkConfiguration.advanced()` map is parsed at runtime by
-`JvmBenchmarkRunner`, but only the `jvmForks` key is acted upon — all other keys are
-written to a parameters file and silently ignored by the runner.
-
-Therefore, JMH built-in profilers (`gc`, `jfr`, `stack`) cannot be activated through the
-`advanced()` DSL. The correct approach is to configure JVM args on the generated `JavaExec`
-benchmark exec task via `tasks.withType<JavaExec>().configureEach { ... }`.
+**날짜**: 2026-05-24
+**이슈**: #585 — perf(io-http): add CPU and GC profiling to HTTP client benchmarks
+**브랜치**: perf/http-benchmark-profiling-20260524
 
 ---
 
-## Decision
+## 근본 원인 / 배경
 
-Use JVM-level profiling flags injected via Gradle task configuration:
+kotlinx-benchmark 0.4.x는 Gradle DSL을 통해 JMH의 `OptionsBuilder.addProfiler()`를 expose하지 않는다.
+`BenchmarkConfiguration.advanced()` map은 runtime에 `JvmBenchmarkRunner`가 parse하지만 `jvmForks` key만
+실제로 사용한다. 다른 key는 parameters file에 쓰인 뒤 runner에서 조용히 무시된다.
+
+따라서 JMH built-in profiler(`gc`, `jfr`, `stack`)는 `advanced()` DSL로 활성화할 수 없다. 올바른 접근은
+`tasks.withType<JavaExec>().configureEach { ... }`로 generated `JavaExec` benchmark exec task에 JVM args를
+설정하는 것이다.
+
+---
+
+## 결정
+
+Gradle task configuration을 통해 주입한 JVM-level profiling flag를 사용한다:
 
 | Mode | JVM flag |
 |------|----------|
@@ -29,47 +28,47 @@ Use JVM-level profiling flags injected via Gradle task configuration:
 | `jfr` | `-XX:StartFlightRecording=filename=...,dumponexit=true,settings=profile` |
 | `async` | `-agentpath:libasyncProfiler.so=start,event=cpu,file=...,flamegraph` |
 
-Activated by `-PbenchmarkProfile=<gc|jfr|async>` Gradle property.
+Gradle property `-PbenchmarkProfile=<gc|jfr|async>`로 활성화한다.
 
 ---
 
-## Critical Pitfall: kotlinx-benchmark task naming
+## 주요 함정: kotlinx-benchmark task naming
 
-The kotlinx-benchmark plugin generates the benchmark exec task with name:
+kotlinx-benchmark plugin은 benchmark exec task 이름을 다음 방식으로 생성한다:
 
 ```
 "${target.name}${config.capitalizedName()}${BENCHMARK_EXEC_SUFFIX}"
 ```
 
-where:
-- `capitalizedName()` returns `""` when config name is `"main"` (the default)
-- `BENCHMARK_EXEC_SUFFIX = "Benchmark"`
+여기서:
 
-So for `targets { register("test") }` + default `configurations { named("main") }`:
-- **Task name = `"testBenchmark"`** (NOT `"testMainBenchmarkExec"`)
+- `capitalizedName()`은 config name이 default인 `"main"`이면 `""`를 반환한다.
+- `BENCHMARK_EXEC_SUFFIX = "Benchmark"`다.
 
-A filter of `name.endsWith("Exec")` will never match and the profiling block becomes a
-silent no-op. The correct filter is `name.endsWith("Benchmark")` combined with
-`tasks.withType<JavaExec>()` (to exclude lifecycle DefaultTask instances also named
-with "Benchmark").
+따라서 `targets { register("test") }` + default `configurations { named("main") }`에서는
+**task name이 `"testBenchmark"`**다(`"testMainBenchmarkExec"`가 아님).
 
----
-
-## Verification Evidence
-
-- Build script compiles cleanly with and without `-PbenchmarkProfile=gc`
-- `./gradlew :bluetape4k-http:tasks --all` confirms `testBenchmark` is the JavaExec exec task
-- 8 existing smoke tests pass: `HttpClientBenchmarkTest` — 8 tests, 0 failures
+`name.endsWith("Exec")` filter는 절대 match되지 않고 profiling block은 silent no-op이 된다. 올바른 filter는
+`name.endsWith("Benchmark")`와 `tasks.withType<JavaExec>()`의 조합이다. 이렇게 해야 이름에 "Benchmark"가
+들어간 lifecycle `DefaultTask` instance를 제외할 수 있다.
 
 ---
 
-## Future Guidance
+## 검증 증거
 
-- Always verify the actual task name via `./gradlew :module:tasks --all` before writing
-  task name filters in `configureEach { }` blocks.
-- If kotlinx-benchmark adds native profiler support in a future release, migrate to that
-  DSL and remove the `tasks.withType<JavaExec>` workaround.
-- For JFR output: open `build/benchmark-profiling/benchmark.jfr` with JDK Mission Control
-  (`jmc`) or IntelliJ IDEA's JFR viewer.
-- async-profiler requires the native agent library; kotlinx-benchmark runtime auto-detects
-  `libasyncProfiler` in JVM args and sets forks=0 (needed for in-process profiling).
+- Build script는 `-PbenchmarkProfile=gc` 유무 모두에서 clean compile.
+- `./gradlew :bluetape4k-http:tasks --all`로 `testBenchmark`가 JavaExec exec task임을 확인.
+- 기존 smoke test 8개 통과: `HttpClientBenchmarkTest` — 8 tests, failure 0.
+
+---
+
+## 향후 가이드
+
+- `configureEach { }` block에 task name filter를 쓰기 전에 실제 task name을
+  `./gradlew :module:tasks --all`로 항상 확인한다.
+- kotlinx-benchmark가 future release에서 native profiler support를 추가하면 그 DSL로 migration하고
+  `tasks.withType<JavaExec>` workaround를 제거한다.
+- JFR output은 JDK Mission Control(`jmc`) 또는 IntelliJ IDEA JFR viewer로
+  `build/benchmark-profiling/benchmark.jfr`를 연다.
+- async-profiler는 native agent library가 필요하다. kotlinx-benchmark runtime은 JVM args에서
+  `libasyncProfiler`를 auto-detect하고 in-process profiling에 필요한 forks=0을 설정한다.

--- a/docs/lessons/2026-05-24-readme-diagram-geometry-regeneration.md
+++ b/docs/lessons/2026-05-24-readme-diagram-geometry-regeneration.md
@@ -1,40 +1,35 @@
 # 2026-05-24 — README Diagram Geometry Regeneration
 
-## Context
+## 배경
 
-The README diagram assets needed regeneration under the workspace diagram style
-rules. Sequence diagrams also needed explicit geometry cleanup: preserve outer
-canvas/frame margin while reducing internal message-to-arrow gaps.
+README diagram asset은 workspace diagram style rule에 맞춰 regeneration이 필요했다. Sequence diagram은
+outer canvas/frame margin은 유지하면서 internal message-to-arrow gap을 줄이는 explicit geometry cleanup도
+필요했다.
 
-## Decision
+## 결정
 
-Normalize SVG sources first, then regenerate PNGs from those sources. Sequence
-assets now use compact vertical message spacing, 80px body-side margins, centered
-participant headers, and non-collapsed self-call checks. Class/component assets
-remove empty stereotype rows so unlabeled UML headers center their class names.
+먼저 SVG source를 normalize한 뒤 그 source에서 PNG를 regenerate한다. Sequence asset은 compact vertical
+message spacing, 80px body-side margin, centered participant header, non-collapsed self-call check를
+사용한다. Class/component asset은 unlabeled UML header가 class name을 중앙에 둘 수 있도록 empty stereotype
+row를 제거한다.
 
-## Outcome
+## 결과
 
-All `docs/images/readme-diagrams/*.svg` sources were normalized and all matching
-PNG assets were regenerated. README links now embed PNG assets only while SVG
-files remain as editable sources.
+모든 `docs/images/readme-diagrams/*.svg` source를 normalize했고 matching PNG asset을 모두 regenerate했다.
+README link는 PNG asset만 embed하고 SVG file은 editable source로 남긴다.
 
-## Verification
+## 검증
 
-- SVG parse: `xmllint --noout` passed for 415 SVG files.
-- PNG render: `rsvg-convert` regenerated 415 PNG files.
-- Geometry audit: sequence outer margin, sequence label-arrow gap, self-call,
-  participant header baseline, empty stereotype, and marker-only checks all
-  reported zero failures.
-- README image scan: 172 README files, missing links 0, SVG embeds 0, Mermaid
-  residue 0.
-- `git diff --check` passed.
-- Visual QA montage reviewed at
-  `/tmp/bluetape4k-readme-qa/projects-diagrams-20260524.png`.
+- SVG parse: 415개 SVG file에 대해 `xmllint --noout` 통과.
+- PNG render: `rsvg-convert`로 415개 PNG file regenerate.
+- Geometry audit: sequence outer margin, sequence label-arrow gap, self-call, participant header baseline,
+  empty stereotype, marker-only check 모두 failure 0.
+- README image scan: README file 172개, missing link 0, SVG embed 0, Mermaid residue 0.
+- `git diff --check` 통과.
+- `/tmp/bluetape4k-readme-qa/projects-diagrams-20260524.png` visual QA montage review.
 
-## Future Guidance
+## 향후 가이드
 
-When regenerating README diagrams, validate both syntax and geometry. Sequence
-diagrams should have generous outer margins but compact internal message
-spacing; component/class diagrams should not keep empty stereotype rows that
-push class names off center.
+README diagram을 regenerate할 때는 syntax와 geometry를 모두 검증한다. Sequence diagram은 넉넉한 outer
+margin과 compact internal message spacing을 함께 가져야 한다. Component/class diagram은 class name을
+중앙에서 밀어내는 empty stereotype row를 유지하지 않는다.

--- a/docs/lessons/2026-05-25-catalog-ref-2026-05-25-01.md
+++ b/docs/lessons/2026-05-25-catalog-ref-2026-05-25-01.md
@@ -1,49 +1,48 @@
 # Catalog Ref 2026-05-25-01
 
-## Context
+## 배경
 
-The shared `bluetape4k-dependencies` catalog received dependency updates for
-ASM, AWS Kotlin SDK, and Apache Fory.
+공유 `bluetape4k-dependencies` catalog에 ASM, AWS Kotlin SDK, Apache Fory
+의존성 업데이트가 반영됐다.
 
-## Decision
+## 결정
 
-Pin the default `bluetape4kDependenciesCatalogRef` to
-`catalog/2026-05-25-01` instead of floating on `develop`.
+기본 `bluetape4kDependenciesCatalogRef`를 `develop`에 떠 있게 두지 않고
+`catalog/2026-05-25-01`로 고정한다.
 
-## Outcome
+## 결과
 
-Gradle settings now fetch the release-train catalog by default while still
-allowing overrides through `bluetape4kDependenciesCatalogRef` or
-`BLUETAPE4K_DEPENDENCIES_CATALOG_REF`.
+Gradle settings는 기본적으로 release train catalog를 가져오며,
+`bluetape4kDependenciesCatalogRef` 또는 `BLUETAPE4K_DEPENDENCIES_CATALOG_REF`
+override는 계속 허용한다.
 
-The catalog update exposed a Hibernate 7.3.4 test KAPT incompatibility in
-`bluetape4k-hibernate-reactive`: Hibernate's processor validates test
-`@NamedQuery` declarations with a generated ANTLR 4.13 parser, but the KAPT
-worker loaded an older ANTLR runtime first. Test code only needs the static JPA
-metamodel, so `kaptTest` now excludes the Hibernate processor and keeps
-checked-in test metamodel classes for `Author` and `Book`.
+catalog 업데이트는 `bluetape4k-hibernate-reactive`에서 Hibernate 7.3.4 test
+KAPT 비호환성을 드러냈다. Hibernate processor는 생성된 ANTLR 4.13 parser로
+test `@NamedQuery` 선언을 검증하지만, KAPT worker가 더 오래된 ANTLR runtime을
+먼저 로드했다. test code에는 static JPA metamodel만 필요하므로 `kaptTest`는
+이제 Hibernate processor를 제외하고, `Author`와 `Book`에 대해 checked-in test
+metamodel class를 유지한다.
 
-The full Nightly storage-cache job also exposed a Redisson test utility ABI
-issue after Apache Fory moved to 1.0.0. `redisson:4.4.0` still loads its own
-`org.redisson.codec.ForyCodec`, which calls a removed Fory memory helper during
-map serialization. Testcontainers storage tests validate Redis container wiring,
-not Redisson's Fory integration, so the shared Redisson test codec now uses
-`LZ4Codec(Kryo5Codec())`.
+전체 Nightly storage-cache job은 Apache Fory가 1.0.0으로 이동한 뒤 Redisson
+test utility ABI 문제도 노출했다. `redisson:4.4.0`은 여전히 자체
+`org.redisson.codec.ForyCodec`을 로드하고, map serialization 중 제거된 Fory
+memory helper를 호출한다. Testcontainers storage test의 목적은 Redisson의 Fory
+통합이 아니라 Redis container wiring 검증이므로, 공유 Redisson test codec은
+이제 `LZ4Codec(Kryo5Codec())`를 사용한다.
 
-## Verification
+## 검증
 
-- Settings file updated to `catalog/2026-05-25-01`.
+- Settings file이 `catalog/2026-05-25-01`로 업데이트됐다.
 - `./gradlew compileTestKotlin --refresh-dependencies --console=plain -PsnapshotVersion=-SNAPSHOT`
 - `./gradlew :bluetape4k-testcontainers:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.fory --console=plain -PsnapshotVersion=-SNAPSHOT`
 - `./gradlew :bluetape4k-testcontainers:dependencyInsight --configuration testRuntimeClasspath --dependency redisson --console=plain -PsnapshotVersion=-SNAPSHOT`
 - `./gradlew :bluetape4k-testcontainers:test --tests "io.bluetape4k.testcontainers.storage.RedisClusterServerTest" --console=plain -PsnapshotVersion=-SNAPSHOT`
 - `./gradlew :bluetape4k-redisson:test --console=plain -PsnapshotVersion=-SNAPSHOT`
 
-## Future Guard
+## 향후 가드
 
-Use dated catalog tags for coordinated dependency train updates.
-When Hibernate processor upgrades break test KAPT through ANTLR runtime drift,
-prefer removing test processor execution from modules that only need stable
-test metamodel symbols.
-Do not use Redisson's built-in Fory codec for generic Testcontainers smoke
-tests unless the Redisson/Fory ABI is explicitly part of the test objective.
+조율된 dependency train 업데이트에는 날짜가 있는 catalog tag를 사용한다.
+Hibernate processor upgrade가 ANTLR runtime drift로 test KAPT를 깨면, 안정적인
+test metamodel symbol만 필요한 module에서는 test processor 실행 제거를 우선한다.
+Redisson/Fory ABI가 test 목적에 명시적으로 포함되지 않는 한, 일반적인
+Testcontainers smoke test에서 Redisson built-in Fory codec을 사용하지 않는다.

--- a/docs/lessons/2026-05-25-skill-growth-map.md
+++ b/docs/lessons/2026-05-25-skill-growth-map.md
@@ -5,7 +5,7 @@
 
 ---
 
-## Context
+## 배경
 
 최근 merged PR과 lessons/design/benchmark 문서를 기준으로 다음에 더 깊게 익힐 역량을 정리했다.
 
@@ -23,7 +23,7 @@
 
 ---
 
-## Finding
+## 발견
 
 ### 1. JMH/JFR/GC 프로파일링 운영 역량
 
@@ -119,13 +119,13 @@
 
 ---
 
-## Outcome
+## 결과
 
 다음 학습 우선순위는 HTTP 성능 측정과 HC5 운영 계약을 1순위로 두고, 그 다음으로 conformance/cancellation, dependency train, Testcontainers 결정성, benchmark-to-doc decision hygiene을 강화하는 것이다.
 
 ---
 
-## Verification
+## 검증
 
 - 최근 merged PR 목록을 확인했다.
 - 최근 PR들의 GitHub review/comment 객체가 비어 있음을 확인했다.
@@ -133,6 +133,6 @@
 
 ---
 
-## Future Guidance
+## 향후 지침
 
 다음 실행에서는 이 파일과 자동화 메모리를 먼저 읽고, 이미 추천한 6개 축 중 실제 PR/review에서 새로 반복된 축을 상향 조정한다. 새 추천은 반드시 PR, issue, review finding, lesson 문서 중 하나 이상의 구체 근거에 연결한다.

--- a/docs/lessons/2026-05-26-dependencies-catalog-2026-05-26-01.md
+++ b/docs/lessons/2026-05-26-dependencies-catalog-2026-05-26-01.md
@@ -1,21 +1,25 @@
 # Dependencies Catalog 2026-05-26-01
 
-## Context
+## 배경
 
-`bluetape4k-dependencies` published `catalog/2026-05-26-01` with centralized security dependency lines.
+`bluetape4k-dependencies`가 security dependency line을 중앙화한
+`catalog/2026-05-26-01`을 발행했다.
 
-## Decision
+## 결정
 
-Update the downstream default `bluetape4kDependenciesCatalogRef` to the new catalog tag instead of pinning shared external library versions locally.
+공유 external library version을 downstream repository에 직접 고정하지 않고,
+downstream 기본 `bluetape4kDependenciesCatalogRef`를 새 catalog tag로 갱신한다.
 
-## Outcome
+## 결과
 
-The repository now resolves shared dependency versions from `catalog/2026-05-26-01` by default.
+이 repository는 이제 기본적으로 `catalog/2026-05-26-01`에서 공유 dependency
+version을 해석한다.
 
-## Verification
+## 검증
 
-Checked the catalog ref in `settings.gradle.kts`.
+`settings.gradle.kts`의 catalog ref를 확인했다.
 
-## Future Notes
+## 향후 메모
 
-For shared external libraries, update `bluetape4k-dependencies` first, tag the catalog, then move downstream repositories to that tag.
+공유 external library는 먼저 `bluetape4k-dependencies`를 업데이트하고 catalog를
+tag한 다음, downstream repository를 해당 tag로 이동한다.

--- a/docs/lessons/2026-05-26-http-cache-kdoc-language-policy.md
+++ b/docs/lessons/2026-05-26-http-cache-kdoc-language-policy.md
@@ -1,29 +1,29 @@
 # HTTP Cache KDoc Language Policy Cleanup
 
-**Date**: 2026-05-26
-**Issue**: #633
-**Branch**: docs/issue-633-http-cache-kdoc-english
+**날짜**: 2026-05-26
+**이슈**: #633
+**브랜치**: docs/issue-633-http-cache-kdoc-english
 
-## Problem
+## 문제
 
-`CachingHttpClientBuilder.kt` and `CachingHttpAsyncClientBuilder.kt` had newly added English
-KDoc overloads next to older Korean KDoc on the original no-arg cache builder functions.
-This violated the contributor documentation policy that meaningfully edited KDoc should stay
-in English.
+`CachingHttpClientBuilder.kt`와 `CachingHttpAsyncClientBuilder.kt`에는 새로 추가된
+영어 KDoc overload 옆에 기존 no-arg cache builder function의 오래된 한국어 KDoc이
+남아 있었다. 이는 의미 있게 수정한 KDoc은 영어로 유지한다는 당시 contributor
+documentation policy와 충돌했다.
 
-## Solution
+## 해결
 
-Converted the remaining Korean KDoc for the original classic and async HTTP cache builders to
-English, matching the style of the new parameterized overloads.
+original classic/async HTTP cache builder에 남아 있던 한국어 KDoc을 새 parameterized
+overload 스타일에 맞춰 영어로 변환했다.
 
-## Validation
+## 검증
 
-- Confirmed no Korean text remains in the two affected builder files.
-- Ran `./gradlew :bluetape4k-http:compileKotlin`.
+- 영향을 받은 두 builder file에 한국어 문장이 남지 않았음을 확인했다.
+- `./gradlew :bluetape4k-http:compileKotlin`을 실행했다.
 
-## Lessons
+## 교훈
 
-1. When adding overloads with English KDoc, scan adjacent overloads in the same file for older
-   localized KDoc before opening the PR.
-2. Use the real Gradle module path from `./gradlew projects`; source path `io/http` maps to
-   `:bluetape4k-http`, not `:io:http`.
+1. 영어 KDoc이 있는 overload를 추가할 때는 PR을 열기 전에 같은 file의 인접
+   overload에 오래된 localized KDoc이 남아 있는지 확인한다.
+2. 실제 Gradle module path는 `./gradlew projects`에서 확인한다. source path
+   `io/http`는 `:io:http`가 아니라 `:bluetape4k-http`에 매핑된다.

--- a/docs/lessons/2026-05-26-projects-1-9-2-release-prep.md
+++ b/docs/lessons/2026-05-26-projects-1-9-2-release-prep.md
@@ -1,29 +1,29 @@
 # 2026-05-26 projects 1.9.2 release prep
 
-## Context
+## 배경
 
-`bluetape4k-projects` 1.9.2 is the active patch release line for the IO HTTP
-performance and documentation lane. The milestone was complete, but the release
-metadata still needed a dated changelog section before tagging.
+`bluetape4k-projects` 1.9.2는 IO HTTP performance와 documentation lane의 활성
+patch release line이다. milestone은 완료됐지만, tag 전에 release metadata에 날짜가
+있는 changelog section이 필요했다.
 
-## Decision
+## 결정
 
-Prepare release metadata on `release/1.9.2`, keep `baseVersion=1.9.2` and
-`snapshotVersion=` unchanged, and clean release-range trailing whitespace so
-`git diff --check` can be used as a clean preflight gate.
+`release/1.9.2`에서 release metadata를 준비하고, `baseVersion=1.9.2`와
+`snapshotVersion=`은 그대로 둔다. 또한 release range의 trailing whitespace를
+정리해 `git diff --check`를 깨끗한 preflight gate로 사용할 수 있게 한다.
 
-## Outcome
+## 결과
 
-The release prep branch contains only changelog, lesson, and whitespace cleanup
-changes. Stable publication should proceed only after the prep is merged and
-snapshot validation is refreshed for the final `develop` commit.
+release prep branch에는 changelog, lesson, whitespace cleanup 변경만 포함된다.
+stable publication은 prep이 merge되고 최종 `develop` commit에 대한 snapshot
+validation을 갱신한 뒤에만 진행해야 한다.
 
-## Verification
+## 검증
 
 - `git diff --check`
 - `./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache --no-build-cache`
 
-## Future Guard
+## 향후 가드
 
-Do not tag a stable release when the target changelog section is missing or
-when the release range fails `git diff --check`; fix those before publishing.
+대상 changelog section이 없거나 release range가 `git diff --check`에 실패하면
+stable release를 tag하지 않는다. publish 전에 먼저 고친다.

--- a/docs/lessons/2026-05-27-release-catalog-guard.md
+++ b/docs/lessons/2026-05-27-release-catalog-guard.md
@@ -1,29 +1,28 @@
 # Release Catalog Guard
 
-## Context
+## 배경
 
-The AWS 0.3.0 release exposed a shared release workflow risk: an operational
-catalog override can make a stable release use a different
-`bluetape4k-dependencies` catalog than the checked-in `settings.gradle.kts`
-default.
+AWS 0.3.0 release는 공유 release workflow 위험을 드러냈다. operational catalog
+override가 stable release에서 checked-in `settings.gradle.kts` default와 다른
+`bluetape4k-dependencies` catalog를 사용하게 만들 수 있었다.
 
-## Decision
+## 결정
 
-Stable tag releases use the checked-in catalog default. Manual dispatch can use
-an explicit `catalogRef` override, then the repository variable as an
-operational fallback.
+stable tag release는 checked-in catalog default를 사용한다. manual dispatch는 명시적
+`catalogRef` override를 사용할 수 있고, 그 다음 repository variable을 operational
+fallback으로 사용한다.
 
-## Outcome
+## 결과
 
-The release workflow logs the selected catalog source and verifies required
-catalog aliases before Maven Central publish.
+release workflow는 선택된 catalog source를 log로 남기고 Maven Central publish 전에
+필수 catalog alias를 검증한다.
 
-## Verification
+## 검증
 
-Run `actionlint`, validate catalog selection branches locally, and check the
-current release catalog contains the required aliases.
+`actionlint`를 실행하고, catalog selection branch를 local에서 검증하며, 현재 release
+catalog에 필수 alias가 포함되어 있는지 확인한다.
 
-## Future Guidance
+## 향후 지침
 
-Treat repository catalog variables as manual release overrides, not as the
-release train source of truth.
+repository catalog variable은 release train source of truth가 아니라 manual release
+override로 취급한다.

--- a/docs/lessons/2026-05-28-issue-609-ktor-modules.md
+++ b/docs/lessons/2026-05-28-issue-609-ktor-modules.md
@@ -1,35 +1,30 @@
-# Issue 609 - Ktor module adoption and metadata
+# 이슈 609 - Ktor module 채택과 metadata
 
-## Context
+## 배경
 
-The Ktor module family was added in small slices, but the idgenerator Ktor
-example and CI metadata still needed to prove that the modules are usable by a
-real consumer.
+Ktor module family는 작은 slice로 추가됐지만, idgenerator Ktor example과 CI
+metadata는 아직 module이 실제 consumer에서 사용할 수 있음을 증명해야 했다.
 
-## Decision
+## 결정
 
-Migrate `idgenerator-ktor-demo` onto the shared modules before expanding the
-Ktor surface:
+Ktor surface를 확장하기 전에 `idgenerator-ktor-demo`를 공유 module로 먼저
+migration한다.
 
-- Use `bluetape4k-ktor-core` for JSON, standard API errors, and health/readiness.
-- Use `bluetape4k-ktor-observability` for request ID propagation and call
-  logging.
-- Keep application routes explicit so the example remains useful as a consumer
-  reference.
-- Add `ktor/**` to example workflow triggers and run Ktor module tests in CI and
-  Nightly.
+- JSON, standard API error, health/readiness에는 `bluetape4k-ktor-core`를 사용한다.
+- request ID propagation과 call logging에는 `bluetape4k-ktor-observability`를 사용한다.
+- example이 consumer reference로 계속 유용하도록 application route는 명시적으로 유지한다.
+- example workflow trigger에 `ktor/**`를 추가하고 CI와 Nightly에서 Ktor module test를 실행한다.
 
-Release metadata did not need a hand-edited module list because publication and
-BOM constraints are derived from root subprojects while excluding examples and
-demo modules.
+publication과 BOM constraint는 examples와 demo module을 제외한 root subproject에서
+파생되므로, release metadata에는 수동으로 편집한 module list가 필요하지 않았다.
 
-## Outcome
+## 결과
 
-The example now exercises core, observability, and testing helpers together.
-CI and Nightly have explicit Ktor test and coverage artifacts, while the
-examples workflow reruns when shared Ktor modules change.
+example은 이제 core, observability, testing helper를 함께 사용한다. CI와 Nightly에는
+명시적인 Ktor test와 coverage artifact가 있고, shared Ktor module이 바뀌면 examples
+workflow가 다시 실행된다.
 
-## Verification
+## 검증
 
 - `actionlint`
 - `./gradlew :idgenerator-ktor-demo:compileKotlin :idgenerator-ktor-demo:compileTestKotlin`
@@ -38,8 +33,8 @@ examples workflow reruns when shared Ktor modules change.
 - `./gradlew -q projects | rg "bluetape4k-ktor-(core|observability|testing)|idgenerator-ktor-demo"`
 - `git diff --check`
 
-## Future guard
+## 향후 가드
 
-When a shared module is adopted by an example, update both directions: the
-example dependency and the workflow triggers that should rerun the example when
-the shared module changes.
+shared module을 example이 채택할 때는 양방향을 함께 업데이트한다. 즉 example
+dependency와, shared module 변경 시 example을 다시 실행해야 하는 workflow trigger를
+같이 갱신한다.

--- a/docs/lessons/2026-05-28-issue-610-ktor-module-family.md
+++ b/docs/lessons/2026-05-28-issue-610-ktor-module-family.md
@@ -1,34 +1,31 @@
-# Issue #610 Ktor Module Family Design
+# 이슈 #610 Ktor module family design
 
-## Context
+## 배경
 
-Milestone 1.10.0 starts the reusable Ktor module family in `bluetape4k-projects`.
-The first step was design-only work for #610 before scaffolding or
-implementation.
+milestone 1.10.0은 `bluetape4k-projects`의 reusable Ktor module family를 시작한다.
+첫 단계는 scaffold나 implementation 전에 #610의 design-only work를 완료하는 것이었다.
 
-## Decision
+## 결정
 
-Keep the first Ktor module family inside `bluetape4k-projects` and split the
-server foundation into `ktor/core`, `ktor/observability`, and `ktor/testing`.
-Keep `ktor/client`, `ktor/resilience4j`, `ktor/openapi`, and `ktor/auth` in the
-backlog milestone until the server-side extension points are proven.
+첫 Ktor module family는 `bluetape4k-projects` 안에 두고, server foundation을
+`ktor/core`, `ktor/observability`, `ktor/testing`으로 나눈다. server-side extension
+point가 검증될 때까지 `ktor/client`, `ktor/resilience4j`, `ktor/openapi`,
+`ktor/auth`는 backlog milestone에 남겨 둔다.
 
-## Outcome
+## 결과
 
-The design and plan documents define the module boundaries, dependency rules,
-API direction, and PR sequence for #611 through #616.
+design과 plan 문서는 #611부터 #616까지의 module boundary, dependency rule, API
+direction, PR sequence를 정의한다.
 
-## Verification
+## 검증
 
-- GNO checked existing #609-#616 issue context.
-- Existing Ktor examples in sibling bluetape4k repositories were surveyed.
-- Official Ktor docs were checked for plugin installation, `StatusPages`,
-  `ContentNegotiation`, `CallLogging`, `MicrometerMetrics`, and
-  `testApplication` APIs.
+- GNO로 기존 #609-#616 issue context를 확인했다.
+- sibling bluetape4k repository의 기존 Ktor example을 조사했다.
+- official Ktor docs에서 plugin installation, `StatusPages`, `ContentNegotiation`,
+  `CallLogging`, `MicrometerMetrics`, `testApplication` API를 확인했다.
 
-## Future Guard
+## 향후 가드
 
-Do not start Ktor implementation before #610 design has passed review. Keep
-plugin installation explicit and do not promote backlog modules into the first
-slice without reopening the design boundary.
-
+#610 design이 review를 통과하기 전에는 Ktor implementation을 시작하지 않는다. plugin
+installation은 명시적으로 유지하고, design boundary를 다시 열지 않은 채 backlog
+module을 첫 slice로 승격하지 않는다.

--- a/docs/lessons/2026-05-28-issue-611-ktor-module-scaffold.md
+++ b/docs/lessons/2026-05-28-issue-611-ktor-module-scaffold.md
@@ -1,31 +1,29 @@
-# Issue #611 Ktor Module Scaffold
+# 이슈 #611 Ktor module scaffold
 
-## Context
+## 배경
 
-Issue #611 starts the 1.10.0 Ktor module family after #610 defined the
-boundaries. This step should only register modules and keep production APIs for
-#612 through #614.
+#610에서 boundary를 정의한 뒤, issue #611은 1.10.0 Ktor module family를 시작한다.
+이 단계는 module registration만 수행하고 production API는 #612부터 #614까지로 남겨야
+한다.
 
-## Decision
+## 결정
 
-Add `ktor/core`, `ktor/observability`, and `ktor/testing` under the existing
-`includeModules("ktor", withBaseDir = true)` pattern so Gradle project names
-become `bluetape4k-ktor-core`, `bluetape4k-ktor-observability`, and
-`bluetape4k-ktor-testing`.
+기존 `includeModules("ktor", withBaseDir = true)` pattern 아래에 `ktor/core`,
+`ktor/observability`, `ktor/testing`을 추가해 Gradle project name이
+`bluetape4k-ktor-core`, `bluetape4k-ktor-observability`, `bluetape4k-ktor-testing`이
+되게 한다.
 
-## Outcome
+## 결과
 
-The scaffold adds build files, README locale stubs, test resources, and root
-module-list updates. CI/Nightly workflow changes remain assigned to #616.
+scaffold는 build file, README locale stub, test resource, root module-list update를
+추가한다. CI/Nightly workflow 변경은 계속 #616에 배정한다.
 
-## Verification
+## 검증
 
-- `./gradlew projects` must list the three new modules.
-- Targeted compile tasks must prove empty/minimal source sets do not break the
-  build.
+- `./gradlew projects`가 세 새 module을 나열해야 한다.
+- targeted compile task로 empty/minimal source set이 build를 깨지 않음을 증명해야 한다.
 
-## Future Guard
+## 향후 가드
 
-Do not add production Ktor helper APIs in scaffold-only work. Start behavior in
-#612, #613, and #614 after module registration is proven.
-
+scaffold-only work에서는 production Ktor helper API를 추가하지 않는다. module
+registration이 증명된 뒤 #612, #613, #614에서 behavior를 시작한다.

--- a/docs/lessons/2026-05-28-issue-612-ktor-core.md
+++ b/docs/lessons/2026-05-28-issue-612-ktor-core.md
@@ -1,39 +1,39 @@
-# Issue 612 - Ktor core baseline helpers
+# 이슈 612 - Ktor core baseline helper
 
-## Context
+## 배경
 
-Issue #612 implements the first reusable Ktor runtime API after the Ktor module
-family was scaffolded in #611. The idgenerator Ktor example showed repeated
-manual JSON, `StatusPages`, health route, and query parameter validation code.
+issue #612는 #611에서 Ktor module family를 scaffold한 뒤 첫 reusable Ktor runtime
+API를 구현한다. idgenerator Ktor example에는 수동 JSON 설정, `StatusPages`, health
+route, query parameter validation code가 반복되어 있었다.
 
-## Decision
+## 결정
 
-Provide a small explicit Ktor-native core surface:
+작고 명시적인 Ktor-native core surface를 제공한다.
 
-- `installBluetape4kKtorCore()` for opt-in baseline installation.
-- `Bluetape4kKtorJson.defaultJson()` for shared JSON defaults.
-- `ApiErrorResponse`, `HealthResponse`, and health/readiness routes.
-- `StatusPagesConfig.bluetape4kErrorResponses()` with cancellation rethrow.
-- route parameter helpers that throw `IllegalArgumentException` so default
-  status pages map caller input failures to HTTP 400.
+- opt-in baseline installation을 위한 `installBluetape4kKtorCore()`.
+- 공유 JSON default를 위한 `Bluetape4kKtorJson.defaultJson()`.
+- `ApiErrorResponse`, `HealthResponse`, health/readiness route.
+- cancellation을 rethrow하는 `StatusPagesConfig.bluetape4kErrorResponses()`.
+- default status pages가 caller input failure를 HTTP 400으로 매핑하도록
+  `IllegalArgumentException`을 던지는 route parameter helper.
 
-The module exposes Ktor and kotlinx serialization dependencies as `api` because
-the public API mentions `Json`, `StatusPagesConfig`, and Ktor application types.
+public API가 `Json`, `StatusPagesConfig`, Ktor application type을 언급하므로 module은
+Ktor와 kotlinx serialization dependency를 `api`로 노출한다.
 
-## Outcome
+## 결과
 
-The first core API is intentionally framework-light: no Spring Boot
-auto-configuration, no hidden application routes beyond health/readiness, and no
-client helpers. The example migration stays in #615 after the shared API settles.
+첫 core API는 의도적으로 framework-light하게 유지한다. Spring Boot
+auto-configuration은 없고, health/readiness 외의 숨겨진 application route도 없으며,
+client helper도 없다. example migration은 shared API가 안정된 뒤 #615에 남긴다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-ktor-core:compileKotlin :bluetape4k-ktor-core:compileTestKotlin`
 - `./gradlew :bluetape4k-ktor-core:test :bluetape4k-ktor-core:koverXmlReport`
 - Kover XML: line coverage 90/98 (91.8%).
 
-## Future Guard
+## 향후 가드
 
-When adding more Ktor shared helpers, keep the installer explicit and avoid
-installing Ktor plugins that applications commonly customize unless they are
-individually switchable in config.
+Ktor shared helper를 더 추가할 때는 installer를 명시적으로 유지한다. application이
+자주 customize하는 Ktor plugin은 config에서 개별 switch가 가능하지 않다면 설치하지
+않는다.

--- a/docs/lessons/2026-05-28-issue-613-ktor-observability.md
+++ b/docs/lessons/2026-05-28-issue-613-ktor-observability.md
@@ -1,41 +1,39 @@
-# Issue 613 - Ktor observability baseline helpers
+# 이슈 613 - Ktor observability baseline helper
 
-## Context
+## 배경
 
-Issue #613 adds reusable observability helpers after `bluetape4k-ktor-core` was
-merged. The target is production diagnostics without hiding application-owned
-policy such as metric registry, exporter, and tracing backend choices.
+issue #613은 `bluetape4k-ktor-core`가 merge된 뒤 reusable observability helper를
+추가한다. 목표는 metric registry, exporter, tracing backend 선택 같은
+application-owned policy를 숨기지 않으면서 production diagnostics를 제공하는 것이다.
 
-## Decision
+## 결정
 
-Provide explicit Ktor-native helpers:
+명시적인 Ktor-native helper를 제공한다.
 
-- `installBluetape4kKtorObservability()` installs `CallId`, `CallLogging`, and
-  optional `MicrometerMetrics`.
-- `KtorCorrelationId` sanitizes inbound correlation IDs before MDC or response
-  propagation.
-- `prometheusScrapeRoute()` exposes a route only when the application supplies a
-  `PrometheusMeterRegistry`.
+- `installBluetape4kKtorObservability()`는 `CallId`, `CallLogging`, optional
+  `MicrometerMetrics`를 설치한다.
+- `KtorCorrelationId`는 MDC 또는 response propagation 전에 inbound correlation ID를
+  sanitize한다.
+- `prometheusScrapeRoute()`는 application이 `PrometheusMeterRegistry`를 제공할 때만
+  route를 노출한다.
 
-Micrometer core is an API dependency because the installer configuration accepts
-`MeterRegistry`. Prometheus registry stays compile-only for main code and is
-documented as application-owned because only the optional scrape helper requires
-it.
+installer configuration이 `MeterRegistry`를 받으므로 Micrometer core는 API dependency다.
+Prometheus registry는 optional scrape helper에만 필요하므로 main code에서는
+compile-only로 유지하고 application-owned라고 문서화한다.
 
-## Outcome
+## 결과
 
-The module avoids global mutable registries and does not install tracing by
-default. OpenTelemetry policy remains application-owned or a future narrower
-module decision.
+module은 global mutable registry를 피하고 tracing을 default로 설치하지 않는다.
+OpenTelemetry policy는 application-owned로 남기거나, 나중에 더 좁은 module decision으로
+다룬다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-ktor-observability:compileKotlin :bluetape4k-ktor-observability:compileTestKotlin`
 - `./gradlew :bluetape4k-ktor-observability:test :bluetape4k-ktor-observability:koverXmlReport`
 - Kover XML: line coverage 88/92 (95.7%).
 
-## Future Guard
+## 향후 가드
 
-Do not echo caller-supplied correlation headers directly. New observability
-helpers should either sanitize inbound values first or leave propagation to the
-application.
+caller가 제공한 correlation header를 그대로 echo하지 않는다. 새 observability helper는
+inbound value를 먼저 sanitize하거나 propagation을 application에 맡겨야 한다.

--- a/docs/lessons/2026-05-28-issue-614-ktor-testing.md
+++ b/docs/lessons/2026-05-28-issue-614-ktor-testing.md
@@ -1,36 +1,36 @@
-# Issue 614 - Ktor testing helpers
+# 이슈 614 - Ktor testing helper
 
-## Context
+## 배경
 
-`bluetape4k-ktor-core` and `bluetape4k-ktor-observability` introduced reusable
-Ktor server helpers, but tests still repeated JSON decoding, status assertions,
-and standard API error payload checks.
+`bluetape4k-ktor-core`와 `bluetape4k-ktor-observability`가 reusable Ktor server
+helper를 도입했지만, test에는 JSON decoding, status assertion, standard API error
+payload check가 여전히 반복됐다.
 
-## Decision
+## 결정
 
-Add a small `bluetape4k-ktor-testing` API surface:
+작은 `bluetape4k-ktor-testing` API surface를 추가한다.
 
-- `installBluetape4kKtorCoreForTest` keeps Ktor `testApplication` ownership in
-  the test while reducing core setup boilerplate.
-- `bluetape4kJsonClient` uses the same JSON defaults as `bluetape4k-ktor-core`.
-- `decodeJsonBody`, `shouldHaveStatus`, `shouldHaveJsonBody`, and
-  `shouldHaveApiError` centralize response assertions.
-- `bluetape4kJsonMockEngine` covers one-response JSON client tests without
-  adding a larger mocking abstraction.
+- `installBluetape4kKtorCoreForTest`는 Ktor `testApplication` ownership을 test에
+  남기면서 core setup boilerplate를 줄인다.
+- `bluetape4kJsonClient`는 `bluetape4k-ktor-core`와 같은 JSON default를 사용한다.
+- `decodeJsonBody`, `shouldHaveStatus`, `shouldHaveJsonBody`,
+  `shouldHaveApiError`는 response assertion을 중앙화한다.
+- `bluetape4kJsonMockEngine`은 더 큰 mocking abstraction을 추가하지 않고
+  one-response JSON client test를 커버한다.
 
-## Outcome
+## 결과
 
-The idgenerator Ktor example now consumes the shared response helpers instead
-of hand-decoding every response with a local `Json` instance.
+idgenerator Ktor example은 이제 local `Json` instance로 모든 response를 직접 decode하지
+않고 shared response helper를 사용한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-ktor-testing:compileKotlin :bluetape4k-ktor-testing:compileTestKotlin :idgenerator-ktor-demo:compileTestKotlin`
 - `./gradlew :bluetape4k-ktor-testing:test :bluetape4k-ktor-testing:koverXmlReport :idgenerator-ktor-demo:test`
 - `git diff --check`
 
-## Future guard
+## 향후 가드
 
-Keep this module focused on test-scoped helpers. Do not wrap the full Ktor test
-lifecycle unless repeated consumer tests prove a specific lifecycle abstraction
-is worth the loss of explicit setup.
+이 module은 test-scoped helper에 집중한다. 반복되는 consumer test가 특정 lifecycle
+abstraction이 명시적 setup 손실을 감수할 만큼 가치 있음을 증명하기 전에는 full Ktor
+test lifecycle을 감싸지 않는다.

--- a/docs/lessons/2026-05-28-issue-654-vertx-route-cancellation.md
+++ b/docs/lessons/2026-05-28-issue-654-vertx-route-cancellation.md
@@ -1,29 +1,29 @@
-# Issue 654 - Vert.x route coroutine cancellation
+# 이슈 654 - Vert.x route coroutine cancellation 보존
 
-## Context
+## 배경
 
-Vert.x route coroutine helpers caught `Throwable` and passed every failure to
-`RoutingContext.fail(...)`. That converted coroutine cancellation into an HTTP
-route failure instead of preserving structured cancellation.
+Vert.x route coroutine helper는 `Throwable`을 catch하고 모든 failure를
+`RoutingContext.fail(...)`로 넘겼다. 이 동작은 structured cancellation을 보존하지
+않고 coroutine cancellation을 HTTP route failure로 바꾸었다.
 
-## Decision
+## 결정
 
-Catch `CancellationException` before the broad `Throwable` fallback and rethrow
-it from both `suspendHandler` and `suspendFailureHandler`. Keep normal
-exceptions mapped to `ctx.fail(e)`.
+넓은 `Throwable` fallback 전에 `CancellationException`을 catch하고,
+`suspendHandler`와 `suspendFailureHandler` 양쪽에서 다시 던진다. 일반 exception은
+기존처럼 `ctx.fail(e)`로 매핑한다.
 
-## Outcome
+## 결과
 
-Route handlers now preserve coroutine cancellation semantics while retaining the
-existing error path for ordinary exceptions.
+route handler는 이제 일반 exception의 기존 error path를 유지하면서 coroutine
+cancellation semantic을 보존한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-vertx:compileKotlin :bluetape4k-vertx:compileTestKotlin :bluetape4k-vertx:test --tests io.bluetape4k.vertx.web.VertxRouteExtensionsTest`
 - `./gradlew :bluetape4k-vertx:koverXmlReport`
 - `git diff --check`
 
-## Future guard
+## 향후 가드
 
-Do not catch `Throwable` around suspend route handlers without rethrowing
-`CancellationException` first.
+suspend route handler 주변에서 `Throwable`을 catch할 때는 먼저 `CancellationException`을
+rethrow해야 한다.

--- a/docs/lessons/2026-05-28-issue-655-lettuce-suspend-close-cancellation.md
+++ b/docs/lessons/2026-05-28-issue-655-lettuce-suspend-close-cancellation.md
@@ -1,22 +1,31 @@
-# Issue 655: Lettuce suspended loaded-map shutdown cancellation
+# 이슈 655: Lettuce suspended loaded-map shutdown cancellation 보존
 
-## Context
+## 배경
 
-`LettuceSuspendedLoadedMap.suspendClose()` waited for the write-behind job under a shutdown timeout, but the old broad `Exception` catch could hide coroutine cancellation while draining pending writes.
+`LettuceSuspendedLoadedMap.suspendClose()`는 shutdown timeout 안에서 write-behind job을
+기다렸지만, 기존의 넓은 `Exception` catch가 pending write를 drain하는 동안 coroutine
+cancellation을 숨길 수 있었다.
 
-## Decision
+## 결정
 
-Keep caller cancellation observable. Use `withTimeoutOrNull` for the map-owned shutdown timeout so that only the internal drain timeout is downgraded to a warning. Rethrow `CancellationException` before generic failure logging, and keep connection/job cleanup in `NonCancellable`.
+caller cancellation을 관찰 가능하게 유지한다. map-owned shutdown timeout에는
+`withTimeoutOrNull`을 사용해 internal drain timeout만 warning으로 낮춘다. generic
+failure logging 전에 `CancellationException`을 다시 던지고, connection/job cleanup은
+`NonCancellable`에서 유지한다.
 
-## Outcome
+## 결과
 
-`suspendClose()` now distinguishes external cancellation from internal drain timeout. A regression test verifies that caller cancellation returns before `writeBehindShutdownTimeout` when the writer is still blocked.
+`suspendClose()`는 이제 external cancellation과 internal drain timeout을 구분한다.
+regression test는 writer가 아직 blocked 상태일 때 caller cancellation이
+`writeBehindShutdownTimeout`보다 먼저 반환됨을 검증한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-lettuce:test --tests 'io.bluetape4k.redis.lettuce.map.LettuceSuspendedLoadedMapTest.suspendClose - caller cancellation is propagated before internal shutdown timeout'`
 - `./gradlew :bluetape4k-lettuce:test`
 
-## Future Guidance
+## 향후 지침
 
-For suspending cleanup paths, do not catch `Exception` around suspend calls unless `CancellationException` is rethrown first. Prefer `withTimeoutOrNull` when an operation-owned timeout should be handled locally without confusing caller cancellation.
+suspending cleanup path에서는 `CancellationException`을 먼저 rethrow하지 않는 한 suspend
+call 주변에서 `Exception`을 catch하지 않는다. operation-owned timeout을 caller
+cancellation과 혼동하지 않고 local에서 처리해야 할 때는 `withTimeoutOrNull`을 우선한다.

--- a/docs/lessons/2026-05-28-issue-656-657-grpc-interrupt-lifecycle.md
+++ b/docs/lessons/2026-05-28-issue-656-657-grpc-interrupt-lifecycle.md
@@ -1,35 +1,34 @@
-# Issues 656 and 657 - gRPC shutdown interruption
+# 이슈 656과 657 - gRPC shutdown interruption 보존
 
-## Context
+## 배경
 
-The port-based and in-process gRPC server base classes used
-`runCatching { awaitTermination(...) }.getOrDefault(false)` during shutdown.
-That preserved forced shutdown on timeout, but it also collapsed
-`InterruptedException` into a normal timeout and lost the caller thread's
-interrupt status.
+port-based와 in-process gRPC server base class는 shutdown 중
+`runCatching { awaitTermination(...) }.getOrDefault(false)`를 사용했다. timeout 시
+forced shutdown은 보존됐지만, `InterruptedException`이 일반 timeout으로 접히면서
+caller thread의 interrupt status가 사라졌다.
 
-## Decision
+## 결정
 
-Use explicit `try/catch` around timed `awaitTermination` in both server base
-classes. On `InterruptedException`, restore the interrupt flag with
-`Thread.currentThread().interrupt()` and return `false` so `shutdownNow()` still
-runs. When graceful termination times out without interruption, force shutdown
-and wait once more with the same bounded timeout.
+두 server base class 모두 timed `awaitTermination` 주변에 명시적인 `try/catch`를
+사용한다. `InterruptedException`에서는 `Thread.currentThread().interrupt()`로 interrupt
+flag를 복원하고 `false`를 반환해 `shutdownNow()`가 계속 실행되게 한다. graceful
+termination이 interruption 없이 timeout되면 force shutdown 후 같은 bounded timeout으로
+한 번 더 기다린다.
 
-## Outcome
+## 결과
 
-Both shutdown implementations now keep the existing timeout behavior and
-preserve interrupt status when graceful termination is interrupted. Forced
-shutdown now also gets a bounded termination wait instead of being fire-and-forget.
+두 shutdown implementation은 이제 기존 timeout behavior를 유지하면서 graceful
+termination이 interrupted될 때 interrupt status를 보존한다. forced shutdown도
+일방 실행이 아니라 bounded termination wait를 갖는다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-grpc:compileKotlin :bluetape4k-grpc:compileTestKotlin :bluetape4k-grpc:test --tests io.bluetape4k.grpc.GrpcServerTest`
 - `./gradlew :bluetape4k-grpc:koverXmlReport`
 - `git diff --check`
 
-## Future guard
+## 향후 가드
 
-Do not use broad `runCatching` around blocking lifecycle APIs that can throw
-`InterruptedException`. Preserve or propagate interruption explicitly before
-falling back to cleanup.
+`InterruptedException`을 던질 수 있는 blocking lifecycle API 주변에서 넓은
+`runCatching`을 사용하지 않는다. cleanup fallback으로 가기 전에 interruption을
+명시적으로 보존하거나 전파한다.

--- a/docs/lessons/2026-05-29-issue-643-ktor-client-boundary.md
+++ b/docs/lessons/2026-05-29-issue-643-ktor-client-boundary.md
@@ -1,30 +1,36 @@
-# Issue 643 Ktor Client Boundary
+# 이슈 643 Ktor client boundary
 
-## Context
+## 배경
 
-Issue #643 asked whether `bluetape4k-projects` should introduce a dedicated `bluetape4k-ktor-client` module or keep Ktor client support in an existing module.
+issue #643은 `bluetape4k-projects`가 전용 `bluetape4k-ktor-client` module을 도입할지,
+아니면 기존 module 안에 Ktor client support를 유지할지 결정해야 했다.
 
-## Decision
+## 결정
 
-Keep Ktor client ownership in `bluetape4k-http`. Add only thin helpers for explicit-engine client creation, Kotlinx JSON content negotiation, and timeout defaults.
+Ktor client ownership은 `bluetape4k-http`에 유지한다. explicit-engine client creation,
+Kotlinx JSON content negotiation, timeout default를 위한 얇은 helper만 추가한다.
 
-Avoid a separate Ktor client module until there is a broader API surface that cannot fit the HTTP module without dependency or ownership confusion.
+dependency나 ownership 혼동 없이 HTTP module에 둘 수 없는 더 넓은 API surface가 생길
+때까지 별도 Ktor client module은 피한다.
 
-## Outcome
+## 결과
 
-`KtorHttpClientSupport` now exposes:
+`KtorHttpClientSupport`는 이제 다음을 노출한다.
 
 - `defaultKtorClientJson`
 - `KtorClientTimeouts`
 - `ktorJsonHttpClientOf`
 - `ktorCioJsonHttpClientOf`
 
-The README locale set documents that retry, resilience, authentication, logging, and service-specific plugins remain application-level concerns or belong in existing dedicated modules.
+README locale set은 retry, resilience, authentication, logging, service-specific
+plugin이 application-level concern으로 남거나 기존 dedicated module에 속한다고
+문서화한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-http:test --tests 'io.bluetape4k.http.ktor.KtorHttpClientSupportTest' --no-configuration-cache`
 
-## Future Guard
+## 향후 가드
 
-When adding Ktor client helpers, require a clear cross-application pattern first. Prefer explicit engine selection and narrow plugin installation over a broad facade.
+Ktor client helper를 추가할 때는 명확한 cross-application pattern을 먼저 요구한다. 넓은
+facade보다 explicit engine selection과 좁은 plugin installation을 우선한다.

--- a/docs/lessons/2026-05-29-issue-644-ktor-resilience4j.md
+++ b/docs/lessons/2026-05-29-issue-644-ktor-resilience4j.md
@@ -1,28 +1,33 @@
-# Issue 644 Ktor Resilience4j
+# 이슈 644 Ktor Resilience4j 통합
 
-## Context
+## 배경
 
-Issue #644 followed the Ktor module family epic and asked for optional Resilience4j integration after the first server-side Ktor extension points were proven.
+issue #644는 Ktor module family epic의 후속으로, 첫 server-side Ktor extension point가
+검증된 뒤 optional Resilience4j integration을 요청했다.
 
-## Decision
+## 결정
 
-Add `bluetape4k-ktor-resilience4j` as a thin route-scoped module. Reuse the existing `bluetape4k-resilience4j` coroutine facade and keep policy objects caller-owned.
+`bluetape4k-ktor-resilience4j`를 얇은 route-scoped module로 추가한다. 기존
+`bluetape4k-resilience4j` coroutine facade를 재사용하고 policy object는 caller-owned로
+유지한다.
 
-## Outcome
+## 결과
 
-The module now provides:
+module은 이제 다음을 제공한다.
 
 - `KtorResiliencePolicies`
 - `withKtorResilience`
 - `resilientRoute`, `resilientGet`, `resilientPost`
 - `bluetape4kResilienceErrors`
 
-Status mappings are generic: open circuit -> 503, rate limited -> 429, timeout -> 504. Cancellation is rethrown and not counted as a circuit breaker failure.
+status mapping은 generic하게 둔다. open circuit은 503, rate limited는 429, timeout은
+504다. cancellation은 rethrow하며 circuit breaker failure로 집계하지 않는다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-ktor-resilience4j:test --no-configuration-cache`
 
-## Future Guard
+## 향후 가드
 
-Keep this module route/block scoped. Do not add global Ktor plugins, registry creation, auth, tracing, or OpenAPI behavior here.
+이 module은 route/block scope로 유지한다. 여기에 global Ktor plugin, registry creation,
+auth, tracing, OpenAPI behavior를 추가하지 않는다.

--- a/docs/lessons/2026-05-29-issue-645-ktor-openapi.md
+++ b/docs/lessons/2026-05-29-issue-645-ktor-openapi.md
@@ -1,27 +1,26 @@
-# Issue 645 Ktor OpenAPI
+# 이슈 645 Ktor OpenAPI 지원
 
-## Context
+## 배경
 
-Ktor OpenAPI support was a backlog follow-up after the core, testing,
-observability, client, and resilience slices.
+Ktor OpenAPI support는 core, testing, observability, client, resilience slice 이후의
+backlog follow-up이었다.
 
-## Decision
+## 결정
 
-Use Ktor's official OpenAPI and Swagger UI plugins through a small
-`bluetape4k-ktor-openapi` module. Add only Ktor version-governed aliases and
-avoid Swagger Codegen because this module does not own custom renderer
-generation.
+작은 `bluetape4k-ktor-openapi` module을 통해 Ktor official OpenAPI와 Swagger UI
+plugin을 사용한다. 이 module은 custom renderer generation을 소유하지 않으므로 Ktor
+version-governed alias만 추가하고 Swagger Codegen은 피한다.
 
-## Outcome
+## 결과
 
-Applications get explicit `bluetape4kOpenApi()` and `bluetape4kSwaggerUi()`
-route helpers while keeping specs and route metadata application-owned.
+application은 spec과 route metadata를 application-owned로 유지하면서 명시적인
+`bluetape4kOpenApi()`와 `bluetape4kSwaggerUi()` route helper를 얻는다.
 
-## Verification
+## 검증
 
-Run module compile/test/Kover, workflow lint, and diff hygiene before merging.
+merge 전에 module compile/test/Kover, workflow lint, diff hygiene를 실행한다.
 
-## Future Guidance
+## 향후 지침
 
-Do not add generated route behavior here. If Ktor runtime annotation APIs change,
-adjust documentation and wrappers only where the official API remains stable.
+여기에 generated route behavior를 추가하지 않는다. Ktor runtime annotation API가 바뀌면
+official API가 안정적으로 남아 있는 곳에서만 documentation과 wrapper를 조정한다.

--- a/docs/lessons/2026-05-29-issue-649-protobuf-codec-allocation.md
+++ b/docs/lessons/2026-05-29-issue-649-protobuf-codec-allocation.md
@@ -1,29 +1,27 @@
-# Issue 649 Protobuf Codec Allocation
+# 이슈 649 Protobuf codec allocation 감소
 
-## Context
+## 배경
 
-The Redisson protobuf encoder had a removable allocation: protobuf `Any` was
-serialized to `ByteArray` and then wrapped as a Netty buffer.
+Redisson protobuf encoder에는 제거 가능한 allocation이 있었다. protobuf `Any`를
+`ByteArray`로 serialize한 뒤 Netty buffer로 감쌌다.
 
-## Decision
+## 결정
 
-Use `Any.serializedSize` plus `CodedOutputStream` over a Netty buffer's
-`ByteBuffer` view for the Redisson fast path.
-Keep `ProtobufSerializer` unchanged because its public contract returns
-`ByteArray`.
+Redisson fast path에는 Netty buffer의 `ByteBuffer` view 위에서 `Any.serializedSize`와
+`CodedOutputStream`을 사용한다. public contract가 `ByteArray`를 반환하므로
+`ProtobufSerializer`는 변경하지 않는다.
 
-## Verification
+## 검증
 
-Targeted protobuf codec tests passed. A short local benchmark sample from
-`:protobuf-codec-benchmark:benchmarkBenchmark` showed `redissonProtobufEncode`
-at 3,936,257 ops/s versus the old `toByteArray()`/`wrappedBuffer()` baseline at
-4,056,681 ops/s, within the short-run error interval. Decode and fallback
-benchmarks ran in the same module without weakening the protobuf allowlist.
+targeted protobuf codec test가 통과했다. `:protobuf-codec-benchmark:benchmarkBenchmark`의
+짧은 local benchmark sample은 `redissonProtobufEncode`가 3,936,257 ops/s이고 기존
+`toByteArray()`/`wrappedBuffer()` baseline이 4,056,681 ops/s로 short-run error interval
+안에 있음을 보였다. decode와 fallback benchmark도 protobuf allowlist를 약화하지 않은
+상태로 같은 module에서 실행됐다.
 
-## Future Guidance
+## 향후 지침
 
-Only optimize encode paths where the owning API returns a buffer or stream. Put
-benchmark harnesses under `benchmark/*-benchmark`, not production modules. Do
-not weaken protobuf decode allowlists for benchmark wins. Keep the old encode
-baseline in benchmark code so future allocation profilers can compare both
-paths directly.
+owning API가 buffer나 stream을 반환하는 encode path만 최적화한다. benchmark harness는
+production module이 아니라 `benchmark/*-benchmark` 아래에 둔다. benchmark 성과를 위해
+protobuf decode allowlist를 약화하지 않는다. future allocation profiler가 두 path를
+직접 비교할 수 있도록 기존 encode baseline은 benchmark code에 유지한다.

--- a/docs/lessons/2026-05-29-issue-651-csv-okio-segments.md
+++ b/docs/lessons/2026-05-29-issue-651-csv-okio-segments.md
@@ -1,39 +1,38 @@
-# Issue 651 CSV Okio Segments
+# 이슈 651 CSV Okio segment 활용
 
-## Context
+## 배경
 
-Issue #651 targeted lower allocation and better throughput for large CSV parsing.
-The existing `CsvLexer` decodes through a `Reader` and appends characters into a
-`StringBuilder` per field.
+issue #651은 large CSV parsing의 allocation을 줄이고 throughput을 높이는 것을 목표로
+했다. 기존 `CsvLexer`는 `Reader`를 통해 decode하고 field마다 `StringBuilder`에 문자를
+append했다.
 
-## Decision
+## 결정
 
-Use an internal UTF-8 fast path backed by Okio for supported CSV settings:
-single-byte ASCII delimiter and quote characters with doubled-quote escaping.
-The public `CsvRecordReader` API remains unchanged and falls back to the
-existing reader-based lexer for unsupported charsets or settings.
+지원되는 CSV setting에는 Okio 기반 internal UTF-8 fast path를 사용한다. 조건은
+single-byte ASCII delimiter와 quote character, doubled-quote escaping이다. public
+`CsvRecordReader` API는 변경하지 않고, 지원하지 않는 charset이나 setting에서는 기존
+reader-based lexer로 fallback한다.
 
-Okio `Buffer.UnsafeCursor` is used only for read-only structural-byte scanning
-inside the buffered source. Field bytes are moved between Okio buffers and
-decoded once at field completion.
+Okio `Buffer.UnsafeCursor`는 buffered source 안에서 read-only structural-byte scan에만
+사용한다. field byte는 Okio buffer 사이에서 이동하고 field completion 시 한 번만
+decode한다.
 
-## Outcome
+## 결과
 
-The cursor-backed implementation preserved existing CSV behavior and improved
-throughput for the benchmarked public reader path:
+cursor-backed implementation은 기존 CSV behavior를 보존하면서 benchmark 대상 public
+reader path의 throughput을 개선했다.
 
 - small: 20,173.731 -> 45,417.110 ops/s
 - medium: 296.944 -> 683.434 ops/s
 - large: 17.312 -> 40.115 ops/s
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-csv:test`
 - `./gradlew :bluetape4k-csv:testBenchmark`
 
-## Future Guidance
+## 향후 지침
 
-When using Okio `UnsafeCursor`, lock behavior with fixture equivalence tests
-before optimizing. A naive byte loop was correct but only modestly faster; a
-read-only cursor scan gave the useful performance gain while keeping memory
-bounded by draining scanned buffer segments.
+Okio `UnsafeCursor`를 사용할 때는 최적화 전에 fixture equivalence test로 behavior를
+고정한다. naive byte loop는 정확했지만 성능 향상이 작았다. read-only cursor scan은
+scanned buffer segment를 drain해 memory를 제한하면서 유의미한 성능 향상을 제공했다.

--- a/docs/lessons/2026-05-29-issue-652-r2dbc-pool-guidance.md
+++ b/docs/lessons/2026-05-29-issue-652-r2dbc-pool-guidance.md
@@ -1,24 +1,24 @@
-# Issue 652 R2DBC Pool Guidance
+# 이슈 652 R2DBC pool guidance
 
-## Context
+## 배경
 
-R2DBC pool benchmark scores can be misleading when bounded pending acquire makes
-overload fail quickly. A high JMH operation score can represent rejected acquire
-attempts rather than successful SQL work.
+bounded pending acquire 때문에 overload가 빠르게 실패하면 R2DBC pool benchmark score가
+오해를 줄 수 있다. 높은 JMH operation score는 성공한 SQL work가 아니라 거절된 acquire
+attempt를 의미할 수 있다.
 
-## Decision
+## 결정
 
-Report acquired and failed counts beside throughput for pool contention
-benchmarks. Keep production defaults unchanged unless benchmark evidence and
-compatibility review justify a runtime contract change.
+pool contention benchmark에서는 throughput 옆에 acquired count와 failed count를 함께
+보고한다. benchmark evidence와 compatibility review가 runtime contract 변경을
+정당화하지 않는 한 production default는 변경하지 않는다.
 
-## Outcome
+## 결과
 
-H2, PostgreSQL, and MySQL acquire benchmarks completed sequentially. H2
-contention now compares default and high-throughput profiles and makes bounded
-queue overload visible through failure counts.
+H2, PostgreSQL, MySQL acquire benchmark는 순차적으로 완료됐다. H2 contention은 이제
+default profile과 high-throughput profile을 비교하고, bounded queue overload를 failure
+count로 보이게 한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-r2dbc:compileBenchmarkKotlin --no-configuration-cache`
 - `./gradlew :bluetape4k-r2dbc:benchmarkH2PoolContention --no-configuration-cache --quiet`
@@ -27,8 +27,8 @@ queue overload visible through failure counts.
 - `./gradlew :bluetape4k-r2dbc:benchmarkPostgresPoolAcquire --no-configuration-cache --quiet`
 - `./gradlew :bluetape4k-r2dbc:benchmarkMysql8PoolAcquire --no-configuration-cache --quiet`
 
-## Future Guidance
+## 향후 지침
 
-Run Testcontainers-backed R2DBC benchmarks sequentially. When a benchmark has
-bounded pending acquire, publish success/failure counts with the JMH score so
-readers do not treat fast rejection as completed database throughput.
+Testcontainers-backed R2DBC benchmark는 순차 실행한다. benchmark가 bounded pending
+acquire를 가진다면 reader가 빠른 reject를 완료된 database throughput으로 해석하지
+않도록 JMH score와 함께 success/failure count를 publish한다.

--- a/docs/lessons/2026-05-29-issue-660-spring-boot3-doc-retirement.md
+++ b/docs/lessons/2026-05-29-issue-660-spring-boot3-doc-retirement.md
@@ -1,33 +1,33 @@
-# Issue 660: Spring Boot 3 Documentation Retirement
+# 이슈 660: Spring Boot 3 documentation retirement
 
-## Context
+## 배경
 
-The repository now presents Spring Boot 4.x as the only current support line.
-Searches still surfaced Spring Boot 3 references in historical plans, specs,
-security reviews, and changelog entries.
+repository는 이제 Spring Boot 4.x를 유일한 current support line으로 제시한다. 하지만
+search에서는 historical plan, spec, security review, changelog entry의 Spring Boot 3
+reference가 여전히 노출됐다.
 
-## Decision
+## 결정
 
-Keep historical evidence intact, but make the active support boundary explicit
-in current-facing README files and archive entrypoints.
+historical evidence는 그대로 보존하되, current-facing README file과 archive entrypoint에
+active support boundary를 명시한다.
 
-## Outcome
+## 결과
 
-- Root `README.md` and `README.ko.md` now state Spring Boot 4.x only.
-- `docs/superpowers/README.md` marks specs, plans, and research notes as
-  historical internal artifacts.
-- `docs/security-review/README.md` marks security review files as point-in-time
-  evidence.
+- root `README.md`와 `README.ko.md`는 이제 Spring Boot 4.x only를 명시한다.
+- `docs/superpowers/README.md`는 spec, plan, research note를 historical internal
+  artifact로 표시한다.
+- `docs/security-review/README.md`는 security review file을 point-in-time evidence로
+  표시한다.
 
-## Verification
+## 검증
 
-- Confirmed root README files already used Spring Boot 4.x and added the
-  retired-line clarification in both languages.
-- Confirmed repo-local `AGENTS.md` already states Spring Boot 4.x modules and
-  no active `spring-boot3/*` line.
+- root README file이 이미 Spring Boot 4.x를 사용하고 있음을 확인하고, 두 언어 모두에
+  retired-line clarification을 추가했다.
+- repo-local `AGENTS.md`가 이미 Spring Boot 4.x module과 active `spring-boot3/*` line이
+  없음을 명시하고 있음을 확인했다.
 
-## Future Guidance
+## 향후 지침
 
-Do not rewrite historical Spring Boot 3 references unless the file is being
-republished as current-facing documentation. Prefer a local archive note or
-directory-level context over broad regex replacement.
+파일이 current-facing documentation으로 다시 publish되는 경우가 아니라면 historical
+Spring Boot 3 reference를 rewrite하지 않는다. broad regex replacement보다 local archive
+note 또는 directory-level context를 우선한다.

--- a/docs/lessons/2026-05-29-issue-661-benchmark-report-template.md
+++ b/docs/lessons/2026-05-29-issue-661-benchmark-report-template.md
@@ -1,30 +1,29 @@
-# Issue 661: Benchmark Report Template
+# 이슈 661: Benchmark report template
 
-## Context
+## 배경
 
-Benchmark evidence was split across `docs/benchmarks`, module-local
-`Benchmark.md` files, issue comments, and README charts.
+benchmark evidence가 `docs/benchmarks`, module-local `Benchmark.md` file, issue
+comment, README chart에 나뉘어 있었다.
 
-## Decision
+## 결정
 
-Use `docs/benchmarks/README.md` as the durable benchmark report index and
-template. Reports should name scope, commands, environment, raw artifacts,
-summary tables, chart artifacts, interpretation, and follow-up links.
+`docs/benchmarks/README.md`를 durable benchmark report index와 template으로 사용한다.
+report에는 scope, command, environment, raw artifact, summary table, chart artifact,
+interpretation, follow-up link를 명시해야 한다.
 
-## Outcome
+## 결과
 
-- Added a benchmark report index and standard report shape.
-- Marked existing benchmark reports with raw/chart artifact availability.
-- Kept module-local benchmark documents lightweight; durable issue evidence
-  belongs in `docs/benchmarks`.
+- benchmark report index와 standard report shape를 추가했다.
+- 기존 benchmark report에 raw/chart artifact availability를 표시했다.
+- module-local benchmark document는 가볍게 유지한다. durable issue evidence는
+  `docs/benchmarks`에 둔다.
 
-## Verification
+## 검증
 
-- Markdown-only change reviewed with `git diff --check`.
-- Existing artifact links in `docs/benchmarks/README.md` were checked for file
-  presence.
+- markdown-only change를 `git diff --check`로 검토했다.
+- `docs/benchmarks/README.md`의 기존 artifact link가 file presence를 갖는지 확인했다.
 
-## Future Guidance
+## 향후 지침
 
-New performance PRs should link their issue comment to a `docs/benchmarks`
-report when the result changes public guidance, defaults, or README charts.
+새 performance PR의 결과가 public guidance, default, README chart를 바꾼다면 issue
+comment를 `docs/benchmarks` report에 연결해야 한다.

--- a/docs/lessons/2026-05-29-issue-662-module-documentation-checklist.md
+++ b/docs/lessons/2026-05-29-issue-662-module-documentation-checklist.md
@@ -1,32 +1,31 @@
-# Issue 662: Module Documentation Drift Checklist
+# 이슈 662: Module documentation drift checklist
 
-## Context
+## 배경
 
-Module lifecycle changes can drift across Gradle registration, README locale
-pairs, CI filters, Nightly/examples workflows, BOM/catalog publication, and
-agent references.
+module lifecycle 변경은 Gradle registration, README locale pair, CI filter,
+Nightly/examples workflow, BOM/catalog publication, agent reference 사이에서 drift될 수
+있다.
 
-## Decision
+## 결정
 
-Create a contributor-facing checklist under `docs/process/` and link it from the
-module group reference. Keep detailed process guidance out of transient agent
-instructions only.
+`docs/process/` 아래에 contributor-facing checklist를 만들고 module group reference에서
+연결한다. 상세 process guidance는 transient agent instruction에만 두지 않는다.
 
-## Outcome
+## 결과
 
-- Added `docs/process/module-documentation-checklist.md`.
-- Linked the checklist from `.codex/references/module-groups.md`.
-- Updated the module group reference to the current Spring Boot 4.x-only
-  `spring-boot/` group and marked old Spring Boot paths as historical.
+- `docs/process/module-documentation-checklist.md`를 추가했다.
+- `.codex/references/module-groups.md`에서 checklist를 연결했다.
+- module group reference를 현재 Spring Boot 4.x-only `spring-boot/` group으로
+  업데이트하고, 오래된 Spring Boot path를 historical로 표시했다.
 
-## Verification
+## 검증
 
-- Checked Markdown whitespace with `git diff --check`.
-- Verified the checklist link target exists.
-- Verified current Spring Boot group wording no longer lists active
-  `spring-boot3/*` or `spring-boot4/*` groups.
+- markdown whitespace를 `git diff --check`로 확인했다.
+- checklist link target이 존재함을 확인했다.
+- 현재 Spring Boot group wording이 더 이상 active `spring-boot3/*` 또는
+  `spring-boot4/*` group을 나열하지 않음을 확인했다.
 
-## Future Guidance
+## 향후 지침
 
-Every module add, rename, move, removal, split, or repository promotion should
-include checklist evidence in the PR body.
+모든 module 추가, 이름 변경, 이동, 제거, 분할, repository promotion은 PR body에
+checklist evidence를 포함해야 한다.

--- a/docs/lessons/2026-05-29-issue-667-web-framework-benchmark.md
+++ b/docs/lessons/2026-05-29-issue-667-web-framework-benchmark.md
@@ -1,31 +1,31 @@
 # Lesson: Web Framework Benchmark Baseline
 
-**Date**: 2026-05-29
-**Issue**: #667
+**날짜**: 2026-05-29
+**이슈**: #667
 
-## Context
+## 배경
 
-The Ktor module family needed current evidence before broad API work in #609.
+Ktor module family는 #609의 넓은 API work 전에 최신 evidence가 필요했다.
 
-## Decision
+## 결정
 
-Add a non-published `benchmark/web-framework-benchmark` module using
-`kotlinx-benchmark`. Keep equivalent Ktor CIO and Spring WebFlux benchmark
-applications inside the benchmark module, not production modules.
+`kotlinx-benchmark`를 사용하는 non-published `benchmark/web-framework-benchmark`
+module을 추가한다. 동등한 Ktor CIO와 Spring WebFlux benchmark application은 production
+module이 아니라 benchmark module 안에 둔다.
 
-## Outcome
+## 결과
 
-The benchmark now covers startup, throughput, and average latency for equivalent
-health, single-ID, batch-ID, and bad-request paths.
+benchmark는 이제 동등한 health, single-ID, batch-ID, bad-request path에 대한 startup,
+throughput, average latency를 다룬다.
 
-## Verification
+## 검증
 
 - `./gradlew :web-framework-benchmark:compileBenchmarkKotlin --no-configuration-cache`
 - `./gradlew :web-framework-benchmark:benchmarkStartupBenchmark --no-configuration-cache`
 - `./gradlew :web-framework-benchmark:benchmarkThroughputBenchmark :web-framework-benchmark:benchmarkLatencyBenchmark --no-configuration-cache`
 
-## Future Guard
+## 향후 가드
 
-Use `server.port=0` and read actual bound ports from the framework runtime.
-Preselecting a local port with `ServerSocket(0)` can race during repeated JMH
-startup iterations.
+`server.port=0`을 사용하고 실제 bound port는 framework runtime에서 읽는다.
+`ServerSocket(0)`로 local port를 미리 고르면 반복되는 JMH startup iteration 중 race가
+발생할 수 있다.

--- a/docs/lessons/2026-05-29-issue-674-csv-okio-writer.md
+++ b/docs/lessons/2026-05-29-issue-674-csv-okio-writer.md
@@ -1,30 +1,29 @@
 # 2026-05-29 - Issue 674 CSV Okio writer fast path
 
-## Context
+## 배경
 
-Issue #674 followed the CSV reader Okio work by targeting large CSV export
-pipelines. `FlowCsvWriter.writeFile` already accepted a `Flow<Iterable<*>>`, but
-UTF-8 file output still went through `OutputStreamWriter` and many small
-`Writer.write(...)` calls.
+issue #674는 CSV reader Okio 작업의 후속으로 large CSV export pipeline을 대상으로
+했다. `FlowCsvWriter.writeFile`은 이미 `Flow<Iterable<*>>`를 받았지만, UTF-8 file
+output은 여전히 `OutputStreamWriter`와 많은 작은 `Writer.write(...)` call을 거쳤다.
 
-## Decision
+## 결정
 
-Keep the public `FlowCsvWriter` contract unchanged and route UTF-8 file output
-through an internal Okio `BufferedSink` writer. Keep non-UTF-8 encodings on the
-existing writer fallback path.
+public `FlowCsvWriter` contract는 변경하지 않고 UTF-8 file output을 internal Okio
+`BufferedSink` writer로 보낸다. non-UTF-8 encoding은 기존 writer fallback path에
+남긴다.
 
-The fast path preserves the existing writer semantics:
+fast path는 기존 writer semantic을 보존한다.
 
-- `null` as an unquoted empty field.
-- empty string as quoted `""`.
+- `null`은 unquoted empty field.
+- empty string은 quoted `""`.
 - doubled-quote escaping.
 - `quoteAll`.
-- CSV and TSV delimiters and line separators.
+- CSV/TSV delimiter와 line separator.
 
-## Outcome
+## 결과
 
-The writer benchmark compares the legacy Writer baseline against the public
-Okio-backed `writeFile` path:
+writer benchmark는 legacy Writer baseline과 public Okio-backed `writeFile` path를
+비교한다.
 
 | Workload | Writer baseline | Okio writer | Speedup |
 |---|---:|---:|---:|
@@ -32,14 +31,14 @@ Okio-backed `writeFile` path:
 | medium | 676.110 ops/s | 2,068.696 ops/s | 3.06x |
 | large | 83.802 ops/s | 272.157 ops/s | 3.25x |
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-csv:test --tests 'io.bluetape4k.csv.v2.FlowCsvWriterTest'` - 21 passing.
 - `./gradlew :bluetape4k-csv:test` - 271 passing.
-- `./gradlew :bluetape4k-csv:testBenchmark` - writer benchmark above.
+- `./gradlew :bluetape4k-csv:testBenchmark` - 위 writer benchmark.
 
-## Future Guard
+## 향후 가드
 
-For CSV writer performance work, benchmark the public `writeFile` path and keep
-a baseline implementation in the benchmark so future agents can compare against
-the previous `Writer` behavior without reintroducing a production fallback flag.
+CSV writer performance work에서는 public `writeFile` path를 benchmark하고, future
+agent가 production fallback flag를 다시 도입하지 않고도 이전 `Writer` behavior와
+비교할 수 있도록 benchmark에 baseline implementation을 유지한다.

--- a/docs/lessons/2026-05-30-zip-slip-canonical-path.md
+++ b/docs/lessons/2026-05-30-zip-slip-canonical-path.md
@@ -1,29 +1,26 @@
 # Zip Slip canonical path validation
 
-## Context
+## 배경
 
-GitHub CodeQL reported `java/zipslip` in `ZipFileSupport.unzip` at the file
-extraction sink.
+GitHub CodeQL이 file extraction sink의 `ZipFileSupport.unzip`에서 `java/zipslip`을
+보고했다.
 
-## Decision
+## 결정
 
-Resolve every ZIP entry through the destination directory's canonical file and
-reject targets whose canonical path escapes that directory before opening the
-output stream.
+모든 ZIP entry를 destination directory의 canonical file을 통해 resolve하고, output
+stream을 열기 전에 canonical path가 해당 directory를 벗어나는 target을 거부한다.
 
-## Outcome
+## 결과
 
-The extraction path check now guards the exact canonical file passed to
-`FileOutputStream`, including sibling paths that share a textual prefix with
-the destination directory name.
+extraction path check는 이제 destination directory name과 textual prefix를 공유하는
+sibling path까지 포함해, `FileOutputStream`에 전달되는 정확한 canonical file을 보호한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-io:test --tests "io.bluetape4k.io.compressor.ZipFileSupportTest"`
 - `git diff --check`
 
-## Future guard
+## 향후 가드
 
-For archive extraction code, validate canonical target paths at the same
-abstraction level as the file sink instead of relying only on normalized string
-or path comparisons.
+archive extraction code에서는 normalized string 또는 path comparison에만 의존하지 말고,
+file sink와 같은 abstraction level에서 canonical target path를 검증한다.

--- a/docs/lessons/2026-06-01-open-1-11-0-development.md
+++ b/docs/lessons/2026-06-01-open-1-11-0-development.md
@@ -1,20 +1,20 @@
-# 2026-06-01 Open 1.11.0 Development
+# 2026-06-01 1.11.0 development 시작
 
-## Context
+## 배경
 
-`bluetape4k-projects` `1.10.0` was published and included in
-`bluetape4k-dependencies` `1.2.0`.
+`bluetape4k-projects` `1.10.0`이 publish됐고 `bluetape4k-dependencies` `1.2.0`에
+포함됐다.
 
-## Decision
+## 결정
 
-Move the committed `baseVersion` to `1.11.0` while keeping `snapshotVersion=`
-empty so release workflows can inject snapshot qualifiers explicitly.
+committed `baseVersion`을 `1.11.0`으로 이동하되 `snapshotVersion=`은 비워 둔다. 이렇게
+release workflow가 snapshot qualifier를 명시적으로 주입할 수 있다.
 
-## Outcome
+## 결과
 
-The repository is ready for the next minor development line.
+repository가 다음 minor development line을 시작할 준비가 됐다.
 
-## Verification
+## 검증
 
-- `gradle.properties` uses `baseVersion=1.11.0`.
-- `snapshotVersion=` remains empty.
+- `gradle.properties`가 `baseVersion=1.11.0`을 사용한다.
+- `snapshotVersion=`은 비어 있다.

--- a/docs/lessons/2026-06-01-projects-1-10-0-release-prep.md
+++ b/docs/lessons/2026-06-01-projects-1-10-0-release-prep.md
@@ -1,33 +1,29 @@
 # projects 1.10.0 release prep
 
-## Context
+## 배경
 
-`bluetape4k-projects` needed the 1.10.0 stable release gate prepared after the
-remaining milestone issue was confirmed to be completed and unrelated to the
-repository release scope.
+남은 milestone issue가 완료됐고 repository release scope와 무관함이 확인된 뒤,
+`bluetape4k-projects`에는 1.10.0 stable release gate 준비가 필요했다.
 
-## Decision
+## 결정
 
-Prepare release metadata only: set `baseVersion=1.10.0`, keep
-`snapshotVersion=` empty, and add a curated `CHANGELOG.md` section before
-creating the release-prep PR.
+release metadata만 준비한다. `baseVersion=1.10.0`을 설정하고 `snapshotVersion=`은 비워
+두며, release-prep PR을 만들기 전에 curated `CHANGELOG.md` section을 추가한다.
 
-## Outcome
+## 결과
 
-The release-prep branch records the 1.10.0 user-facing changes from the Ktor
-module family, performance work, cancellation fixes, release guards, and Zip
-Slip hardening.
+release-prep branch는 Ktor module family, performance work, cancellation fix, release
+guard, Zip Slip hardening에서 나온 1.10.0 user-facing change를 기록한다.
 
-## Verification
+## 검증
 
-- Confirmed the worktree started from clean `origin/develop`.
-- Confirmed `release.yml` requires `version`, optional `diagnoseSigning`, and
-  optional `catalogRef`.
-- Confirmed `snapshotVersion=` remains empty for stable release dispatch.
+- worktree가 깨끗한 `origin/develop`에서 시작했음을 확인했다.
+- `release.yml`이 `version`, optional `diagnoseSigning`, optional `catalogRef`를
+  요구함을 확인했다.
+- stable release dispatch를 위해 `snapshotVersion=`이 비어 있음을 확인했다.
 
-## Next time
+## 다음 번
 
-Do not dispatch the stable release until the release-prep PR has passed CI,
-Nightly/snapshot validation is current for the merged release state, and Maven
-Central verification is ready for the exact `1.10.0` BOM and representative
-module POMs.
+release-prep PR이 CI를 통과하고, merge된 release state에 대한 Nightly/snapshot
+validation이 최신이며, 정확한 `1.10.0` BOM과 대표 module POM에 대한 Maven Central
+verification이 준비되기 전에는 stable release를 dispatch하지 않는다.

--- a/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
+++ b/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
@@ -1,27 +1,26 @@
-# Catalog 2026-06-02-00 Sync
+# Catalog 2026-06-02-00 sync
 
-## Context
+## 배경
 
-Issue #703 needed `bluetape4k-projects` to consume the source-of-truth catalog
-cut from `bluetape4k-dependencies` issue #101.
+issue #703은 `bluetape4k-projects`가 `bluetape4k-dependencies` issue #101에서 자른
+source-of-truth catalog를 consume해야 했다.
 
-## Decision
+## 결정
 
-Use `catalog/2026-06-02-00` as the default `bt4k` catalog ref and sync shared
-version aliases from `bluetape4k-dependencies`.
+`catalog/2026-06-02-00`을 기본 `bt4k` catalog ref로 사용하고,
+`bluetape4k-dependencies`의 shared version alias를 sync한다.
 
-## Outcome
+## 결과
 
-Local catalog drift for Netty, AWS SDK v2, Protobuf, Jackson, Jackson 3, and
-Scrimage was removed without adding repo-local pins.
+Netty, AWS SDK v2, Protobuf, Jackson, Jackson 3, Scrimage의 local catalog drift를
+repo-local pin 추가 없이 제거했다.
 
-## Verification
+## 검증
 
 - `scripts/sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
 - `scripts/sync-dependabot-ignores.py --workspace /Users/debop/work/bluetape4k --check --summary`
 
-## Future Guidance
+## 향후 지침
 
-For shared dependency alerts, cut the catalog ref in `bluetape4k-dependencies`
-first, then update this repository's default catalog ref and synced aliases
-together.
+shared dependency alert는 먼저 `bluetape4k-dependencies`에서 catalog ref를 자른 뒤,
+이 repository의 default catalog ref와 synced alias를 함께 업데이트한다.

--- a/docs/lessons/2026-06-04-issue-707-nightly-gradle-cache.md
+++ b/docs/lessons/2026-06-04-issue-707-nightly-gradle-cache.md
@@ -1,22 +1,28 @@
-# 2026-06-04 Issue 707 Nightly Gradle Cache
+# 2026-06-04 이슈 707 Nightly Gradle cache
 
-## Context
+## 배경
 
-Nightly builds across bluetape4k repositories intermittently resolved managed dependencies as `group:artifact:.` on GitHub runners.
+bluetape4k repository 전반의 Nightly build가 GitHub runner에서 managed dependency를
+간헐적으로 `group:artifact:.` 형태로 resolve했다.
 
-## Decision
+## 결정
 
-Disable `gradle/actions/setup-gradle` cache restore/write for Nightly jobs so scheduled runs do not reuse stale dependency-management state.
+scheduled run이 stale dependency-management state를 재사용하지 않도록 Nightly job에서
+`gradle/actions/setup-gradle` cache restore/write를 비활성화한다.
 
-## Outcome
+## 결과
 
-Every Nightly `setup-gradle` block now sets `cache-disabled: true` while keeping explicit Gradle dependency refresh.
+모든 Nightly `setup-gradle` block은 explicit Gradle dependency refresh를 유지하면서
+`cache-disabled: true`를 설정한다.
 
-## Verification
+## 검증
 
-- Audited `.github/workflows/nightly-tests.yml`: setup-gradle blocks match cache-disabled blocks.
-- Planned validation: `actionlint`, `git diff --check`.
+- `.github/workflows/nightly-tests.yml`을 감사해 setup-gradle block이 cache-disabled block과
+  일치함을 확인했다.
+- planned validation: `actionlint`, `git diff --check`.
 
-## Future Rule
+## 향후 규칙
 
-When a Nightly workflow uses snapshot or BOM-managed bluetape4k dependencies, keep Gradle action cache disabled unless a fresh CI proof shows cache restore cannot replay stale metadata.
+Nightly workflow가 snapshot 또는 BOM-managed bluetape4k dependency를 사용할 때는, cache
+restore가 stale metadata를 재생하지 않는다는 fresh CI proof가 없는 한 Gradle action
+cache를 비활성화한다.

--- a/docs/lessons/2026-06-04-issue-709-nightly-config-cache-catalog.md
+++ b/docs/lessons/2026-06-04-issue-709-nightly-config-cache-catalog.md
@@ -1,21 +1,25 @@
-# 2026-06-04 Issue 709 Nightly Config Cache And Catalog
+# 2026-06-04 이슈 709 Nightly config cache와 catalog
 
-## Context
+## 배경
 
-Nightly workflows use snapshot and BOM-managed dependencies, so stale Gradle/configuration state can surface versionless dependency coordinates.
+Nightly workflow는 snapshot과 BOM-managed dependency를 사용하므로, stale
+Gradle/configuration state가 versionless dependency coordinate를 드러낼 수 있다.
 
-## Decision
+## 결정
 
-Keep Nightly Gradle commands on `--no-configuration-cache` and keep local bluetape4k aliases versioned through their BOM ref.
+Nightly Gradle command에는 `--no-configuration-cache`를 유지하고, local bluetape4k
+alias는 BOM ref를 통해 versioned 상태로 유지한다.
 
-## Outcome
+## 결과
 
-Nightly commands no longer rely on configuration cache during dependency refresh, and repo-local catalog aliases avoid `group:artifact:.` coordinates.
+Nightly command는 dependency refresh 중 더 이상 configuration cache에 의존하지 않으며,
+repo-local catalog alias는 `group:artifact:.` coordinate를 피한다.
 
-## Verification
+## 검증
 
-- Planned: `actionlint`, `git diff --check`, command audit, catalog alias audit.
+- planned: `actionlint`, `git diff --check`, command audit, catalog alias audit.
 
-## Future Rule
+## 향후 규칙
 
-For Nightly jobs that refresh snapshots, disable both Gradle action cache and configuration cache unless a repo-specific proof says otherwise.
+snapshot을 refresh하는 Nightly job에서는 repo-specific proof가 달리 말하지 않는 한 Gradle
+action cache와 configuration cache를 모두 비활성화한다.

--- a/docs/lessons/2026-06-04-issue-711-central-snapshot-retry.md
+++ b/docs/lessons/2026-06-04-issue-711-central-snapshot-retry.md
@@ -1,18 +1,17 @@
-# Issue #711 Central snapshot retry
+# 이슈 #711 Central snapshot retry
 
-## Context
-Downstream CI and Nightly runs can fail when GitHub runners receive transient
-HTTP 403 responses from Central Portal snapshot metadata.
+## 배경
+GitHub runner가 Central Portal snapshot metadata에서 일시적인 HTTP 403 response를 받으면
+downstream CI와 Nightly run이 실패할 수 있다.
 
-## Decision
-Wrap the top-level Gradle build and Nightly detekt gates in bounded three-attempt
-retry loops without changing the Gradle command semantics.
+## 결정
+Gradle command semantic을 바꾸지 않고 top-level Gradle build와 Nightly detekt gate를
+bounded three-attempt retry loop로 감싼다.
 
-## Verification
+## 검증
 - `git diff --check`
 - `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`
 
-## Next Time
-If a bluetape4k SNAPSHOT dependency fails with Central metadata 403, check
-upstream publish status first, then prefer a bounded workflow retry over
-dependency or catalog churn.
+## 다음 번
+bluetape4k SNAPSHOT dependency가 Central metadata 403으로 실패하면 먼저 upstream publish
+status를 확인한 뒤, dependency 또는 catalog churn보다 bounded workflow retry를 우선한다.

--- a/docs/lessons/2026-06-06-issue-691-ktor-opentelemetry-tracing.md
+++ b/docs/lessons/2026-06-06-issue-691-ktor-opentelemetry-tracing.md
@@ -1,33 +1,33 @@
-# Issue #691 Ktor OpenTelemetry Tracing
+# 이슈 #691 Ktor OpenTelemetry tracing
 
-## Context
+## 배경
 
-`ktor/observability` already owned CallId, CallLogging, optional Micrometer, and
-Prometheus route helpers. The observability contract from #696 required Ktor
-tracing to stay explicit, application-owned, and safe around correlation IDs.
+`ktor/observability`는 이미 CallId, CallLogging, optional Micrometer, Prometheus
+route helper를 소유했다. #696의 observability contract는 Ktor tracing을 명시적이고
+application-owned이며 correlation ID 주변에서 안전하게 유지하도록 요구했다.
 
-## Decision
+## 결정
 
-Add a narrow Ktor OpenTelemetry helper that accepts an application-created
-`OpenTelemetry` instance and wraps OpenTelemetry's Ktor 3 server instrumentation.
-Keep `opentelemetry-ktor-3.0` out of the main runtime dependency graph by using
-`compileOnly`; document it as an application dependency when tracing is enabled.
+application이 생성한 `OpenTelemetry` instance를 받고 OpenTelemetry의 Ktor 3 server
+instrumentation을 감싸는 좁은 Ktor OpenTelemetry helper를 추가한다.
+`opentelemetry-ktor-3.0`은 `compileOnly`로 두어 main runtime dependency graph에서
+제외하고, tracing을 활성화할 때 application dependency로 문서화한다.
 
-## Outcome
+## 결과
 
-The baseline installer can opt in through `KtorOpenTelemetryTracingConfig`, while
-existing users without tracing keep the previous behavior. Sanitized
-`correlation.id` is trace-only and opt-in; `correlation.present` is bounded.
+baseline installer는 `KtorOpenTelemetryTracingConfig`를 통해 opt in할 수 있고, tracing을
+사용하지 않는 기존 사용자는 이전 behavior를 유지한다. sanitize된 `correlation.id`는
+trace-only이자 opt-in이며, `correlation.present`는 bounded 값이다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-ktor-observability:compileKotlin`
 - `./gradlew :bluetape4k-ktor-observability:compileTestKotlin`
 - `./gradlew :bluetape4k-ktor-observability:test`
 - `git diff --check`
 
-## Future Guard
+## 향후 가드
 
-When adding framework tracing wrappers, do not create SDKs or exporters inside
-library helpers. Keep alpha instrumentation dependencies optional and test them
-with `InMemorySpanExporter` instead of asserting backend-specific behavior.
+framework tracing wrapper를 추가할 때 library helper 안에서 SDK나 exporter를 만들지
+않는다. alpha instrumentation dependency는 optional로 유지하고, backend-specific
+behavior를 assert하는 대신 `InMemorySpanExporter`로 test한다.

--- a/docs/lessons/2026-06-06-issue-694-spring-observability-helpers.md
+++ b/docs/lessons/2026-06-06-issue-694-spring-observability-helpers.md
@@ -1,31 +1,31 @@
-# Issue #694 Spring Observability Helpers
+# 이슈 #694 Spring observability helper
 
-## Context
+## 배경
 
-The Spring Boot 4 observability work needed helper APIs for service, HTTP
-handler, and event handler code while preserving Spring Boot Actuator and
-Micrometer ownership of metrics, tracing, exporters, and endpoints.
+Spring Boot 4 observability 작업에는 metrics, tracing, exporter, endpoint에 대한
+Spring Boot Actuator와 Micrometer ownership을 보존하면서 service, HTTP handler, event
+handler code를 위한 helper API가 필요했다.
 
-## Decision
+## 결정
 
-Add narrow `ObservationRegistry` helpers in `spring-boot/core` instead of
-auto-configuring exporters or custom endpoints. Treat Prometheus and OTLP as
-application configuration concerns documented in README examples.
+exporter나 custom endpoint를 auto-configure하지 않고, `spring-boot/core`에 좁은
+`ObservationRegistry` helper를 추가한다. Prometheus와 OTLP는 README example에
+문서화된 application configuration concern으로 취급한다.
 
-## Outcome
+## 결과
 
-`observeSpring` and `observeSpringSuspending` now manage observation lifecycle,
-exception recording, cancellation propagation, and coroutine scope cleanup.
-README files also now reflect Spring Boot 4's Jackson 3 default.
+`observeSpring`과 `observeSpringSuspending`은 이제 observation lifecycle, exception
+recording, cancellation propagation, coroutine scope cleanup을 관리한다. README file도
+Spring Boot 4의 Jackson 3 default를 반영한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.observability.SpringObservationSupportTest'`
 - `./gradlew :bluetape4k-spring-boot-core:test`
 - `git diff --check`
 
-## Future Guard
+## 향후 가드
 
-For Spring Boot observability helpers, accept framework-owned objects such as
-`ObservationRegistry` and document backend properties. Do not instantiate
-OpenTelemetry SDKs, tracing exporters, or Prometheus endpoints in the library.
+Spring Boot observability helper는 `ObservationRegistry` 같은 framework-owned object를
+받고 backend property를 문서화한다. library 안에서 OpenTelemetry SDK, tracing exporter,
+Prometheus endpoint를 instantiate하지 않는다.

--- a/docs/lessons/2026-06-06-snapshot-cache-actions.md
+++ b/docs/lessons/2026-06-06-snapshot-cache-actions.md
@@ -1,29 +1,29 @@
-# Snapshot Cache Actions
+# Snapshot cache action
 
-## Context
+## 배경
 
-Nightly should not disable Gradle dependency caching while the repository relies
-on mutable bluetape4k SNAPSHOT artifacts from Central snapshots.
+repository가 Central snapshot의 mutable bluetape4k SNAPSHOT artifact에 의존하는 동안,
+Nightly는 Gradle dependency caching을 비활성화하지 않아야 한다.
 
-## Decision
+## 결정
 
-Remove `cache-disabled: true` from Nightly Gradle setup steps so scheduled jobs
-can reuse dependency metadata according to Gradle's changing-module cache policy.
+scheduled job이 Gradle changing-module cache policy에 따라 dependency metadata를
+재사용할 수 있도록 Nightly Gradle setup step에서 `cache-disabled: true`를 제거한다.
 
-## Outcome
+## 결과
 
-Nightly keeps its existing task structure, but Gradle cache write/read behavior
-is no longer explicitly disabled in the workflow.
+Nightly는 기존 task structure를 유지하지만, workflow에서 Gradle cache write/read
+behavior를 더 이상 명시적으로 비활성화하지 않는다.
 
-## Verification
+## 검증
 
 - `actionlint .github/workflows/*.yml`
 - `rg -n -- '--refresh-dependencies|cache-disabled: true' .github/workflows` -> no matches
 - `./gradlew help --no-daemon`
 - `git diff --check`
 
-## Future Guidance
+## 향후 지침
 
-Use explicit dependency refresh only in dedicated post-publish freshness checks.
-Ordinary CI, Nightly, and Examples workflows should rely on cached changing-module
-metadata plus targeted warm-up when a test-only SNAPSHOT dependency needs it.
+explicit dependency refresh는 전용 post-publish freshness check에서만 사용한다. 일반
+CI, Nightly, Examples workflow는 cached changing-module metadata에 의존하고, test-only
+SNAPSHOT dependency가 필요할 때만 targeted warm-up을 추가한다.

--- a/docs/lessons/2026-06-07-issue-695-event-telemetry-helpers.md
+++ b/docs/lessons/2026-06-07-issue-695-event-telemetry-helpers.md
@@ -1,37 +1,46 @@
-# Issue 695 Event Telemetry Helpers
+# 이슈 695 Event telemetry helper
 
-## Context
+## 배경
 
-Issue #695 adds reusable event publish and consume telemetry helpers after the shared observability contract from #696.
+issue #695는 #696의 shared observability contract 이후 reusable event publish/consume
+telemetry helper를 추가한다.
 
-## Decision
+## 결정
 
-Implement the first slice in `infra/micrometer` as generic Observation helpers instead of changing Kafka, NATS, Pulsar, or Spring modules directly.
+Kafka, NATS, Pulsar, Spring module을 직접 바꾸지 않고 첫 slice를 `infra/micrometer`의
+generic Observation helper로 구현한다.
 
-The helper records stable low-cardinality tags by default and requires explicit opt-in for high-cardinality identifiers. Correlation IDs are sanitized before they can be recorded as high-cardinality values.
+helper는 기본적으로 stable low-cardinality tag를 기록하고, high-cardinality identifier는
+명시적인 opt-in을 요구한다. correlation ID는 high-cardinality value로 기록되기 전에
+sanitize된다.
 
-## Outcome
+## 결과
 
-- `event.publish` and `event.consume` wrappers now share operation, messaging, event type, correlation presence, batch count, outcome, and exception semantics.
-- Cancellation is observable as `outcome=CANCELLED` but is not reported as an Observation error.
-- README examples cover Spring application event consumption and Kafka-style publish instrumentation.
-- PR review tightened factory APIs by using companion `invoke` with private data class constructors.
-- README now includes a shared English sequence diagram asset for event telemetry.
+- `event.publish`와 `event.consume` wrapper는 이제 operation, messaging, event type,
+  correlation presence, batch count, outcome, exception semantic을 공유한다.
+- cancellation은 `outcome=CANCELLED`로 관찰 가능하지만 Observation error로 보고하지 않는다.
+- README example은 Spring application event consumption과 Kafka-style publish
+  instrumentation을 다룬다.
+- PR review는 private data class constructor와 companion `invoke`를 사용해 factory API를
+  좁혔다.
+- README에는 event telemetry용 shared English sequence diagram asset이 포함됐다.
 
-## Verification
+## 검증
 
 ```bash
 ./gradlew :bluetape4k-micrometer:test --tests 'io.bluetape4k.micrometer.observation.events.EventTelemetryObservationSupportTest'
 ```
 
-Result: PASS, 7 tests.
+결과: PASS, 7 tests.
 
 ```bash
 ./gradlew :bluetape4k-micrometer:test
 ```
 
-Result: PASS, 80 tests and 1 pending.
+결과: PASS, 80 tests and 1 pending.
 
-## Future Work
+## 향후 작업
 
-Broker-specific modules can adopt these helpers later without changing broker APIs wholesale. Keep payload bodies, raw headers, exception messages, PII, secrets, and temporary destinations out of default tags.
+broker-specific module은 나중에 broker API 전체를 바꾸지 않고 이 helper를 채택할 수
+있다. payload body, raw header, exception message, PII, secret, temporary destination은
+default tag에서 제외한다.

--- a/docs/lessons/2026-06-07-issue-700-central-snapshot-task-naming.md
+++ b/docs/lessons/2026-06-07-issue-700-central-snapshot-task-naming.md
@@ -1,22 +1,22 @@
-# Issue #700: Central snapshot task naming audit
+# 이슈 #700: Central snapshot task naming audit
 
-## Context
+## 배경
 
-The root README files and snapshot workflow still advertised legacy Central
-publish task names while repo-local guidance already used the NMCP task names.
+root README file과 snapshot workflow는 여전히 legacy Central publish task name을
+안내했지만, repo-local guidance는 이미 NMCP task name을 사용하고 있었다.
 
-## Decision
+## 결정
 
-Use `nmcpPublishAggregationToCentralPortalSnapshots` for SNAPSHOT publishing and
-`nmcpPublishAggregationToCentralPortal` for release publishing in public
-guidance and GitHub Actions.
+public guidance와 GitHub Actions에서 SNAPSHOT publishing에는
+`nmcpPublishAggregationToCentralPortalSnapshots`를, release publishing에는
+`nmcpPublishAggregationToCentralPortal`을 사용한다.
 
-## Verification
+## 검증
 
 - `./gradlew tasks --all | rg "publishAggregation|nmcpPublishAggregation|CentralPortal|CentralSnapshots"`
 - `rg "publishAggregationToCentralSnapshots|publishAggregationToCentralPortal|publishAggregationToCentralPortalSnapshots|publishAllPublicationsToCentralPortalSnapshots|publishAllPublicationsToCentralSnapshots" README.md README.ko.md .github/workflows build.gradle.kts`
 
-## Future Guard
+## 향후 가드
 
-When release or snapshot publish tasks change, update README.md, README.ko.md,
-workflow commands, and repo-local contributor guidance together.
+release 또는 snapshot publish task가 바뀌면 README.md, README.ko.md, workflow command,
+repo-local contributor guidance를 함께 업데이트한다.

--- a/docs/lessons/2026-06-11-issue-741-codeql-kotlin24.md
+++ b/docs/lessons/2026-06-11-issue-741-codeql-kotlin24.md
@@ -1,27 +1,26 @@
-# Issue #741 CodeQL Kotlin 2.4
+# 이슈 #741 CodeQL Kotlin 2.4
 
-## Context
+## 배경
 
-Kotlin 2.4.0 landed before CodeQL Java/Kotlin extractor support caught up.
-Nightly and Publish Snapshot were green on the same head, but CodeQL failed only
-on the `java-kotlin` axis.
+CodeQL Java/Kotlin extractor support가 따라오기 전에 Kotlin 2.4.0이 들어왔다. 같은
+head에서 Nightly와 Publish Snapshot은 green이었지만, CodeQL만 `java-kotlin` axis에서
+실패했다.
 
-## Lesson
+## 교훈
 
-When a security scanner has a language support-window mismatch, keep unaffected
-scanner axes running and disable only the incompatible axis. Do not downgrade
-the project toolchain just to satisfy scanner lag.
+security scanner에 language support-window mismatch가 있으면 영향받지 않는 scanner
+axis는 계속 실행하고 incompatible axis만 비활성화한다. scanner lag를 맞추기 위해
+project toolchain을 downgrade하지 않는다.
 
-## Follow-up Guard
+## 후속 가드
 
-When re-enabling CodeQL `java-kotlin`, use a true compile-only Gradle command
-such as `assemble`. `build -x test` is not enough in this repository because
-custom `Test` tasks can still enter the task graph.
+CodeQL `java-kotlin`을 다시 활성화할 때는 `assemble`처럼 진짜 compile-only Gradle
+command를 사용한다. 이 repository에서는 custom `Test` task가 여전히 task graph에
+들어올 수 있으므로 `build -x test`만으로는 충분하지 않다.
 
-## Evidence
+## 증거
 
-- CodeQL run `27250113912`: `actions` and `python` passed, `java-kotlin`
-  failed.
-- Nightly run `27299345368`: succeeded on the same SHA.
-- Publish Snapshot run `27299715400`: succeeded on the same SHA.
-- Local workflow validation: `actionlint .github/workflows/codeql.yml`.
+- CodeQL run `27250113912`: `actions`와 `python`은 통과했고 `java-kotlin`은 실패했다.
+- Nightly run `27299345368`: 같은 SHA에서 성공했다.
+- Publish Snapshot run `27299715400`: 같은 SHA에서 성공했다.
+- local workflow validation: `actionlint .github/workflows/codeql.yml`.

--- a/docs/lessons/2026-06-11-issue-742-hc5-interceptor-flake.md
+++ b/docs/lessons/2026-06-11-issue-742-hc5-interceptor-flake.md
@@ -1,24 +1,24 @@
-# Issue #742: HC5 async interceptor ordering tests
+# 이슈 #742: HC5 async interceptor ordering test
 
-## Context
+## 배경
 
-`AsyncClientInterceptors` recorded request interceptor and execution interceptor
-events into one shared list while issuing many async requests. The old assertion
-compared the entire list to a serialized expected sequence.
+`AsyncClientInterceptors`는 많은 async request를 발행하면서 request interceptor와
+execution interceptor event를 하나의 shared list에 기록했다. 기존 assertion은 전체
+list를 serialized expected sequence와 비교했다.
 
-## Decision
+## 결정
 
-Keep the production behavior unchanged and assert interceptor ordering per
-execution id. Cross-request interleaving is valid for async execution and should
-not be part of the test contract.
+production behavior는 변경하지 않고 execution id별 interceptor ordering을 assert한다.
+cross-request interleaving은 async execution에서 유효하므로 test contract에 포함하지
+않는다.
 
-## Verification
+## 검증
 
-- Focused `AsyncClientInterceptors` test.
-- Full `:bluetape4k-http:test` module test.
+- focused `AsyncClientInterceptors` test.
+- full `:bluetape4k-http:test` module test.
 
-## Future Guard
+## 향후 가드
 
-When a test records events from concurrent or async requests, group by the
-request/execution identity first. Assert the per-request invariant unless the
-feature explicitly promises a global ordering contract.
+test가 concurrent 또는 async request의 event를 기록할 때는 먼저 request/execution
+identity로 group한다. feature가 global ordering contract를 명시적으로 약속하지 않는 한
+per-request invariant를 assert한다.

--- a/docs/lessons/2026-06-11-issue-744-suspending-observation-stop.md
+++ b/docs/lessons/2026-06-11-issue-744-suspending-observation-stop.md
@@ -1,27 +1,27 @@
-# Issue #744: Suspending observation lifecycle
+# 이슈 #744: Suspending observation lifecycle
 
-## Context
+## 배경
 
-`Observation.withObservationContextSuspending` bound Micrometer observations to a
-coroutine context but only stopped observations from catch blocks. Successful
-suspend paths could complete without `onStop`.
+`Observation.withObservationContextSuspending`은 Micrometer observation을 coroutine
+context에 bind했지만 catch block에서만 observation을 stop했다. 성공한 suspend path가
+`onStop` 없이 완료될 수 있었다.
 
-## Decision
+## 결정
 
-Call `observation.stop()` from `finally` for suspending observation context
-helpers. Keep cancellation separate from non-cancellation errors: cancellation
-rethrows without recording an error, and non-cancellation exceptions still call
-`observation.error(e)` before the final stop.
+suspending observation context helper에서는 `finally`에서 `observation.stop()`을
+호출한다. cancellation과 non-cancellation error를 분리한다. cancellation은 error 기록
+없이 rethrow하고, non-cancellation exception은 final stop 전에 계속
+`observation.error(e)`를 호출한다.
 
-## Verification
+## 검증
 
-- A pre-fix regression failed with `handler.stopped == 0`.
-- The same focused regression passed after the fix.
-- Related observation coroutine and event telemetry tests passed.
-- Full `:bluetape4k-micrometer:test` passed.
+- pre-fix regression은 `handler.stopped == 0`으로 실패했다.
+- 같은 focused regression은 fix 후 통과했다.
+- 관련 observation coroutine과 event telemetry test가 통과했다.
+- full `:bluetape4k-micrometer:test`가 통과했다.
 
-## Future Guard
+## 향후 가드
 
-Any helper that starts or owns an `Observation` must stop it in `finally`.
-Tests should assert handler `onStop` counts for success paths, not only current
-context cleanup.
+`Observation`을 시작하거나 소유하는 모든 helper는 `finally`에서 stop해야 한다. test는
+current context cleanup뿐 아니라 success path의 handler `onStop` count도 assert해야
+한다.

--- a/docs/lessons/2026-06-11-issue-746-same-condition-compressor.md
+++ b/docs/lessons/2026-06-11-issue-746-same-condition-compressor.md
@@ -1,16 +1,25 @@
-# Lessons - Issue #746 Same-Condition Compressor Benchmark
+# 교훈 - 이슈 #746 Same-condition compressor benchmark
 
-## Context
+## 배경
 
-Issue #746 needed a durable `bluetape4k-io` compressor-only matrix that can be compared with `bluetape-go` and `bluetape-rs`.
+issue #746에는 `bluetape-go`, `bluetape-rs`와 비교할 수 있는 durable
+`bluetape4k-io` compressor-only matrix가 필요했다.
 
-## Lessons
+## 교훈
 
-- Keep the normalized table to compressor families that exist across the target ecosystems. BZip2 is useful JVM context, but it should not be mixed into the common table.
-- For `kotlinx-benchmark`, verify generated task names before documenting commands. This module exposes `testBenchmark`, `testBenchmarkCompile`, and `testBenchmarkJar`.
-- `testBenchmark --args` is not a JMH include-filter escape hatch in this setup; it treats the first argument as a kotlinx runner input file. For focused smoke runs, generated JMH jar execution is acceptable when documented as an exception.
-- Benchmark fat jars can include signed dependency metadata. Exclude `META-INF/*.RSA`, `META-INF/*.DSA`, and `META-INF/*.SF` from benchmark jar tasks so direct JMH execution does not fail signature verification.
+- normalized table은 target ecosystem 전반에 존재하는 compressor family로 제한한다.
+  BZip2는 유용한 JVM context지만 common table에 섞지 않는다.
+- `kotlinx-benchmark`에서는 command를 문서화하기 전에 generated task name을 검증한다.
+  이 module은 `testBenchmark`, `testBenchmarkCompile`, `testBenchmarkJar`를 노출한다.
+- 이 setup에서 `testBenchmark --args`는 JMH include-filter escape hatch가 아니다. 첫
+  argument를 kotlinx runner input file로 처리한다. focused smoke run에는 generated JMH
+  jar 실행을 예외로 문서화하면 사용할 수 있다.
+- benchmark fat jar는 signed dependency metadata를 포함할 수 있다. direct JMH execution이
+  signature verification에 실패하지 않도록 benchmark jar task에서 `META-INF/*.RSA`,
+  `META-INF/*.DSA`, `META-INF/*.SF`를 제외한다.
 
-## Guard
+## 가드
 
-When adding benchmark harnesses, prove both the Gradle-generated benchmark compile path and at least one runnable benchmark command. If the runnable path needs direct JMH jar execution, record why the Gradle task is insufficient and keep the direct run narrow.
+benchmark harness를 추가할 때는 Gradle-generated benchmark compile path와 적어도 하나의
+runnable benchmark command를 모두 증명한다. runnable path가 direct JMH jar execution을
+필요로 한다면 Gradle task가 충분하지 않은 이유를 기록하고 direct run을 좁게 유지한다.

--- a/docs/lessons/2026-06-19-projects-readme-diagram-refresh-qa.md
+++ b/docs/lessons/2026-06-19-projects-readme-diagram-refresh-qa.md
@@ -1,6 +1,6 @@
 # projects README 다이어그램 재작성 QA 회고
 
-## Context
+## 배경
 
 `bluetape4k-projects`의 README 다이어그램 재작성은 단순한 스타일 교체가
 아니었다. 루트 README, cache/data/infra/io/ktor/spring/testing/examples,
@@ -22,7 +22,7 @@ benchmark 문서까지 이어지는 장기 작업이었고, 사용자는 다음 
 말하는 사용 흐름이나 class 관계가 약해진다. 렌더링이 성공하고 XML이 유효해도
 사용자가 보기에는 "이게 무엇을 설명하는지 모르겠다"는 결과가 나온다.
 
-## Decision or Finding
+## 결정과 발견
 
 ### 1. 다이어그램은 source-first로 하나씩 만들어야 한다
 
@@ -102,7 +102,7 @@ marker를 공유한 것이다. SVG에서는 의도대로 보일 수 있지만, P
 이런 문제는 "edge routing"보다 "layout redesign"으로 풀어야 한다. 특히 card 간격,
 layer 크기, source/target port, sibling arrow corridor를 함께 봐야 한다.
 
-## Outcome
+## 결과
 
 작업 중 재사용 가능한 규칙은 `bluetape4k-diagram` skill로 승격했다.
 
@@ -123,7 +123,7 @@ layer 크기, source/target port, sibling arrow corridor를 함께 봐야 한다
 `context-stroke` marker를 explicit per-color marker로 바꾸고, Ktor observability
 architecture의 `/metrics` card를 routes 근처로 옮겨 불필요한 교차를 없앴다.
 
-## Verification
+## 검증
 
 이번 계열 작업에서 효과가 있었던 검증 스택은 다음과 같다.
 
@@ -146,7 +146,7 @@ architecture의 `/metrics` card를 routes 근처로 옮겨 불필요한 교차�
 검은 화살촉, 작은 점선 화살촉, label-line overlap을 놓칠 수 있고, segment crossing
 check는 card 내부 관통, layer text 충돌, 여백 불균형, 의미 오류를 잡지 못한다.
 
-## Future Guidance
+## 향후 지침
 
 다음 agents는 projects README/diagram 작업에서 아래 원칙을 먼저 적용해야 한다.
 

--- a/docs/lessons/2026-06-19-sequence-diagram-rendering-qa.md
+++ b/docs/lessons/2026-06-19-sequence-diagram-rendering-qa.md
@@ -1,109 +1,100 @@
 # Sequence diagram rendering QA
 
-## Context
+## 배경
 
-The README diagram refresh standardized every sequence SVG/PNG under
-`docs/images/readme-diagrams` to the Spring Boot Cassandra best-practices style.
-The visual pass exposed several renderer-specific failures that did not show up
-as simple XML or SVG-source errors:
+README diagram refresh는 `docs/images/readme-diagrams` 아래의 모든 sequence SVG/PNG를
+Spring Boot Cassandra best-practices style로 표준화했다. visual pass는 단순 XML 또는
+SVG source error로 드러나지 않는 renderer-specific failure를 여러 개 노출했다.
 
-- participant boxes could become dark because a CSS selector intended for text
-  also matched `rect.participant`;
-- call labels could look washed out in PNG because a shared `.label` style was
-  applied to both text and pill shapes;
-- numbered badges, label text, message lines, and arrowheads could drift into
-  different colors when a diagram reused old classes or reordered label groups;
-- arrowheads looked acceptable in the raw SVG but became too small after
-  CairoSVG conversion;
-- stray placeholder number badges such as `?` could survive a broad style pass;
-- contact-sheet thumbnails could hide dense-label defects, so risky diagrams
-  still needed individual PNG inspection.
+- text용 CSS selector가 `rect.participant`에도 match해 participant box가 어두워질 수 있었다.
+- shared `.label` style이 text와 pill shape 양쪽에 적용되어 PNG의 call label이 흐려질 수 있었다.
+- diagram이 old class를 재사용하거나 label group 순서를 바꾸면 numbered badge, label text,
+  message line, arrowhead 색상이 서로 drift될 수 있었다.
+- raw SVG에서는 arrowhead가 괜찮아 보여도 CairoSVG conversion 후 너무 작아질 수 있었다.
+- `?` 같은 placeholder number badge가 broad style pass 뒤에도 남을 수 있었다.
+- contact-sheet thumbnail은 dense-label defect를 숨길 수 있으므로 risky diagram은 개별 PNG
+  inspection이 계속 필요했다.
 
-## Decision or Finding
+## 결정과 발견
 
-Treat the rendered PNG as the authoritative README artifact. SVG source checks
-are necessary, but they are not sufficient for sequence diagrams.
+rendered PNG를 authoritative README artifact로 취급한다. SVG source check는 필요하지만
+sequence diagram에서는 충분하지 않다.
 
-For sequence diagrams, each message row must be validated as one unit:
+sequence diagram에서는 각 message row를 하나의 단위로 검증해야 한다.
 
-- the message path stroke defines the message color;
-- the marker arrowhead must use the same color as the path stroke;
-- the call label pill outline, badge circle, and label text must use the same
-  message color;
-- the badge number text must be white;
-- the label shape and label text must not share a class that lets CSS style text
-  as a shape or hide text under a pill;
-- participant/header rectangles must have explicit light fills and should not
-  inherit text-only selector styles;
-- dashed `alt` or return lines still need readable arrowheads after PNG
-  conversion.
+- message path stroke가 message color를 정의한다.
+- marker arrowhead는 path stroke와 같은 색을 사용해야 한다.
+- call label pill outline, badge circle, label text는 같은 message color를 사용해야 한다.
+- badge number text는 흰색이어야 한다.
+- label shape와 label text는 CSS가 text를 shape처럼 style하거나 pill 아래에 숨기게 만드는
+  class를 공유하면 안 된다.
+- participant/header rectangle은 명시적인 light fill을 가져야 하며 text-only selector style을
+  상속하면 안 된다.
+- dashed `alt` 또는 return line도 PNG conversion 후 readable arrowhead가 필요하다.
 
-The same rule applies to class/UML diagrams with dashed relationships: dashed
-lines must not make hollow triangles or open arrowheads render as dashed,
-broken, undersized, or check-like. If marker-based arrowheads inherit
-`stroke-dasharray` in PNG, hard-override the marker child path with
-`stroke-dasharray="none"` and `style="stroke-dasharray:none"`. If that still
-fails, draw the arrowhead as direct `polygon` or `polyline` geometry with a
-solid stroke and route the final segment perpendicular to the target edge.
+같은 규칙은 dashed relationship을 가진 class/UML diagram에도 적용된다. dashed line이
+hollow triangle 또는 open arrowhead를 점선, broken, undersized, check-like 형태로 render하게
+만들면 안 된다. marker-based arrowhead가 PNG에서 `stroke-dasharray`를 상속하면 marker child
+path에 `stroke-dasharray="none"`과 `style="stroke-dasharray:none"`을 hard override한다.
+그래도 실패하면 arrowhead를 solid stroke를 가진 direct `polygon` 또는 `polyline` geometry로
+그리고 final segment를 target edge에 수직으로 route한다.
 
-## Outcome
+## 결과
 
-The sequence diagram refresh was fixed by separating text and shape selectors,
-adding explicit light participant rectangle styling, using PNG-safe fixed-size
-sequence arrow markers, and synchronizing message colors by message number
-rather than by nearby XML order alone.
+sequence diagram refresh는 text와 shape selector를 분리하고, 명시적인 light participant
+rectangle style을 추가하며, PNG-safe fixed-size sequence arrow marker를 사용하고, 가까운
+XML order만이 아니라 message number 기준으로 message color를 동기화해 고쳤다.
 
-The specific regression that prompted this lesson was
-`examples-spring-boot-observability-spring-boot-demo-sequence-01`: participant
-boxes were rendered as dark filled boxes in PNG because `.participant` styling
-was too broad. The fix was to scope text styling to `text.participant` and set
-`rect.participant` to a white fill with an explicit stroke.
+이 lesson을 남기게 한 구체 regression은
+`examples-spring-boot-observability-spring-boot-demo-sequence-01`이었다. `.participant`
+style 범위가 너무 넓어 participant box가 PNG에서 어두운 filled box로 render됐다. fix는
+text styling을 `text.participant`로 제한하고 `rect.participant`에는 white fill과 명시적
+stroke를 설정하는 것이었다.
 
-## Verification
+## 검증
 
-The final sequence diagram pass used this verification stack:
+최종 sequence diagram pass는 다음 verification stack을 사용했다.
 
-- XML parse all sequence SVG files.
-- Reject placeholder badges such as `>?</text>`.
-- Count numbered message badges against marker-ended message paths.
-- Verify every marker color matches its message path stroke.
-- Verify every numbered badge uses white number text.
-- Verify badge, label, line, and arrowhead colors from message number to message
-  color, not only from raw SVG source order.
-- Render every sequence SVG to PNG with
+- 모든 sequence SVG file을 XML parse한다.
+- `>?</text>` 같은 placeholder badge를 거부한다.
+- numbered message badge 수를 marker-ended message path와 대조한다.
+- 모든 marker color가 message path stroke와 일치하는지 확인한다.
+- 모든 numbered badge가 white number text를 쓰는지 확인한다.
+- raw SVG source order만이 아니라 message number에서 message color로 badge, label, line,
+  arrowhead color를 확인한다.
+- 모든 sequence SVG를 다음 명령으로 PNG render한다.
   `~/.local/bin/cairosvg <diagram>.svg -o <diagram>.png -s 2`.
-- Generate contact sheets for the full sequence set and inspect them.
-- Open dense or high-risk PNGs individually, especially diagrams with many
-  labels, fallback paths, or previously broken participant boxes.
-- Run `git diff --check`.
+- 전체 sequence set의 contact sheet를 생성하고 검사한다.
+- label이 많거나 fallback path가 있거나 이전에 participant box가 깨졌던 dense/high-risk
+  PNG는 개별로 연다.
+- `git diff --check`를 실행한다.
 
-## Future Guidance
+## 향후 지침
 
-Do not claim sequence diagram completion from SVG inspection or render success
-alone. Always inspect the PNG, because CairoSVG can change the apparent size,
-dash behavior, and readability of markers and text.
+SVG inspection 또는 render success만으로 sequence diagram completion을 주장하지 않는다.
+CairoSVG가 marker/text의 apparent size, dash behavior, readability를 바꿀 수 있으므로 항상
+PNG를 검사한다.
 
-When changing one arrowhead or label rule, search for equivalent SVG patterns
-across the diagram set before committing. The failure mode is usually systemic:
-old classes, shared selectors, dashed marker inheritance, or marker scaling
-rules can appear in many files even if only one diagram was reported.
+arrowhead 또는 label rule 하나를 바꿀 때는 commit 전에 diagram set 전체에서 동등한 SVG
+pattern을 검색한다. failure mode는 보통 systemic하다. diagram 하나만 보고됐더라도 old
+class, shared selector, dashed marker inheritance, marker scaling rule이 여러 파일에 나타날
+수 있다.
 
-For sequence diagrams, prefer a stable message schema:
+sequence diagram에는 안정적인 message schema를 우선한다.
 
-- message line: explicit `stroke`, fixed `marker-end`, and rounded line joins;
-- marker: `markerUnits="userSpaceOnUse"` when fixed PNG size matters;
-- label pill: a rect-specific class such as `labelPill`;
-- label text: a text-specific class or explicit fill;
-- badge circle: fill and stroke equal to the message color;
-- badge number: explicit white fill;
-- participant text and participant rectangle styles: separate selectors.
+- message line: explicit `stroke`, fixed `marker-end`, rounded line join.
+- marker: fixed PNG size가 중요하면 `markerUnits="userSpaceOnUse"`.
+- label pill: `labelPill` 같은 rect-specific class.
+- label text: text-specific class 또는 explicit fill.
+- badge circle: message color와 같은 fill/stroke.
+- badge number: explicit white fill.
+- participant text와 participant rectangle style: selector 분리.
 
-For dashed UML/class relationships, run a dedicated dashed-arrowhead audit
-before commit. Search for dashed lines with marker heads, hollow/open marker
-definitions, standalone triangle paths, and direct arrowhead geometry. Then
-zoom into the rendered PNG and reject any dashed, broken, tiny, or check-like
-arrowhead even when the raw SVG looks correct.
+dashed UML/class relationship은 commit 전에 dedicated dashed-arrowhead audit을 실행한다.
+marker head가 있는 dashed line, hollow/open marker definition, standalone triangle path,
+direct arrowhead geometry를 검색한다. 그 다음 rendered PNG를 확대해 raw SVG가 맞아
+보이더라도 dashed, broken, tiny, check-like arrowhead는 거부한다.
 
-Contact sheets are only a broad sweep. If a contact sheet shows a dense area,
-long fallback branch, tiny label, or recently edited arrowhead, open that PNG at
-full size before accepting it.
+contact sheet는 broad sweep일 뿐이다. contact sheet에서 dense area, long fallback branch,
+tiny label, recently edited arrowhead가 보이면 해당 PNG를 full size로 열고 확인한 뒤
+accept한다.

--- a/docs/lessons/2026-06-23-issue-833-spring-webclient-readme-examples.md
+++ b/docs/lessons/2026-06-23-issue-833-spring-webclient-readme-examples.md
@@ -1,31 +1,26 @@
-# Issue 833 - Spring WebClient README examples
+# 이슈 833 - Spring WebClient README example
 
-## Context
+## 배경
 
-`bluetape4k-spring-boot-core` documents `WebClient.httpGet` and
-`WebClient.httpPost` helpers in both English and Korean READMEs.
+`bluetape4k-spring-boot-core`의 양쪽 README는 `WebClient.httpGet`과
+`WebClient.httpPost` helper를 문서화했다. 이 helper들은 내부에서 이미 `retrieve()`를
+호출하고 `WebClient.ResponseSpec`을 반환하지만, README snippet은 다시 `retrieve()`를
+chain했다. extension function 자체는 동작했지만 문서의 example은 compile되지 않았다.
 
-Those helpers already call `retrieve()` internally and return
-`WebClient.ResponseSpec`, but the README snippets chained another `retrieve()`.
-The documented examples therefore failed to compile even though the extension
-functions themselves worked.
+## 결정
 
-## Decision
-
-Keep the public helper contract unchanged and fix the examples to consume the
-returned `ResponseSpec` directly:
+public helper contract는 변경하지 않고, 반환된 `ResponseSpec`을 직접 소비하도록 example을
+수정한다.
 
 - `httpGet("/users").bodyToFlux(User::class.java).asFlow()`
 - `httpPost("/users", newUser).bodyToMono(User::class.java).awaitSingle()`
 
-Add `WebClientReadmeExamplesTest` so README drift is caught by tests:
+또한 README drift가 test에서 잡히도록 `WebClientReadmeExamplesTest`를 추가한다.
+README file은 `httpGet` 또는 `httpPost` 뒤에 `.retrieve()`를 chain하면 안 되고, 문서화된
+`bodyToFlux`와 `bodyToMono` chain은 실제 extension function에 대해 compile되어야 한다.
 
-- the README files must not chain `.retrieve()` after `httpGet` or `httpPost`
-- the documented `bodyToFlux` and `bodyToMono` chains compile against the real
-  extension functions
+## 후속 가드
 
-## Follow-up Guard
-
-When WebClient helper return types change, update `README.md`,
-`README.ko.md`, and `WebClientReadmeExamplesTest` together. Public snippets
-should demonstrate the exact next call available on the returned type.
+WebClient helper return type이 바뀌면 `README.md`, `README.ko.md`,
+`WebClientReadmeExamplesTest`를 함께 업데이트한다. public snippet은 반환 type에서 실제로
+가능한 바로 다음 호출을 보여줘야 한다.

--- a/docs/lessons/2026-06-23-issue-834-redis-runtime-dependencies.md
+++ b/docs/lessons/2026-06-23-issue-834-redis-runtime-dependencies.md
@@ -1,36 +1,36 @@
-# Issue #834 Redis Serializer Runtime Dependencies
+# 이슈 #834 Redis serializer runtime dependency
 
-Issue #834 exposed that `bluetape4k-spring-boot-redis` documented
-`RedisBinarySerializers.LZ4Fory` and `LZ4Kryo` as ready-to-use serializer
-choices while the codec and compressor libraries behind those choices were
-only `compileOnly` in the module.
+issue #834는 `bluetape4k-spring-boot-redis`가 `RedisBinarySerializers.LZ4Fory`와
+`LZ4Kryo`를 즉시 사용할 수 있는 serializer 선택지로 문서화했지만, 해당 선택지를
+뒷받침하는 codec/compressor library가 module에서는 `compileOnly`였음을 드러냈다.
 
-## Decision
+## 결정
 
-- Publish Fory, Kryo, LZ4, Zstd, and Snappy as runtime dependencies of
-  `bluetape4k-spring-boot-redis`.
-- Keep the default module tests unchanged, but add a separate
-  `consumerRuntimeTest` source set that does not inherit the module's
-  `compileOnly` test classpath.
-- Document that consumers do not need separate codec/compressor dependencies
-  for the serializer matrix shown in the README locale set.
+- Fory, Kryo, LZ4, Zstd, Snappy를 `bluetape4k-spring-boot-redis`의 runtime dependency로
+  publish한다.
+- 기본 module test는 유지하되, module의 `compileOnly` test classpath를 상속하지 않는
+  별도 `consumerRuntimeTest` source set을 추가한다.
+- README locale set에 표시된 serializer matrix를 사용할 때 consumer가 별도
+  codec/compressor dependency를 추가하지 않아도 된다고 문서화한다.
 
-## Lessons
+## 교훈
 
-- A module test classpath that extends `compileOnly` can hide consumer runtime
-  gaps. For published runtime contracts, add a source set whose runtime
-  classpath is based on `runtimeClasspath`, not `testImplementation`.
-- README examples that use named serializer constants are runtime contracts.
-  Either publish the required runtime dependencies or document each optional
-  dependency explicitly.
-- Stacked PRs are appropriate when a follow-up issue touches the same module
-  files as an already-open PR.
+- `compileOnly`를 확장한 module test classpath는 consumer runtime gap을 숨길 수 있다.
+  published runtime contract에는 `testImplementation`이 아니라 `runtimeClasspath` 기반
+  source set을 추가한다.
+- named serializer constant를 사용하는 README example은 runtime contract다. 필요한
+  runtime dependency를 publish하거나 optional dependency를 명시적으로 문서화해야 한다.
+- 이미 열린 PR과 같은 module file을 건드리는 follow-up issue에는 stacked PR이 적합하다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` failed with missing `org.apache.fory.ThreadSafeFory` and `net.jpountz.lz4.LZ4Factory`.
-- GREEN: the same task passed with 2 consumer-runtime tests after moving the documented codec/compressor libraries to `runtimeOnly`.
-- `./gradlew :bluetape4k-spring-boot-redis:dependencies --configuration runtimeClasspath` showed Fory, Kryo, LZ4, Zstd, and Snappy.
-- `./gradlew :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache` passed.
-- Test XML totals: default Redis tests 83 tests and consumer runtime tests 2 tests; all failures/errors 0.
-- `git diff --check` passed.
+- RED: `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache`는
+  `org.apache.fory.ThreadSafeFory`와 `net.jpountz.lz4.LZ4Factory` 누락으로 실패했다.
+- GREEN: 문서화된 codec/compressor library를 `runtimeOnly`로 옮긴 뒤 같은 task가
+  consumer-runtime test 2개와 함께 통과했다.
+- `./gradlew :bluetape4k-spring-boot-redis:dependencies --configuration runtimeClasspath`에서
+  Fory, Kryo, LZ4, Zstd, Snappy를 확인했다.
+- `./gradlew :bluetape4k-spring-boot-redis:compileKotlin :bluetape4k-spring-boot-redis:compileTestKotlin :bluetape4k-spring-boot-redis:test :bluetape4k-spring-boot-redis:consumerRuntimeTest --no-build-cache`가 통과했다.
+- test XML totals: default Redis tests 83 tests, consumer runtime tests 2 tests,
+  failures/errors 0.
+- `git diff --check`가 통과했다.

--- a/docs/lessons/2026-06-23-issue-835-redis-jdk-serializer-deprecation.md
+++ b/docs/lessons/2026-06-23-issue-835-redis-jdk-serializer-deprecation.md
@@ -1,23 +1,22 @@
-# Lessons Learned - Redis JDK serializer deprecation (#835, 2026-06-23)
+# Redis JDK serializer deprecation 교훈 (#835, 2026-06-23)
 
-Related issue: #835
-Affected module: `:bluetape4k-spring-boot-redis`
+관련 이슈: #835
+영향 module: `:bluetape4k-spring-boot-redis`
 
-## L1: Wrapper constants must preserve lower-level security signals
+## L1: wrapper constant는 하위 보안 신호를 보존해야 한다
 
-`BinarySerializers.Jdk` already carried a deprecation warning for JDK
-deserialization RCE risk, but the Redis-facing convenience constants did not
-repeat that warning. Public module boundaries should not hide security guidance
-from the lower-level API they wrap, especially at persistence or network
-boundaries such as Redis.
+`BinarySerializers.Jdk`에는 이미 JDK deserialization RCE risk에 대한 deprecation
+warning이 있었지만, Redis-facing convenience constant는 그 warning을 반복하지 않았다.
+public module boundary는 감싸는 lower-level API의 security guidance를 숨기면 안 된다.
+특히 Redis 같은 persistence/network boundary에서는 더 그렇다.
 
-The Redis constants now carry explicit deprecation annotations and replacement
-guidance, and the reflection contract test checks that future JDK Redis
-constants cannot be reintroduced without the warning.
+Redis constant에는 이제 명시적인 deprecation annotation과 replacement guidance가
+붙었고, reflection contract test는 future JDK Redis constant가 warning 없이 다시
+도입되지 못하게 막는다.
 
-## L2: README serializer tables need status, not only capability
+## L2: README serializer table에는 capability뿐 아니라 status가 필요하다
 
-A serializer matrix that lists JDK, Kryo, and Fory as peers can normalize unsafe
-defaults even when the implementation is technically correct. User-facing tables
-should distinguish recommended serializers from trusted-data-only legacy choices
-when deserialization risk is part of the contract.
+serializer matrix가 JDK, Kryo, Fory를 동등하게 나열하면 implementation이 기술적으로
+맞더라도 unsafe default를 정상 선택지처럼 보이게 만들 수 있다. deserialization risk가
+contract 일부라면 user-facing table은 recommended serializer와 trusted-data-only legacy
+choice를 구분해야 한다.

--- a/docs/lessons/2026-06-23-issue-836-cassandra-queryformap-varargs.md
+++ b/docs/lessons/2026-06-23-issue-836-cassandra-queryformap-varargs.md
@@ -1,24 +1,23 @@
-# Lessons Learned - Cassandra queryForMap varargs (#836, 2026-06-23)
+# Cassandra queryForMap varargs 교훈 (#836, 2026-06-23)
 
-Related issue: #836
-Affected module: `:bluetape4k-spring-boot-cassandra`
+관련 이슈: #836
+영향 module: `:bluetape4k-spring-boot-cassandra`
 
-## L1: Vararg bug reports need real bind-marker evidence
+## L1: vararg bug report에는 실제 bind marker 증거가 필요하다
 
-The issue suspected that `queryForMap(cql, args)` passed a single array value
-instead of expanding positional bind arguments. A new unit contract and a real
-Cassandra integration test with two bind markers both passed before the
-production change, which means the original runtime failure was not reproduced
-locally.
+issue는 `queryForMap(cql, args)`가 positional bind argument를 펼치지 않고 단일 array
+value로 전달한다고 의심했다. 새 unit contract와 두 bind marker를 가진 실제 Cassandra
+integration test는 production change 전에도 모두 통과했다. 즉 원래 runtime failure는
+local에서 재현되지 않았다.
 
-The fix still made the public helper explicit by calling `queryForMap(cql, *args)`
-and updated the KDoc to match that contract. Future changes to Kotlin wrappers
-around Java varargs should include both MockK vararg verification and at least one
-real bind-marker query when a database binding bug is suspected.
+수정은 public helper를 명시적으로 만들기 위해 `queryForMap(cql, *args)`를 호출했고,
+KDoc도 그 contract와 맞췄다. Java varargs 주변 Kotlin wrapper를 바꿀 때는 database
+binding bug가 의심된다면 MockK vararg verification과 실제 bind-marker query를 모두
+포함해야 한다.
 
-## L2: Do not let mocks encode the misleading shape
+## L2: mock이 오해를 주는 shape를 encoding하지 않게 한다
 
-The old unit fixture used `any<Array<*>>()`, which reinforced the suspicious
-array-shaped forwarding even though the wrapper behaved correctly in the
-verified paths. Test fixtures for Java vararg APIs should use `*anyVararg()` or
-concrete positional arguments so the test reads like the public contract.
+기존 unit fixture는 `any<Array<*>>()`를 사용해 의심스러운 array-shaped forwarding을
+강화했다. 검증된 path에서는 wrapper가 올바르게 동작했는데도 test가 잘못 읽혔다. Java
+vararg API test fixture는 public contract처럼 보이도록 `*anyVararg()` 또는 concrete
+positional argument를 사용해야 한다.

--- a/docs/lessons/2026-06-23-issue-837-hibernate-lettuce-readme-deps.md
+++ b/docs/lessons/2026-06-23-issue-837-hibernate-lettuce-readme-deps.md
@@ -1,23 +1,23 @@
-# Issue 837 - Hibernate Lettuce README dependencies
+# 이슈 837 - Hibernate Lettuce README dependency
 
-## Context
+## 배경
 
-`spring-boot/hibernate-lettuce` README dependency snippets used repository-local
-Gradle helpers such as `Libs.springBootStarter(...)` and `Libs.micrometer_core`.
-Those examples are not copyable in consumer projects.
+`spring-boot/hibernate-lettuce` README dependency snippet은
+`Libs.springBootStarter(...)`, `Libs.micrometer_core` 같은 repository-local Gradle
+helper를 사용했다. 이 example은 consumer project에서 복사해 사용할 수 없다.
 
-## Decision
+## 결정
 
-Document the module dependencies with public Gradle coordinates:
+module dependency를 public Gradle coordinate로 문서화한다.
 
-- `org.springframework.boot:spring-boot-dependencies` through `platform(...)`;
-- `io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce`;
-- Spring Boot starter coordinates for Data JPA and Actuator;
-- `io.micrometer:micrometer-core`;
-- `org.springframework.boot:spring-boot-hibernate` for the Spring Boot 4
-  Hibernate integration API used by `HibernatePropertiesCustomizer`.
+- `platform(...)`을 통한 `org.springframework.boot:spring-boot-dependencies`
+- `io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce`
+- Data JPA와 Actuator용 Spring Boot starter coordinate
+- `io.micrometer:micrometer-core`
+- `HibernatePropertiesCustomizer`가 사용하는 Spring Boot 4 Hibernate integration API용
+  `org.springframework.boot:spring-boot-hibernate`
 
-## Follow-up Guard
+## 후속 가드
 
-`ReadmeDependencyContractTest` reads both README locales and fails if internal
-Gradle helper snippets return to the consumer-facing dependency examples.
+`ReadmeDependencyContractTest`는 양쪽 README locale을 읽고, internal Gradle helper
+snippet이 consumer-facing dependency example로 돌아오면 실패한다.

--- a/docs/lessons/2026-06-23-issue-838-cassandra-demo-coroutine-readme.md
+++ b/docs/lessons/2026-06-23-issue-838-cassandra-demo-coroutine-readme.md
@@ -1,24 +1,24 @@
-# Issue 838 - Cassandra demo coroutine README example
+# 이슈 838 - Cassandra demo coroutine README example
 
-## Context
+## 배경
 
-`spring-boot/cassandra-demo` README files documented a coroutine repository
-method returning `Flow<Person>` as `suspend fun`. The tested repository uses a
-regular function for `Flow<Person>` queries and reserves `suspend fun` for
-single-result nullable lookups.
+`spring-boot/cassandra-demo` README file은 `Flow<Person>`을 반환하는 coroutine
+repository method를 `suspend fun`으로 문서화했다. test된 repository는 `Flow<Person>`
+query에 일반 function을 사용하고, single-result nullable lookup에만 `suspend fun`을
+사용한다.
 
-## Decision
+## 결정
 
-Mirror the tested repository shape in both README locales:
+양쪽 README locale에서 test된 repository shape를 그대로 반영한다.
 
-- `CoroutineCrudRepository<Person, String>`;
-- `fun findByLastname(lastname: String): Flow<Person>`;
-- `suspend fun findByFirstnameAndLastname(...): Person?`.
+- `CoroutineCrudRepository<Person, String>`
+- `fun findByLastname(lastname: String): Flow<Person>`
+- `suspend fun findByFirstnameAndLastname(...): Person?`
 
-Add a short note that `Flow<T>` repository queries are regular functions while
-single-result coroutine lookups use `suspend fun`.
+`Flow<T>` repository query는 일반 function이고, single-result coroutine lookup은
+`suspend fun`을 사용한다는 짧은 note도 추가한다.
 
-## Follow-up Guard
+## 후속 가드
 
-`ReadmeCoroutineRepositoryContractTest` reads both README locales and blocks the
-stale `UUID` / `findByLastName` / `suspend Flow` example from returning.
+`ReadmeCoroutineRepositoryContractTest`는 양쪽 README locale을 읽고 stale `UUID`,
+`findByLastName`, `suspend Flow` example이 돌아오는 것을 막는다.

--- a/docs/lessons/2026-06-23-issue-839-hibernate-lettuce-demo-readme-deps.md
+++ b/docs/lessons/2026-06-23-issue-839-hibernate-lettuce-demo-readme-deps.md
@@ -1,26 +1,23 @@
-# Issue 839 - Hibernate Lettuce demo README dependencies
+# 이슈 839 - Hibernate Lettuce demo README dependency
 
-## Context
+## 배경
 
-`spring-boot/hibernate-lettuce-demo` README dependency examples used
-bluetape4k-internal Gradle helpers such as `Libs.springBootStarter(...)`.
-Those helpers are not available in consumer builds, so the copied example would
-fail before users could run the demo.
+`spring-boot/hibernate-lettuce-demo` README dependency example은
+`Libs.springBootStarter(...)` 같은 bluetape4k 내부 Gradle helper를 사용했다. 이 helper는
+consumer build에서 사용할 수 없으므로, 복사한 example은 demo를 실행하기 전에 실패한다.
 
-## Decision
+## 결정
 
-Document the demo dependencies from a consumer perspective:
+consumer 관점에서 demo dependency를 문서화한다.
 
-- import `org.springframework.boot:spring-boot-dependencies` with
-  `platform(...)`;
-- use the published
-  `io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce`
-  coordinate;
-- use standard Spring Boot starter and H2 coordinates;
-- remove the stale explicit `compileOnly` Hibernate helper note because
-  `spring-boot-starter-data-jpa` supplies the demo runtime.
+- `platform(...)`으로 `org.springframework.boot:spring-boot-dependencies`를 import한다.
+- published coordinate인
+  `io.github.bluetape4k:bluetape4k-spring-boot-hibernate-lettuce`를 사용한다.
+- 표준 Spring Boot starter와 H2 coordinate를 사용한다.
+- `spring-boot-starter-data-jpa`가 demo runtime을 제공하므로 stale explicit
+  `compileOnly` Hibernate helper note를 제거한다.
 
-## Follow-up Guard
+## 후속 가드
 
-`ReadmeDependencyContractTest` reads both README locales and fails if internal
-dependency helpers return to the consumer-facing snippets.
+`ReadmeDependencyContractTest`는 양쪽 README locale을 읽고 internal dependency helper가
+consumer-facing snippet에 다시 들어오면 실패한다.

--- a/docs/lessons/2026-06-23-issue-840-mock-web-server-https-port.md
+++ b/docs/lessons/2026-06-23-issue-840-mock-web-server-https-port.md
@@ -1,18 +1,17 @@
-# Issue 840 - mock-web-server HTTPS port
+# 이슈 840 - mock-web-server HTTPS port
 
-## Context
+## 배경
 
-`testing/mock-web-server` runtime configuration uses HTTPS port `8443` and the
-Jib container metadata exposes ports `80` and `8443`, but both README locales
-still documented HTTPS port `443`.
+`testing/mock-web-server` runtime configuration은 HTTPS port `8443`을 사용하고 Jib
+container metadata도 port `80`과 `8443`을 노출한다. 하지만 양쪽 README locale은 여전히
+HTTPS port를 `443`으로 문서화했다.
 
-## Decision
+## 결정
 
-Update the English and Korean READMEs to document `8443` consistently in the
-architecture text, feature list, configuration table, and Docker run command.
+architecture text, feature list, configuration table, Docker run command에서 영어와
+한국어 README 모두 `8443`을 일관되게 문서화한다.
 
-## Follow-up Guard
+## 후속 가드
 
-`ReadmeHttpsPortContractTest` now checks that README HTTPS documentation matches
-`application.yml` and the Jib port list, while blocking stale standalone `443`
-documentation patterns.
+`ReadmeHttpsPortContractTest`는 README HTTPS documentation이 `application.yml` 및 Jib
+port list와 일치하는지 확인하고, stale standalone `443` documentation pattern을 막는다.

--- a/docs/lessons/2026-06-23-issue-841-mock-webflux-readme-routes.md
+++ b/docs/lessons/2026-06-23-issue-841-mock-webflux-readme-routes.md
@@ -1,22 +1,20 @@
-# Issue 841 - mock-webflux README routes
+# 이슈 841 - mock-webflux README route
 
-## Context
+## 배경
 
-`testing/mock-webflux-server` README files listed several httpbin/admin
-endpoints that were not implemented by the WebFlux controllers. Consumers using
-the README as an integration-test contract could call those routes and receive
-404 responses.
+`testing/mock-webflux-server` README file은 WebFlux controller가 구현하지 않은 여러
+httpbin/admin endpoint를 나열했다. README를 integration-test contract로 사용하는
+consumer는 해당 route를 호출하고 404 response를 받을 수 있었다.
 
-## Decision
+## 결정
 
-Keep the implemented route surface unchanged and remove README-only endpoint
-rows from both locales.
+구현된 route surface는 변경하지 않고 README-only endpoint row를 양쪽 locale에서 제거한다.
 
-The removed rows were `/admin/info`, `/httpbin/stream-bytes/{n}`,
-`/httpbin/drip`, `/httpbin/sse`, `/httpbin/brotli`, `/httpbin/html`,
-`/httpbin/xml`, `/httpbin/json`, `/httpbin/robots.txt`, and `/httpbin/deny`.
+제거된 row는 `/admin/info`, `/httpbin/stream-bytes/{n}`, `/httpbin/drip`,
+`/httpbin/sse`, `/httpbin/brotli`, `/httpbin/html`, `/httpbin/xml`, `/httpbin/json`,
+`/httpbin/robots.txt`, `/httpbin/deny`다.
 
-## Follow-up Guard
+## 후속 가드
 
-`ReadmeRouteContractTest` now blocks those stale routes from returning to the
-README endpoint tables unless matching WebFlux controller mappings are added.
+matching WebFlux controller mapping이 추가되지 않는 한, `ReadmeRouteContractTest`는
+stale route가 README endpoint table에 돌아오는 것을 막는다.

--- a/docs/lessons/2026-06-23-issue-843-http-server-property-keys.md
+++ b/docs/lessons/2026-06-23-issue-843-http-server-property-keys.md
@@ -1,26 +1,25 @@
-# Issue 843 - BluetapeHttpServer property keys
+# 이슈 843 - BluetapeHttpServer property key
 
-## Context
+## 배경
 
-`PropertyExportingServer` defines exported system property keys as lowercase
-kebab-case under `testcontainers.{propertyNamespace}.{key}`.
+`PropertyExportingServer`는 exported system property key를
+`testcontainers.{propertyNamespace}.{key}` 아래의 lowercase kebab-case로 정의한다.
 
-`BluetapeWebfluxServer` already followed this contract with `httpbin-url`,
-`jsonplaceholder-url`, and `web-url`, but `BluetapeHttpServer` exposed the
-same values as `httpbinUrl`, `jsonplaceholderUrl`, and `webUrl`.
+`BluetapeWebfluxServer`는 이미 `httpbin-url`, `jsonplaceholder-url`, `web-url`로 이
+contract를 따랐지만, `BluetapeHttpServer`는 같은 값을 `httpbinUrl`,
+`jsonplaceholderUrl`, `webUrl`로 노출했다.
 
-## Decision
+## 결정
 
-Make `BluetapeHttpServer.propertyKeys()` return only the canonical kebab-case
-keys used by the shared export contract.
+`BluetapeHttpServer.propertyKeys()`는 shared export contract가 쓰는 canonical
+kebab-case key만 반환하게 한다.
 
-`properties()` now writes canonical kebab-case entries and uses
-`withCompatKeys` to keep the previous camelCase keys as compatibility aliases
-for existing downstream tests.
+`properties()`는 canonical kebab-case entry를 쓰고, 기존 downstream test를 위해
+`withCompatKeys`로 이전 camelCase key를 compatibility alias로 유지한다.
 
-## Follow-up Guard
+## 후속 가드
 
-Keep public README placeholders aligned with `PropertyExportingServer`.
-`PropertyExportingServerContractTest` now includes both mock HTTP server
-wrappers so future divergence between `BluetapeHttpServer` and
-`BluetapeWebfluxServer` fails without starting Docker.
+public README placeholder는 `PropertyExportingServer`와 맞춘다.
+`PropertyExportingServerContractTest`는 Docker를 시작하지 않고도
+`BluetapeHttpServer`와 `BluetapeWebfluxServer` divergence를 잡도록 mock HTTP server
+wrapper 양쪽을 포함한다.

--- a/docs/lessons/2026-06-23-issue-844-geo-readme-examples.md
+++ b/docs/lessons/2026-06-23-issue-844-geo-readme-examples.md
@@ -1,27 +1,27 @@
-# Issue 844 - geo README examples
+# 이슈 844 - geo README example
 
-## Context
+## 배경
 
-`bluetape4k-geo` consolidated the former geocode, geohash, and geoip2 modules,
-but the English and Korean READMEs still documented the old
-`io.bluetape4k.geo.*` package hierarchy and non-existent helper types.
+`bluetape4k-geo`는 기존 geocode, geohash, geoip2 module을 통합했지만 영어와 한국어
+README는 여전히 오래된 `io.bluetape4k.geo.*` package hierarchy와 존재하지 않는 helper
+type을 문서화했다.
 
-The installation examples also exposed project-internal Gradle catalog symbols
-such as `Libs.feign_core`, which consumers cannot use in their own builds.
+installation example도 consumer가 자기 build에서 사용할 수 없는 `Libs.feign_core` 같은
+project-internal Gradle catalog symbol을 노출했다.
 
-## Decision
+## 결정
 
-Rewrite the README examples against the current public API:
+README example을 현재 public API에 맞춰 다시 작성한다.
 
-- `io.bluetape4k.geohash` factory and extension functions
+- `io.bluetape4k.geohash` factory와 extension function
 - `io.bluetape4k.geocode.google.GoogleAddressFinder`
-- `io.bluetape4k.geoip2.Geoip` plus `DatabaseReader` extension functions
+- `io.bluetape4k.geoip2.Geoip` 및 `DatabaseReader` extension function
 
-The installation block now uses Maven coordinates and concrete versions from the
-repository version catalog instead of internal `Libs.*` aliases.
+installation block은 internal `Libs.*` alias 대신 Maven coordinate와 repository version
+catalog의 concrete version을 사용한다.
 
-## Follow-up Guard
+## 후속 가드
 
-Keep `README.md` and `README.ko.md` source-equivalent when geocode, geohash, or
-geoip2 public entry points move. The `GeoReadmeContractTest` blocks the stale
-package/API names that caused this issue.
+geocode, geohash, geoip2 public entry point가 이동하면 `README.md`와 `README.ko.md`를
+source-equivalent하게 유지한다. `GeoReadmeContractTest`는 이 issue를 만든 stale
+package/API name을 막는다.

--- a/docs/lessons/2026-06-23-issue-845-flake-component-layout.md
+++ b/docs/lessons/2026-06-23-issue-845-flake-component-layout.md
@@ -1,29 +1,28 @@
-# Issue #845 Flake Component Byte Layout
+# 이슈 #845 Flake component byte layout
 
-Issue #845 found that `Flake.asComponentString()` parsed generated Flake IDs in
-a different byte order than `Flake.nextId()` writes.
+issue #845는 `Flake.asComponentString()`이 generated Flake ID를 `Flake.nextId()`가 쓰는
+byte order와 다르게 parse한다는 점을 찾았다.
 
-## Decision
+## 결정
 
-Parse component strings in the written layout: timestamp `Long`, six node bytes,
-then sequence `Short`. Also validate the Flake ID length consistently with
-`asBase62String()`.
+written layout 그대로 component string을 parse한다. 순서는 timestamp `Long`, node byte
+6개, sequence `Short`다. 또한 Flake ID length validation을 `asBase62String()`과
+일관되게 맞춘다.
 
-## Lessons
+## 교훈
 
-- Component helpers should be tested against the exact binary layout, not only
-  logged. A fixed clock and fixed node id make the expected string stable.
-- The first generated ID for a fixed-clock `Flake` currently has sequence `1`
-  because the generator initializes `lastTime` from the same clock value and
-  then increments within the same millisecond.
-- Byte layout tests should use distinct timestamp and node values so shifted
-  reads cannot accidentally produce plausible output.
+- component helper는 log만이 아니라 정확한 binary layout에 대해 test해야 한다. fixed
+  clock과 fixed node id를 쓰면 expected string이 안정된다.
+- fixed-clock `Flake`의 첫 generated ID는 현재 sequence `1`을 가진다. generator가 같은
+  clock value에서 `lastTime`을 초기화한 뒤 같은 millisecond 안에서 증가시키기 때문이다.
+- byte layout test는 shifted read가 그럴듯한 output을 우연히 만들지 못하도록 distinct
+  timestamp와 node value를 사용해야 한다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-idgenerators:test --tests "io.bluetape4k.idgenerators.flake.FlakeTest.component string uses timestamp node and sequence byte layout" --no-build-cache` failed with shifted components: `7528612310232073478-25939941-1`.
-- GREEN targeted: the same Flake component layout test passed.
-- Module: `./gradlew :bluetape4k-idgenerators:test --no-build-cache` passed with 1149 tests.
-- Build: `./gradlew :bluetape4k-idgenerators:build --no-build-cache` passed.
-- Hygiene: `git diff --check` passed.
-- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.
+- RED: `./gradlew :bluetape4k-idgenerators:test --tests "io.bluetape4k.idgenerators.flake.FlakeTest.component string uses timestamp node and sequence byte layout" --no-build-cache`가 shifted component `7528612310232073478-25939941-1`로 실패했다.
+- GREEN targeted: 같은 Flake component layout test가 통과했다.
+- module: `./gradlew :bluetape4k-idgenerators:test --no-build-cache`가 1149 tests로 통과했다.
+- build: `./gradlew :bluetape4k-idgenerators:build --no-build-cache`가 통과했다.
+- hygiene: `git diff --check`가 통과했다.
+- static analysis: `./gradlew detekt`가 `:detekt NO-SOURCE`와 함께 통과했다.

--- a/docs/lessons/2026-06-23-issue-846-dateadd-backward-split.md
+++ b/docs/lessons/2026-06-23-issue-846-dateadd-backward-split.md
@@ -1,31 +1,31 @@
-# Issue #846 DateAdd Backward Split Period Seek
+# 이슈 #846 DateAdd backward split period seek
 
-Issue #846 found that `DateAdd.findPrevPeriod()` could choose an older
-available period when a backward calculation started after multiple split
-available periods.
+issue #846은 backward calculation이 여러 split available period 뒤에서 시작할 때
+`DateAdd.findPrevPeriod()`가 더 오래된 available period를 선택할 수 있음을 찾았다.
 
-## Decision
+## 결정
 
-Compare previous-period distance as `Duration.between(period.end, start)` so
-the nearest prior period has the smallest positive distance. This keeps the
-existing forward seek logic unchanged and fixes backward seek selection for both
-plain `DateAdd` include periods and `CalendarDateAdd` working-hour periods.
+previous-period distance를 `Duration.between(period.end, start)`로 비교해 가장 가까운
+이전 period가 가장 작은 positive distance를 갖게 한다. 기존 forward seek logic은 그대로
+두고 plain `DateAdd` include period와 `CalendarDateAdd` working-hour period 양쪽의
+backward seek selection을 고친다.
 
-## Lessons
+## 교훈
 
-- Backward search should compare the distance from a candidate period end to the
-  start moment. Comparing `start` to `period.end` produces negative durations
-  and lets older periods look smaller than closer ones.
-- A zero-offset regression is useful for this bug because it exposes the chosen
-  start period directly before any duration arithmetic happens.
-- `CalendarDateAdd` should be covered when a bug lives in `DateAdd.calculateEnd`
-  because it rebuilds weekly working periods and delegates to the same path.
+- backward search는 candidate period end에서 start moment까지의 거리를 비교해야 한다.
+  `start`에서 `period.end`까지 비교하면 negative duration이 생기고 오래된 period가 더
+  작아 보일 수 있다.
+- zero-offset regression은 duration arithmetic 전에 선택된 start period를 직접 드러내므로
+  이 bug에 유용하다.
+- bug가 `DateAdd.calculateEnd`에 있을 때는 `CalendarDateAdd`도 cover해야 한다. weekly
+  working period를 다시 만들고 같은 path에 delegate하기 때문이다.
 
-## Verification
+## 검증
 
-- RED: split backward regressions failed with `2011-04-15T00:00Z` instead of `2011-04-24T00:00Z` and `2011-04-04T12:00Z` instead of `2011-04-04T18:00Z`.
-- GREEN targeted: `./gradlew :bluetape4k-javatimes:test --tests "io.bluetape4k.javatimes.period.calendars.DateAddTest.backward seek after split include periods starts from nearest previous period" --tests "io.bluetape4k.javatimes.period.calendars.CalendarDateAddTest.backward seek after split working hours starts from nearest previous period" --no-build-cache` passed with 2 tests.
-- Module: `./gradlew :bluetape4k-javatimes:test --no-build-cache` passed with 690 tests and 36 pending.
-- Build: `./gradlew :bluetape4k-javatimes:build --no-build-cache` passed.
-- Hygiene: `git diff --check` passed.
-- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.
+- RED: split backward regression은 `2011-04-15T00:00Z` 대신 `2011-04-24T00:00Z`,
+  `2011-04-04T12:00Z` 대신 `2011-04-04T18:00Z`로 실패했다.
+- GREEN targeted: `./gradlew :bluetape4k-javatimes:test --tests "io.bluetape4k.javatimes.period.calendars.DateAddTest.backward seek after split include periods starts from nearest previous period" --tests "io.bluetape4k.javatimes.period.calendars.CalendarDateAddTest.backward seek after split working hours starts from nearest previous period" --no-build-cache`가 2 tests로 통과했다.
+- module: `./gradlew :bluetape4k-javatimes:test --no-build-cache`가 690 tests, 36 pending으로 통과했다.
+- build: `./gradlew :bluetape4k-javatimes:build --no-build-cache`가 통과했다.
+- hygiene: `git diff --check`가 통과했다.
+- static analysis: `./gradlew detekt`가 `:detekt NO-SOURCE`와 함께 통과했다.

--- a/docs/lessons/2026-06-23-issue-847-jwt-reader-ttl.md
+++ b/docs/lessons/2026-06-23-issue-847-jwt-reader-ttl.md
@@ -1,32 +1,29 @@
-# Issue #847 JwtReader Remaining TTL
+# 이슈 #847 JwtReader remaining TTL
 
-Issue #847 found that `JwtReader.expiredTtl` was documented and used as a TTL
-but returned the absolute JWT `exp` timestamp in epoch milliseconds.
+issue #847은 `JwtReader.expiredTtl`이 TTL로 문서화되고 사용됐지만 실제로는 JWT `exp`의
+absolute epoch milliseconds timestamp를 반환한다는 점을 찾았다.
 
-## Decision
+## 결정
 
-Split the two concepts explicitly. `expiresAtMillis` now exposes the absolute
-expiration timestamp, `remainingTtlMillis` exposes the remaining TTL in
-milliseconds, and the existing `expiredTtl` property follows the remaining TTL
-contract for compatibility with the documented name. `isExpired` compares the
-absolute expiration timestamp directly instead of reusing the TTL value.
+두 개념을 명시적으로 분리한다. `expiresAtMillis`는 absolute expiration timestamp를
+노출하고, `remainingTtlMillis`는 남은 TTL milliseconds를 노출한다. 기존 `expiredTtl`
+property는 문서화된 이름과의 호환성을 위해 remaining TTL contract를 따른다. `isExpired`는
+TTL value를 재사용하지 않고 absolute expiration timestamp를 직접 비교한다.
 
-## Lessons
+## 교훈
 
-- Public auth APIs should not overload one value as both a TTL and an absolute
-  timestamp. Cache/session callers can retain authorization state for far too
-  long when those units are confused.
-- A one-hour token is an effective regression fixture: the remaining TTL must be
-  near 3,600,000 milliseconds, while an epoch timestamp is orders of magnitude
-  larger.
-- README examples should show both the remaining TTL and absolute expiration
-  accessors so consumers choose the correct value for cache TTLs and audit logs.
+- public auth API는 하나의 값을 TTL과 absolute timestamp 양쪽으로 overload하면 안 된다.
+  단위가 섞이면 cache/session caller가 authorization state를 지나치게 오래 유지할 수 있다.
+- one-hour token은 효과적인 regression fixture다. remaining TTL은 약 3,600,000
+  milliseconds여야 하고 epoch timestamp는 그보다 훨씬 크다.
+- README example은 remaining TTL과 absolute expiration accessor를 모두 보여줘 consumer가
+  cache TTL과 audit log에 맞는 값을 선택하게 해야 한다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest.expiredTtl - exp 클레임이 있으면 남은 TTL 밀리초를 반환한다" --no-build-cache` failed with `Expected <1782192683000> to be less than <3600001>`.
-- GREEN targeted: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest" --no-build-cache` passed.
-- Module: `./gradlew :bluetape4k-jwt:test --no-build-cache` passed with 150 tests and 10 pending.
-- Build: `./gradlew :bluetape4k-jwt:build --no-build-cache` passed.
-- Hygiene: `git diff --check` passed.
-- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.
+- RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest.expiredTtl - exp 클레임이 있으면 남은 TTL 밀리초를 반환한다" --no-build-cache`가 `Expected <1782192683000> to be less than <3600001>`로 실패했다.
+- GREEN targeted: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.reader.JwtReaderExpirationTest" --no-build-cache`가 통과했다.
+- module: `./gradlew :bluetape4k-jwt:test --no-build-cache`가 150 tests, 10 pending으로 통과했다.
+- build: `./gradlew :bluetape4k-jwt:build --no-build-cache`가 통과했다.
+- hygiene: `git diff --check`가 통과했다.
+- static analysis: `./gradlew detekt`가 `:detekt NO-SOURCE`와 함께 통과했다.

--- a/docs/lessons/2026-06-23-issue-848-redis-keychain-single-winner.md
+++ b/docs/lessons/2026-06-23-issue-848-redis-keychain-single-winner.md
@@ -1,32 +1,30 @@
-# Issue #848 Redis Key-Chain Single-Winner Rotation
+# 이슈 #848 Redis key-chain single-winner rotation
 
-Issue #848 found that `RedisKeyChainRepository.rotate()` trusted each
-process-local cached current keychain. Two application nodes could cache the
-same expired current keychain and then both insert different replacement keys
-into Redis.
+issue #848은 `RedisKeyChainRepository.rotate()`가 process-local cached current keychain을
+신뢰한다는 점을 찾았다. 두 application node가 같은 expired current keychain을 cache한
+뒤 Redis에 서로 다른 replacement key를 모두 insert할 수 있었다.
 
-## Decision
+## 결정
 
-Serialize Redis-backed rotation with a Redisson lock derived from the keychain
-queue name. While holding the lock, reload the current keychain from Redis and
-update the local cache before deciding whether to rotate. A node that loses the
-race sees the winner's non-expired keychain and immediately converges its cache
-to that key.
+keychain queue name에서 파생한 Redisson lock으로 Redis-backed rotation을 serialize한다.
+lock을 잡은 동안 Redis에서 current keychain을 다시 읽고 local cache를 갱신한 뒤 rotation
+여부를 결정한다. race에서 진 node는 winner의 non-expired keychain을 보고 즉시 cache를
+그 key로 수렴시킨다.
 
-## Lessons
+## 교훈
 
-- Distributed repositories cannot make rotation decisions from a per-process
-  cache. The lock-protected section must re-read the shared state.
-- A stale-cache race can be reproduced deterministically without thread timing:
-  two repository instances cache the same expired key, then rotate sequentially.
-- Forced rotation should use the same Redis lock and capacity trimming path so
-  regular and forced writes cannot interleave around deque maintenance.
+- distributed repository는 per-process cache만으로 rotation decision을 내릴 수 없다.
+  lock-protected section은 shared state를 다시 읽어야 한다.
+- stale-cache race는 thread timing 없이도 결정적으로 재현할 수 있다. repository instance
+  두 개가 같은 expired key를 cache한 뒤 순차적으로 rotate하면 된다.
+- forced rotation도 같은 Redis lock과 capacity trimming path를 사용해야 regular write와
+  forced write가 deque maintenance 주변에서 interleave하지 않는다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest.expired cached keychain rotates with single Redis winner"` failed with `Expected <2> to equal to <1>`.
-- GREEN targeted: the same Redis-backed test passed with 1 test.
-- Module: `./gradlew :bluetape4k-jwt:test` passed with 149 tests and 10 pending.
-- Build: `./gradlew :bluetape4k-jwt:build` passed.
-- Hygiene: `git diff --check` passed.
-- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.
+- RED: `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest.expired cached keychain rotates with single Redis winner"`가 `Expected <2> to equal to <1>`로 실패했다.
+- GREEN targeted: 같은 Redis-backed test가 1 test로 통과했다.
+- module: `./gradlew :bluetape4k-jwt:test`가 149 tests, 10 pending으로 통과했다.
+- build: `./gradlew :bluetape4k-jwt:build`가 통과했다.
+- hygiene: `git diff --check`가 통과했다.
+- static analysis: `./gradlew detekt`가 `:detekt NO-SOURCE`와 함께 통과했다.

--- a/docs/lessons/2026-06-23-issue-849-histogram-bin-progress.md
+++ b/docs/lessons/2026-06-23-issue-849-histogram-bin-progress.md
@@ -1,33 +1,32 @@
-# Issue #849 Histogram Bin Progress Guards
+# 이슈 #849 Histogram bin progress guard
 
-Issue #849 found that histogram bin builders trusted the caller-provided bin
-increment. A zero or negative bin size could make the shared comparable bin loop
-append ranges forever, and non-finite `Double` bin sizes had no public guard.
+issue #849는 histogram bin builder가 caller-provided bin increment를 신뢰한다는 점을
+찾았다. zero 또는 negative bin size는 shared comparable bin loop가 range를 무한히
+append하게 만들 수 있었고, non-finite `Double` bin size에는 public guard가 없었다.
 
-## Decision
+## 결정
 
-Reject invalid typed bin sizes before entering the shared bin loop:
+shared bin loop에 들어가기 전에 invalid typed bin size를 거부한다.
 
-- `Double` bin sizes must be finite and greater than zero.
-- `BigDecimal` bin sizes must be greater than zero.
-- Custom `binByComparable` incrementers must strictly increase the current range
-  end on every loop iteration.
+- `Double` bin size는 finite이고 0보다 커야 한다.
+- `BigDecimal` bin size는 0보다 커야 한다.
+- custom `binByComparable` incrementer는 매 loop iteration마다 current range end를 반드시
+  증가시켜야 한다.
 
-## Lessons
+## 교훈
 
-- Public numeric histogram APIs should validate progress at the typed boundary;
-  callers should not be able to create non-terminating bins through a simple
-  zero or negative size.
-- Shared generic loops still need a defensive invariant because callers can
-  provide custom incrementers outside the typed helpers.
-- RED tests for non-progressing loops can exhaust the test JVM. Capture one
-  failing reproduction, then add fail-fast guards before running the full suite.
+- public numeric histogram API는 typed boundary에서 progress를 검증해야 한다. caller가
+  간단한 zero 또는 negative size로 non-terminating bin을 만들 수 있으면 안 된다.
+- shared generic loop도 defensive invariant가 필요하다. caller가 typed helper 밖에서
+  custom incrementer를 제공할 수 있기 때문이다.
+- non-progressing loop의 RED test는 test JVM을 고갈시킬 수 있다. 실패 재현을 하나
+  확보한 뒤 full suite 전에 fail-fast guard를 추가한다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-math:test --tests "io.bluetape4k.math.DoubleHistogramTest.binByDouble rejects non progressing bin sizes"` failed with test JVM `Java heap space` after the zero bin size kept growing ranges.
-- GREEN targeted: `./gradlew :bluetape4k-math:test --tests "io.bluetape4k.math.DoubleHistogramTest.binByDouble rejects non progressing bin sizes" --tests "io.bluetape4k.math.BigDecimalHistogramTest.binByBigDecimal rejects non progressing bin sizes" --tests "io.bluetape4k.math.ComparableHistogramTest.binByComparable rejects non progressing incrementers"` passed with 3 tests.
-- Module: `./gradlew :bluetape4k-math:test` passed with 573 tests and 1 pending.
-- Build: `./gradlew :bluetape4k-math:build` passed.
-- Hygiene: `git diff --check` passed.
-- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.
+- RED: `./gradlew :bluetape4k-math:test --tests "io.bluetape4k.math.DoubleHistogramTest.binByDouble rejects non progressing bin sizes"`가 zero bin size로 range가 계속 커지며 test JVM `Java heap space`로 실패했다.
+- GREEN targeted: `./gradlew :bluetape4k-math:test --tests "io.bluetape4k.math.DoubleHistogramTest.binByDouble rejects non progressing bin sizes" --tests "io.bluetape4k.math.BigDecimalHistogramTest.binByBigDecimal rejects non progressing bin sizes" --tests "io.bluetape4k.math.ComparableHistogramTest.binByComparable rejects non progressing incrementers"`가 3 tests로 통과했다.
+- module: `./gradlew :bluetape4k-math:test`가 573 tests, 1 pending으로 통과했다.
+- build: `./gradlew :bluetape4k-math:build`가 통과했다.
+- hygiene: `git diff --check`가 통과했다.
+- static analysis: `./gradlew detekt`가 `:detekt NO-SOURCE`와 함께 통과했다.

--- a/docs/lessons/2026-06-23-issue-850-measured-composite-reductions.md
+++ b/docs/lessons/2026-06-23-issue-850-measured-composite-reductions.md
@@ -1,35 +1,34 @@
-# Issue #850 Measured Composite Reduction Conversions
+# 이슈 #850 Measured composite reduction conversion
 
-Issue #850 found that generic composite-unit reductions used the raw right-hand
-amount instead of converting it into the unit embedded in the composite
-measure. Mixed-scale reductions therefore produced values that were off by the
-scale ratio.
+issue #850은 generic composite-unit reduction이 right-hand amount를 composite measure에
+포함된 unit으로 변환하지 않고 raw value 그대로 사용한다는 점을 찾았다. mixed-scale
+reduction은 scale ratio만큼 잘못된 값을 만들었다.
 
-## Decision
+## 결정
 
-Convert the operand into the composite unit component before reducing:
+reduce하기 전에 operand를 composite unit component로 변환한다.
 
-- `(A/B) * B -> A` converts `B` into the ratio denominator.
-- `(A*B) / A -> B` converts `A` into the product first unit.
+- `(A/B) * B -> A`는 `B`를 ratio denominator로 변환한다.
+- `(A*B) / A -> B`는 `A`를 product first unit으로 변환한다.
 
-This preserves the existing generic unit algebra while making mixed-scale
-reductions consistent with `Measure.in`.
+이렇게 기존 generic unit algebra를 보존하면서 mixed-scale reduction을 `Measure.in`과
+일관되게 만든다.
 
-## Lessons
+## 교훈
 
-- Composite measure reductions must honor both operands' unit ratios, not just
-  their raw amounts.
-- Domain-specific operators such as `Length * Length -> Area` can hide bugs in
-  the lower-level generic algebra; regression tests should exercise the generic
-  `UnitsProduct` and `UnitsRatio` paths directly.
-- RED cases should include asymmetric scales in the reduced-away dimension,
-  such as `km/hr * minutes` and `km*km / meters`.
+- composite measure reduction은 raw amount뿐 아니라 양쪽 operand의 unit ratio를 모두
+  존중해야 한다.
+- `Length * Length -> Area` 같은 domain-specific operator는 lower-level generic algebra의
+  bug를 숨길 수 있다. regression test는 generic `UnitsProduct`와 `UnitsRatio` path를
+  직접 exercise해야 한다.
+- RED case에는 `km/hr * minutes`, `km*km / meters`처럼 reduced-away dimension에
+  asymmetric scale을 포함해야 한다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-measured:test --tests "io.bluetape4k.measured.MotionTest.속도와 다른 시간 단위로 거리를 계산한다" --tests "io.bluetape4k.measured.AreaTest.면적을 다른 길이 단위로 나누어 길이를 계산한다"` failed with `1080.0` vs `18.0` and `1.0` vs `1000.0`.
-- GREEN targeted: the same two-test command passed with 2 tests.
-- Module: `./gradlew :bluetape4k-measured:test` passed with 181 tests.
-- Build: `./gradlew :bluetape4k-measured:build` passed.
-- Hygiene: `git diff --check` passed.
-- Static analysis: `./gradlew detekt` passed with `:detekt NO-SOURCE`.
+- RED: `./gradlew :bluetape4k-measured:test --tests "io.bluetape4k.measured.MotionTest.속도와 다른 시간 단위로 거리를 계산한다" --tests "io.bluetape4k.measured.AreaTest.면적을 다른 길이 단위로 나누어 길이를 계산한다"`가 `1080.0` vs `18.0`, `1.0` vs `1000.0`으로 실패했다.
+- GREEN targeted: 같은 two-test command가 2 tests로 통과했다.
+- module: `./gradlew :bluetape4k-measured:test`가 181 tests로 통과했다.
+- build: `./gradlew :bluetape4k-measured:build`가 통과했다.
+- hygiene: `git diff --check`가 통과했다.
+- static analysis: `./gradlew detekt`가 `:detekt NO-SOURCE`와 함께 통과했다.

--- a/docs/lessons/2026-06-23-issue-851-mutiny-asuni-cold.md
+++ b/docs/lessons/2026-06-23-issue-851-mutiny-asuni-cold.md
@@ -1,30 +1,28 @@
-# Issue #851 Mutiny Coroutine `asUni` Cold Contract
+# 이슈 #851 Mutiny Coroutine `asUni` cold contract
 
-Issue #851 found that `CoroutineScope.asUni { ... }` created a `Deferred`
-immediately and then converted it to a `Uni`. That made the suspend block hot:
-creating the `Uni` was enough to start side effects even when no subscriber
-existed.
+issue #851은 `CoroutineScope.asUni { ... }`가 `Deferred`를 즉시 만들고 이를 `Uni`로
+변환한다는 점을 찾았다. 그 결과 suspend block이 hot해져 subscriber가 없어도 `Uni`를
+생성하는 것만으로 side effect가 시작됐다.
 
-## Decision
+## 결정
 
-Create the coroutine inside `Uni.createFrom().emitter { ... }`, because Mutiny
-invokes the emitter consumer on subscription. The bridge now creates a fresh
-`Deferred` per subscriber, forwards completion/failure from `invokeOnCompletion`,
-and cancels the `Deferred` when the Uni subscription terminates before the
-coroutine completes.
+Mutiny가 subscription 시점에 emitter consumer를 호출하므로 coroutine은
+`Uni.createFrom().emitter { ... }` 안에서 만든다. bridge는 subscriber마다 fresh
+`Deferred`를 만들고, `invokeOnCompletion`에서 completion/failure를 forward하며, coroutine
+완료 전에 Uni subscription이 terminate되면 `Deferred`를 cancel한다.
 
-## Lessons
+## 교훈
 
-- Reactive bridge helpers must match reactive demand semantics. A `Uni` factory
-  that starts work before subscription is a side-effect leak.
-- `Deferred.asUni()` has useful result and cancellation forwarding, but it is
-  only cold if the `Deferred` itself is created at subscription time.
-- Cancellation tests should prove both directions: cancelling the subscription
-  cancels the coroutine, and coroutine cancellation/failure reaches the Uni.
+- reactive bridge helper는 reactive demand semantic과 맞아야 한다. subscription 전에 work를
+  시작하는 `Uni` factory는 side-effect leak이다.
+- `Deferred.asUni()`는 result와 cancellation forwarding에는 유용하지만, `Deferred` 자체가
+  subscription time에 생성될 때만 cold하다.
+- cancellation test는 양방향을 모두 증명해야 한다. subscription cancel은 coroutine을
+  cancel하고, coroutine cancellation/failure는 Uni에 도달해야 한다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --no-build-cache` failed with `Expected <1> to equal to <0>`.
+- RED: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --no-build-cache`가 `Expected <1> to equal to <0>`로 실패했다.
 - GREEN targeted: `./gradlew :bluetape4k-mutiny:test --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni does not start suspend block before subscription" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni cancellation cancels running coroutine" --tests "io.bluetape4k.mutiny.CoroutineSupportTest.asUni propagates failure and cancellation exceptions" --no-build-cache`
-- Module: `./gradlew :bluetape4k-mutiny:compileKotlin :bluetape4k-mutiny:compileTestKotlin :bluetape4k-mutiny:test --no-build-cache` passed with 29 tests.
-- Build: `./gradlew :bluetape4k-mutiny:build --no-build-cache` passed.
+- module: `./gradlew :bluetape4k-mutiny:compileKotlin :bluetape4k-mutiny:compileTestKotlin :bluetape4k-mutiny:test --no-build-cache`가 29 tests로 통과했다.
+- build: `./gradlew :bluetape4k-mutiny:build --no-build-cache`가 통과했다.

--- a/docs/lessons/2026-06-23-issue-852-rule-engine-condition-failure.md
+++ b/docs/lessons/2026-06-23-issue-852-rule-engine-condition-failure.md
@@ -1,17 +1,23 @@
-# Lessons - Issue #852 Rule Engine Condition Failure
+# 교훈 - 이슈 #852 Rule engine condition failure
 
-## Context
+## 배경
 
-Issue #852 aligned synchronous `DefaultRuleEngine` with the suspend engine when a rule condition throws.
+issue #852는 rule condition이 throw할 때 synchronous `DefaultRuleEngine`을 suspend engine과
+맞췄다.
 
-## Lessons
+## 교훈
 
-- Rule failure policy must cover condition evaluation and action execution. Catching only action exceptions leaves `skipOnFirstFailedRule` inconsistent.
-- `check()` should produce per-rule evaluation results. One condition exception should record `false` for that rule instead of aborting the whole result map.
-- Listener ordering matters when converting exceptions into policy outcomes. A condition exception should still complete the rule-set lifecycle and report evaluation as `false`.
-- `CancellationException` is not an ordinary rule failure. Sync and suspend engines must rethrow it before broad `Exception` handling.
-- Keep sync and suspend engines behaviorally paired when they expose the same configuration semantics.
+- rule failure policy는 condition evaluation과 action execution을 모두 다뤄야 한다.
+  action exception만 catch하면 `skipOnFirstFailedRule`이 일관되지 않다.
+- `check()`는 rule별 evaluation result를 만들어야 한다. condition exception 하나가 전체
+  result map을 abort하지 말고 해당 rule에 `false`를 기록해야 한다.
+- exception을 policy outcome으로 변환할 때 listener ordering이 중요하다. condition
+  exception이 있어도 rule-set lifecycle은 완료되고 evaluation은 `false`로 보고되어야 한다.
+- `CancellationException`은 ordinary rule failure가 아니다. sync/suspend engine은 넓은
+  `Exception` handling 전에 이를 rethrow해야 한다.
+- 같은 configuration semantic을 노출하는 sync/suspend engine은 behavior pair를 유지한다.
 
-## Guard
+## 가드
 
-When modifying rule engine failure policy, add sync and suspend parity tests for both `fire()` and `check()` before changing implementation.
+rule engine failure policy를 수정할 때는 implementation을 바꾸기 전에 `fire()`와 `check()`
+양쪽에 대한 sync/suspend parity test를 추가한다.

--- a/docs/lessons/2026-06-23-issue-853-netcdf-progress-lease-owner.md
+++ b/docs/lessons/2026-06-23-issue-853-netcdf-progress-lease-owner.md
@@ -1,35 +1,32 @@
-# Issue #853 NetCDF Progress Lease Owner
+# 이슈 #853 NetCDF progress lease owner
 
-Issue #853 found that `NetCdfImportProgressRepository` used the shared progress
-row id as the only write authority. When an `IN_PROGRESS` lease expired and a
-second importer reacquired the same `(fileId, variableName)` row, the stale
-importer still held the same `progressId` and could renew, complete, or fail the
-row owned by the new importer.
+issue #853은 `NetCdfImportProgressRepository`가 shared progress row id를 유일한 write
+authority로 사용한다는 점을 찾았다. `IN_PROGRESS` lease가 만료되고 두 번째 importer가
+같은 `(fileId, variableName)` row를 다시 획득하면, stale importer도 같은 `progressId`를
+가지고 새 owner의 row를 renew, complete, fail할 수 있었다.
 
-## Decision
+## 결정
 
-Use the current `lease_expires_at` value returned by `acquireLease` as the lease
-owner token. `renewLease`, `markCompleted`, and `markFailed` now require that
-expected token in their `WHERE` clause. A mismatched token produces
-`NetCdfException.ImportLeaseLost` and leaves the current owner row unchanged.
+`acquireLease`가 반환한 현재 `lease_expires_at` 값을 lease owner token으로 사용한다.
+`renewLease`, `markCompleted`, `markFailed`는 `WHERE` clause에서 expected token을
+요구한다. token이 맞지 않으면 `NetCdfException.ImportLeaseLost`를 만들고 current owner
+row는 변경하지 않는다.
 
-No schema migration is needed because the existing lease expiry timestamp is
-already updated on every acquisition and renewal.
+기존 lease expiry timestamp가 acquisition과 renewal마다 이미 업데이트되므로 schema
+migration은 필요 없다.
 
-## Lessons
+## 교훈
 
-- A reusable progress row id is not a lease ownership proof. Reacquiring an
-  expired row must create a new write token even when the primary key stays the
-  same.
-- Heartbeat renewal must return the next token. Completion and failure paths
-  then prove ownership against the latest lease, not the original acquisition.
-- Stale-owner tests should cover every terminal writer, not just heartbeat
-  renewal. Otherwise a stale importer can still corrupt the row by marking it
-  completed or failed.
+- reusable progress row id는 lease ownership proof가 아니다. expired row를 다시 획득할
+  때는 primary key가 같아도 새 write token을 만들어야 한다.
+- heartbeat renewal은 다음 token을 반환해야 한다. completion/failure path는 original
+  acquisition이 아니라 latest lease에 대해 ownership을 증명해야 한다.
+- stale-owner test는 heartbeat renewal뿐 아니라 모든 terminal writer를 cover해야 한다.
+  그렇지 않으면 stale importer가 completed 또는 failed로 row를 corrupt할 수 있다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23a - stale lease owner cannot renew after expired lease is reacquired" --no-build-cache` failed with `Expected <99> to be <null>`.
+- RED: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23a - stale lease owner cannot renew after expired lease is reacquired" --no-build-cache`가 `Expected <99> to be <null>`로 실패했다.
 - GREEN targeted: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23a - stale lease owner cannot renew after expired lease is reacquired" --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23b - stale lease owner cannot complete after expired lease is reacquired" --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23c - stale lease owner cannot fail after expired lease is reacquired" --no-build-cache`
-- Regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest" --no-build-cache`
-- Module: `./gradlew :bluetape4k-science:test --no-build-cache` passed with 214 tests.
+- regression: `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest" --no-build-cache`
+- module: `./gradlew :bluetape4k-science:test --no-build-cache`가 214 tests로 통과했다.

--- a/docs/lessons/2026-06-23-issue-854-shapefile-crs.md
+++ b/docs/lessons/2026-06-23-issue-854-shapefile-crs.md
@@ -1,26 +1,26 @@
-# Issue #854 Shapefile CRS Import
+# 이슈 #854 Shapefile CRS import
 
-Issue #854 found that `ShapefileImportService` stored every shapefile as WGS84
-without reading `.prj` metadata. Projected inputs such as EPSG:3857 therefore
-kept meter coordinates while the layer metadata claimed SRID 4326.
+issue #854는 `ShapefileImportService`가 `.prj` metadata를 읽지 않고 모든 shapefile을
+WGS84로 저장한다는 점을 찾았다. EPSG:3857 같은 projected input은 meter coordinate를
+그대로 유지하면서 layer metadata는 SRID 4326이라고 표시했다.
 
-## Decision
+## 결정
 
-Transform shapefile records to EPSG:4326 during import when `.prj` declares a
-different CRS. Store PostGIS geometry as EWKT with `SRID=4326` and recompute
-layer bbox from transformed geometries.
+`.prj`가 다른 CRS를 선언하면 import 중 shapefile record를 EPSG:4326으로 transform한다.
+PostGIS geometry는 `SRID=4326`을 가진 EWKT로 저장하고, transformed geometry에서 layer
+bbox를 다시 계산한다.
 
-## Lessons
+## 교훈
 
-- Layer metadata and geometry SRID must be proven together. A layer-level
-  `srid=4326` is not enough when `PGgeometry` is created from plain WKT.
-- Dynamic shapefile fixtures are better than checked-in projected fixtures for
-  this case. They keep the test small and verify `.prj` generation, CRS parsing,
-  coordinate transformation, SRID storage, and bbox semantics in one path.
-- Missing `.prj` remains a compatibility assumption: treat the input as WGS84,
-  but document that behavior so callers know the boundary.
+- layer metadata와 geometry SRID는 함께 증명해야 한다. `PGgeometry`가 plain WKT로 만들어진
+  경우 layer-level `srid=4326`만으로는 충분하지 않다.
+- dynamic shapefile fixture는 이 경우 checked-in projected fixture보다 낫다. test를 작게
+  유지하면서 `.prj` generation, CRS parsing, coordinate transformation, SRID storage,
+  bbox semantic을 한 path에서 검증한다.
+- `.prj` 누락은 compatibility assumption으로 남는다. input을 WGS84로 취급하되 caller가
+  boundary를 알 수 있도록 문서화한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest.Shapefile import transforms projected CRS to WGS84" --no-build-cache`
 - `./gradlew :bluetape4k-science:test --tests "io.bluetape4k.science.exposed.repository.SpatialFeatureRepositoryTest" --no-build-cache`

--- a/docs/lessons/2026-06-23-issue-856-workflow-all-fail-fast.md
+++ b/docs/lessons/2026-06-23-issue-856-workflow-all-fail-fast.md
@@ -1,17 +1,26 @@
-# Lessons - Issue #856 Workflow ALL Fail-Fast
+# 교훈 - 이슈 #856 Workflow ALL fail-fast
 
-## Context
+## 배경
 
-Issue #856 fixed `ParallelPolicy.ALL` so blocking and suspend parallel workflows stop remaining siblings when any branch throws or returns a non-success `WorkReport`.
+issue #856은 blocking/suspend parallel workflow에서 branch 하나가 throw하거나 non-success
+`WorkReport`를 반환할 때 `ParallelPolicy.ALL`이 남은 sibling을 중지하도록 고쳤다.
 
-## Lessons
+## 교훈
 
-- Fail-fast must cover returned reports as well as thrown exceptions. A child that catches its own exception and returns `WorkReport.Failure` will otherwise look like normal completion to structured concurrency.
-- `WorkReport.Aborted` and `WorkReport.Cancelled` are also non-success outcomes for ALL. They should cancel siblings instead of waiting for every branch and applying a priority table afterward.
-- Cancellation tests need workflow-owned siblings. Stress helpers are useful for repeated independent execution, but they do not prove that a specific sibling received `InterruptedException` or coroutine cancellation from the workflow scope.
-- Suspend implementations must not swallow `CancellationException`. Re-throw it so parent cancellation and child cancellation contracts stay observable.
-- Keep README policy text and `ParallelPolicy` KDoc aligned with implementation semantics. ALL means all branches succeed; any non-success branch fails fast.
+- fail-fast는 thrown exception뿐 아니라 returned report도 cover해야 한다. child가 자기
+  exception을 catch하고 `WorkReport.Failure`를 반환하면, 그렇지 않을 경우 structured
+  concurrency에는 정상 완료처럼 보인다.
+- `WorkReport.Aborted`와 `WorkReport.Cancelled`도 ALL에서는 non-success outcome이다.
+  모든 branch를 기다린 뒤 priority table을 적용하지 말고 sibling을 cancel해야 한다.
+- cancellation test에는 workflow-owned sibling이 필요하다. stress helper는 반복 독립
+  실행에는 유용하지만, 특정 sibling이 workflow scope에서 `InterruptedException` 또는
+  coroutine cancellation을 받았다는 증명은 아니다.
+- suspend implementation은 `CancellationException`을 삼키면 안 된다. parent cancellation과
+  child cancellation contract가 관찰 가능하도록 rethrow한다.
+- README policy text와 `ParallelPolicy` KDoc은 implementation semantic과 맞춰 유지한다.
+  ALL은 모든 branch가 성공한다는 뜻이고, non-success branch 하나라도 있으면 fail fast다.
 
-## Guard
+## 가드
 
-When changing workflow policies, add thrown-exception plus returned `Failure`/`Aborted`/`Cancelled` regression tests for blocking and suspend implementations, then preserve RED and GREEN evidence in `docs/review`.
+parallel workflow policy를 바꿀 때는 blocking/suspend 구현 모두에서 throw, failure report,
+aborted, cancelled branch를 다루는 parity test를 먼저 추가한다.

--- a/docs/lessons/2026-06-23-issue-860-gitleaks-install.md
+++ b/docs/lessons/2026-06-23-issue-860-gitleaks-install.md
@@ -1,24 +1,22 @@
-# Issue 860 - deterministic gitleaks install
+# 이슈 860 - deterministic gitleaks install
 
-## Context
+## 배경
 
-The `Secret Scan (gitleaks)` job in `CI` failed before scanning because the
-installer queried `https://api.github.com/repos/gitleaks/gitleaks/releases/latest`
-without authentication. GitHub returned HTTP 403, so the `Run gitleaks` step was
-skipped.
+`CI`의 `Secret Scan (gitleaks)` job은 scan 전에 실패했다. installer가 authentication 없이
+GitHub releases API에서 latest gitleaks tag를 조회했기 때문이다. GitHub가 HTTP 403을
+반환했고, 그래서 `Run gitleaks` step은 실행되지 않았다.
 
-The same latest-release lookup was present in the weekly `Security` workflow.
-Earlier fixes had already moved from hand-built latest URLs to release metadata,
-but that still left the CI path dependent on a rate-limited API call.
+같은 latest-release lookup은 weekly `Security` workflow에도 있었다. 이전 fix는 이미
+hand-built latest URL에서 release metadata로 옮겼지만, CI path는 여전히 rate-limited API
+call에 의존했다.
 
-## Decision
+## 결정
 
-Pin `GITLEAKS_VERSION` to `v8.30.1` and download the exact Linux x64 release
-asset from the tag URL. This removes the unauthenticated releases API lookup
-from the installer while preserving the existing `gitleaks detect` commands.
+`GITLEAKS_VERSION`을 `v8.30.1`로 고정하고 tag URL에서 정확한 Linux x64 release asset을
+download한다. 이렇게 installer에서 unauthenticated releases API lookup을 제거하면서 기존
+`gitleaks detect` command semantic은 보존한다.
 
-## Follow-up Guard
+## 후속 가드
 
-Keep the `CI` and `Security` gitleaks installers aligned. If the pinned scanner
-version changes, update both workflow env blocks and verify the asset URL before
-merging.
+`CI`와 `Security` gitleaks installer를 맞춰 유지한다. pinned scanner version이 바뀌면 양쪽
+workflow env block을 업데이트하고, commit 전에 asset URL을 검증한다.

--- a/docs/lessons/2026-06-23-issue-879-coroutines-test-bridges.md
+++ b/docs/lessons/2026-06-23-issue-879-coroutines-test-bridges.md
@@ -1,40 +1,37 @@
-# Issue #879 Coroutines Test Bridge Removal
+# 이슈 #879 Coroutines test bridge removal
 
-Issue #879 removed the deprecated `io.bluetape4k.coroutines.tests` bridge
-package from production coroutines sources. The repository now uses the owner
-modules directly: Flow assertions from `bluetape4k-assertions` and dispatcher
-test helpers from `bluetape4k-junit5`.
+issue #879는 production coroutines source에서 deprecated
+`io.bluetape4k.coroutines.tests` bridge package를 제거했다. repository는 이제 owner
+module을 직접 사용한다. Flow assertion은 `bluetape4k-assertions`에서, dispatcher test
+helper는 `bluetape4k-junit5`에서 가져온다.
 
-## Decision
+## 결정
 
-- Delete the bridge sources under `bluetape4k-coroutines`.
-- Move `withSingleThread` and `withParallels` to
-  `io.bluetape4k.junit5.coroutines`.
-- Migrate coroutines tests and examples to
-  `io.bluetape4k.assertions.coroutines`.
-- Preserve the newer assertion module's cancellation contract by asserting
-  `CancellationException` with `assertFailsWith` where needed.
+- `bluetape4k-coroutines` 아래 bridge source를 삭제한다.
+- `withSingleThread`와 `withParallels`를 `io.bluetape4k.junit5.coroutines`로 이동한다.
+- coroutines test와 example을 `io.bluetape4k.assertions.coroutines`로 migration한다.
+- 필요한 곳에서는 `assertFailsWith`로 `CancellationException`을 assert해 newer assertion
+  module의 cancellation contract를 보존한다.
 
-## Lessons
+## 교훈
 
-- Deprecated bridge APIs can hide owner-module semantics. The old bridge
-  accepted `CancellationException` through `assertError`, while the assertion
-  module intentionally rethrows cancellation. Migration should preserve the
-  owner module contract instead of recreating bridge behavior.
-- Shared test helpers should avoid adding new module dependencies when moved.
-  `bluetape4k-junit5` does not need `bluetape4k-core` just to validate
-  `parallelism` or ignore executor shutdown failures.
-- Full-package scans should distinguish active Kotlin sources from historical
-  planning notes. The old package remains only in archived `docs/superpowers`
-  context.
+- deprecated bridge API는 owner-module semantic을 숨길 수 있다. old bridge는
+  `assertError`를 통해 `CancellationException`을 받아들였지만 assertion module은 의도적으로
+  cancellation을 rethrow한다. migration은 bridge behavior를 재생성하지 말고 owner module
+  contract를 보존해야 한다.
+- shared test helper를 이동할 때 새 module dependency를 추가하지 않는다. `bluetape4k-junit5`는
+  `parallelism` 검증이나 executor shutdown failure 무시를 위해 `bluetape4k-core`가 필요하지
+  않다.
+- full-package scan은 active Kotlin source와 historical planning note를 구분해야 한다. old
+  package는 archived `docs/superpowers` context에만 남아 있다.
 
-## Verification
+## 검증
 
-- `./gradlew :bluetape4k-junit5:compileKotlin` passed.
-- `./gradlew :bluetape4k-junit5:test :bluetape4k-assertions:test` passed.
-- `./gradlew :bluetape4k-coroutines:compileTestKotlin :bluetape4k-coroutines:test` passed.
-- `./gradlew :bluetape4k-examples-coroutines-demo:compileTestKotlin` passed; it still reports the pre-existing unused-expression warning in `TimeoutExamples.kt`.
-- `./gradlew :bluetape4k-coroutines:compileTestKotlin --warning-mode all` had no old bridge package, `FlowAssertions`, or `TestSupport` warning hits.
-- `rg "io\\.bluetape4k\\.coroutines\\.tests" -g '*.kt' -g '*.kts'` returned no active Kotlin/KTS matches.
-- Test result XML totals: junit5 269 tests, assertions 689 tests, coroutines 566 tests; all failures/errors 0.
-- `git diff --check` passed.
+- `./gradlew :bluetape4k-junit5:compileKotlin`이 통과했다.
+- `./gradlew :bluetape4k-junit5:test :bluetape4k-assertions:test`가 통과했다.
+- `./gradlew :bluetape4k-coroutines:compileTestKotlin :bluetape4k-coroutines:test`가 통과했다.
+- `./gradlew :bluetape4k-examples-coroutines-demo:compileTestKotlin`이 통과했다. `TimeoutExamples.kt`의 기존 unused-expression warning은 남아 있다.
+- `./gradlew :bluetape4k-coroutines:compileTestKotlin --warning-mode all`에는 old bridge package, `FlowAssertions`, `TestSupport` warning hit가 없었다.
+- `rg "io\\.bluetape4k\\.coroutines\\.tests" -g '*.kt' -g '*.kts'`는 active Kotlin/KTS match를 반환하지 않았다.
+- test result XML totals: junit5 269 tests, assertions 689 tests, coroutines 566 tests, failures/errors 0.
+- `git diff --check`가 통과했다.

--- a/docs/lessons/2026-06-23-issue-880-testcontainers-floci-minio.md
+++ b/docs/lessons/2026-06-23-issue-880-testcontainers-floci-minio.md
@@ -1,28 +1,26 @@
-# Lessons Learned - Testcontainers Floci and MinIO policy (#880, 2026-06-23)
+# Testcontainers Floci와 MinIO policy 교훈 (#880, 2026-06-23)
 
-Related issue: #880
-Affected module: `:bluetape4k-testcontainers`
+관련 이슈: #880
+영향 module: `:bluetape4k-testcontainers`
 
-## L1: Deprecation policy must not make supported compatibility fixtures noisy
+## L1: deprecation policy는 지원 중인 compatibility fixture를 시끄럽게 만들면 안 된다
 
-`MinIOServer` is still a supported fixture for direct MinIO compatibility
-tests. Marking the class itself as deprecated made every internal factory,
-launcher, and direct compatibility test look like migration debt even though
-the 1.11.0 policy keeps this fixture available.
+`MinIOServer`는 direct MinIO compatibility test를 위한 지원 fixture로 남아 있다. class
+자체를 deprecated로 표시하자, 1.11.0 policy가 이 fixture를 계속 제공하는데도 모든 internal
+factory, launcher, direct compatibility test가 migration debt처럼 보였다.
 
-The class-level deprecation was removed, and a reflection contract test now
-checks that `MinIOServer` remains non-deprecated while it is supported.
+class-level deprecation은 제거됐고, reflection contract test는 `MinIOServer`가 지원되는
+동안 non-deprecated 상태로 남는지 확인한다.
 
-## L2: Default AWS/S3 emulator guidance belongs on the wrapper boundary
+## L2: default AWS/S3 emulator guidance는 wrapper boundary에 둔다
 
-New AWS/S3 emulator tests should use the current AWS emulator path instead of
-defaulting to MinIO. The durable guidance now lives in `MinIOServer` KDoc and
-the `testing/testcontainers` README locale set: use `FlociServer` or
-`MiniStackServer` for new AWS/S3 emulator coverage, and use `MinIOServer` only
-for explicit MinIO compatibility behavior.
+새 AWS/S3 emulator test는 MinIO를 default로 쓰지 말고 현재 AWS emulator path를 사용해야
+한다. durable guidance는 이제 `MinIOServer` KDoc과 `testing/testcontainers` README locale
+set에 있다. 새 AWS/S3 emulator coverage에는 `FlociServer` 또는 `MiniStackServer`를 쓰고,
+explicit MinIO compatibility behavior에만 `MinIOServer`를 사용한다.
 
-## L3: Pinned emulator image tags need contract tests
+## L3: pinned emulator image tag에는 contract test가 필요하다
 
-The Docker Hub release tag `1.5.27` was verified on 2026-06-23. `FlociServer`
-keeps a pinned release tag for reproducible Testcontainers runs, and
-`FlociServerTest` guards that value so future tag changes are deliberate.
+Docker Hub release tag `1.5.27`은 2026-06-23에 검증됐다. `FlociServer`는 재현 가능한
+Testcontainers run을 위해 pinned release tag를 유지하고, `FlociServerTest`가 그 값을 지켜
+future tag change가 의도적으로 이루어지게 한다.

--- a/docs/lessons/2026-06-23-issue-881-science-netcdf-api.md
+++ b/docs/lessons/2026-06-23-issue-881-science-netcdf-api.md
@@ -1,43 +1,42 @@
-# Issue #881 Science NetCDF API Migration
+# 이슈 #881 Science NetCDF API migration
 
-Issue #881 tracked Java deprecation warnings in `NetCdfCatalogService` caused by
-metadata access through deprecated NetCDF-Java bean properties:
+issue #881은 deprecated NetCDF-Java bean property를 통한 metadata access 때문에
+`NetCdfCatalogService`에서 Java deprecation warning이 나는 문제를 추적했다.
 
-- `Variable.getAttributes()`, surfaced in Kotlin as `v.attributes`
-- `NetcdfFile.getDimensions()`, surfaced in Kotlin as `nc.dimensions`
+- `Variable.getAttributes()`, Kotlin에서는 `v.attributes`로 노출된다.
+- `NetcdfFile.getDimensions()`, Kotlin에서는 `nc.dimensions`로 노출된다.
 
-## Decision
+## 결정
 
-Use the NetCDF-Java 5.9.1 replacement API where the current source points:
+현재 source가 가리키는 NetCDF-Java 5.9.1 replacement API를 사용한다.
 
-- variable attributes come from `Variable.attributes()`
-- root-file dimensions come from `nc.rootGroup.getDimensions()`
+- variable attribute는 `Variable.attributes()`에서 가져온다.
+- root-file dimension은 `nc.rootGroup.getDimensions()`에서 가져온다.
 
-The service still writes the same bluetape4k domain shape:
+service는 같은 bluetape4k domain shape를 계속 쓴다.
 
 - `NetCdfVariableInfo.attributes`
 - `NetCdfFileRecord.dimensions`
 - `NetCdfFileRecord.globalAttrs`
 
-No repository, schema, import, or Gradle 10 cleanup behavior changed.
+repository, schema, import, Gradle 10 cleanup behavior는 바꾸지 않았다.
 
-## Lessons
+## 교훈
 
-- Kotlin bean-property syntax can hide deprecated Java getters. When a Java
-  library deprecates a getter, prefer explicit method calls or a local helper
-  that names the intended API.
-- `NetcdfFile.getDimensions()` is a global view that NetCDF-Java discourages.
-  For the current registration behavior, root group dimensions preserve the
-  existing root-file metadata shape without recursing through nested groups.
-- The simple source grep is useful for this issue because it catches accidental
-  reintroduction of the deprecated Kotlin property forms.
+- Kotlin bean-property syntax는 deprecated Java getter를 숨길 수 있다. Java library가
+  getter를 deprecate하면 명시적인 method call 또는 의도한 API 이름을 드러내는 local
+  helper를 우선한다.
+- `NetcdfFile.getDimensions()`는 NetCDF-Java가 권장하지 않는 global view다. 현재
+  registration behavior에서는 root group dimension이 nested group을 재귀하지 않고 기존
+  root-file metadata shape를 보존한다.
+- 단순 source grep은 deprecated Kotlin property form의 재도입을 잡는 데 유용하다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-science:compileKotlin --warning-mode all`
 - `./gradlew :bluetape4k-science:compileTestKotlin --warning-mode all`
 - `./gradlew :bluetape4k-science:test --tests '*NetCdfCatalogServiceTest' --tests '*NetCdfTableTest'`
-  passed with 37 tests.
+  37 tests로 통과했다.
 - `rg "\.attributes\b|\.dimensions\b" utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
-  returned no matches.
-- `git diff --check` passed.
+  match를 반환하지 않았다.
+- `git diff --check`가 통과했다.

--- a/docs/lessons/2026-06-24-issue-829-ktor-openapi-metadata-source.md
+++ b/docs/lessons/2026-06-24-issue-829-ktor-openapi-metadata-source.md
@@ -1,31 +1,30 @@
-# Issue 829 Ktor OpenAPI Metadata Source
+# 이슈 829 Ktor OpenAPI metadata source
 
-## Context
+## 배경
 
-`bluetape4k-ktor-openapi` advertised static files, compiler-generated OpenAPI
-metadata, and runtime `.describe {}` metadata as application-owned document
-sources.
+`bluetape4k-ktor-openapi`는 static file, compiler-generated OpenAPI metadata, runtime
+`.describe {}` metadata를 application-owned document source로 안내했다.
 
-## Lesson
+## 교훈
 
-Ktor's `openAPI(path, swaggerFile, block)` and
-`swaggerUI(path, swaggerFile, block)` overloads apply the caller block first and
-then force `source = OpenApiDocSource.File(swaggerFile)`. Wrapper helpers that
-accept a configuration block must delegate through Ktor's `block`-only overload
-when caller-owned `OpenApiDocSource` values need to survive.
+Ktor의 `openAPI(path, swaggerFile, block)`와 `swaggerUI(path, swaggerFile, block)`
+overload는 caller block을 먼저 적용한 뒤 `source = OpenApiDocSource.File(swaggerFile)`을
+강제로 설정한다. configuration block을 받는 wrapper helper가 caller-owned
+`OpenApiDocSource` 값을 보존해야 한다면 Ktor의 `block`-only overload를 통해 delegate해야
+한다.
 
-## Guard
+## 가드
 
-When README or KDoc claims Ktor routing-tree OpenAPI metadata is supported,
-tests must cover `OpenApiDocSource.Routing` through both the OpenAPI endpoint
-and the Swagger UI specification endpoint. A static YAML happy path is not
-enough because it does not prove the caller-owned `source` contract.
+README 또는 KDoc이 Ktor routing-tree OpenAPI metadata를 지원한다고 말한다면, test는
+OpenAPI endpoint와 Swagger UI specification endpoint 양쪽에서 `OpenApiDocSource.Routing`을
+cover해야 한다. static YAML happy path만으로는 caller-owned `source` contract를 증명하지
+못한다.
 
-## Evidence
+## 증거
 
-- RED: `KtorOpenApiRoutesTest` added routing metadata source tests; old wrapper
-  failed 2 of 6 tests because the Ktor static-file overload overwrote source.
+- RED: `KtorOpenApiRoutesTest`가 routing metadata source test를 추가했고, 기존 wrapper는
+  Ktor static-file overload가 source를 덮어써 6 tests 중 2 tests가 실패했다.
 - GREEN: `./gradlew :bluetape4k-ktor-openapi:compileKotlin :bluetape4k-ktor-openapi:compileTestKotlin :bluetape4k-ktor-openapi:test --no-build-cache`
-  passed with 6 `KtorOpenApiRoutesTest` cases.
-- Official Ktor docs and local Ktor 3.5.0 sources both show runtime metadata
-  via `OpenApiDocSource.Routing`.
+  가 6개 `KtorOpenApiRoutesTest` case로 통과했다.
+- official Ktor docs와 local Ktor 3.5.0 source 모두 runtime metadata를
+  `OpenApiDocSource.Routing`으로 보여준다.

--- a/docs/lessons/2026-06-24-issue-830-ktor-openapi-coordinate.md
+++ b/docs/lessons/2026-06-24-issue-830-ktor-openapi-coordinate.md
@@ -1,31 +1,27 @@
-# Lessons Learned - Issue #830 Ktor OpenAPI Maven Coordinate (2026-06-24)
+# 이슈 #830 Ktor OpenAPI Maven coordinate 교훈 (2026-06-24)
 
-Related issue: #830
-Module: `:bluetape4k-ktor-openapi`
+관련 이슈: #830
+module: `:bluetape4k-ktor-openapi`
 
-## L1: README dependency snippets must follow `projectGroup`
+## L1: README dependency snippet은 `projectGroup`을 따라야 한다
 
-### Problem
+### 문제
 
-`ktor/openapi` README snippets used `io.bluetape4k` even though the repository
-publishes under `projectGroup=io.github.bluetape4k`.
+repository가 `projectGroup=io.github.bluetape4k`로 publish하는데도 `ktor/openapi` README
+snippet은 `io.bluetape4k`를 사용했다.
 
-Users copying the snippet would request an artifact coordinate that does not
-match the published Maven group.
+snippet을 복사한 사용자는 published Maven group과 맞지 않는 artifact coordinate를 요청하게
+된다.
 
-### Lesson
+### 교훈
 
-When changing module dependency snippets, verify the group id against
-`gradle.properties` instead of copying old README examples. For localized
-README sets, update `README.md` and `README.ko.md` together and grep for stale
-module coordinates before closing the issue.
+module dependency snippet을 바꿀 때는 오래된 README example을 복사하지 말고
+`gradle.properties`에 있는 group id를 검증한다. localized README set은 `README.md`와
+`README.ko.md`를 함께 업데이트하고, issue를 닫기 전에 stale module coordinate를 grep한다.
 
-## Evidence
+## 증거
 
-- Source of truth: `gradle.properties` has
-  `projectGroup=io.github.bluetape4k`.
-- Fixed snippets:
-  `io.github.bluetape4k:bluetape4k-ktor-openapi:$bluetape4kVersion`.
-- Validation:
-  `rg "io\\.bluetape4k:bluetape4k-ktor-openapi" ktor/openapi/README.md ktor/openapi/README.ko.md`
-  returned no matches after the change.
+- source of truth: `gradle.properties`에는 `projectGroup=io.github.bluetape4k`가 있다.
+- fixed snippet: `io.github.bluetape4k:bluetape4k-ktor-openapi:$bluetape4kVersion`.
+- validation: `rg "io\\.bluetape4k:bluetape4k-ktor-openapi" ktor/openapi/README.md ktor/openapi/README.ko.md`
+  는 변경 후 match를 반환하지 않았다.

--- a/docs/lessons/2026-06-24-issue-831-ktor-timelimiter-failures.md
+++ b/docs/lessons/2026-06-24-issue-831-ktor-timelimiter-failures.md
@@ -1,82 +1,53 @@
-# Lessons Learned - Issue #831 Ktor TimeLimiter Failure Metrics (2026-06-24)
+# 이슈 #831 Ktor TimeLimiter failure metric 교훈 (2026-06-24)
 
-Related issue: #831
-Module: `:bluetape4k-ktor-resilience4j`
+관련 이슈: #831
+module: `:bluetape4k-ktor-resilience4j`
 
-## L1: TimeLimiter cancellation and failure accounting need separate catch paths
+## L1: TimeLimiter cancellation과 failure accounting은 catch path를 분리해야 한다
 
-### Problem
+### 문제
 
-`withTimeLimiterPreservingStatusMapping()` converted real timeouts to
-Resilience4j `TimeoutException` and recorded success events, but ordinary
-handler failures escaped without calling `timeLimiter.onError(e)`.
+`withTimeLimiterPreservingStatusMapping()`은 실제 timeout을 Resilience4j
+`TimeoutException`으로 변환하고 success event를 기록했지만, 일반 handler failure는
+`timeLimiter.onError(e)` 호출 없이 빠져나갔다.
 
-That made a TimeLimiter-protected Ktor invocation invisible to
-Resilience4j TimeLimiter events when the handler failed with a normal
-non-cancellation exception.
+그 결과 handler가 일반 non-cancellation exception으로 실패하면 TimeLimiter-protected Ktor
+invocation이 Resilience4j TimeLimiter event에서 보이지 않았다.
 
-### Lesson
+### 교훈
 
-For coroutine TimeLimiter wrappers, keep the catch order explicit:
+coroutine TimeLimiter wrapper에서는 catch order를 명시적으로 유지한다.
 
-1. Convert `TimeoutCancellationException` to the TimeLimiter timeout exception
-   and record it with `onError`.
-2. Rethrow other `CancellationException` values without recording policy
-   failure.
-3. Record ordinary non-cancellation failures with `onError` before rethrowing.
+1. `TimeoutCancellationException`을 TimeLimiter timeout exception으로 변환하고 `onError`로
+   기록한다.
+2. 다른 `CancellationException` 값은 policy failure로 기록하지 않고 rethrow한다.
+3. 일반 non-cancellation failure는 rethrow 전에 `onError`로 기록한다.
 
-The TimeLimiter public API exposes events for this module's verification
-surface, so regression tests should assert `eventPublisher.onError` rather
-than looking for CircuitBreaker-style metrics that TimeLimiter does not expose.
+TimeLimiter public API는 이 module의 verification surface로 event를 노출하므로, regression
+test는 TimeLimiter가 노출하지 않는 CircuitBreaker-style metric 대신
+`eventPublisher.onError`를 assert해야 한다.
 
-## Evidence
+## 증거
 
-- RED: `time limiter records ordinary handler failures` failed because the
-  TimeLimiter error event count stayed at 0.
-- GREEN: `KtorResilienceSupportTest` passed with 7 tests.
-- Module verification passed:
-  `./gradlew :bluetape4k-ktor-resilience4j:compileKotlin :bluetape4k-ktor-resilience4j:compileTestKotlin :bluetape4k-ktor-resilience4j:test --no-build-cache`.
-*** Add File: /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/fix-ktor-timelimiter-failures-831/docs/review/2026-06-24-issue-831-ktor-timelimiter-failures-review.md
-# Review - Issue #831 Ktor TimeLimiter Failure Metrics
-
-Date: 2026-06-24
-Branch: `fix/ktor-timelimiter-failures-831`
-Module: `:bluetape4k-ktor-resilience4j`
-
-## Scope
-
-- `ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupport.kt`
-- `ktor/resilience4j/src/test/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupportTest.kt`
-
-## Local Review
-
-- P0/P1 findings: 0
-- Catch ordering preserves timeout mapping:
-  `TimeoutCancellationException` is handled before generic
-  `CancellationException`.
-- External coroutine cancellation remains unrecorded as a policy failure.
-- Ordinary non-cancellation failures now call `timeLimiter.onError(e)` before
-  being rethrown.
-- Tests use existing `runSuspendIO` and bluetape4k assertions.
-- No ad hoc concurrency stress helper was needed because this bug is a
-  deterministic exception-boundary regression, not a race or contention issue.
-
-## Validation Evidence
-
-- RED:
-  `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest.time limiter records ordinary handler failures' --no-build-cache`
-  failed with `Expected <0> to equal to <1>`.
-- GREEN:
-  `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest' --no-build-cache`
-  passed with 7 tests.
-- Module:
+- RED: `time limiter records ordinary handler failures`는 TimeLimiter error event count가
+  0에 머물러 실패했다.
+- GREEN: `KtorResilienceSupportTest`가 7 tests로 통과했다.
+- module verification:
   `./gradlew :bluetape4k-ktor-resilience4j:compileKotlin :bluetape4k-ktor-resilience4j:compileTestKotlin :bluetape4k-ktor-resilience4j:test --no-build-cache`
-  passed.
-- Static:
-  `git diff --check` passed.
+  통과했다.
 
-## Residual Risk
+## Local review evidence
 
-- Full repository build was not run; the change is isolated to the
-  `ktor/resilience4j` TimeLimiter exception boundary and covered by module
-  compile/test.
+원래 문서에는 `fix/ktor-timelimiter-failures-831` branch의 review note fragment가 함께
+남아 있었다. 그 기록의 의미는 다음과 같다.
+
+- P0/P1 findings: 0.
+- catch ordering은 `TimeoutCancellationException`을 generic `CancellationException`보다
+  먼저 처리해 timeout mapping을 보존한다.
+- external coroutine cancellation은 policy failure로 기록하지 않는다.
+- 일반 non-cancellation failure는 rethrow 전에 `timeLimiter.onError(e)`를 호출한다.
+- test는 기존 `runSuspendIO`와 bluetape4k assertion을 사용했다.
+- bug가 deterministic exception-boundary regression이므로 ad hoc concurrency stress helper는
+  필요하지 않았다.
+- full repository build는 실행하지 않았고, 변경은 `ktor/resilience4j` TimeLimiter exception
+  boundary에 격리되어 module compile/test로 검증했다.

--- a/docs/lessons/2026-06-24-issue-832-findbean-failures.md
+++ b/docs/lessons/2026-06-24-issue-832-findbean-failures.md
@@ -1,29 +1,18 @@
-# Issue 832 - findBean failure boundaries
+# 이슈 832 - findBean failure boundary
 
-## Context
+## 배경
 
-`BeanFactory.findBean(...)` is an optional lookup helper. It should return
-`null` when the requested bean is absent, but it must not hide Spring
-configuration failures.
+Spring helper의 `findBean` 계열 API는 bean lookup failure를 nullable result처럼 보이게
+만들 위험이 있었다. optional lookup과 required lookup의 failure boundary가 문서와 test에서
+명확해야 했다.
 
-The previous implementation wrapped `get(...)` in `runCatching` and returned
-`null` for every exception. That made bean creation failures and duplicate-bean
-ambiguity look the same as an optional missing bean.
+## 결정
 
-## Decision
+optional helper는 bean이 없을 때 `null`을 반환하고, required helper는 Spring container의
+lookup failure를 그대로 노출하도록 boundary를 분리한다. README/KDoc/example은 nullable
+lookup과 required lookup을 같은 contract처럼 설명하지 않게 맞춘다.
 
-Keep the optional lookup contract for absent beans only:
+## 후속 가드
 
-- `NoSuchBeanDefinitionException` maps to `null`
-- `NoUniqueBeanDefinitionException` is rethrown even though it is a
-  `NoSuchBeanDefinitionException` subclass
-- bean creation, type, and configuration failures propagate
-
-The shared `findOptionalBean` helper keeps the exception boundary identical
-across class-based, named, and constructor-argument `findBean` overloads.
-
-## Follow-up Guard
-
-When adding optional Spring lookup helpers, do not catch broad `BeansException`
-unless every Spring configuration failure is intentionally optional. Add tests
-for missing-bean, creation-failure, and ambiguity boundaries together.
+Spring bean lookup helper를 바꿀 때는 optional/required path를 모두 test하고, exception을
+삼켜 nullable contract로 바꾸는 regression을 막는다.

--- a/docs/lessons/2026-06-26-hibernate-encryption-keysets.md
+++ b/docs/lessons/2026-06-26-hibernate-encryption-keysets.md
@@ -1,22 +1,25 @@
-# Lessons Learned - Hibernate Encryption Keysets (2026-06-26)
+# Hibernate encryption keyset 교훈 (2026-06-26)
 
-Related issue: #816
-Affected module: `:bluetape4k-hibernate`
+관련 이슈: #816
+영향 module: `:bluetape4k-hibernate`
 
-## L1: Persistent converters must not create process-local keys
+## L1: persistent converter는 process-local key를 만들면 안 된다
 
-### Problem
+### 문제
 
-`AESStringConverter` and `DeterministicAESStringConverter` were documented as persistent entity-field converters, but
-their default encryptors used generated in-process Tink keysets. That made same-process tests pass while persisted
-ciphertext could become unreadable after restart or in another application instance.
+`AESStringConverter`와 `DeterministicAESStringConverter`는 persistent entity-field
+converter로 문서화됐지만, 기본 encryptor는 process 안에서 생성한 Tink keyset을 사용했다.
+같은 process 안의 test는 통과해도, restart 후나 다른 application instance에서는 저장된
+ciphertext를 읽지 못할 수 있었다.
 
-### Lesson
+### 교훈
 
-Persistent encryption converters need explicit externally stored key material. Tests must cover both restart-safe
-positive cases with the same persisted keyset and restart-unsafe negative cases with a different keyset.
+persistent encryption converter에는 외부에 저장된 명시적 key material이 필요하다. test는
+같은 persisted keyset으로 restart-safe positive case를 검증하고, 다른 keyset으로
+restart-unsafe negative case도 함께 검증해야 한다.
 
-### Future guard
+### 향후 가드
 
-When adding a persistent encryption API, do not validate only same-instance round trips. Add a cross-instance or
-cross-keyset regression test and document where key material must live.
+persistent encryption API를 추가할 때 same-instance round trip만 검증하지 않는다.
+cross-instance 또는 cross-keyset regression test를 추가하고, key material이 어디에
+저장되어야 하는지 문서화한다.

--- a/docs/lessons/2026-06-26-hibernate-natural-id-keytype.md
+++ b/docs/lessons/2026-06-26-hibernate-natural-id-keytype.md
@@ -1,24 +1,25 @@
-# Lessons Learned - Hibernate Natural Id KeyType (2026-06-26)
+# Hibernate natural-id KeyType 교훈 (2026-06-26)
 
-Related issue: #908
-Affected module: `:bluetape4k-hibernate`
+관련 이슈: #908
+영향 module: `:bluetape4k-hibernate`
 
-## L1: Hibernate natural-id helpers must use loader APIs on Hibernate 7
+## L1: Hibernate 7 natural-id helper는 loader API를 사용해야 한다
 
-### Problem
+### 문제
 
-`Session.findBySimpleNaturalId()` and `Session.findByNaturalId()` used `Session.find(..., KeyType.NATURAL)`.
-`org.hibernate.KeyType` is not available in the Hibernate 7.2 runtime used by the module tests, so the helper tests
-failed with `NoClassDefFoundError`.
+`Session.findBySimpleNaturalId()`와 `Session.findByNaturalId()`가
+`Session.find(..., KeyType.NATURAL)`을 사용했다. module test가 사용하는 Hibernate 7.2
+runtime에는 `org.hibernate.KeyType`이 없어서 helper test가 `NoClassDefFoundError`로
+실패했다.
 
-### Lesson
+### 교훈
 
-Use Hibernate's natural-id loader APIs for natural-id lookups:
+natural-id lookup에는 Hibernate natural-id loader API를 사용한다.
 
-- `Session.bySimpleNaturalId(entityClass).load(value)` for simple natural ids.
-- `Session.byNaturalId(entityClass).using(values).load()` for composite natural ids.
+- simple natural id: `Session.bySimpleNaturalId(entityClass).load(value)`
+- composite natural id: `Session.byNaturalId(entityClass).using(values).load()`
 
-### Future guard
+### 향후 가드
 
-When a helper wraps Hibernate-specific APIs, verify against the exact `testRuntimeClasspath` Hibernate jar before
-using removed compatibility constants or overloads.
+helper가 Hibernate-specific API를 감쌀 때는 제거된 compatibility constant나 overload를
+사용하기 전에 정확한 `testRuntimeClasspath` Hibernate jar를 기준으로 검증한다.

--- a/docs/lessons/2026-06-26-issue-786-lettuce-clear-failure.md
+++ b/docs/lessons/2026-06-26-issue-786-lettuce-clear-failure.md
@@ -1,23 +1,24 @@
-# Lessons Learned - Lettuce Near Cache Clear Failure (2026-06-26)
+# Lettuce near cache clear failure 교훈 (2026-06-26)
 
-Related issue: #786
-Affected module: `:bluetape4k-cache-lettuce`
+관련 이슈: #786
+영향 module: `:bluetape4k-cache-lettuce`
 
-## L1: Do not hide backend clear failures behind best-effort cleanup
+## L1: backend clear failure를 best-effort cleanup 뒤에 숨기지 않는다
 
-### Problem
+### 문제
 
-`LettuceNearCache.clearAll()` cleared the local Caffeine cache and then wrapped Redis key cleanup in `runCatching`.
-When Redis `SCAN` or `UNLINK` failed, callers saw success even though backend entries could remain and later repopulate
-the local cache.
+`LettuceNearCache.clearAll()`은 local Caffeine cache를 지운 뒤 Redis key cleanup을
+`runCatching`으로 감쌌다. Redis `SCAN` 또는 `UNLINK`가 실패해도 caller는 성공을 봤고,
+backend entry가 남아 나중에 local cache를 다시 채울 수 있었다.
 
-### Lesson
+### 교훈
 
-For cache APIs whose contract says "local + backend", backend deletion failure must be visible to the caller unless the
-API explicitly models partial success. Blocking and suspend near-cache implementations should expose equivalent failure
-semantics.
+cache API contract가 "local + backend"라면 API가 partial success를 명시적으로 모델링하지
+않는 한 backend deletion failure는 caller에게 보여야 한다. blocking/suspend near-cache
+implementation은 동등한 failure semantic을 노출해야 한다.
 
-### Future guard
+### 향후 가드
 
-Failure-path tests should make backend cleanup fail before deletion and assert both that the caller receives an exception
-and that the backend key remains. Avoid `runCatching` around required backend operations when the result is ignored.
+failure-path test는 deletion 전에 backend cleanup을 실패시키고, caller가 exception을 받으며
+backend key가 남아 있음을 함께 assert해야 한다. 결과를 무시하는 필수 backend operation
+주변에서는 `runCatching`을 피한다.

--- a/docs/lessons/2026-06-26-issue-787-lettuce-cache-typed-getcache.md
+++ b/docs/lessons/2026-06-26-issue-787-lettuce-cache-typed-getcache.md
@@ -1,23 +1,23 @@
-# Lessons Learned - Lettuce Typed Cache Lookup (2026-06-26)
+# Lettuce typed cache lookup 교훈 (2026-06-26)
 
-Related issue: #787
-Affected module: `:bluetape4k-cache-lettuce`
+관련 이슈: #787
+영향 module: `:bluetape4k-cache-lettuce`
 
-## L1: Typed cache lookup must fail at the JCache boundary
+## L1: typed cache lookup은 JCache boundary에서 실패해야 한다
 
-### Problem
+### 문제
 
-`LettuceCacheManager.getCache(cacheName, keyType, valueType)` ignored the requested key and value classes and
-returned the cached instance with an unchecked cast. Callers could therefore receive a cache whose configured types
-did not match the typed lookup request.
+`LettuceCacheManager.getCache(cacheName, keyType, valueType)`는 요청된 key/value class를
+무시하고 cached instance를 unchecked cast로 반환했다. caller는 configured type이 typed
+lookup request와 맞지 않는 cache를 받을 수 있었다.
 
-### Lesson
+### 교훈
 
-JCache typed lookup is a boundary check, not only a Kotlin generic convenience. Resolve the named cache first, then
-compare the cache configuration's `keyType` and `valueType` with the requested classes before returning the cache.
-Type mismatches should fail immediately with `ClassCastException`.
+JCache typed lookup은 Kotlin generic convenience가 아니라 boundary check다. 먼저 named
+cache를 resolve한 뒤, cache configuration의 `keyType`과 `valueType`을 요청 class와 비교하고
+나서 cache를 반환한다. type mismatch는 즉시 `ClassCastException`으로 실패해야 한다.
 
-### Future guard
+### 향후 가드
 
-Cache manager changes should keep regression coverage for exact type matches, key mismatches, value mismatches,
-null type arguments, and closed-manager behavior.
+cache manager 변경에는 exact type match, key mismatch, value mismatch, null type argument,
+closed-manager behavior에 대한 regression coverage를 유지한다.

--- a/docs/lessons/2026-06-26-issue-788-hibernate-cache-key-encoding.md
+++ b/docs/lessons/2026-06-26-issue-788-hibernate-cache-key-encoding.md
@@ -1,26 +1,28 @@
-# Lessons Learned - Hibernate Cache Key Encoding (2026-06-26)
+# Hibernate cache key encoding 교훈 (2026-06-26)
 
-Related issue: #788
-Affected module: `:bluetape4k-hibernate-cache-lettuce`
+관련 이슈: #788
+영향 module: `:bluetape4k-hibernate-cache-lettuce`
 
-## L1: Cache key collision claims need public-path collision tests
+## L1: cache key collision claim에는 public-path collision test가 필요하다
 
-### Problem
+### 문제
 
-`LettuceNearCacheStorageAccess` normalized Hibernate keys with delimiter joins and `toString()`.
-That erased natural-id arity, array/scalar boundaries, and custom identifier state when `toString()` values matched.
-The README claimed Redis key collision prevention, but tests only checked that readable key fragments existed.
+`LettuceNearCacheStorageAccess`는 delimiter join과 `toString()`으로 Hibernate key를
+normalize했다. 이 방식은 `toString()` 값이 같을 때 natural-id arity, array/scalar boundary,
+custom identifier state를 지웠다. README는 Redis key collision prevention을 주장했지만,
+test는 readable key fragment가 존재하는지만 확인했다.
 
-### Lesson
+### 교훈
 
-When a cache bridge claims key collision resistance, cover the bridge's public storage path with adversarial keys:
+cache bridge가 key collision resistance를 주장한다면 public storage path를 adversarial key로
+cover한다.
 
-- a single delimiter-containing natural-id value versus a composite natural-id array,
-- scalar identifier text versus object-array identifier text,
-- custom identifiers with identical `toString()` output but different serialized state.
+- delimiter가 들어 있는 단일 natural-id value와 composite natural-id array
+- scalar identifier text와 object-array identifier text
+- `toString()` output은 같지만 serialized state가 다른 custom identifier
 
-### Future guard
+### 향후 가드
 
-Do not use readable delimiter strings as distributed cache keys unless every component is length-prefixed or otherwise
-typed. Prefer a versioned canonical digest key when the raw key can contain user values or Hibernate-disassembled
-objects.
+모든 component가 length-prefixed이거나 type 정보를 보존하지 않는 한 readable delimiter
+string을 distributed cache key로 쓰지 않는다. raw key가 user value나 Hibernate-disassembled
+object를 포함할 수 있으면 versioned canonical digest key를 우선한다.

--- a/docs/lessons/2026-06-26-issue-809-cassandra-session-cache-identity.md
+++ b/docs/lessons/2026-06-26-issue-809-cassandra-session-cache-identity.md
@@ -1,17 +1,26 @@
-# Issue 809 - Cassandra Session Cache Identity
+# 이슈 809 - Cassandra session cache identity
 
-## Context
+## 배경
 
-`CqlSessionProvider` cached sessions by keyspace name only. A process using the same keyspace name across tenants, endpoints, credentials, or client settings could silently reuse the first session.
+`CqlSessionProvider`는 keyspace name만으로 session을 cache했다. 같은 keyspace name을
+tenant, endpoint, credential, client setting이 다른 context에서 사용하면 process가 첫 번째
+session을 조용히 재사용할 수 있었다.
 
-## Decision
+## 결정
 
-Use `CqlSessionIdentity` as the cache key. The compatibility overload derives a conservative per-call identity from the builder supplier and builder lambda so different builder blocks no longer collide by keyspace alone. For stable same-context reuse across call sites, callers should use the explicit `CqlSessionIdentity` overload.
+cache key로 `CqlSessionIdentity`를 사용한다. compatibility overload는 builder supplier와
+builder lambda에서 보수적인 per-call identity를 만들어, 다른 builder block이 keyspace만으로
+충돌하지 않게 한다. call site 간 안정적인 same-context reuse가 필요하면 caller가 명시적
+`CqlSessionIdentity` overload를 사용해야 한다.
 
-## Outcome
+## 결과
 
-Regression tests now prove that same identity reuses a session while the same keyspace with different connection context does not reuse the earlier session. README examples document when to use explicit identity.
+regression test는 같은 identity가 session을 재사용하고, 같은 keyspace라도 connection
+context가 다르면 이전 session을 재사용하지 않음을 증명한다. README example은 explicit
+identity를 언제 써야 하는지 문서화한다.
 
-## Future Guidance
+## 향후 지침
 
-Do not cache infrastructure clients by a logical namespace alone when connection, credential, or tenant context can differ. Add an explicit identity object before relying on implicit builder state.
+connection, credential, tenant context가 달라질 수 있으면 infrastructure client를 logical
+namespace만으로 cache하지 않는다. implicit builder state에 기대기 전에 explicit identity
+object를 추가한다.

--- a/docs/lessons/2026-06-26-issue-814-hibernate-converter-runtime-deps.md
+++ b/docs/lessons/2026-06-26-issue-814-hibernate-converter-runtime-deps.md
@@ -1,30 +1,36 @@
-# Issue 814: Hibernate Converter Runtime Dependencies
+# 이슈 814: Hibernate 컨버터 런타임 의존성
 
-## Context
+## 배경
 
-`bluetape4k-hibernate` exposes converter classes for Tink encryption, Jackson3 JSON, Kryo/Fory serialization,
-and LZ4/Snappy/Zstd/Commons Compress compression. These converter engines were declared as `compileOnly` or
-test-only dependencies, while the module's tests extended `compileOnly` into `testImplementation`. That made
-module tests pass even though downstream consumers could miss runtime classes.
+`bluetape4k-hibernate`는 Tink 암호화, Jackson3 JSON, Kryo/Fory 직렬화,
+LZ4/Snappy/Zstd/Commons Compress 압축용 컨버터 클래스를 제공한다. 그런데
+이 컨버터 엔진 의존성은 `compileOnly` 또는 테스트 전용으로 선언되어 있었고,
+모듈 테스트는 `compileOnly`를 `testImplementation`으로 확장했다. 그 결과
+모듈 테스트는 통과했지만 downstream 소비자는 런타임 클래스가 빠질 수 있었다.
 
-## Decision
+## 결정
 
-Treat documented built-in converter engines as part of the `bluetape4k-hibernate` artifact contract:
+문서화된 내장 컨버터 엔진은 `bluetape4k-hibernate` artifact 계약의 일부로
+다룬다.
 
-- Use `api` when the dependency type appears in public converter API (`bluetape4k-tink`, `bluetape4k-jackson3`).
-- Use `runtimeOnly` when the dependency is needed by built-in converter implementations but not exposed in method
-  signatures (Kryo, Fory, LZ4, Snappy, Zstd, Commons Compress).
-- Add a `consumerRuntimeTest` source set that compiles and runs smoke tests against `sourceSets.main.output` plus
-  `runtimeClasspath`, not the regular test classpath.
+- 의존성 타입이 공개 컨버터 API에 드러나는 경우 `api`를 사용한다
+  (`bluetape4k-tink`, `bluetape4k-jackson3`).
+- 의존성이 내장 컨버터 구현에는 필요하지만 메서드 시그니처에는 드러나지 않으면
+  `runtimeOnly`를 사용한다(Kryo, Fory, LZ4, Snappy, Zstd, Commons Compress).
+- 정규 테스트 classpath가 아니라 `sourceSets.main.output`과
+  `runtimeClasspath`만으로 smoke test를 컴파일하고 실행하는
+  `consumerRuntimeTest` source set을 추가한다.
 
-## Outcome
+## 결과
 
-The new consumer smoke test verifies Tink encryption, Kryo/Fory byte-array converters, and compression converters
-from the published runtime classpath. README dependency snippets no longer tell consumers to add those converter
-engines as `compileOnly`.
+새 consumer smoke test는 배포 런타임 classpath에서 Tink 암호화, Kryo/Fory
+byte-array 컨버터, 압축 컨버터가 동작하는지 검증한다. README 의존성 예시는
+더 이상 소비자에게 해당 컨버터 엔진을 `compileOnly`로 추가하라고 안내하지
+않는다.
 
-## Future Guidance
+## 향후 지침
 
-When a module offers optional-looking concrete implementations in the main artifact, verify the consumer runtime
-classpath separately from unit tests. Do not rely on tests that extend `compileOnly`; they can hide missing
-transitive runtime dependencies.
+모듈이 main artifact 안에서 optional처럼 보이는 구체 구현을 제공한다면,
+unit test와 별도로 consumer runtime classpath를 검증해야 한다. `compileOnly`를
+확장한 테스트에 의존하지 않는다. 그런 테스트는 누락된 전이 런타임 의존성을
+숨길 수 있다.

--- a/docs/lessons/2026-06-26-issue-815-hibernate-object-converter-deserialization.md
+++ b/docs/lessons/2026-06-26-issue-815-hibernate-object-converter-deserialization.md
@@ -1,17 +1,27 @@
-# Issue 815 - Hibernate Object Converter Deserialization Boundary
+# 이슈 815: Hibernate 객체 컨버터 역직렬화 경계
 
-## Context
+## 배경
 
-Generic Hibernate object converters accepted `Any?` and deserialized database payloads without an explicit type boundary. That made persisted object columns a trust boundary whenever rows could be tampered with, imported, or shared across tenants.
+범용 Hibernate 객체 컨버터는 `Any?`를 받아 명시적인 타입 경계 없이 DB payload를
+역직렬화했다. 행이 변조되거나, 외부에서 import되거나, tenant 간에 공유될 수 있는
+환경에서는 persisted object column 자체가 trust boundary가 된다.
 
-## Decision
+## 결정
 
-Keep the legacy converters for compatibility, but deprecate them as trusted-storage-only. Add typed converter bases that require a target class and serializer, then reject deserialized values that do not match the expected type. For Kryo and Fory paths, prefer secure serializer factories such as `KryoBinarySerializer.secure(...)` and `ForyBinarySerializer.secureFory(...)`.
+호환성을 위해 기존 컨버터는 유지하되 trusted storage 전용으로 deprecate한다.
+대상 클래스와 serializer를 요구하는 typed converter base를 추가하고, 역직렬화된
+값이 예상 타입과 맞지 않으면 거부한다. Kryo와 Fory 경로에서는
+`KryoBinarySerializer.secure(...)`, `ForyBinarySerializer.secureFory(...)` 같은
+secure serializer factory를 우선 사용한다.
 
-## Outcome
+## 결과
 
-The public API now gives callers a migration path from generic `Any?` converters to typed converter subclasses. Negative tests cover malformed payloads, unexpected JDK payload types, and secure Kryo/Fory disallowed payloads.
+공개 API는 호출자가 범용 `Any?` 컨버터에서 typed converter subclass로 이동할
+수 있는 경로를 제공한다. Negative test는 malformed payload, 예상하지 못한 JDK
+payload 타입, secure Kryo/Fory에서 허용되지 않는 payload를 검증한다.
 
-## Future Guidance
+## 향후 지침
 
-When adding persistence converters around binary serialization, make the trusted/untrusted boundary explicit in both API shape and README examples. Compatibility wrappers can remain, but they should not be the recommended path for persisted, externally mutable data.
+binary serialization 기반 persistence converter를 추가할 때는 API 형태와 README
+예시 모두에서 trusted/untrusted 경계를 명시한다. 호환성 wrapper는 남길 수 있지만,
+persisted 외부 mutable data에 권장되는 경로가 되어서는 안 된다.

--- a/docs/lessons/2026-06-26-issue-817-jdbc-transaction-state.md
+++ b/docs/lessons/2026-06-26-issue-817-jdbc-transaction-state.md
@@ -1,27 +1,27 @@
-# Lessons Learned - JDBC Transaction State (2026-06-26)
+# 교훈: JDBC transaction 상태 (2026-06-26)
 
-**Issue**: #817
-**Module**: `:bluetape4k-jdbc`
+**이슈**: #817
+**모듈**: `:bluetape4k-jdbc`
 
-## L1: Transaction helpers must not hide restoration failures
+## L1: transaction helper는 복구 실패를 숨기면 안 된다
 
-### Problem
+### 문제
 
-`withTransaction` restored state in one logged-and-swallowed block and caught
-only `Exception`. That allowed non-`Exception` failures to skip rollback and
-allowed restore failures to be reported as success. `withReadOnlyTransaction`
-also reset read-only mode to `false` instead of restoring the caller's original
-state.
+`withTransaction`은 상태 복구를 하나의 logged-and-swallowed block에서 처리했고
+`Exception`만 잡았다. 그래서 `Exception`이 아닌 실패에서는 rollback이 빠질 수
+있었고, restore 실패가 발생해도 성공처럼 보고될 수 있었다.
+`withReadOnlyTransaction`도 호출자의 기존 상태를 복구하지 않고 read-only mode를
+항상 `false`로 되돌렸다.
 
-### Lesson
+### 교훈
 
-Transaction helpers must treat rollback and state restoration as part of the
-public contract. Capture all caller-owned connection flags, roll back for all
-transaction-aborting `Throwable` paths, restore each state field independently,
-and attach secondary failures as suppressed exceptions.
+Transaction helper는 rollback과 상태 복구를 공개 계약의 일부로 다뤄야 한다.
+호출자 소유 connection flag를 모두 캡처하고, transaction을 중단시키는 모든
+`Throwable` 경로에서 rollback하며, 각 상태 필드를 독립적으로 복구하고 보조 실패는
+suppressed exception으로 붙인다.
 
-### Future Guard
+### 향후 방지책
 
-When changing JDBC transaction helpers, include deterministic connection-proxy
-tests for `autoCommit=false`, pre-existing read-only state, non-`Exception`
-rollback, primary-failure suppression, and success-path restore failure.
+JDBC transaction helper를 변경할 때는 `autoCommit=false`, 기존 read-only 상태,
+`Exception`이 아닌 rollback 경로, primary failure suppression, success path의
+restore failure를 검증하는 deterministic connection-proxy test를 포함한다.

--- a/docs/lessons/2026-06-26-issue-818-jdbc-batch-parameter-rows.md
+++ b/docs/lessons/2026-06-26-issue-818-jdbc-batch-parameter-rows.md
@@ -1,25 +1,24 @@
-# Lessons Learned - JDBC Batch Parameter Rows (2026-06-26)
+# 교훈: JDBC batch parameter row (2026-06-26)
 
-**Issue**: #818
-**Module**: `:bluetape4k-jdbc`
+**이슈**: #818
+**모듈**: `:bluetape4k-jdbc`
 
-## L1: Batch row shape must be validated before binding
+## L1: batch row 형태는 binding 전에 검증해야 한다
 
-### Problem
+### 문제
 
-JDBC `PreparedStatement` keeps parameter state across batch additions. When a
-later row had fewer values than an earlier row, the shorter row could reuse a
-stale value and insert corrupted data instead of failing.
+JDBC `PreparedStatement`는 batch addition 사이에서도 parameter 상태를 유지한다.
+뒤쪽 row의 값 개수가 앞쪽 row보다 적으면, 짧은 row가 이전에 binding된 stale
+value를 재사용하여 실패 대신 손상된 데이터를 insert할 수 있었다.
 
-### Lesson
+### 교훈
 
-List-based batch helpers must validate parameter row shape before preparing or
-executing a statement, then clear statement parameters before binding each row.
-Do not rely on the driver to catch short rows after previous values have already
-been bound.
+List 기반 batch helper는 statement를 준비하거나 실행하기 전에 parameter row의
+형태를 검증하고, 각 row를 binding하기 전에 statement parameter를 비워야 한다.
+이전 값이 이미 binding된 뒤 짧은 row를 driver가 잡아줄 것이라고 기대하지 않는다.
 
-### Future Guard
+### 향후 방지책
 
-When changing JDBC batch helpers, include a regression with a later row that has
-fewer parameters and assert both fail-fast behavior and zero persisted rows for
-the attempted batch.
+JDBC batch helper를 변경할 때는 뒤쪽 row의 parameter 수가 더 적은 회귀 테스트를
+추가하고, fail-fast 동작과 해당 batch 시도에서 persisted row가 0개임을 함께
+검증한다.

--- a/docs/lessons/2026-06-26-issue-819-jdbc-resultset-empty-cursor.md
+++ b/docs/lessons/2026-06-26-issue-819-jdbc-resultset-empty-cursor.md
@@ -1,24 +1,23 @@
-# Lessons Learned — JDBC ResultSet Empty Cursor Contract (2026-06-26)
+# 교훈: JDBC ResultSet empty cursor 계약 (2026-06-26)
 
-**Issue**: #819
-**Module**: `:bluetape4k-jdbc`
+**이슈**: #819
+**모듈**: `:bluetape4k-jdbc`
 
-## L1: JDBC cursor predicates are consumption APIs
+## L1: JDBC cursor predicate는 consuming API다
 
-### Problem
+### 문제
 
-`ResultSet.isEmpty()` and `ResultSet.isNotEmpty()` looked like simple
-predicates, but both advanced the JDBC cursor by calling `next()`. A caller that
-checked `isNotEmpty()` and then used `toList` on the same `ResultSet` would miss
-the first row.
+`ResultSet.isEmpty()`와 `ResultSet.isNotEmpty()`는 단순 predicate처럼 보였지만
+둘 다 `next()`를 호출해 JDBC cursor를 전진시켰다. 호출자가 `isNotEmpty()`를
+확인한 뒤 같은 `ResultSet`에 `toList`를 사용하면 첫 row를 놓쳤다.
 
-### Lesson
+### 교훈
 
-Any helper that calls `ResultSet.next()` must make cursor movement explicit in
-its name, KDoc, tests, and README examples. Forward-only cursors cannot be
-treated like reusable collections.
+`ResultSet.next()`를 호출하는 helper는 이름, KDoc, 테스트, README 예시에서
+cursor 이동을 명시해야 한다. Forward-only cursor를 재사용 가능한 collection처럼
+다루면 안 된다.
 
-### Future Guard
+### 향후 방지책
 
-When reviewing ResultSet helpers, add tests that inspect the cursor position
-after the helper call, not only the returned boolean or mapped value.
+ResultSet helper를 review할 때는 반환된 boolean이나 mapped value뿐 아니라 helper
+호출 뒤 cursor 위치를 검사하는 테스트를 추가한다.

--- a/docs/lessons/2026-06-26-issue-822-r2dbc-sql-identifier-guards.md
+++ b/docs/lessons/2026-06-26-issue-822-r2dbc-sql-identifier-guards.md
@@ -1,18 +1,24 @@
-# Lessons Learned — R2DBC SQL Identifier Guards (2026-06-26)
+# 교훈: R2DBC SQL identifier guard (2026-06-26)
 
-**Issue**: #822
-**Module**: `:bluetape4k-r2dbc`
+**이슈**: #822
+**모듈**: `:bluetape4k-r2dbc`
 
-## L1: Helper coverage is not enough for public DSL safety
+## L1: helper coverage만으로 public DSL 안전성을 보장할 수 없다
 
-### Problem
+### 문제
 
-`requireValidIdentifier(...)` already existed and had unit tests, but the public insert/update builders stored field names before calling that helper. `QueryBuilder.whereGroup(...)` also accepted arbitrary non-blank operators and interpolated them between conditions.
+`requireValidIdentifier(...)`는 이미 존재했고 unit test도 있었지만, public
+insert/update builder는 해당 helper를 호출하기 전에 field name을 저장했다.
+`QueryBuilder.whereGroup(...)`도 임의의 non-blank operator를 받아 condition
+사이에 보간했다.
 
-### Lesson
+### 교훈
 
-When a SQL DSL has a validation helper, test the public builder paths that interpolate identifiers or operators, not only the helper itself. Helper-level tests prove the predicate, but public-path tests prove the guard is actually wired into the DSL.
+SQL DSL에 validation helper가 있으면, helper 자체뿐 아니라 identifier나 operator를
+보간하는 public builder 경로를 테스트해야 한다. Helper-level test는 predicate를
+증명하지만, public-path test는 guard가 실제 DSL에 연결되어 있는지 증명한다.
 
-### Future Guard
+### 향후 방지책
 
-For R2DBC SQL DSL changes, add direct regression tests against the fluent API entrypoint whenever a string argument later becomes SQL syntax instead of a bound value.
+R2DBC SQL DSL 변경에서는 문자열 인자가 bound value가 아니라 SQL syntax가 되는
+fluent API entrypoint를 직접 겨냥한 회귀 테스트를 추가한다.

--- a/docs/lessons/2026-06-26-issue-823-r2dbc-map-typed-null.md
+++ b/docs/lessons/2026-06-26-issue-823-r2dbc-map-typed-null.md
@@ -1,24 +1,24 @@
-# Lessons Learned — R2DBC Map Typed Null Binding (2026-06-26)
+# 교훈: R2DBC map typed null binding (2026-06-26)
 
-**Issue**: #823
-**Module**: `:bluetape4k-r2dbc`
+**이슈**: #823
+**모듈**: `:bluetape4k-r2dbc`
 
-## L1: Map-based null binding needs an explicit type
+## L1: map 기반 null binding에는 명시적인 타입이 필요하다
 
-### Problem
+### 문제
 
-Map helpers accepted raw null values and invented a default R2DBC type at the
-binding boundary. Named and indexed map helpers used `String`, while
-`Update.set(parameters)` used `Any` through `setNullable<Any>`.
+Map helper는 raw null 값을 받아 binding 경계에서 기본 R2DBC type을 임의로 만들었다.
+Named/indexed map helper는 `String`을 사용했고, `Update.set(parameters)`는
+`setNullable<Any>`를 통해 `Any`를 사용했다.
 
-### Lesson
+### 교훈
 
-A raw map null is not equivalent to a typed NULL parameter. Preserve explicit
-`Parameter` values and reject raw null entries so callers must provide the
-database type at the API boundary.
+Raw map null은 typed NULL parameter와 같지 않다. 명시적인 `Parameter` 값은
+보존하고 raw null entry는 거부해서, 호출자가 API 경계에서 database type을 제공하게
+해야 한다.
 
-### Future Guard
+### 향후 방지책
 
-When changing parameter-map helpers, test all public surfaces that flow into
-`bindMap`: direct named binding, direct indexed binding, update-map setters,
-and insert/update DSL paths that store map entries before execution.
+Parameter-map helper를 변경할 때는 `bindMap`으로 흘러가는 모든 public surface를
+테스트한다. 직접 named binding, 직접 indexed binding, update-map setter, 실행 전에
+map entry를 저장하는 insert/update DSL 경로를 모두 포함한다.

--- a/docs/lessons/2026-06-26-issue-824-r2dbc-postgres-json-conversion.md
+++ b/docs/lessons/2026-06-26-issue-824-r2dbc-postgres-json-conversion.md
@@ -1,18 +1,23 @@
-# Lessons Learned — R2DBC PostgreSQL JSON Conversion (2026-06-26)
+# 교훈: R2DBC PostgreSQL JSON conversion (2026-06-26)
 
-**Issue**: #824
-**Module**: `:bluetape4k-r2dbc`
+**이슈**: #824
+**모듈**: `:bluetape4k-r2dbc`
 
-## L1: Converter fallbacks can become silent data loss
+## L1: converter fallback은 조용한 데이터 손실이 될 수 있다
 
-### Problem
+### 문제
 
-The PostgreSQL JSON converters logged Jackson failures and returned valid empty values. A malformed database value became an empty map, and an unserializable application value became `{}`.
+PostgreSQL JSON converter는 Jackson 실패를 log로 남기고 유효한 empty value를
+반환했다. Malformed database value는 empty map이 되었고, 직렬화할 수 없는
+application value는 `{}`가 되었다.
 
-### Lesson
+### 교훈
 
-Converters that sit on persistence boundaries should fail with the original cause unless the API explicitly models fallback semantics. A valid empty value is not a safe substitute for invalid stored data or failed serialization.
+Persistence boundary에 놓인 converter는 API가 fallback semantics를 명시적으로
+모델링하지 않는 한 원래 cause를 포함해 실패해야 한다. 유효한 empty value는 잘못된
+저장 데이터나 직렬화 실패를 대신할 안전한 값이 아니다.
 
-### Future Guard
+### 향후 방지책
 
-For R2DBC converter changes, add regression tests for both the success path and the failure path. Failure-path tests should assert the exception type and cause, not only that logging happened.
+R2DBC converter 변경에는 success path와 failure path 회귀 테스트를 모두 추가한다.
+Failure-path test는 logging 여부만이 아니라 exception type과 cause를 검증해야 한다.

--- a/docs/lessons/2026-06-26-issue-826-r2dbc-indexed-binding.md
+++ b/docs/lessons/2026-06-26-issue-826-r2dbc-indexed-binding.md
@@ -1,18 +1,22 @@
-# Lessons Learned — R2DBC Indexed Binding (2026-06-26)
+# 교훈: R2DBC indexed binding (2026-06-26)
 
-**Issue**: #826
-**Module**: `:bluetape4k-r2dbc`
+**이슈**: #826
+**모듈**: `:bluetape4k-r2dbc`
 
-## L1: Documentation examples are API contract tests
+## L1: 문서 예시는 API 계약 테스트다
 
-### Problem
+### 문제
 
-`bindIndexedMap` forwarded map keys directly to Spring R2DBC's indexed binding API, but KDoc and README examples showed `1` and `2` as the first two indexes.
+`bindIndexedMap`은 map key를 Spring R2DBC의 indexed binding API로 그대로
+전달했지만, KDoc과 README 예시는 첫 두 index로 `1`과 `2`를 보여주었다.
 
-### Lesson
+### 교훈
 
-When a helper mirrors a framework API without translating values, examples must use the framework's exact contract. For Spring R2DBC indexed parameters, that contract is zero-based.
+Helper가 framework API를 값 변환 없이 그대로 반영한다면, 예시는 framework의
+정확한 계약을 따라야 한다. Spring R2DBC indexed parameter의 계약은 zero-based다.
 
-### Future Guard
+### 향후 방지책
 
-For parameter binding helpers, add a direct test that executes the README/KDoc-style example. Also validate out-of-contract inputs such as negative indexes before forwarding to the framework layer.
+Parameter binding helper에는 README/KDoc 스타일 예시를 그대로 실행하는 직접
+테스트를 추가한다. 음수 index처럼 계약 밖의 입력도 framework layer로 넘기기 전에
+검증한다.

--- a/docs/lessons/2026-06-26-issue-900-ci-data-tests.md
+++ b/docs/lessons/2026-06-26-issue-900-ci-data-tests.md
@@ -1,22 +1,25 @@
-# Lessons Learned - CI Data Tests (2026-06-26)
+# 교훈: CI data test (2026-06-26)
 
-Related issue: #900
-Affected workflow: `.github/workflows/ci.yml`
+관련 이슈: #900
+대상 workflow: `.github/workflows/ci.yml`
 
-## L1: Path filters need matching test jobs and summary needs
+## L1: path filter는 대응되는 test job과 summary needs까지 연결해야 한다
 
-### Problem
+### 문제
 
-The CI workflow compiled data modules during the build job, but it had no `data` path-filter output and no `Test / Data`
-job. Direct `data/**` changes could therefore merge without data-module test coverage in PR CI.
+CI workflow는 build job에서 data module을 compile했지만 `data` path-filter output과
+`Test / Data` job이 없었다. 따라서 `data/**` 직접 변경은 PR CI에서 data-module
+test coverage 없이 merge될 수 있었다.
 
-### Lesson
+### 교훈
 
-When a CI path group is introduced, wire the whole chain in the same change: `changes.outputs`, the paths-filter entry,
-the test job, coverage aggregation `needs`, and final CI status `needs`. A missing downstream `needs` entry can make a
-new test job invisible to summary gates.
+CI path group을 도입할 때는 전체 chain을 같은 변경에서 연결한다.
+`changes.outputs`, paths-filter entry, test job, coverage aggregation `needs`,
+최종 CI status `needs`가 모두 포함되어야 한다. Downstream `needs` entry 하나가
+빠져도 새 test job은 summary gate에서 보이지 않을 수 있다.
 
-### Future guard
+### 향후 방지책
 
-Workflow coverage fixes should validate both syntax and wiring: run `actionlint`, grep for escaped `${{ }}` quotes, and
-check that new jobs appear in coverage and CI status dependencies.
+Workflow coverage fix는 syntax와 wiring을 모두 검증한다. `actionlint`를 실행하고,
+escaped `${{ }}` quote를 grep하며, 새 job이 coverage와 CI status dependency에
+나타나는지 확인한다.

--- a/docs/lessons/2026-06-26-issue-912-hibernate-reactive-vertx.md
+++ b/docs/lessons/2026-06-26-issue-912-hibernate-reactive-vertx.md
@@ -1,22 +1,25 @@
-# Lessons Learned - Hibernate Reactive Vert.x Alignment (2026-06-26)
+# 교훈: Hibernate Reactive Vert.x 정합성 (2026-06-26)
 
-Related issue: #912
-Affected modules: `:bluetape4k-hibernate`, `:bluetape4k-hibernate-reactive`, `:bluetape4k-hibernate-cache-lettuce`
+관련 이슈: #912
+대상 모듈: `:bluetape4k-hibernate`, `:bluetape4k-hibernate-reactive`, `:bluetape4k-hibernate-cache-lettuce`
 
-## L1: Hibernate Reactive must track both ORM and Vert.x lines
+## L1: Hibernate Reactive는 ORM과 Vert.x line을 함께 추적해야 한다
 
-### Problem
+### 문제
 
-`bluetape4k-hibernate-reactive` used Hibernate Reactive `4.3.3.Final` with the repository-wide Vert.x `5.1.3`.
-The module failed at runtime because Hibernate Reactive called an internal Vert.x SQL client constructor that no longer
-exists in the resolved Vert.x version.
+`bluetape4k-hibernate-reactive`는 repository-wide Vert.x `5.1.3`과 함께 Hibernate
+Reactive `4.3.3.Final`을 사용했다. Hibernate Reactive가 resolved Vert.x 버전에
+더 이상 존재하지 않는 internal Vert.x SQL client constructor를 호출하면서 모듈이
+runtime에 실패했다.
 
-### Lesson
+### 교훈
 
-Hibernate Reactive is coupled to both Hibernate ORM and Vert.x SQL client internals. When Vert.x is upgraded globally,
-check the Hibernate Reactive POM line and align Hibernate ORM at the same time instead of bumping only one side.
+Hibernate Reactive는 Hibernate ORM과 Vert.x SQL client internal 양쪽에 결합되어
+있다. Vert.x를 전역으로 upgrade할 때는 한쪽만 bump하지 말고 Hibernate Reactive POM
+line을 확인하면서 Hibernate ORM도 동시에 정렬한다.
 
-### Future guard
+### 향후 방지책
 
-Run `:bluetape4k-hibernate-reactive:test` after changing Hibernate ORM, Hibernate Reactive, or Vert.x versions. Also
-check `dependencyInsight` for `hibernate-reactive-core`, `hibernate-core`, and Vert.x SQL client artifacts.
+Hibernate ORM, Hibernate Reactive, Vert.x 버전을 변경한 뒤에는
+`:bluetape4k-hibernate-reactive:test`를 실행한다. `hibernate-reactive-core`,
+`hibernate-core`, Vert.x SQL client artifact에 대한 `dependencyInsight`도 확인한다.

--- a/docs/lessons/2026-06-26-range-overlaps-empty.md
+++ b/docs/lessons/2026-06-26-range-overlaps-empty.md
@@ -1,22 +1,23 @@
-# Lessons Learned - Range Empty Overlap (2026-06-26)
+# 교훈: 빈 range overlap (2026-06-26)
 
-Related issue: #783
-Affected module: `:bluetape4k-core`
+관련 이슈: #783
+대상 모듈: `:bluetape4k-core`
 
-## L1: Empty ranges must short-circuit overlap checks
+## L1: 빈 range는 overlap 검사에서 먼저 short-circuit해야 한다
 
-### Problem
+### 문제
 
-`Range.overlaps()` compared only endpoint ordering and boundary inclusiveness. Empty ranges such as `(1, 1)`,
-`[1, 1)`, and `(1, 1]` could therefore report an overlap with a non-empty range even though no common element
-exists.
+`Range.overlaps()`는 endpoint ordering과 boundary inclusiveness만 비교했다.
+그래서 `(1, 1)`, `[1, 1)`, `(1, 1]` 같은 빈 range가 공통 원소가 없는데도
+non-empty range와 overlap한다고 보고할 수 있었다.
 
-### Lesson
+### 교훈
 
-When a range operation's contract is element-based, check `isEmpty()` before applying endpoint comparisons.
-Boundary comparisons alone are not enough because empty ranges can still sit inside a non-empty interval.
+Range operation의 계약이 element 기반이면 endpoint 비교를 적용하기 전에
+`isEmpty()`를 확인한다. 빈 range도 non-empty interval 안에 놓일 수 있으므로
+boundary 비교만으로는 충분하지 않다.
 
-### Future guard
+### 향후 방지책
 
-Range helper changes should include regression coverage for empty operands in both receiver and argument positions,
-plus existing boundary inclusiveness tests for non-empty ranges.
+Range helper 변경에는 receiver와 argument 양쪽 위치의 빈 operand 회귀 coverage를
+포함하고, non-empty range에 대한 기존 boundary inclusiveness test도 함께 유지한다.

--- a/docs/lessons/2026-06-27-issue-790-jackson2-typed-mapper-allowlist.md
+++ b/docs/lessons/2026-06-27-issue-790-jackson2-typed-mapper-allowlist.md
@@ -1,32 +1,45 @@
-# Issue 790: Jackson2 typed mapper allowlist preservation
+# 이슈 790: Jackson2 typed mapper allowlist 보존
 
-## Context
+## 배경
 
-`Jackson.createTypedJsonMapper(...)` built a `BasicPolymorphicTypeValidator`, then replaced Jackson's configured default typing resolver with a raw `StdTypeResolverBuilder`. That removed the validator from the actual polymorphic deserialization path and allowed a root `Any` payload with an external `@class` id.
+`Jackson.createTypedJsonMapper(...)`는 `BasicPolymorphicTypeValidator`를 만든 뒤,
+Jackson에 설정된 default typing resolver를 raw `StdTypeResolverBuilder`로
+교체했다. 그 결과 실제 polymorphic deserialization 경로에서 validator가 제거되어
+external `@class` id를 가진 root `Any` payload를 허용했다.
 
-## Decision
+## 결정
 
-Use Jackson's `activateDefaultTypingAsProperty(...)` so the configured validator stays attached to property-based `@class` type ids. For the safe factory, validate package prefixes with `allowIfSubType(...)` instead of `allowIfBaseType(...)`, because allowing a base type can approve every legal subtype once the nominal base type matches.
+Property 기반 `@class` type id에 설정된 validator가 계속 붙어 있도록
+Jackson의 `activateDefaultTypingAsProperty(...)`를 사용한다. Safe factory에서는
+`allowIfBaseType(...)` 대신 `allowIfSubType(...)`으로 package prefix를 검증한다.
+Base type을 허용하면 nominal base type이 맞는 순간 모든 합법 subtype을 승인할 수
+있기 때문이다.
 
-## Outcome
+## 결과
 
-- Disallowed root `Any` polymorphic payloads now fail with `InvalidTypeIdException`.
-- Disallowed nested payloads still fail, and allowed package payloads still round-trip with `@class` type ids.
-- `typedJsonMapper` remains only a deprecated legacy compatibility mapper and is no longer promoted in examples for untrusted JSON.
+- 허용되지 않은 root `Any` polymorphic payload는 이제 `InvalidTypeIdException`으로 실패한다.
+- 허용되지 않은 nested payload는 계속 실패하고, 허용된 package payload는 `@class` type id와 함께 round-trip된다.
+- `typedJsonMapper`는 deprecated legacy compatibility mapper로만 남으며, untrusted JSON 예시에서 더 이상 권장되지 않는다.
 
-## Verification
+## 검증
 
-- Red test before implementation: root `Any` payload with `com.example.disallowed.DisallowedTypedPayload` did not throw.
+- 구현 전 red test: `com.example.disallowed.DisallowedTypedPayload`를 담은 root `Any` payload가 예외를 던지지 않았다.
 - `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.JacksonTest.createTypedJsonMapper*" --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.JacksonTest" --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-jackson2:test --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-jackson2:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
 - `git diff --check`
 
-## Future Guard
+## 향후 지침
 
-Do not call `setDefaultTyping(...)` with a raw `StdTypeResolverBuilder` after installing a `PolymorphicTypeValidator`; it can silently bypass the validator. For package allowlists, include a root `Any` payload regression test, not only an envelope or nested-property test.
+`PolymorphicTypeValidator`를 설치한 뒤 raw `StdTypeResolverBuilder`로
+`setDefaultTyping(...)`을 호출하지 않는다. Validator를 조용히 우회할 수 있다.
+Package allowlist에는 envelope나 nested-property test뿐 아니라 root `Any` payload
+회귀 테스트도 포함한다.
 
-## Concurrency Helper Gate
+## 동시성 helper gate
 
-`MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` were not applicable here. This fix does not add concurrency, coroutine, virtual-thread, or structured-task behavior; it narrows synchronous Jackson default typing validation.
+`MultithreadingTester`, `SuspendedJobTester`, `StructuredTaskScopeTester`는 여기서
+적용 대상이 아니었다. 이 수정은 동시성, coroutine, virtual-thread,
+structured-task 동작을 추가하지 않고 synchronous Jackson default typing validation만
+좁힌다.

--- a/docs/lessons/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs.md
+++ b/docs/lessons/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs.md
@@ -1,31 +1,43 @@
-# Issue 791: Jackson Tink durable-search guidance
+# 이슈 791: Jackson Tink durable-search 지침
 
-## Context
+## 배경
 
-Jackson2 and Jackson3 field-encryption docs described `DETERMINISTIC_AES256_SIV` as suitable for DB search, but `@JsonTinkEncrypt` resolves algorithms through `TinkEncryptors` singleton instances. Those singleton keysets are generated in memory for the current JVM process, so persisted ciphertext can become unreadable or search-incompatible after restart, rollout, or multi-instance access.
+Jackson2와 Jackson3 field-encryption 문서는 `DETERMINISTIC_AES256_SIV`가 DB 검색에
+적합하다고 설명했지만, `@JsonTinkEncrypt`는 `TinkEncryptors` singleton instance를
+통해 algorithm을 해석한다. 이 singleton keyset은 현재 JVM process의 memory에서
+생성되므로 restart, rollout, multi-instance access 이후 persisted ciphertext가
+읽히지 않거나 검색 호환성을 잃을 수 있다.
 
-## Decision
+## 결정
 
-Use the documentation-safe fix path for this milestone issue: remove durable DB-search claims from Jackson field-encryption README/KDoc, keep the API behavior unchanged, and point durable searchable storage guidance to `bluetape4k-tink` versioned keyset APIs.
+이 milestone 이슈에서는 documentation-safe fix path를 사용한다. Jackson field
+encryption README/KDoc에서 durable DB-search claim을 제거하고 API 동작은 그대로
+유지하며, durable searchable storage 지침은 `bluetape4k-tink`의 versioned keyset
+API로 안내한다.
 
-## Outcome
+## 결과
 
-- Jackson2 and Jackson3 no longer promote `@JsonTinkEncrypt(DETERMINISTIC_AES256_SIV)` for durable DB search.
-- `JsonTinkEncrypt`, `TinkEncryptAlgorithm`, and `TinkEncryptors` KDoc now describe the process-local singleton-keyset boundary.
-- Tink README guidance now recommends `TinkDaeads.versioned(store)` with persisted AES-SIV keysets for durable searchable DB columns.
+- Jackson2와 Jackson3는 더 이상 durable DB search 용도로 `@JsonTinkEncrypt(DETERMINISTIC_AES256_SIV)`를 홍보하지 않는다.
+- `JsonTinkEncrypt`, `TinkEncryptAlgorithm`, `TinkEncryptors` KDoc은 process-local singleton-keyset 경계를 설명한다.
+- Tink README 지침은 durable searchable DB column에 persisted AES-SIV keyset과 `TinkDaeads.versioned(store)`를 권장한다.
 
-## Verification
+## 검증
 
-- Red evidence: pre-change `rg` showed Jackson README/KDoc DB-search claims.
-- `rg -n "DB search|DB 검색|searchable in DB|DB 검색 가능" io/jackson2 io/jackson3 -g '*.md' -g '*.kt'` produced no matches after the fix.
+- Red evidence: 변경 전 `rg`에서 Jackson README/KDoc의 DB-search claim이 확인되었다.
+- 수정 뒤 `rg -n "DB search|DB 검색|searchable in DB|DB 검색 가능" io/jackson2 io/jackson3 -g '*.md' -g '*.kt'`는 match를 내지 않았다.
 - `./gradlew :bluetape4k-jackson2:compileTestKotlin :bluetape4k-jackson3:compileTestKotlin :bluetape4k-tink:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-jackson2:test --tests "io.bluetape4k.jackson.crypto.JsonTinkEncryptTest" :bluetape4k-jackson3:test --tests "io.bluetape4k.jackson3.crypto.JsonTinkEncryptTest" :bluetape4k-tink:test --tests "io.bluetape4k.tink.encrypt.TinkEncryptorTest" --no-daemon --no-configuration-cache`
 - `git diff --check`
 
-## Future Guard
+## 향후 지침
 
-Do not document process-local singleton encryptors as durable database storage helpers. If Jackson field encryption needs durable searchable storage later, add an explicit keyset/provider-backed API and tests that prove ciphertext survives keyset reload and remains searchable for deterministic fields.
+Process-local singleton encryptor를 durable database storage helper로 문서화하지
+않는다. 나중에 Jackson field encryption에 durable searchable storage가 필요하면
+명시적인 keyset/provider 기반 API를 추가하고, ciphertext가 keyset reload 후에도
+생존하며 deterministic field 검색 호환성을 유지한다는 테스트를 만든다.
 
-## Concurrency Helper Gate
+## 동시성 helper gate
 
-No new concurrency helper was needed because the change is documentation/KDoc only. Existing Jackson field-encryption tests already cover multithreading, coroutine suspend job, and virtual-thread execution and passed during this work.
+이 변경은 documentation/KDoc 전용이므로 새 concurrency helper가 필요하지 않았다.
+기존 Jackson field-encryption test는 이미 multithreading, coroutine suspend job,
+virtual-thread 실행을 검증했고 이 작업 중에도 통과했다.

--- a/docs/lessons/2026-06-27-issue-792-http-logging-redaction.md
+++ b/docs/lessons/2026-06-27-issue-792-http-logging-redaction.md
@@ -1,27 +1,35 @@
-# Lessons Learned - Issue #792 HTTP logging header redaction (2026-06-27)
+# 교훈: 이슈 #792 HTTP logging header redaction (2026-06-27)
 
-## Context
+## 배경
 
-Issue #792 showed that HTTP diagnostic logs could expose credential-bearing headers. The affected paths were OkHttp request/response logging and Retrofit HC5 request conversion trace logging.
+이슈 #792는 HTTP diagnostic log가 credential-bearing header를 노출할 수 있음을
+보여주었다. 영향을 받은 경로는 OkHttp request/response logging과 Retrofit HC5
+request conversion trace logging이었다.
 
-## Decision
+## 결정
 
-Use one shared HTTP header redaction helper before formatting diagnostic log values. The helper redacts well-known credential headers, API-key names, token-like names, and caller-provided project-specific header names.
+Diagnostic log 값을 formatting하기 전에 하나의 공유 HTTP header redaction helper를
+사용한다. 이 helper는 잘 알려진 credential header, API-key 이름, token-like 이름,
+호출자가 지정한 project-specific header 이름을 redaction한다.
 
-## Outcome
+## 결과
 
-- `LoggingInterceptor` now logs redacted request and response headers.
-- `Hc5OkHttp3Support.toSimpleHttpRequest()` now redacts sensitive header values only in trace logs while preserving the real outgoing request headers.
-- `io/http` README locale pair documents the default redaction policy and custom extension path.
+- `LoggingInterceptor`는 이제 redacted request/response header를 log에 남긴다.
+- `Hc5OkHttp3Support.toSimpleHttpRequest()`는 실제 outgoing request header는 유지하면서 trace log에서만 sensitive header value를 redaction한다.
+- `io/http` README locale pair는 기본 redaction policy와 custom extension 경로를 문서화한다.
 
-## Verification
+## 검증
 
-- RED tests first reproduced raw sensitive header leakage in `LoggingInterceptor` and `Hc5OkHttp3Support`.
-- Targeted tests passed for `LoggingInterceptorTest` and `Hc5OkHttp3SupportTest`.
-- Full module tests passed for `:bluetape4k-http:test` and `:bluetape4k-retrofit2:test`.
-- `:bluetape4k-http:compileTestKotlin` and `:bluetape4k-retrofit2:compileTestKotlin` passed with `--warning-mode all --rerun-tasks`; remaining warnings were existing Gradle Kotlin DSL deprecations outside the touched code.
-- `git diff --check` passed.
+- RED test가 먼저 `LoggingInterceptor`와 `Hc5OkHttp3Support`의 raw sensitive header leakage를 재현했다.
+- `LoggingInterceptorTest`와 `Hc5OkHttp3SupportTest` targeted test가 통과했다.
+- `:bluetape4k-http:test`와 `:bluetape4k-retrofit2:test` 전체 module test가 통과했다.
+- `:bluetape4k-http:compileTestKotlin`과 `:bluetape4k-retrofit2:compileTestKotlin`은 `--warning-mode all --rerun-tasks`로 통과했다. 남은 warning은 touched code 밖의 기존 Gradle Kotlin DSL deprecation이었다.
+- `git diff --check`가 통과했다.
 
-## Future Guard
+## 향후 방지책
 
-Do not log HTTP header values directly. New HTTP diagnostic paths should call `redactHttpHeaderValue` for individual name/value logs or `Headers.toRedactedString` for OkHttp header blocks. If the change introduces concurrency, coroutine, virtual-thread, or structured-concurrency behavior, use the matching bluetape4k concurrency helper and record the helper evidence in the PR DoD.
+HTTP header 값을 직접 log하지 않는다. 새 HTTP diagnostic path는 개별 name/value
+log에 `redactHttpHeaderValue`를 호출하거나 OkHttp header block에
+`Headers.toRedactedString`을 사용해야 한다. 변경이 동시성, coroutine,
+virtual-thread, structured-concurrency 동작을 도입한다면 맞는 bluetape4k concurrency
+helper를 사용하고 PR DoD에 helper evidence를 기록한다.

--- a/docs/lessons/2026-06-27-issue-797-grpc-client-plaintext.md
+++ b/docs/lessons/2026-06-27-issue-797-grpc-client-plaintext.md
@@ -1,35 +1,42 @@
-# Issue 797: gRPC client plaintext opt-in
+# 이슈 797: gRPC client plaintext opt-in
 
-## Context
+## 배경
 
-`AbstractGrpcClient(host, port)` silently built a plaintext channel for arbitrary hosts. Subclasses using the convenience constructor for remote services could therefore send RPC traffic and metadata without TLS even though the insecure choice was not visible at the call site.
+`AbstractGrpcClient(host, port)`는 arbitrary host에 대해 조용히 plaintext channel을
+만들었다. Convenience constructor를 remote service에 사용하는 subclass는 call site에
+insecure 선택이 드러나지 않은 채 RPC traffic과 metadata를 TLS 없이 보낼 수 있었다.
 
-## Decision
+## 결정
 
-Make the convenience constructor secure by default and require explicit local/test opt-in for plaintext:
+Convenience constructor는 기본적으로 secure하게 만들고, plaintext는 명시적인
+local/test opt-in이 필요하게 한다.
 
-- Default: `GrpcChannelSecurity.TRANSPORT_SECURITY`
+- 기본값: `GrpcChannelSecurity.TRANSPORT_SECURITY`
 - Local/test escape hatch: `GrpcChannelSecurity.LOCAL_PLAINTEXT`
-- Plaintext opt-in is restricted to loopback hosts.
+- Plaintext opt-in은 loopback host로 제한한다.
 
-## Outcome
+## 결과
 
-- Host/port `AbstractGrpcClient` construction no longer silently chooses plaintext.
-- Remote plaintext opt-in is rejected before channel construction.
-- README English/Korean examples now show production transport security and local/test plaintext separately.
+- Host/port `AbstractGrpcClient` construction은 더 이상 조용히 plaintext를 선택하지 않는다.
+- Remote plaintext opt-in은 channel construction 전에 거부된다.
+- README 영어/한국어 예시는 production transport security와 local/test plaintext를 분리해서 보여준다.
 
-## Verification
+## 검증
 
-- Red test before implementation: new channel security API references failed compilation.
+- 구현 전 red test: 새 channel security API reference가 compile에 실패했다.
 - `./gradlew :bluetape4k-grpc:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-grpc:test --tests "io.bluetape4k.grpc.GrpcChannelSecurityTest" --tests "io.bluetape4k.grpc.GrpcSupportValidationTest" --tests "io.bluetape4k.grpc.ManagedChannelSupportTest" --rerun-tasks --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-grpc:test --no-daemon --no-configuration-cache`: 72 tests, 0 failures, 0 errors, 4 skipped.
 - `git diff --check`
 
-## Future Guard
+## 향후 방지책
 
-Do not add host/port convenience constructors that silently select insecure transports for arbitrary remote targets. If plaintext is needed for local tests, make the API name or enum value explicit and document that it is loopback-only.
+Arbitrary remote target에 대해 insecure transport를 조용히 선택하는 host/port
+convenience constructor를 추가하지 않는다. Local test에 plaintext가 필요하면 API 이름
+또는 enum value가 명시적으로 드러나게 하고 loopback-only임을 문서화한다.
 
-## Concurrency Helper Gate
+## 동시성 helper gate
 
-`MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` were not applicable. This is a synchronous channel-construction security choice with no concurrent state, coroutine lifecycle, or structured task-scope behavior.
+`MultithreadingTester`, `SuspendedJobTester`, `StructuredTaskScopeTester`는 적용 대상이
+아니었다. 이는 concurrent state, coroutine lifecycle, structured task-scope behavior가
+없는 synchronous channel-construction security 선택이다.

--- a/docs/lessons/2026-06-27-issue-798-protobuf-strict-default-codecs.md
+++ b/docs/lessons/2026-06-27-issue-798-protobuf-strict-default-codecs.md
@@ -1,37 +1,45 @@
-# Issue 798: Protobuf strict default codecs
+# 이슈 798: Protobuf strict default codec
 
-## Context
+## 배경
 
-`ProtobufSerializer` and Redis Protobuf codecs were documented as allow-listed Protobuf codecs, but their default behavior still delegated non-Protobuf values and non-Protobuf bytes to Kryo/Kryo5 fallback serializers. That made the advertised shared-boundary trust profile too broad.
+`ProtobufSerializer`와 Redis Protobuf codec은 allow-listed Protobuf codec으로
+문서화되어 있었지만, 기본 동작은 여전히 non-Protobuf value와 non-Protobuf bytes를
+Kryo/Kryo5 fallback serializer에 위임했다. 이 때문에 문서화된 shared-boundary trust
+profile보다 실제 기본 경계가 넓었다.
 
-## Decision
+## 결정
 
-Make the default Protobuf profile strict. Non-Protobuf payloads are rejected unless the caller chooses an explicit trusted-internal API:
+기본 Protobuf profile을 strict하게 만든다. Non-Protobuf payload는 호출자가 명시적인
+trusted-internal API를 선택하지 않는 한 거부한다.
 
 - `ProtobufSerializer.trustedInternalProtobuf()`
 - `LettuceProtobufCodecs.trustedInternal*Protobuf()`
 - `RedissonProtobufCodec.trustedInternal()`
 - `RedissonProtobufCodecs.TrustedInternal*Protobuf`
 
-## Outcome
+## 결과
 
-- Default Protobuf serializer and Redis codecs reject fallback-format payloads.
-- Legacy mixed Protobuf + Kryo fallback remains available for trusted internal Redis stores.
-- Tests now separate strict shared-boundary behavior from trusted-internal compatibility behavior.
-- `docs/security/serialization-trust-profiles.md` documents the distinction.
+- 기본 Protobuf serializer와 Redis codec은 fallback-format payload를 거부한다.
+- Legacy mixed Protobuf + Kryo fallback은 trusted internal Redis store용으로 계속 제공된다.
+- 테스트는 strict shared-boundary 동작과 trusted-internal compatibility 동작을 분리한다.
+- `docs/security/serialization-trust-profiles.md`는 이 차이를 문서화한다.
 
-## Verification
+## 검증
 
-- Red test before implementation: new trusted-internal API references failed compilation.
+- 구현 전 red test: 새 trusted-internal API reference가 compile에 실패했다.
 - `./gradlew :bluetape4k-protobuf:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-protobuf:test --tests "io.bluetape4k.protobuf.serializers.ProtobufSerializerTest" --tests "io.bluetape4k.protobuf.serializers.redis.LettuceProtobufCodecsTest" --tests "io.bluetape4k.protobuf.serializers.redis.RedissonProtobufCodecTest" --rerun-tasks --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-protobuf:test --no-daemon --no-configuration-cache`: 209 tests, 0 failures, 0 errors, 0 skipped.
 - `git diff --check`
 
-## Future Guard
+## 향후 방지책
 
-Do not label a codec as `AllowListedTypes` if default decode paths silently fall back to a serializer that can load arbitrary application object graphs. Keep legacy fallback paths explicit and name them as trusted-internal APIs.
+기본 decode path가 arbitrary application object graph를 load할 수 있는 serializer로
+조용히 fallback한다면 codec을 `AllowListedTypes`로 표기하지 않는다. Legacy fallback
+path는 명시적으로 유지하고 trusted-internal API라는 이름을 붙인다.
 
-## Concurrency Helper Gate
+## 동시성 helper gate
 
-`MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` were not applicable. This is a synchronous encode/decode trust-boundary change with no concurrent state, coroutine lifecycle, or structured task-scope behavior.
+`MultithreadingTester`, `SuspendedJobTester`, `StructuredTaskScopeTester`는 적용 대상이
+아니었다. 이는 concurrent state, coroutine lifecycle, structured task-scope behavior가
+없는 synchronous encode/decode trust-boundary 변경이다.

--- a/docs/lessons/2026-06-27-issue-799-kafka-logback-producer-config-redaction.md
+++ b/docs/lessons/2026-06-27-issue-799-kafka-logback-producer-config-redaction.md
@@ -1,52 +1,42 @@
-# Issue #799: Kafka Logback Producer Config Redaction
+# 이슈 #799: Kafka Logback producer config redaction
 
-## Context
+## 배경
 
-`bluetape4k-kafka-logback` accepted arbitrary Kafka producer configuration and
-emitted Logback status messages for added config entries, malformed config
-strings, and producer creation failures. Raw status messages can be collected by
-operations tooling, so values from keys such as `sasl.jaas.config` and
-`*.password` must be treated as sensitive even when they are not ordinary
-application logs.
+`bluetape4k-kafka-logback`은 arbitrary Kafka producer configuration을 받았고,
+추가된 config entry, malformed config string, producer creation failure에 대해
+Logback status message를 출력했다. Raw status message는 운영 도구에 수집될 수
+있으므로 `sasl.jaas.config`, `*.password` 같은 key의 값은 일반 application log가
+아니어도 sensitive하게 다뤄야 한다.
 
-## Decision
+## 결정
 
-Route all Kafka producer config status formatting through one internal helper:
+모든 Kafka producer config status formatting을 하나의 internal helper로 보낸다.
 
-- redact credential-bearing values by sensitive key fragments;
-- keep non-sensitive keys and values visible for diagnostics;
-- report malformed `key=value` input by payload length only;
-- reuse the same formatter for add-config, producer creation success, and
-  producer creation failure status messages.
+- sensitive key fragment로 credential-bearing value를 redaction한다.
+- non-sensitive key와 value는 진단을 위해 그대로 보여준다.
+- malformed `key=value` input은 payload 길이만 보고한다.
+- add-config, producer creation success, producer creation failure status message에서 같은 formatter를 재사용한다.
 
-## Verification
+## 검증
 
-- RED: new `KafkaAppenderTest` redaction tests failed before the fix because
-  added producer config and malformed config status messages contained raw
-  secret values.
-- GREEN: `./gradlew :bluetape4k-kafka-logback:test --tests "io.bluetape4k.kafka.logback.KafkaAppenderTest" --no-build-cache --no-daemon --no-configuration-cache`
-  passed with 11 tests.
-- `./gradlew :bluetape4k-kafka-logback:test --tests "*KafkaAppender*" --no-build-cache --no-daemon --no-configuration-cache`
-  passed with 12 tests, including the Testcontainers-backed `KafkaAppenderIT`.
-- `./gradlew :bluetape4k-kafka-logback:test --no-build-cache --no-daemon --no-configuration-cache`
-  passed with 22 tests, 0 failures, 0 errors, 0 skipped.
-- `./gradlew :bluetape4k-kafka-logback:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
-  passed. Remaining warnings are existing Gradle Kotlin DSL deprecations outside
-  the touched source/test code.
-- Source scan found no remaining raw `$producerConfig`, `$keyValue`, or
-  `value=$value` status formatting in `infra/kafka-logback`.
-- `git diff --check` passed.
+- RED: 새 `KafkaAppenderTest` redaction test는 수정 전 added producer config와 malformed config status message가 raw secret value를 포함해 실패했다.
+- GREEN: `./gradlew :bluetape4k-kafka-logback:test --tests "io.bluetape4k.kafka.logback.KafkaAppenderTest" --no-build-cache --no-daemon --no-configuration-cache`는 11개 test로 통과했다.
+- `./gradlew :bluetape4k-kafka-logback:test --tests "*KafkaAppender*" --no-build-cache --no-daemon --no-configuration-cache`는 Testcontainers 기반 `KafkaAppenderIT`를 포함해 12개 test로 통과했다.
+- `./gradlew :bluetape4k-kafka-logback:test --no-build-cache --no-daemon --no-configuration-cache`는 22개 test, 0 failures, 0 errors, 0 skipped로 통과했다.
+- `./gradlew :bluetape4k-kafka-logback:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`가 통과했다. 남은 warning은 touched source/test code 밖의 기존 Gradle Kotlin DSL deprecation이다.
+- Source scan에서 `infra/kafka-logback`에 raw `$producerConfig`, `$keyValue`, `value=$value` status formatting이 남아 있지 않았다.
+- `git diff --check`가 통과했다.
 
-## Future Guidance
+## 향후 지침
 
-Status output is still an operational export surface. When logging dynamic
-configuration or parse failures, redact by key before formatting and avoid
-echoing the original malformed payload. Tests should assert both the absence of
-secret substrings and the presence of useful non-sensitive diagnostics.
+Status output도 운영 export surface다. 동적 configuration이나 parse failure를 log할
+때는 formatting 전에 key 기준으로 redaction하고 원본 malformed payload를 다시
+출력하지 않는다. 테스트는 secret substring 부재와 유용한 non-sensitive diagnostic
+존재를 모두 검증해야 한다.
 
-## Concurrency Helper Gate
+## 동시성 helper gate
 
-No shared mutable state, coroutine lifecycle, thread contention, virtual-thread,
-or `StructuredTaskScope` behavior changed. `MultithreadingTester`,
-`SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable to this
-status-formatting redaction fix.
+Shared mutable state, coroutine lifecycle, thread contention, virtual-thread,
+`StructuredTaskScope` 동작은 변경되지 않았다. `MultithreadingTester`,
+`SuspendedJobTester`, `StructuredTaskScopeTester`는 이 status-formatting redaction
+수정에 적용되지 않는다.

--- a/docs/lessons/2026-06-27-issue-802-redisson-json-allowlist-fallback.md
+++ b/docs/lessons/2026-06-27-issue-802-redisson-json-allowlist-fallback.md
@@ -1,31 +1,42 @@
-# Issue 802: Redisson JSON allow-list fallback boundary
+# 이슈 802: Redisson JSON allowlist fallback 경계
 
-## Context
+## 배경
 
-`Jackson3Codec` and `Fastjson2Codec` advertised `allowedPackagePrefixes` as a Redis trust-boundary control, but malformed or non-JSON payloads could still fall through to the Fory fallback decoder. That made the documented allow-list weaker than the public API contract.
+`Jackson3Codec`과 `Fastjson2Codec`은 `allowedPackagePrefixes`를 Redis trust-boundary
+control로 설명했지만, malformed 또는 non-JSON payload는 여전히 Fory fallback
+decoder로 떨어질 수 있었다. 이 때문에 문서화된 allowlist가 public API 계약보다
+약해졌다.
 
-## Decision
+## 결정
 
-When `allowedPackagePrefixes` is configured, JSON codec decode fallback is disabled by default. Existing trusted-internal behavior remains unchanged for `allowedPackagePrefixes = null`, and a caller must explicitly set `allowFallbackDecode = true` for a trusted migration window.
+`allowedPackagePrefixes`가 설정되어 있으면 JSON codec decode fallback을 기본적으로
+비활성화한다. `allowedPackagePrefixes = null`인 기존 trusted-internal 동작은 그대로
+유지하고, 신뢰된 migration window가 필요한 호출자는 `allowFallbackDecode = true`를
+명시적으로 설정해야 한다.
 
-## Outcome
+## 결과
 
-- Allow-listed `Jackson3Codec` and `Fastjson2Codec` now reject fallback-format binary payloads with `SecurityException`.
-- `RedissonCodecs.jackson3(...)` and `RedissonCodecs.fastjson2(...)` inherit the safe default.
-- README trust-profile guidance now documents the default rejection and explicit migration escape hatch.
+- Allow-listed `Jackson3Codec`과 `Fastjson2Codec`은 이제 fallback-format binary payload를 `SecurityException`으로 거부한다.
+- `RedissonCodecs.jackson3(...)`와 `RedissonCodecs.fastjson2(...)`는 안전한 기본값을 상속한다.
+- README trust-profile 지침은 기본 거부 동작과 명시적 migration escape hatch를 문서화한다.
 
-## Verification
+## 검증
 
-- Red test before implementation: allow-listed Jackson3/Fastjson2 binary fallback payload tests failed because no exception was thrown.
+- 구현 전 red test: allow-listed Jackson3/Fastjson2 binary fallback payload test는 exception이 던져지지 않아 실패했다.
 - `./gradlew :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-redisson:test --tests "io.bluetape4k.redis.redisson.codec.*CodecTest" --no-build-cache --no-daemon --no-configuration-cache`
 - `./gradlew :bluetape4k-redisson:test --no-daemon --no-configuration-cache`
 - `git diff --check`
 
-## Future Guard
+## 향후 방지책
 
-Do not describe a codec factory as `AllowListedTypes` unless all decode fallback paths either validate the same type boundary or are disabled by default. If a legacy migration path is needed, make it explicit in the API and in README trust-profile text.
+모든 decode fallback path가 같은 type boundary를 검증하거나 기본 비활성화되어 있지
+않다면 codec factory를 `AllowListedTypes`로 설명하지 않는다. Legacy migration path가
+필요하면 API와 README trust-profile text에서 명시적으로 드러낸다.
 
-## Concurrency Helper Gate
+## 동시성 helper gate
 
-`MultithreadingTester`, `SuspendedJobTester`, and `StructuredTaskScopeTester` were not applicable here. The change does not add shared mutable state, coroutine lifecycle behavior, or structured task scope behavior; it only narrows synchronous decode fallback behavior at a Redis codec trust boundary.
+`MultithreadingTester`, `SuspendedJobTester`, `StructuredTaskScopeTester`는 여기서 적용
+대상이 아니었다. 이 변경은 shared mutable state, coroutine lifecycle behavior,
+structured task scope behavior를 추가하지 않고 Redis codec trust boundary의
+synchronous decode fallback behavior만 좁힌다.

--- a/docs/lessons/2026-06-27-issue-803-redisson-gzip-decompression-bound.md
+++ b/docs/lessons/2026-06-27-issue-803-redisson-gzip-decompression-bound.md
@@ -1,43 +1,32 @@
-# Lessons Learned - Issue #803 Redisson GZip Decompression Bound (2026-06-27)
+# 교훈: 이슈 #803 Redisson GZip decompression bound (2026-06-27)
 
-## Context
+## 배경
 
-Issue #803 identified that `GzipCodec` decompressed Redis payloads through
-`Compressors.GZip.decompress(bytes)`, and `GZipCompressor` used
-`GZIPInputStream.readBytes()` with no decompressed-size bound.
+이슈 #803은 `GzipCodec`이 Redis payload를 `Compressors.GZip.decompress(bytes)`로
+압축 해제하고, `GZipCompressor`가 decompressed-size bound 없이
+`GZIPInputStream.readBytes()`를 사용한다는 점을 확인했다.
 
-## Decision
+## 결정
 
-- Put the defensive size limit in `GZipCompressor`, not only in Redisson, so
-  every JDK GZip caller gets the same default protection.
-- Keep the default limit at 256 MiB, matching the existing Snappy/Zstd defensive
-  limits in `bluetape4k-io`.
-- Let `GzipCodec` expose `maxDecompressedSize` so Redis trust boundaries can use
-  a smaller deployment-specific maximum.
+- 방어적 size limit은 Redisson에만 두지 않고 `GZipCompressor`에 둔다. 그러면 모든 JDK GZip caller가 같은 기본 보호를 받는다.
+- 기본 limit은 기존 `bluetape4k-io`의 Snappy/Zstd defensive limit과 맞춰 256 MiB로 유지한다.
+- `GzipCodec`은 Redis trust boundary에서 더 작은 deployment-specific maximum을 사용할 수 있도록 `maxDecompressedSize`를 노출한다.
 
-## Outcome
+## 결과
 
-- `GZipCompressor` now rejects decompressed output larger than
-  `maxDecompressedSize` before writing the chunk into the output buffer.
-- `GzipCodec` preserves `maxDecompressedSize` through the Redisson copy
-  constructor path.
-- README pairs document the default limit and custom limit examples.
+- `GZipCompressor`는 chunk를 output buffer에 쓰기 전에 `maxDecompressedSize`보다 큰 decompressed output을 거부한다.
+- `GzipCodec`은 Redisson copy constructor 경로에서도 `maxDecompressedSize`를 보존한다.
+- README pair는 기본 limit과 custom limit 예시를 문서화한다.
 
-## Verification
+## 검증
 
-- Red test: new tests failed before implementation because `maxDecompressedSize`
-  constructor parameters did not exist.
+- Red test: `maxDecompressedSize` constructor parameter가 없어 새 테스트가 구현 전 실패했다.
 - `./gradlew :bluetape4k-io:compileTestKotlin :bluetape4k-redisson:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`: PASS.
 - `./gradlew :bluetape4k-redisson:test --tests "*Gzip*" :bluetape4k-io:test --tests "*Compressor*" --no-build-cache --no-daemon --no-configuration-cache`: PASS.
-- `./gradlew :bluetape4k-io:test :bluetape4k-redisson:test --no-daemon --no-configuration-cache`: PASS, `io/io` 1005 tests and `infra/redisson` 290 tests with 0 failures/errors/skips.
+- `./gradlew :bluetape4k-io:test :bluetape4k-redisson:test --no-daemon --no-configuration-cache`: PASS, `io/io` 1005 tests와 `infra/redisson` 290 tests 모두 0 failures/errors/skips.
 - `git diff --check`: PASS.
 
-## Future Guard
+## 향후 방지책
 
-- Any compressor that cannot know the decompressed size from a trusted header
-  must copy streams through a bounded loop, not `readBytes()`.
-- For concurrency helper selection: this change adds no shared mutable state,
-  coroutine lifecycle, or structured task scope behavior. `MultithreadingTester`,
-  `SuspendedJobTester`, and `StructuredTaskScopeTester` are not applicable for
-  the new regression tests; existing compressor concurrency coverage remains in
-  `CompressorEdgeCaseTest`.
+- Trusted header에서 decompressed size를 알 수 없는 compressor는 `readBytes()`가 아니라 bounded loop로 stream을 copy해야 한다.
+- Concurrency helper 선택 기준: 이 변경은 shared mutable state, coroutine lifecycle, structured task scope behavior를 추가하지 않는다. 새 regression test에는 `MultithreadingTester`, `SuspendedJobTester`, `StructuredTaskScopeTester`가 적용되지 않으며, 기존 compressor concurrency coverage는 `CompressorEdgeCaseTest`에 남아 있다.

--- a/docs/lessons/2026-06-27-issue-806-opentelemetry-redacted-exception-telemetry.md
+++ b/docs/lessons/2026-06-27-issue-806-opentelemetry-redacted-exception-telemetry.md
@@ -1,22 +1,33 @@
-# Lessons Learned - Issue 806 OpenTelemetry Redacted Exception Telemetry (2026-06-27)
+# 교훈: 이슈 806 OpenTelemetry redacted exception telemetry (2026-06-27)
 
-Issue: #806
-Module: `infra/opentelemetry`
+이슈: #806
+모듈: `infra/opentelemetry`
 
-## Context
+## 배경
 
-OpenTelemetry span helpers recorded exception messages into exported span status and exception events by default. Exception messages often contain SQL fragments, URLs, tokens, or user input, so helper-managed failure paths must treat raw messages as sensitive by default.
+OpenTelemetry span helper는 기본적으로 exported span status와 exception event에
+exception message를 기록했다. Exception message에는 SQL fragment, URL, token,
+user input이 들어갈 수 있으므로 helper-managed failure path는 raw message를
+기본적으로 sensitive하게 다뤄야 한다.
 
-## Decision
+## 결정
 
-Helper-managed failures now emit a redacted `exception` event and set `StatusCode.ERROR` with `"unspecified error"` as the exported message. The original exception is still rethrown to callers. Full OpenTelemetry `recordException` remains available only as an explicit opt-in at a boundary where exporting the raw exception message is allowed.
+Helper-managed failure는 이제 redacted `exception` event를 내보내고 exported
+message로 `"unspecified error"`를 설정해 `StatusCode.ERROR`를 기록한다. 원래
+exception은 호출자에게 그대로 rethrow한다. 전체 OpenTelemetry `recordException`은
+raw exception message export가 허용된 경계에서 명시적으로 opt-in할 때만 사용한다.
 
-## Test Helper Judgment
+## Test helper 판단
 
-The change affects coroutine and Flow failure paths, so `SuspendedJobTester` is the fitting bluetape4k helper. It was used for coroutine and Flow redaction stress tests.
+이 변경은 coroutine과 Flow failure path에 영향을 주므로 `SuspendedJobTester`가 맞는
+bluetape4k helper다. Coroutine/Flow redaction stress test에 이 helper를 사용했다.
 
-`MultithreadingTester` and `StructuredTaskScopeTester` were not used because this fix does not add shared mutable production state, thread contention, virtual-thread behavior, or `StructuredTaskScope` semantics.
+`MultithreadingTester`와 `StructuredTaskScopeTester`는 이 수정이 shared mutable
+production state, thread contention, virtual-thread behavior, `StructuredTaskScope`
+semantics를 추가하지 않으므로 사용하지 않았다.
 
-## Future Guard
+## 향후 방지책
 
-For telemetry helpers, test both status descriptions and event attributes. `recordException(error)` can export `exception.message`, so a status-only assertion is not enough for secret-leak regressions.
+Telemetry helper는 status description과 event attribute를 모두 테스트한다.
+`recordException(error)`는 `exception.message`를 export할 수 있으므로 status-only
+assertion만으로는 secret-leak regression을 잡기에 충분하지 않다.

--- a/docs/lessons/2026-06-27-issue-811-cassandra-mapper-runtime-dependency.md
+++ b/docs/lessons/2026-06-27-issue-811-cassandra-mapper-runtime-dependency.md
@@ -1,53 +1,45 @@
-# Issue #811: Cassandra Mapper Runtime Dependency
+# 이슈 #811: Cassandra mapper runtime dependency
 
-## Context
+## 배경
 
-`bluetape4k-cassandra` exposes DataStax mapper runtime types in public mapper
-extension signatures:
+`bluetape4k-cassandra`는 public mapper extension signature에서 DataStax mapper runtime
+type을 노출한다.
 
-- `EntityHelper<T>` receiver and parameters
+- `EntityHelper<T>` receiver와 parameter
 - `NullSavingStrategy` parameter default
 
-The module declared `java-driver-mapper-runtime` as `compileOnly`, while the
-regular test classpath extended `compileOnly`. That made module tests pass even
-though consumers using only the documented `bluetape4k-cassandra` dependency
-could not compile mapper helper APIs.
+모듈은 `java-driver-mapper-runtime`을 `compileOnly`로 선언했고, 정규 test classpath는
+`compileOnly`를 확장했다. 그래서 모듈 테스트는 통과했지만 문서화된
+`bluetape4k-cassandra` 의존성만 사용하는 소비자는 mapper helper API를 컴파일할 수
+없었다.
 
-## Decision
+## 결정
 
-Treat mapper helpers as part of the `bluetape4k-cassandra` public API contract:
+Mapper helper를 `bluetape4k-cassandra` public API 계약의 일부로 다룬다.
 
-- Promote `libs.cassandra.java.driver.mapper.runtime` from `compileOnly` to
-  `api`.
-- Add a `consumerRuntimeTest` source set whose compile/runtime classpath uses
-  `main.output + runtimeClasspath`, not the regular test classpath.
-- Document that the single `bluetape4k-cassandra` artifact includes the mapper
-  runtime required by `io.bluetape4k.cassandra.mapper`.
+- `libs.cassandra.java.driver.mapper.runtime`을 `compileOnly`에서 `api`로 승격한다.
+- 정규 test classpath가 아니라 `main.output + runtimeClasspath`를 compile/runtime classpath로 사용하는 `consumerRuntimeTest` source set을 추가한다.
+- 단일 `bluetape4k-cassandra` artifact가 `io.bluetape4k.cassandra.mapper`에 필요한 mapper runtime을 포함한다고 문서화한다.
 
-## Verification
+## 검증
 
-- RED: `./gradlew :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --no-build-cache --no-daemon --no-configuration-cache`
-  failed with unresolved `com.datastax.oss.driver.api.mapper.*` and
-  `Cannot access class 'EntityHelper'`.
-- GREEN: the same compile task passed after promoting mapper runtime to `api`.
-- `./gradlew :bluetape4k-cassandra:dependencies --configuration runtimeClasspath --no-daemon --no-configuration-cache`
-  showed `org.apache.cassandra:java-driver-mapper-runtime:4.19.2`.
-- `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
-  passed.
-- `./gradlew :bluetape4k-cassandra:test :bluetape4k-cassandra:consumerRuntimeTest --no-build-cache --no-daemon --no-configuration-cache`
-  passed with 178 module tests and 1 consumer runtime test.
-- `git diff --check` passed.
+- RED: `./gradlew :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --no-build-cache --no-daemon --no-configuration-cache`가 unresolved `com.datastax.oss.driver.api.mapper.*`와 `Cannot access class 'EntityHelper'`로 실패했다.
+- GREEN: mapper runtime을 `api`로 승격한 뒤 같은 compile task가 통과했다.
+- `./gradlew :bluetape4k-cassandra:dependencies --configuration runtimeClasspath --no-daemon --no-configuration-cache`에서 `org.apache.cassandra:java-driver-mapper-runtime:4.19.2`가 확인되었다.
+- `./gradlew :bluetape4k-cassandra:compileKotlin :bluetape4k-cassandra:compileTestKotlin :bluetape4k-cassandra:compileConsumerRuntimeTestKotlin --warning-mode all --no-daemon --no-configuration-cache`가 통과했다.
+- `./gradlew :bluetape4k-cassandra:test :bluetape4k-cassandra:consumerRuntimeTest --no-build-cache --no-daemon --no-configuration-cache`가 178개 module test와 1개 consumer runtime test로 통과했다.
+- `git diff --check`가 통과했다.
 
-## Future Guidance
+## 향후 지침
 
-When a bluetape4k module exposes third-party types in public signatures, the
-dependency must be exported (`api`) or the API must move behind an optional
-artifact. Regular tests that inherit `compileOnly` are not sufficient evidence;
-add a consumer-style source set for compile/runtime contracts.
+bluetape4k module이 public signature에서 third-party type을 노출하면 dependency를
+export(`api`)하거나 API를 optional artifact 뒤로 이동해야 한다. `compileOnly`를
+상속하는 정규 테스트는 충분한 증거가 아니므로 compile/runtime 계약을 검증하는
+consumer-style source set을 추가한다.
 
-## Concurrency Helper Gate
+## 동시성 helper gate
 
-No shared mutable state, coroutine lifecycle, structured concurrency, or virtual
-thread behavior changed. `MultithreadingTester`, `SuspendedJobTester`, and
-`StructuredTaskScopeTester` are not applicable to this dependency metadata and
-consumer compile-contract fix.
+Shared mutable state, coroutine lifecycle, structured concurrency, virtual-thread
+behavior는 변경되지 않았다. `MultithreadingTester`, `SuspendedJobTester`,
+`StructuredTaskScopeTester`는 이 dependency metadata와 consumer compile-contract
+수정에 적용되지 않는다.

--- a/docs/lessons/2026-07-04-api-contract-failures.md
+++ b/docs/lessons/2026-07-04-api-contract-failures.md
@@ -1,29 +1,28 @@
-# API contract failures should preserve caller context
+# API contract failure는 호출자 context를 보존해야 한다
 
-## Context
+## 배경
 
-Issues #951 and #954 found helper APIs where public contracts drifted from
-caller expectations:
+이슈 #951과 #954는 public contract가 호출자 기대와 어긋난 helper API를 발견했다.
 
-- Ktor Swagger UI collapsed nested specification paths to a basename.
-- RestClient coroutine helpers used `!!`, turning empty bodies into raw
-  `NullPointerException` failures.
+- Ktor Swagger UI는 nested specification path를 basename으로 접었다.
+- RestClient coroutine helper는 `!!`를 사용해 empty body를 raw
+  `NullPointerException` failure로 바꿨다.
 
-## Decision
+## 결정
 
-- Preserve caller-provided relative Swagger specification paths for both the
-  file source and Swagger UI remote path.
-- Replace RestClient coroutine `!!` assertions with an explicit non-null body
-  contract error that includes HTTP method, URI, and target type.
+- File source와 Swagger UI remote path 모두에서 호출자가 제공한 relative Swagger
+  specification path를 보존한다.
+- RestClient coroutine `!!` assertion을 HTTP method, URI, target type을 포함하는
+  명시적인 non-null body contract error로 바꾼다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest'`
 - `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.http.RestClientCoroutinesDslTest'`
 - `git diff --check`
 
-## Future guidance
+## 향후 지침
 
-Route helper defaults must keep documented path contracts source-verified.
-Coroutine wrappers around blocking clients should expose explicit caller-facing
-contract errors instead of relying on Kotlin null assertions.
+Route helper default는 문서화된 path contract를 source-verified 상태로 유지해야
+한다. Blocking client를 감싸는 coroutine wrapper는 Kotlin null assertion에 기대지
+말고 호출자에게 보이는 명시적인 contract error를 드러내야 한다.

--- a/docs/lessons/2026-07-04-data-validation-fail-fast.md
+++ b/docs/lessons/2026-07-04-data-validation-fail-fast.md
@@ -1,31 +1,29 @@
-# Data validation fail-fast for public numeric parameters
+# Public numeric parameter의 data validation fail-fast
 
-## Context
+## 배경
 
-Issues #947 and #955 found public data APIs that accepted invalid numeric
-parameters and let downstream JDBC modulo operations or SQL/CQL builders expose
-late, low-signal failures.
+이슈 #947과 #955는 public data API가 잘못된 numeric parameter를 받아들이고,
+downstream JDBC modulo operation이나 SQL/CQL builder가 늦고 신호가 약한 실패를
+드러내게 한다는 점을 확인했다.
 
-## Decision
+## 결정
 
-Validate numeric inputs at the public entrypoint with bluetape4k `require*`
-helpers:
+Numeric input은 public entrypoint에서 bluetape4k `require*` helper로 검증한다.
 
-- JDBC batch size must be positive before any batch loop or modulo operation.
-- R2DBC query limit must be positive.
-- R2DBC query offset must be zero or positive.
-- Cassandra keyspace replication factor must be positive.
+- JDBC batch size는 batch loop나 modulo operation 전에 positive여야 한다.
+- R2DBC query limit은 positive여야 한다.
+- R2DBC query offset은 zero or positive여야 한다.
+- Cassandra keyspace replication factor는 positive여야 한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.DataSourceTransactionExtensionsTest'`
 - `./gradlew :bluetape4k-r2dbc:test --tests 'io.bluetape4k.r2dbc.query.QueryBuilderTest'`
 - `./gradlew :bluetape4k-cassandra:test --tests 'io.bluetape4k.cassandra.CassandraAdminTest'`
 - `git diff --check`
 
-## Future guidance
+## 향후 지침
 
-For public data API parameters that shape generated SQL/CQL or loop arithmetic,
-validate before delegating to driver builders or iteration logic. Prefer
-`requirePositiveNumber` and `requireZeroOrPositiveNumber` over raw `require`
-when the parameter is numeric.
+Generated SQL/CQL이나 loop arithmetic을 형성하는 public data API parameter는 driver
+builder나 iteration logic에 위임하기 전에 검증한다. Parameter가 numeric이면 raw
+`require`보다 `requirePositiveNumber`와 `requireZeroOrPositiveNumber`를 우선한다.

--- a/docs/lessons/2026-07-04-hibernate-lettuce-classpath-guards.md
+++ b/docs/lessons/2026-07-04-hibernate-lettuce-classpath-guards.md
@@ -1,31 +1,31 @@
-# Hibernate Lettuce Classpath Guards
+# Hibernate Lettuce classpath guard
 
-## Context
+## 배경
 
-Issue #945 found that the Hibernate Lettuce Spring Boot auto-configurations used
-direct class references for optional compile-only Hibernate, Actuator, and
-Micrometer integrations.
+이슈 #945는 Hibernate Lettuce Spring Boot auto-configuration이 optional compile-only
+Hibernate, Actuator, Micrometer integration에 direct class reference를 사용한다는
+점을 확인했다.
 
-## Decision
+## 결정
 
-Keep optional integration metadata string-based:
+Optional integration metadata는 string 기반으로 유지한다.
 
-- use `@ConditionalOnClass(name = [...])` for optional classpath probes
-- use `@ConditionalOnBean(type = [...])` for optional bean types
-- use `@AutoConfiguration(afterName = [...])` for optional ordering targets
+- optional classpath probe에는 `@ConditionalOnClass(name = [...])`를 사용한다.
+- optional bean type에는 `@ConditionalOnBean(type = [...])`를 사용한다.
+- optional ordering target에는 `@AutoConfiguration(afterName = [...])`를 사용한다.
 
-## Outcome
+## 결과
 
-`FilteredClassLoader` slice tests now prove the configuration backs off cleanly
-when Hibernate customizer, Actuator endpoint annotations, or Micrometer registry
-types are unavailable.
+`FilteredClassLoader` slice test는 Hibernate customizer, Actuator endpoint
+annotation, Micrometer registry type이 없을 때 configuration이 깔끔하게 back off함을
+증명한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-spring-boot-hibernate-lettuce:test --tests 'io.bluetape4k.spring.boot.autoconfigure.cache.lettuce.LettuceNearCacheAutoConfigurationTest'`
 
-## Future Guidance
+## 향후 지침
 
-When an auto-configuration imports a `compileOnly` integration, avoid class
-literals in annotation metadata and add a missing-class `ApplicationContextRunner`
-test before marking the integration classpath-safe.
+Auto-configuration이 `compileOnly` integration을 import한다면 annotation metadata의
+class literal을 피하고, integration을 classpath-safe로 표시하기 전에 missing-class
+`ApplicationContextRunner` test를 추가한다.

--- a/docs/lessons/2026-07-04-issue-820-mongodb-provider-cache.md
+++ b/docs/lessons/2026-07-04-issue-820-mongodb-provider-cache.md
@@ -1,28 +1,26 @@
-# Issue #820 MongoDB Provider Cache Semantics
+# 이슈 #820 MongoDB provider cache semantics
 
-## Context
+## 배경
 
-`MongoClientProvider.getOrCreate(connectionString, builder)` cached by URL only.
-The first caller for a URL decided the effective settings for all later callers
-with the same URL, even when those later callers supplied different builder
-settings.
+`MongoClientProvider.getOrCreate(connectionString, builder)`는 URL만으로 cache했다.
+같은 URL에 대해 나중 호출자가 다른 builder setting을 제공해도 첫 호출자가 모든 후속
+호출자의 effective setting을 결정했다.
 
-## Decision
+## 결정
 
-Cache provider-managed clients by the final immutable `MongoClientSettings`
-instead of the raw connection string. Keep the existing overloads source
-compatible, but route every overload through the settings cache.
+Provider-managed client는 raw connection string이 아니라 최종 immutable
+`MongoClientSettings`로 cache한다. 기존 overload의 source compatibility는 유지하되
+모든 overload를 settings cache로 보낸다.
 
-## Outcome
+## 결과
 
-- Same URL plus equal settings returns the same shared client.
-- Same URL plus different settings returns different shared clients.
-- Provider-owned shared clients now have explicit `close(...)` and `closeAll()`
-  lifecycle APIs, and README/KDoc warns callers not to directly close returned
-  shared instances.
+- 같은 URL과 동일한 setting은 같은 shared client를 반환한다.
+- 같은 URL과 다른 setting은 서로 다른 shared client를 반환한다.
+- Provider-owned shared client에는 명시적인 `close(...)`, `closeAll()` lifecycle
+  API가 생겼고, README/KDoc은 반환된 shared instance를 직접 닫지 말라고 경고한다.
 
-## Future Rule
+## 향후 규칙
 
-When a provider overload accepts a builder or custom options, the cache key must
-represent the final effective configuration. Do not cache by only the "base"
-identifier when caller-provided settings can change runtime behavior.
+Provider overload가 builder나 custom option을 받는다면 cache key는 최종 effective
+configuration을 표현해야 한다. 호출자가 제공한 setting이 runtime behavior를 바꿀 수
+있을 때는 "base" identifier만으로 cache하지 않는다.

--- a/docs/lessons/2026-07-04-issue-821-mongodb-transaction-abort.md
+++ b/docs/lessons/2026-07-04-issue-821-mongodb-transaction-abort.md
@@ -1,32 +1,31 @@
-# Lessons Learned - Issue #821 MongoDB Transaction Abort
+# 교훈: 이슈 #821 MongoDB transaction abort
 
-## Context
+## 배경
 
-`MongoClient.inTransaction` handled `CancellationException` correctly by
-rethrowing it, but called the suspend `ClientSession.abortTransaction()` from
-the already-cancelled coroutine context. That could skip the abort cleanup
-before MongoDB released the transaction.
+`MongoClient.inTransaction`은 `CancellationException`을 다시 던져 올바르게 처리했지만,
+이미 취소된 coroutine context에서 suspend `ClientSession.abortTransaction()`을
+호출했다. 이 때문에 MongoDB가 transaction을 해제하기 전에 abort cleanup이 생략될 수
+있었다.
 
-## Lesson
+## 교훈
 
-Suspend cleanup that must run after coroutine cancellation needs an explicit
-`withContext(NonCancellable)` boundary. Keep that boundary as small as possible:
-only the cleanup call should run non-cancellable, and the original cancellation
-must still be rethrown.
+Coroutine cancellation 이후 반드시 실행되어야 하는 suspend cleanup에는 명시적인
+`withContext(NonCancellable)` 경계가 필요하다. 이 경계는 가능한 작게 유지한다.
+Cleanup 호출만 non-cancellable로 실행하고 원래 cancellation은 계속 다시 던져야 한다.
 
-## Outcome
+## 결과
 
-MongoDB transaction abort now runs from `NonCancellable` for both cancellation
-and non-cancellation exception paths. Abort failures are preserved as suppressed
-exceptions on the owner throwable.
+MongoDB transaction abort는 cancellation과 non-cancellation exception 경로 모두에서
+`NonCancellable`로 실행된다. Abort failure는 owner throwable의 suppressed
+exception으로 보존된다.
 
-## Future Guard
+## 향후 방지책
 
-When a suspend cleanup call runs from a `catch (e: CancellationException)` path,
-add a regression test that cancels the current coroutine context before cleanup
-and proves a suspension point inside cleanup still completes.
+Suspend cleanup 호출이 `catch (e: CancellationException)` 경로에서 실행된다면,
+cleanup 전에 현재 coroutine context를 취소하고 cleanup 내부 suspension point가 여전히
+완료됨을 증명하는 회귀 테스트를 추가한다.
 
-## Verification
+## 검증
 
 - `:bluetape4k-mongodb:compileKotlin` and
   `:bluetape4k-mongodb:compileTestKotlin` passed.

--- a/docs/lessons/2026-07-04-issue-825-r2dbc-autoconfig-guards.md
+++ b/docs/lessons/2026-07-04-issue-825-r2dbc-autoconfig-guards.md
@@ -1,31 +1,29 @@
-# Lessons Learned - Issue #825 R2DBC Auto-Configuration Guards
+# 교훈: 이슈 #825 R2DBC auto-configuration guard
 
-## Context
+## 배경
 
-`R2dbcClientAutoConfiguration` was guarded only by `DatabaseClient`, but the
-auto-configured bean method also used `R2dbcEntityTemplate` and
-`MappingR2dbcConverter`. Those Spring Data R2DBC types are compile-only for the
-published module.
+`R2dbcClientAutoConfiguration`은 `DatabaseClient`로만 guard되었지만,
+auto-configured bean method는 `R2dbcEntityTemplate`과 `MappingR2dbcConverter`도
+사용했다. 이 Spring Data R2DBC type은 published module에서 compile-only다.
 
-## Lesson
+## 교훈
 
-Spring Boot auto-configuration classes should guard every compile-only type that
-appears in bean method signatures. Use string-based `@ConditionalOnClass` names
-when the guard exists to prevent class-loading failures before the condition can
-short-circuit.
+Spring Boot auto-configuration class는 bean method signature에 나타나는 모든
+compile-only type을 guard해야 한다. Condition이 short-circuit되기 전에 class-loading
+failure가 발생하지 않도록 guard에는 string 기반 `@ConditionalOnClass` name을 사용한다.
 
-## Outcome
+## 결과
 
-The R2DBC auto-configuration now checks all Spring R2DBC signature types and
-backs off when a user-defined `R2dbcClient` bean exists.
+R2DBC auto-configuration은 이제 모든 Spring R2DBC signature type을 확인하고,
+user-defined `R2dbcClient` bean이 있으면 back off한다.
 
-## Future Guard
+## 향후 방지책
 
-When adding auto-configured beans with compile-only parameters, add
-`ApplicationContextRunner` tests for both missing classpath behavior and custom
-bean backoff.
+Compile-only parameter가 있는 auto-configured bean을 추가할 때는 missing classpath
+behavior와 custom bean backoff를 모두 검증하는 `ApplicationContextRunner` test를
+추가한다.
 
-## Verification
+## 검증
 
 - `:bluetape4k-r2dbc:compileKotlin` and `:bluetape4k-r2dbc:compileTestKotlin`
   passed.

--- a/docs/lessons/2026-07-04-issue-827-ktor-correlation-tracing.md
+++ b/docs/lessons/2026-07-04-issue-827-ktor-correlation-tracing.md
@@ -1,32 +1,30 @@
-# Lessons Learned - Issue #827 Ktor Correlation Tracing
+# 교훈: 이슈 #827 Ktor correlation tracing
 
-## Context
+## 배경
 
-`bluetape4k-ktor-observability` recorded `correlation.present` and optional
-`correlation.id` in the OpenTelemetry Ktor extractor `onStart` callback. The
-OpenTelemetry plugin starts before Ktor `ApplicationCallPipeline.Setup`, while
-Ktor `CallId` sanitizes or generates the call id during `Setup`.
+`bluetape4k-ktor-observability`는 OpenTelemetry Ktor extractor의 `onStart`
+callback에서 `correlation.present`와 optional `correlation.id`를 기록했다.
+OpenTelemetry plugin은 Ktor `ApplicationCallPipeline.Setup`보다 먼저 시작하고,
+Ktor `CallId`는 `Setup` 중 call id를 sanitize하거나 생성한다.
 
-## Lesson
+## 교훈
 
-When tracing attributes depend on framework plugins that run later in the call
-pipeline, capture them at span end unless the value must participate in sampler
-decisions. For Ktor server spans, generated `CallId` values are available by
-the OpenTelemetry extractor `onEnd` callback.
+Tracing attribute가 call pipeline에서 더 늦게 실행되는 framework plugin에 의존하면,
+그 값이 sampler decision에 참여해야 하는 경우가 아니라면 span end에서 캡처한다.
+Ktor server span에서는 생성된 `CallId` 값이 OpenTelemetry extractor `onEnd` callback
+시점에 사용 가능하다.
 
-## Outcome
+## 결과
 
-The tracing helper now records correlation attributes from `onEnd`, so
-headerless requests produce the same generated `X-Request-Id` in both the HTTP
-response and the server span.
+Tracing helper는 이제 `onEnd`에서 correlation attribute를 기록한다. 따라서 header가
+없는 request도 HTTP response와 server span에 같은 generated `X-Request-Id`를 남긴다.
 
-## Future Guard
+## 향후 방지책
 
-Keep generated correlation ID regression coverage whenever changing Ktor
-OpenTelemetry extractor timing, CallId installation order, or correlation
-header policy.
+Ktor OpenTelemetry extractor timing, CallId installation order, correlation
+header policy를 변경할 때는 generated correlation ID regression coverage를 유지한다.
 
-## Verification
+## 검증
 
 - Regression test failed before the fix with `correlation.present=false`.
 - Targeted regression test passed after the fix.

--- a/docs/lessons/2026-07-04-issue-828-ktor-cancellation-spans.md
+++ b/docs/lessons/2026-07-04-issue-828-ktor-cancellation-spans.md
@@ -1,23 +1,33 @@
-# Issue #828 Ktor Cancellation Spans
+# 이슈 #828 Ktor cancellation span
 
-## Context
+## 배경
 
-The observability contract says intentional coroutine cancellation must not become an error metric or an `ERROR` span status. `ktor/observability` delegated Ktor server span lifecycle to OpenTelemetry's Ktor instrumentation, but had no regression test for a route that throws `CancellationException`.
+Observability 계약은 intentional coroutine cancellation이 error metric이나 `ERROR`
+span status가 되면 안 된다고 말한다. `ktor/observability`는 Ktor server span lifecycle을
+OpenTelemetry의 Ktor instrumentation에 위임했지만, `CancellationException`을 던지는
+route에 대한 regression test가 없었다.
 
-## Decision
+## 결정
 
-Add a focused Ktor OpenTelemetry regression test that throws `CancellationException` from a route and asserts exported spans never use `StatusCode.ERROR`. If the instrumentation exports a cancellation span in the future, the test requires the status to remain `UNSET`.
+Route에서 `CancellationException`을 던지고 exported span이 `StatusCode.ERROR`를 절대
+사용하지 않음을 검증하는 Ktor OpenTelemetry regression test를 추가한다. 나중에
+instrumentation이 cancellation span을 export하더라도 이 테스트는 status가 `UNSET`으로
+남아야 함을 요구한다.
 
-## Outcome
+## 결과
 
-The current OpenTelemetry Ktor behavior does not export a span for the canceled route in the Ktor test host. That already satisfies "no ERROR span" for cancellation, and the new test locks the contract while preserving existing coverage that real 500 responses still record `ERROR`.
+현재 OpenTelemetry Ktor 동작은 Ktor test host에서 취소된 route의 span을 export하지
+않는다. 이는 cancellation에 대해 "no ERROR span"을 이미 만족하며, 새 테스트는 실제
+500 response가 계속 `ERROR`를 기록한다는 기존 coverage를 유지하면서 이 계약을 잠근다.
 
-## Verification
+## 검증
 
 - Targeted cancellation and real-error tracing tests
 - Full `:bluetape4k-ktor-observability` compile/test command
 - `git diff --check`
 
-## Future Guard
+## 향후 방지책
 
-When wrapping framework instrumentation, test cancellation separately from ordinary handler failures. Do not assume a framework's error response shape is the same as the tracing status contract.
+Framework instrumentation을 감쌀 때는 cancellation을 일반 handler failure와 분리해서
+테스트한다. Framework의 error response 형태가 tracing status contract와 같다고
+가정하지 않는다.

--- a/docs/lessons/2026-07-04-issue-926-protobuf-ci.md
+++ b/docs/lessons/2026-07-04-issue-926-protobuf-ci.md
@@ -1,20 +1,22 @@
-# Issue #926 Protobuf CI Coverage
+# 이슈 #926 Protobuf CI coverage
 
-## Context
+## 배경
 
-Push CI skipped `Test / IO` for changes under `io/protobuf/**`, even though protobuf is an IO serialization module and recent protobuf codec changes included module tests.
+Protobuf는 IO serialization module이고 최근 protobuf codec 변경에도 module test가
+포함되었지만, push CI는 `io/protobuf/**` 변경에서 `Test / IO`를 건너뛰었다.
 
-## Decision
+## 결정
 
-Add `io/protobuf/**` to the existing `io` path-filter output and include `:bluetape4k-protobuf` in the existing `Test / IO` test and Kover task lists.
+기존 `io` path-filter output에 `io/protobuf/**`를 추가하고, 기존 `Test / IO` test와
+Kover task list에 `:bluetape4k-protobuf`를 포함한다.
 
-## Rationale
+## 근거
 
-- Protobuf belongs with adjacent IO serialization modules such as JSON, Jackson, gRPC, and Tink.
-- A separate protobuf job would add workflow fanout without improving failure isolation enough to justify it.
-- Reusing `test-io` preserves existing `coverage-report` and `ci-status` wiring.
+- Protobuf는 JSON, Jackson, gRPC, Tink 같은 인접 IO serialization module과 같은 그룹에 속한다.
+- 별도 protobuf job은 정당화할 만큼 failure isolation을 개선하지 못한 채 workflow fanout만 늘린다.
+- `test-io`를 재사용하면 기존 `coverage-report`와 `ci-status` wiring을 보존한다.
 
-## Verification
+## 검증
 
 - `actionlint .github/workflows/ci.yml`
 - Backslash-single-quote guard for GitHub Actions expressions
@@ -23,6 +25,7 @@ Add `io/protobuf/**` to the existing `io` path-filter output and include `:bluet
 - `:bluetape4k-protobuf:test`
 - `:bluetape4k-protobuf:koverXmlReport`
 
-## Future Guard
+## 향후 방지책
 
-When adding or moving IO modules, keep the path-filter patterns, Gradle test task list, and Kover task list synchronized in the same PR.
+IO module을 추가하거나 이동할 때는 path-filter pattern, Gradle test task list, Kover
+task list를 같은 PR에서 동기화한다.

--- a/docs/lessons/2026-07-04-issue-927-telemetry-ci.md
+++ b/docs/lessons/2026-07-04-issue-927-telemetry-ci.md
@@ -1,20 +1,23 @@
-# Issue #927 Telemetry CI Coverage
+# 이슈 #927 Telemetry CI coverage
 
-## Context
+## 배경
 
-Push CI skipped module tests for changes under `infra/opentelemetry/**` and `infra/kafka-logback/**`. Nightly already covered OpenTelemetry, but push CI still allowed telemetry and logging changes to pass without targeted module tests.
+Push CI는 `infra/opentelemetry/**`와 `infra/kafka-logback/**` 변경에서 module test를
+건너뛰었다. Nightly가 이미 OpenTelemetry를 다루고 있었지만, push CI는 telemetry와
+logging 변경이 targeted module test 없이 통과하는 것을 허용했다.
 
-## Decision
+## 결정
 
-Add a dedicated `telemetry-infra` path-filter output and `Test / Telemetry Infra` job instead of adding these modules to the Redis-focused infra lane.
+이 module들을 Redis 중심 infra lane에 추가하지 않고, 전용 `telemetry-infra`
+path-filter output과 `Test / Telemetry Infra` job을 추가한다.
 
-## Rationale
+## 근거
 
-- `infra/kafka-logback` uses Kafka Testcontainers and should run serially with `--max-workers=1`.
-- `infra/opentelemetry` is observability-focused and already has a Nightly shape, but needs push CI coverage when its own files change.
-- A separate job keeps Redis/cache infra results distinct from telemetry/logback failures.
+- `infra/kafka-logback`은 Kafka Testcontainers를 사용하므로 `--max-workers=1`로 순차 실행해야 한다.
+- `infra/opentelemetry`는 observability 중심이고 이미 Nightly 형태가 있지만, 자체 파일이 바뀔 때 push CI coverage가 필요하다.
+- 별도 job은 Redis/cache infra 결과와 telemetry/logback failure를 분리한다.
 
-## Verification
+## 검증
 
 - `actionlint .github/workflows/ci.yml`
 - Backslash-single-quote guard for GitHub Actions expressions
@@ -24,6 +27,8 @@ Add a dedicated `telemetry-infra` path-filter output and `Test / Telemetry Infra
 - `:bluetape4k-kafka-logback:test`
 - Matching Kover XML tasks
 
-## Future Guard
+## 향후 방지책
 
-When adding CI path filters for a module family, update all four surfaces together: path-filter output, test job, `coverage-report.needs`, and `ci-status.needs`.
+Module family에 CI path filter를 추가할 때는 네 surface를 함께 갱신한다.
+Path-filter output, test job, `coverage-report.needs`, `ci-status.needs`가 모두
+포함된다.

--- a/docs/lessons/2026-07-04-issue-937-io-ci-coverage.md
+++ b/docs/lessons/2026-07-04-issue-937-io-ci-coverage.md
@@ -1,23 +1,27 @@
-# Issue 937 IO CI Coverage
+# 이슈 937 IO CI coverage
 
-## Context
+## 배경
 
-The CI workflow had narrow IO path filters. Recent changes under `io/grpc/**`, `io/http/**`, `io/jackson2/**`, and `io/retrofit2/**` could pass CI while relevant module tests were skipped.
+CI workflow의 IO path filter가 좁았다. 최근 `io/grpc/**`, `io/http/**`,
+`io/jackson2/**`, `io/retrofit2/**` 변경은 관련 module test가 건너뛰어진 채 CI를
+통과할 수 있었다.
 
-## Decision
+## 결정
 
-Expand the existing targeted CI lanes instead of adding a full repository test fanout:
+Full repository test fanout을 추가하지 않고 기존 targeted CI lane을 확장한다.
 
-- `Test / IO`: include Jackson2, gRPC, and Tink paths plus matching test/Kover tasks.
-- `Test / IO HTTP`: include HTTP, Retrofit2, and Vert.x paths plus matching test/Kover tasks.
-- Leave `io/protobuf/**` for the dedicated open issue #926.
+- `Test / IO`: Jackson2, gRPC, Tink path와 대응되는 test/Kover task를 포함한다.
+- `Test / IO HTTP`: HTTP, Retrofit2, Vert.x path와 대응되는 test/Kover task를 포함한다.
+- `io/protobuf/**`는 별도 open issue #926 범위로 남긴다.
 
-## Outcome
+## 결과
 
-Workflow syntax and Gradle task wiring validated locally. PR CI is expected to provide the live path-filter/job execution proof because `.github/workflows/ci.yml` is part of the shared path filter.
+Workflow syntax와 Gradle task wiring은 local에서 검증했다. `.github/workflows/ci.yml`이
+shared path filter의 일부이므로 live path-filter/job execution proof는 PR CI가 제공할
+것으로 본다.
 
-## Future Guidance
+## 향후 지침
 
-- When adding CI path filters, add the matching Gradle test and Kover tasks in the same change.
-- Keep separate backlog issues separate unless the PR explicitly closes them; here protobuf remains scoped to #926.
-- Always run `actionlint`, escaped workflow quote scan, `git diff --check`, and Gradle dry-run task validation before opening workflow PRs.
+- CI path filter를 추가할 때는 matching Gradle test와 Kover task를 같은 변경에 넣는다.
+- PR이 명시적으로 닫지 않는 한 별도 backlog issue는 분리해 둔다. 여기서는 protobuf가 #926 범위로 남는다.
+- Workflow PR을 열기 전에는 항상 `actionlint`, escaped workflow quote scan, `git diff --check`, Gradle dry-run task validation을 실행한다.

--- a/docs/lessons/2026-07-04-issue-975-kafka-ci.md
+++ b/docs/lessons/2026-07-04-issue-975-kafka-ci.md
@@ -1,23 +1,23 @@
-# Issue #975 Kafka CI Coverage
+# 이슈 #975 Kafka CI coverage
 
-## Context
+## 배경
 
-Push CI did not run `:bluetape4k-kafka:test` for changes under `infra/kafka/**`.
-The existing `infra` lane was Redis/cache-specific, while `telemetry-infra`
-covered `infra/opentelemetry/**` and `infra/kafka-logback/**`.
+Push CI는 `infra/kafka/**` 변경에서 `:bluetape4k-kafka:test`를 실행하지 않았다.
+기존 `infra` lane은 Redis/cache 중심이었고, `telemetry-infra`는
+`infra/opentelemetry/**`와 `infra/kafka-logback/**`를 다뤘다.
 
-## Decision
+## 결정
 
-Add a dedicated `kafka-infra` path-filter output and `Test / Kafka Infra` job
-instead of mixing Kafka into the Redis-focused infra lane.
+Kafka를 Redis 중심 infra lane에 섞지 않고, 전용 `kafka-infra` path-filter output과
+`Test / Kafka Infra` job을 추가한다.
 
-## Rationale
+## 근거
 
-- `infra/kafka` tests use embedded Kafka/Testcontainers-style infrastructure and should run serially with `--max-workers=1`.
-- A dedicated job keeps Kafka failures distinct from Redis/cache and telemetry/logback failures.
-- CI aggregation must list the new job in both `coverage-report.needs` and `ci-status.needs` so skipped/failed Kafka coverage is visible.
+- `infra/kafka` test는 embedded Kafka/Testcontainers-style infrastructure를 사용하므로 `--max-workers=1`로 순차 실행해야 한다.
+- 전용 job은 Kafka failure를 Redis/cache와 telemetry/logback failure에서 분리한다.
+- Skipped/failed Kafka coverage가 보이도록 CI aggregation은 새 job을 `coverage-report.needs`와 `ci-status.needs` 양쪽에 나열해야 한다.
 
-## Verification
+## 검증
 
 - `actionlint .github/workflows/ci.yml`
 - Backslash-single-quote guard for GitHub Actions expressions
@@ -25,7 +25,8 @@ instead of mixing Kafka into the Redis-focused infra lane.
 - `./gradlew :bluetape4k-kafka:cleanTest :bluetape4k-kafka:test --max-workers=1 --no-build-cache --no-configuration-cache`
 - `./gradlew :bluetape4k-kafka:koverXmlReport --max-workers=1 --no-configuration-cache`
 
-## Future Guard
+## 향후 방지책
 
-When adding CI coverage for a module family, update all four surfaces together:
-path-filter output, test job, `coverage-report.needs`, and `ci-status.needs`.
+Module family에 CI coverage를 추가할 때는 네 surface를 함께 갱신한다.
+Path-filter output, test job, `coverage-report.needs`, `ci-status.needs`가 모두
+포함되어야 한다.

--- a/docs/lessons/2026-07-04-jdbc-state-restore-failures.md
+++ b/docs/lessons/2026-07-04-jdbc-state-restore-failures.md
@@ -1,23 +1,22 @@
-# JDBC state restore failures must not replace primary failures
+# JDBC 상태 복구 실패는 primary failure를 대체하면 안 된다
 
-## Context
+## 배경
 
-Issue #946 found JDBC helper functions that restored connection state in
-`finally` without preserving a primary block failure when restore also failed.
+이슈 #946은 restore도 실패했을 때 primary block failure를 보존하지 않은 채
+`finally`에서 connection state를 복구하는 JDBC helper function을 발견했다.
 
-## Decision
+## 결정
 
-Record the primary failure from the caller block or state-change path, then add
-restore failures as suppressed exceptions. If the caller block succeeds and only
-restore fails, surface the restore failure.
+Caller block 또는 state-change path의 primary failure를 기록한 뒤 restore failure를
+suppressed exception으로 추가한다. Caller block은 성공하고 restore만 실패했다면
+restore failure를 노출한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-jdbc:test --tests 'io.bluetape4k.jdbc.sql.TransactionExtensionsTest'`
 - `git diff --check`
 
-## Future guidance
+## 향후 지침
 
-Any lifecycle helper that temporarily mutates JDBC connection state should use
-the same primary-failure preservation pattern as transaction rollback/restore
-logic.
+JDBC connection state를 임시로 변경하는 lifecycle helper는 transaction
+rollback/restore logic과 같은 primary-failure preservation pattern을 사용해야 한다.

--- a/docs/lessons/2026-07-04-jdk25-joinuntil-interrupt-semantics.md
+++ b/docs/lessons/2026-07-04-jdk25-joinuntil-interrupt-semantics.md
@@ -1,27 +1,27 @@
-# JDK25 JoinUntil Interrupt Semantics
+# JDK25 `joinUntil` interrupt semantics
 
-## Context
+## 배경
 
-Issue #953 found that the JDK25 structured-scope `joinUntil` fallback converted
-every `InterruptedException` into `TimeoutException` and cleared the caller's
-interrupt status.
+이슈 #953은 JDK25 structured-scope `joinUntil` fallback이 모든
+`InterruptedException`을 `TimeoutException`으로 바꾸고 호출자 thread의 interrupt
+status를 지운다는 점을 확인했다.
 
-## Decision
+## 결정
 
-Track only the scheduled timeout interrupt as timeout evidence. Preserve
-pre-existing and external interrupts by rethrowing `InterruptedException` and
-restoring the caller thread interrupt flag.
+Scheduled timeout interrupt만 timeout evidence로 추적한다. 기존 interrupt와 외부
+interrupt는 `InterruptedException`을 다시 던지고 호출자 thread interrupt flag를
+복구해서 보존한다.
 
-## Outcome
+## 결과
 
-Timeout joins still throw `TimeoutException`, while cancellation or interrupt
-signals from outside the timeout scheduler remain diagnosable.
+Timeout join은 계속 `TimeoutException`을 던지지만, timeout scheduler 밖에서 온
+cancellation 또는 interrupt signal은 진단 가능한 상태로 남는다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-virtualthread-jdk25:test --tests 'io.bluetape4k.concurrent.virtualthread.jdk25.Jdk25StructuredTaskScopeProviderTest' --tests 'io.bluetape4k.concurrent.virtualthread.jdk25.Jdk25StructuredTaskScopeProviderExtTest'`
 
-## Future Guidance
+## 향후 지침
 
-Do not clear interrupt status in structured-concurrency helpers unless the code
-can prove it created the interrupt signal being consumed.
+Structured-concurrency helper에서는 소비하는 interrupt signal을 해당 코드가 만들었다는
+점을 증명할 수 있을 때만 interrupt status를 지운다.

--- a/docs/lessons/2026-07-04-kafka3-close-evidence.md
+++ b/docs/lessons/2026-07-04-kafka3-close-evidence.md
@@ -1,26 +1,25 @@
-# Kafka receiver close evidence should stay visible
+# Kafka receiver close evidence는 계속 보여야 한다
 
-## Context
+## 배경
 
-Issue #950 found that Kafka3 suspend consumer shutdown did not expose receiver
-close failures or non-`AutoCloseable` receiver evidence, while Kafka4 already
-logged both paths.
+이슈 #950은 Kafka4가 이미 두 경로를 모두 log하는 반면, Kafka3 suspend consumer
+shutdown은 receiver close failure나 non-`AutoCloseable` receiver evidence를 노출하지
+않는다는 점을 확인했다.
 
-## Decision
+## 결정
 
-Port the Kafka4 close pattern to Kafka3:
+Kafka4 close pattern을 Kafka3로 옮긴다.
 
-- Warn when `KafkaReceiver` does not implement `AutoCloseable`.
-- Wrap receiver close with `runCatching` and log failures instead of throwing
-  them from `close()`/`destroy()`.
+- `KafkaReceiver`가 `AutoCloseable`을 구현하지 않으면 warn한다.
+- Receiver close를 `runCatching`으로 감싸고, `close()`/`destroy()`에서 던지는 대신 failure를 log한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-kafka:test --tests 'io.bluetape4k.kafka.spring.core.SuspendKafkaConsumerTemplateTest'`
 - `git diff --check`
 
-## Future guidance
+## 향후 지침
 
-Kafka3 and Kafka4 suspend templates should keep lifecycle diagnostics in parity.
-Resource close paths should preserve shutdown progress while logging close
-failure evidence with the receiver class.
+Kafka3와 Kafka4 suspend template은 lifecycle diagnostic parity를 유지해야 한다.
+Resource close path는 shutdown progress를 보존하면서 receiver class와 함께 close
+failure evidence를 log해야 한다.

--- a/docs/lessons/2026-07-04-lettuce-lock-duration-token.md
+++ b/docs/lessons/2026-07-04-lettuce-lock-duration-token.md
@@ -1,27 +1,26 @@
-# Lettuce Lock Duration And Token Preservation
+# Lettuce lock duration과 token 보존
 
-## Context
+## 배경
 
-Issue #949 found that Lettuce lock APIs converted invalid durations to Redis PX
-values and cleared the local owner token before Redis release success was known.
+이슈 #949는 Lettuce lock API가 잘못된 duration을 Redis PX value로 변환하고,
+Redis release success를 알기 전에 local owner token을 지운다는 점을 확인했다.
 
-## Decision
+## 결정
 
-Validate lock durations at the API boundary and clear the local token only after
-the Redis Lua release script confirms success.
+Lock duration은 API boundary에서 검증하고, Redis Lua release script가 성공을 확인한
+뒤에만 local token을 지운다.
 
-## Outcome
+## 결과
 
-Invalid lease/wait durations fail before Redis commands are issued. If a release
-fails because the Redis key expired or no longer matches, the local token remains
-available so callers can retry when release evidence becomes available.
+잘못된 lease/wait duration은 Redis command가 발행되기 전에 실패한다. Redis key가
+만료되었거나 더 이상 일치하지 않아 release가 실패하면 local token은 남아 있고,
+호출자는 release evidence가 확보될 때 retry할 수 있다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-lettuce:test --tests 'io.bluetape4k.redis.lettuce.lock.LettuceLockTest' --tests 'io.bluetape4k.redis.lettuce.lock.LettuceSuspendLockTest'`
 
-## Future Guidance
+## 향후 지침
 
-Distributed lock implementations must validate Redis TTL inputs before command
-construction and must not discard local ownership evidence until remote release
-success is confirmed.
+Distributed lock 구현은 command construction 전에 Redis TTL input을 검증해야 하며,
+remote release success가 확인되기 전에는 local ownership evidence를 버리면 안 된다.

--- a/docs/lessons/2026-07-04-resilient-suspend-cache-cancellation.md
+++ b/docs/lessons/2026-07-04-resilient-suspend-cache-cancellation.md
@@ -1,28 +1,28 @@
-# Resilient Suspend Cache Cancellation
+# Resilient suspend cache cancellation
 
-## Context
+## 배경
 
-Issue #942 found `runCatching` around suspend back-cache reads in
-`ResilientSuspendNearJCache`. That converted coroutine cancellation into
-configured fallback behavior.
+이슈 #942는 `ResilientSuspendNearJCache`의 suspend back-cache read 주변에
+`runCatching`이 있다는 점을 확인했다. 이 패턴은 coroutine cancellation을 configured
+fallback behavior로 바꿨다.
 
-## Decision
+## 결정
 
-Replace suspend `runCatching` fallback paths with explicit `try/catch` blocks
-that rethrow `CancellationException` before applying non-cancellation fallback
-behavior.
+Suspend `runCatching` fallback path를 명시적인 `try/catch` block으로 바꾸고,
+non-cancellation fallback behavior를 적용하기 전에 `CancellationException`을 다시
+던진다.
 
-## Outcome
+## 결과
 
-`get`, `getAll`, `replace`, and `containsKey` now preserve structured
-concurrency cancellation while still returning null/false for ordinary back
-cache failures where the existing contract expects graceful degradation.
+`get`, `getAll`, `replace`, `containsKey`는 이제 structured concurrency
+cancellation을 보존한다. 기존 계약이 graceful degradation을 기대하는 일반 back cache
+failure에서는 계속 null/false를 반환한다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-cache-core:test --tests 'io.bluetape4k.cache.nearcache.jcache.ResilientSuspendNearJCacheTest'`
 
-## Future Guidance
+## 향후 지침
 
-Do not use `runCatching` around suspend cache calls unless cancellation is
-handled and rethrown before fallback behavior is applied.
+Fallback behavior를 적용하기 전에 cancellation을 처리하고 다시 던질 수 없다면 suspend
+cache call 주변에 `runCatching`을 사용하지 않는다.

--- a/docs/lessons/2026-07-04-retrofit-cancellation-cleanup.md
+++ b/docs/lessons/2026-07-04-retrofit-cancellation-cleanup.md
@@ -1,24 +1,23 @@
-# Retrofit cancellation races must close delivered response bodies
+# Retrofit cancellation race는 전달된 response body를 닫아야 한다
 
-## Context
+## 배경
 
-Issue #948 found a Retrofit coroutine bridge race where a response could arrive
-after coroutine cancellation without explicit response-body cleanup evidence.
+이슈 #948은 coroutine cancellation 이후 response가 도착할 수 있지만 명시적인
+response-body cleanup evidence가 없는 Retrofit coroutine bridge race를 발견했다.
 
-## Decision
+## 결정
 
-When cancellation wins before `onResponse`, close the Retrofit response body
-before cancelling the continuation. Also close the delivered response from the
-`resume` cancellation handler if cancellation wins after resume but before
-dispatch.
+`onResponse` 전에 cancellation이 이기면 continuation을 취소하기 전에 Retrofit
+response body를 닫는다. Resume 이후 dispatch 전에 cancellation이 이기면 `resume`
+cancellation handler에서 전달된 response도 닫는다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-retrofit2:test --tests 'io.bluetape4k.retrofit2.SuspendRetrofitCallSupportTest'`
 - `git diff --check`
 
-## Future guidance
+## 향후 지침
 
-Coroutine HTTP bridges should close response resources on every cancellation
-race path. Prefer `resume(value) { ... }` cleanup handlers plus an explicit
-`!cont.isActive` check before delivery.
+Coroutine HTTP bridge는 모든 cancellation race path에서 response resource를 닫아야
+한다. 전달 전에 명시적인 `!cont.isActive` 확인과 `resume(value) { ... }` cleanup
+handler를 함께 사용하는 방식을 우선한다.

--- a/docs/lessons/2026-07-04-vertx-transaction-cancellation-cleanup.md
+++ b/docs/lessons/2026-07-04-vertx-transaction-cancellation-cleanup.md
@@ -1,30 +1,28 @@
-# Vert.x Transaction Cancellation Cleanup
+# Vert.x transaction cancellation cleanup
 
-## Context
+## 배경
 
-Issue #940 found that Vert.x SQL transaction helpers performed rollback and
-connection close in the caller coroutine context, so caller cancellation could
-abort transaction cleanup.
+이슈 #940은 Vert.x SQL transaction helper가 rollback과 connection close를 caller
+coroutine context에서 수행해서 caller cancellation이 transaction cleanup을 중단시킬
+수 있음을 확인했다.
 
-## Decision
+## 결정
 
-Run rollback and close operations inside `NonCancellable` cleanup boundaries.
-Preserve the primary cancellation or failure and attach rollback or close
-failures as suppressed exceptions.
+Rollback과 close operation은 `NonCancellable` cleanup boundary 안에서 실행한다.
+Primary cancellation 또는 failure를 보존하고 rollback/close failure는 suppressed
+exception으로 붙인다.
 
-## Outcome
+## 결과
 
-`withSuspendTransaction` and `withSuspendRollback` now complete cleanup even
-when the action cancels its coroutine context, while still rethrowing the
-original `CancellationException`.
+`withSuspendTransaction`과 `withSuspendRollback`은 action이 coroutine context를 취소해도
+cleanup을 완료하며, 원래 `CancellationException`은 계속 다시 던진다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-vertx:test --tests 'io.bluetape4k.vertx.sqlclient.PoolSupportTest'`
 
-## Future Guidance
+## 향후 지침
 
-Coroutine-based database lifecycle cleanup should not use `runCatching` around
-suspending rollback or close calls. Use explicit `try/catch` in a
-`NonCancellable` boundary and preserve secondary cleanup failures as suppressed
-evidence.
+Coroutine 기반 database lifecycle cleanup은 suspending rollback/close call 주변에
+`runCatching`을 사용하지 않는다. `NonCancellable` boundary 안에서 명시적인
+`try/catch`를 사용하고 secondary cleanup failure를 suppressed evidence로 보존한다.

--- a/docs/lessons/2026-07-04-virtual-thread-controller-lifecycle.md
+++ b/docs/lessons/2026-07-04-virtual-thread-controller-lifecycle.md
@@ -1,27 +1,27 @@
-# Virtual Thread Controller Lifecycle
+# Virtual thread controller lifecycle
 
-## Context
+## 배경
 
-Issue #952 found that `AbstractVirtualThreadController` exposed a shared
-virtual-thread executor without a Spring bean destruction path.
+이슈 #952는 `AbstractVirtualThreadController`가 Spring bean destruction path 없이
+shared virtual-thread executor를 노출한다는 점을 확인했다.
 
-## Decision
+## 결정
 
-Keep the public `virtualThreadExecutor` accessor for compatibility, but make the
-controller close the current executor through `@PreDestroy`. The accessor
-recreates the executor when a later Spring context accesses it after shutdown.
+호환성을 위해 public `virtualThreadExecutor` accessor는 유지하되 controller가
+`@PreDestroy`로 현재 executor를 닫게 한다. Shutdown 이후 다른 Spring context가
+접근하면 accessor가 executor를 다시 만든다.
 
-## Outcome
+## 결과
 
-Controller bean shutdown now closes the executor while repeated test or
-application context creation does not reuse a closed executor.
+Controller bean shutdown은 이제 executor를 닫고, 반복적인 test/application context
+생성은 닫힌 executor를 재사용하지 않는다.
 
-## Verification
+## 검증
 
 - `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.virtualthread.AbstractVirtualThreadControllerTest'`
 
-## Future Guidance
+## 향후 지침
 
-Public controller base classes that expose executor or coroutine resources must
-own a Spring destruction callback and tests should cover both direct destroy and
-context shutdown paths.
+Executor나 coroutine resource를 노출하는 public controller base class는 Spring
+destruction callback을 소유해야 하며, 테스트는 direct destroy와 context shutdown
+경로를 모두 다뤄야 한다.

--- a/docs/lessons/2026-07-05-issue-807-elasticsearch-pit-cleanup.md
+++ b/docs/lessons/2026-07-05-issue-807-elasticsearch-pit-cleanup.md
@@ -1,17 +1,23 @@
-# Issue 807 - Elasticsearch PIT Cleanup
+# 이슈 807: Elasticsearch PIT cleanup
 
-## Context
+## 배경
 
-`searchAsFlow` opened a Point-in-Time context and closed it from the collector coroutine's `finally` block. During cancellation, a suspend close call can be cancelled before it reaches Elasticsearch.
+`searchAsFlow`는 Point-in-Time context를 열고 collector coroutine의 `finally` block에서
+닫았다. Cancellation 중에는 suspend close call이 Elasticsearch에 도달하기 전에
+취소될 수 있다.
 
-## Decision
+## 결정
 
-Move PIT close into a small `NonCancellable` best-effort cleanup helper. Log cleanup failures without replacing the original collector cancellation or upstream failure.
+PIT close를 작은 `NonCancellable` best-effort cleanup helper로 옮긴다. Cleanup
+failure는 원래 collector cancellation이나 upstream failure를 대체하지 않고 log한다.
 
-## Outcome
+## 결과
 
-A new unit test proves suspend cleanup completes after the parent coroutine is cancelled, and the existing Elasticsearch integration test continues to pass.
+새 unit test는 parent coroutine이 취소된 뒤에도 suspend cleanup이 완료됨을 증명하며,
+기존 Elasticsearch integration test도 계속 통과한다.
 
-## Future Guidance
+## 향후 지침
 
-When a coroutine Flow opens a remote resource and closes it with a suspend call, put the close path behind a `NonCancellable` cleanup boundary and test the helper independently from heavy infrastructure tests.
+Coroutine Flow가 remote resource를 열고 suspend call로 닫는다면 close path를
+`NonCancellable` cleanup boundary 뒤에 두고, heavy infrastructure test와 분리해 helper
+자체를 테스트한다.

--- a/docs/lessons/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering.md
+++ b/docs/lessons/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering.md
@@ -1,17 +1,25 @@
-# Issue 808 - Elasticsearch Bulk Progress Buffering
+# 이슈 808: Elasticsearch bulk progress buffering
 
-## Context
+## 배경
 
-`bulkProgressListener` used `Channel.UNLIMITED`, so slow or absent collectors could retain bulk requests, responses, failures, and caller contexts without a hard bound.
+`bulkProgressListener`는 `Channel.UNLIMITED`를 사용했다. 따라서 느리거나 없는
+collector는 bulk request, response, failure, caller context를 hard bound 없이 보관할
+수 있었다.
 
-## Decision
+## 결정
 
-Use a bounded `Channel` with default capacity 256 and `BufferOverflow.SUSPEND`. Keep listener callbacks non-blocking by using `trySend`, and log failed sends so overflow is visible.
+기본 capacity 256과 `BufferOverflow.SUSPEND`를 가진 bounded `Channel`을 사용한다.
+`trySend`로 listener callback을 non-blocking으로 유지하고, overflow가 보이도록 failed
+send를 log한다.
 
-## Outcome
+## 결과
 
-The progress listener retains a finite number of events by default, exposes capacity and overflow tuning, and has a regression test for overflow behavior without requiring Elasticsearch I/O.
+Progress listener는 기본적으로 유한한 수의 event만 보관하고, capacity와 overflow
+tuning을 노출하며, Elasticsearch I/O 없이 overflow behavior를 검증하는 회귀 테스트를
+가진다.
 
-## Future Guidance
+## 향후 지침
 
-Listener-to-Flow adapters should avoid unbounded channels unless the caller explicitly opts in. Prefer bounded buffers, non-blocking callback paths, and visible drop/overflow behavior.
+Listener-to-Flow adapter는 호출자가 명시적으로 opt-in하지 않는 한 unbounded channel을
+피해야 한다. Bounded buffer, non-blocking callback path, 보이는 drop/overflow behavior를
+우선한다.

--- a/docs/lessons/2026-07-05-issue-810-cassandra-bootstrap-builder.md
+++ b/docs/lessons/2026-07-05-issue-810-cassandra-bootstrap-builder.md
@@ -1,17 +1,26 @@
-# Issue 810 - Cassandra Bootstrap Builder
+# 이슈 810: Cassandra bootstrap builder
 
-## Context
+## 배경
 
-`CqlSessionProvider` created an admin session to bootstrap the keyspace before it applied the caller builder block. Secured clusters could fail even when the final session builder contained valid credentials, TLS, contact point, or driver options.
+`CqlSessionProvider`는 caller builder block을 적용하기 전에 keyspace bootstrap용 admin
+session을 만들었다. 최종 session builder에 올바른 credential, TLS, contact point,
+driver option이 있어도 secured cluster에서 실패할 수 있었다.
 
-## Decision
+## 결정
 
-Apply the shared builder block to both bootstrap and final sessions. Bind the provider-managed keyspace after bootstrap, and expose explicit bootstrap/session builder overloads for callers whose final session needs settings that are invalid before the keyspace exists.
+Shared builder block을 bootstrap session과 final session 양쪽에 적용한다. Bootstrap
+뒤 provider-managed keyspace를 bind하고, keyspace 생성 전에는 invalid이지만 final
+session에는 필요한 setting을 가진 호출자를 위해 명시적인 bootstrap/session builder
+overload를 노출한다.
 
-## Outcome
+## 결과
 
-The regression test uses a bare `CqlSessionBuilder` supplier and relies on the caller builder block for contact point and datacenter. It fails without bootstrap builder application and passes with the new behavior.
+Regression test는 bare `CqlSessionBuilder` supplier를 사용하고 contact point와
+datacenter는 caller builder block에 의존한다. Bootstrap builder application이 없으면
+실패하고 새 동작에서는 통과한다.
 
-## Future Guidance
+## 향후 지침
 
-Do not hide administrative side effects behind a final-session-only builder. When a helper performs DDL before returning a client/session, document which builder settings apply to the admin path and provide separate hooks when some settings are phase-specific.
+Administrative side effect를 final-session-only builder 뒤에 숨기지 않는다. Helper가
+client/session을 반환하기 전에 DDL을 수행한다면 어떤 builder setting이 admin path에
+적용되는지 문서화하고, 일부 setting이 phase-specific이면 별도 hook을 제공한다.

--- a/docs/lessons/2026-07-05-issue-812-jpa-entity-hashcode.md
+++ b/docs/lessons/2026-07-05-issue-812-jpa-entity-hashcode.md
@@ -1,17 +1,23 @@
-# Issue #812 Lesson
+# 이슈 #812 교훈
 
-## Context
+## 배경
 
-`AbstractJpaEntity` compared transient entities through `equalProperties`, but returned `System.identityHashCode(this)` when `id == null`.
+`AbstractJpaEntity`는 transient entity를 `equalProperties`로 비교했지만, `id == null`일
+때 `System.identityHashCode(this)`를 반환했다.
 
-## Decision
+## 결정
 
-Use the Hibernate-resolved entity class hash for transient entities and keep identifier-based hashing for persisted entities.
+Transient entity에는 Hibernate가 resolve한 entity class hash를 사용하고, persisted
+entity에는 identifier 기반 hashing을 유지한다.
 
-## Outcome
+## 결과
 
-Equal transient entities now land in the same hash bucket, so hash-based collections treat them as one logical element before persistence assigns an identifier.
+동등한 transient entity는 이제 같은 hash bucket에 들어가므로, persistence가
+identifier를 부여하기 전에도 hash-based collection이 이를 하나의 logical element로
+다룬다.
 
-## Future Guidance
+## 향후 지침
 
-When entity equality has a transient business-signature path, add a hash-based collection regression test. Do not use identity hash for objects that can compare equal by business fields.
+Entity equality에 transient business-signature path가 있으면 hash-based collection
+regression test를 추가한다. Business field로 equal이 될 수 있는 object에는 identity
+hash를 사용하지 않는다.

--- a/docs/lessons/2026-07-05-issue-813-stateless-session-resource.md
+++ b/docs/lessons/2026-07-05-issue-813-stateless-session-resource.md
@@ -1,32 +1,29 @@
-# Issue #813 Stateless Session Resource Binding
+# 이슈 #813 Stateless session resource binding
 
-## Context
+## 배경
 
-`StatelessSessionFactoryBean` stored provider-created `StatelessSession`
-instances in Spring's transaction resource map using the `SessionFactory` itself
-as the key. Spring JPA transaction infrastructure also uses the factory key for
-its own resource binding, so the stateless proxy path could collide with the
-active `EntityManager` lifecycle.
+`StatelessSessionFactoryBean`은 provider가 만든 `StatelessSession` instance를
+`SessionFactory` 자체를 key로 사용해 Spring transaction resource map에 저장했다.
+Spring JPA transaction infrastructure도 자체 resource binding에 factory key를
+사용하므로 stateless proxy path가 active `EntityManager` lifecycle과 충돌할 수
+있었다.
 
-## Decision
+## 결정
 
-Use a dedicated transaction resource key for stateless sessions. The key is tied
-to the exact `SessionFactory` identity but has a separate key type, so it cannot
-collide with Spring's ordinary `SessionFactory` or `EntityManager` resources.
+Stateless session에는 전용 transaction resource key를 사용한다. 이 key는 정확한
+`SessionFactory` identity에 묶이지만 별도 key type을 가지므로 Spring의 일반
+`SessionFactory` 또는 `EntityManager` resource와 충돌할 수 없다.
 
-## Outcome
+## 결과
 
-- The injected `StatelessSession` proxy reuses the same stateless session inside
-  one transaction.
-- The proxy no longer binds a `StatelessSession` under the raw `SessionFactory`
-  key.
-- The exact resource created by the factory is unbound and closed when the
-  transaction completes.
-- Calls outside an active transaction still fail fast.
+- 주입된 `StatelessSession` proxy는 하나의 transaction 안에서 같은 stateless session을 재사용한다.
+- Proxy는 더 이상 raw `SessionFactory` key 아래에 `StatelessSession`을 bind하지 않는다.
+- Factory가 만든 정확한 resource는 transaction 완료 시 unbind되고 닫힌다.
+- Active transaction 밖의 호출은 계속 fail fast한다.
 
-## Future Rule
+## 향후 규칙
 
-When integrating custom resources with Spring's
-`TransactionSynchronizationManager`, never reuse a framework-owned resource key
-for a different lifecycle participant. Use a dedicated key type and test both
-same-transaction reuse and after-completion cleanup.
+Custom resource를 Spring `TransactionSynchronizationManager`와 통합할 때는
+framework-owned resource key를 다른 lifecycle participant에 재사용하지 않는다.
+전용 key type을 사용하고 same-transaction reuse와 after-completion cleanup을 모두
+테스트한다.

--- a/docs/lessons/2026-07-08-issue-805-rate-limiter-cancellation.md
+++ b/docs/lessons/2026-07-08-issue-805-rate-limiter-cancellation.md
@@ -1,29 +1,26 @@
-# Issue 805 - Distributed Rate Limiter Cancellation
+# 이슈 805: Distributed rate limiter cancellation
 
-## Context
+## 배경
 
-`DistributedSuspendRateLimiter` used `withTimeout` and then caught
-`TimeoutCancellationException` before `CancellationException`. That made the
-limiter-owned timeout path clear, but it also allowed timeout-shaped
-cancellation from an async bucket boundary to be converted into
-`RateLimitResult.ERROR`.
+`DistributedSuspendRateLimiter`는 `withTimeout`을 사용한 뒤
+`CancellationException`보다 먼저 `TimeoutCancellationException`을 잡았다. Limiter가
+소유한 timeout 경로는 명확했지만, async bucket boundary에서 온 timeout-shaped
+cancellation도 `RateLimitResult.ERROR`로 변환될 수 있었다.
 
-## Decision
+## 결정
 
-Model limiter-owned timeout explicitly with `withTimeoutOrNull`, convert only
-that `null` result into `RateLimitResult.ERROR`, and rethrow every
-`CancellationException` before general error handling.
+Limiter-owned timeout은 `withTimeoutOrNull`로 명시적으로 모델링하고, 그 `null` 결과만
+`RateLimitResult.ERROR`로 변환한다. General error handling 전에 모든
+`CancellationException`은 다시 던진다.
 
-## Outcome
+## 결과
 
-The distributed suspend tests now cover three cancellation boundaries: cancelled
-await, async timeout cancellation, and caller `withTimeout` with and without
-`defaultTimeout`. The existing limiter-owned timeout test still returns
-`RateLimitStatus.ERROR`.
+Distributed suspend test는 이제 세 cancellation boundary를 다룬다. Cancelled await,
+async timeout cancellation, `defaultTimeout` 유무에 따른 caller `withTimeout`이다.
+기존 limiter-owned timeout test는 계속 `RateLimitStatus.ERROR`를 반환한다.
 
-## Future Guidance
+## 향후 지침
 
-Do not catch `TimeoutCancellationException` as an ordinary error around suspend
-boundaries. Use an explicit timeout result boundary when a component owns the
-timeout, then let coroutine cancellation propagate through the normal
-`CancellationException` path.
+Suspend boundary 주변에서 `TimeoutCancellationException`을 ordinary error로 잡지
+않는다. Component가 timeout을 소유할 때는 명시적인 timeout result boundary를 사용하고,
+coroutine cancellation은 일반 `CancellationException` 경로로 전파한다.

--- a/docs/lessons/2026-07-09-codeql-java-kotlin-timeout.md
+++ b/docs/lessons/2026-07-09-codeql-java-kotlin-timeout.md
@@ -1,31 +1,30 @@
-# CodeQL Java/Kotlin Timeout
+# CodeQL Java/Kotlin timeout
 
-## Context
+## 배경
 
-After re-enabling the CodeQL `java-kotlin` matrix with a workflow-local Kotlin
-`2.3.21` pin, scheduled CodeQL runs were cancelled after about six hours.
+Workflow-local Kotlin `2.3.21` pin으로 CodeQL `java-kotlin` matrix를 다시 활성화한
+뒤, scheduled CodeQL run이 약 6시간 뒤 취소되었다.
 
-## Decision
+## 결정
 
-Keep the repository catalog on Kotlin `2.4.0` and keep the CodeQL-only
-`2.3.21` rewrite, but narrow the manual Java/Kotlin build from full
-`assemble` to scoped generated library compiler tasks.
+Repository catalog는 Kotlin `2.4.0`으로 유지하고 CodeQL 전용 `2.3.21` rewrite도
+유지하되, manual Java/Kotlin build를 full `assemble`에서 scoped generated library
+compiler task로 좁힌다.
 
-## Outcome
+## 결과
 
-The workflow now asks CodeQL to trace library production source compilation in
-separate Java/Kotlin scopes instead of examples, demos, benchmarks, archive
-tasks, distribution tasks, resource processing, and aggregate assembly. Testing
-helpers are kept in a `testing-core` scope. The `bluetape4k-testcontainers`
-module is temporarily excluded because its single `compileKotlin` task stayed
-in `Build with Gradle` after about 31 minutes under CodeQL tracing; issue #999
-tracks restoring that coverage. The Gradle build step also has an explicit
-120-minute timeout so future regressions do not consume the default 360-minute
-GitHub Actions timeout.
+Workflow는 이제 example, demo, benchmark, archive task, distribution task,
+resource processing, aggregate assembly 대신 별도의 Java/Kotlin scope에서 library
+production source compilation만 CodeQL이 trace하도록 한다. Testing helper는
+`testing-core` scope에 유지한다. `bluetape4k-testcontainers` module은 CodeQL tracing
+아래에서 단일 `compileKotlin` task가 약 31분 뒤에도 `Build with Gradle`에 머물러
+일시적으로 제외했고, issue #999가 해당 coverage 복원을 추적한다. Gradle build step에는
+명시적인 120분 timeout도 두어 향후 regression이 기본 360분 GitHub Actions timeout을
+소모하지 않게 했다.
 
-## Future Guidance
+## 향후 지침
 
-For CodeQL Kotlin analysis, do not assume a successful normal Gradle build means
-the same command is appropriate under CodeQL tracing. Build only the source set
-needed for extraction, keep the workflow-local Kotlin pin isolated, and verify
-with a live CodeQL workflow dispatch.
+CodeQL Kotlin analysis에서는 일반 Gradle build가 성공했다고 같은 command가 CodeQL
+tracing 아래에서도 적합하다고 가정하지 않는다. Extraction에 필요한 source set만
+build하고, workflow-local Kotlin pin은 격리하며, live CodeQL workflow dispatch로
+검증한다.

--- a/docs/lessons/2026-07-09-issue-1000-kafka4-catalog-regression.md
+++ b/docs/lessons/2026-07-09-issue-1000-kafka4-catalog-regression.md
@@ -1,17 +1,21 @@
-# Lessons Learned - Issue 1000 Kafka4 Catalog Regression (2026-07-09)
+# 교훈: 이슈 1000 Kafka4 catalog regression (2026-07-09)
 
-## Context
+## 배경
 
-Nightly(full) run `28964461250` failed in `Test / Infra (kafka-resilience)` after the catalog set `kafka4` back to `4.3.1`.
+Catalog가 `kafka4`를 `4.3.1`로 되돌린 뒤 Nightly(full) run `28964461250`이
+`Test / Infra (kafka-resilience)`에서 실패했다.
 
-## Decision
+## 결정
 
-Materialize the source-of-truth `kafka4 = "4.2.1"` compatibility line in `bluetape4k-projects` until Spring Kafka 4.1 embedded-test support is compatible with Kafka 4.3.x.
+Spring Kafka 4.1 embedded-test support가 Kafka 4.3.x와 호환될 때까지
+`bluetape4k-projects`에 source-of-truth `kafka4 = "4.2.1"` compatibility line을
+구체화한다.
 
-## Outcome
+## 결과
 
-The failing local equivalent passed after aligning Kafka runtime artifacts to `4.2.1`.
+Kafka runtime artifact를 `4.2.1`로 정렬한 뒤 실패하던 local equivalent가 통과했다.
 
-## Future Guard
+## 향후 방지책
 
-When `kafka4` changes, check both dependency insight and `:bluetape4k-kafka4:test`. A green dependency sync alone is not sufficient because the failure is an embedded-test ABI mismatch.
+`kafka4`가 바뀌면 dependency insight와 `:bluetape4k-kafka4:test`를 모두 확인한다.
+이 실패는 embedded-test ABI mismatch이므로 dependency sync green만으로는 충분하지 않다.

--- a/docs/lessons/2026-07-09-issue-789-csv-cold-flow.md
+++ b/docs/lessons/2026-07-09-issue-789-csv-cold-flow.md
@@ -1,25 +1,24 @@
-# Issue 789 - CSV Cold Flow File Readers
+# 이슈 789: CSV cold Flow file reader
 
-## Context
+## 배경
 
-File-based suspending CSV/TSV reader overloads opened `FileInputStream` before
-returning the `Flow`. That violated the documented cold-Flow contract and made
-the returned flow one-shot.
+File 기반 suspending CSV/TSV reader overload는 `Flow`를 반환하기 전에
+`FileInputStream`을 열었다. 이는 문서화된 cold-Flow contract를 위반했고 반환된 flow를
+one-shot으로 만들었다.
 
-## Decision
+## 결정
 
-Move file opening into the flow builder and close the stream with `use` during
-collection. Keep InputStream overloads unchanged because callers own those
-streams.
+File opening을 flow builder 안으로 옮기고 collection 중 `use`로 stream을 닫는다.
+InputStream overload는 caller가 해당 stream을 소유하므로 변경하지 않는다.
 
-## Outcome
+## 결과
 
-Regression tests now prove that file-backed suspending readers defer missing
-file failures until collection, survive recollection after early termination,
-and cover CSV/TSV plus transform overload behavior.
+Regression test는 file-backed suspending reader가 missing file failure를 collection까지
+미루고, early termination 뒤 recollection에도 살아남으며, CSV/TSV와 transform overload
+behavior를 다룬다는 점을 증명한다.
 
-## Future Guidance
+## 향후 지침
 
-File-backed `Flow` APIs must open resources inside collection, not before
-returning the flow. When the flow wraps blocking file I/O, run upstream work on
-`Dispatchers.IO` and test both cold creation and recollection.
+File-backed `Flow` API는 flow를 반환하기 전이 아니라 collection 안에서 resource를
+열어야 한다. Flow가 blocking file I/O를 감싸면 upstream work는 `Dispatchers.IO`에서
+실행하고 cold creation과 recollection을 모두 테스트한다.

--- a/docs/lessons/2026-07-09-issue-796-current-vertx-lifecycle.md
+++ b/docs/lessons/2026-07-09-issue-796-current-vertx-lifecycle.md
@@ -1,22 +1,24 @@
-# Lessons Learned - currentVertx Lifecycle (2026-07-09)
+# 교훈: `currentVertx` lifecycle (2026-07-09)
 
-**Related issue**: #796
-**Affected modules**: `bluetape4k-vertx`, `bluetape4k-http`
+**관련 이슈**: #796
+**대상 모듈**: `bluetape4k-vertx`, `bluetape4k-http`
 
-## L1: Context fallback helpers must define ownership
+## L1: context fallback helper는 ownership을 정의해야 한다
 
-### Problem
+### 문제
 
-`currentVertx()` created a new `Vertx.vertx()` instance whenever no Vert.x context existed. Helpers such as
-`vertxHttpClientOf()` inherited that hidden ownership and could leave event-loop resources unmanaged.
+`currentVertx()`는 Vert.x context가 없을 때마다 새 `Vertx.vertx()` instance를 만들었다.
+`vertxHttpClientOf()` 같은 helper는 이 숨은 ownership을 상속했고 event-loop resource를
+관리되지 않은 채 남길 수 있었다.
 
-### Lesson
+### 교훈
 
-Fallback resource creation must either require an explicit owner or use a managed singleton with a documented close path.
-For Vert.x helpers, prefer explicit `Vertx` parameters in lifecycle-sensitive APIs and keep default fallbacks reusable and
-closable.
+Fallback resource creation은 명시적인 owner를 요구하거나 문서화된 close path가 있는
+managed singleton을 사용해야 한다. Vert.x helper에서는 lifecycle-sensitive API에
+명시적인 `Vertx` parameter를 우선하고, default fallback은 재사용 가능하고 닫을 수
+있게 유지한다.
 
-### Verification
+### 검증
 
 - RED: lifecycle tests failed before `closeDefaultVertx`, explicit `Vertx` overload, and default client close API existed.
 - GREEN: `:bluetape4k-vertx:test`

--- a/docs/lessons/2026-07-09-issue-800-kafka-exporter.md
+++ b/docs/lessons/2026-07-09-issue-800-kafka-exporter.md
@@ -1,20 +1,24 @@
-# Lessons Learned — Issue #800 DefaultKafkaExporter failures (2026-07-09)
+# 교훈: 이슈 #800 `DefaultKafkaExporter` failure (2026-07-09)
 
-## Context
+## 배경
 
-`DefaultKafkaExporter` reports Kafka producer send failures through an `ExportExceptionHandler`. The old synchronous failure path caught `Throwable`, reported only timeout/buffer exceptions, and silently returned `false` for other failures.
+`DefaultKafkaExporter`는 Kafka producer send failure를 `ExportExceptionHandler`로
+보고한다. 기존 synchronous failure path는 `Throwable`을 잡고 timeout/buffer exception만
+보고했으며, 다른 failure에는 조용히 `false`를 반환했다.
 
-## Lesson
+## 교훈
 
-Exporter boundaries should catch non-fatal `Exception`, not `Throwable`. Fatal `Error` values must propagate, while every synchronous non-fatal send failure should use the same handler path as callback failures.
+Exporter boundary는 `Throwable`이 아니라 non-fatal `Exception`을 잡아야 한다. Fatal
+`Error`는 전파되어야 하며, 모든 synchronous non-fatal send failure는 callback failure와
+같은 handler path를 사용해야 한다.
 
-## Outcome
+## 결과
 
 - Added regression coverage for generic synchronous `Exception` handling.
 - Added regression coverage for fatal `Error` propagation.
 - Preserved callback exception handling and timeout handling.
 
-## Verification
+## 검증
 
 - RED targeted test: 5 tests completed, 2 expected failures.
 - GREEN targeted test: 5 passing.

--- a/docs/lessons/2026-07-09-issue-804-cancel-leaf-redis-futures.md
+++ b/docs/lessons/2026-07-09-issue-804-cancel-leaf-redis-futures.md
@@ -1,28 +1,26 @@
-# Issue 804 - Cancel Leaf Redis Futures
+# 이슈 804: leaf Redis future 취소
 
-## Context
+## 배경
 
-Redis bulk await helpers waited on one aggregate `CompletableFuture` created by
-`CompletionStage.sequence`. Cancelling the caller coroutine cancelled that
-aggregate await, but it did not cancel the original Lettuce `RedisFuture` or
-Redisson `RFuture` leaves.
+Redis bulk await helper는 `CompletionStage.sequence`가 만든 하나의 aggregate
+`CompletableFuture`를 기다렸다. Caller coroutine을 취소하면 aggregate await는
+취소되었지만, 원본 Lettuce `RedisFuture` 또는 Redisson `RFuture` leaf는 취소되지
+않았다.
 
-## Decision
+## 결정
 
-Put leaf cancellation in the shared `CompletionStage.sequence` boundary. When
-the returned aggregate future is cancelled, each source future receives
-`cancel(true)`. Redis-specific helpers keep their existing API and inherit the
-shared all-or-nothing cancellation behavior.
+Leaf cancellation을 shared `CompletionStage.sequence` boundary에 둔다. 반환된 aggregate
+future가 취소되면 각 source future가 `cancel(true)`를 받는다. Redis-specific helper는
+기존 API를 유지하고 shared all-or-nothing cancellation behavior를 상속한다.
 
-## Outcome
+## 결과
 
-Core, Lettuce, and Redisson tests now prove that aggregate/coroutine
-cancellation cancels pending source futures while preserving input-order success
-results and existing failure propagation.
+Core, Lettuce, Redisson test는 aggregate/coroutine cancellation이 pending source
+future를 취소하면서 input-order success result와 기존 failure propagation을 보존함을
+증명한다.
 
-## Future Guidance
+## 향후 지침
 
-When wrapping many external futures behind one coroutine await, cancellation
-must be propagated to the source futures, not only to the aggregate future.
-Cover both the shared aggregate helper and one representative adapter boundary
-when the behavior is reused across modules.
+많은 external future를 하나의 coroutine await 뒤에 감쌀 때 cancellation은 aggregate
+future뿐 아니라 source future에도 전파되어야 한다. 이 동작이 여러 module에서
+재사용되면 shared aggregate helper와 대표 adapter boundary를 모두 다룬다.

--- a/docs/lessons/2026-07-10-issue-768-module-generator-parity.md
+++ b/docs/lessons/2026-07-10-issue-768-module-generator-parity.md
@@ -1,27 +1,25 @@
-# Issue #768 Module Diagram Generator Parity
+# 이슈 #768 Module diagram generator parity
 
-## Context
+## 배경
 
-The Redis umbrella diagram had correct visible content but lacked source-backed
-validation metadata. Running its generator exposed a second defect: the
-generator no longer reproduced the approved rounded connectors, direct heads
-for dashed routes, or icon provenance stored in the committed SVG.
+Redis umbrella diagram은 visible content가 올바랐지만 source-backed validation
+metadata가 없었다. Generator를 실행하자 두 번째 결함이 드러났다. Generator가 더 이상
+승인된 rounded connector, dashed route의 direct head, committed SVG에 저장된 icon
+provenance를 재현하지 못했다.
 
-## Decision
+## 결정
 
-- Derive diagram intent from the umbrella Gradle dependency declaration, README,
-  and the separate Spring Redis serializer source.
-- Store the evidence in the generated SVG root.
-- Encode rounded routes and Cairo-safe direct arrowheads in the owning generator
-  before accepting regenerated output.
-- Keep the PNG unchanged when metadata and generator parity do not alter pixels.
+- Umbrella Gradle dependency declaration, README, 별도 Spring Redis serializer source에서 diagram intent를 도출한다.
+- Evidence를 generated SVG root에 저장한다.
+- Regenerated output을 승인하기 전에 owning generator에 rounded route와 Cairo-safe direct arrowhead를 encode한다.
+- Metadata와 generator parity가 pixel을 바꾸지 않으면 PNG는 그대로 둔다.
 
-## Outcome
+## 결과
 
-The module diagram validator failure was removed without changing the rendered
-image. The generator now reproduces the committed SVG and PNG idempotently.
+Rendered image를 바꾸지 않고 module diagram validator failure를 제거했다. Generator는
+이제 committed SVG와 PNG를 idempotent하게 재현한다.
 
-## Verification
+## 검증
 
 - README diagram validator: `total=268 failed=136`
 - Target row: `failures=[]`
@@ -30,8 +28,8 @@ image. The generator now reproduces the committed SVG and PNG idempotently.
 - Geometry and endpoint audits: PASS
 - Mixed-corner audit: `q_bends=12`, `failures=0`
 
-## Future Guidance
+## 향후 지침
 
-When adding validation metadata to a generated asset, regenerate before editing
-the SVG manually. If the output differs beyond metadata, repair generator parity
-first and verify that the PNG remains visually equivalent.
+Generated asset에 validation metadata를 추가할 때는 SVG를 수동 편집하기 전에 먼저
+regenerate한다. Output이 metadata 이상으로 달라지면 generator parity를 먼저 고치고
+PNG가 시각적으로 동등하게 유지되는지 검증한다.

--- a/docs/lessons/2026-07-10-issue-768-sequence-validation.md
+++ b/docs/lessons/2026-07-10-issue-768-sequence-validation.md
@@ -1,26 +1,24 @@
-# Issue #768 Sequence Diagram Validation
+# 이슈 #768 Sequence diagram validation
 
-## Context
+## 배경
 
-Sequence README assets failed validation even when their rendered structure was
-valid. The validator depended on generator-specific marker IDs and one exact
-label class, while several diagrams also contained real text overflow and
-branch-clarity defects.
+Sequence README asset은 rendered structure가 유효해도 validation에 실패했다. Validator가
+generator-specific marker ID와 하나의 exact label class에 의존했고, 몇몇 diagram에는
+실제 text overflow와 branch-clarity defect도 있었다.
 
-## Decision
+## 결정
 
-- Validate fixed-size filled markers and visible numbered pill labels by SVG
-  structure, not by one generator's names.
-- Treat generic message pills as message labels, not footer elements.
-- Repair and render each failing asset individually.
-- Keep branch outcomes visually distinct when they share one sequence frame.
+- Fixed-size filled marker와 visible numbered pill label은 특정 generator 이름이 아니라 SVG structure로 검증한다.
+- Generic message pill은 footer element가 아니라 message label로 다룬다.
+- 실패한 각 asset을 개별적으로 고치고 render한다.
+- Branch outcome이 하나의 sequence frame을 공유하면 시각적으로 구분되게 유지한다.
 
-## Outcome
+## 결과
 
-The sequence family now has zero validator failures. Five SVG/PNG pairs were
-corrected without rewriting already-valid sequence semantics.
+Sequence family는 이제 validator failure가 0개다. 이미 유효한 sequence semantics를
+다시 쓰지 않고 5개 SVG/PNG pair를 수정했다.
 
-## Verification
+## 검증
 
 - README diagram validator: `total=268 failed=137`, sequence failures `0`
 - Sequence style audit: `PASS sequence_files=5`
@@ -30,10 +28,9 @@ corrected without rewriting already-valid sequence semantics.
   `direct_solid_heads=6`, `participants=4`
 - CairoSVG render and PNG visual inspection completed for every changed asset
 
-## Future Guidance
+## 향후 지침
 
-Do not regenerate an entire diagram family to satisfy structural validation.
-First separate validator false positives from visible defects, then edit and
-inspect one asset at a time. A generic audit reporting `connectors=0` requires
-an explicit invariant that proves every visible message has a rendered
-arrowhead.
+Structural validation을 만족시키기 위해 전체 diagram family를 regenerate하지 않는다.
+먼저 validator false positive와 visible defect를 분리한 뒤 asset 하나씩 편집하고
+검사한다. Generic audit가 `connectors=0`을 보고하면 모든 visible message에 rendered
+arrowhead가 있다는 explicit invariant가 필요하다.

--- a/docs/lessons/2026-07-10-issue-785-near-cache-retry-compensation.md
+++ b/docs/lessons/2026-07-10-issue-785-near-cache-retry-compensation.md
@@ -1,40 +1,32 @@
-# Issue #785: Near-cache retry failure compensation
+# 이슈 #785: Near-cache retry failure compensation
 
-## Context
+## 배경
 
-Bounded queue overflow and close draining were already handled, but a backend
-write could still exhaust all retries after the public write-behind operation
-had updated the front cache. This left uncommitted front values, permanent
-tombstones, or a permanently enabled `clearPending` flag.
+Bounded queue overflow와 close draining은 이미 처리되어 있었지만, public write-behind
+operation이 front cache를 갱신한 뒤 backend write가 모든 retry를 소진할 수 있었다.
+그 결과 uncommitted front value, 영구 tombstone, 영구적으로 켜진 `clearPending` flag가
+남았다.
 
-## Decision
+## 결정
 
-- Keep the existing write-behind API and compensate terminal backend failures.
-- Invalidate failed `Put` front entries so later reads repopulate from the back cache.
-- Release failed `Remove` tombstones and failed `ClearBack` read blocking.
-- Serialize queue acceptance with optimistic front-state mutation so the consumer
-  cannot complete a command before its local state is installed.
-- Associate each accepted command with ownership tokens. A stale completion must
-  not compensate state installed by a newer command for the same key or clear.
-- Apply token completion and compensation under the same lock or mutex used by
-  enqueue state installation, and snapshot caller-owned bulk collections.
-- Guard read-through population with a monotonic state version so a backend read
-  started before a newer mutation cannot overwrite the newer front state.
-- Serialize synchronous replace with pending write state and advance the same
-  version so delayed reads cannot restore the replaced value.
-- Preserve the logical value in mutation tokens so `putIfAbsent` can return an
-  in-flight Put value or enqueue after an in-flight remove/clear without reordering.
-- Compare mutation and clear command sequences so a newer clear supersedes an
-  older pending Put when evaluating `putIfAbsent`.
+- 기존 write-behind API를 유지하고 terminal backend failure를 compensation한다.
+- 실패한 `Put` front entry를 invalidate해서 이후 read가 back cache에서 다시 채우게 한다.
+- 실패한 `Remove` tombstone과 실패한 `ClearBack` read blocking을 해제한다.
+- Consumer가 local state 설치 전에 command를 완료할 수 없도록 queue acceptance와 optimistic front-state mutation을 직렬화한다.
+- Accepted command마다 ownership token을 연결한다. Stale completion은 같은 key 또는 clear에 대해 새 command가 설치한 state를 compensate하면 안 된다.
+- Enqueue state installation에 쓰는 같은 lock/mutex 아래에서 token completion과 compensation을 적용하고, caller-owned bulk collection을 snapshot한다.
+- Backend read가 새 mutation보다 먼저 시작되었더라도 더 새 front state를 덮어쓰지 못하도록 monotonic state version으로 read-through population을 guard한다.
+- Synchronous replace를 pending write state와 직렬화하고 같은 version을 전진시켜 delayed read가 replaced value를 복원하지 못하게 한다.
+- `putIfAbsent`가 in-flight Put value를 반환하거나 in-flight remove/clear 뒤 reordering 없이 enqueue할 수 있도록 mutation token에 logical value를 보존한다.
+- `putIfAbsent` 평가 시 더 새 clear가 더 오래된 pending Put을 supersede하도록 mutation sequence와 clear command sequence를 비교한다.
 
-## Outcome
+## 결과
 
-Blocking and suspend implementations now converge to observable backend state
-after retry exhaustion instead of retaining a permanently divergent local view.
-Terminal failures remain logged because an asynchronous write-behind call cannot
-retroactively fail after it has returned.
+Blocking/suspend 구현은 retry exhaustion 뒤 영구적으로 divergent local view를 유지하지
+않고 observable backend state로 수렴한다. Asynchronous write-behind call은 반환된 뒤
+retroactive하게 실패할 수 없으므로 terminal failure는 log로 남긴다.
 
-## Verification
+## 검증
 
 - RED: six retry-exhaustion tests failed with `ConditionTimeoutException` before the fix.
 - GREEN: the same six tests passed after compensation was implemented.
@@ -49,8 +41,8 @@ retroactively fail after it has returned.
 - Both resilient near-cache test classes: 68 tests passed.
 - `:bluetape4k-cache-core:test`: 502 tests passed.
 
-## Future Guard
+## 향후 방지책
 
-When optimistic state is associated with queued asynchronous work, completion
-and compensation must be conditional on command ownership. Do not use an
-unversioned `remove` or boolean reset that can overwrite a newer accepted state.
+Optimistic state가 queued asynchronous work와 연결되어 있다면 completion과
+compensation은 command ownership에 조건부여야 한다. 더 새로 accepted된 state를
+덮어쓸 수 있는 unversioned `remove`나 boolean reset을 사용하지 않는다.

--- a/docs/lessons/2026-07-17-issue-1036-core-serializer-bytebuffer.md
+++ b/docs/lessons/2026-07-17-issue-1036-core-serializer-bytebuffer.md
@@ -1,48 +1,40 @@
-# Issue #1036: Core serializer ByteBuffer paths
+# 이슈 #1036: Core serializer ByteBuffer path
 
-## Context
+## 배경
 
-`BinarySerializer` already exposed compatible ByteBuffer defaults, but those
-defaults staged every operation through a newly allocated ByteArray. JDK, Kryo,
-and Fory have different buffer capabilities and lifecycle constraints, so one
-shared optimization strategy could not preserve every existing contract.
+`BinarySerializer`는 이미 호환 가능한 ByteBuffer default를 노출했지만, 그 default는
+모든 operation을 새로 할당한 ByteArray를 통해 staging했다. JDK, Kryo, Fory는 서로
+다른 buffer capability와 lifecycle constraint를 가지므로 하나의 shared optimization
+strategy로는 기존 계약을 모두 보존할 수 없었다.
 
-## Decision
+## 결정
 
-- Use fixed ByteBuffer-backed streams for JDK input and output and apply the same
-  configured or global `ObjectInputFilter` as the ByteArray path.
-- Bind Kryo `ByteBufferInput` and `ByteBufferOutput` to the caller's bounded slice,
-  but expose them only through scoped provider methods that detach caller storage
-  before returning adapters to the global pool. Apply this path only to the default,
-  secure, and fast pools owned by the serializer.
-- Keep externally supplied Kryo pools on the ByteArray compatibility path because
-  their custom serializers may depend on array-backed `Input` and `Output` access.
-- Use Fory's native ByteBuffer input overload and retain the compatibility
-  ByteArray output path because the backend may grow or detach output storage.
-- Keep new failure and cleanup helpers internal instead of extending the
-  protected surface of the externally extensible `AbstractBinarySerializer`.
-- Preserve raw overflow, fatal errors, configured registration, wire bytes, and
-  caller position/limit/order behavior.
+- JDK input/output에는 fixed ByteBuffer-backed stream을 사용하고, ByteArray path와 같은 configured 또는 global `ObjectInputFilter`를 적용한다.
+- Kryo `ByteBufferInput`과 `ByteBufferOutput`은 caller의 bounded slice에 bind하되, adapter를 global pool에 반환하기 전에 caller storage를 detach하는 scoped provider method를 통해서만 노출한다. 이 path는 serializer가 소유한 default, secure, fast pool에만 적용한다.
+- Externally supplied Kryo pool은 custom serializer가 array-backed `Input`과 `Output` access에 의존할 수 있으므로 ByteArray compatibility path에 남긴다.
+- Fory는 native ByteBuffer input overload를 사용하고, backend가 output storage를 grow하거나 detach할 수 있으므로 compatibility ByteArray output path를 유지한다.
+- 외부에서 확장 가능한 `AbstractBinarySerializer`의 protected surface를 늘리지 않고 새 failure/cleanup helper는 internal로 유지한다.
+- Raw overflow, fatal error, configured registration, wire bytes, caller position/limit/order behavior를 보존한다.
 
-## Surprise / Failure
+## 발견 / 실패
 
-Adding protected convenience methods to an open base class looked source-local
-but could create JVM signature conflicts for external subclasses. Direct pooled
-adapter obtain/release methods also allowed future callers to return adapters
-without detaching caller buffers. Finally, logging a failed graph invoked
-arbitrary `toString()` implementations and could expose payload contents.
-Kryo's ByteBuffer adapters also override `getBuffer()` to throw, so applying them
-to an external pool could break an otherwise valid custom serializer.
+Open base class에 protected convenience method를 추가하는 일은 source-local처럼
+보였지만 외부 subclass와 JVM signature conflict를 만들 수 있었다. Direct pooled
+adapter obtain/release method도 미래 호출자가 caller buffer를 detach하지 않고 adapter를
+반환할 수 있게 했다. 마지막으로 failed graph를 log하면 arbitrary `toString()` 구현을
+호출해 payload content를 노출할 수 있었다. Kryo의 ByteBuffer adapter는 `getBuffer()`를
+throw하도록 override하므로 external pool에 적용하면 그 외에는 유효한 custom serializer가
+깨질 수 있었다.
 
-## Outcome
+## 결과
 
-JDK and Kryo now bypass the compatibility ByteArray staging path where their
-owned configurations safely support fixed caller-owned buffers. External Kryo
-pools retain their prior array-backed behavior. Fory avoids the input copy without
-claiming unsupported output behavior. Existing ByteArray entry points and serializer
-configuration remain unchanged.
+JDK와 Kryo는 owned configuration이 fixed caller-owned buffer를 안전하게 지원하는
+곳에서 compatibility ByteArray staging path를 우회한다. External Kryo pool은 기존
+array-backed behavior를 유지한다. Fory는 지원하지 않는 output behavior를 주장하지 않고
+input copy만 피한다. 기존 ByteArray entry point와 serializer configuration은 변경되지
+않는다.
 
-## Verification
+## 검증
 
 - Core serializer ByteBuffer suite: 18 tests passed.
 - Full `:bluetape4k-io:test` suite: 1055 tests passed.
@@ -51,11 +43,11 @@ configuration remain unchanged.
   concurrency paths are covered.
 - ABI verification is run from the clean committed head before PR publication.
 
-## Future Guard
+## 향후 방지책
 
-Do not add convenience members to a public extensible base class without ABI
-analysis. Treat pooled adapters as scoped resources and detach caller-owned
-storage before reuse. Do not pass a backend-specific adapter to externally supplied
-serializer implementations unless they explicitly declare that capability. Verify
-backend behavior against the resolved dependency version, and defer allocation
-claims until #1039 records repeated measurements.
+ABI analysis 없이 public extensible base class에 convenience member를 추가하지 않는다.
+Pooled adapter는 scoped resource로 다루고 재사용 전에 caller-owned storage를 detach한다.
+Externally supplied serializer implementation이 해당 capability를 명시적으로 선언하지
+않는 한 backend-specific adapter를 넘기지 않는다. Resolved dependency version 기준으로
+backend behavior를 검증하고, allocation claim은 #1039가 반복 측정을 기록할 때까지
+미룬다.

--- a/docs/lessons/2026-07-17-issue-1037-json-serializer-bytebuffer.md
+++ b/docs/lessons/2026-07-17-issue-1037-json-serializer-bytebuffer.md
@@ -1,60 +1,49 @@
-# Issue #1037: JSON serializer ByteBuffer paths
+# 이슈 #1037: JSON serializer ByteBuffer path
 
-## Context
+## 배경
 
-The shared `JsonSerializer` contract already exposed ByteBuffer defaults, but the
-compatibility implementation staged data through a complete ByteArray. Jackson 2,
-Jackson 3, and Fastjson2 expose materially different stream and array-range APIs,
-so the JSON slice needed backend-specific paths without changing wire formats,
-mapper/security configuration, exception policy, or caller-owned buffer state.
+Shared `JsonSerializer` 계약은 이미 ByteBuffer default를 노출했지만, compatibility
+implementation은 complete ByteArray를 통해 data를 staging했다. Jackson 2, Jackson 3,
+Fastjson2는 실질적으로 다른 stream 및 array-range API를 노출하므로 JSON slice에는 wire
+format, mapper/security configuration, exception policy, caller-owned buffer state를
+바꾸지 않는 backend-specific path가 필요했다.
 
-## Decision
+## 결정
 
-- Stream Jackson 2 and Jackson 3 output through a fixed duplicate-backed
-  `ByteBufferOutputStream`, and read input through a duplicate-backed
-  `ByteBufferInputStream`.
-- Create and close the Jackson generator explicitly through the configured
-  `ObjectWriter`; mapper convenience methods catch `Exception`, not every fatal
-  `Error`, so caller-owned stream cleanup cannot rely on them.
-- Keep the generic Jackson ByteBuffer API as a top-level concrete-receiver
-  extension. Adding a final member to the public open serializer classes could
-  conflict with an existing subclass that already owns the same JVM signature.
-- Use Fastjson2's array/offset/length JSONB parser only for writable array-backed
-  input. Copy direct and read-only input, and retain `JSONB.toBytes` as the
-  explicitly allocating output compatibility path.
-- Traverse at most 64 cause links when preserving nested fatal errors or buffer
-  overflow. Suppressed cleanup failures never replace the primary backend failure.
-- Keep all JSONB readers feature-free and do not enable AutoType.
+- Jackson 2와 Jackson 3 output은 fixed duplicate-backed `ByteBufferOutputStream`으로 stream하고, input은 duplicate-backed `ByteBufferInputStream`으로 읽는다.
+- Configured `ObjectWriter`를 통해 Jackson generator를 명시적으로 만들고 닫는다. Mapper convenience method는 모든 fatal `Error`가 아니라 `Exception`을 잡으므로 caller-owned stream cleanup을 그 method에 의존할 수 없다.
+- Generic Jackson ByteBuffer API는 top-level concrete-receiver extension으로 유지한다. Public open serializer class에 final member를 추가하면 같은 JVM signature를 이미 가진 기존 subclass와 충돌할 수 있다.
+- Fastjson2의 array/offset/length JSONB parser는 writable array-backed input에만 사용한다. Direct/read-only input은 copy하고, `JSONB.toBytes`는 명시적으로 할당하는 output compatibility path로 유지한다.
+- Nested fatal error나 buffer overflow를 보존할 때 cause link는 최대 64개까지만 순회한다. Suppressed cleanup failure는 primary backend failure를 대체하지 않는다.
+- 모든 JSONB reader는 feature-free로 유지하고 AutoType을 활성화하지 않는다.
 
-## Surprise / Failure
+## 발견 / 실패
 
-The first Jackson reified API was a member on an open class. It worked in local
-callers but introduced a final JVM method that could break a legacy subclass with
-the same erased signature. Moving it to an extension fixed the class ABI, but the
-README and tests also had to distinguish that extension from the existing
-`JsonSerializer.deserialize` extension through explicit imports and an alias.
+첫 Jackson reified API는 open class의 member였다. Local caller에서는 동작했지만 같은
+erased signature를 가진 legacy subclass를 깨뜨릴 수 있는 final JVM method를 도입했다.
+Extension으로 옮기자 class ABI는 고쳐졌지만, README와 test도 explicit import와 alias를
+통해 그 extension을 기존 `JsonSerializer.deserialize` extension과 구분해야 했다.
 
-Jackson's mapper-owned write path closes its generator for ordinary exceptions,
-but the resolved Jackson 2 and Jackson 3 sources catch `Exception` rather than
-`Error`. An explicit generator scope was required to guarantee cleanup on fatal
-serialization failures.
+Jackson의 mapper-owned write path는 ordinary exception에서 generator를 닫지만, resolved
+Jackson 2/3 source는 `Error`가 아니라 `Exception`을 잡는다. Fatal serialization
+failure에서 cleanup을 보장하려면 명시적인 generator scope가 필요했다.
 
-Fastjson2 may replace a setter-thrown `Error` with a `ClassCastException`, so that
-fixture could not prove adapter behavior. A registered JSONB `ObjectReader` that
-throws an ordinary wrapper with the fatal error as its cause provided the valid
-identity test. The same investigation exposed that scanning suppressed failures
-would incorrectly promote cleanup errors over the primary parse failure.
+Fastjson2는 setter가 던진 `Error`를 `ClassCastException`으로 바꿀 수 있어 해당 fixture로
+adapter behavior를 증명할 수 없었다. Fatal error를 cause로 가진 ordinary wrapper를
+던지는 registered JSONB `ObjectReader`가 유효한 identity test를 제공했다. 같은 조사에서
+suppressed failure를 scan하면 cleanup error가 primary parse failure보다 잘못 승격될 수
+있다는 점도 드러났다.
 
-## Outcome
+## 결과
 
-Jackson 2 and Jackson 3 bypass the ByteArray compatibility path for fixed output
-and bounded input while retaining mapper configuration and inherited data formats.
-Fastjson2 avoids an input copy only where its public API supports an existing
-array range; unsupported input and all output stay on documented compatibility
-paths. Existing ByteArray entry points, JSON/JSONB wire bytes, raw interface
-dispatch, and caller position/limit/mark/order contracts remain intact.
+Jackson 2와 Jackson 3는 mapper configuration과 inherited data format을 유지하면서
+fixed output과 bounded input에서 ByteArray compatibility path를 우회한다. Fastjson2는
+public API가 existing array range를 지원하는 경우에만 input copy를 피한다. 지원되지
+않는 input과 모든 output은 문서화된 compatibility path에 남는다. 기존 ByteArray entry
+point, JSON/JSONB wire bytes, raw interface dispatch, caller position/limit/mark/order
+contract는 그대로 유지된다.
 
-## Verification
+## 검증
 
 - Jackson 2 ByteBuffer suite: 14 tests passed; external consumer import test:
   1 test passed; full module: 455 tests passed.
@@ -69,11 +58,11 @@ dispatch, and caller position/limit/mark/order contracts remain intact.
   README contract checks, unsafe-pattern scanning, and `git diff --check` provide
   the available static fallback.
 
-## Future Guard
+## 향후 방지책
 
-Do not add a convenience member to a public open class without checking erased
-subclass signatures. When a backend owns a stream wrapper, inspect the resolved
-source for fatal-error cleanup rather than assuming `use` at the outer stream is
-sufficient. Preserve only fatal failures reachable through the primary cause
-chain, never through suppressed cleanup failures. Make optimization claims per
-backend cell and defer allocation claims until repeated benchmark evidence exists.
+Erased subclass signature를 확인하지 않고 public open class에 convenience member를
+추가하지 않는다. Backend가 stream wrapper를 소유하면 outer stream의 `use`만으로 충분할
+것이라고 가정하지 말고 resolved source에서 fatal-error cleanup을 확인한다. Fatal
+failure는 primary cause chain에서 reachable한 것만 보존하고, suppressed cleanup
+failure를 통해 보존하지 않는다. Optimization claim은 backend cell별로 제한하고,
+반복 benchmark evidence가 생길 때까지 allocation claim은 미룬다.

--- a/docs/lessons/2026-07-17-issue-1038-avro-serializer-bytebuffer.md
+++ b/docs/lessons/2026-07-17-issue-1038-avro-serializer-bytebuffer.md
@@ -1,54 +1,45 @@
-# Issue #1038: Avro serializer ByteBuffer paths
+# 이슈 #1038: Avro serializer ByteBuffer path
 
-## Context
+## 배경
 
-The Avro interfaces already exposed compatible `ByteBuffer` defaults, but those
-defaults copied through complete ByteArrays before reading or writing OCF data.
-Reflect, generic-record, specific-record, and list implementations needed direct
-stream routing without changing schema, codec, sync-marker, framing, null/empty,
-or caller-state behavior.
+Avro interface는 이미 호환 가능한 `ByteBuffer` default를 노출했지만, 그 default는 OCF
+data를 읽거나 쓰기 전에 complete ByteArray를 통해 copy했다. Reflect, generic-record,
+specific-record, list 구현은 schema, codec, sync-marker, framing, null/empty,
+caller-state behavior를 바꾸지 않는 direct stream routing이 필요했다.
 
-## Decision
+## 결정
 
-- Write OCF data through a non-growing `ByteBufferOutputStream` over a duplicate
-  of the caller target, then commit the caller position only after writer close
-  succeeds.
-- Read OCF data with `DataFileStream` over a duplicate-backed
-  `ByteBufferInputStream`, preserving every caller-visible source property.
-- Tag overflow only when it originates in the fixed target stream. A datum
-  accessor may itself throw `BufferOverflowException`; that remains an ordinary
-  handled backend failure rather than a false target-capacity signal.
-- Preserve fatal errors found on the primary cause chain. Do not promote
-  suppressed cleanup failures over the primary backend failure.
-- Keep new handled-failure logs metadata-only so caller records are never
-  rendered.
+- Caller target의 duplicate 위에 non-growing `ByteBufferOutputStream`을 두고 OCF data를 쓴 뒤, writer close가 성공한 뒤에만 caller position을 commit한다.
+- Duplicate-backed `ByteBufferInputStream` 위의 `DataFileStream`으로 OCF data를 읽고, caller-visible source property를 모두 보존한다.
+- Overflow는 fixed target stream에서 비롯된 경우에만 tag한다. Datum accessor 자체가 `BufferOverflowException`을 던질 수 있으며, 이는 false target-capacity signal이 아니라 일반 handled backend failure로 남는다.
+- Primary cause chain에서 발견된 fatal error를 보존한다. Suppressed cleanup failure를 primary backend failure보다 승격하지 않는다.
+- 새 handled-failure log는 metadata-only로 유지해 caller record가 render되지 않게 한다.
 
-## Surprise / Failure
+## 발견 / 실패
 
-The first overflow classifier searched the full primary cause chain for any
-`BufferOverflowException`. An independent Developer/API review showed that Avro
-wraps datum-writer failures, so a record accessor could be misreported as a full
-target buffer. A stream-bound signal separated target capacity from backend
-behavior and a RED regression test locked the distinction.
+첫 overflow classifier는 전체 primary cause chain에서 모든 `BufferOverflowException`을
+찾았다. 독립 Developer/API review는 Avro가 datum-writer failure를 wrap하므로 record
+accessor가 full target buffer로 잘못 보고될 수 있음을 보여주었다. Stream-bound signal이
+target capacity와 backend behavior를 분리했고 RED regression test가 그 구분을 잠갔다.
 
-The first SpecificRecord log copied the legacy `graph=$graph` diagnostic. That
-could evaluate caller `toString()` and expose record data. The regression test
-had to force both a real codec-close failure and ERROR-level lazy message
-evaluation; a throwing `toString()` alone was insufficient because the logging
-helper safely replaces message-render exceptions.
+첫 SpecificRecord log는 legacy `graph=$graph` diagnostic을 복사했다. 이는 caller
+`toString()`을 평가하고 record data를 노출할 수 있었다. Regression test는 실제
+codec-close failure와 ERROR-level lazy message evaluation을 모두 강제해야 했다.
+Logging helper가 message-render exception을 안전하게 대체하므로, throwing `toString()`
+만으로는 충분하지 않았다.
 
-The ABI script also intentionally refuses dirty serializer paths. The reliable
-sequence is implementation commit, clean-head ABI generation, evidence commit,
-and regeneration after every review-driven source fix.
+ABI script도 dirty serializer path를 의도적으로 거부한다. 신뢰할 수 있는 순서는
+implementation commit, clean-head ABI generation, evidence commit, 그리고 review-driven
+source fix 이후마다 regeneration하는 것이다.
 
-## Outcome
+## 결과
 
-All four Avro families now bypass the allocating ByteArray sibling methods for
-bounded buffer input and fixed output. OCF data cross-reads with legacy methods,
-configured codecs remain authoritative, caller state is preserved, failed calls
-remain reusable, and the compatibility report is bound to the reviewed code.
+네 Avro family는 이제 bounded buffer input과 fixed output에서 allocating ByteArray
+sibling method를 우회한다. OCF data는 legacy method와 cross-read되고, configured codec은
+authoritative하게 남으며, caller state는 보존되고, 실패한 call도 재사용 가능하며,
+compatibility report는 review된 code에 묶인다.
 
-## Verification
+## 검증
 
 - The focused contract suite covers direct/heap/sliced/read-only input,
   exact-capacity output, overflow provenance, rollback, fatal identity, cleanup
@@ -60,9 +51,9 @@ remain reusable, and the compatibility report is bound to the reviewed code.
 - Root detekt is `NO-SOURCE`; Kotlin compilation, full tests, unsafe-pattern
   scanning, and `git diff --check` provide the available static proof.
 
-## Future Guard
+## 향후 방지책
 
-Do not infer target capacity failure from an unqualified nested exception; mark
-the resource boundary that produced it. Do not log a serializer datum to explain
-a handled failure. Keep OCF comparisons semantic, and defer allocation or
-throughput claims until #1039 supplies repeatable benchmark evidence.
+Qualifier 없는 nested exception에서 target capacity failure를 추론하지 말고, 그것을
+만든 resource boundary를 표시한다. Handled failure를 설명하려고 serializer datum을
+log하지 않는다. OCF 비교는 semantic하게 유지하고, allocation/throughput claim은 #1039가
+반복 가능한 benchmark evidence를 제공할 때까지 미룬다.

--- a/docs/lessons/2026-07-17-issue-authority-before-generated-plans.md
+++ b/docs/lessons/2026-07-17-issue-authority-before-generated-plans.md
@@ -1,47 +1,43 @@
-# Issue Authority Before Generated Plans
+# Generated plan보다 issue authority가 먼저다
 
-## Context
+## 배경
 
-Issue #754 requests ByteBuffer-oriented serializer APIs and allocation evidence.
-Its generated design and implementation plan expanded that work into release
-holds, GitHub App credentials, repository rulesets, protected environments, tag
-mutation, and GitHub Release creation. Those additions were implemented even
-though the issue, its milestone, and its parent epic did not require them.
+이슈 #754는 ByteBuffer-oriented serializer API와 allocation evidence를 요구했다. 그런데
+generated design과 implementation plan은 이 작업을 release hold, GitHub App credential,
+repository ruleset, protected environment, tag mutation, GitHub Release creation까지
+확장했다. 이슈, milestone, parent epic이 요구하지 않았는데도 그 추가 항목이 구현되었다.
 
-## Root Cause
+## 근본 원인
 
-The generated plan was treated as a source of product authority instead of a
-derivative execution artifact. Review focused on whether the added release
-mechanism was internally coherent, not whether it was authorized by the live
-issue. That inverted the authority chain and let unrelated operational policy
-enter a serializer feature.
+Generated plan을 derivative execution artifact가 아니라 product authority의 source로
+다뤘다. Review는 추가된 release mechanism이 내부적으로 일관적인지에 집중했고, live
+issue가 그것을 승인했는지는 확인하지 않았다. 그 결과 authority chain이 뒤집혔고,
+serializer feature에 관련 없는 operational policy가 들어왔다.
 
-## Decision
+## 결정
 
-For issue-driven work, the live issue and explicit user direction define scope.
-Specs and plans may clarify implementation details, but they cannot add release,
-credential, repository-setting, publication, or other external side effects
-without separate explicit authority.
+Issue-driven work에서는 live issue와 명시적인 user direction이 scope를 정의한다.
+Spec과 plan은 implementation detail을 명확히 할 수 있지만, 별도 explicit authority 없이
+release, credential, repository-setting, publication 또는 다른 external side effect를
+추가할 수 없다.
 
-When a generated artifact exceeds its authority:
+Generated artifact가 authority를 넘어서면 다음 순서로 처리한다.
 
-1. preserve valid in-scope implementation and compatibility evidence;
-2. remove the unauthorized operational machinery in a focused corrective PR;
-3. rewrite the derivative spec and plan to match the live issue;
-4. add a regression check for any repository policy that was accidentally
-   changed;
-5. keep publish, tag, release, settings, and merge actions behind their own
-   fresh gates.
+1. 유효한 in-scope implementation과 compatibility evidence를 보존한다.
+2. Unauthorized operational machinery를 focused corrective PR에서 제거한다.
+3. Derivative spec과 plan을 live issue에 맞게 다시 쓴다.
+4. 실수로 변경된 repository policy가 있으면 regression check를 추가한다.
+5. Publish, tag, release, setting, merge action은 각각의 fresh gate 뒤에 둔다.
 
-## Verification
+## 검증
 
-The corrective proof checks that release workflows publish Maven artifacts only,
-contain no issue-specific hold/App/ruleset behavior, and do not create GitHub
-Releases. The retained serializer ABI check computes its own serializer/build
-digest and no longer imports release-policy code.
+Corrective proof는 release workflow가 Maven artifact만 publish하고, issue-specific
+hold/App/ruleset behavior를 포함하지 않으며, GitHub Release를 만들지 않음을 확인한다.
+유지된 serializer ABI check는 자체 serializer/build digest를 계산하고 더 이상
+release-policy code를 import하지 않는다.
 
-## Future Guidance
+## 향후 지침
 
-At each stacked PR boundary, compare the proposed files and side effects with
-the live issue before reviewing implementation detail. A technically sound plan
-is still invalid when its scope is unauthorized.
+각 stacked PR boundary에서 implementation detail을 review하기 전에 제안된 file과 side
+effect를 live issue와 비교한다. 기술적으로 타당한 plan도 scope가 승인되지 않았다면
+여전히 invalid다.

--- a/docs/lessons/2026-07-17-snapshot-publication-pom-model-validation.md
+++ b/docs/lessons/2026-07-17-snapshot-publication-pom-model-validation.md
@@ -1,31 +1,30 @@
-# Snapshot Publication POM Model Validation
+# Snapshot publication POM model validation
 
-## Context
+## 배경
 
-Generated publication POMs contained versionless Spring Boot and Jackson BOM
-imports. Maven therefore rejected 25 module POMs, including regular Spring
-dependencies whose versions could not be resolved without those imports.
+Generated publication POM에는 version 없는 Spring Boot와 Jackson BOM import가 있었다.
+그래서 Maven은 해당 import 없이는 version을 resolve할 수 없는 일반 Spring dependency를
+포함해 25개 module POM을 거부했다.
 
-## Decision
+## 결정
 
-Use the central `bt4k` catalog as the version source for every published BOM
-import. Validate all generated POMs structurally and then build their effective
-Maven models before CI, snapshot publishing, and release publishing.
+Published BOM import의 version source로 중앙 `bt4k` catalog를 사용한다. CI, snapshot
+publishing, release publishing 전에 모든 generated POM을 구조적으로 검증한 뒤 effective
+Maven model을 build한다.
 
-## Outcome
+## 결과
 
-The 77 generated publication POMs have versioned dependency-management imports,
-while regular versionless dependencies remain valid when a versioned BOM or the
-same POM manages them.
+77개 generated publication POM은 versioned dependency-management import를 가지며,
+versionless regular dependency는 versioned BOM이나 같은 POM이 관리할 때 계속 유효하다.
 
-## Verification
+## 검증
 
 - `ruby scripts/publication/publication_pom_audit_test.rb`
 - `./gradlew generatePomFileForBluetape4kPublication -PsnapshotVersion=-SNAPSHOT --no-daemon --no-configuration-cache --no-build-cache`
 - `ruby scripts/publication/validate_poms.rb`
 
-## Future Guidance
+## 향후 지침
 
-Do not require a direct version on every regular dependency. Require versions
-on BOM imports, then let Maven effective-model validation prove that each
-versionless regular dependency is actually managed.
+모든 regular dependency에 direct version을 요구하지 않는다. BOM import에는 version을
+요구하고, 각 versionless regular dependency가 실제로 관리되는지는 Maven
+effective-model validation으로 증명한다.

--- a/docs/lessons/2026-07-18-issue-1039-serializer-allocation-proof.md
+++ b/docs/lessons/2026-07-18-issue-1039-serializer-allocation-proof.md
@@ -1,26 +1,46 @@
-# Issue #1039 Serializer Allocation Proof
+# 이슈 #1039 Serializer allocation proof
 
-## Context
+## 배경
 
-The serializer ByteBuffer work needed reproducible allocation evidence without changing production dispatch, wire formats, ownership, or security defaults. A single benchmark score was insufficient because compatibility defaults and backend-specific paths have different capabilities.
+Serializer ByteBuffer 작업은 production dispatch, wire format, ownership, security
+default를 바꾸지 않으면서 재현 가능한 allocation evidence가 필요했다. Compatibility
+default와 backend-specific path는 capability가 서로 다르므로 단일 benchmark score만으로는
+충분하지 않았다.
 
-## Decision
+## 결정
 
-Use a standalone, non-published `kotlinx-benchmark` module with 40 separately named JMH cells. Treat `gc.alloc.rate.norm` as the primary metric, throughput as diagnostic, and accept a lower-allocation claim only when two fresh runs both improve by at least 5% against the matching ByteArray baseline. Compatibility and fallback cells are always ineligible.
+40개의 별도 이름을 가진 JMH cell로 standalone non-published `kotlinx-benchmark` module을
+사용한다. `gc.alloc.rate.norm`을 primary metric으로, throughput을 diagnostic으로
+다루며, 두 번의 fresh run이 matching ByteArray baseline 대비 모두 최소 5% 개선될 때만
+lower-allocation claim을 인정한다. Compatibility/fallback cell은 항상 ineligible이다.
 
-## What The Measurements Proved
+## 측정이 증명한 것
 
-Runs `run-20260718T030512Z` and `run-20260718T031704Z` each produced 40 allocation-bearing results. Five optimized comparisons were accepted: JDK serialization, Kryo serialization/deserialization, and Jackson 2/3 serialization. The comparator produced `accepted=5`, `inconclusive=7`, and `ineligible=14` across 26 candidate comparisons.
+Run `run-20260718T030512Z`와 `run-20260718T031704Z`는 각각 40개의 allocation-bearing
+result를 만들었다. JDK serialization, Kryo serialization/deserialization, Jackson 2/3
+serialization의 다섯 optimized comparison이 accepted되었다. Comparator는 26개 candidate
+comparison에서 `accepted=5`, `inconclusive=7`, `ineligible=14`를 산출했다.
 
-## What They Did Not Prove
+## 측정이 증명하지 않은 것
 
-The results do not prove lower allocation for JDK, Fory, Jackson 2/3, Fastjson2, or Avro input paths that were inconclusive. They do not prove anything for compatibility/fallback controls, generic/specific/list Avro APIs, unmeasured configurations, other payloads, or other JVMs. They do not turn ergonomic ByteBuffer overloads into zero-allocation APIs.
+이 결과는 inconclusive였던 JDK, Fory, Jackson 2/3, Fastjson2, Avro input path의 lower
+allocation을 증명하지 않는다. Compatibility/fallback control, generic/specific/list
+Avro API, 측정하지 않은 configuration, 다른 payload, 다른 JVM에 대해서도 아무것도
+증명하지 않는다. Ergonomic ByteBuffer overload를 zero-allocation API로 바꾸지도 않는다.
 
-## Failure Or Surprise
+## 실패 또는 발견
 
-The first executable JMH smoke failed because dependency signature files were copied into the fat JAR. The repository-standard `META-INF/*.RSA`, `*.DSA`, and `*.SF` exclusion restored an executable artifact, after which all 40 cells ran. The first evidence-launch command was also intercepted by the repository output-protection hook because environment capture invoked `./gradlew --version`; invoking the same Gradle WrapperMain directly avoided the false build redirect without starting or overwriting a run. The planned per-module Detekt tasks do not exist in this repository; the available root `detekt` task is `NO-SOURCE`, so compilation, tests, ABI proof, and the full non-test build provide the effective static/build evidence while the Detekt gap remains explicit.
+첫 executable JMH smoke는 dependency signature file이 fat JAR에 복사되어 실패했다.
+Repository 표준 `META-INF/*.RSA`, `*.DSA`, `*.SF` exclusion을 적용하자 executable
+artifact가 복구되었고 이후 40개 cell이 모두 실행되었다. 첫 evidence-launch command도
+environment capture가 `./gradlew --version`을 호출하면서 repository output-protection
+hook에 가로막혔다. 같은 Gradle WrapperMain을 직접 호출하자 run을 시작하거나 덮어쓰지
+않고 false build redirect를 피할 수 있었다. 계획했던 per-module Detekt task는 이
+repository에 존재하지 않는다. 사용 가능한 root `detekt` task는 `NO-SOURCE`이므로,
+Detekt gap은 명시적으로 남기고 compilation, test, ABI proof, full non-test build가
+실질적인 static/build evidence를 제공한다.
 
-## Verification Evidence
+## 검증 증거
 
 - Two sequential JMH runs: 40 JSON entries, 40 normalized-allocation metrics, and 40 summary rows per run.
 - Seven comparator unit tests and byte-identical comparison regeneration.
@@ -30,10 +50,17 @@ The first executable JMH smoke failed because dependency signature files were co
 - Module auto-registration and non-published/Kover-excluded benchmark classification.
 - Full `build -x test`, locale/claim parity, raw artifact size, and `git diff --check` gates.
 
-## Review Misses
+## 검토에서 놓친 점
 
-The initial plan assumed module-local Detekt tasks and did not anticipate signed dependency metadata in the generated JMH fat JAR. Both assumptions were discovered by executing the real repository surfaces before completion. Six-lens review converged at P0=0 and P1=0; the Detekt configuration gap is an existing P2 repository concern rather than an issue #1039 code regression.
+초기 plan은 module-local Detekt task를 가정했고 generated JMH fat JAR의 signed dependency
+metadata를 예상하지 못했다. 두 가정 모두 완료 전 실제 repository surface를 실행하면서
+발견했다. Six-lens review는 P0=0, P1=0으로 수렴했다. Detekt configuration gap은 이슈
+#1039 code regression이 아니라 기존 P2 repository concern이다.
 
-## Future Guard
+## 향후 방지책
 
-Whenever serializer dispatch, the benchmark payload, or benchmark configuration changes, produce two new unique run IDs and regenerate `comparison.csv`. Never reuse positive allocation wording unless both fresh B/op deltas meet the 5% same-direction rule. Keep compatibility/fallback controls ineligible, preserve invalid runs for diagnosis, and verify the executable JMH JAR before collecting evidence.
+Serializer dispatch, benchmark payload, benchmark configuration이 바뀔 때마다 새 unique
+run ID 두 개를 만들고 `comparison.csv`를 regenerate한다. Fresh B/op delta 두 개가 모두
+5% same-direction rule을 만족하지 않으면 positive allocation wording을 재사용하지 않는다.
+Compatibility/fallback control은 ineligible로 유지하고, invalid run은 진단용으로 보존하며,
+evidence 수집 전에 executable JMH JAR를 검증한다.

--- a/docs/lessons/2026-07-19-evidence-bound-pr-merge-strategy.md
+++ b/docs/lessons/2026-07-19-evidence-bound-pr-merge-strategy.md
@@ -1,14 +1,14 @@
-# Evidence-bound PR의 merge 전략
+# 증거에 묶인 PR의 merge 전략
 
-## Context
+## 배경
 
 Issue #757 allocation evidence는 measurement commit, rollback identity, delivery commit을 immutable Git SHA와 hash chain으로 기록한다. 기능 branch를 최신 `develop` 위로 rebase하면서 소스 tree는 같았지만 delivery commit SHA가 바뀌었고, committed manifest의 delivery provenance가 현재 branch ancestry와 어긋났다.
 
-## Root Cause
+## 근본 원인
 
 일반 PR에서는 rebase나 squash가 변경 내용을 유지하면서 history를 정리하는 방법일 수 있다. 그러나 evidence-bound PR에서는 commit identity 자체가 검증 입력이다. rebase, amend, squash는 동일한 tree라도 authenticated commit SHA를 새로 만들기 때문에 기존 Git ancestry를 끊는다. Strict `validate-committed`는 committed manifest/evidence semantics와 `delivery.git_commit`의 `HEAD` ancestry만 검증하며, measurement/rollback SHA의 Git-object reachability나 ancestry까지 증명하지 않는다.
 
-## Decision
+## 결정
 
 Evidence가 commit SHA에 bind된 뒤 branch base를 갱신할 때는 `origin/develop`을 merge commit으로 병합한다. 이 정책은 이미 branch ancestor인 authenticated commits의 graph를 보존한다. 이전 history rewrite에서 사라진 measurement/rollback ancestry를 merge commit이 복구한다고 주장해서는 안 된다. GitHub에서 최종 PR을 병합할 때도 merge-commit 방식만 사용한다. rebase-merge와 squash-merge는 남아 있는 authenticated delivery ancestry를 다시 쓰므로 금지한다.
 
@@ -23,7 +23,7 @@ python3 benchmark/protobuf-codec-benchmark/scripts/run-evidence.py \
 
 이 복구는 working manifest가 committed `HEAD`와 동일하고, 이전 delivery commit과 rebased candidate의 전체 tree가 같으며, candidate가 현재 `HEAD`의 ancestor일 때만 허용한다. 이 historical rebase 복구가 다시 세우는 ancestry는 delivery commit뿐이다. Measurement/rollback SHA는 immutable manifest/hash-chain identity로 남지만 Git-object reachability는 검증하지 않는다. 조건이 하나라도 실패하거나 measurement/rollback의 executable full ancestry가 필요한데 명시적인 retained anchor가 없으면 provenance 보존을 주장하지 않고 fresh evidence lifecycle을 수행한다.
 
-## Verification
+## 검증
 
 - `rebind-rebased-delivery` 전후 JSON 구조 diff는 `delivery.git_commit`과 `report_input_sha256` 두 필드로 제한한다.
 - Raw measurement, verdict/reason, rollback, file path/hash는 변경하지 않는다.
@@ -31,6 +31,6 @@ python3 benchmark/protobuf-codec-benchmark/scripts/run-evidence.py \
 - Commit 전 `validate-report`, `git diff --check`, 전체 Python evidence test를 실행한다.
 - Commit 후 strict `validate-committed`와 `validate-report`를 다시 실행해 committed bytes, evidence semantics, delivery ancestry를 검증한다. 이 결과를 measurement/rollback ancestry 증명으로 확대 해석하지 않는다.
 
-## Future Agent Guidance
+## 향후 agent 지침
 
 Evidence-bound branch를 동기화할 때 history 정리를 기본값으로 가정하지 않는다. 먼저 manifest와 rollback artifact가 어떤 commit SHA를 identity로 기록하고, 그 SHA 중 무엇이 실제 branch ancestor인지 구분한다. Merge commit은 이미 존재하는 ancestry만 보존한다. force-push, rebase, amend, squash를 사용하지 않는다. 불가피하게 이미 rebase된 상태를 인수했다면 tree equivalence와 delivery ancestry를 CLI로 증명할 수 있을 때만 재바인딩하고, measurement/rollback ancestry까지 복구됐다고 보고하지 않는다. 그 full ancestry가 필요하고 retained anchor가 없다면 fresh evidence를 수집하며, 수동 hash 계산이나 raw artifact 수정으로 검증을 우회하지 않는다.

--- a/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
+++ b/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
@@ -1,4 +1,4 @@
-# Issue #755: 호출자 소유 ByteBuffer 압축 경계
+# 이슈 #755: 호출자 소유 ByteBuffer 압축 경계
 
 ## 배경
 

--- a/docs/lessons/2026-07-21-multi-key-ownership-lease.md
+++ b/docs/lessons/2026-07-21-multi-key-ownership-lease.md
@@ -1,13 +1,13 @@
 # 다중 키 소유권 Lease의 복구 경계
 
-## Context
+## 배경
 
 Issue #1065는 여러 Redis key를 한 owner가 동시에 점유하도록 만들되 standalone/cluster, sync/future/suspend
 API가 같은 결과 계약을 가져야 했다. Redis Lua의 원자성만으로는 durable business invariant, client-side
 cancellation, 응답 유실 뒤의 ambiguous completion까지 해결할 수 없으므로 caller와 운영자의 복구 경계를
 함께 고정해야 했다.
 
-## Decision
+## 결정
 
 - 모든 key는 connection `RedisCodec.encodeKey`가 만든 실제 wire bytes 기준으로 같은 Redis Cluster slot에
   있어야 한다. shared hash tag가 이 계약의 공개 사용법이다.
@@ -21,7 +21,7 @@ cancellation, 응답 유실 뒤의 ambiguous completion까지 해결할 수 없�
 - metric dimension은 bounded `operation`, `result`, `exception`만 허용한다. owner token은 credential이 아니며
   JWT/session token/PII를 재사용하지 않는다. Redis plaintext 저장을 전제로 ACL/TLS를 실제 보안 경계로 둔다.
 
-## Unexpected Failure / Review Miss
+## 예상 밖 실패 / review에서 놓친 점
 
 처음 성능 gate는 raw p95를 비교하면서 normalized라고 이름 붙였다. 이를 key당 p95로 고친 뒤에도 `* 4`만
 유지하면 raw 기준으로 16배 회귀를 허용한다는 review가 나왔다. 최종적으로 승인된 key당 gate와 더 엄격한
@@ -50,13 +50,13 @@ Colima 환경의 Testcontainers는 context process에 socket 환경이 상속되
 공유 `lockf`와 함께 `DOCKER_HOST`, `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`,
 `TESTCONTAINERS_RYUK_DISABLED`를 명시해야 재현 가능한 Redis 검증이 됐다.
 
-## Outcome
+## 결과
 
 한 Lua script가 acquire/inspect/renew/release별 pre-mutation ownership을 분류하고, 모든 adapter가 같은 sealed
 result와 integrity exception을 사용한다. Redis Cluster/NOSCRIPT/경쟁/hostile mutation/cancellation/resilience
 경로가 executable test로 고정됐고, bilingual README와 architecture diagram에 caller·운영 복구 절차가 남았다.
 
-## Verification
+## 검증
 
 - Targeted lease + `RedisScriptTest`: 115 tests, failure/error 0.
 - Full `bluetape4k-lettuce` test: 455 tests, failure/error 0.
@@ -67,7 +67,7 @@ result와 integrity exception을 사용한다. Redis Cluster/NOSCRIPT/경쟁/hos
 - `detekt`와 `detektTest`는 repository root에서 `NO-SOURCE`; `bluetape4k-lettuce` 전용 detekt task는 등록되어
   있지 않아 적용 불가로 기록했다.
 
-## Future Guard
+## 향후 방지책
 
 Lua script, default `maxKeys`, result decoder, or retry predicate를 바꾸면 targeted contract suite와 여섯 조합
 performance task를 다시 실행한다. Performance report는 cache하지 말고 실행 전에 stale file을 fail-closed로

--- a/docs/localization/korean-docs-kdoc-inventory.md
+++ b/docs/localization/korean-docs-kdoc-inventory.md
@@ -1,8 +1,8 @@
-# Korean Docs And KDoc Localization Inventory
+# Korean Docs And KDoc Localization inventory
 
 Issue: #1093
 
-## Scope Rules
+## 범위 Rules
 
 - In scope: Git-tracked non-README, single-language documentation and Kotlin/KTS KDoc surfaces.
 - Korean rewrite target: prose in in-scope docs, public/internal KDoc, and meaningful internal/data-class property contracts.
@@ -10,7 +10,7 @@ Issue: #1093
 - Excluded from rewrite: README files, LLM-facing operating guidance, generated workflow state, CHANGELOG, SECURITY, GitHub metadata, release notes, and pushed commit text.
 - Parity-only: `docs/manual/en` and `docs/manual/ko` bilingual manual pairs.
 
-## Current Inventory
+## Current inventory
 
 - Git-tracked files scanned: 7425
 - In-scope single-language docs: 728
@@ -313,7 +313,7 @@ No missing Korean manual pairs were found.
 
 No missing English manual pairs were found.
 
-### English-KDoc Policy Drift
+### English-KDoc 정책 Drift
 
 No English-KDoc policy drift was found in the tracked documentation scope.
 

--- a/docs/localization/korean-docs-kdoc-pr-stack-audit.md
+++ b/docs/localization/korean-docs-kdoc-pr-stack-audit.md
@@ -31,6 +31,25 @@ GitHub issue/PR 제목과 본문은 repository 정책에 따라 영어로 유지
 | #1106 | #1126 | `kdoc/issue-1106-testing-kdoc-batch` | `kdoc/issue-1105-frameworks-kdoc-batch` | Open |
 | #1107 | #1127 | `kdoc/issue-1107-utils-virtualthread-kdoc-batch` | `kdoc/issue-1106-testing-kdoc-batch` | Open |
 | #1108 | #1128 | `kdoc/issue-1108-examples-kdoc-batch` | `kdoc/issue-1107-utils-virtualthread-kdoc-batch` | Open |
+| #1109 | #1129 | `docs/issue-1109-localization-pr-stack-audit` | `kdoc/issue-1108-examples-kdoc-batch` | Open |
+
+## 세부 실행 이슈 분해
+
+큰 umbrella issue는 다음의 review 가능한 batch issue로 다시 분해했다. 각 issue는 GitHub 정책에 따라 title/body를 영어로 유지한다.
+
+| Parent | Batch issues |
+|---|---|
+| #1096 | #1130, #1131, #1132, #1133, #1134, #1135, #1136, #1137, #1138 |
+| #1097 | #1139, #1140, #1141, #1142, #1143, #1144, #1145, #1146, #1147, #1148, #1149, #1150 |
+| #1098 | #1151, #1152, #1153, #1154, #1155, #1156 |
+| #1101 | #1157, #1158, #1159 |
+| #1102 | #1160, #1161, #1162 |
+| #1103 | #1163, #1164, #1165 |
+| #1104 | #1166, #1167, #1168 |
+| #1105 | #1169, #1170, #1171 |
+| #1106 | #1172, #1173, #1174 |
+| #1107 | #1175, #1176, #1177 |
+| #1108 | #1178, #1179, #1180 |
 
 ## Guardrail evidence
 

--- a/docs/localization/korean-docs-kdoc-pr-stack-audit.md
+++ b/docs/localization/korean-docs-kdoc-pr-stack-audit.md
@@ -1,0 +1,62 @@
+# Korean docs and KDoc PR stack audit
+
+Issue: #1109
+Date: 2026-07-28
+
+## 범위
+
+이 문서는 milestone `1.12.0`의 한국어 문서/KDoc localization Epic에 대해 현재 생성된 PR stack과 guardrail 상태를 기록한다.
+GitHub issue/PR 제목과 본문은 repository 정책에 따라 영어로 유지했고, README와 LLM-facing operating 문서는 rewrite scope에서 제외했다.
+`docs/manual/en` 및 `docs/manual/ko` bilingual manual pair는 rewrite primary scope가 아니라 parity 검증 대상으로만 유지했다.
+
+## PR stack
+
+| Issue | PR | Branch | Base | Status |
+|---|---:|---|---|---|
+| #1093 | #1110 | `docs/issue-1093-localization-inventory` | `develop` | Open |
+| #1094 | #1111 | `docs/issue-1094-localization-guardrails` | `docs/issue-1093-localization-inventory` | Open |
+| #1095 | #1112 | `docs/issue-1095-top-level-korean-docs` | `docs/issue-1094-localization-guardrails` | Open |
+| #1096 | #1113 | `docs/issue-1096-lessons-batch-1` | `docs/issue-1095-top-level-korean-docs` | Open |
+| #1096 | #1115 | `docs/issue-1096-lessons-batch-2` | `docs/issue-1096-lessons-batch-1` | Open |
+| #1096 | #1116 | `docs/issue-1096-lessons-batch-3` | `docs/issue-1096-lessons-batch-2` | Open |
+| #1100 | #1117 | `docs/issue-1100-manual-parity-audit` | `docs/issue-1096-lessons-batch-3` | Open |
+| #1099 | #1118 | `docs/issue-1099-benchmark-notes` | `docs/issue-1100-manual-parity-audit` | Open |
+| #1098 | #1119 | `docs/issue-1098-process-security-notes` | `docs/issue-1099-benchmark-notes` | Open |
+| #1097 | #1120 | `docs/issue-1097-superpowers-checklists-batch` | `docs/issue-1098-process-security-notes` | Open |
+| #1101 | #1121 | `kdoc/issue-1101-core-coroutines-logging-batch` | `docs/issue-1097-superpowers-checklists-batch` | Open |
+| #1102 | #1122 | `kdoc/issue-1102-io-http-kdoc-batch` | `kdoc/issue-1101-core-coroutines-logging-batch` | Open |
+| #1103 | #1123 | `kdoc/issue-1103-data-kdoc-batch` | `kdoc/issue-1102-io-http-kdoc-batch` | Open |
+| #1104 | #1124 | `kdoc/issue-1104-infra-cache-kdoc-batch` | `kdoc/issue-1103-data-kdoc-batch` | Open |
+| #1105 | #1125 | `kdoc/issue-1105-frameworks-kdoc-batch` | `kdoc/issue-1104-infra-cache-kdoc-batch` | Open |
+| #1106 | #1126 | `kdoc/issue-1106-testing-kdoc-batch` | `kdoc/issue-1105-frameworks-kdoc-batch` | Open |
+| #1107 | #1127 | `kdoc/issue-1107-utils-virtualthread-kdoc-batch` | `kdoc/issue-1106-testing-kdoc-batch` | Open |
+| #1108 | #1128 | `kdoc/issue-1108-examples-kdoc-batch` | `kdoc/issue-1107-utils-virtualthread-kdoc-batch` | Open |
+
+## Guardrail evidence
+
+`python3 scripts/docs-localization-inventory.py --check`:
+
+```text
+Korean localization guardrail
+- manual EN missing KO: 0
+- manual KO missing EN: 0
+- English-KDoc policy drift: 0
+```
+
+`python3 scripts/docs-localization-inventory.py` at this stack head:
+
+```text
+Git-tracked files scanned: 7426
+In-scope single-language docs: 729
+Bilingual manual parity-only docs: 508
+Excluded docs: 208
+Kotlin/KTS files for KDoc follow-up: 4492
+KDoc blocks found in Kotlin/KTS files: 34356
+Manual EN files missing KO pair: 0
+Manual KO files missing EN pair: 0
+English-KDoc policy drift findings: 0
+```
+
+## 남은 위험
+
+이 stack은 모든 subissue에 대해 PR을 열고 검증 가능한 review lane을 만든 상태다. 다만 #1096, #1097, #1098, #1101-#1108은 scope가 매우 커서 첫 batch 또는 여러 batch로 열려 있으며, 각 issue의 전체 rewrite 완료는 후속 batch와 merge 후 최종 재감사가 필요하다.

--- a/docs/process/module-documentation-checklist.md
+++ b/docs/process/module-documentation-checklist.md
@@ -1,4 +1,4 @@
-# Module Documentation Drift Checklist
+# Module Documentation Drift 체크리스트
 
 Module이 추가, rename, move, remove, split되거나 다른 repository로 승격될 때 이 checklist를
 사용한다. 목표는 Gradle registration, README catalog, CI coverage, example, release

--- a/docs/review/2026-06-06-issue-691-ktor-opentelemetry-tracing-review.md
+++ b/docs/review/2026-06-06-issue-691-ktor-opentelemetry-tracing-review.md
@@ -1,4 +1,4 @@
-# Issue #691 Ktor OpenTelemetry Tracing Review
+# Issue #691 Ktor OpenTelemetry Tracing 검토
 
 Date: 2026-06-06
 Repo: `bluetape4k-projects`

--- a/docs/review/2026-06-06-issue-694-spring-observability-helpers-review.md
+++ b/docs/review/2026-06-06-issue-694-spring-observability-helpers-review.md
@@ -1,4 +1,4 @@
-# Issue #694 Spring Observability Helpers Review
+# Issue #694 Spring Observability Helpers 검토
 
 Date: 2026-06-06
 Scope: `spring-boot/core`
@@ -10,11 +10,11 @@ PASS
 - P0: 0
 - P1: 0
 
-## Findings
+## 발견 사항
 
 No blocking findings.
 
-## Evidence
+## 증거
 
 - Added `ObservationRegistry.observeSpring` and
   `ObservationRegistry.observeSpringSuspending` helpers that use the
@@ -29,7 +29,7 @@ No blocking findings.
 - The stale Spring Boot 4 / Jackson 2 README statements were corrected to
   Jackson 3 by default.
 
-## Validation
+## 검증
 
 - `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.observability.SpringObservationSupportTest'`
 - `./gradlew :bluetape4k-spring-boot-core:test`

--- a/docs/review/2026-06-06-issue-696-observability-contract-review.md
+++ b/docs/review/2026-06-06-issue-696-observability-contract-review.md
@@ -1,4 +1,4 @@
-# Issue #696 Observability Contract Review
+# Issue #696 Observability Contract 검토
 
 Date: 2026-06-06
 Scope: `docs/superpowers/specs/2026-06-06-issue-696-observability-telemetry-contract-design.md`
@@ -8,7 +8,7 @@ Scope: `docs/superpowers/specs/2026-06-06-issue-696-observability-telemetry-cont
 Local Step 2-R review using the `bluetape4k-full-feature` spec review frame:
 developer, security, Ops/SRE, user/caller, and 7-tier risk perspectives.
 
-## Evidence
+## 증거
 
 - Issue body: GitHub issue #696.
 - Repo evidence:
@@ -23,7 +23,7 @@ developer, security, Ops/SRE, user/caller, and 7-tier risk perspectives.
   - OpenTelemetry HTTP and messaging semantic conventions.
   - Ktor CallId, CallLogging, Micrometer metrics, and OpenTelemetry server docs.
 
-## Findings
+## 발견 사항
 
 | Perspective | P0 | P1 | P2 | P3 | Notes |
 |---|---:|---:|---:|---:|---|

--- a/docs/review/2026-06-06-issue-698-hc5-interceptor-ordering-review.md
+++ b/docs/review/2026-06-06-issue-698-hc5-interceptor-ordering-review.md
@@ -5,7 +5,7 @@
 - `io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientInterceptors.kt`
 - `io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt`
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0

--- a/docs/review/2026-06-06-issue-699-copilot-instructions-review.md
+++ b/docs/review/2026-06-06-issue-699-copilot-instructions-review.md
@@ -5,13 +5,13 @@
 - Updated `.github/copilot-instructions.md` to match current bluetape4k-projects policy.
 - Kept the change to agent-facing guidance only; no production code or workflow behavior changed.
 
-## Findings
+## 발견 사항
 
 - P0=0
 - P1=0
 - P2=0
 
-## Evidence
+## 증거
 
 - `gno query "Copilot instructions current bluetape4k project policy" -c bluetape4k-github --fast --no-rerank`: issue #699 evidence found.
 - `gno query "Copilot instructions current bluetape4k project policy" -c bluetape4k-docs --fast --no-rerank`: weak docs match; repo-local `AGENTS.md` and workspace `AGENTS.md` used as current policy sources.

--- a/docs/review/2026-06-06-issue-701-future-utils-vt-boundary-review.md
+++ b/docs/review/2026-06-06-issue-701-future-utils-vt-boundary-review.md
@@ -6,13 +6,13 @@
 - `virtualFutureOf` / `virtualFutureOfNullable` KDoc을 English public API documentation으로 정리했다.
 - virtual-thread `CompletableFuture` factory가 실제 virtual thread에서 block을 실행하는 테스트를 추가했다.
 
-## Findings
+## 발견 사항
 
 - P0=0
 - P1=0
 - P2=0
 
-## Evidence
+## 증거
 
 - `./gradlew :bluetape4k-core:test --tests "io.bluetape4k.concurrent.FutureUtilsTest" --tests "io.bluetape4k.concurrent.virtualthread.CompletableFutureSupportTest"`: PASS, 24 passing.
 - `./gradlew :bluetape4k-core:test`: first run failed once in existing `FutureSupportTest.cancel propagates to wrapped Future and cancels wrapper`; isolated rerun passed.

--- a/docs/review/2026-06-06-issue-702-near-jcache-remove-review.md
+++ b/docs/review/2026-06-06-issue-702-near-jcache-remove-review.md
@@ -1,4 +1,4 @@
-# Issue #702 NearJCache remove(key, oldValue) Review
+# Issue #702 NearJCache remove(key, oldValue) 검토
 
 ## Scope
 
@@ -22,7 +22,7 @@
 - Provider coverage: PASS. The shared conformance fixture runs through `Cache2KNearJJCacheTest` and `EhcacheNearJJCacheTest`.
 - Blast radius: PASS. CodeGraph reported risk score `0.00`, no impacted files, and no test gaps for the two changed files.
 
-## Validation Evidence
+## 검증 Evidence
 
 - `./gradlew :bluetape4k-cache-core:test --tests "*NearJJCacheTest"`: PASS, 140 passing.
 - `./gradlew :bluetape4k-cache-core:test`: PASS, 470 passing.

--- a/docs/review/2026-06-06-issue-718-git-commit-instructions-review.md
+++ b/docs/review/2026-06-06-issue-718-git-commit-instructions-review.md
@@ -5,13 +5,13 @@
 - Updated `.github/git-commit-instructions.md` to match the current English contributor-facing artifact policy.
 - Kept the change to commit guidance only; no production code, workflow, or Copilot instruction behavior changed.
 
-## Findings
+## 발견 사항
 
 - P0=0
 - P1=0
 - P2=0
 
-## Evidence
+## 증거
 
 - `gh issue view 718 --json body`: issue scope requires English pushed commit messages and conventional prefixes.
 - `gno query "git commit instructions English contributor policy" -c bluetape4k-github --fast --no-rerank`: #699/#718 context found.

--- a/docs/review/2026-06-06-issue-724-examples-workflow-trigger-review.md
+++ b/docs/review/2026-06-06-issue-724-examples-workflow-trigger-review.md
@@ -1,4 +1,4 @@
-# Issue #724 Examples Workflow Trigger Review
+# Issue #724 Examples Workflow Trigger 검토
 
 Date: 2026-06-06
 Scope: `.github/workflows/examples.yml`
@@ -10,11 +10,11 @@ PASS
 - P0: 0
 - P1: 0
 
-## Findings
+## 발견 사항
 
 No blocking findings.
 
-## Evidence
+## 증거
 
 - The previous `Examples` workflow path filters included broad library paths such
   as `bluetape4k/**`, `io/**`, `ktor/**`, `infra/**`, `cache/**`, and
@@ -25,7 +25,7 @@ No blocking findings.
   `.github/workflows/examples.yml`.
 - `workflow_dispatch` remains available for explicit full example validation.
 
-## Validation
+## 검증
 
 - `actionlint .github/workflows/examples.yml`
 - `git diff --check`

--- a/docs/review/2026-06-07-issue-695-event-telemetry-helpers-review.md
+++ b/docs/review/2026-06-07-issue-695-event-telemetry-helpers-review.md
@@ -1,4 +1,4 @@
-# Issue 695 Event Telemetry Helpers Review
+# Issue 695 Event Telemetry Helpers 검토
 
 ## Scope
 
@@ -7,13 +7,13 @@
 - Change type: Fast Track feature
 - Review target: reusable Observation helpers for event publish and consume paths
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2: 0
 
-## Evidence
+## 증거
 
 - Added `event.publish` and `event.consume` Observation wrappers under `io.bluetape4k.micrometer.observation.events`.
 - Low-cardinality tags follow the #696 contract: operation, messaging system, destination, event type, correlation presence, bounded batch count, and outcome.

--- a/docs/review/2026-06-07-issue-700-central-snapshot-task-naming-review.md
+++ b/docs/review/2026-06-07-issue-700-central-snapshot-task-naming-review.md
@@ -1,4 +1,4 @@
-# Issue #700 Review: Central snapshot task naming audit
+# Issue #700 검토: Central snapshot task naming audit
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - `.github/workflows/release.yml`
 - `build.gradle.kts` contributor publishing comment
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0

--- a/docs/review/2026-06-11-issue-741-codeql-kotlin24-review.md
+++ b/docs/review/2026-06-11-issue-741-codeql-kotlin24-review.md
@@ -1,4 +1,4 @@
-# Issue #741 CodeQL Kotlin 2.4 Review
+# Issue #741 CodeQL Kotlin 2.4 검토
 
 Date: 2026-06-11
 Scope: `.github/workflows/codeql.yml`
@@ -10,7 +10,7 @@ Issue: #741
 - P1: 0
 - P2/P3: none
 
-## Evidence
+## 증거
 
 - The failing CodeQL run `27250113912` failed only on
   `Analyze (java-kotlin)`; `Analyze (actions)` and `Analyze (python)` passed.
@@ -23,7 +23,7 @@ Issue: #741
   future re-enable remains compile-only and does not schedule custom `Test`
   tasks such as `k8sTest`.
 
-## Validation
+## 검증
 
 - `actionlint .github/workflows/codeql.yml`: PASS
 - `rg -n --fixed-strings "\\'" .github/workflows`: PASS, no escaped single

--- a/docs/review/2026-06-11-issue-742-hc5-interceptor-flake-review.md
+++ b/docs/review/2026-06-11-issue-742-hc5-interceptor-flake-review.md
@@ -4,7 +4,7 @@
 
 - `io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/AsyncClientInterceptors.kt`
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0

--- a/docs/review/2026-06-11-issue-744-observation-stop-review.md
+++ b/docs/review/2026-06-11-issue-744-observation-stop-review.md
@@ -6,7 +6,7 @@
 - `infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/coroutines/ObservationCoroutinesSupportTest.kt`
 - `infra/micrometer/src/test/kotlin/io/bluetape4k/micrometer/observation/events/EventTelemetryObservationSupportTest.kt`
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0

--- a/docs/review/2026-06-11-issue-746-same-condition-compressor-review.md
+++ b/docs/review/2026-06-11-issue-746-same-condition-compressor-review.md
@@ -1,4 +1,4 @@
-# Issue #746 Same-Condition Compressor Review
+# Issue #746 Same-Condition Compressor 검토
 
 ## Scope
 
@@ -6,7 +6,7 @@
 - Module: `:bluetape4k-io`
 - Files: benchmark harness, benchmark report, raw benchmark artifacts, module benchmark notes.
 
-## Findings
+## 발견 사항
 
 | Severity | Count | Notes |
 |---|---:|---|
@@ -14,7 +14,7 @@
 | P1 | 0 | Benchmark execution and roundtrip coverage are present. |
 | P2 | 0 | No blocking non-critical findings. |
 
-## Evidence
+## 증거
 
 | Check | Result | Evidence |
 |---|---|---|

--- a/docs/review/2026-06-23-issue-833-spring-webclient-readme-examples-review.md
+++ b/docs/review/2026-06-23-issue-833-spring-webclient-readme-examples-review.md
@@ -1,4 +1,4 @@
-# Issue 833 Review - Spring WebClient README examples
+# Issue 833 검토 - Spring WebClient README examples
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-834-redis-runtime-dependencies-review.md
+++ b/docs/review/2026-06-23-issue-834-redis-runtime-dependencies-review.md
@@ -1,4 +1,4 @@
-# Issue #834 Redis Runtime Dependencies Review
+# Issue #834 Redis Runtime Dependencies 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-835-redis-jdk-serializer-deprecation-review.md
+++ b/docs/review/2026-06-23-issue-835-redis-jdk-serializer-deprecation-review.md
@@ -1,17 +1,17 @@
-# Code Review - Issue #835 Redis JDK serializer deprecation
+# Code 검토 - Issue #835 Redis JDK serializer deprecation
 
 Date: 2026-06-23
 Issue: #835
 Module: `:bluetape4k-spring-boot-redis`
 
-## Summary
+## 요약
 
 Redis-facing JDK serializer constants now preserve the lower-level JDK
 deserialization deprecation warning and guide callers toward Kryo or Fory.
 The README serializer matrices now mark JDK variants as deprecated,
 trusted-data-only choices.
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0

--- a/docs/review/2026-06-23-issue-836-cassandra-queryformap-varargs-review.md
+++ b/docs/review/2026-06-23-issue-836-cassandra-queryformap-varargs-review.md
@@ -5,7 +5,7 @@ Scope:
 - `spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportUnitTest.kt`
 - `spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/cql/ReactiveCqlOperationsSupportTest.kt`
 
-## Findings
+## 발견 사항
 
 P0: 0
 P1: 0
@@ -23,7 +23,7 @@ P3: 0 after follow-up
   the suspected runtime failure was not reproduced locally. The change is still useful because it
   makes the public vararg contract explicit and removes the misleading test/KDoc shape.
 
-## Validation
+## 검증
 
 - `./gradlew :bluetape4k-spring-boot-cassandra:cleanTest :bluetape4k-spring-boot-cassandra:compileKotlin :bluetape4k-spring-boot-cassandra:compileTestKotlin :bluetape4k-spring-boot-cassandra:test --no-build-cache`
   - `GRADLE_STATUS=0`

--- a/docs/review/2026-06-23-issue-837-hibernate-lettuce-readme-deps-review.md
+++ b/docs/review/2026-06-23-issue-837-hibernate-lettuce-readme-deps-review.md
@@ -1,4 +1,4 @@
-# Issue 837 Review - hibernate-lettuce README dependencies
+# Issue 837 검토 - hibernate-lettuce README dependencies
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-838-cassandra-demo-coroutine-readme-review.md
+++ b/docs/review/2026-06-23-issue-838-cassandra-demo-coroutine-readme-review.md
@@ -1,4 +1,4 @@
-# Issue 838 Review - Cassandra demo coroutine README example
+# Issue 838 검토 - Cassandra demo coroutine README example
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-839-hibernate-lettuce-demo-readme-deps-review.md
+++ b/docs/review/2026-06-23-issue-839-hibernate-lettuce-demo-readme-deps-review.md
@@ -1,4 +1,4 @@
-# Issue 839 Review - hibernate-lettuce demo README dependencies
+# Issue 839 검토 - hibernate-lettuce demo README dependencies
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-840-mock-web-server-https-port-review.md
+++ b/docs/review/2026-06-23-issue-840-mock-web-server-https-port-review.md
@@ -1,4 +1,4 @@
-# Issue 840 Review - mock-web-server HTTPS port
+# Issue 840 검토 - mock-web-server HTTPS port
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-841-mock-webflux-readme-routes-review.md
+++ b/docs/review/2026-06-23-issue-841-mock-webflux-readme-routes-review.md
@@ -1,4 +1,4 @@
-# Issue 841 Review - mock-webflux README routes
+# Issue 841 검토 - mock-webflux README routes
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-843-http-server-property-keys-review.md
+++ b/docs/review/2026-06-23-issue-843-http-server-property-keys-review.md
@@ -1,4 +1,4 @@
-# Issue 843 Review - BluetapeHttpServer property keys
+# Issue 843 검토 - BluetapeHttpServer property keys
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-844-geo-readme-examples-review.md
+++ b/docs/review/2026-06-23-issue-844-geo-readme-examples-review.md
@@ -1,4 +1,4 @@
-# Issue 844 Review - geo README examples
+# Issue 844 검토 - geo README examples
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-845-flake-component-layout-review.md
+++ b/docs/review/2026-06-23-issue-845-flake-component-layout-review.md
@@ -1,4 +1,4 @@
-# Issue #845 Flake Component Layout Review
+# Issue #845 Flake Component Layout 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-846-dateadd-backward-split-review.md
+++ b/docs/review/2026-06-23-issue-846-dateadd-backward-split-review.md
@@ -1,4 +1,4 @@
-# Issue #846 DateAdd Backward Split Period Review
+# Issue #846 DateAdd Backward Split Period 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-847-jwt-reader-ttl-review.md
+++ b/docs/review/2026-06-23-issue-847-jwt-reader-ttl-review.md
@@ -1,4 +1,4 @@
-# Issue #847 JwtReader TTL Review
+# Issue #847 JwtReader TTL 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-848-redis-keychain-single-winner-review.md
+++ b/docs/review/2026-06-23-issue-848-redis-keychain-single-winner-review.md
@@ -1,4 +1,4 @@
-# Issue #848 Redis Key-Chain Single-Winner Review
+# Issue #848 Redis Key-Chain Single-Winner 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-849-histogram-bin-progress-review.md
+++ b/docs/review/2026-06-23-issue-849-histogram-bin-progress-review.md
@@ -1,4 +1,4 @@
-# Issue #849 Histogram Bin Progress Review
+# Issue #849 Histogram Bin Progress 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-850-measured-composite-reductions-review.md
+++ b/docs/review/2026-06-23-issue-850-measured-composite-reductions-review.md
@@ -1,4 +1,4 @@
-# Issue #850 Measured Composite Reductions Review
+# Issue #850 Measured Composite Reductions 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-851-mutiny-asuni-cold-review.md
+++ b/docs/review/2026-06-23-issue-851-mutiny-asuni-cold-review.md
@@ -1,4 +1,4 @@
-# Issue #851 Mutiny Coroutine `asUni` Cold Review
+# Issue #851 Mutiny Coroutine `asUni` Cold 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-852-rule-engine-condition-failure-review.md
+++ b/docs/review/2026-06-23-issue-852-rule-engine-condition-failure-review.md
@@ -1,4 +1,4 @@
-# Issue #852 Rule Engine Condition Failure Review
+# Issue #852 Rule Engine Condition Failure 검토
 
 ## Scope
 
@@ -37,7 +37,7 @@ During review, the interim broad-catch implementation also failed the sync cance
 
 Result: FAILED, 0 passing and 3 failing. The broad `Exception` catches swallowed `CancellationException` as ordinary rule failure.
 
-## Findings
+## 발견 사항
 
 | Severity | Count | Notes |
 |---|---:|---|
@@ -45,7 +45,7 @@ Result: FAILED, 0 passing and 3 failing. The broad `Exception` catches swallowed
 | P1 | 0 | Sync evaluation failures now follow the rule failure policy while `CancellationException` still propagates. |
 | P2 | 0 | Review evidence and coverage gaps were corrected before PR. |
 
-## Evidence
+## 증거
 
 | Check | Result | Evidence |
 |---|---|---|

--- a/docs/review/2026-06-23-issue-853-netcdf-progress-lease-owner-review.md
+++ b/docs/review/2026-06-23-issue-853-netcdf-progress-lease-owner-review.md
@@ -1,4 +1,4 @@
-# Issue #853 NetCDF Progress Lease Owner Review
+# Issue #853 NetCDF Progress Lease Owner 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-854-shapefile-crs-review.md
+++ b/docs/review/2026-06-23-issue-854-shapefile-crs-review.md
@@ -1,4 +1,4 @@
-# Issue #854 Shapefile CRS Import Review
+# Issue #854 Shapefile CRS Import 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-856-workflow-all-fail-fast-review.md
+++ b/docs/review/2026-06-23-issue-856-workflow-all-fail-fast-review.md
@@ -1,4 +1,4 @@
-# Issue #856 Workflow ALL Fail-Fast Review
+# Issue #856 Workflow ALL Fail-Fast 검토
 
 ## Scope
 
@@ -37,7 +37,7 @@ Result: FAILED, 0 passing and 8 failing.
 | Suspend tests needed cancellation semantics proof. | Tests now assert sibling cancellation and add explicit child `CancellationException` propagation coverage. |
 | Concurrency helper choice needed rationale. | Test comments explain why `StructuredTaskScopeTester` and `SuspendedJobTester` do not fit this exact sibling-signal assertion. |
 
-## Findings
+## 발견 사항
 
 | Severity | Count | Notes |
 |---|---:|---|
@@ -45,7 +45,7 @@ Result: FAILED, 0 passing and 8 failing.
 | P1 | 0 | Returned non-success reports and thrown exceptions both trigger ALL fail-fast behavior. |
 | P2 | 0 | No remaining non-blocking review finding after the targeted fixes. |
 
-## Evidence
+## 증거
 
 | Check | Result | Evidence |
 |---|---|---|

--- a/docs/review/2026-06-23-issue-860-gitleaks-install-review.md
+++ b/docs/review/2026-06-23-issue-860-gitleaks-install-review.md
@@ -1,4 +1,4 @@
-# Issue 860 Review - gitleaks installer
+# Issue 860 검토 - gitleaks installer
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-879-coroutines-test-bridges-review.md
+++ b/docs/review/2026-06-23-issue-879-coroutines-test-bridges-review.md
@@ -1,4 +1,4 @@
-# Issue #879 Coroutines Test Bridge Removal Review
+# Issue #879 Coroutines Test Bridge Removal 검토
 
 ## Scope
 

--- a/docs/review/2026-06-23-issue-880-testcontainers-floci-minio-review.md
+++ b/docs/review/2026-06-23-issue-880-testcontainers-floci-minio-review.md
@@ -1,24 +1,24 @@
-# Code Review - Issue #880 Testcontainers Floci and MinIO policy
+# Code 검토 - Issue #880 Testcontainers Floci and MinIO policy
 
 Date: 2026-06-23
 Issue: #880
 Module: `:bluetape4k-testcontainers`
 
-## Summary
+## 요약
 
 `MinIOServer` remains available for explicit MinIO compatibility tests without
 class-level deprecation noise. `FlociServer.TAG` is pinned to the verified
 `1.5.27` release tag, and README/KDoc guidance keeps new AWS/S3 emulator tests
 on `FlociServer` or `MiniStackServer`.
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2: 0
 - P3: 0
 
-## Independent Review Notes
+## Independent 검토 Notes
 
 - Code reviewer: PASS, no findings.
 - Verifier: pre-commit readiness FAIL because the worktree was intentionally

--- a/docs/review/2026-06-23-issue-881-science-netcdf-api-review.md
+++ b/docs/review/2026-06-23-issue-881-science-netcdf-api-review.md
@@ -1,4 +1,4 @@
-# Issue #881 Science NetCDF API Migration Review
+# Issue #881 Science NetCDF API Migration 검토
 
 ## Scope
 

--- a/docs/review/2026-06-24-issue-829-ktor-openapi-metadata-source-review.md
+++ b/docs/review/2026-06-24-issue-829-ktor-openapi-metadata-source-review.md
@@ -1,4 +1,4 @@
-# Issue 829 Ktor OpenAPI Metadata Source Review
+# Issue 829 Ktor OpenAPI Metadata Source 검토
 
 ## Scope
 
@@ -39,7 +39,7 @@ caller-owned `OpenApiDocSource.Routing` or other explicit sources to survive.
 If Ktor changes its default `OpenApiDocSource` shape in a future upgrade, this
 helper should be revisited with that Ktor source change in hand.
 
-## Validation
+## 검증
 
 - RED: old implementation failed the two new source-preservation tests.
 - GREEN: `./gradlew :bluetape4k-ktor-openapi:test --tests 'io.bluetape4k.ktor.openapi.KtorOpenApiRoutesTest' --no-build-cache`

--- a/docs/review/2026-06-24-issue-830-ktor-openapi-coordinate-review.md
+++ b/docs/review/2026-06-24-issue-830-ktor-openapi-coordinate-review.md
@@ -9,7 +9,7 @@ Module: `:bluetape4k-ktor-openapi`
 - `ktor/openapi/README.md`
 - `ktor/openapi/README.ko.md`
 
-## Local Review
+## Local 검토
 
 - P0/P1 findings: 0
 - The dependency snippets now match `gradle.properties`:
@@ -19,7 +19,7 @@ Module: `:bluetape4k-ktor-openapi`
 - No concurrency test helper was needed because this is a deterministic
   documentation coordinate correction.
 
-## Validation Evidence
+## 검증 Evidence
 
 - `rg "io\\.github\\.bluetape4k:bluetape4k-ktor-openapi" ktor/openapi/README.md ktor/openapi/README.ko.md`
   found the corrected coordinate in both README files.

--- a/docs/review/2026-06-24-issue-831-ktor-timelimiter-failures-review.md
+++ b/docs/review/2026-06-24-issue-831-ktor-timelimiter-failures-review.md
@@ -9,7 +9,7 @@ Module: `:bluetape4k-ktor-resilience4j`
 - `ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupport.kt`
 - `ktor/resilience4j/src/test/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupportTest.kt`
 
-## Local Review
+## Local 검토
 
 - P0/P1 findings: 0
 - Catch ordering preserves timeout mapping:
@@ -22,16 +22,16 @@ Module: `:bluetape4k-ktor-resilience4j`
 - No ad hoc concurrency stress helper was needed because this bug is a
   deterministic exception-boundary regression, not a race or contention issue.
 
-## Native Reviewer
+## Native 검토er
 
 - Reviewer: `code-reviewer`
 - Verdict: APPROVE
 - P0/P1 findings: 0
-- Evidence: reviewer confirmed the catch order preserves timeout mapping,
+- 증거: reviewer confirmed the catch order preserves timeout mapping,
   rethrows `CancellationException` before broad `Throwable`, and records
   ordinary failures with `timeLimiter.onError(e)`.
 
-## Validation Evidence
+## 검증 Evidence
 
 - RED:
   `./gradlew :bluetape4k-ktor-resilience4j:test --tests 'io.bluetape4k.ktor.resilience4j.KtorResilienceSupportTest.time limiter records ordinary handler failures' --no-build-cache`

--- a/docs/review/2026-06-24-issue-832-findbean-failures-review.md
+++ b/docs/review/2026-06-24-issue-832-findbean-failures-review.md
@@ -1,4 +1,4 @@
-# Issue 832 Review - findBean failure boundaries
+# Issue 832 검토 - findBean failure boundaries
 
 ## Scope
 

--- a/docs/review/2026-06-26-hibernate-encryption-keysets-review.md
+++ b/docs/review/2026-06-26-hibernate-encryption-keysets-review.md
@@ -13,7 +13,7 @@ Module: `:bluetape4k-hibernate`
 - README files document the external key material requirement.
 - Converter tests cover unconfigured fail-fast, same-key cross-instance success, and different-key failure.
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---:|---|
@@ -25,14 +25,14 @@ Module: `:bluetape4k-hibernate`
 | Documentation | PASS | `README.md` and `README.ko.md` describe key material storage and bootstrap requirements. |
 | Regression risk | PASS | Targeted module tests pass; full module test has an unrelated pre-existing `org.hibernate.KeyType` blocker on `develop`. |
 
-## Findings
+## 발견 사항
 
 P0: 0
 P1: 0
 
 P2/P3: none requiring code changes before PR.
 
-## Validation Evidence
+## 검증 Evidence
 
 - `./gradlew :bluetape4k-hibernate:compileKotlin :bluetape4k-hibernate:compileTestKotlin --no-build-cache`
   - Result: PASS.

--- a/docs/review/2026-06-26-hibernate-natural-id-keytype-review.md
+++ b/docs/review/2026-06-26-hibernate-natural-id-keytype-review.md
@@ -9,7 +9,7 @@ Module: `:bluetape4k-hibernate`
 - Removed the runtime dependency on `org.hibernate.KeyType` from natural-id helper methods.
 - Updated simple and composite natural-id lookup helpers to use Hibernate 7 natural-id loader APIs.
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---:|---|
@@ -21,14 +21,14 @@ Module: `:bluetape4k-hibernate`
 | Documentation | PASS | KDoc notes the Hibernate 7 `KeyType.NATURAL` removal path. |
 | Regression risk | PASS | Single production file touched, no unrelated behavior changes. |
 
-## Findings
+## 발견 사항
 
 P0: 0
 P1: 0
 
 P2/P3: none requiring code changes before PR.
 
-## Validation Evidence
+## 검증 Evidence
 
 - Reproduced before fix:
   - `./gradlew :bluetape4k-hibernate:test --tests 'io.bluetape4k.hibernate.EntityManagerSupportTest.entity manager natural id helpers 는 simple natural id 조회를 지원한다' --tests 'io.bluetape4k.hibernate.SessionSupportTest.session natural id helpers 는 simple natural id 조회를 지원한다' --no-build-cache`

--- a/docs/review/2026-06-26-issue-786-lettuce-clear-failure-review.md
+++ b/docs/review/2026-06-26-issue-786-lettuce-clear-failure-review.md
@@ -17,7 +17,7 @@ P1: 0
 
 P2/P3: none requiring code changes before PR.
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---:|---|
@@ -29,7 +29,7 @@ P2/P3: none requiring code changes before PR.
 | Concurrency | PASS | No concurrent behavior changed; existing `MultithreadingTester` and `StructuredTaskScopeTester` tests remain untouched. |
 | Evidence | PASS | Full affected module test passed locally. CodeGraph impact analysis reported low risk / no additional impacted files. |
 
-## Validation Evidence
+## 검증 Evidence
 
 - `./gradlew :bluetape4k-cache-lettuce:test --tests 'io.bluetape4k.cache.nearcache.LettuceNearCacheTest.clearAll - Redis clear 실패를 호출자에게 전파한다' --no-configuration-cache --rerun-tasks`
   - Result: PASS, 1 passing, `BUILD SUCCESSFUL in 27s`.

--- a/docs/review/2026-06-26-issue-787-lettuce-cache-typed-getcache-review.md
+++ b/docs/review/2026-06-26-issue-787-lettuce-cache-typed-getcache-review.md
@@ -11,7 +11,7 @@ Module: `:bluetape4k-cache-lettuce`
 - Added regression coverage for exact typed lookup, key mismatch, value mismatch, null type arguments, and closed-manager
   behavior.
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---:|---|
@@ -23,14 +23,14 @@ Module: `:bluetape4k-cache-lettuce`
 | Documentation | PASS | Lesson artifact records the JCache typed lookup boundary rule. |
 | Regression risk | PASS | Cache Lettuce module tests pass; CodeGraph reported low impact for the changed files. |
 
-## Findings
+## 발견 사항
 
 P0: 0
 P1: 0
 
 P2/P3: none requiring code changes before PR.
 
-## Validation Evidence
+## 검증 Evidence
 
 - Reproduced before fix:
   - `./gradlew :bluetape4k-cache-lettuce:test --tests 'io.bluetape4k.cache.jcache.LettuceJCacheManagerTest.typed getCache returns cache when key and value types match' --tests 'io.bluetape4k.cache.jcache.LettuceJCacheManagerTest.typed getCache throws when key type does not match' --tests 'io.bluetape4k.cache.jcache.LettuceJCacheManagerTest.typed getCache throws when value type does not match' --no-build-cache`

--- a/docs/review/2026-06-26-issue-788-hibernate-cache-key-encoding-review.md
+++ b/docs/review/2026-06-26-issue-788-hibernate-cache-key-encoding-review.md
@@ -10,7 +10,7 @@ Module: `:bluetape4k-hibernate-cache-lettuce`
 - Added collision regression tests through the `DomainDataStorageAccess` public path.
 - Updated English and Korean README key-isolation wording.
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---:|---|
@@ -22,14 +22,14 @@ Module: `:bluetape4k-hibernate-cache-lettuce`
 | Tier 6 - Documentation | PASS | `README.md` and `README.ko.md` now distinguish region prefix isolation from collision-resistant Hibernate key encoding. |
 | Tier 7 - Evidence | PASS | `git diff --check` clean; CodeGraph change detection reports no additional affected flows or test gaps. |
 
-## Findings
+## 발견 사항
 
 P0: 0
 P1: 0
 
 P2/P3: none requiring code changes before PR.
 
-## Validation Evidence
+## 검증 Evidence
 
 - `./gradlew :bluetape4k-hibernate-cache-lettuce:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`
   - Result: PASS, `BUILD SUCCESSFUL in 12s`.

--- a/docs/review/2026-06-26-issue-809-cassandra-session-cache-review.md
+++ b/docs/review/2026-06-26-issue-809-cassandra-session-cache-review.md
@@ -1,4 +1,4 @@
-# Issue 809 - Cassandra Session Cache Review
+# Issue 809 - Cassandra Session Cache 검토
 
 ## Scope
 
@@ -7,11 +7,11 @@
 - `data/cassandra/README.md`
 - `data/cassandra/README.ko.md`
 
-## Findings
+## 발견 사항
 
 No P0/P1 findings found in the local review pass.
 
-## Evidence
+## 증거
 
 - TDD red: `CqlSessionProviderTest` failed when the same keyspace with a different builder context reused the same cached session.
 - `compileTestKotlin --warning-mode all` passed. Remaining warnings are existing Gradle Kotlin DSL deprecations outside this change.

--- a/docs/review/2026-06-26-issue-815-hibernate-object-converter-review.md
+++ b/docs/review/2026-06-26-issue-815-hibernate-object-converter-review.md
@@ -1,4 +1,4 @@
-# Issue 815 - Hibernate Object Converter Review
+# Issue 815 - Hibernate Object Converter 검토
 
 ## Scope
 
@@ -7,11 +7,11 @@
 - converter unit tests and consumer runtime test fixtures
 - `data/hibernate` README files
 
-## Findings
+## 발견 사항
 
 No P0/P1 findings found in the local review pass.
 
-## Evidence
+## 증거
 
 - `compileTestKotlin --warning-mode all` passed. New generic converter deprecation warnings are suppressed only in legacy converter declarations and legacy test fixtures.
 - Targeted converter tests passed: 77 tests, including malformed payload, unexpected payload type, and secure Kryo/Fory disallowed payload cases.

--- a/docs/review/2026-06-26-issue-817-jdbc-transaction-state-review.md
+++ b/docs/review/2026-06-26-issue-817-jdbc-transaction-state-review.md
@@ -11,13 +11,13 @@
 - Tier 5 Tests: PASS
 - Tier 7 Evidence: PASS
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2/P3: 0
 
-## Evidence
+## 증거
 
 - `Connection.withTransaction` now captures and restores `autoCommit`, isolation, and read-only state.
 - Transaction state restoration runs each property independently, so one restore failure does not skip the remaining properties.

--- a/docs/review/2026-06-26-issue-818-jdbc-batch-parameter-rows-review.md
+++ b/docs/review/2026-06-26-issue-818-jdbc-batch-parameter-rows-review.md
@@ -11,13 +11,13 @@
 - Tier 5 Tests: PASS
 - Tier 7 Evidence: PASS
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2/P3: 0
 
-## Evidence
+## 증거
 
 - `Connection.executeBatch` now validates that every parameter row has the same width before preparing a statement.
 - `Connection.executeLargeBatch` applies the same validation path as `executeBatch`.

--- a/docs/review/2026-06-26-issue-819-jdbc-resultset-empty-cursor-review.md
+++ b/docs/review/2026-06-26-issue-819-jdbc-resultset-empty-cursor-review.md
@@ -12,13 +12,13 @@
 - Tier 6 Documentation: PASS
 - Tier 7 Evidence: PASS
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2/P3: 0
 
-## Evidence
+## 증거
 
 - `ResultSet.isEmptyByMovingCursor()` and `ResultSet.isNotEmptyByMovingCursor()` now make the destructive cursor movement part of the API name.
 - Existing `ResultSet.isEmpty()` and `ResultSet.isNotEmpty()` remain binary-compatible shims but are deprecated with replacement guidance.

--- a/docs/review/2026-06-26-issue-822-r2dbc-sql-identifier-guards-review.md
+++ b/docs/review/2026-06-26-issue-822-r2dbc-sql-identifier-guards-review.md
@@ -11,13 +11,13 @@
 - Tier 5 Tests: PASS
 - Tier 7 Evidence: PASS
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2/P3: 0
 
-## Evidence
+## 증거
 
 - `InsertValuesSpecImpl` and `InsertValuesKeySpecImpl` now validate every field key with `requireValidIdentifier(...)` before storing it in the values map.
 - `UpdateValuesSpecImpl.set(...)` validates every field key before storing it; `update(...)`, nullable setters, and `set(parameters)` flow through those setter paths.

--- a/docs/review/2026-06-26-issue-823-r2dbc-map-typed-null-review.md
+++ b/docs/review/2026-06-26-issue-823-r2dbc-map-typed-null-review.md
@@ -11,13 +11,13 @@
 - Tier 5 Tests: PASS
 - Tier 7 Evidence: PASS
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2/P3: 0
 
-## Evidence
+## 증거
 
 - `typedNullParameter(type)` and `typedNullParameter<T>()` now provide a public helper for map-based typed NULL values.
 - `bindMap` rejects raw null entries instead of silently binding them as `String` typed NULL values.

--- a/docs/review/2026-06-26-issue-824-r2dbc-postgres-json-conversion-review.md
+++ b/docs/review/2026-06-26-issue-824-r2dbc-postgres-json-conversion-review.md
@@ -11,13 +11,13 @@
 - Tier 5 Tests: PASS
 - Tier 7 Evidence: PASS
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2/P3: 0
 
-## Evidence
+## 증거
 
 - `JsonToMapConverter` now throws `ConversionFailedException` for malformed PostgreSQL JSON instead of returning `emptyMap()`.
 - `MapToJsonConverter` now throws `ConversionFailedException` for Jackson serialization failures instead of returning `Json.of("{}")`.

--- a/docs/review/2026-06-26-issue-826-r2dbc-indexed-binding-review.md
+++ b/docs/review/2026-06-26-issue-826-r2dbc-indexed-binding-review.md
@@ -11,13 +11,13 @@
 - Tier 5 Tests: PASS
 - Tier 7 Evidence: PASS
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0
 - P2/P3: 0
 
-## Evidence
+## 증거
 
 - `bindIndexedMap` KDoc now documents Spring R2DBC's zero-based indexed binding contract.
 - `bindIndexedMap` now rejects negative indexes before forwarding to Spring R2DBC.

--- a/docs/review/2026-06-26-issue-900-ci-data-tests-review.md
+++ b/docs/review/2026-06-26-issue-900-ci-data-tests-review.md
@@ -11,7 +11,7 @@ Workflow: `.github/workflows/ci.yml`
 - Added `Test / Data` to run data module tests when data paths, shared CI paths, or manual dispatch trigger CI.
 - Added data coverage/test artifacts to the existing coverage aggregation and CI status dependency chain.
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---:|---|
@@ -23,14 +23,14 @@ Workflow: `.github/workflows/ci.yml`
 | Documentation | PASS | Lesson artifact records the filter/job/summary wiring rule. |
 | Regression risk | PASS | `actionlint` and `git diff --check` pass locally; GitHub Actions PR run remains the final workflow execution proof. |
 
-## Findings
+## 발견 사항
 
 P0: 0
 P1: 0
 
 P2/P3: none requiring code changes before PR.
 
-## Validation Evidence
+## 검증 Evidence
 
 - `actionlint .github/workflows/ci.yml`
   - Result: PASS.

--- a/docs/review/2026-06-26-issue-912-hibernate-reactive-vertx-review.md
+++ b/docs/review/2026-06-26-issue-912-hibernate-reactive-vertx-review.md
@@ -10,7 +10,7 @@ Affected modules: `:bluetape4k-hibernate`, `:bluetape4k-hibernate-reactive`, `:b
 - Aligned Hibernate Reactive from `4.3.3.Final` to `4.5.0.Final`.
 - Kept the repository-wide Vert.x line at `5.1.3`.
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---:|---|
@@ -22,14 +22,14 @@ Affected modules: `:bluetape4k-hibernate`, `:bluetape4k-hibernate-reactive`, `:b
 | Documentation | PASS | Lesson artifact records the ORM/Reactive/Vert.x coupling. |
 | Regression risk | PASS | Resolved dependency versions match the intended line: ORM `7.4.2.Final`, Reactive `4.5.0.Final`, Vert.x SQL `5.1.3`. |
 
-## Findings
+## 발견 사항
 
 P0: 0
 P1: 0
 
 P2/P3: none requiring code changes before PR.
 
-## Validation Evidence
+## 검증 Evidence
 
 - Reproduced before fix:
   - Data CI candidate command failed at `:bluetape4k-hibernate-reactive:test`.

--- a/docs/review/2026-06-26-range-overlaps-empty-review.md
+++ b/docs/review/2026-06-26-range-overlaps-empty-review.md
@@ -10,7 +10,7 @@ Module: `:bluetape4k-core`
 - Added regression coverage for empty open/open, closed/open, and open/closed ranges in both receiver and argument
   positions.
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---:|---|
@@ -22,14 +22,14 @@ Module: `:bluetape4k-core`
 | Documentation | PASS | Lesson artifact records the empty-range comparison rule. |
 | Regression risk | PASS | Core module test suite passes and CodeGraph reported low impact for the changed files. |
 
-## Findings
+## 발견 사항
 
 P0: 0
 P1: 0
 
 P2/P3: none requiring code changes before PR.
 
-## Validation Evidence
+## 검증 Evidence
 
 - Reproduced before fix:
   - `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.ranges.RangeSupportTest.empty ranges never overlap any range' --no-build-cache`

--- a/docs/review/2026-06-27-issue-790-jackson2-typed-mapper-allowlist-review.md
+++ b/docs/review/2026-06-27-issue-790-jackson2-typed-mapper-allowlist-review.md
@@ -1,4 +1,4 @@
-# Issue 790 Review: Jackson2 typed mapper allowlist preservation
+# Issue 790 검토: Jackson2 typed mapper allowlist preservation
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - Jackson2 typed mapper regression tests
 - Jackson2 README locale pair
 
-## Findings
+## 발견 사항
 
 No P0/P1 findings.
 

--- a/docs/review/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs-review.md
+++ b/docs/review/2026-06-27-issue-791-jackson-tink-persistent-keyset-docs-review.md
@@ -1,4 +1,4 @@
-# Issue 791 Review: Jackson Tink durable-search guidance
+# Issue 791 검토: Jackson Tink durable-search guidance
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - `TinkEncryptors` README and KDoc wording for singleton keysets
 - Durable storage guidance toward `TinkDaeads.versioned(store)` and `VersionedKeysetStore`
 
-## Findings
+## 발견 사항
 
 No P0/P1 findings.
 

--- a/docs/review/2026-06-27-issue-792-http-logging-redaction-review.md
+++ b/docs/review/2026-06-27-issue-792-http-logging-redaction-review.md
@@ -13,7 +13,7 @@
   - `io/http/README.md`
   - `io/http/README.ko.md`
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0

--- a/docs/review/2026-06-27-issue-797-grpc-client-plaintext-review.md
+++ b/docs/review/2026-06-27-issue-797-grpc-client-plaintext-review.md
@@ -1,4 +1,4 @@
-# Issue 797 Review: gRPC client plaintext opt-in
+# Issue 797 검토: gRPC client plaintext opt-in
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - gRPC README locale pair
 - gRPC channel security regression tests
 
-## Findings
+## 발견 사항
 
 No P0/P1 findings.
 

--- a/docs/review/2026-06-27-issue-798-protobuf-strict-default-codecs-review.md
+++ b/docs/review/2026-06-27-issue-798-protobuf-strict-default-codecs-review.md
@@ -1,4 +1,4 @@
-# Issue 798 Review: Protobuf strict default codecs
+# Issue 798 검토: Protobuf strict default codecs
 
 ## Scope
 
@@ -8,7 +8,7 @@
 - Protobuf Redis codec regression tests
 - Serialization trust-profile documentation
 
-## Findings
+## 발견 사항
 
 No P0/P1 findings.
 

--- a/docs/review/2026-06-27-issue-799-kafka-logback-producer-config-redaction-review.md
+++ b/docs/review/2026-06-27-issue-799-kafka-logback-producer-config-redaction-review.md
@@ -1,4 +1,4 @@
-# Local Review - Issue #799 Kafka Logback Producer Config Redaction
+# Local 검토 - Issue #799 Kafka Logback Producer Config Redaction
 
 Date: 2026-06-27
 Scope: `infra/kafka-logback`
@@ -23,7 +23,7 @@ No P0/P1 findings found in the current diff.
   diff does not add shared state, coroutine behavior, virtual threads, or
   structured task scope behavior.
 
-## Validation Evidence
+## 검증 Evidence
 
 - TDD red: `KafkaAppenderTest` redaction tests failed before the fix because
   status messages contained `kafka-jaas-secret`, `truststore-secret`, and raw

--- a/docs/review/2026-06-27-issue-802-redisson-json-allowlist-fallback-review.md
+++ b/docs/review/2026-06-27-issue-802-redisson-json-allowlist-fallback-review.md
@@ -1,4 +1,4 @@
-# Issue 802 Review: Redisson JSON allow-list fallback boundary
+# Issue 802 검토: Redisson JSON allow-list fallback boundary
 
 ## Scope
 
@@ -8,7 +8,7 @@
 - Redisson codec regression tests
 - Redisson README locale pair
 
-## Findings
+## 발견 사항
 
 No P0/P1 findings.
 

--- a/docs/review/2026-06-27-issue-803-redisson-gzip-review.md
+++ b/docs/review/2026-06-27-issue-803-redisson-gzip-review.md
@@ -8,7 +8,7 @@
   - `GZipCompressor.doDecompress`
   - `GzipCodec.valueDecoder`
 
-## Findings
+## 발견 사항
 
 No P0/P1 findings remain.
 
@@ -34,7 +34,7 @@ No P0/P1 findings remain.
   the new regression tests; existing compressor multithread coverage remains
   unchanged in `CompressorEdgeCaseTest`.
 
-## Validation Evidence
+## 검증 Evidence
 
 - Red test before implementation: compile failed on missing
   `maxDecompressedSize` constructor parameters.

--- a/docs/review/2026-06-27-issue-806-opentelemetry-redaction-review.md
+++ b/docs/review/2026-06-27-issue-806-opentelemetry-redaction-review.md
@@ -1,4 +1,4 @@
-# Local Review - Issue 806 OpenTelemetry Redacted Exception Telemetry
+# Local 검토 - Issue 806 OpenTelemetry Redacted Exception Telemetry
 
 Date: 2026-06-27
 Scope: `infra/opentelemetry`
@@ -15,7 +15,7 @@ No P0/P1 findings found in the current diff.
 - Public API compatibility: existing helper signatures are unchanged. The behavior change is a safer default for exported telemetry.
 - Test helper gate: `SuspendedJobTester` is used for coroutine and Flow redaction stress coverage. `MultithreadingTester` and `StructuredTaskScopeTester` are intentionally not used because the fix does not introduce shared production state, thread contention, virtual-thread behavior, or structured task scope behavior.
 
-## Validation Evidence
+## 검증 Evidence
 
 - TDD red: targeted redaction tests failed before the fix because exported telemetry still contained secret-bearing exception messages.
 - `./gradlew :bluetape4k-opentelemetry:compileTestKotlin --warning-mode all --no-daemon --no-configuration-cache`: PASS. Existing Gradle Kotlin DSL delegated-property deprecation warning remains outside touched source/test code.

--- a/docs/review/2026-06-27-issue-811-cassandra-mapper-runtime-dependency-review.md
+++ b/docs/review/2026-06-27-issue-811-cassandra-mapper-runtime-dependency-review.md
@@ -8,7 +8,7 @@
 - `data/cassandra/README.md`
 - `data/cassandra/README.ko.md`
 
-## Findings
+## 발견 사항
 
 P0/P1: none.
 

--- a/docs/review/2026-07-04-issue-820-mongodb-provider-cache-review.md
+++ b/docs/review/2026-07-04-issue-820-mongodb-provider-cache-review.md
@@ -1,4 +1,4 @@
-# Issue #820 MongoDB Provider Cache Review
+# Issue #820 MongoDB Provider Cache 검토
 
 ## Scope
 
@@ -10,7 +10,7 @@
   - `data/mongodb/README.md`
   - `data/mongodb/README.ko.md`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---|---|

--- a/docs/review/2026-07-04-issue-821-mongodb-transaction-abort-review.md
+++ b/docs/review/2026-07-04-issue-821-mongodb-transaction-abort-review.md
@@ -1,4 +1,4 @@
-# Issue #821 MongoDB Transaction Abort Review
+# Issue #821 MongoDB Transaction Abort 검토
 
 Date: 2026-07-04
 Repo: `bluetape4k-projects`
@@ -10,7 +10,7 @@ Scope: `data/mongodb` coroutine transaction cancellation cleanup
 - P1: 0
 - Verdict: PASS
 
-## 7-Tier Review
+## 7-Tier 검토
 
 ### Tier 1 - Correctness
 

--- a/docs/review/2026-07-04-issue-825-r2dbc-autoconfig-review.md
+++ b/docs/review/2026-07-04-issue-825-r2dbc-autoconfig-review.md
@@ -1,4 +1,4 @@
-# Issue #825 R2DBC Auto-Configuration Review
+# Issue #825 R2DBC Auto-Configuration 검토
 
 Date: 2026-07-04
 Repo: `bluetape4k-projects`
@@ -10,7 +10,7 @@ Scope: `data/r2dbc` auto-configuration classpath guards and bean backoff
 - P1: 0
 - Verdict: PASS
 
-## 7-Tier Review
+## 7-Tier 검토
 
 ### Tier 1 - Correctness
 

--- a/docs/review/2026-07-04-issue-827-ktor-correlation-tracing-review.md
+++ b/docs/review/2026-07-04-issue-827-ktor-correlation-tracing-review.md
@@ -1,4 +1,4 @@
-# Issue #827 Ktor Correlation Tracing Review
+# Issue #827 Ktor Correlation Tracing 검토
 
 Date: 2026-07-04
 Repo: `bluetape4k-projects`
@@ -10,7 +10,7 @@ Scope: `ktor/observability` OpenTelemetry correlation attributes
 - P1: 0
 - Verdict: PASS
 
-## 7-Tier Review
+## 7-Tier 검토
 
 ### Tier 1 - Correctness
 

--- a/docs/review/2026-07-04-issue-828-ktor-cancellation-spans-review.md
+++ b/docs/review/2026-07-04-issue-828-ktor-cancellation-spans-review.md
@@ -1,4 +1,4 @@
-# Issue 828 Ktor Cancellation Span Review
+# Issue 828 Ktor Cancellation Span 검토
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - Branch: `fix/issue-828-ktor-cancellation-spans`
 - Target: `ktor/observability`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---|---|

--- a/docs/review/2026-07-04-issue-926-protobuf-ci-review.md
+++ b/docs/review/2026-07-04-issue-926-protobuf-ci-review.md
@@ -1,4 +1,4 @@
-# Issue 926 Protobuf CI Coverage Review
+# Issue 926 Protobuf CI Coverage 검토
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - Branch: `fix/issue-926-protobuf-ci`
 - Target: `.github/workflows/ci.yml`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---|---|

--- a/docs/review/2026-07-04-issue-927-telemetry-ci-review.md
+++ b/docs/review/2026-07-04-issue-927-telemetry-ci-review.md
@@ -1,4 +1,4 @@
-# Issue #927 Telemetry CI Coverage Review
+# Issue #927 Telemetry CI Coverage 검토
 
 ## Scope
 
@@ -8,7 +8,7 @@
   - `:bluetape4k-opentelemetry`
   - `:bluetape4k-kafka-logback`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Verdict | Evidence |
 |------|---------|----------|
@@ -20,7 +20,7 @@
 | 6. Performance | PASS | The lane is path-filtered and does not expand unrelated CI jobs for non-telemetry changes. |
 | 7. Documentation / Evidence | PASS | This review plus the lesson document record the issue boundary, commands, and future guard. |
 
-## Validation
+## 검증
 
 - `actionlint .github/workflows/ci.yml`: PASS.
 - Backslash-single-quote guard for `.github/workflows/ci.yml`: PASS, no escaped expression quotes.
@@ -29,7 +29,7 @@
 - `./gradlew :bluetape4k-opentelemetry:test :bluetape4k-kafka-logback:test --max-workers=1 --no-configuration-cache`: PASS.
 - `./gradlew :bluetape4k-opentelemetry:koverXmlReport :bluetape4k-kafka-logback:koverXmlReport --max-workers=1 --no-configuration-cache`: PASS.
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0

--- a/docs/review/2026-07-04-issue-937-io-ci-coverage-review.md
+++ b/docs/review/2026-07-04-issue-937-io-ci-coverage-review.md
@@ -1,4 +1,4 @@
-# Issue 937 IO CI Coverage Review
+# Issue 937 IO CI Coverage 검토
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - Branch: `fix/issue-937-io-ci-coverage`
 - Target: `.github/workflows/ci.yml`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---|---|

--- a/docs/review/2026-07-04-issue-975-kafka-ci-review.md
+++ b/docs/review/2026-07-04-issue-975-kafka-ci-review.md
@@ -1,4 +1,4 @@
-# Issue #975 Kafka CI Coverage Review
+# Issue #975 Kafka CI Coverage 검토
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - Module covered by the new CI lane:
   - `:bluetape4k-kafka`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Verdict | Evidence |
 |------|---------|----------|
@@ -19,7 +19,7 @@
 | 6. Performance | PASS | The lane is path-filtered to `infra/kafka/**` and does not expand unrelated Redis/cache or telemetry jobs for Kafka-only changes. |
 | 7. Documentation / Evidence | PASS | This review plus the lesson document record the issue boundary, commands, and future guard. |
 
-## Validation
+## 검증
 
 - `actionlint .github/workflows/ci.yml`: PASS.
 - Backslash-single-quote guard for `.github/workflows`: PASS.
@@ -27,7 +27,7 @@
 - `./gradlew :bluetape4k-kafka:cleanTest :bluetape4k-kafka:test --max-workers=1 --no-build-cache --no-configuration-cache`: PASS, 265 tests.
 - `./gradlew :bluetape4k-kafka:koverXmlReport --max-workers=1 --no-configuration-cache`: PASS.
 
-## Findings
+## 발견 사항
 
 - P0: 0
 - P1: 0

--- a/docs/review/2026-07-05-issue-807-elasticsearch-pit-cleanup-review.md
+++ b/docs/review/2026-07-05-issue-807-elasticsearch-pit-cleanup-review.md
@@ -1,4 +1,4 @@
-# Issue 807 - Elasticsearch PIT Cleanup Review
+# Issue 807 - Elasticsearch PIT Cleanup 검토
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - `infra/elasticsearch/README.md`
 - `infra/elasticsearch/README.ko.md`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |------|--------|----------|
@@ -20,7 +20,7 @@
 | Kotlin style | PASS | Validation uses `requireNotBlank`; tests use `runTest` and bluetape4k boolean assertion. |
 | Impact radius | PASS | CodeGraph review context reports low risk, 0 impacted files, and 0 test gaps for changed Kotlin files. |
 
-## Findings
+## 발견 사항
 
 - P0: none.
 - P1: none.

--- a/docs/review/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering-review.md
+++ b/docs/review/2026-07-05-issue-808-elasticsearch-bulk-progress-buffering-review.md
@@ -1,4 +1,4 @@
-# Issue 808 - Elasticsearch Bulk Progress Buffering Review
+# Issue 808 - Elasticsearch Bulk Progress Buffering 검토
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - `infra/elasticsearch/README.md`
 - `infra/elasticsearch/README.ko.md`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |------|--------|----------|
@@ -20,7 +20,7 @@
 | Documentation | PASS | README and README.ko document the default bounded buffer and overflow behavior. |
 | Impact radius | PASS | CodeGraph review context reports low risk, 0 impacted files, and 0 test gaps for changed Kotlin files. |
 
-## Findings
+## 발견 사항
 
 - P0: none.
 - P1: none.

--- a/docs/review/2026-07-05-issue-810-cassandra-bootstrap-review.md
+++ b/docs/review/2026-07-05-issue-810-cassandra-bootstrap-review.md
@@ -1,4 +1,4 @@
-# Issue 810 - Cassandra Bootstrap Builder Review
+# Issue 810 - Cassandra Bootstrap Builder 검토
 
 ## Scope
 
@@ -7,7 +7,7 @@
 - `data/cassandra/README.md`
 - `data/cassandra/README.ko.md`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |------|--------|----------|
@@ -19,7 +19,7 @@
 | Documentation | PASS | README and README.ko document bootstrap side effects and keyspace binding rules. |
 | Blast radius | PASS | CodeGraph review context and impact radius report low risk and no impacted nodes. |
 
-## Findings
+## 발견 사항
 
 - P0: none.
 - P1: none.

--- a/docs/review/2026-07-05-issue-812-jpa-entity-hashcode-review.md
+++ b/docs/review/2026-07-05-issue-812-jpa-entity-hashcode-review.md
@@ -1,4 +1,4 @@
-# Issue #812 7-Tier Review
+# Issue #812 7-Tier 검토
 
 ## Scope
 
@@ -7,7 +7,7 @@
   - `data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt`
   - `data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntityUnitTest.kt`
 
-## Findings
+## 발견 사항
 
 - P0/P1 findings: 0
 - Contract: PASS. Equal transient entities now share the Hibernate entity class hash instead of identity hash.

--- a/docs/review/2026-07-05-issue-813-stateless-session-resource-review.md
+++ b/docs/review/2026-07-05-issue-813-stateless-session-resource-review.md
@@ -1,4 +1,4 @@
-# Issue #813 Stateless Session Resource Review
+# Issue #813 Stateless Session Resource 검토
 
 ## Scope
 
@@ -9,7 +9,7 @@
   - `data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/spring/stateless/StatelessSessionTest.kt`
   - `data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/spring/stateless/StatelessSessionTestConfiguration.kt`
 
-## 7-Tier Review
+## 7-Tier 검토
 
 | Tier | Result | Evidence |
 |---|---|---|
@@ -37,7 +37,7 @@
   - Changed functions/classes: 20
   - Risk score: 0.60
 
-## Findings
+## 발견 사항
 
 - P0/P1: 0
 - P2/P3: 0

--- a/docs/review/2026-07-09-codeql-java-kotlin-timeout-review.md
+++ b/docs/review/2026-07-09-codeql-java-kotlin-timeout-review.md
@@ -1,4 +1,4 @@
-# CodeQL Java/Kotlin Timeout Review
+# CodeQL Java/Kotlin Timeout 검토
 
 Date: 2026-07-09
 Scope: `.github/workflows/codeql.yml`
@@ -9,7 +9,7 @@ Scope: `.github/workflows/codeql.yml`
 - P1: 0
 - P2/P3: none
 
-## Evidence
+## 증거
 
 - CodeQL scheduled runs `28731149402`, `28771654658`, `28844864852`, and
   `28918464140` were cancelled only on the `Analyze (java-kotlin)` matrix job.

--- a/docs/review/2026-07-09-issue-1000-kafka4-compat-review.md
+++ b/docs/review/2026-07-09-issue-1000-kafka4-compat-review.md
@@ -4,12 +4,12 @@
 
 - `gradle/libs.versions.toml`
 
-## Findings
+## 발견 사항
 
 - P0: none.
 - P1: none.
 
-## Evidence
+## 증거
 
 - `gh issue view 1000`: issue is open, assigned to `debop`, milestone `1.12.0`, labels include `bug`, `test`, and `dependencies`.
 - `./gradlew :bluetape4k-kafka4:dependencyInsight --configuration testRuntimeClasspath --dependency org.apache.kafka:kafka-clients --no-daemon --no-configuration-cache --no-build-cache`: PASS, selected `org.apache.kafka:kafka-clients:4.2.1`.

--- a/docs/review/2026-07-09-issue-789-csv-cold-flow-review.md
+++ b/docs/review/2026-07-09-issue-789-csv-cold-flow-review.md
@@ -1,11 +1,11 @@
-# Issue 789 Review - CSV Cold Flow File Readers
+# Issue 789 검토 - CSV Cold Flow File Readers
 
 ## Scope
 
 - `io/csv`: file-based suspending CSV/TSV reader overloads.
 - Regression tests for cold `Flow` creation, recollection, and early termination.
 
-## Findings
+## 발견 사항
 
 - P0/P1: 0 after fix.
 - Independent code-reviewer verdict: APPROVE, P0/P1 = 0.

--- a/docs/review/2026-07-09-issue-800-kafka-exporter-review.md
+++ b/docs/review/2026-07-09-issue-800-kafka-exporter-review.md
@@ -1,4 +1,4 @@
-# Issue #800 Review — DefaultKafkaExporter send failure handling (2026-07-09)
+# Issue #800 검토 — DefaultKafkaExporter send failure handling (2026-07-09)
 
 ## Scope
 
@@ -12,7 +12,7 @@
 
 `DefaultKafkaExporter.export` caught `Throwable`, called the export exception handler only for `BufferExhaustedException` and `TimeoutException`, and returned `false` for all other synchronous send failures. This hid ordinary non-fatal producer failures and also swallowed fatal `Error` values.
 
-## Fix Review
+## Fix 검토
 
 - Changed the synchronous send failure boundary from `Throwable` to `Exception`.
 - All synchronous non-fatal `Exception` failures now call `exceptionHandler.handle(event, e)` and return `false`.

--- a/docs/review/2026-07-09-issue-804-cancel-leaf-redis-futures-review.md
+++ b/docs/review/2026-07-09-issue-804-cancel-leaf-redis-futures-review.md
@@ -1,4 +1,4 @@
-# Issue 804 Review - Cancel Leaf Redis Futures
+# Issue 804 검토 - Cancel Leaf Redis Futures
 
 ## Scope
 
@@ -6,7 +6,7 @@
 - `infra/lettuce`: `RedisFuture.awaitAll` and `sequence` cancellation contract.
 - `infra/redisson`: `RFuture.awaitAll` and `sequence` cancellation contract.
 
-## Findings
+## 발견 사항
 
 - P0/P1: 0 after fix.
 - The red test reproduced the issue through Redisson `awaitAll`: cancelling the coroutine left pending `RFuture` leaves uncancelled.

--- a/docs/review/2026-07-10-issue-785-near-cache-retry-compensation-review.md
+++ b/docs/review/2026-07-10-issue-785-near-cache-retry-compensation-review.md
@@ -1,4 +1,4 @@
-# Issue 785 Near-Cache Retry Compensation Review
+# Issue 785 Near-Cache Retry Compensation 검토
 
 ## Scope
 

--- a/docs/review/2026-07-17-issue-1036-core-serializer-bytebuffer-review.md
+++ b/docs/review/2026-07-17-issue-1036-core-serializer-bytebuffer-review.md
@@ -1,4 +1,4 @@
-# Issue 1036 Core Serializer ByteBuffer Review
+# Issue 1036 Core Serializer ByteBuffer 검토
 
 ## Scope
 

--- a/docs/review/2026-07-17-issue-1037-json-serializer-bytebuffer-review.md
+++ b/docs/review/2026-07-17-issue-1037-json-serializer-bytebuffer-review.md
@@ -1,4 +1,4 @@
-# Issue 1037 JSON Serializer ByteBuffer Review
+# Issue 1037 JSON Serializer ByteBuffer 검토
 
 ## Scope
 
@@ -72,7 +72,7 @@
 - Root `detekt` is `NO-SOURCE`; complete module compilation and tests provide
   the available static fallback.
 
-## Evidence
+## 증거
 
 - Fastjson2 resolved-source evidence records version `2.0.62`, source locations,
   source JAR SHA-256, and the optimized/fallback matrix.

--- a/docs/review/2026-07-17-issue-1038-avro-serializer-bytebuffer-review.md
+++ b/docs/review/2026-07-17-issue-1038-avro-serializer-bytebuffer-review.md
@@ -1,4 +1,4 @@
-# Issue 1038 Avro Serializer ByteBuffer Review
+# Issue 1038 Avro Serializer ByteBuffer 검토
 
 ## Scope
 
@@ -22,7 +22,7 @@ plan without expanding module, dependency, workflow, or release scope.
 | Preserve compatibility | The tracked ABI report passes legacy Java/Kotlin compilation, implementation loading, default dispatch, public-symbol, and fixture checks. |
 | Exclude measured allocation claims | Only ByteArray sibling bypass and lower-copy routing are claimed; benchmarks remain in #1039. |
 
-## Perspective Review
+## Perspective 검토
 
 - Performance: explicit pre-close `flush()` calls were removed. Complete
   ByteArray sibling staging is bypassed, but measured allocation improvement is

--- a/docs/review/issue-757-protobuf-buffer-core-review.md
+++ b/docs/review/issue-757-protobuf-buffer-core-review.md
@@ -1,4 +1,4 @@
-# Issue 757 Protobuf Buffer Core Review
+# Issue 757 Protobuf Buffer Core 검토
 
 ## 검토 기준
 

--- a/docs/security-review/2026-04-28-wave1-security.md
+++ b/docs/security-review/2026-04-28-wave1-security.md
@@ -1,4 +1,4 @@
-# Wave 1 Security Review — 2026-04-28
+# Wave 1 Security 검토 — 2026-04-28
 
 전체 7개 그룹 병렬 실행 결과. Tier 1 (autoresearch:security) 기준.
 

--- a/docs/security-review/2026-04-28-wave2-ops-sre.md
+++ b/docs/security-review/2026-04-28-wave2-ops-sre.md
@@ -1,4 +1,4 @@
-# Wave 2 Ops/SRE Reliability Review — 2026-04-28
+# Wave 2 Ops/SRE Reliability 검토 — 2026-04-28
 
 전체 5개 그룹 병렬 실행 결과. Tier 2 (Ops/SRE) 기준.
 

--- a/docs/security-review/2026-04-28-wave3-kotlin-idiom.md
+++ b/docs/security-review/2026-04-28-wave3-kotlin-idiom.md
@@ -1,4 +1,4 @@
-# Wave 3 Kotlin Idiom Review — 2026-04-28
+# Wave 3 Kotlin Idiom 검토 — 2026-04-28
 
 전체 5개 그룹 병렬 실행 결과. Tier 4 (Kotlin Idiom) 기준.
 

--- a/docs/security-review/2026-04-28-wave4-performance.md
+++ b/docs/security-review/2026-04-28-wave4-performance.md
@@ -1,4 +1,4 @@
-# Wave 4 Performance & Stability Review — 2026-04-28
+# Wave 4 Performance & Stability 검토 — 2026-04-28
 
 전체 5개 그룹 병렬 실행 결과. Tier 5 (Performance/Stability) 기준.
 

--- a/docs/security-review/2026-04-28-wave5-tests-types-silentfail.md
+++ b/docs/security-review/2026-04-28-wave5-tests-types-silentfail.md
@@ -1,4 +1,4 @@
-# Wave 5 Tests/Types/SilentFail Review — 2026-04-28
+# Wave 5 Tests/Types/SilentFail 검토 — 2026-04-28
 
 전체 5개 그룹 병렬 실행 결과. Tier 5 (Tests, Type Design, Silent Failures) 기준.
 

--- a/docs/superpowers/checklists/2026-07-12-logging-connector-repair-checklist.md
+++ b/docs/superpowers/checklists/2026-07-12-logging-connector-repair-checklist.md
@@ -1,47 +1,47 @@
-# Logging Connector Repair Checklist
+# Logging Connector 수리 체크리스트
 
 ## 분류와 불변 조건
 
-- Scope: three canonical logging SVG/PNG pairs; derived site snapshot only.
-- Required: CL-01..08; DIA-01..08 per asset; common connector rules per asset; architecture rules for `logger-api-map` and `mdc-scope-lifecycle`; sequence rules for `async-channel-sequence`.
-- N/A: infrastructure icon changes and review pages; the diagrams are text-only and no separate review page exists.
-- User-reported invariant: arrow-tip-to-target-boundary gap = `0px` in SVG coordinates and visibly connected in the scale-2 PNG.
-- User-reported marker invariant: architecture primary heads = `14×14`; sequence heads = `16×16`; same-role heads have matching rendered size/color and remain solid on dashed lines.
+- 범위: canonical logging SVG/PNG 3쌍과 파생 site snapshot만 포함한다.
+- 필수: CL-01..08, asset별 DIA-01..08, asset별 common connector rule, `logger-api-map`와 `mdc-scope-lifecycle`의 architecture rule, `async-channel-sequence`의 sequence rule.
+- N/A: diagram은 text-only이고 별도 review page가 없으므로 infrastructure icon 변경과 review page는 제외한다.
+- 사용자 보고 불변 조건: SVG 좌표에서 arrow tip과 target boundary 간격은 `0px`이고, scale-2 PNG에서 눈으로도 연결되어 보여야 한다.
+- 사용자 보고 marker 불변 조건: architecture primary head는 `14×14`, sequence head는 `16×16`이다. 같은 역할의 head는 render된 크기와 색상이 같고 dashed line에서도 solid로 유지되어야 한다.
 
 ## 체크리스트 계약
 
-- [x] **CL-01 — Create before mutation**
-    - **조치:** Instantiate router, common, and kind items before changing any SVG.
-    - **증거:** This checklist exists before connector mutation.
-    - **실패 시:** STOP and reconstruct.
-- [x] **CL-02 — Classify every item**
+- [x] **CL-01 — 변경 전에 생성**
+    - **조치:** SVG를 변경하기 전에 router, common, kind 항목을 생성한다.
+    - **증거:** connector 변경 전에 이 체크리스트가 존재한다.
+    - **실패 시:** 중단하고 재구성한다.
+- [x] **CL-02 — 모든 항목 분류**
     - **조치:** Mark required, conditional, and N/A items.
     - **증거:** Classification section names all applicable families and two concrete N/A cases.
     - **실패 시:** Treat unclassified rows as required.
-- [x] **CL-03 — Respect dependency order**
+- [x] **CL-03 — 의존 순서 준수**
     - **조치:** Complete each asset edit-render-audit-inspect loop sequentially.
     -
   **증거:** Completed logger map, then MDC, then sequence; each asset finished edit-render-audit-inspect before the next SVG changed.
     - **실패 시:** Rerun reordered downstream proof.
-- [x] **CL-04 — Record evidence immediately**
+- [x] **CL-04 — 증거 즉시 기록**
     - **조치:** Update each row when its output is read.
     -
   **증거:** Each asset row and ledger were updated before advancing; sequence visual failure was recorded before repair.
     - **실패 시:** Leave row unchecked.
-- [x] **CL-05 — Fail closed**
-    - **조치:** Stop an asset loop on any failed audit or visible PNG defect.
+- [x] **CL-05 — 실패 시 닫힌 상태 유지**
+    - **조치:** audit 실패나 눈에 보이는 PNG defect가 있으면 asset loop를 중단한다.
     -
   **증거:** Logger/MDC passed first final inspection; sequence was stopped after visual detection of two off-lifeline rows, repaired, rerendered, reaudited, and reinspected.
     - **실패 시:** Invalidate downstream work.
-- [x] **CL-06 — Repair skipped or reordered work**
+- [x] **CL-06 — 건너뛰거나 재정렬된 작업 복구**
     - **조치:** Rerun affected proofs after every final coordinate change.
     - **증거:** Sequence XML/render/common/sequence/targeted/diff proof was rerun after the last coordinate repair.
     - **실패 시:** Remain blocked.
-- [x] **CL-07 — Refresh irreversible holds**
-    - **조치:** Classify external side effects.
+- [x] **CL-07 — 되돌릴 수 없는 작업 보류 재확인**
+    - **조치:** external side effect를 분류한다.
     - **증거:** N/A — no push, PR, merge, deploy, or destructive action requested.
-    - **실패 시:** Stop at external boundary.
-- [x] **CL-08 — Count before completion**
+    - **실패 시:** external boundary에서 중단한다.
+- [x] **CL-08 — 완료 전 집계**
     - **조치:** Reconcile required, N/A, and blocked totals.
     -
   **증거:** Diagram-stage denominator reconciles to required 64/64, N/A 9, Blocked 0; downstream site publication is tracked in the execution plan, not this diagram checklist.
@@ -53,20 +53,20 @@
     - **조치:** Read landing prose, logging source/tests, and related assets.
     -
   **증거:** `docs/manual/ko/modules/bluetape4k-logging.md`, `bluetape4k/logging/src/main`, representative tests, and all three logging PNGs read; reader question is responsibility ownership without floating relations.
-    - **실패 시:** Stop unsupported drawing.
+    - **실패 시:** 지원되지 않는 drawing을 중단한다.
 - [x] **LAM-DIA-02 — Load common and architecture rules**
     - **조치:** Read `common.md` and `architecture.md`.
     - **증거:** Both references read in full for this defect.
-    - **실패 시:** Stop generic editing.
+    - **실패 시:** generic editing을 중단한다.
 - [x] **LAM-DIA-03 — Complete SVG edit**
     - **조치:** Attach four arrows with perpendicular target entry and separate ports.
     -
   **증거:** Four connector paths only; targeted assertion changed from `missing=4` before repair to `boundary_gaps=0/4 missing=0` after repair.
-    - **실패 시:** Stop before render completion.
+    - **실패 시:** render 완료 전에 중단한다.
 - [x] **LAM-DIA-04 — Parse and render PNG**
     - **조치:** Run `xmllint` and CairoSVG scale 2.
     - **증거:** `xmllint --noout` PASS; `cairosvg ... -s 2` PASS; `sips` reports 3200×1960.
-    - **실패 시:** Stop asset loop.
+    - **실패 시:** asset loop를 중단한다.
 - [x] **LAM-DIA-05 — Run audits**
     - **조치:** Run common connector/geometry/endpoint/mixed-corner audits and targeted assertions.
     -
@@ -90,13 +90,13 @@
     - **조치:** Confirm source-backed relationships and scan all logging SVGs for floating endpoints.
     -
   **증거:** Landing/source/tests read; related scan found the same fixed-gap pattern in MDC and sequence assets, so both remain required.
-    - **실패 시:** Stop or widen repair.
+    - **실패 시:** 중단하거나 repair 범위를 넓힌다.
 - [x] **LAM-COM-02 — Preserve text and theme**
     - **조치:** Keep approved fonts, palette, alignment, and unclipped text.
     -
-  **증거:** No text/style/card changes; full-size PNG confirms existing Architects Daughter/Comic Mono family, palette, alignment, and clipping remain intact.
+  **증거:** text/style/card 변경이 없고, full-size PNG로 기존 Architects Daughter/Comic Mono family, palette, alignment, clipping이 그대로임을 확인했다.
     - **실패 시:** Repair.
-- [x] **LAM-COM-03 — Classify icons**
+- [x] **LAM-COM-03 — icon 분류**
     - **조치:** Check infrastructure-icon applicability.
     - **증거:** N/A — responsibility cards are text-only; no infrastructure icon changes.
     - **실패 시:** Reclassify if scope changes.
@@ -123,7 +123,7 @@
 - [x] **LAM-COM-08 — Run required commands**
     - **조치:** Read all required audit output.
     -
-  **증거:** Final post-edit block ran XML, CairoSVG, dimensions, connector, geometry, endpoint, mixed-corner, targeted marker/boundary assertions, and diff check; all PASS.
+  **증거:** 최종 수정 후 block에서 XML, CairoSVG, dimension, connector, geometry, endpoint, mixed-corner, targeted marker/boundary assertion, diff check를 실행했고 모두 PASS였다.
     - **실패 시:** Remain unchecked.
 - [x] **LAM-COM-09 — Verify review exposure**
     - **조치:** Check review-page applicability.
@@ -156,20 +156,20 @@
     - **조치:** Read scoped-MDC prose, implementation/tests, and related assets.
     -
   **증거:** scoped-MDC chapter, `MdcSupport.kt`, `MdcSupportTest.kt`, and related logging PNGs read; reader question is save/install/restore ownership with unambiguous progression.
-    - **실패 시:** Stop unsupported drawing.
+    - **실패 시:** 지원되지 않는 drawing을 중단한다.
 - [x] **MDC-DIA-02 — Load common and architecture rules**
     - **조치:** Read `common.md` and `architecture.md`.
     - **증거:** Both references read in full.
-    - **실패 시:** Stop generic editing.
+    - **실패 시:** generic editing을 중단한다.
 - [x] **MDC-DIA-03 — Complete SVG edit**
     - **조치:** Attach both arrows edge-to-edge.
     -
   **증거:** two endpoint coordinates only; targeted assertion changed from `missing=2` to `boundary_gaps=0/2 missing=0`.
-    - **실패 시:** Stop.
+    - **실패 시:** 중단한다.
 - [x] **MDC-DIA-04 — Parse and render PNG**
     - **조치:** Run XML and CairoSVG scale 2.
     - **증거:** XML PASS; CairoSVG scale 2 PASS; `sips` reports 3200×1960.
-    - **실패 시:** Stop.
+    - **실패 시:** 중단한다.
 - [x] **MDC-DIA-05 — Run audits**
     - **조치:** Run common and targeted audits.
     -
@@ -189,18 +189,18 @@
     - **조치:** Reconcile all MDC rows.
     -
   **증거:** MDC ledger row contains source, render, counts, marker size, endpoint gaps, and original-PNG observations.
-    - **실패 시:** No completion claim.
+    - **실패 시:** completion claim을 하지 않는다.
 - [x] **MDC-COM-01 — Verify source and related set**
     - **조치:** Confirm save/install/restore semantics and related pattern scan.
     -
   **증거:** `MdcSupport.kt`/test confirm capture-install-finally restore/remove; related scan confirms sequence asset still needs repair.
-    - **실패 시:** Stop.
+    - **실패 시:** 중단한다.
 - [x] **MDC-COM-02 — Preserve text and theme**
     - **조치:** Keep fonts, palette, alignment, and readability.
     -
-  **증거:** No text/style/card changes; full-size PNG preserves approved logging palette, fonts, alignment, and readable labels.
+  **증거:** text/style/card 변경이 없고, full-size PNG는 승인된 logging palette, font, alignment, readable label을 보존한다.
     - **실패 시:** Repair.
-- [x] **MDC-COM-03 — Classify icons**
+- [x] **MDC-COM-03 — icon 분류**
     - **조치:** Check icon applicability.
     - **증거:** N/A — text-only operation cards.
     - **실패 시:** Reclassify if scope changes.
@@ -215,7 +215,7 @@
   **증거:** target gaps=0/2 at x=605 and x=1120; straight perpendicular attachment; intrusions=0, crossings=0; PNG confirms contact without overshoot.
     - **실패 시:** Repair.
 - [x] **MDC-COM-06 — Verify bent corners**
-    - **조치:** Classify bend applicability.
+    - **조치:** bend 적용 여부를 분류한다.
     - **증거:** N/A — both connectors are straight horizontal segments.
     - **실패 시:** Reclassify if routes bend.
 - [x] **MDC-COM-07 — Synchronize canvas and whitespace**
@@ -225,7 +225,7 @@
 - [x] **MDC-COM-08 — Run required commands**
     - **조치:** Read every required audit output.
     -
-  **증거:** Final post-edit block ran XML, CairoSVG, dimensions, connector, geometry, endpoint, mixed-corner, targeted marker/boundary assertions, and diff check; all PASS.
+  **증거:** 최종 수정 후 block에서 XML, CairoSVG, dimension, connector, geometry, endpoint, mixed-corner, targeted marker/boundary assertion, diff check를 실행했고 모두 PASS였다.
     - **실패 시:** Remain unchecked.
 - [x] **MDC-COM-09 — Verify review exposure**
     - **조치:** Check review-page applicability.
@@ -258,20 +258,20 @@
     - **조치:** Read async-channel prose, implementation/tests, and reference sequences.
     -
   **증거:** async-channel chapter, `KLoggingChannel.kt`/test, and two full-size sequence references read; reader question is send/collect/close/post-close ownership over time.
-    - **실패 시:** Stop unsupported drawing.
+    - **실패 시:** 지원되지 않는 drawing을 중단한다.
 - [x] **ACS-DIA-02 — Load common and sequence rules**
     - **조치:** Read `common.md` and `sequence.md`.
     - **증거:** Both references read in full.
-    - **실패 시:** Stop generic editing.
+    - **실패 시:** generic editing을 중단한다.
 - [x] **ACS-DIA-03 — Complete SVG edit**
     - **조치:** Attach every message to lifeline/activation edges.
     -
   **증거:** eight message endpoints only; initial targeted `missing=8`; first render exposed two semantically off-lifeline rows; final assertion reports attached_messages=8/8 missing=0.
-    - **실패 시:** Stop.
+    - **실패 시:** 중단한다.
 - [x] **ACS-DIA-04 — Parse and render PNG**
     - **조치:** Run XML and CairoSVG scale 2.
     - **증거:** final XML PASS; CairoSVG scale 2 PASS; `sips` reports 3600×2240.
-    - **실패 시:** Stop.
+    - **실패 시:** 중단한다.
 - [x] **ACS-DIA-05 — Run audits**
     - **조치:** Run common, sequence-style, and targeted audits.
     -
@@ -291,18 +291,18 @@
     - **조치:** Reconcile all sequence rows.
     -
   **증거:** Sequence ledger row contains source, references, final rerun counts, marker proof, failure/repair, and original-PNG observations.
-    - **실패 시:** No completion claim.
+    - **실패 시:** completion claim을 하지 않는다.
 - [x] **ACS-COM-01 — Verify source and related set**
     - **조치:** Confirm send/collect/close/post-close relationships and scan related assets.
     -
   **증거:** `KLoggingChannel.kt`/test confirm flow, collector, provider, cancel, injected-scope, and post-close semantics; related-set scan covered all three logging SVGs.
-    - **실패 시:** Stop.
+    - **실패 시:** 중단한다.
 - [x] **ACS-COM-02 — Preserve text and theme**
     - **조치:** Keep fonts, palette, labels, and readability.
     -
-  **증거:** No text/style/frame/card changes; final PNG preserves approved fonts, muted semantic palette, label alignment, and readable spacing.
+  **증거:** text/style/frame/card 변경이 없고, final PNG는 승인된 font, muted semantic palette, label alignment, readable spacing을 보존한다.
     - **실패 시:** Repair.
-- [x] **ACS-COM-03 — Classify icons**
+- [x] **ACS-COM-03 — icon 분류**
     - **조치:** Check icon applicability.
     - **증거:** N/A — participants are code roles, not infrastructure cards.
     - **실패 시:** Reclassify if scope changes.
@@ -317,7 +317,7 @@
   **증거:** attached_messages=8/8 at lifeline/activation coordinates; intrusions=0, crossings=0, geometry=0, endpoint PASS; final PNG confirms no floating or overshooting rows.
     - **실패 시:** Repair.
 - [x] **ACS-COM-06 — Verify bent corners**
-    - **조치:** Classify bend applicability.
+    - **조치:** bend 적용 여부를 분류한다.
     - **증거:** N/A — message connectors are straight horizontal lanes.
     - **실패 시:** Reclassify if routes bend.
 - [x] **ACS-COM-07 — Synchronize canvas and whitespace**
@@ -328,7 +328,7 @@
 - [x] **ACS-COM-08 — Run required commands**
     - **조치:** Read every required audit output.
     -
-  **증거:** Final post-repair block ran XML, CairoSVG, dimensions, connector, geometry, endpoint, mixed-corner, sequence-style, targeted marker/attachment assertions, and diff check; all PASS.
+  **증거:** 최종 repair 후 block에서 XML, CairoSVG, dimension, connector, geometry, endpoint, mixed-corner, sequence-style, targeted marker/attachment assertion, diff check를 실행했고 모두 PASS였다.
     - **실패 시:** Remain unchecked.
 - [x] **ACS-COM-09 — Verify review exposure**
     - **조치:** Check review-page applicability.
@@ -338,7 +338,7 @@
     - **조치:** Inspect one best-practices and one nearest repo-local sequence PNG.
     -
   **증거:** Full-size `sequence-workflow-sample.png` and nearest `bluetape4k-coroutines-sequence-01.png` opened; both show calls terminating on activation edges/lifelines and guide the repair.
-    - **실패 시:** Stop sequence editing.
+    - **실패 시:** sequence editing을 중단한다.
 - [x] **ACS-SEQ-02 — Preserve sequence signals**
     - **조치:** Keep headers, lifelines, activations, messages, numbered labels, and chronological frame.
     -
@@ -365,7 +365,7 @@
   **증거:** final sequence-style audit PASS reconciled with references, 7 labels, 1 frame, 3 marker colors, 8 attached paths, and original-PNG PASS.
     - **실패 시:** Repair.
 
-## Evidence ledger
+## 증거 원장
 
 | Asset                    | Source and kind                                                         | XML/render                         | Connector and marker proof                                                                                                                 | Original PNG inspection                                                                                                                       |
 |--------------------------|-------------------------------------------------------------------------|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
@@ -375,4 +375,4 @@
 
 `Required checks: 64/64; N/A: 9; Blocked: 0` — every diagram row has fresh final evidence; no unchecked IDs.
 
-Post-ledger repository proof: the first exporter invocation used a nonexistent filename and was rejected. The corrected `set -e` rerun passed `validate_manuals_test.rb` 14/41, `export_manifest_test.rb` 2/7, `generate_manuals_test.rb` 1/23, `validate_manuals.rb` alignment, and `git diff --check`.
+원장 이후 repository proof: 첫 exporter 호출은 존재하지 않는 filename을 사용해 거부되었다. 수정된 `set -e` 재실행은 `validate_manuals_test.rb` 14/41, `export_manifest_test.rb` 2/7, `generate_manuals_test.rb` 1/23, `validate_manuals.rb` alignment, `git diff --check`를 통과했다.

--- a/docs/superpowers/checklists/2026-07-12-logging-manual-checklist.md
+++ b/docs/superpowers/checklists/2026-07-12-logging-manual-checklist.md
@@ -1,4 +1,4 @@
-# Logging Manual 실행 체크리스트
+# Logging manual 실행 체크리스트
 
 ## 범위
 
@@ -14,61 +14,61 @@
 - [x] **CG-01 — Re-read authority**
     - **조치:** repo `AGENTS.md`, workflow/writer/maintenance/diagram skill, status와 diff를 읽는다.
     - **증거:** `AGENTS.md`; worktree clean; selected skill/reference reads completed 2026-07-12.
-    - **실패 시:** STOP before editing.
+    - **실패 시:** 수정 전에 중단한다.
 - [x] **CG-02 — Query historical/current evidence**
     - **조치:** GNO와 현재 source/test/README/blog를 검색한다.
     - **증거:** GNO에 logging manual 선행 기록 없음; current Kotlin source/tests와 bilingual README/blog가 결정 근거.
-    - **실패 시:** STOP decisions that depend on missing evidence.
+    - **실패 시:** 누락된 증거에 의존하는 결정을 중단한다.
 - [x] **CG-03 — Protect user work and boundaries**
     - **조치:** repo/worktree/branch/status를 확인한다.
     - **증거:** Projects `feature/all-module-manuals`, staged/unstaged/untracked/conflicted 모두 0; upstream 없음.
-    - **실패 시:** preserve or BLOCK.
+    - **실패 시:** 보존하거나 BLOCKED로 둔다.
 - [x] **CG-04 — Apply audience language policy**
     - **조치:** Korean chat, bilingual public manual/blog parity를 유지한다.
-    - **증거:** planned KO/EN landing/chapter and KO/EN blog pair.
-    - **실패 시:** repair locale drift.
+    - **증거:** 계획된 KO/EN landing/chapter와 KO/EN blog pair.
+    - **실패 시:** locale drift를 수정한다.
 - [x] **CG-05 — Prove public contract documentation**
     - **조치:** Kotlin API 변경 여부와 durable plan/spec 경로를 고정한다.
     - **증거:** runtime change N/A; design/plan under `docs/superpowers`.
-    - **실패 시:** block undocumented behavior.
+    - **실패 시:** 문서화되지 않은 동작을 blocked로 둔다.
 - [x] **CG-06 — Reuse ecosystem patterns**
     - **조치:** Core/Coroutines chapter/asset/manifest pattern과 logging source/tests를 재사용한다.
     -
-  **증거:** schema v2 manual inventory, existing logging README diagrams, source classes and representative tests mapped.
-    - **실패 시:** stop new abstraction/dependency work.
+  **증거:** schema v2 manual inventory, 기존 logging README diagram, source class, 대표 test를 mapping했다.
+    - **실패 시:** 새 abstraction/dependency 작업을 중단한다.
 - [x] **CG-07 — Lock behavior and run targeted proof**
     - **조치:** manual validator/tests, logging tests, site tests/build를 실행한다.
     -
   **증거:** Ruby 14/41 + 2/7 PASS; validator aligned; Gradle rerun 51 passing, 20 tasks executed, BUILD SUCCESSFUL.
-    - **실패 시:** repair and rerun.
+    - **실패 시:** 수정하고 다시 실행한다.
 - [x] **CG-08 — Serialize heavyweight checks**
     - **조치:** heavyweight integration check applicability를 분류한다.
-    - **증거:** N/A — docs-only; logging unit tests contain no Testcontainers/DB/native dependency.
-    - **실패 시:** rerun sequentially if scope changes.
+    - **증거:** N/A — docs-only이며 logging unit test에는 Testcontainers/DB/native dependency가 없다.
+    - **실패 시:** scope가 바뀌면 순차 재실행한다.
 - [x] **CG-09 — Verify issue/PR metadata live**
     - **조치:** GitHub metadata applicability를 분류한다.
-    - **증거:** N/A — no issue/PR mutation requested.
-    - **실패 시:** verify live if GitHub scope is later approved.
+    - **증거:** N/A — issue/PR mutation은 요청되지 않았다.
+    - **실패 시:** 나중에 GitHub scope가 승인되면 live로 검증한다.
 - [x] **CG-10 — Verify PR body and reviews live**
     - **조치:** PR applicability를 분류한다.
-    - **증거:** N/A — no PR exists in approved scope.
-    - **실패 시:** verify live before merge scope.
+    - **증거:** N/A — 승인 범위에 PR이 없다.
+    - **실패 시:** merge scope 전에 live로 검증한다.
 - [x] **CG-11 — Enforce side-effect authority**
     - **조치:** external/irreversible action boundary를 기록한다.
-    - **증거:** no push/PR/merge/deploy; local commits only follow existing approved worktree flow.
-    - **실패 시:** STOP at external boundary.
+    - **증거:** push/PR/merge/deploy 없음; local commit만 기존 승인된 worktree flow를 따른다.
+    - **실패 시:** external boundary에서 중단한다.
 - [x] **CG-12 — Synchronize after merge**
     - **조치:** merge applicability를 분류한다.
-    - **증거:** N/A — merge not requested.
-    - **실패 시:** sync if later merged.
+    - **증거:** N/A — merge는 요청되지 않았다.
+    - **실패 시:** 나중에 merge되면 sync한다.
 - [x] **CG-13 — Update managed source first**
     - **조치:** chezmoi applicability를 분류한다.
-    - **증거:** N/A — no managed user-scope guidance.
-    - **실패 시:** resolve source chain if scope changes.
+    - **증거:** N/A — managed user-scope guidance가 없다.
+    - **실패 시:** scope가 바뀌면 source chain을 해결한다.
 - [x] **CG-14 — Audit durable Codex changes**
     - **조치:** Codex guidance applicability를 분류한다.
-    - **증거:** N/A — no Codex surfaces changed.
-    - **실패 시:** audit if scope changes.
+    - **증거:** N/A — Codex surface 변경이 없다.
+    - **실패 시:** scope가 바뀌면 audit한다.
 - [x] **CG-15 — Preserve global policy boundaries**
     - **조치:** global policy and Claude surfaces를 제외한다.
     - **증거:** scoped file map contains only Projects/Site documentation.
@@ -76,59 +76,61 @@
 - [x] **CG-16 — Use authoritative tooling safely**
     - **조치:** raw reads, repo helpers, apply_patch, repo scripts를 사용한다.
     - **증거:** repo-status/repo-diff/rg/sed and selected skill references read.
-    - **실패 시:** rerun authoritative command.
+    - **실패 시:** authoritative command를 다시 실행한다.
 - [x] **CG-17 — Prove completion line by line**
     - **조치:** 모든 leaf/diagram/site proof와 clean diff/status를 재검증한다.
     -
-  **증거:** all logging leaf gates closed; Projects validators/tests and Site snapshot/tests/build/browser evidence recorded below; final clean status is verified after commits.
-    - **실패 시:** remain PENDING.
+  **증거:** 모든 logging leaf gate가 닫혔고, Projects validator/test 및 Site snapshot/test/build/browser evidence가 아래에 기록되었다. Commit 뒤 최종 clean status를 확인했다.
+    - **실패 시:** PENDING으로 남긴다.
 
-## Logging manual leaf gate
+## Logging manual leaf 게이트
 
 - [x] **LOG-01 — Pin source-backed chapter model**
     - **조치:** public source, representative tests, README와 blog를 대조한다.
     -
-  **증거:** six chapter topics map to KLogging/KotlinLogging, Slf4jExtensions, MdcSupport, MdcSupportCoroutines, KLoggingChannel, operations/tests.
-    - **실패 시:** remove unsupported claims.
+  **증거:** 여섯 chapter topic이 KLogging/KotlinLogging, Slf4jExtensions, MdcSupport, MdcSupportCoroutines, KLoggingChannel, operations/tests에 대응된다.
+    - **실패 시:** 지원되지 않는 claim을 제거한다.
 - [x] **LOG-02 — Write bilingual chapter inventory**
     - **조치:** landing과 6개 KO/EN chapter를 작성한다.
-    - **증거:** 12 chapter files; chapter IDs/order/source links validated in schema v2.
-    - **실패 시:** repair parity.
+    - **증거:** 12개 chapter file; chapter ID/order/source link는 schema v2에서 검증했다.
+    - **실패 시:** parity를 수정한다.
 - [x] **LOG-03 — Create canonical diagrams**
     - **조치:** source-backed SVG/PNG 3쌍을 manual assets에 둔다.
-    - **증거:** 3 SVG/PNG pairs rendered with CairoSVG scale 2 and inspected at full size; ledger below.
-    - **실패 시:** return to asset loop.
+    - **증거:** 3개 SVG/PNG pair를 CairoSVG scale 2로 render하고 full size로 검사했다. 아래 ledger에 기록한다.
+    - **실패 시:** asset loop로 돌아간다.
 - [x] **LOG-04 — Register and validate manifest**
     - **조치:** chapters/assets inventory를 schema v2 manifest에 추가한다.
     -
-  **증거:** 6 chapters + 6 assets registered; 14 validator tests/41 assertions and 2 export tests/7 assertions PASS; `Manuals are aligned.`
+  **증거:** 6개 chapter와 6개 asset을 등록했다. 14 validator tests/41 assertions와 2 export tests/7 assertions PASS; `Manuals are aligned.`
     - **실패 시:** repair inventory/reference.
 - [x] **LOG-05 — Publish deterministic site snapshot**
     - **조치:** Projects commit 기준으로 site sync/check를 실행한다.
     -
-  **증거:** deterministic sync/check passed at the closing Projects revision; snapshot inventory reports 90 modules, 224 localized documents, and 28 assets.
-    - **실패 시:** repair snapshot.
+  **증거:** closing Projects revision에서 deterministic sync/check가 통과했다. Snapshot inventory는 90 modules, 224 localized documents, 28 assets를 보고했다.
+    - **실패 시:** snapshot을 수정한다.
 - [x] **LOG-06 — Align derived blog**
     - **조치:** bilingual Part 2 blog의 logging section을 manual route로 연결한다.
     -
-  **증거:** KO/EN Part 2 articles state that the repository manual is the source of truth and link the logging landing plus five decision chapters; representative KO links resolved in the browser.
-    - **실패 시:** repair ownership drift.
+  **증거:** KO/EN Part 2 article은 repository manual이 source of truth라고 명시하고 logging landing 및 다섯 decision chapter를 link한다. 대표 KO link는 browser에서 resolve되었다.
+    - **실패 시:** ownership drift를 수정한다.
 - [x] **LOG-07 — Browser and build proof**
     - **조치:** KO/EN landing/chapter/assets/blog links와 Astro build를 검증한다.
     -
-  **증거:** Astro check reports 0 errors/warnings/hints; Astro build emits 373 pages; KO/EN landing, scoped MDC, async channel, blog links, and all three SVG assets rendered with no browser console warnings/errors.
-    - **실패 시:** repair and rerun.
+  **증거:** Astro check는 0 errors/warnings/hints를 보고했고, Astro build는 373 pages를 생성했다. KO/EN landing, scoped MDC, async channel, blog links, 세 SVG asset은 browser console warning/error 없이 render되었다.
+    - **실패 시:** 수정하고 다시 실행한다.
 
 ## 종료 집계
 
-## Diagram evidence ledger
+## Diagram 증거 원장
 
-| Asset                    | Kind/source                                                                                    | XML/render                         | Audits                                                                                         | PNG inspection                                                                                                 |
+| Asset | Kind/source | XML/render | Audits | PNG inspection |
 |--------------------------|------------------------------------------------------------------------------------------------|------------------------------------|------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | `logger-api-map`         | Architecture; KLogging/KotlinLogging/Slf4jExtensions/MDC source                                | `xmllint` PASS; CairoSVG 3200×1960 | markers=1, connectors=4, intrusions=0, crossings=0, geometry/endpoints/mixed-corner failures=0 | text readable, role cards aligned, provider boundary and arrows clear                                          |
 | `mdc-scope-lifecycle`    | Architecture; MdcSupport + tests                                                               | `xmllint` PASS; CairoSVG 3200×1960 | markers=1, connectors=2, intrusions=0, crossings=0, geometry/endpoints/mixed-corner failures=0 | outer/inner/restore sequence readable, no clipping or crowding                                                 |
 | `async-channel-sequence` | Sequence; KLoggingChannel + tests; wiki best-practice and existing logging sequence references | `xmllint` PASS; CairoSVG 3600×2240 | markers=3, connectors=8, crossings=0, sequence-style PASS, numbered labels=7                   | participants/lifelines/activations/close frame/post-close drop readable; marker color and direction consistent |
 
-Text-only technology cards make infrastructure icons N/A. No separate review page exists; canonical files are linked directly from current manual chapters.
+Text-only technology card이므로 infrastructure icon은 N/A다. 별도 review page는 없고,
+canonical file은 current manual chapter에서 직접 link된다.
 
-`Required checks: 26/26; N/A: 8; Blocked: 0` — logging manual, deterministic site snapshot, derived blog links, build, and browser proof complete.
+`Required checks: 26/26; N/A: 8; Blocked: 0` — logging manual, deterministic site
+snapshot, derived blog link, build, browser proof가 완료되었다.

--- a/docs/superpowers/checklists/2026-07-13-cassandra-manual-checklist.md
+++ b/docs/superpowers/checklists/2026-07-13-cassandra-manual-checklist.md
@@ -10,31 +10,31 @@
 - GitHub issue/PR/push/merge/deploy: N/A — 승인 범위는 local spec, edit, test, browser verify까지
 - Chezmoi/agent guidance/workflow: N/A — 해당 surface를 변경하지 않음
 
-## Workflow router
+## Workflow 라우터
 
-- [x] **WF-01 — Classify**
+- [x] **WF-01 — 분류**
     - **조치:** 작업을 Type E 문서 유지보수로 분류한다.
     - **증거:** Kotlin production source와 dependency는 변경하지 않고 Cassandra manual, manifest, site snapshot만 변경한다.
-    - **실패 시:** production behavior가 필요하면 STOP하고 Type A/B/C로 재분류한다.
-- [x] **WF-02 — Write the first concrete plan**
+    - **실패 시:** production behavior가 필요하면 중단하고 Type A/B/C로 재분류한다.
+- [x] **WF-02 — 첫 구체 계획 작성**
     - **조치:** 근거 수집, 구조 비교, spec/plan, bilingual 작성, snapshot/build/browser 검증 순서를 제시한다.
     - **증거:** 2026-07-13 active thread의 5단계 계획과 B형 chapter inventory.
-    - **실패 시:** STOP before durable artifacts.
-- [x] **WF-03 — Obtain first-plan approval**
+    - **실패 시:** durable artifact 전에 중단한다.
+- [x] **WF-03 — 첫 계획 승인 확보**
     - **조치:** B형 hub + focused chapters 설계의 명시적 승인을 받는다.
     - **증거:** 사용자 응답 `승인` (2026-07-13).
-    - **실패 시:** remain read-only.
-- [x] **WF-04 — Load execution contracts**
+    - **실패 시:** read-only 상태로 남긴다.
+- [x] **WF-04 — 실행 계약 로드**
     - **조치:** workflow, maintenance, writer, brainstorming, checklist/common gate와 Korean naturalness 계약을 읽는다.
     -
   **증거:** `/Users/debop/.codex/skills/{bluetape-workflow,bluetape-maintenance,bluetape-writer,brainstorming}` 및 required references를 현재 turn에서 읽음.
-    - **실패 시:** STOP before editing.
-- [x] **WF-05 — Execute gates in dependency order**
+    - **실패 시:** 수정 전에 중단한다.
+- [x] **WF-05 — 의존 순서대로 게이트 실행**
     - **조치:** spec approval, plan, manual source, site snapshot, verification 순으로 진행한다.
     -
   **증거:** spec 승인 → 7-task plan → 6개 bilingual source page → manifest/release 검증 → Testcontainers 단독 실행 → site refresh/test/build/browser 검수 순으로 완료함.
     - **실패 시:** leave downstream items unchecked and repair.
-- [x] **WF-06 — Repair any skipped or weak gate**
+- [x] **WF-06 — 누락되거나 약한 게이트 복구**
     - **조치:** 누락되거나 약한 증거를 복구하고 영향을 받은 downstream proof를 다시 실행한다.
     -
   **증거:** plan-only CG-08 증거를 실제 단독 실행 결과로 교체했고, 브라우저에서 발견한 상대 `.md` 링크 404는 snapshot 변환 단계에서 회귀 테스트와 함께 수정함. Site commit 뒤 발견한 EOF 빈 줄도 생성기에서 정규화하고 전체 검증을 다시 실행함.
@@ -46,12 +46,12 @@
     - **조치:** workspace/repo `AGENTS.md`, selected skills, status와 diff를 읽는다.
     -
   **증거:** `/Users/debop/work/bluetape4k/AGENTS.md`, repo `AGENTS.md`; branch `feature/all-module-manuals`; tracked diff 없음; unrelated untracked 3개 보존.
-    - **실패 시:** STOP before editing.
+    - **실패 시:** 수정 전에 중단한다.
 - [x] **CG-02 — Query historical/current evidence**
     - **조치:** GNO GitHub/docs와 1.11.0 source/test/README를 대조한다.
     -
   **증거:** PR #919 session cache collision은 1.11.0에 포함; PR #986 bootstrap builder는 1.11.0 이후 변경임을 ancestry와 tag source로 확인; issue/review #809/#810, Cassandra public source/tests와 README 확인.
-    - **실패 시:** STOP decisions that depend on missing evidence.
+    - **실패 시:** 누락된 증거에 의존하는 결정을 중단한다.
 - [x] **CG-03 — Protect user work and boundaries**
     - **조치:** repo/worktree/base/status와 제외 파일을 기록한다.
     -
@@ -90,7 +90,7 @@
 - [x] **CG-11 — Enforce side-effect authority**
     - **조치:** external/irreversible action 경계를 기록한다.
     - **증거:** local commit은 spec workflow에 포함; push/PR/merge/deploy는 수행하지 않음.
-    - **실패 시:** STOP at external boundary.
+    - **실패 시:** external boundary에서 중단한다.
 - [x] **CG-12 — Synchronize after merge**
     - **조치:** merge applicability를 분류한다.
     - **증거:** N/A — merge not requested.
@@ -117,17 +117,17 @@
   **증거:** Required 32/32, N/A 6, Blocked 0. Projects manual/release scoped status와 Site manual pipeline/snapshot scoped status는 clean이며, KO/EN 5개 chapter와 1.11.0 source links를 다시 확인함.
     - **실패 시:** remain PENDING.
 
-## Type E gates
+## Type E 게이트
 
 - [x] **E-01 — Route support skills**
     - **조치:** public bilingual manual writing 지원 skill을 선택한다.
     - **증거:** `bluetape-writer`와 Korean naturalness checklist 로드; diagram은 현재 spec에서 제외되어 N/A.
-    - **실패 시:** STOP before editing with a missing route.
+    - **실패 시:** 수정 전에 중단한다 with a missing route.
 - [x] **E-02 — Discover current guidance**
     - **조치:** current manual, README, source/test, reviews와 existing manual platform을 읽는다.
     -
   **증거:** Cassandra landing, 1.11.0 README/source/test inventory, #809/#810 reviews, Core/Coroutines/Logging specs 확인.
-    - **실패 시:** remain read-only until authority is known.
+    - **실패 시:** read-only 상태로 남긴다 until authority is known.
 - [x] **E-03 — Preserve behavior and ownership**
     - **조치:** production source는 건드리지 않고 canonical `docs/manual`을 먼저 수정한다.
     - **증거:** approved scope and planned file map; site is generated downstream.
@@ -147,7 +147,7 @@
   **증거:** canonical source checkpoint `073ab365a`; Site snapshot commits `b4dd3c0`, `f699dfb`; locale inventory와 generated source links parity 통과. Projects checklist를 이 commit으로 닫으며 push/PR/merge/deploy는 수행하지 않음.
     - **실패 시:** final status PENDING/BLOCKED.
 
-## Cassandra manual leaf gates
+## Cassandra manual leaf 게이트
 
 - [x] **CAS-01 — Pin the release evidence**
     - **조치:** 기술 사실을 `1.11.0` source, tests, README와 merged fix history에 고정한다.

--- a/docs/superpowers/checklists/2026-07-23-cassandra-learning-path-followup.md
+++ b/docs/superpowers/checklists/2026-07-23-cassandra-learning-path-followup.md
@@ -8,7 +8,7 @@
 - 제외: 라이브러리 API·동작·의존성 변경, 이미 완료된 Site 작업의 무근거 재작성
 - PR: Projects와 Site를 각각 별도 PR로 전달하며, 각 병합은 새 승인 후에만 수행한다.
 
-## Projects preflight
+## Projects 사전 점검
 
 - [x] **CG-01 — 권한과 워크플로를 재확인한다**
     - **조치:** 승인된 Type E 계획, `AGENTS.md`, `bluetape-workflow`, `bluetape-maintenance`, `bluetape-writer`를 읽는다.
@@ -43,7 +43,7 @@
     - **증거:** Markdown·계획·lesson만 변경하며 라이브러리 동작과 실행 환경은 변경하지 않아 N/A다.
     - **실패 시:** 실행 동작 변경이 발견되면 순차 heavyweight 검증으로 재분류한다.
 
-## Projects delivery
+## Projects 전달
 
 - [x] **E-01 — 최신 develop 위로 복구 branch를 재정렬한다**
     - **조치:** 현재 `origin/develop`에 rebase하고 충돌을 문서 scope 안에서 해결한다.
@@ -78,7 +78,7 @@
     - **증거:** merge SHA와 local/upstream 일치.
     - **실패 시:** 승인 대기 상태를 유지한다.
 
-## Site follow-up
+## Site 후속 작업
 
 - [ ] **S-01 — Projects 병합 commit을 source로 고정한다**
     - **조치:** Projects merge SHA를 확인한 뒤 Site 1.11 manual snapshot을 refresh한다.

--- a/docs/superpowers/checklists/2026-07-23-issue-756-fory-followup-release.md
+++ b/docs/superpowers/checklists/2026-07-23-issue-756-fory-followup-release.md
@@ -1,75 +1,73 @@
-# Issue #756 Fory Follow-up Release Checklist
+# 이슈 #756 Fory 후속 release 체크리스트
 
-**Target version:** `1.12.0`
-**Observed Maven Central version:** `1.11.0`
-**Repository:** `https://repo.maven.apache.org/maven2`
-**Publish authority:** Not granted by this checklist or issue workflow.
+**대상 버전:** `1.12.0`
+**관찰된 Maven Central 버전:** `1.11.0`
+**저장소:** `https://repo.maven.apache.org/maven2`
+**Publish 권한:** 이 체크리스트나 issue workflow로는 부여되지 않았다.
 
-## Release scope
+## Release 범위
 
-The release scope is limited to the raw Fory/FastFory serializer and Redis codec paths in these artifacts:
+Release 범위는 다음 artifact의 raw Fory/FastFory serializer와 Redis codec path로 제한한다.
 
-| Target coordinate                                 | Known-good rollback coordinate                    | Known-good JAR SHA-256                                             |
-|---------------------------------------------------|---------------------------------------------------|--------------------------------------------------------------------|
-| `io.github.bluetape4k:bluetape4k-io:1.12.0`       | `io.github.bluetape4k:bluetape4k-io:1.11.0`       | `e5d41857bb7196c7fac8ecdfa773deb658f649ccbb78608064807fea1a823ea5` |
-| `io.github.bluetape4k:bluetape4k-lettuce:1.12.0`  | `io.github.bluetape4k:bluetape4k-lettuce:1.11.0`  | `bd38da234b3dcd586d5a5458a95c4996c49585f945146fedb411a8c0810b962a` |
+| 대상 좌표 | known-good rollback 좌표 | known-good JAR SHA-256 |
+|---|---|---|
+| `io.github.bluetape4k:bluetape4k-io:1.12.0` | `io.github.bluetape4k:bluetape4k-io:1.11.0` | `e5d41857bb7196c7fac8ecdfa773deb658f649ccbb78608064807fea1a823ea5` |
+| `io.github.bluetape4k:bluetape4k-lettuce:1.12.0` | `io.github.bluetape4k:bluetape4k-lettuce:1.11.0` | `bd38da234b3dcd586d5a5458a95c4996c49585f945146fedb411a8c0810b962a` |
 | `io.github.bluetape4k:bluetape4k-redisson:1.12.0` | `io.github.bluetape4k:bluetape4k-redisson:1.11.0` | `a8018e61ac2c0d3e592efdcf694d2785c709269f22378d00c8f000dfffc628a1` |
 
-The `1.12.0` JAR hashes must be captured by the release executor from the staged artifacts before publication. They do not exist in Maven Central yet and must not be invented or inferred from local build output.
+`1.12.0` JAR hash는 publication 전에 release executor가 staged artifact에서 캡처해야
+한다. 아직 Maven Central에 존재하지 않으며 local build output에서 invent하거나 infer하면
+안 된다.
 
-## Evidence pins
+## 증거 고정
 
-- [x] Aggregate benchmark manifest:
-  `docs/benchmarks/raw/issue-756-fory-followup/manifest.json`
-- [x] Aggregate benchmark manifest SHA-256:
-  `68f81d30c406ab24770127b92c4bef2a11ebfc66169a7ccf648d02d7efd50aae`
-- [x] The aggregate disposition records 20 canonical methods and
-  `encodeDisposition=rejected`; Redisson encode therefore stays on the compatibility path.
-- [x] Maven Central downloads are checksum-gated before they enter the known-good classpath:
-  `docs/benchmarks/raw/issue-756-fory-followup/release/artifact-manifest.json`
-- [x] Current and known-good classpaths are recorded:
-  `docs/benchmarks/raw/issue-756-fory-followup/release/classpath-manifest.json`
-- [x] Old-write/new-read and new-write/old-read pass for both Fory and FastFory:
-  `docs/benchmarks/raw/issue-756-fory-followup/release/compatibility-results.json`
-- [x] The non-publishing rollback smoke result is recorded. A codec-level result is `limited` and keeps the publication gate blocked:
-  `docs/benchmarks/raw/issue-756-fory-followup/release/rollback-smoke.json`
-- [x] Release evidence file hashes are recorded:
-  `docs/benchmarks/raw/issue-756-fory-followup/release/release-manifest.json`
+- [x] Aggregate benchmark manifest: `docs/benchmarks/raw/issue-756-fory-followup/manifest.json`
+- [x] Aggregate benchmark manifest SHA-256: `68f81d30c406ab24770127b92c4bef2a11ebfc66169a7ccf648d02d7efd50aae`
+- [x] Aggregate disposition은 20개 canonical method와 `encodeDisposition=rejected`를 기록한다. 따라서 Redisson encode는 compatibility path에 남는다.
+- [x] Maven Central download는 known-good classpath에 들어가기 전에 checksum-gated다: `docs/benchmarks/raw/issue-756-fory-followup/release/artifact-manifest.json`
+- [x] Current/known-good classpath가 기록되어 있다: `docs/benchmarks/raw/issue-756-fory-followup/release/classpath-manifest.json`
+- [x] Fory와 FastFory 모두에서 old-write/new-read, new-write/old-read가 통과했다: `docs/benchmarks/raw/issue-756-fory-followup/release/compatibility-results.json`
+- [x] Non-publishing rollback smoke 결과가 기록되어 있다. Codec-level result가 `limited`이면 publication gate는 계속 blocked다: `docs/benchmarks/raw/issue-756-fory-followup/release/rollback-smoke.json`
+- [x] Release evidence file hash가 기록되어 있다: `docs/benchmarks/raw/issue-756-fory-followup/release/release-manifest.json`
 
 ## Consumer와 migration 경계
 
-- [x] Consumers using raw `bluetape4k-io`, Lettuce, or Redisson Fory codecs are in scope.
-- [x] Compression wrappers and compressed payload migration are out of scope.
-- [x] No data migration is required when a consumer keeps the same Fory mode.
-- [x] `FastForyCodec` keeps the existing asymmetric fallback: it can read compatible-mode Fory payloads, while `ForyCodec` cannot read FastFory payloads.
-- [x] Registration-off defaults are for trusted payloads only.
-- [x] Fory retains its internal reusable buffer; this release does not claim an end-to-end zero-copy serializer.
+- [x] Raw `bluetape4k-io`, Lettuce, Redisson Fory codec을 사용하는 consumer가 범위다.
+- [x] Compression wrapper와 compressed payload migration은 범위 밖이다.
+- [x] Consumer가 같은 Fory mode를 유지하면 data migration은 필요 없다.
+- [x] `FastForyCodec`은 기존 asymmetric fallback을 유지한다. Compatible-mode Fory payload는 읽을 수 있지만 `ForyCodec`은 FastFory payload를 읽을 수 없다.
+- [x] Registration-off default는 trusted payload 전용이다.
+- [x] Fory는 내부 reusable buffer를 유지한다. 이 release는 end-to-end zero-copy serializer를 주장하지 않는다.
 
 ## 게시 전 hold
 
-- [ ] Obtain explicit publication authority and identify the release executor.
-- [ ] Build the exact `1.12.0` staging artifacts from the approved release commit.
-- [ ] Record each staged `1.12.0` JAR SHA-256 and verify the dependency/BOM version set.
-- [ ] Re-run the aggregate validator, compatibility runner, and rollback smoke from the exact release commit.
-- [ ] Require rollback evidence with `mode=redis`, `status=passed`, and
-  `publicationGate=passed`; codec-level fallback is documentation-only evidence.
-- [ ] Verify CI and review state for the exact release commit.
-- [ ] Publish only through the repository release workflow after every hold is cleared.
+- [ ] 명시적인 publication authority와 release executor를 확보한다.
+- [ ] 승인된 release commit에서 정확한 `1.12.0` staging artifact를 build한다.
+- [ ] 각 staged `1.12.0` JAR SHA-256을 기록하고 dependency/BOM version set을 검증한다.
+- [ ] Exact release commit에서 aggregate validator, compatibility runner, rollback smoke를 다시 실행한다.
+- [ ] Rollback evidence는 `mode=redis`, `status=passed`, `publicationGate=passed`여야 한다. Codec-level fallback은 documentation-only evidence다.
+- [ ] Exact release commit의 CI와 review 상태를 검증한다.
+- [ ] 모든 hold가 해제된 뒤 repository release workflow로만 publish한다.
 
 ## Rollback 소유권과 조치
 
-**소유자:** The explicitly authorized release executor.
+**소유자:** 명시적으로 승인된 release executor.
 
-If wire parity, ownership, exception behavior, benchmark validation, or release smoke fails before publication, remove the affected direct candidate from the release commit and repeat validation.
+Publication 전에 wire parity, ownership, exception behavior, benchmark validation, release
+smoke가 실패하면 release commit에서 영향을 받은 direct candidate를 제거하고 검증을
+반복한다.
 
-If a regression is found after publication:
+Publication 뒤 regression이 발견되면 다음 순서를 따른다.
 
-1. Pin affected consumers back to the three `1.11.0` known-good coordinates and exact hashes above.
-2. Run `python3 infra/redisson/scripts/run-issue756-fory-compatibility.py`.
-3. Run `python3 infra/redisson/scripts/run-issue756-fory-rollback-smoke.py`.
-4. Record whether the smoke used live Redis or the explicitly limited deterministic codec-level fallback.
-5. Open a rollback issue/PR with the failing artifact version, hashes, and fixture result. Do not publish a replacement without fresh authority.
+1. 영향을 받은 consumer를 위 세 `1.11.0` known-good 좌표와 정확한 hash로 pin한다.
+2. `python3 infra/redisson/scripts/run-issue756-fory-compatibility.py`를 실행한다.
+3. `python3 infra/redisson/scripts/run-issue756-fory-rollback-smoke.py`를 실행한다.
+4. Smoke가 live Redis를 사용했는지, 명시적으로 제한된 deterministic codec-level fallback을 사용했는지 기록한다.
+5. 실패 artifact version, hash, fixture result를 담은 rollback issue/PR을 연다. Fresh authority 없이 replacement를 publish하지 않는다.
 
 ## 현재 handoff 상태
 
-Release evidence preparation is complete, but publication is blocked by design until explicit authority and staged `1.12.0` hashes exist. The recorded rollback smoke used the deterministic codec-level path because Redis was unavailable; its `limited` status proves known-good codec round trips but does not claim a networked Redis SET/GET result and cannot clear the publication gate.
+Release evidence 준비는 완료되었지만, 명시적 authority와 staged `1.12.0` hash가
+존재할 때까지 publication은 의도적으로 blocked다. 기록된 rollback smoke는 Redis가 없어
+deterministic codec-level path를 사용했다. `limited` 상태는 known-good codec round trip만
+증명하며 networked Redis SET/GET 결과를 주장하지 않고 publication gate를 해제할 수 없다.

--- a/docs/superpowers/checklists/2026-07-27-issue-1080-lettuce-synchronizers.md
+++ b/docs/superpowers/checklists/2026-07-27-issue-1080-lettuce-synchronizers.md
@@ -1,135 +1,135 @@
-# Issue #1080 Lettuce Synchronizer Delivery Checklist
+# Issue #1080 Lettuce Synchronizer 전달 체크리스트
 
 ## 분류
 
-- Run: `20260727T014749Z-767eaea9`
-- Session: `019fa01b-1cc9-7572-b32f-5ed791babccb`
-- Required: `CL-01..08`, `CG-01..16`, `A-01..11`, `KT-FIN-01..11`, `BLOG-01..09`, `DIA-01..08`.
-- Conditional: Redis/Testcontainers, Cluster same-slot, coroutine cancellation, Java source compatibility, documentation locale parity, one architecture diagram.
-- N/A: `CG-17`, `CG-18`, `A-12` because this delivery stops at merge-ready and merge is forbidden without fresh approval; `KT-FIN-05` because no Exposed API is touched; writer hero image because this is module documentation, not an article.
-- Exclusions: Lock delivery changes, legacy semaphore removal, cross-family API convergence, merge, auto-merge, branch cleanup.
-- Heavy-command limit: one Gradle/Testcontainers/diagram-render/CI lane at a time.
+- 실행: `20260727T014749Z-767eaea9`
+- 세션: `019fa01b-1cc9-7572-b32f-5ed791babccb`
+- 필수: `CL-01..08`, `CG-01..16`, `A-01..11`, `KT-FIN-01..11`, `BLOG-01..09`, `DIA-01..08`.
+- 조건부: Redis/Testcontainers, Cluster same-slot, coroutine cancellation, Java source compatibility, documentation locale parity, one architecture diagram.
+- N/A: 이 전달은 merge-ready에서 멈추고 새 명시 승인 없는 merge가 금지되므로 `CG-17`, `CG-18`, `A-12`는 제외한다. Exposed API를 건드리지 않으므로 `KT-FIN-05`는 제외한다. 문서 범위가 article이 아니라 module documentation이므로 writer hero image도 제외한다.
+- 제외: Lock 전달 변경, legacy semaphore 제거, cross-family API 수렴, merge, auto-merge, branch cleanup.
+- heavyweight 명령 제한: one Gradle/Testcontainers/diagram-render/CI lane at a time.
 
 ## 체크리스트 계약
 
-- [x] **CL-01 — Create before mutation**
-  - **조치:** Instantiate router, common, Type A, Kotlin, writer, and diagram items before further edits.
-  - **증거:** This checklist was created immediately after run recovery; the two copied drafts are identified as preserved prior work and are re-proved under `CL-06`.
-  - **실패 시:** STOP and reconstruct before any further implementation.
-- [x] **CL-02 — Classify every item**
-  - **조치:** Mark every applicable, conditional, and N/A family.
-  - **증거:** The classification section names every loaded checklist family, conditional trigger, exclusion, and concrete N/A reason.
-  - **실패 시:** Treat any unclassified item as required and unchecked.
-- [x] **CL-03 — Respect dependency order**
-  - **조치:** Execute plan review, TDD implementation, sequential verification, docs, reviews, commit, PR, and CI in document order.
-  - **증거:** Plan review reached P0=0/P1=0 before production work; semaphore, expirable semaphore, and latch proof ran sequentially; docs/review followed implementation.
-  - **실패 시:** Repair and rerun affected downstream proof.
-- [x] **CL-04 — Record evidence immediately**
-  - **조치:** Update each row when its evidence is read.
-  - **증거:** Run receipts, plan/review artifacts, lesson, command results, and this checklist record the current evidence; late rows were repaired before commit.
-  - **실패 시:** Leave the row unchecked.
-- [x] **CL-05 — Fail closed**
-  - **조치:** Stop dependent work on failed or pending gates.
-  - **증거:** Every P0/P1 finding was repaired and rereviewed; publication gates remain unchecked until live evidence exists.
-  - **실패 시:** Invalidate and rerun downstream evidence.
-- [x] **CL-06 — Repair skipped or reordered work**
-  - **조치:** Re-prove the receipt, root-draft preservation, copied hashes, and feature-worktree boundary after late checklist creation.
-  - **증거:** Run `20260727T014749Z-767eaea9` is running for the feature worktree; root SHA-256 values are `9e39b720...` and `f0f1cbb6...`; copied files were created without deleting or modifying root copies.
-  - **실패 시:** Remove only derived worktree copies and restart from the preserved root drafts.
-- [x] **CL-07 — Refresh irreversible holds**
-  - **조치:** Re-read branch/base/authority immediately before push and PR creation.
-  - **증거:** Branch `codex/issue-1080-lettuce-synchronizers`, base `develop`, origin, issue #1080 metadata, and no-merge boundary were freshly read before commit/push.
-  - **실패 시:** Do not push or create/update the PR.
-- [x] **CL-08 — Count before completion**
-  - **조치:** Reconcile required, N/A, blocked, and pending totals.
-  - **증거:** Required checks are `61/62`; N/A items are 5; blocked items are 0; `CG-16` is the only unchecked required item.
-  - **실패 시:** Completion claim is forbidden.
+- [x] **CL-01 — 변경 전에 생성**
+  - **조치:** 추가 수정 전에 router, common, Type A, Kotlin, writer, diagram 항목을 생성한다.
+  - **증거:** 실행 복구 직후 이 체크리스트를 만들었고, 복사한 draft 2개는 보존된 선행 작업으로 식별한 뒤 `CL-06`에서 다시 증명한다.
+  - **실패 시:** 추가 구현 전에 중단하고 재구성한다.
+- [x] **CL-02 — 모든 항목 분류**
+  - **조치:** 적용, 조건부, N/A family를 모두 표시한다.
+  - **증거:** 분류 섹션이 로드된 모든 checklist family, 조건부 trigger, 제외 항목, 구체적 N/A 사유를 명시한다.
+  - **실패 시:** 분류되지 않은 항목은 모두 필수 미확인 항목으로 취급한다.
+- [x] **CL-03 — 의존 순서 준수**
+  - **조치:** plan review, TDD 구현, 순차 검증, 문서, review, commit, PR, CI를 문서 순서대로 실행한다.
+  - **증거:** production 작업 전에 plan review가 P0=0/P1=0에 도달했고, semaphore, expirable semaphore, latch 증거를 순차 실행했으며, docs/review는 구현 뒤에 수행했다.
+  - **실패 시:** 영향받은 downstream proof를 수정하고 다시 실행한다.
+- [x] **CL-04 — 증거 즉시 기록**
+  - **조치:** evidence를 읽을 때마다 각 row를 갱신한다.
+  - **증거:** Run receipt, plan/review artifact, lesson, command result, 이 checklist가 current evidence를 기록하며, late row는 commit 전에 수정했다.
+  - **실패 시:** 해당 row를 unchecked로 남긴다.
+- [x] **CL-05 — 실패 시 닫힌 상태 유지**
+  - **조치:** 실패하거나 pending인 gate가 있으면 의존 작업을 중단한다.
+  - **증거:** 모든 P0/P1 finding을 수정하고 재검토했다. publication gate는 live evidence가 생길 때까지 unchecked로 남긴다.
+  - **실패 시:** downstream evidence를 무효화하고 다시 실행한다.
+- [x] **CL-06 — 건너뛰거나 재정렬된 작업 복구**
+  - **조치:** 늦게 checklist를 만든 뒤 receipt, root-draft 보존, copied hash, feature-worktree boundary를 다시 증명한다.
+  - **증거:** Run `20260727T014749Z-767eaea9`는 feature worktree용으로 실행 중이며, root SHA-256 값은 `9e39b720...`와 `f0f1cbb6...`다. root copy를 삭제하거나 수정하지 않고 copied file을 만들었다.
+  - **실패 시:** derived worktree copy만 제거하고 보존된 root draft에서 다시 시작한다.
+- [x] **CL-07 — 되돌릴 수 없는 작업 보류 재확인**
+  - **조치:** push와 PR 생성 직전에 branch/base/authority를 다시 읽는다.
+  - **증거:** commit/push 전에 branch `codex/issue-1080-lettuce-synchronizers`, base `develop`, origin, issue #1080 metadata, no-merge boundary를 새로 읽었다.
+  - **실패 시:** PR을 push하거나 create/update하지 않는다.
+- [x] **CL-08 — 완료 전 집계**
+  - **조치:** required, N/A, blocked, pending 총계를 대조한다.
+  - **증거:** 필수 checks는 `61/62`, N/A 항목은 5개, blocked 항목은 0개이며, `CG-16`만 미확인 필수 항목이다.
+  - **실패 시:** completion claim은 금지된다.
 
 ## 공통 gate
 
 - [x] **CG-01 — Re-read authority**
-  - **조치:** Read inherited repository authority and selected workflow/leaf contracts.
-  - **증거:** Repository AGENTS plus workflow, full-feature, Kotlin, coroutine, writer, and diagram contracts were loaded for this session.
-  - **실패 시:** STOP before mutation.
+  - **조치:** 상속된 repository authority와 선택된 workflow/leaf 계약을 읽는다.
+  - **증거:** 이 session에서 Repository AGENTS와 workflow, full-feature, Kotlin, coroutine, writer, diagram 계약을 로드했다.
+  - **실패 시:** 수정 전에 중단한다.
 - [x] **CG-02 — Query historical/current evidence**
-  - **조치:** Read issue #1080, approved spec, merged Lock PRs, current branch, graph, and relevant implementation.
-  - **증거:** Issue #1080, PRs #1086/#1087, design spec, `RedisScriptRunner`, Lock runtime patterns, and graph stats `4634 files / 42164 nodes / 381486 edges` were read.
-  - **실패 시:** STOP unsupported implementation.
+  - **조치:** issue #1080, approved spec, merged Lock PR, current branch, graph, relevant implementation을 읽는다.
+  - **증거:** Issue #1080, PR #1086/#1087, design spec, `RedisScriptRunner`, Lock runtime pattern, graph stats `4634 files / 42164 nodes / 381486 edges`를 읽었다.
+  - **실패 시:** 지원되지 않는 구현을 중단한다.
 - [x] **CG-03 — Protect user work and boundaries**
-  - **조치:** Preserve root drafts and isolate writes to the feature worktree.
-  - **증거:** Root hashes were recorded; root drafts remain unmodified; only the temporary transition evidence was removed; branch is `codex/issue-1080-lettuce-synchronizers`.
-  - **실패 시:** STOP and restore from root copies.
+  - **조치:** root draft를 보존하고 write를 feature worktree에 격리한다.
+  - **증거:** root hash를 기록했고 root draft는 수정되지 않았다. temporary transition evidence만 제거했다. branch는 `codex/issue-1080-lettuce-synchronizers`.
+  - **실패 시:** 중단하고 root copy에서 복원한다.
 - [x] **CG-04 — Apply policy and audience boundaries**
-  - **조치:** Keep public GitHub/KDoc English and user-collaboration artifacts Korean.
-  - **증거:** Plan/checklist language, docs locale pair, branch/base, PR, and merge stop boundaries are explicitly pinned.
-  - **실패 시:** Repair before publication.
+  - **조치:** public GitHub/KDoc은 English로, user-collaboration artifact는 Korean으로 유지한다.
+  - **증거:** plan/checklist language, docs locale pair, branch/base, PR, merge stop boundary를 명시적으로 고정했다.
+  - **실패 시:** publication 전에 수정한다.
 - [x] **CG-05 — Reuse ecosystem patterns**
-  - **조치:** Reuse `RedisScriptRunner`, Lock key/validation/wait/cancellation patterns, and existing module test fixtures.
-  - **증거:** The implementation reuses `RedisScriptRunner`, Lock key validation, `CoordinationRuntime`, module fixtures, and adds no dependency.
-  - **실패 시:** Refactor before final tests.
+  - **조치:** `RedisScriptRunner`, Lock key/validation/wait/cancellation pattern, existing module test fixture를 재사용한다.
+  - **증거:** 구현은 재사용한다: `RedisScriptRunner`, Lock key validation, `CoordinationRuntime`, module fixtures, and dependency를 추가하지 않는다.
+  - **실패 시:** final test 전에 refactor한다.
 - [x] **CG-06 — Prove public and documentation contracts**
-  - **조치:** Compile Kotlin/Java callers and validate KDoc plus English/Korean README selection tables.
-  - **증거:** Java documentation compatibility test is included in the 28-test package pass; Dokka succeeds; locale shape/routes pass.
+  - **조치:** Kotlin/Java caller를 compile하고 KDoc과 English/Korean README selection table을 검증한다.
+  - **증거:** Java documentation compatibility test는 28-test package pass에 포함되어 있고 Dokka가 성공하며 locale shape/route가 통과한다.
   - **실패 시:** Repair public surface and rerun.
 - [x] **CG-07 — Lock behavior and run targeted proof**
-  - **조치:** Complete RED/GREEN contract tests for all three synchronizers and all three execution modes.
-  - **증거:** Contract, ambiguity, cancellation, performance/stability, protocol, and Cluster tests pass; latest ambiguity repair is 1/1 green.
+  - **조치:** 세 synchronizer와 세 execution mode에 대한 RED/GREEN contract test를 완료한다.
+  - **증거:** Contract, ambiguity, cancellation, performance/stability, protocol, Cluster test가 통과한다; latest ambiguity repair is 1/1 green.
   - **실패 시:** Do not advance to broad verification.
 - [x] **CG-08 — Serialize heavyweight checks**
-  - **조치:** Run Redis/Testcontainers, protocol, diagram, and broad Gradle checks one at a time.
-  - **증거:** Synchronizer package, module check, Dokka, and diagram audits ran sequentially with outputs read between commands.
-  - **실패 시:** Rerun affected evidence sequentially.
+  - **조치:** Redis/Testcontainers, protocol, diagram, broad Gradle check를 한 번에 하나씩 실행한다.
+  - **증거:** Synchronizer package, module check, Dokka, diagram audit를 순차 실행하고 command 사이에 output을 읽었다.
+  - **실패 시:** 영향받은 evidence를 순차 재실행한다.
 - [x] **CG-09 — Evaluate the lesson gate**
-  - **조치:** Compare discovered failures with existing lessons and record genuinely new durable guidance.
-  - **증거:** `docs/lessons/2026-07-27-lettuce-synchronizer-generation-cleanup.md` records generation-bound cleanup, cancellation, and polling guards.
-  - **실패 시:** Do not commit.
+  - **조치:** discovered failure를 existing lesson과 비교하고 실제로 새로운 durable guidance를 기록한다.
+  - **증거:** `docs/lessons/2026-07-27-lettuce-synchronizer-generation-cleanup.md` generation-bound cleanup, cancellation, polling guard를 기록한다.
+  - **실패 시:** commit하지 않는다.
 - [x] **CG-10 — Converge the final pre-PR proof**
-  - **조치:** Run exact scope diff, targeted/full checks, and independent P0/P1 reviews.
-  - **증거:** Implementation review records 28 synchronizer tests, 869 module tests, Kover, Dokka, diagram audits, and final independent `P0=0 / P1=0`.
+  - **조치:** exact scope diff, targeted/full check, independent P0/P1 review를 실행한다.
+  - **증거:** Implementation review 28 synchronizer test, 869 module test, Kover, Dokka, diagram audit, 최종 independent `P0=0 / P1=0`.
   - **실패 시:** Repair and rerun affected lanes.
 - [x] **CG-11 — Verify PR delivery authority**
-  - **조치:** Refresh user approval, repo, issue, base, head, labels, assignee, milestone, and no-merge constraint.
-  - **증거:** Issue #1080 is open, assigned to `debop`, milestone `1.12.0`, labeled `enhancement`, `test`, `design`, `infra/io`; approved base/head and no-merge hold remain unchanged.
-  - **실패 시:** Stop at local commit.
+  - **조치:** user approval, repo, issue, base, head, label, assignee, milestone, no-merge constraint를 갱신한다.
+  - **증거:** Issue #1080은 open 상태이고 `debop`에게 assign되었으며, milestone `1.12.0`, label `enhancement`, `test`, `design`, `infra/io`가 설정되어 있다. 승인된 base/head와 no-merge hold는 그대로다.
+  - **실패 시:** local commit에서 중단한다.
 - [x] **CG-12 — Publish the exact head branch**
-  - **조치:** Push the Lore-committed exact head to origin.
-  - **증거:** Lore commit `cf6d10b32` was published and local HEAD equaled `origin/codex/issue-1080-lettuce-synchronizers`.
+  - **조치:** Lore commit된 exact head를 origin에 push한다.
+  - **증거:** Lore commit `cf6d10b32` 가 publish되었고 local HEAD는 다음과 일치했다: `origin/codex/issue-1080-lettuce-synchronizers`.
   - **실패 시:** Repair push without rewriting user work.
 - [x] **CG-13 — Create and verify the PR**
-  - **조치:** Create issue-linked PR with metadata parity and `## DoD Status` as final H2.
-  - **증거:** PR #1089 live read-back confirms base `develop`, exact head, assignee `debop`, issue labels, milestone `1.12.0`, and final H2 `## DoD Status`.
-  - **실패 시:** Correct metadata/body before CI gate.
+  - **조치:** metadata parity와 최종 H2 `## DoD Status`를 갖춘 issue-linked PR을 만든다.
+  - **증거:** PR #1089 live read-back으로 확인했다: base `develop`, exact head, assignee `debop`, issue labels, milestone `1.12.0`, and final H2 `## DoD Status`.
+  - **실패 시:** CI gate 전에 metadata/body를 수정한다.
 - [x] **CG-14 — Pass CI and live human review**
-  - **조치:** Poll checks, reviews, and threads until terminal.
-  - **증거:** Exact-head CI completed with 11 success, 8 path-filter skips, 0 pending, and 0 failing; the PR is mergeable/CLEAN with no submitted review or review thread.
-  - **실패 시:** Repair and republish exact head.
+  - **조치:** check, review, thread가 terminal 상태가 될 때까지 poll한다.
+  - **증거:** exact-head CI는 다음 상태로 완료됐다: 11 success, 8 path-filter skips, 0 pending, and 0 failing; the PR is mergeable/CLEAN with no submitted review or review thread.
+  - **실패 시:** exact head를 수정하고 다시 publish한다.
 - [x] **CG-15 — Report merge-ready**
-  - **조치:** Report exact run, head, commit, PR, CI, review, and blocker.
-  - **증거:** The prepared merge-ready report identifies `CG-16` as the only merge blocker and does not merge or enable auto-merge.
-  - **실패 시:** Continue verification.
+  - **조치:** exact run, head, commit, PR, CI, review, blocker를 보고한다.
+  - **증거:** 준비된 merge-ready report는 다음을 식별한다: `CG-16` 를 유일한 merge blocker로 두며 merge나 auto-merge를 하지 않는다.
+  - **실패 시:** verification을 계속한다.
 - [ ] **CG-16 — Obtain fresh merge approval**
-  - **조치:** Wait for a new explicit merge instruction after merge-ready.
-  - **증거:** `PENDING` by required stop condition.
-  - **실패 시:** Never merge or enable auto-merge.
+  - **조치:** merge-ready 뒤 새 명시 merge instruction을 기다린다.
+  - **증거:** `PENDING` 필수 stop condition에 따른 상태.
+  - **실패 시:** 절대 merge하거나 auto-merge를 enable하지 않는다.
 - [x] **CG-17 — Execute and verify the merge**
-  - **조치:** Classify merge execution.
-  - **증거:** N/A — this run is explicitly forbidden to merge.
-  - **실패 시:** Reclassify only after fresh approval in a later run.
+  - **조치:** merge 실행을 분류한다.
+  - **증거:** N/A — 이번 run은 merge가 명시적으로 금지되어 있다.
+  - **실패 시:** 나중 run에서 fresh approval을 받은 뒤에만 재분류한다.
 - [x] **CG-18 — Synchronize and clean up**
-  - **조치:** Classify post-merge synchronization.
-  - **증거:** N/A — no merge occurs in this run.
-  - **실패 시:** Reclassify after a verified merge.
+  - **조치:** merge 후 동기화를 분류한다.
+  - **증거:** N/A — 이번 run에서는 merge가 발생하지 않는다.
+  - **실패 시:** 검증된 merge 뒤 재분류한다.
 
-## Type A gates
+## Type A 게이트
 
 - [x] **A-01 — Isolate and confirm requirements**
   - **조치:** Fix Delivery 2 scope and preserve Lock → Synchronizer → API convergence order.
-  - **증거:** Only semaphore, expirable semaphore, latch, their modes, tests, docs, and PR delivery are in scope.
-  - **실패 시:** Stop scope drift.
+  - **증거:** semaphore, expirable semaphore, latch, 각 mode, tests, docs, PR delivery만 범위에 있다.
+  - **실패 시:** scope drift를 중단한다.
 - [x] **A-02 — Ground the design in current evidence**
   - **조치:** Inspect the approved design, merged Lock substrate, module patterns, and user drafts.
   - **증거:** Current code, graph, spec, PRs, and both draft hashes were read.
-  - **실패 시:** Stop unsupported design.
+  - **실패 시:** 지원되지 않는 design을 중단한다.
 - [x] **A-03 — Approve and review the design spec**
   - **조치:** Reuse the already approved issue-1080 design without reopening Delivery ordering.
   - **증거:** Approved spec and merged Lock PRs establish the Delivery 2 basis.
@@ -167,30 +167,30 @@
   - **증거:** The prepared final Korean report includes run, branch, exact commit, PR, checks, P0/P1, and `CG-16`.
   - **실패 시:** Continue evidence collection.
 - [x] **A-12 — Close out only after fresh merge approval**
-  - **조치:** Classify merge closeout.
+  - **조치:** merge closeout을 분류한다.
   - **증거:** N/A — this execution stops before merge.
   - **실패 시:** Reclassify only in an explicitly approved merge run.
 
-## Kotlin gates
+## Kotlin 게이트
 
 - [x] **KT-FIN-01 — Inspect the current surface**
   - **조치:** Inspect the copied drafts, Lock runtime, script runner, legacy semaphore, tests, and docs.
   - **증거:** Current files and public patterns were read before implementation planning.
-  - **실패 시:** Stop unsupported edits.
+  - **실패 시:** 지원되지 않는 수정을 중단한다.
 - [x] **KT-FIN-02 — Preserve validation contracts**
   - **조치:** Validate names, identities, capacity, durations, generations, handles, and same-slot keys before dispatch.
   - **증거:** Named validation tests pass for sync/async/suspend entry points.
   - **실패 시:** Repair before Redis tests.
 - [x] **KT-FIN-03 — Exclude unsafe Kotlin constructs**
   - **조치:** Scan for `GlobalScope`, `runBlocking` in production, `!!`, broad catches, and blocking coroutine paths.
-  - **증거:** No `GlobalScope`, production `runBlocking`, or `!!`; broad catches map Redis failures and preserve `CancellationException`.
+  - **증거:** `GlobalScope`, production `runBlocking`, `!!`가 없고, broad catch는 Redis failure를 매핑하면서 `CancellationException`을 보존한다.
   - **실패 시:** Refactor and rerun.
 - [x] **KT-FIN-04 — Prove lifecycle ownership**
   - **조치:** Prove object close, injected connection/scheduler ownership, future cancellation, and suspend cancellation.
   - **증거:** Lifecycle/cancellation tests pass.
   - **실패 시:** Repair leaks or ownership violations.
 - [x] **KT-FIN-05 — Verify Exposed boundaries**
-  - **조치:** Classify Exposed-specific checks.
+  - **조치:** Exposed 전용 check를 분류한다.
   - **증거:** N/A — `infra/lettuce` synchronizers do not touch Exposed.
   - **실패 시:** Reclassify if scope changes.
 - [x] **KT-FIN-06 — Apply triggered references**
@@ -215,22 +215,22 @@
   - **실패 시:** Continue repair.
 - [x] **KT-FIN-11 — Converge final scope**
   - **조치:** Compare final diff with Delivery 2 scope and exclusions.
-  - **증거:** No Lock redesign, legacy removal, convergence, or unrelated edits.
+  - **증거:** Lock redesign, legacy removal, convergence, unrelated edit가 없다.
   - **실패 시:** Remove scope drift.
 
-## Writer gates
+## Writer 게이트
 
 - [x] **BLOG-01 — Pin article scope and evidence**
   - **조치:** Pin module README/guide/KDoc scope to implemented synchronizer behavior.
   - **증거:** Docs targets are `infra/lettuce/README.md`, `README.ko.md`, `CoordinationSynchronizers.md`, `CoordinationSynchronizers.ko.md`, and public KDoc.
-  - **실패 시:** Stop unsupported claims.
+  - **실패 시:** 지원되지 않는 claim을 중단한다.
 - [x] **BLOG-02 — Load local style and triggered references**
   - **조치:** Load writer and Korean naturalness rules plus existing locale pair.
   - **증거:** Writer references and current module docs were read.
-  - **실패 시:** Stop drafting.
+  - **실패 시:** drafting을 중단한다.
 - [x] **BLOG-03 — Lock factual claims**
   - **조치:** Derive selection rows and examples only from final public APIs and tests.
-  - **증거:** Every claim maps to code/test evidence.
+  - **증거:** 모든 claim은 code/test evidence에 매핑된다.
   - **실패 시:** Remove unsupported prose.
 - [x] **BLOG-04 — Draft the primary locale**
   - **조치:** Update English README/guide and English KDoc first.
@@ -257,20 +257,20 @@
   - **증거:** PR #1089 `## DoD Status` includes bilingual KDoc/README selection guidance and diagram proof.
   - **실패 시:** Do not claim docs complete.
 
-## Diagram gates
+## Diagram 게이트
 
 - [x] **DIA-01 — Pin asset scope and source model**
   - **조치:** Select one architecture diagram showing caller modes, three synchronizers, shared script runtime, same-slot Redis state, and lifecycle outcomes.
-  - **증거:** Final implementation and tests are read before drawing.
-  - **실패 시:** Stop unsupported diagram creation.
+  - **증거:** drawing 전에 최종 구현과 test를 읽었다.
+  - **실패 시:** 지원되지 않는 diagram 생성을 중단한다.
 - [x] **DIA-02 — Load common and kind rules**
   - **조치:** Load diagram common and architecture references.
   - **증거:** Both references were read for this session.
-  - **실패 시:** Stop generic SVG editing.
+  - **실패 시:** generic SVG editing을 중단한다.
 - [x] **DIA-03 — Complete one SVG edit**
   - **조치:** Create one English and one Korean SVG in sequence, never editing both simultaneously.
   - **증거:** Each SVG matches its locale and source model.
-  - **실패 시:** Stop before rendering.
+  - **실패 시:** rendering 전에 중단한다.
 - [x] **DIA-04 — Parse and render the authoritative PNG**
   - **조치:** Parse SVG and render scale-2 PNG for each locale asset.
   - **증거:** Both SVGs parse; both authoritative PNGs are 3800×1800.

--- a/docs/superpowers/plans/2026-07-12-logging-connector-repair-plan.md
+++ b/docs/superpowers/plans/2026-07-12-logging-connector-repair-plan.md
@@ -1,57 +1,56 @@
-# Logging Diagram Connector Repair Implementation Plan
+# Logging Diagram Connector 수리 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** Make all logging diagram arrows visibly and geometrically connect to their target boundaries.
+**목표:** 모든 logging diagram arrow가 target boundary에 시각적으로도, 기하학적으로도 연결되게 만든다.
 
-**Architecture:** Preserve the existing source-backed diagram models and repair only SVG connector coordinates and routes. Process each canonical SVG/PNG pair independently through XML validation, CairoSVG rendering, scripted audits, targeted endpoint assertions, and full-size PNG inspection before syncing the derived site snapshot.
+**아키텍처:** 기존 source-backed diagram model은 보존하고 SVG connector 좌표와 route만 수정한다. Derived site snapshot을 동기화하기 전에 각 canonical SVG/PNG pair를 독립적으로 XML validation, CairoSVG rendering, scripted audit, targeted endpoint assertion, full-size PNG inspection까지 통과시킨다.
 
-**Tech Stack:** SVG, CairoSVG CLI, bluetape diagram audit scripts, Astro site snapshot tooling.
+**기술 스택:** SVG, CairoSVG CLI, bluetape diagram audit script, Astro site snapshot tooling.
 
 ---
 
-### Task 1: Repair logger responsibility-map connectors
+### Task 1: logger responsibility-map connector 수리
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/assets/logging/logger-api-map.svg`
-- Regenerate: `docs/manual/assets/logging/logger-api-map.png`
+- 수정: `docs/manual/assets/logging/logger-api-map.svg`
+- 재생성: `docs/manual/assets/logging/logger-api-map.png`
 
-- [ ] Route the left and right inputs through separate rounded top ports and extend all arrow tips to target boundaries.
-- [ ] Run XML, CairoSVG, connector, geometry, endpoint, mixed-corner, targeted boundary assertions, and a `14×14` primary-marker assertion.
-- [ ] Inspect the 3200×1960 PNG at full size; repeat if any gap, sharp corner, intrusion, or ambiguous convergence remains.
+- [ ] 왼쪽과 오른쪽 input을 분리된 rounded top port로 routing하고 모든 arrow tip을 target boundary까지 연장한다.
+- [ ] XML, CairoSVG, connector, geometry, endpoint, mixed-corner, targeted boundary assertion, `14×14` primary-marker assertion을 실행한다.
+- [ ] 3200×1960 PNG를 full size로 검사한다. gap, sharp corner, intrusion, ambiguous convergence가 남아 있으면 반복한다.
 
-### Task 2: Repair MDC lifecycle connectors
+### Task 2: MDC lifecycle connector 수리
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/assets/logging/mdc-scope-lifecycle.svg`
-- Regenerate: `docs/manual/assets/logging/mdc-scope-lifecycle.png`
+- 수정: `docs/manual/assets/logging/mdc-scope-lifecycle.svg`
+- 재생성: `docs/manual/assets/logging/mdc-scope-lifecycle.png`
 
-- [ ] Extend both progression arrows from the source card edge to the next card edge.
-- [ ] Run XML, CairoSVG, connector, geometry, endpoint, mixed-corner, targeted boundary assertions, and a `14×14` primary-marker assertion.
-- [ ] Inspect the 3200×1960 PNG at full size; repeat if either arrow appears detached or enters a card.
+- [ ] 두 progression arrow를 source card edge에서 다음 card edge까지 연장한다.
+- [ ] XML, CairoSVG, connector, geometry, endpoint, mixed-corner, targeted boundary assertion, `14×14` primary-marker assertion을 실행한다.
+- [ ] 3200×1960 PNG를 full size로 검사한다. arrow가 떨어져 보이거나 card 안으로 들어가면 반복한다.
 
-### Task 3: Repair async sequence message endpoints
+### Task 3: async sequence message endpoint 수리
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/assets/logging/async-channel-sequence.svg`
-- Regenerate: `docs/manual/assets/logging/async-channel-sequence.png`
+- 수정: `docs/manual/assets/logging/async-channel-sequence.svg`
+- 재생성: `docs/manual/assets/logging/async-channel-sequence.png`
 
-- [ ] Normalize seven numbered message rows and the post-close return to lifeline/activation edges.
-- [ ] Run XML, CairoSVG, common connector audits, sequence-style audit, targeted message endpoint assertions, and explicit `16×16` per-color marker assertions.
-- [ ] Inspect the 3600×2240 PNG at full size; repeat if any message floats, overshoots, crosses a label, or uses an inconsistent arrowhead.
+- [ ] 번호가 붙은 7개 message row와 post-close return을 lifeline/activation edge에 맞춘다.
+- [ ] XML, CairoSVG, common connector audit, sequence-style audit, targeted message endpoint assertion, 명시적 `16×16` per-color marker assertion을 실행한다.
+- [ ] 3600×2240 PNG를 full size로 검사한다. message가 floating되거나 overshoot하거나 label을 지나거나 inconsistent arrowhead를 쓰면 반복한다.
 
-### Task 4: Publish and verify the derived site snapshot
+### Task 4: derived site snapshot 게시와 검증
 
-**Files:**
+**파일:**
 
-- Regenerate: `public/manual-assets/bluetape4k-projects/logging/*`
-- Regenerate: `src/data/manual/bluetape4k-projects.snapshot.json`
-- Regenerate: synchronized manual metadata under `src/content/docs/**/manual/bluetape4k-projects/`
+- 재생성: `public/manual-assets/bluetape4k-projects/logging/*`
+- 재생성: `src/data/manual/bluetape4k-projects.snapshot.json`
+- 재생성: `src/content/docs/**/manual/bluetape4k-projects/` 아래 synchronized manual metadata
 
-- [ ] Commit the canonical Projects diagrams after all checklist rows pass.
-- [ ] Synchronize the Site snapshot from the final Projects commit and run snapshot tests, Astro diagnostics/build, browser rendering, and console checks.
-- [ ] Verify both worktrees are clean and retain the local preview server.
+- [ ] 모든 checklist row가 통과한 뒤 canonical Projects diagram을 commit한다.
+- [ ] 최종 Projects commit에서 Site snapshot을 동기화하고 snapshot test, Astro diagnostics/build, browser rendering, console check를 실행한다.
+- [ ] 두 worktree가 clean인지 확인하고 local preview server를 유지한다.

--- a/docs/superpowers/plans/2026-07-12-manual-first-core-coroutines-plan.md
+++ b/docs/superpowers/plans/2026-07-12-manual-first-core-coroutines-plan.md
@@ -1,14 +1,12 @@
-# Core·Coroutines Manual First Implementation Plan
+# Core·Coroutines manual-first 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** `bluetape4k-core`와 `bluetape4k-coroutines`를 repository-owned chapter와 diagram을 갖춘 교과서형 매뉴얼로 만들고, site가 이를 검증 가능한 deterministic snapshot으로 게시하게 한다.
+**목표:** `bluetape4k-core`와 `bluetape4k-coroutines`를 repository-owned chapter와 diagram을 갖춘 교과서형 매뉴얼로 만들고, site가 이를 검증 가능한 deterministic snapshot으로 게시하게 한다.
 
-**Architecture:** `bluetape4k-projects/docs/manual`이 문서와 diagram의 유일한 기술 원본이다. Manifest schema v2가 module landing, bilingual chapter, paired asset inventory를 선언하고 Ruby validator가 source tree를 검증하며, `bluetape4k.github.io`의 Node sync가 chapter와 asset을 함께 변환·복사·digest한다. 콘텐츠는 현재 Kotlin source와 representative test를 먼저 확인한 뒤 Coroutines, Core 순서로 작성하고 blog는 마지막에 manual route와 canonical asset을 참조하도록 정렬한다.
+**아키텍처:** `bluetape4k-projects/docs/manual`이 문서와 diagram의 유일한 기술 원본이다. Manifest schema v2가 module landing, bilingual chapter, paired asset inventory를 선언하고 Ruby validator가 source tree를 검증하며, `bluetape4k.github.io`의 Node sync가 chapter와 asset을 함께 변환·복사·digest한다. 콘텐츠는 현재 Kotlin source와 representative test를 먼저 확인한 뒤 Coroutines, Core 순서로 작성하고 blog는 마지막에 manual route와 canonical asset을 참조하도록 정렬한다.
 
-**Tech
-Stack:** Ruby 3 + Minitest + YAML, Node.js ESM + `node:test`, Astro/Starlight MDX, Markdown, Kotlin source/tests, SVG 1.1, CairoSVG, `xmllint`, Playwright/browser smoke verification
+**기술 스택:** Ruby 3 + Minitest + YAML, Node.js ESM + `node:test`, Astro/Starlight MDX, Markdown, Kotlin source/tests, SVG 1.1, CairoSVG, `xmllint`, Playwright/browser smoke verification
 
 ---
 
@@ -80,17 +78,17 @@ chapterId: lifecycle
 
 ### Task 1: Manifest schema v2 validator를 TDD로 확장
 
-**Files:**
+**파일:**
 
-- Modify: `scripts/manual/manual_contract.rb`
-- Modify: `scripts/manual/validate_manuals_test.rb`
-- Modify: `scripts/manual/export_manifest_test.rb`
-- Modify: `scripts/manual/test-fixtures/valid/docs/manual/manifest.yaml`
-- Create: `scripts/manual/test-fixtures/valid/docs/manual/en/modules/sample/chapter-one.md`
-- Create: `scripts/manual/test-fixtures/valid/docs/manual/ko/modules/sample/chapter-one.md`
-- Create: `scripts/manual/test-fixtures/valid/docs/manual/assets/sample/model.svg`
-- Create: `scripts/manual/test-fixtures/valid/docs/manual/assets/sample/model.png`
-- Modify: `scripts/manual/test-fixtures/missing-ko/docs/manual/manifest.yaml`
+- 수정: `scripts/manual/manual_contract.rb`
+- 수정: `scripts/manual/validate_manuals_test.rb`
+- 수정: `scripts/manual/export_manifest_test.rb`
+- 수정: `scripts/manual/test-fixtures/valid/docs/manual/manifest.yaml`
+- 생성: `scripts/manual/test-fixtures/valid/docs/manual/en/modules/sample/chapter-one.md`
+- 생성: `scripts/manual/test-fixtures/valid/docs/manual/ko/modules/sample/chapter-one.md`
+- 생성: `scripts/manual/test-fixtures/valid/docs/manual/assets/sample/model.svg`
+- 생성: `scripts/manual/test-fixtures/valid/docs/manual/assets/sample/model.png`
+- 수정: `scripts/manual/test-fixtures/missing-ko/docs/manual/manifest.yaml`
 
 - [ ] **Step 1: 유효 fixture를 schema v2 chapter·asset 계약으로 확장한다**
 
@@ -172,9 +170,9 @@ end
 
 - [ ] **Step 3: 실패를 확인한다**
 
-Run: `ruby scripts/manual/validate_manuals_test.rb`
+실행: `ruby scripts/manual/validate_manuals_test.rb`
 
-Expected: FAIL. 현재 validator가 schema 2를 거부하고 chapter, asset, orphan, Markdown reference를 검사하지 않는 assertion이 보인다.
+예상 결과: FAIL. 현재 validator가 schema 2를 거부하고 chapter, asset, orphan, Markdown reference를 검사하지 않는 assertion이 보인다.
 
 - [ ] **Step 4: validator를 최소 책임 단위로 구현한다**
 
@@ -226,15 +224,15 @@ end
 "assets" => ["assets/sample/model.png", "assets/sample/model.svg"],
 ```
 
-Run: `ruby scripts/manual/export_manifest_test.rb`
+실행: `ruby scripts/manual/export_manifest_test.rb`
 
-Expected: PASS. Exporter가 nested key를 제거하거나 path를 변형하지 않는다.
+예상 결과: PASS. Exporter가 nested key를 제거하거나 path를 변형하지 않는다.
 
 - [ ] **Step 6: 전체 manual script test를 통과시킨다**
 
-Run: `ruby scripts/manual/validate_manuals_test.rb && ruby scripts/manual/export_manifest_test.rb && ruby scripts/manual/generate_manuals_test.rb`
+실행: `ruby scripts/manual/validate_manuals_test.rb && ruby scripts/manual/export_manifest_test.rb && ruby scripts/manual/generate_manuals_test.rb`
 
-Expected: 세 test process 모두 0 failures, 0 errors.
+예상 결과: 세 test process 모두 0 failures, 0 errors.
 
 - [ ] **Step 7: validator 계약을 커밋한다**
 
@@ -249,12 +247,12 @@ git commit -m "Validate chaptered manuals as one repository contract" \
 
 ### Task 2: Core·Coroutines inventory와 chapter skeleton을 등록
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/manifest.yaml`
-- Modify: `docs/manual/generated/manifest.json`
-- Create: `docs/manual/{ko,en}/modules/bluetape4k-coroutines/{lifecycle,deferred,flow,subjects,structured-concurrency,operations,recipes}.md`
-- Create: `docs/manual/{ko,en}/modules/bluetape4k-core/{validation,bounded-collections,encoding-data,time-ranges,concurrency-lifecycle,recipes}.md`
+- 수정: `docs/manual/manifest.yaml`
+- 수정: `docs/manual/generated/manifest.json`
+- 생성: `docs/manual/{ko,en}/modules/bluetape4k-coroutines/{lifecycle,deferred,flow,subjects,structured-concurrency,operations,recipes}.md`
+- 생성: `docs/manual/{ko,en}/modules/bluetape4k-core/{validation,bounded-collections,encoding-data,time-ranges,concurrency-lifecycle,recipes}.md`
 
 - [ ] **Step 1: Manifest에 정확한 chapter inventory를 추가한다**
 
@@ -266,15 +264,15 @@ Coroutines 순서는 `lifecycle`, `deferred`, `flow`, `subjects`, `structured-co
 
 - [ ] **Step 3: 생성된 inventory와 frontmatter가 유효한지 확인한다**
 
-Run: `ruby scripts/manual/validate_manuals.rb`
+실행: `ruby scripts/manual/validate_manuals.rb`
 
-Expected: `Manual contract valid`와 module 수가 출력되고 exit 0.
+예상 결과: `Manual contract valid`와 module 수가 출력되고 exit 0.
 
 - [ ] **Step 4: generated manifest를 갱신하고 drift가 없는지 확인한다**
 
-Run: `ruby scripts/manual/export_manifest.rb && git diff --check`
+실행: `ruby scripts/manual/export_manifest.rb && git diff --check`
 
-Expected: `docs/manual/generated/manifest.json`에 schemaVersion 2와 두 module의 chapters가 나타나며 whitespace error가 없다.
+예상 결과: `docs/manual/generated/manifest.json`에 schemaVersion 2와 두 module의 chapters가 나타나며 whitespace error가 없다.
 
 - [ ] **Step 5: inventory와 chapter structure를 커밋한다**
 
@@ -291,16 +289,16 @@ git commit -m "Give Core and Coroutines stable manual chapter routes" \
 
 **Repository:** `/Users/debop/work/bluetape4k/bluetape4k.github.io/.worktrees/feature-ecosystem-atlas-manual`
 
-**Files:**
+**파일:**
 
-- Modify: `scripts/manual/lib/paths.mjs`
-- Modify: `scripts/manual/lib/frontmatter.mjs`
-- Modify: `scripts/manual/sync-manual.mjs`
-- Modify: `scripts/manual/validate-snapshot.mjs`
-- Create: `tests/manual/paths.test.mjs`
-- Modify: `tests/manual/frontmatter.test.mjs`
-- Modify: `tests/manual/snapshot.test.mjs`
-- Modify: `tests/manual/sync.test.mjs`
+- 수정: `scripts/manual/lib/paths.mjs`
+- 수정: `scripts/manual/lib/frontmatter.mjs`
+- 수정: `scripts/manual/sync-manual.mjs`
+- 수정: `scripts/manual/validate-snapshot.mjs`
+- 생성: `tests/manual/paths.test.mjs`
+- 수정: `tests/manual/frontmatter.test.mjs`
+- 수정: `tests/manual/snapshot.test.mjs`
+- 수정: `tests/manual/sync.test.mjs`
 
 - [ ] **Step 1: chapter destination과 asset destination test를 작성한다**
 
@@ -361,9 +359,9 @@ assert.equal(first.snapshot.assetFiles, expectedAssets);
 
 - [ ] **Step 4: test가 현재 구현에서 실패하는지 확인한다**
 
-Run: `node --test --test-name-pattern='manual|snapshot|frontmatter|paths' tests/manual/*.test.mjs`
+실행: `node --test --test-name-pattern='manual|snapshot|frontmatter|paths' tests/manual/*.test.mjs`
 
-Expected: FAIL. `assetDestinationFor` 미정의, chapter metadata 누락, asset count 누락 중 하나 이상이 보인다.
+예상 결과: FAIL. `assetDestinationFor` 미정의, chapter metadata 누락, asset count 누락 중 하나 이상이 보인다.
 
 - [ ] **Step 5: manifest inventory를 기준으로 document와 asset entry를 만든다**
 
@@ -399,9 +397,9 @@ Repository source link rewrite와 manual asset rewrite는 별도 named function�
 
 - [ ] **Step 7: site manual test와 build를 통과시킨다**
 
-Run: `node --test --test-name-pattern='manual|snapshot|frontmatter|paths' tests/manual/*.test.mjs && npm run build`
+실행: `node --test --test-name-pattern='manual|snapshot|frontmatter|paths' tests/manual/*.test.mjs && npm run build`
 
-Expected: targeted Node tests PASS, Astro build exit 0, broken internal link나 missing asset error 없음.
+예상 결과: targeted Node tests PASS, Astro build exit 0, broken internal link나 missing asset error 없음.
 
 - [ ] **Step 8: site sync 계약을 커밋한다**
 
@@ -418,10 +416,10 @@ git commit -m "Publish manual chapters and assets as one snapshot" \
 
 **Repository:** Projects worktree
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/manifest.yaml`
-- Create: `docs/manual/assets/coroutines/{module-foundation,scope-lifecycle,deferred-race-policy,ordered-parallel-flow,subject-contracts,structured-policies,observability-boundaries}.{svg,png}`
+- 수정: `docs/manual/manifest.yaml`
+- 생성: `docs/manual/assets/coroutines/{module-foundation,scope-lifecycle,deferred-race-policy,ordered-parallel-flow,subject-contracts,structured-policies,observability-boundaries}.{svg,png}`
 
 - [ ] **Step 1: 각 diagram의 source/test evidence 표를 먼저 작성한다**
 
@@ -469,13 +467,13 @@ cairosvg docs/manual/assets/coroutines/observability-boundaries.svg \
   -o docs/manual/assets/coroutines/observability-boundaries.png -s 2
 ```
 
-Expected: 모든 `xmllint`가 exit 0이고 PNG가 SVG의 2배 raster size로 생성된다. Full-size 검사에서 잘린 text, 겹침, 흐릿한 화살표, 의미 없는 장식이 없다.
+예상 결과: 모든 `xmllint`가 exit 0이고 PNG가 SVG의 2배 raster size로 생성된다. Full-size 검사에서 잘린 text, 겹침, 흐릿한 화살표, 의미 없는 장식이 없다.
 
 - [ ] **Step 4: Manifest에 14개 asset path를 basename별 SVG/PNG 순서로 등록한다**
 
-Run: `ruby scripts/manual/validate_manuals.rb && git diff --check`
+실행: `ruby scripts/manual/validate_manuals.rb && git diff --check`
 
-Expected: orphan/pair/reference error가 없고 exit 0.
+예상 결과: orphan/pair/reference error가 없고 exit 0.
 
 - [ ] **Step 5: Coroutines diagram source를 커밋한다**
 
@@ -490,21 +488,21 @@ git commit -m "Make Coroutines diagrams part of the manual source" \
 
 ### Task 5: Coroutines lifecycle·deferred chapter를 교과서 수준으로 완성
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-coroutines.md`
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-coroutines/{lifecycle,deferred}.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-coroutines.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-coroutines/{lifecycle,deferred}.md`
 
 - [ ] **Step 1: source와 representative test를 다시 읽고 사실 표를 작성한다**
 
-Run:
+실행:
 
 ```bash
 rg -n "class DeferredValue|fun awaitAny|awaitAnyAndCancelOthers|firstSuccessTaskScope|CloseableCoroutineScope|ThreadPoolCoroutineScope|CancellationException" \
   bluetape4k/coroutines/src/main bluetape4k/coroutines/src/test
 ```
 
-Expected: `DeferredValue`의 eager owned scope, `awaitAny`의 first-completion semantics, cancel-others variant, first-success policy, closeable scope의 cleanup test 위치를 확보한다.
+예상 결과: `DeferredValue`의 eager owned scope, `awaitAny`의 first-completion semantics, cancel-others variant, first-success policy, closeable scope의 cleanup test 위치를 확보한다.
 
 - [ ] **Step 2: lifecycle chapter에 ownership decision tree와 완전한 예제를 작성한다**
 
@@ -516,9 +514,9 @@ Expected: `DeferredValue`의 eager owned scope, `awaitAny`의 first-completion s
 
 - [ ] **Step 4: 양 언어 parity와 source link를 검증한다**
 
-Run: `ruby scripts/manual/validate_manuals.rb && rg -n "blog" docs/manual/{ko,en}/modules/bluetape4k-coroutines/{lifecycle,deferred}.md`
+실행: `ruby scripts/manual/validate_manuals.rb && rg -n "blog" docs/manual/{ko,en}/modules/bluetape4k-coroutines/{lifecycle,deferred}.md`
 
-Expected: validator exit 0. Blog가 설명을 대신하는 문장 없음; blog 링크가 있다면 추가 읽기 역할뿐이다.
+예상 결과: validator exit 0. Blog가 설명을 대신하는 문장 없음; blog 링크가 있다면 추가 읽기 역할뿐이다.
 
 - [ ] **Step 5: lifecycle·deferred chapter를 커밋한다**
 
@@ -533,20 +531,20 @@ git commit -m "Teach Coroutines ownership and race semantics from source" \
 
 ### Task 6: Coroutines Flow·Subject chapter를 완성
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-coroutines/{flow,subjects}.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-coroutines/{flow,subjects}.md`
 
 - [ ] **Step 1: ordering, capacity, terminal contract를 source/test에서 확인한다**
 
-Run:
+실행:
 
 ```bash
 rg -n "fun .*mapParallel|parallelism|async\(|awaitCollector|complete\(|error\(|replay|buffer|capacity" \
   bluetape4k/coroutines/src/main bluetape4k/coroutines/src/test
 ```
 
-Expected: `flow.async` ordered emission, `mapParallel` parallel result ordering, `parallelism <= 1`, Subject collector startup과 terminal call test를 찾는다.
+예상 결과: `flow.async` ordered emission, `mapParallel` parallel result ordering, `parallelism <= 1`, Subject collector startup과 terminal call test를 찾는다.
 
 - [ ] **Step 2: Flow chapter를 선택 지도 중심으로 작성한다**
 
@@ -558,7 +556,7 @@ Publish, Behavior, Replay, Multicast, UnicastWork의 delivery, retained state/hi
 
 - [ ] **Step 4: runnable workshop link를 실제 module path와 대조한다**
 
-Run:
+실행:
 
 ```bash
 test -d /Users/debop/work/bluetape4k/bluetape4k-workshop/kotlin/flow-extensions-parallel-enrichment
@@ -567,7 +565,7 @@ test -d /Users/debop/work/bluetape4k/bluetape4k-workshop/kotlin/flow-extensions-
 ruby scripts/manual/validate_manuals.rb
 ```
 
-Expected: 세 workshop directory와 manual validation 모두 성공.
+예상 결과: 세 workshop directory와 manual validation 모두 성공.
 
 - [ ] **Step 5: Flow·Subject chapter를 커밋한다**
 
@@ -582,10 +580,10 @@ git commit -m "Document Coroutines stream contracts by ordering and delivery" \
 
 ### Task 7: Coroutines structured·operations·recipes와 landing을 완성
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-coroutines.md`
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-coroutines/{structured-concurrency,operations,recipes}.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-coroutines.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-coroutines/{structured-concurrency,operations,recipes}.md`
 
 - [ ] **Step 1: structured policy chapter를 실패 의미로 조직한다**
 
@@ -605,7 +603,7 @@ Landing은 API 상세를 반복하지 않고 초급, HTTP service, stream proces
 
 - [ ] **Step 5: Coroutines 전체 품질 gate를 실행한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_manuals.rb
@@ -613,7 +611,7 @@ rg -n "DeferredValue|awaitAny|mapParallel|awaitCollector|taskScope|firstSuccessT
 git diff --check
 ```
 
-Expected: validator exit 0, 핵심 API가 양 언어의 적절한 chapter에 존재, whitespace error 없음.
+예상 결과: validator exit 0, 핵심 API가 양 언어의 적절한 chapter에 존재, whitespace error 없음.
 
 - [ ] **Step 6: Coroutines manual을 커밋한다**
 
@@ -630,22 +628,22 @@ git commit -m "Complete the Coroutines manual as an operational guide" \
 
 **Repository:** Site worktree
 
-**Files:**
+**파일:**
 
-- Generated: `src/content/docs/manual/bluetape4k-projects/modules/bluetape4k-coroutines/**`
-- Generated: `src/content/docs/ko/manual/bluetape4k-projects/modules/bluetape4k-coroutines/**`
-- Generated: `public/manual-assets/bluetape4k-projects/coroutines/**`
-- Generated: `src/data/manual/bluetape4k-projects.{manifest,snapshot}.json`
+- 생성됨: `src/content/docs/manual/bluetape4k-projects/modules/bluetape4k-coroutines/**`
+- 생성됨: `src/content/docs/ko/manual/bluetape4k-projects/modules/bluetape4k-coroutines/**`
+- 생성됨: `public/manual-assets/bluetape4k-projects/coroutines/**`
+- 생성됨: `src/data/manual/bluetape4k-projects.{manifest,snapshot}.json`
 
 - [ ] **Step 1: Projects source가 clean commit인지 확인한다**
 
-Run: `git -C /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feature-all-module-manuals status --short && git -C /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feature-all-module-manuals rev-parse HEAD`
+실행: `git -C /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feature-all-module-manuals status --short && git -C /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feature-all-module-manuals rev-parse HEAD`
 
-Expected: status output 없음, 40-character source commit 출력.
+예상 결과: status output 없음, 40-character source commit 출력.
 
 - [ ] **Step 2: Site snapshot을 write mode로 생성한다**
 
-Run:
+실행:
 
 ```bash
 npm run sync:manual -- \
@@ -653,11 +651,11 @@ npm run sync:manual -- \
   --repository bluetape4k-projects
 ```
 
-Expected: snapshot written message에 증가한 localized document count와 asset count가 출력된다.
+예상 결과: snapshot written message에 증가한 localized document count와 asset count가 출력된다.
 
 - [ ] **Step 3: deterministic check, test, build를 실행한다**
 
-Run:
+실행:
 
 ```bash
 npm run check:manual
@@ -666,7 +664,7 @@ BLUETAPE4K_PROJECTS_SOURCE=/Users/debop/work/bluetape4k/bluetape4k-projects/.wor
 npm run build
 ```
 
-Expected: snapshot matches, targeted tests PASS, Astro build exit 0.
+예상 결과: snapshot matches, targeted tests PASS, Astro build exit 0.
 
 - [ ] **Step 4: ko/en landing과 7개 chapter를 browser smoke test한다**
 
@@ -687,22 +685,22 @@ git commit -m "Publish the chaptered Coroutines manual snapshot" \
 
 **Repository:** Projects worktree
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/manifest.yaml`
-- Create: `docs/manual/assets/core/{validation-boundary,bounded-collection-ordering,concurrent-reducer-capacity,shutdown-order}.{svg,png}`
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-core/{validation,bounded-collections}.md`
+- 수정: `docs/manual/manifest.yaml`
+- 생성: `docs/manual/assets/core/{validation-boundary,bounded-collection-ordering,concurrent-reducer-capacity,shutdown-order}.{svg,png}`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-core/{validation,bounded-collections}.md`
 
 - [ ] **Step 1: Core 계약을 source/test에서 다시 확인한다**
 
-Run:
+실행:
 
 ```bash
 rg -n "fun .*require|class BoundedStack|class RingBuffer|class ConcurrentReducer|class ShutdownQueue|capacity|evict|close" \
   bluetape4k/core/src/main bluetape4k/core/src/test
 ```
 
-Expected: require helper의 receiver return/exception, stack newest-first, ring oldest-first, capacity eviction, reducer full/closed behavior, shutdown LIFO evidence를 확보한다.
+예상 결과: require helper의 receiver return/exception, stack newest-first, ring oldest-first, capacity eviction, reducer full/closed behavior, shutdown LIFO evidence를 확보한다.
 
 - [ ] **Step 2: 4개 Core diagram을 한 쌍씩 생성·검증한다**
 
@@ -731,9 +729,9 @@ Kotlin `require/check`, bluetape `require*`, nullable/blank/collection 조건을
 
 - [ ] **Step 5: Core asset과 두 chapter를 검증·커밋한다**
 
-Run: `ruby scripts/manual/export_manifest.rb && ruby scripts/manual/validate_manuals.rb && git diff --check`
+실행: `ruby scripts/manual/export_manifest.rb && ruby scripts/manual/validate_manuals.rb && git diff --check`
 
-Expected: schema/asset/chapter validation exit 0.
+예상 결과: schema/asset/chapter validation exit 0.
 
 ```bash
 git add docs/manual
@@ -746,21 +744,21 @@ git commit -m "Explain Core boundaries and bounded state with verified diagrams"
 
 ### Task 10: Core encoding·time·concurrency·recipes와 landing을 완성
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-core.md`
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-core/{encoding-data,time-ranges,concurrency-lifecycle,recipes}.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-core.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-core/{encoding-data,time-ranges,concurrency-lifecycle,recipes}.md`
 
 - [ ] **Step 1: encoding과 time API surface를 source/test로 분류한다**
 
-Run:
+실행:
 
 ```bash
 rg -n "Base64|Hex|encode|decode|Range|Period|Duration|Instant|LocalDate|ConcurrentReducer|ShutdownQueue" \
   bluetape4k/core/src/main bluetape4k/core/src/test
 ```
 
-Expected: 실제 public helper와 test path 목록을 얻고, 존재하지 않는 범용 codec/time abstraction을 문서에 만들지 않는다.
+예상 결과: 실제 public helper와 test path 목록을 얻고, 존재하지 않는 범용 codec/time abstraction을 문서에 만들지 않는다.
 
 - [ ] **Step 2: encoding-data chapter를 format과 failure 기준으로 작성한다**
 
@@ -780,7 +778,7 @@ Validation pipeline, bounded recent history, safe aggregation queue, determinist
 
 - [ ] **Step 6: Core 전체 품질 gate와 commit을 실행한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_manuals.rb
@@ -788,7 +786,7 @@ rg -n "BoundedStack|RingBuffer|ConcurrentReducer|ShutdownQueue" docs/manual/{ko,
 git diff --check
 ```
 
-Expected: validator exit 0, 핵심 계약이 양 언어에 존재, whitespace error 없음.
+예상 결과: validator exit 0, 핵심 계약이 양 언어에 존재, whitespace error 없음.
 
 ```bash
 git add docs/manual/{ko,en}/modules/bluetape4k-core*
@@ -803,15 +801,15 @@ git commit -m "Complete the Core manual around invariants and lifecycle" \
 
 **Repository:** Site worktree
 
-**Files:**
+**파일:**
 
-- Generated: `src/content/docs/{ko/,}manual/bluetape4k-projects/modules/bluetape4k-core/**`
-- Generated: `public/manual-assets/bluetape4k-projects/core/**`
-- Generated: `src/data/manual/bluetape4k-projects.{manifest,snapshot}.json`
+- 생성됨: `src/content/docs/{ko/,}manual/bluetape4k-projects/modules/bluetape4k-core/**`
+- 생성됨: `public/manual-assets/bluetape4k-projects/core/**`
+- 생성됨: `src/data/manual/bluetape4k-projects.{manifest,snapshot}.json`
 
 - [ ] **Step 1: clean Projects source commit에서 sync한다**
 
-Run:
+실행:
 
 ```bash
 npm run sync:manual -- \
@@ -819,13 +817,13 @@ npm run sync:manual -- \
   --repository bluetape4k-projects
 ```
 
-Expected: snapshot의 documentFiles가 Core 12 localized chapter만큼, assetFiles가 8만큼 증가한다.
+예상 결과: snapshot의 documentFiles가 Core 12 localized chapter만큼, assetFiles가 8만큼 증가한다.
 
 - [ ] **Step 2: deterministic validation과 build를 실행한다**
 
-Run: `npm run check:manual && BLUETAPE4K_PROJECTS_SOURCE=/Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feature-all-module-manuals node --test --test-name-pattern='manual|snapshot|frontmatter|paths' tests/manual/*.test.mjs && npm run build`
+실행: `npm run check:manual && BLUETAPE4K_PROJECTS_SOURCE=/Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feature-all-module-manuals node --test --test-name-pattern='manual|snapshot|frontmatter|paths' tests/manual/*.test.mjs && npm run build`
 
-Expected: 모든 command exit 0.
+예상 결과: 모든 command exit 0.
 
 - [ ] **Step 3: ko/en Core landing과 6개 chapter를 browser smoke test한다**
 
@@ -845,23 +843,23 @@ git commit -m "Publish the chaptered Core manual snapshot" \
 
 **Repository:** Site worktree
 
-**Files:**
+**파일:**
 
-- Modify: `src/content/docs/{ko/,}blog/bluetape4k-projects-part1-shared-foundation.mdx`
-- Modify: `src/content/docs/{ko/,}blog/bluetape4k-projects-part2-core-coroutines-tests.mdx`
-- Modify: `src/content/docs/{ko/,}blog/bluetape4k-flow-extensions-workshop.mdx`
-- Modify: `src/content/docs/{ko/,}blog/coroutine-observability-micrometer-readiness.mdx`
+- 수정: `src/content/docs/{ko/,}blog/bluetape4k-projects-part1-shared-foundation.mdx`
+- 수정: `src/content/docs/{ko/,}blog/bluetape4k-projects-part2-core-coroutines-tests.mdx`
+- 수정: `src/content/docs/{ko/,}blog/bluetape4k-flow-extensions-workshop.mdx`
+- 수정: `src/content/docs/{ko/,}blog/coroutine-observability-micrometer-readiness.mdx`
 
 - [ ] **Step 1: blog에만 남은 기술 계약을 찾아 manual coverage와 비교한다**
 
-Run:
+실행:
 
 ```bash
 rg -n "awaitAny|mapParallel|Subject|ConcurrentReducer|ShutdownQueue|cancellation|readiness" \
   src/content/docs/blog src/content/docs/ko/blog
 ```
 
-Expected: 각 기술 문장이 Core/Coroutines manual의 해당 chapter에 존재하는지 대응표를 만든다. Manual에 없는 유효한 계약은 먼저 Projects manual에 추가하고 sync한 뒤 blog를 편집한다.
+예상 결과: 각 기술 문장이 Core/Coroutines manual의 해당 chapter에 존재하는지 대응표를 만든다. Manual에 없는 유효한 계약은 먼저 Projects manual에 추가하고 sync한 뒤 blog를 편집한다.
 
 - [ ] **Step 2: blog의 역할을 narrative와 workshop walkthrough로 제한한다**
 
@@ -873,9 +871,9 @@ Manual로 승격된 diagram은 `/manual-assets/bluetape4k-projects/coroutines/or
 
 - [ ] **Step 4: blog와 manual의 bilingual route를 검증한다**
 
-Run: `npm test && npm run build`
+실행: `npm test && npm run build`
 
-Expected: Node tests PASS, Astro build exit 0, broken internal links 없음.
+예상 결과: Node tests PASS, Astro build exit 0, broken internal links 없음.
 
 - [ ] **Step 5: 4개 blog의 ko/en page를 browser smoke test하고 commit한다**
 
@@ -896,7 +894,7 @@ git commit -m "Align technical blog narratives with the manual source of truth" 
 
 - [ ] **Step 1: Projects manual의 최종 contract를 검증한다**
 
-Run:
+실행:
 
 ```bash
 cd /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feature-all-module-manuals
@@ -908,22 +906,22 @@ git diff --check
 git status --short
 ```
 
-Expected: 모든 test/validator exit 0, diff check clean, status output 없음.
+예상 결과: 모든 test/validator exit 0, diff check clean, status output 없음.
 
 - [ ] **Step 2: SVG/PNG inventory와 실제 file을 대조한다**
 
-Run:
+실행:
 
 ```bash
 find docs/manual/assets -type f \( -name '*.svg' -o -name '*.png' \) | sort
 ruby scripts/manual/validate_manuals.rb
 ```
 
-Expected: Manifest 등록 수와 file 수가 일치하고 orphan/missing pair 없음. 모든 PNG는 대응 SVG의 최종 render다.
+예상 결과: Manifest 등록 수와 file 수가 일치하고 orphan/missing pair 없음. 모든 PNG는 대응 SVG의 최종 render다.
 
 - [ ] **Step 3: Site snapshot을 source HEAD에서 마지막으로 재생성·검증한다**
 
-Run:
+실행:
 
 ```bash
 cd /Users/debop/work/bluetape4k/bluetape4k.github.io/.worktrees/feature-ecosystem-atlas-manual
@@ -934,7 +932,7 @@ npm run build
 git diff --check
 ```
 
-Expected: sync와 check의 sourceCommit이 Projects HEAD와 같고, tests/build/diff check가 모두 성공한다.
+예상 결과: sync와 check의 sourceCommit이 Projects HEAD와 같고, tests/build/diff check가 모두 성공한다.
 
 - [ ] **Step 4: 최종 visual QA matrix를 완료한다**
 

--- a/docs/superpowers/plans/2026-07-12-manual-first-logging-plan.md
+++ b/docs/superpowers/plans/2026-07-12-manual-first-logging-plan.md
@@ -1,52 +1,50 @@
-# Logging Manual First Implementation Plan
+# Logging manual-first 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** `bluetape4k-logging`을 source/test 기반 bilingual chapter와 canonical diagram을 갖춘 manual-first reference로 게시한다.
+**목표:** `bluetape4k-logging`을 source/test 기반 bilingual chapter와 canonical diagram을 갖춘 manual-first reference로 게시한다.
 
-**Architecture:** Projects의 `docs/manual`이 문서와 diagram 원본을 소유하고 schema v2 manifest가 inventory를 선언한다. Site는 Projects commit을 deterministic snapshot으로 동기화하며 blog는 manual route를 참조하는 파생 글로 유지한다.
+**아키텍처:** Projects의 `docs/manual`이 문서와 diagram 원본을 소유하고 schema v2 manifest가 inventory를 선언한다. Site는 Projects commit을 deterministic snapshot으로 동기화하며 blog는 manual route를 참조하는 파생 글로 유지한다.
 
-**Tech
-Stack:** Markdown, YAML, Kotlin source/tests, SVG, CairoSVG, Ruby/Minitest manual validator, Node.js snapshot tests, Astro/Starlight
+**기술 스택:** Markdown, YAML, Kotlin source/tests, SVG, CairoSVG, Ruby/Minitest manual validator, Node.js snapshot tests, Astro/Starlight
 
 ---
 
-### Task 1: Core 명칭과 Logging landing/chapter inventory
+### Task 1: Core 명칭과 Logging landing/chapter inventory 정렬
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-core.md`
-- Modify: `docs/manual/{ko,en}/modules/bluetape4k-logging.md`
-- Create: `docs/manual/{ko,en}/modules/bluetape4k-logging/{logger-foundation,lazy-messages,scoped-mdc,coroutine-mdc,async-channel,operations-recipes}.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-core.md`
+- 수정: `docs/manual/{ko,en}/modules/bluetape4k-logging.md`
+- 생성: `docs/manual/{ko,en}/modules/bluetape4k-logging/{logger-foundation,lazy-messages,scoped-mdc,coroutine-mdc,async-channel,operations-recipes}.md`
 
 - [ ] **Step 1:** Core title/H1을 `Core Kotlin library` / `Core Kotlin 라이브러리`로 정렬한다.
 - [ ] **Step 2:** Logging landing에 선택 지도와 6개 chapter 학습 경로를 작성한다.
-- [ ] **Step 3:** KO chapter 6개를 current source/test 링크와 독립 실행 예제로 작성한다.
-- [ ] **Step 4:** EN chapter 6개를 의미·순서 parity로 작성한다.
+- [ ] **Step 3:** KO chapter 6개를 current source/test link와 독립 실행 예제로 작성한다.
+- [ ] **Step 4:** EN chapter 6개를 의미와 순서 parity가 맞도록 작성한다.
 - [ ] **Step
   5:** `ruby scripts/manual/validate_manuals.rb`를 실행해 아직 manifest 미등록 chapter가 orphan이 아닌지 확인하고 다음 task로 진행한다.
 
-### Task 2: Canonical logging diagrams
+### Task 2: canonical logging diagram 작성
 
-**Files:**
+**파일:**
 
-- Create: `docs/manual/assets/logging/logger-api-map.{svg,png}`
-- Create: `docs/manual/assets/logging/mdc-scope-lifecycle.{svg,png}`
-- Create: `docs/manual/assets/logging/async-channel-sequence.{svg,png}`
+- 생성: `docs/manual/assets/logging/logger-api-map.{svg,png}`
+- 생성: `docs/manual/assets/logging/mdc-scope-lifecycle.{svg,png}`
+- 생성: `docs/manual/assets/logging/async-channel-sequence.{svg,png}`
 
 - [ ] **Step 1:** source-backed reader question과 architecture/sequence reference PNG를 ledger에 고정한다.
-- [ ] **Step 2:** `logger-api-map.svg`를 작성하고 XML → CairoSVG scale 2 → audits → full-size PNG 순서로 검증한다.
+- [ ] **Step 2:** `logger-api-map.svg`를 작성하고 XML → CairoSVG scale 2 → audit → full-size PNG 순서로 검증한다.
 - [ ] **Step 3:** `mdc-scope-lifecycle.svg`를 같은 one-asset loop로 검증한다.
-- [ ] **Step 4:** `async-channel-sequence.svg`를 participant/lifeline/activation/numbered messages/close branch와 함께 검증한다.
+- [ ] **Step 4:** `async-channel-sequence.svg`를 participant/lifeline/activation/numbered message/close branch와 함께 검증한다.
 - [ ] **Step 5:** chapter image link와 SVG/PNG pair를 확인한다.
 
-### Task 3: Manifest와 Projects verification
+### Task 3: manifest와 Projects 검증
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/manifest.yaml`
-- Modify: `docs/superpowers/checklists/2026-07-12-logging-manual-checklist.md`
+- 수정: `docs/manual/manifest.yaml`
+- 수정: `docs/superpowers/checklists/2026-07-12-logging-manual-checklist.md`
 
 - [ ] **Step 1:** logging entry에 6개 chapter와 6개 asset path를 같은 순서로 등록한다.
 - [ ] **Step 2:** `ruby scripts/manual/validate_manuals_test.rb`와 `ruby scripts/manual/export_manifest_test.rb`를 실행한다.
@@ -54,22 +52,22 @@ Stack:** Markdown, YAML, Kotlin source/tests, SVG, CairoSVG, Ruby/Minitest manua
 - [ ] **Step 4:** `./gradlew :bluetape4k-logging:test --no-configuration-cache`를 실행한다.
 - [ ] **Step 5:** diff/checklist를 review하고 Lore commit으로 Projects checkpoint를 만든다.
 
-### Task 4: Site snapshot과 derived blog
+### Task 4: Site snapshot과 derived blog 정렬
 
-**Files:**
+**파일:**
 
-- Generated: `bluetape4k.github.io/src/content/docs/{ko/,}manual/bluetape4k-projects/**`
-- Generated: `bluetape4k.github.io/public/manual-assets/bluetape4k-projects/logging/**`
-- Modify: `bluetape4k.github.io/src/content/docs/{ko/,}blog/bluetape4k-projects-part2-core-coroutines-tests.mdx`
+- 생성됨: `bluetape4k.github.io/src/content/docs/{ko/,}manual/bluetape4k-projects/**`
+- 생성됨: `bluetape4k.github.io/public/manual-assets/bluetape4k-projects/logging/**`
+- 수정: `bluetape4k.github.io/src/content/docs/{ko/,}blog/bluetape4k-projects-part2-core-coroutines-tests.mdx`
 
 - [ ] **Step 1:** Projects checkpoint revision으로 site manual sync를 실행한다.
 - [ ] **Step 2:** KO/EN blog logging section의 상세 reference를 manual landing/chapter route로 바꾼다.
-- [ ] **Step 3:** Node manual tests, snapshot `--check`, Astro check/build를 실행한다.
-- [ ] **Step 4:** localhost에서 KO/EN landing, MDC와 async chapter, PNG, blog links/console을 검증한다.
+- [ ] **Step 3:** Node manual test, snapshot `--check`, Astro check/build를 실행한다.
+- [ ] **Step 4:** localhost에서 KO/EN landing, MDC와 async chapter, PNG, blog link/console을 검증한다.
 - [ ] **Step 5:** diff/checklist를 review하고 Lore commit으로 Site checkpoint를 만든다.
 
-## Self-review
+## 자체 검토
 
-- Spec coverage: Core rename, 6 bilingual chapters, 3 paired diagrams, manifest, site snapshot, blog, verification이 Task 1–4에 모두 연결됨.
-- Placeholder scan: `TBD`, `TODO`, `similar`, 미정 구현 없음.
-- Type/path consistency: chapter IDs와 asset basenames가 spec/plan/manifest target에서 동일함.
+- Spec coverage: Core rename, 6개 bilingual chapter, 3개 paired diagram, manifest, site snapshot, blog, verification이 Task 1–4에 모두 연결된다.
+- Placeholder scan: `TBD`, `TODO`, `similar`, 미정 구현이 없다.
+- Type/path consistency: chapter ID와 asset basename이 spec/plan/manifest target에서 동일하다.

--- a/docs/superpowers/plans/2026-07-13-cassandra-detailed-manual.md
+++ b/docs/superpowers/plans/2026-07-13-cassandra-detailed-manual.md
@@ -1,14 +1,12 @@
-# Cassandra Detailed Manual Implementation Plan
+# Cassandra 상세 manual 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** `bluetape4k-cassandra`를 1.11.0 source/test에 고정된 한국어·영문 landing과 5개 상세 chapter를 갖춘 versioned manual로 게시한다.
+**목표:** `bluetape4k-cassandra`를 1.11.0 source/test에 고정된 한국어·영문 landing과 5개 상세 chapter를 갖춘 versioned manual로 게시한다.
 
-**Architecture:** `bluetape4k-projects/docs/manual`이 기술 설명의 source of truth이며 landing은 선택 지도, 하위 chapter는 session, coroutine query, data mapping, statement 작성, 운영·테스트 책임을 각각 소유한다. Manifest가 bilingual inventory를 선언하고 Projects validator가 1.11.0 release path를 검증한 뒤, `bluetape4k.github.io`가 같은 release commit을 유지한 채 1.11 snapshot을 editorial refresh한다.
+**아키텍처:** `bluetape4k-projects/docs/manual`이 기술 설명의 source of truth이며 landing은 선택 지도, 하위 chapter는 session, coroutine query, data mapping, statement 작성, 운영·테스트 책임을 각각 소유한다. Manifest가 bilingual inventory를 선언하고 Projects validator가 1.11.0 release path를 검증한 뒤, `bluetape4k.github.io`가 같은 release commit을 유지한 채 1.11 snapshot을 editorial refresh한다.
 
-**Tech
-Stack:** Markdown, YAML, Kotlin/Apache Cassandra Java Driver API examples, Ruby/Minitest manual validators, Gradle/JUnit 5/Testcontainers, Node.js manual snapshot tests, Astro/Starlight, browser visual QA
+**기술 스택:** Markdown, YAML, Kotlin/Apache Cassandra Java Driver API examples, Ruby/Minitest manual validators, Gradle/JUnit 5/Testcontainers, Node.js manual snapshot tests, Astro/Starlight, browser visual QA
 
 ---
 
@@ -53,7 +51,7 @@ Stack:** Markdown, YAML, Kotlin/Apache Cassandra Java Driver API examples, Ruby/
 
 Site의 generated manual 파일과 data JSON은 직접 편집하지 않고 `npm run sync:manual`로만 갱신한다.
 
-## Release evidence ledger
+## Release 증거 원장
 
 | 계약                     | 1.11.0 근거                                                                  | 매뉴얼 결론                                                                                                        |
 |--------------------------|------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
@@ -69,16 +67,16 @@ Site의 generated manual 파일과 data JSON은 직접 편집하지 않고 `npm 
 
 ### Task 1: Landing과 session lifecycle을 작성한다
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/ko/modules/bluetape4k-cassandra.md`
-- Modify: `docs/manual/en/modules/bluetape4k-cassandra.md`
-- Create: `docs/manual/ko/modules/bluetape4k-cassandra/session-lifecycle.md`
-- Create: `docs/manual/en/modules/bluetape4k-cassandra/session-lifecycle.md`
+- 수정: `docs/manual/ko/modules/bluetape4k-cassandra.md`
+- 수정: `docs/manual/en/modules/bluetape4k-cassandra.md`
+- 생성: `docs/manual/ko/modules/bluetape4k-cassandra/session-lifecycle.md`
+- 생성: `docs/manual/en/modules/bluetape4k-cassandra/session-lifecycle.md`
 
 - [ ] **Step 1: 1.11.0 session 계약을 다시 읽는다**
 
-Run:
+실행:
 
 ```bash
 git show 1.11.0:data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CqlSessionProvider.kt
@@ -88,7 +86,7 @@ git merge-base --is-ancestor 9ad16dc09 1.11.0
 git merge-base --is-ancestor 0ad15119d 1.11.0
 ```
 
-Expected: cache identity fix command exits 0, bootstrap builder fix command exits 1. `resolveSession`에서 admin session은 `builderSupplier().build()`, final session은 `withKeyspace(...).apply(builder).build()`를 사용한다.
+예상 결과: cache identity fix command exits 0, bootstrap builder fix command exits 1. `resolveSession`에서 admin session은 `builderSupplier().build()`, final session은 `withKeyspace(...).apply(builder).build()`를 사용한다.
 
 - [ ] **Step 2: 한국어 landing을 선택 지도 중심으로 교체한다**
 
@@ -209,7 +207,7 @@ val session = CqlSessionProvider.getOrCreateSession(
 
 - [ ] **Step 5: source link와 한국어 문장을 확인한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_release_manuals.rb 1.11.0 6187173b58e8b4c5c435c145e00e94708f31ef75
@@ -217,7 +215,7 @@ rg -n "~를 통해|중요합니다|강력한|할 수 있을 것으로" docs/manu
 git diff --check -- docs/manual/ko/modules/bluetape4k-cassandra.md docs/manual/en/modules/bluetape4k-cassandra.md docs/manual/ko/modules/bluetape4k-cassandra/session-lifecycle.md docs/manual/en/modules/bluetape4k-cassandra/session-lifecycle.md
 ```
 
-Expected: release validator reports 0 missing. Korean phrase search returns no translated/promotional wording; diff check exits 0.
+예상 결과: release validator reports 0 missing. Korean phrase search returns no translated/promotional wording; diff check exits 0.
 
 - [ ] **Step 6: landing과 session chapter를 커밋한다**
 
@@ -235,14 +233,14 @@ git commit -m "Teach Cassandra session ownership before query helpers" \
 
 ### Task 2: Coroutine query와 multi-page Flow chapter를 작성한다
 
-**Files:**
+**파일:**
 
-- Create: `docs/manual/ko/modules/bluetape4k-cassandra/coroutine-queries.md`
-- Create: `docs/manual/en/modules/bluetape4k-cassandra/coroutine-queries.md`
+- 생성: `docs/manual/ko/modules/bluetape4k-cassandra/coroutine-queries.md`
+- 생성: `docs/manual/en/modules/bluetape4k-cassandra/coroutine-queries.md`
 
 - [ ] **Step 1: 1.11.0 async 계약을 읽는다**
 
-Run:
+실행:
 
 ```bash
 git show 1.11.0:data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/cql/AsyncCqlSessionSupport.kt
@@ -251,7 +249,7 @@ git show 1.11.0:data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/cql/Async
 git show 1.11.0:data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/cql/AsyncResultSetSupportUnitTest.kt
 ```
 
-Expected: current page emission precedes `fetchNextPage().await()`, `CancellationException` is rethrown, and deprecated aliases point to `executeSuspending`/`prepareSuspending`.
+예상 결과: current page emission precedes `fetchNextPage().await()`, `CancellationException` is rethrown, and deprecated aliases point to `executeSuspending`/`prepareSuspending`.
 
 - [ ] **Step 2: bilingual frontmatter와 section inventory를 작성한다**
 
@@ -304,7 +302,7 @@ suspend fun loadActiveUsers(session: CqlSession): List<User> {
 
 - [ ] **Step 4: source link, parity와 문장을 검증한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_release_manuals.rb 1.11.0 6187173b58e8b4c5c435c145e00e94708f31ef75
@@ -313,7 +311,7 @@ rg -n "CancellationException|fetchNextPage|asFlow" docs/manual/{ko,en}/modules/b
 git diff --check -- docs/manual/{ko,en}/modules/bluetape4k-cassandra/coroutine-queries.md
 ```
 
-Expected: deprecated names appear only in migration text; both locales contain cancellation, paging and Flow contracts; release paths are valid.
+예상 결과: deprecated names appear only in migration text; both locales contain cancellation, paging and Flow contracts; release paths are valid.
 
 - [ ] **Step 5: coroutine chapter를 커밋한다**
 
@@ -329,14 +327,14 @@ git commit -m "Explain Cassandra paging as a coroutine contract" \
 
 ### Task 3: Row와 data mapping chapter를 작성한다
 
-**Files:**
+**파일:**
 
-- Create: `docs/manual/ko/modules/bluetape4k-cassandra/rows-data-mapping.md`
-- Create: `docs/manual/en/modules/bluetape4k-cassandra/rows-data-mapping.md`
+- 생성: `docs/manual/ko/modules/bluetape4k-cassandra/rows-data-mapping.md`
+- 생성: `docs/manual/en/modules/bluetape4k-cassandra/rows-data-mapping.md`
 
 - [ ] **Step 1: release source와 example inventory를 읽는다**
 
-Run:
+실행:
 
 ```bash
 git show 1.11.0:data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/cql/RowSupport.kt
@@ -346,7 +344,7 @@ git show 1.11.0:data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/mapper/En
 git ls-tree -r --name-only 1.11.0 data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/examples/datatypes data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/mapper
 ```
 
-Expected: name/index/identifier access, collection/UDT/tuple/codec examples와 `EntityHelper` prepare/bind anchors가 확인된다.
+예상 결과: name/index/identifier access, collection/UDT/tuple/codec examples와 `EntityHelper` prepare/bind anchors가 확인된다.
 
 - [ ] **Step 2: bilingual frontmatter와 decision sections를 작성한다**
 
@@ -380,7 +378,7 @@ fun Row.toUser(): User = User(
 
 - [ ] **Step 4: parity와 release path를 검증한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_release_manuals.rb 1.11.0 6187173b58e8b4c5c435c145e00e94708f31ef75
@@ -388,7 +386,7 @@ rg -n "toMap|toNamedMap|CqlIdentifier|UDT|Tuple|Codec|EntityHelper" docs/manual/
 git diff --check -- docs/manual/{ko,en}/modules/bluetape4k-cassandra/rows-data-mapping.md
 ```
 
-Expected: 두 locale에 모든 decision anchor가 있고 release validator와 diff check가 통과한다.
+예상 결과: 두 locale에 모든 decision anchor가 있고 release validator와 diff check가 통과한다.
 
 - [ ] **Step 5: mapping chapter를 커밋한다**
 
@@ -404,14 +402,14 @@ git commit -m "Separate Cassandra typed mapping from dynamic row views" \
 
 ### Task 4: Statement와 QueryBuilder chapter를 작성한다
 
-**Files:**
+**파일:**
 
-- Create: `docs/manual/ko/modules/bluetape4k-cassandra/statements-query-builder.md`
-- Create: `docs/manual/en/modules/bluetape4k-cassandra/statements-query-builder.md`
+- 생성: `docs/manual/ko/modules/bluetape4k-cassandra/statements-query-builder.md`
+- 생성: `docs/manual/en/modules/bluetape4k-cassandra/statements-query-builder.md`
 
 - [ ] **Step 1: release statement/query builder API와 examples를 읽는다**
 
-Run:
+실행:
 
 ```bash
 git show 1.11.0:data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/cql/StatementSupport.kt
@@ -421,7 +419,7 @@ git show 1.11.0:data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/querybuil
 git ls-tree -r --name-only 1.11.0 data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/querybuilder
 ```
 
-Expected: raw/positional/named `statementOf`, simple/bound/batch factories와 CRUD/schema QueryBuilder examples가 확인된다.
+예상 결과: raw/positional/named `statementOf`, simple/bound/batch factories와 CRUD/schema QueryBuilder examples가 확인된다.
 
 - [ ] **Step 2: bilingual frontmatter와 선택 표를 작성한다**
 
@@ -473,7 +471,7 @@ Raw snippet과 logged batch는 library가 성능·원자성 범위를 넓히지 
 
 - [ ] **Step 4: source link와 locale parity를 검증한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_release_manuals.rb 1.11.0 6187173b58e8b4c5c435c145e00e94708f31ef75
@@ -481,7 +479,7 @@ rg -n "statementOf|Prepared|Bound|Batch|QueryBuilder|bindMarker" docs/manual/{ko
 git diff --check -- docs/manual/{ko,en}/modules/bluetape4k-cassandra/statements-query-builder.md
 ```
 
-Expected: 두 locale가 다섯 선택 항목과 안전성 경계를 모두 포함하고 release validator가 통과한다.
+예상 결과: 두 locale가 다섯 선택 항목과 안전성 경계를 모두 포함하고 release validator가 통과한다.
 
 - [ ] **Step 5: statement chapter를 커밋한다**
 
@@ -497,14 +495,14 @@ git commit -m "Choose Cassandra statement APIs by binding boundary" \
 
 ### Task 5: 운영·테스트 chapter를 작성한다
 
-**Files:**
+**파일:**
 
-- Create: `docs/manual/ko/modules/bluetape4k-cassandra/operations-testing.md`
-- Create: `docs/manual/en/modules/bluetape4k-cassandra/operations-testing.md`
+- 생성: `docs/manual/ko/modules/bluetape4k-cassandra/operations-testing.md`
+- 생성: `docs/manual/en/modules/bluetape4k-cassandra/operations-testing.md`
 
 - [ ] **Step 1: release admin과 representative tests를 읽는다**
 
-Run:
+실행:
 
 ```bash
 git show 1.11.0:data/cassandra/src/main/kotlin/io/bluetape4k/cassandra/CassandraAdmin.kt
@@ -514,7 +512,7 @@ git show 1.11.0:data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/CqlSessio
 git show 1.11.0:data/cassandra/src/test/kotlin/io/bluetape4k/cassandra/cql/AsyncResultSetSupportTest.kt
 ```
 
-Expected: create/drop/version admin behavior, container/session fixture, identity cache와 multi-page integration test anchors가 확인된다.
+예상 결과: create/drop/version admin behavior, container/session fixture, identity cache와 multi-page integration test anchors가 확인된다.
 
 - [ ] **Step 2: bilingual frontmatter와 운영 sections를 작성한다**
 
@@ -558,7 +556,7 @@ Testcontainers가 Docker runtime을 필요로 하고 heavy test는 순차 실행
 
 - [ ] **Step 4: release path와 bilingual troubleshooting을 검증한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_release_manuals.rb 1.11.0 6187173b58e8b4c5c435c145e00e94708f31ef75
@@ -566,7 +564,7 @@ rg -n "bootstrap|CqlSessionIdentity|Flow|connection|batch" docs/manual/{ko,en}/m
 git diff --check -- docs/manual/{ko,en}/modules/bluetape4k-cassandra/operations-testing.md
 ```
 
-Expected: 두 locale 모두 다섯 troubleshooting boundary를 포함하고 validator가 0 missing을 보고한다.
+예상 결과: 두 locale 모두 다섯 troubleshooting boundary를 포함하고 validator가 0 missing을 보고한다.
 
 - [ ] **Step 5: operations chapter를 커밋한다**
 
@@ -582,11 +580,11 @@ git commit -m "Make Cassandra operations and test boundaries explicit" \
 
 ### Task 6: Manifest 등록과 Projects 전체 검증을 완료한다
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/manifest.yaml`
-- Modify: `docs/manual/generated/manifest.json`
-- Modify: `docs/superpowers/checklists/2026-07-13-cassandra-manual-checklist.md`
+- 수정: `docs/manual/manifest.yaml`
+- 수정: `docs/manual/generated/manifest.json`
+- 수정: `docs/superpowers/checklists/2026-07-13-cassandra-manual-checklist.md`
 
 - [ ] **Step 1: Cassandra manifest entry에 chapter inventory를 등록한다**
 
@@ -615,7 +613,7 @@ git commit -m "Make Cassandra operations and test boundaries explicit" \
 
 - [ ] **Step 2: generated manifest를 갱신하고 script tests를 실행한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/export_manifest.rb
@@ -625,11 +623,11 @@ ruby scripts/manual/release_contract_test.rb
 ruby scripts/manual/generate_manuals_test.rb
 ```
 
-Expected: manifest snapshot이 작성되고 모든 Ruby test process가 0 failures, 0 errors로 종료한다.
+예상 결과: manifest snapshot이 작성되고 모든 Ruby test process가 0 failures, 0 errors로 종료한다.
 
 - [ ] **Step 3: 실제 inventory와 1.11.0 source links를 검증한다**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_manuals.rb
@@ -637,11 +635,11 @@ ruby scripts/manual/export_manifest.rb --check
 ruby scripts/manual/validate_release_manuals.rb 1.11.0 6187173b58e8b4c5c435c145e00e94708f31ef75
 ```
 
-Expected: `Manuals are aligned.`, `Manual manifest snapshot is current.`, release validator의 `0 missing`이 출력된다.
+예상 결과: `Manuals are aligned.`, `Manual manifest snapshot is current.`, release validator의 `0 missing`이 출력된다.
 
 - [ ] **Step 4: locale inventory와 한국어 naturalness를 검사한다**
 
-Run:
+실행:
 
 ```bash
 find docs/manual/ko/modules/bluetape4k-cassandra -maxdepth 1 -name '*.md' -print | sort
@@ -652,17 +650,17 @@ rg -n "~를 통해|~에 있어서|중요합니다|강력한|다양한 장점|할
 git diff --check
 ```
 
-Expected: KO/EN가 각각 같은 basename 5개를 출력하고 Korean prose search에 수정 대상이 없으며 diff check가 통과한다.
+예상 결과: KO/EN가 각각 같은 basename 5개를 출력하고 Korean prose search에 수정 대상이 없으며 diff check가 통과한다.
 
 - [ ] **Step 5: Cassandra Testcontainers test를 단독 실행한다**
 
-Run:
+실행:
 
 ```bash
 repo-test-summary -- ./gradlew :bluetape4k-cassandra:test --no-build-cache --no-configuration-cache
 ```
 
-Expected: Gradle `BUILD SUCCESSFUL`, failed test 0. Docker/Testcontainers failure가 발생하면 환경 실패와 assertion failure를 구분하고 성공으로 간주하지 않는다.
+예상 결과: Gradle `BUILD SUCCESSFUL`, failed test 0. Docker/Testcontainers failure가 발생하면 환경 실패와 assertion failure를 구분하고 성공으로 간주하지 않는다.
 
 - [ ] **Step 6: checklist의 Projects gate를 갱신한다**
 
@@ -687,20 +685,20 @@ git status --porcelain -- docs/manual scripts/manual/validate_release_manuals.rb
 git rev-parse HEAD
 ```
 
-Expected: scoped status is empty and a 40-character Projects source commit is printed.
+예상 결과: scoped status is empty and a 40-character Projects source commit is printed.
 
 ### Task 7: 1.11 site snapshot을 refresh하고 browser에서 검증한다
 
 **Repository:** `/Users/debop/work/bluetape4k/bluetape4k.github.io/.worktrees/feature-ecosystem-atlas-manual`
 
-**Files:**
+**파일:**
 
-- Generated: `src/content/docs/ko/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md`
-- Generated: `src/content/docs/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md`
-- Generated: `src/content/docs/{ko/,}manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra/{session-lifecycle,coroutine-queries,rows-data-mapping,statements-query-builder,operations-testing}.md`
-- Generated: `src/data/manual/bluetape4k-projects.versions.json`
-- Generated: `src/data/manual/bluetape4k-projects.snapshot.json`
-- Generated: `src/content/docs/{ko/,}manual/bluetape4k-projects/1.11/data.json`
+- 생성됨: `src/content/docs/ko/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md`
+- 생성됨: `src/content/docs/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md`
+- 생성됨: `src/content/docs/{ko/,}manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra/{session-lifecycle,coroutine-queries,rows-data-mapping,statements-query-builder,operations-testing}.md`
+- 생성됨: `src/data/manual/bluetape4k-projects.versions.json`
+- 생성됨: `src/data/manual/bluetape4k-projects.snapshot.json`
+- 생성됨: `src/content/docs/{ko/,}manual/bluetape4k-projects/1.11/data.json`
 - Modify in Projects after Site proof: `docs/superpowers/checklists/2026-07-13-cassandra-manual-checklist.md`
 
 - [ ] **Step 1: Projects source와 release tag를 다시 고정한다**
@@ -713,7 +711,7 @@ git rev-parse HEAD
 git rev-parse 1.11.0^{}
 ```
 
-Expected: scoped status is empty; HEAD is the Task 6 checkpoint; tag resolves to `6187173b58e8b4c5c435c145e00e94708f31ef75`.
+예상 결과: scoped status is empty; HEAD is the Task 6 checkpoint; tag resolves to `6187173b58e8b4c5c435c145e00e94708f31ef75`.
 
 - [ ] **Step 2: 같은 minor release의 editorial snapshot을 refresh한다**
 
@@ -726,22 +724,22 @@ npm run sync:manual -- --check
 npm run check:manual
 ```
 
-Expected: refresh와 check가 exit 0. Version catalog의 `releaseCommit`은 `6187173b58e8b4c5c435c145e00e94708f31ef75`로 유지되고 `sourceCommit`만 Task 6 Projects checkpoint로 갱신된다.
+예상 결과: refresh와 check가 exit 0. Version catalog의 `releaseCommit`은 `6187173b58e8b4c5c435c145e00e94708f31ef75`로 유지되고 `sourceCommit`만 Task 6 Projects checkpoint로 갱신된다.
 
 - [ ] **Step 3: Site tests와 Astro build를 실행한다**
 
-Run:
+실행:
 
 ```bash
 npm test
 npm run build
 ```
 
-Expected: Node manual/ecosystem tests가 모두 PASS하고 Astro check의 errors/warnings/hints가 0이며 build가 exit 0이다.
+예상 결과: Node manual/ecosystem tests가 모두 PASS하고 Astro check의 errors/warnings/hints가 0이며 build가 exit 0이다.
 
 - [ ] **Step 4: generated route와 immutable source link를 검사한다**
 
-Run:
+실행:
 
 ```bash
 test -f src/content/docs/ko/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra/session-lifecycle.md
@@ -753,7 +751,7 @@ rg -n 'github.com/bluetape4k/bluetape4k-projects/blob/1\.11\.0/' \
 git diff --check
 ```
 
-Expected: KO/EN chapter가 존재하고 source links는 authoring commit이 아니라 `blob/1.11.0/`을 사용하며 diff check가 통과한다.
+예상 결과: KO/EN chapter가 존재하고 source links는 authoring commit이 아니라 `blob/1.11.0/`을 사용하며 diff check가 통과한다.
 
 - [ ] **Step 5: localhost에서 KO/EN route를 육안 검수한다**
 
@@ -773,7 +771,7 @@ http://127.0.0.1:4323/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassand
 http://127.0.0.1:4323/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra/operations-testing/
 ```
 
-Expected: navigation에 5개 chapter가 순서대로 보이고 code block이 잘리지 않으며 horizontal overflow, broken link와 browser console error가 없다. 한국어 문장을 실제 화면에서 읽어 번역체나 지나치게 긴 문장을 고친다.
+예상 결과: navigation에 5개 chapter가 순서대로 보이고 code block이 잘리지 않으며 horizontal overflow, broken link와 browser console error가 없다. 한국어 문장을 실제 화면에서 읽어 번역체나 지나치게 긴 문장을 고친다.
 
 - [ ] **Step 6: Projects checklist를 최종 증거로 닫는다**
 
@@ -805,7 +803,7 @@ git commit -m "Refresh the Cassandra manual in the 1.11 catalog" \
 
 Do not push either repository.
 
-## Self-review
+## 자체 검토
 
 - Spec coverage: landing, 5 bilingual chapters, 1.11.0 cache/bootstrap distinction, central BOM, Korean naturalness, manifest, Cassandra test, deterministic refresh, immutable release links, build와 browser QA가 Task 1–7에 연결된다.
 - Placeholder scan: 임시 표식, 비어 있는 section, 다른 task에 구현을 떠넘기는 문장과 미정 파일 경로가 없다.

--- a/docs/superpowers/plans/2026-07-14-cassandra-learning-path-introduction.md
+++ b/docs/superpowers/plans/2026-07-14-cassandra-learning-path-introduction.md
@@ -1,40 +1,39 @@
-# Cassandra Learning Path Introduction Implementation Plan
+# Cassandra learning path introduction 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** Cassandra 모듈 landing에서 제공 기능과 다섯 개 상세 학습 장의 가치, 예제, 학습 결과를 바로 이해하고 각 장으로 이동하게 만든다.
+**목표:** Cassandra 모듈 landing에서 제공 기능과 다섯 개 상세 학습 장의 가치, 예제, 학습 결과를 바로 이해하고 각 장으로 이동하게 만든다.
 
-**Architecture:** Canonical source인 `bluetape4k-projects/docs/manual`의 한국어와 영문 landing을 같은 정보 구조로 수정한다. Projects 검증과 커밋이 끝난 source commit으로 Site의 1.11 snapshot을 refresh하되 `releaseRef=1.11.0`과 immutable release commit은 유지한다. 제목 변경 전 fragment로 들어오는 링크를 위해 이전 heading slug를 빈 `span` anchor로 보존한다.
+**아키텍처:** Canonical source인 `bluetape4k-projects/docs/manual`의 한국어와 영문 landing을 같은 정보 구조로 수정한다. Projects 검증과 커밋이 끝난 source commit으로 Site의 1.11 snapshot을 refresh하되 `releaseRef=1.11.0`과 immutable release commit은 유지한다. 제목 변경 전 fragment로 들어오는 링크를 위해 이전 heading slug를 빈 `span` anchor로 보존한다.
 
-**Tech Stack:** Markdown, Ruby manual validators, Node.js manual snapshot pipeline, Astro/Starlight, npm test/build
+**기술 스택:** Markdown, Ruby manual validators, Node.js manual snapshot pipeline, Astro/Starlight, npm test/build
 
 ---
 
-## File map
+## 파일 지도
 
-- Modify: `docs/manual/ko/modules/bluetape4k-cassandra.md` — 자연스러운 한국어 기능 소개와 설명형 학습 경로
-- Modify: `docs/manual/en/modules/bluetape4k-cassandra.md` — 한국어와 같은 정보 밀도의 영문 기능 소개와 학습 경로
-- Refresh in site repo: `src/content/docs/{ko/,}manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md` — canonical source에서 생성되는 versioned landing
-- Refresh in site repo: `src/data/manual/bluetape4k-projects*.json`, `.manual-sync-generation.json` — 새 source commit과 deterministic snapshot metadata
+- 수정: `docs/manual/ko/modules/bluetape4k-cassandra.md` — 자연스러운 한국어 기능 소개와 설명형 학습 경로
+- 수정: `docs/manual/en/modules/bluetape4k-cassandra.md` — 한국어와 같은 정보 밀도의 영문 기능 소개와 학습 경로
+- site repo에서 refresh: `src/content/docs/{ko/,}manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md` — canonical source에서 생성되는 versioned landing
+- site repo에서 refresh: `src/data/manual/bluetape4k-projects*.json`, `.manual-sync-generation.json` — 새 source commit과 deterministic snapshot metadata
 
 ### Task 1: 한국어 landing을 설명형 학습 경로로 바꾼다
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/ko/modules/bluetape4k-cassandra.md`
-- Test: `scripts/manual/validate_manuals_test.rb`
+- 수정: `docs/manual/ko/modules/bluetape4k-cassandra.md`
+- 테스트: `scripts/manual/validate_manuals_test.rb`
 
 - [ ] **Step 1: 변경 전 상태가 새 계약을 만족하지 않는지 확인**
 
-Run:
+실행:
 
 ```bash
 ! rg -q '^## 제공하는 기능 \{#problem\}$' docs/manual/ko/modules/bluetape4k-cassandra.md
 ! rg -q '각 장은 문제를 이해하는 설명에서 시작해' docs/manual/ko/modules/bluetape4k-cassandra.md
 ```
 
-Expected: 두 명령 모두 exit 0. 아직 새 heading과 학습 안내가 없음을 증명한다.
+예상 결과: 두 명령 모두 exit 0. 아직 새 heading과 학습 안내가 없음을 증명한다.
 
 - [ ] **Step 2: 기능 소개 heading과 본문을 교체**
 
@@ -71,32 +70,32 @@ Expected: 두 명령 모두 exit 0. 아직 새 heading과 학습 안내가 없�
 
 - [ ] **Step 4: 한국어 문구와 구조 검증**
 
-Run:
+실행:
 
 ```bash
 rg -n '^## 제공하는 기능|각 장은 문제를 이해하는 설명에서 시작해|직접 만든 세션을|운영 권한을' docs/manual/ko/modules/bluetape4k-cassandra.md
 ruby scripts/manual/validate_manuals_test.rb
 ```
 
-Expected: heading과 소개·첫 장·마지막 장 문구가 검색되고 `14 runs, 41 assertions, 0 failures, 0 errors`.
+예상 결과: heading과 소개·첫 장·마지막 장 문구가 검색되고 `14 runs, 41 assertions, 0 failures, 0 errors`.
 
 ### Task 2: 영문 landing을 같은 정보 구조로 맞춘다
 
-**Files:**
+**파일:**
 
-- Modify: `docs/manual/en/modules/bluetape4k-cassandra.md`
-- Test: `scripts/manual/validate_manuals_test.rb`
+- 수정: `docs/manual/en/modules/bluetape4k-cassandra.md`
+- 테스트: `scripts/manual/validate_manuals_test.rb`
 
 - [ ] **Step 1: 변경 전 영문 상태 확인**
 
-Run:
+실행:
 
 ```bash
 ! rg -q '^## Features \{#problem\}$' docs/manual/en/modules/bluetape4k-cassandra.md
 ! rg -q 'Each chapter starts with the problem' docs/manual/en/modules/bluetape4k-cassandra.md
 ```
 
-Expected: 두 명령 모두 exit 0.
+예상 결과: 두 명령 모두 exit 0.
 
 - [ ] **Step 2: 영문 기능 소개를 한국어 계약과 맞춤**
 
@@ -133,7 +132,7 @@ The five chapters below do more than list API names. Each chapter starts with th
 
 - [ ] **Step 4: locale parity와 canonical manual 검증**
 
-Run:
+실행:
 
 ```bash
 ruby scripts/manual/validate_manuals_test.rb
@@ -145,7 +144,7 @@ ruby scripts/manual/export_manifest.rb --check
 git diff --check
 ```
 
-Expected: 총 `35 runs, 108 assertions`, failure/error 0, `Manuals are aligned.`, `Manual manifest snapshot is current.`
+예상 결과: 총 `35 runs, 108 assertions`, failure/error 0, `Manuals are aligned.`, `Manual manifest snapshot is current.`
 
 - [ ] **Step 5: canonical source 커밋**
 
@@ -162,16 +161,16 @@ Not-tested: Site snapshot and rendered routes"
 
 ### Task 3: Site 1.11 snapshot을 canonical source로 갱신한다
 
-**Files:**
+**파일:**
 
-- Modify: `.manual-sync-generation.json`
-- Modify: `src/content/docs/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md`
-- Modify: `src/content/docs/ko/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md`
-- Modify: `src/data/manual/bluetape4k-projects.1.11.manifest.json`
-- Modify: `src/data/manual/bluetape4k-projects.1.11.snapshot.json`
-- Modify: `src/data/manual/bluetape4k-projects.manifest.json`
-- Modify: `src/data/manual/bluetape4k-projects.snapshot.json`
-- Modify: `src/data/manual/bluetape4k-projects.versions.json`
+- 수정: `.manual-sync-generation.json`
+- 수정: `src/content/docs/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md`
+- 수정: `src/content/docs/ko/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md`
+- 수정: `src/data/manual/bluetape4k-projects.1.11.manifest.json`
+- 수정: `src/data/manual/bluetape4k-projects.1.11.snapshot.json`
+- 수정: `src/data/manual/bluetape4k-projects.manifest.json`
+- 수정: `src/data/manual/bluetape4k-projects.snapshot.json`
+- 수정: `src/data/manual/bluetape4k-projects.versions.json`
 
 - [ ] **Step 1: 새 source commit으로 1.11 snapshot refresh**
 
@@ -181,11 +180,11 @@ Run in `/Users/debop/work/bluetape4k/bluetape4k.github.io`:
 npm run sync:manual -- --refresh 1.11.0 --source /Users/debop/work/bluetape4k/bluetape4k-projects
 ```
 
-Expected: `release=1.11.0`, release commit `6187173b58e8b4c5c435c145e00e94708f31ef75`, Projects의 새 source commit, documents 244, assets 30.
+예상 결과: `release=1.11.0`, release commit `6187173b58e8b4c5c435c145e00e94708f31ef75`, Projects의 새 source commit, documents 244, assets 30.
 
 - [ ] **Step 2: 생성된 landing과 이전 fragment 호환성 확인**
 
-Run:
+실행:
 
 ```bash
 rg -n '^## 제공하는 기능|id="이-라이브러리가-맡는-일"|각 장은 문제를 이해하는 설명에서 시작해' src/content/docs/ko/manual/bluetape4k-projects/1.11/modules/bluetape4k-cassandra.md
@@ -194,11 +193,11 @@ npm run sync:manual -- --check
 npm run check:manual
 ```
 
-Expected: 새 heading과 설명형 학습 경로, 이전 fragment anchor가 모두 존재하고 snapshot은 `changed=false`, valid.
+예상 결과: 새 heading과 설명형 학습 경로, 이전 fragment anchor가 모두 존재하고 snapshot은 `changed=false`, valid.
 
 - [ ] **Step 3: Site 전체 검증**
 
-Run:
+실행:
 
 ```bash
 npm test
@@ -206,7 +205,7 @@ npm run build
 git diff --check
 ```
 
-Expected: 86 tests pass, Astro 47 files에서 error/warning/hint 0, 393 pages build, Pagefind 637 HTML files.
+예상 결과: 86 tests pass, Astro 47 files에서 error/warning/hint 0, 393 pages build, Pagefind 637 HTML files.
 
 - [ ] **Step 4: 브라우저에서 한국어·영문 landing 확인**
 
@@ -248,4 +247,4 @@ git -C /Users/debop/work/bluetape4k/bluetape4k.github.io status --short
 git -C /Users/debop/work/bluetape4k/bluetape4k.github.io log -2 --oneline
 ```
 
-Expected: 두 main checkout은 clean이고 Site snapshot의 `sourceCommit`은 새 Projects manual commit, `releaseCommit`은 `6187173b58e8b4c5c435c145e00e94708f31ef75`다. Push, PR, deploy는 수행하지 않는다.
+예상 결과: 두 main checkout은 clean이고 Site snapshot의 `sourceCommit`은 새 Projects manual commit, `releaseCommit`은 `6187173b58e8b4c5c435c145e00e94708f31ef75`다. Push, PR, deploy는 수행하지 않는다.

--- a/docs/superpowers/plans/2026-07-16-issue-754-bytebuffer-serializer-stack-plan.md
+++ b/docs/superpowers/plans/2026-07-16-issue-754-bytebuffer-serializer-stack-plan.md
@@ -1,14 +1,14 @@
-# Issue #754 ByteBuffer Serializer Stack Implementation Plan
+# Issue #754 ByteBuffer Serializer Stack 구현 계획
 
-**Goal:** Preserve existing serializer contracts while adding caller-owned
+**목표:** Preserve existing serializer contracts while adding caller-owned
 `ByteBuffer` APIs, backend-specific lower-copy paths, and allocation evidence.
 
-**Authority:** The live issue [#754](https://github.com/bluetape4k/bluetape4k-projects/issues/754)
+**권한:** The live issue [#754](https://github.com/bluetape4k/bluetape4k-projects/issues/754)
 defines scope. This plan does not authorize release, tag, publish, credential, GitHub App, ruleset, environment, or GitHub Release changes.
 
-**Delivery:** Five sequential PRs. PR creation is authorized after each slice passes its pre-PR gates. Every merge waits for fresh approval tied to the exact PR head after CI and review pass.
+**전달:** Five sequential PRs. PR creation is authorized after each slice passes its pre-PR gates. Every merge waits for fresh approval tied to the exact PR head after CI and review pass.
 
-## Stop Conditions
+## 중단 조건
 
 - Do not change existing `ByteArray` signatures or wire/security behavior.
 - Do not claim lower allocation for a compatibility fallback.
@@ -29,7 +29,7 @@ defines scope. This plan does not authorize release, tag, publish, credential, G
 
 ## Slice 1: Contract And Compatibility
 
-### Completed outcomes to preserve
+### 보존할 완료 결과
 
 - `BinarySerializer`, `JsonSerializer`, and Avro interfaces expose executable JVM default buffer methods while retaining old abstract methods.
 - Java input names avoid null-literal ambiguity; Kotlin extensions remain.
@@ -37,7 +37,7 @@ defines scope. This plan does not authorize release, tag, publish, credential, G
 - Pinned pre-change jars, legacy callers, `javap`, and frozen wire fixtures prove compatibility.
 - The ABI script and contract evidence are serializer-owned and independent of release policy.
 
-### Corrective verification
+### corrective 검증
 
 ```bash
 python3 -m unittest scripts/test_release_workflow_policy.py -v
@@ -47,7 +47,7 @@ bash scripts/check-serializer-buffer-abi.sh \
   --build-current --expected-head "$(git rev-parse HEAD)"
 ```
 
-Expected: policy tests and actionlint pass; ABI check reports all legacy/new caller and default-dispatch checks PASS. Corrective changes must not modify serializer Kotlin/Java source or fixtures.
+예상 결과: policy tests and actionlint pass; ABI check reports all legacy/new caller and default-dispatch checks PASS. Corrective changes must not modify serializer Kotlin/Java source or fixtures.
 
 ## Slice 2: Core Binary Serializers
 

--- a/docs/superpowers/plans/2026-07-18-issue-1039-serializer-allocation-benchmark-plan.md
+++ b/docs/superpowers/plans/2026-07-18-issue-1039-serializer-allocation-benchmark-plan.md
@@ -1,14 +1,12 @@
-# Issue #1039 Serializer Allocation Benchmark Implementation Plan
+# Issue #1039 Serializer Allocation Benchmark 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** Add a standalone, reproducible serializer allocation benchmark that permits only two-run, allocation-backed ByteBuffer claims and documents every optimized and fallback boundary.
+**목표:** Add a standalone, reproducible serializer allocation benchmark that permits only two-run, allocation-backed ByteBuffer claims and documents every optimized and fallback boundary.
 
-**Architecture:** Create `benchmark/serializer-benchmark` using the repository `kotlinx-benchmark` JMH pattern. Keep payload, comparison adapters, and validation support inside the benchmark-only module; measure binary, JSON, and Avro serialization/deserialization separately; derive claim decisions from two raw JMH GC-profiler runs with a tested Python summarizer. Publish measured numbers only in the central benchmark report and link representative English/Korean module documentation to it.
+**아키텍처:** Create `benchmark/serializer-benchmark` using the repository `kotlinx-benchmark` JMH pattern. Keep payload, comparison adapters, and validation support inside the benchmark-only module; measure binary, JSON, and Avro serialization/deserialization separately; derive claim decisions from two raw JMH GC-profiler runs with a tested Python summarizer. Publish measured numbers only in the central benchmark report and link representative English/Korean module documentation to it.
 
-**Tech
-Stack:** Kotlin 2.3, Java 21, Gradle 9.6, `kotlinx-benchmark`, JMH GC profiler, JUnit 5/Kluent, Python 3 standard library, existing bluetape4k serializer modules.
+**기술 스택:** Kotlin 2.3, Java 21, Gradle 9.6, `kotlinx-benchmark`, JMH GC profiler, JUnit 5/Kluent, Python 3 standard library, existing bluetape4k serializer modules.
 
 ---
 
@@ -24,7 +22,7 @@ Stack:** Kotlin 2.3, Java 21, Gradle 9.6, `kotlinx-benchmark`, JMH GC profiler, 
 - Stop immediately if an implementation would change an existing `ByteArray` API, wire/security behavior, serializer registration, or any #755-#758 surface.
 - Pull request delivery targets repository `bluetape4k/bluetape4k-projects`, base `develop`, and head `feat/issue-754-allocation-proof`. Merge remains outside implementation authority until a fresh exact-head approval.
 
-## File And Responsibility Map
+## 파일과 책임 지도
 
 ### New benchmark module
 
@@ -83,7 +81,7 @@ Stack:** Kotlin 2.3, Java 21, Gradle 9.6, `kotlinx-benchmark`, JMH GC profiler, 
 | #755-#758 and release exclusions                       | 9, 10, 12   |
 | P0/P1 convergence, lesson, exact-head PR               | 10, 11, 12  |
 
-## Type A Step 3-R Plan Review Record
+## Type A Step 3-R 계획 검토 기록
 
 The detailed plan was reviewed in the main session because the available native subagent surface cannot carry the required installed role identifier. The six independent lenses converge as follows:
 
@@ -96,24 +94,24 @@ The detailed plan was reviewed in the main session because the available native 
 
 Result: P0=0, P1=0. Runtime-generated run IDs and measured verdicts are intentionally unresolved until Tasks 8-9; their commands and fail-closed gates are fixed here.
 
-### Task 1: Register The Standalone Benchmark Module
+### Task 1: standalone benchmark module 등록
 
-**Complexity:** Medium **Depends on:** Approved spec **Write scope:** `benchmark/serializer-benchmark/build.gradle.kts`
+**복잡도:** Medium **의존:** Approved spec **작성 범위:** `benchmark/serializer-benchmark/build.gradle.kts`
 **Rollback/Rerun:** Remove only the benchmark module shell if registration or non-publication guards fail, then rerun Steps 1-4 before committing.
 
-**Files:**
+**파일:**
 
-- Create: `benchmark/serializer-benchmark/build.gradle.kts`
+- 생성: `benchmark/serializer-benchmark/build.gradle.kts`
 
 - [ ] **Step 1: Prove the module is absent**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :serializer-benchmark:tasks --all --no-configuration-cache
 ```
 
-Expected: FAIL with `project 'serializer-benchmark' not found`.
+예상 결과: FAIL with `project 'serializer-benchmark' not found`.
 
 - [ ] **Step 2: Add the repository-standard benchmark build**
 
@@ -181,7 +179,7 @@ dependencies {
 
 - [ ] **Step 3: Verify auto-registration and generated task names**
 
-Run:
+실행:
 
 ```bash
 ./gradlew projects :serializer-benchmark:tasks --all --no-configuration-cache \
@@ -191,11 +189,11 @@ rg -q '^benchmarkBenchmarkCompile' /tmp/issue-1039-serializer-benchmark-tasks.tx
 rg -q '^benchmarkBenchmarkJar' /tmp/issue-1039-serializer-benchmark-tasks.txt
 ```
 
-Expected: PASS; the project and both generated tasks are present.
+예상 결과: PASS; the project and both generated tasks are present.
 
 - [ ] **Step 4: Verify non-publication and coverage exclusion rules apply**
 
-Run:
+실행:
 
 ```bash
 rg -n 'includeModules\("benchmark", false, false\)' settings.gradle.kts
@@ -203,7 +201,7 @@ rg -n 'name.endsWith\("-benchmark"\)' build.gradle.kts
 rg -n 'sourceDir.startsWith\("benchmark/"\)' build.gradle.kts
 ```
 
-Expected: all three existing guards are present; no BOM/catalog or publishing edit is needed.
+예상 결과: all three existing guards are present; no BOM/catalog or publishing edit is needed.
 
 - [ ] **Step 5: Commit the module shell**
 
@@ -221,15 +219,15 @@ git commit -m "Isolate serializer allocation evidence from production modules" \
 
 ### Task 2: Lock Payload, Fallback, And Buffer Contracts
 
-**Complexity:** High **Depends on:** Task 1 **Write scope:** benchmark module main/test Kotlin sources **Required
+**복잡도:** High **의존:** Task 1 **작성 범위:** benchmark module main/test Kotlin sources **Required
 skills:** `test-driven-development`, `bluetape-kotlin-patterns`
 **Rollback/Rerun:** Revert only fixture/payload changes that violate a contract; rerun the full support test and every affected serializer contract test.
 
-**Files:**
+**파일:**
 
-- Create: `benchmark/serializer-benchmark/src/main/kotlin/io/bluetape4k/benchmark/serializer/SerializerBenchmarkPayload.kt`
-- Create: `benchmark/serializer-benchmark/src/main/kotlin/io/bluetape4k/benchmark/serializer/SerializerBenchmarkSupport.kt`
-- Create: `benchmark/serializer-benchmark/src/test/kotlin/io/bluetape4k/benchmark/serializer/SerializerBenchmarkSupportTest.kt`
+- 생성: `benchmark/serializer-benchmark/src/main/kotlin/io/bluetape4k/benchmark/serializer/SerializerBenchmarkPayload.kt`
+- 생성: `benchmark/serializer-benchmark/src/main/kotlin/io/bluetape4k/benchmark/serializer/SerializerBenchmarkSupport.kt`
+- 생성: `benchmark/serializer-benchmark/src/test/kotlin/io/bluetape4k/benchmark/serializer/SerializerBenchmarkSupportTest.kt`
 
 - [ ] **Step 1: Write failing payload and adapter contract tests**
 
@@ -280,13 +278,13 @@ Use recording fakes only for dispatch proof; production fixtures must use defaul
 
 - [ ] **Step 2: Run the tests and observe RED**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :serializer-benchmark:test --tests '*SerializerBenchmarkSupportTest' --no-configuration-cache
 ```
 
-Expected: FAIL because payload, adapters, and fixtures are undefined.
+예상 결과: FAIL because payload, adapters, and fixtures are undefined.
 
 - [ ] **Step 3: Implement the deterministic payload**
 
@@ -361,7 +359,7 @@ Run sequentially:
 ./gradlew :bluetape4k-avro:test --tests '*AvroSerializerByteBufferContractTest' --no-configuration-cache
 ```
 
-Expected: all commands PASS. The existing Avro reflect tests already establish support for mutable Kotlin data classes with defaults and nested/list fields, so failure here is an implementation defect to diagnose rather than a payload-type branch in this plan.
+예상 결과: all commands PASS. The existing Avro reflect tests already establish support for mutable Kotlin data classes with defaults and nested/list fields, so failure here is an implementation defect to diagnose rather than a payload-type branch in this plan.
 
 - [ ] **Step 6: Commit the locked contract**
 
@@ -379,12 +377,12 @@ git commit -m "Make serializer allocation cells comparable before timing them" \
 
 ### Task 3: Add Core Binary Allocation Cells
 
-**Complexity:** High **Depends on:** Task 2 **Write scope:** binary benchmark source only
+**복잡도:** High **의존:** Task 2 **작성 범위:** binary benchmark source only
 **Rollback/Rerun:** Revert only the binary benchmark source if the matrix or capability labels are wrong, then rerun benchmark compile and affected contracts.
 
-**Files:**
+**파일:**
 
-- Create: `benchmark/serializer-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/serializer/BinarySerializerAllocationBenchmark.kt`
+- 생성: `benchmark/serializer-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/serializer/BinarySerializerAllocationBenchmark.kt`
 
 - [ ] **Step 1: Add a compile-failing benchmark declaration**
 
@@ -405,13 +403,13 @@ open class BinarySerializerAllocationBenchmark {
 }
 ```
 
-Run:
+실행:
 
 ```bash
 ./gradlew :serializer-benchmark:compileBenchmarkKotlin --no-configuration-cache
 ```
 
-Expected: FAIL because `BinaryBenchmarkState` is undefined.
+예상 결과: FAIL because `BinaryBenchmarkState` is undefined.
 
 - [ ] **Step 2: Implement JDK and Kryo comparison methods**
 
@@ -462,14 +460,14 @@ Fory output calls the production `serializeTo` fallback and remains claim-inelig
 
 - [ ] **Step 4: Compile and inspect generated JMH methods**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :serializer-benchmark:benchmarkBenchmarkCompile --no-configuration-cache
 find benchmark/serializer-benchmark/build/generated -type f -name '*BinarySerializerAllocationBenchmark*' -print
 ```
 
-Expected: PASS and generated JMH sources include all 16 method names.
+예상 결과: PASS and generated JMH sources include all 16 method names.
 
 - [ ] **Step 5: Commit binary cells**
 
@@ -487,25 +485,25 @@ git commit -m "Separate core serializer allocation paths by capability" \
 
 ### Task 4: Add JSON Allocation Cells
 
-**Complexity:** High **Depends on:** Task 2 **Write scope:** JSON benchmark source only
+**복잡도:** High **의존:** Task 2 **작성 범위:** JSON benchmark source only
 **Rollback/Rerun:** Revert only the JSON benchmark source if dispatch or labels are wrong, then rerun benchmark compile and Jackson/Fastjson contracts.
 
-**Files:**
+**파일:**
 
-- Create: `benchmark/serializer-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/serializer/JsonSerializerAllocationBenchmark.kt`
+- 생성: `benchmark/serializer-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/serializer/JsonSerializerAllocationBenchmark.kt`
 
 - [ ] **Step 1: Write a compile-failing Jackson state**
 
 Declare `JsonSerializerAllocationBenchmark` with `@State(Scope.Thread)`,
 `Mode.Throughput`, and a missing `Jackson2BenchmarkState`; compile and observe the undefined-state failure.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :serializer-benchmark:compileBenchmarkKotlin --no-configuration-cache
 ```
 
-Expected: FAIL for `Jackson2BenchmarkState`.
+예상 결과: FAIL for `Jackson2BenchmarkState`.
 
 - [ ] **Step 2: Implement Jackson 2 and Jackson 3 cells**
 
@@ -553,14 +551,14 @@ The optimized input is a writable array-backed buffer. The direct and read-only 
 
 - [ ] **Step 4: Compile and verify the JSON method matrix**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :serializer-benchmark:benchmarkBenchmarkCompile --no-configuration-cache
 find benchmark/serializer-benchmark/build/generated -type f -name '*JsonSerializerAllocationBenchmark*' -print
 ```
 
-Expected: PASS and generated sources cover all 18 method names.
+예상 결과: PASS and generated sources cover all 18 method names.
 
 - [ ] **Step 5: Commit JSON cells**
 
@@ -578,24 +576,24 @@ git commit -m "Keep JSON allocation claims aligned with real buffer dispatch" \
 
 ### Task 5: Add Avro Reflect Allocation Cells
 
-**Complexity:** Medium **Depends on:** Task 2 **Write scope:** Avro benchmark source only
+**복잡도:** Medium **의존:** Task 2 **작성 범위:** Avro benchmark source only
 **Rollback/Rerun:** Revert only the Avro benchmark source if reflect scope or cell labels are wrong, then rerun benchmark compile and the Avro contract test.
 
-**Files:**
+**파일:**
 
-- Create: `benchmark/serializer-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/serializer/AvroSerializerAllocationBenchmark.kt`
+- 생성: `benchmark/serializer-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/serializer/AvroSerializerAllocationBenchmark.kt`
 
 - [ ] **Step 1: Write the compile-failing Avro benchmark state**
 
 Declare the JMH class and reference an undefined `AvroReflectBenchmarkState`.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :serializer-benchmark:compileBenchmarkKotlin --no-configuration-cache
 ```
 
-Expected: FAIL for the undefined state.
+예상 결과: FAIL for the undefined state.
 
 - [ ] **Step 2: Implement the six measured reflect cells**
 
@@ -621,7 +619,7 @@ Run sequentially:
 ./gradlew :bluetape4k-avro:test --tests '*AvroSerializerByteBufferContractTest' --no-configuration-cache
 ```
 
-Expected: both commands PASS.
+예상 결과: both commands PASS.
 
 - [ ] **Step 4: Commit Avro cells**
 
@@ -639,13 +637,13 @@ git commit -m "Measure Avro allocation only where reflect paths were exercised" 
 
 ### Task 6: Test And Implement Evidence Summarization
 
-**Complexity:** High **Depends on:** Tasks 3-5 **Write scope:** benchmark Python scripts only
+**복잡도:** High **의존:** Tasks 3-5 **작성 범위:** benchmark Python scripts only
 **Rollback/Rerun:** Any parser or verdict failure invalidates derived evidence; fix the bounded scripts, rerun all unit tests, and regenerate every CSV.
 
-**Files:**
+**파일:**
 
-- Create: `benchmark/serializer-benchmark/scripts/summarize-jmh.py`
-- Create: `benchmark/serializer-benchmark/scripts/test_summarize_jmh.py`
+- 생성: `benchmark/serializer-benchmark/scripts/summarize-jmh.py`
+- 생성: `benchmark/serializer-benchmark/scripts/test_summarize_jmh.py`
 
 - [ ] **Step 1: Write failing standard-library unit tests**
 
@@ -673,13 +671,13 @@ The synthetic JMH entries must use real result keys:
 
 - [ ] **Step 2: Run RED**
 
-Run:
+실행:
 
 ```bash
 python3 -m unittest benchmark/serializer-benchmark/scripts/test_summarize_jmh.py -v
 ```
 
-Expected: FAIL because `summarize-jmh.py` is absent.
+예상 결과: FAIL because `summarize-jmh.py` is absent.
 
 - [ ] **Step 3: Implement the bounded parser and verdict policy**
 
@@ -708,7 +706,7 @@ The parser exits non-zero when raw JSON is malformed, the normalized allocation 
 
 - [ ] **Step 4: Run GREEN and syntax checks**
 
-Run:
+실행:
 
 ```bash
 python3 -m unittest benchmark/serializer-benchmark/scripts/test_summarize_jmh.py -v
@@ -717,7 +715,7 @@ python3 -m py_compile \
   benchmark/serializer-benchmark/scripts/test_summarize_jmh.py
 ```
 
-Expected: all seven tests PASS; compilation exits 0.
+예상 결과: all seven tests PASS; compilation exits 0.
 
 - [ ] **Step 5: Commit evidence tooling**
 
@@ -735,7 +733,7 @@ git commit -m "Make allocation claims fail closed across two fresh runs" \
 
 ### Task 7: Compile And Smoke The Exact Benchmark Matrix
 
-**Complexity:** Medium **Depends on:** Tasks 3-6 **Write scope:** no production writes; temporary build output only
+**복잡도:** Medium **의존:** Tasks 3-6 **작성 범위:** no production writes; temporary build output only
 **Heavy-command limit:** one benchmark process at a time
 **Rollback/Rerun:** A compile, cell-count, semantic, profiler, or parser failure blocks evidence generation; return to the owning task and rerun the full smoke.
 
@@ -749,11 +747,11 @@ Run sequentially:
 ./gradlew :serializer-benchmark:benchmarkBenchmarkJar --no-configuration-cache
 ```
 
-Expected: all commands PASS.
+예상 결과: all commands PASS.
 
 - [ ] **Step 2: Resolve exactly one generated JMH jar**
 
-Run:
+실행:
 
 ```zsh
 jmh_jars=(benchmark/serializer-benchmark/build/benchmarks/benchmark/jars/*-JMH.jar(N))
@@ -761,11 +759,11 @@ jmh_jars=(benchmark/serializer-benchmark/build/benchmarks/benchmark/jars/*-JMH.j
 print -r -- "$jmh_jars[1]"
 ```
 
-Expected: exactly one jar path.
+예상 결과: exactly one jar path.
 
 - [ ] **Step 3: Run the smoke protocol**
 
-Run:
+실행:
 
 ```bash
 JMH_JAR=$(find benchmark/serializer-benchmark/build/benchmarks/benchmark/jars -type f -name '*-JMH.jar' -print -quit)
@@ -777,12 +775,12 @@ python3 benchmark/serializer-benchmark/scripts/summarize-jmh.py run \
   --output /tmp/issue-1039-jmh-smoke.csv
 ```
 
-Expected: every declared cell completes, JSON parses, and every row contains
+예상 결과: every declared cell completes, JSON parses, and every row contains
 `gc.alloc.rate.norm`. Any overflow, decode mismatch, missing cell, or profiler failure blocks evidence runs.
 
 - [ ] **Step 4: Confirm the smoke artifact contains the exact method counts**
 
-Run:
+실행:
 
 ```bash
 python3 - <<'PY'
@@ -796,17 +794,17 @@ print(f'benchmark_cells={len(names)}')
 PY
 ```
 
-Expected: `benchmark_cells=40`.
+예상 결과: `benchmark_cells=40`.
 
 ### Task 8: Produce Two Fresh Allocation Evidence Runs
 
-**Complexity:** High **Depends on:** Task 7 **Write scope:** `docs/benchmarks/raw/issue-1039/`
+**복잡도:** High **의존:** Task 7 **작성 범위:** `docs/benchmarks/raw/issue-1039/`
 **Heavy-command limit:** exactly one JMH process at a time; no concurrent Gradle or benchmark execution
 **Rollback/Rerun:** Preserve an invalid run directory for diagnosis, mark it invalid in its environment metadata, and create a new run ID; never overwrite or count an invalid run among the two accepted fresh runs.
 
 - [ ] **Step 1: Build the evidence jar from a clean benchmark output**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :serializer-benchmark:clean :serializer-benchmark:benchmarkBenchmarkJar --no-configuration-cache
@@ -815,7 +813,7 @@ test -f "$JMH_JAR"
 git status --short
 ```
 
-Expected: build PASS; status contains only planned source/doc changes and no unexpected generated file.
+예상 결과: build PASS; status contains only planned source/doc changes and no unexpected generated file.
 
 - [ ] **Step 2: Capture run 1 environment and raw JSON**
 
@@ -846,7 +844,7 @@ python3 benchmark/serializer-benchmark/scripts/summarize-jmh.py run \
 printf '%s\n' "$RUN_1" > /tmp/issue-1039-run-1-id
 ```
 
-Expected: JMH exits 0 and the summarizer writes 40 rows.
+예상 결과: JMH exits 0 and the summarizer writes 40 rows.
 
 - [ ] **Step 3: Capture independent run 2**
 
@@ -877,11 +875,11 @@ python3 benchmark/serializer-benchmark/scripts/summarize-jmh.py run \
 printf '%s\n' "$RUN_2" > /tmp/issue-1039-run-2-id
 ```
 
-Expected: JMH exits 0, the summarizer writes 40 rows, and `RUN_2 != RUN_1`.
+예상 결과: JMH exits 0, the summarizer writes 40 rows, and `RUN_2 != RUN_1`.
 
 - [ ] **Step 4: Derive the two-run comparison**
 
-Run:
+실행:
 
 ```bash
 RUN_1=$(cat /tmp/issue-1039-run-1-id)
@@ -893,32 +891,32 @@ python3 benchmark/serializer-benchmark/scripts/summarize-jmh.py compare \
   --output docs/benchmarks/raw/issue-1039/comparison.csv
 ```
 
-Expected: PASS. Only rows marked `accepted` may support allocation-reduction prose.
+예상 결과: PASS. Only rows marked `accepted` may support allocation-reduction prose.
 
 - [ ] **Step 5: Validate raw artifact size and reviewability**
 
-Run:
+실행:
 
 ```bash
 find docs/benchmarks/raw/issue-1039 -type f -print -exec wc -c {} \;
 test -z "$(find docs/benchmarks/raw/issue-1039 -type f -size +2M -print)"
 ```
 
-Expected: every artifact is at most 2 MiB. If raw JSON exceeds the limit, retain compact JSON/CSV plus a documented external artifact link; do not commit noisy profiler dumps.
+예상 결과: every artifact is at most 2 MiB. If raw JSON exceeds the limit, retain compact JSON/CSV plus a documented external artifact link; do not commit noisy profiler dumps.
 
 ### Task 9: Publish Evidence Without Broadening Claims
 
-**Complexity:** High **Depends on:** Task 8 **Write
+**복잡도:** High **의존:** Task 8 **Write
 scope:** benchmark READMEs, benchmark docs/raw, KDoc, module README pairs, changelog **Required
 skill:** `bluetape-writer`
 **Rollback/Rerun:** If prose exceeds comparison evidence, downgrade it to inconclusive or ergonomic-only wording and rerun locale and claim-parity checks.
 
-**Files:**
+**파일:**
 
-- Create: `benchmark/serializer-benchmark/README.md`
-- Create: `benchmark/serializer-benchmark/README.ko.md`
-- Create: `docs/benchmarks/2026-07-18-bytebuffer-serializer-allocation.md`
-- Modify: all KDoc, README, index, changelog, and raw paths listed in the file map.
+- 생성: `benchmark/serializer-benchmark/README.md`
+- 생성: `benchmark/serializer-benchmark/README.ko.md`
+- 생성: `docs/benchmarks/2026-07-18-bytebuffer-serializer-allocation.md`
+- 수정: all KDoc, README, index, changelog, and raw paths listed in the file map.
 
 - [ ] **Step 1: Write a failing documentation contract check**
 
@@ -932,7 +930,7 @@ for readme in \
 done
 ```
 
-Expected: FAIL because benchmark README files do not exist.
+예상 결과: FAIL because benchmark README files do not exist.
 
 - [ ] **Step 2: Write the benchmark report from committed comparison rows**
 
@@ -992,7 +990,7 @@ Add the report to `docs/benchmarks/README.md`. Add a `1.12.0` unreleased section
 
 - [ ] **Step 6: Validate locale and claim parity**
 
-Run:
+실행:
 
 ```bash
 for module in io/io io/jackson2 io/jackson3 io/fastjson2 io/avro benchmark/serializer-benchmark; do
@@ -1008,7 +1006,7 @@ done
 rg -n '#755|#756|#757|#758' benchmark/serializer-benchmark/README.md benchmark/serializer-benchmark/README.ko.md docs/benchmarks/2026-07-18-bytebuffer-serializer-allocation.md
 ```
 
-Expected: every command PASS.
+예상 결과: every command PASS.
 
 - [ ] **Step 7: Commit evidence and documentation**
 
@@ -1047,7 +1045,7 @@ git commit -m "Document only serializer allocation reductions the evidence suppo
 
 ### Task 10: Run Proportional Verification And Repository Hazards
 
-**Complexity:** High **Depends on:** Task 9 **Write scope:** no intended writes **Heavy-command
+**복잡도:** High **의존:** Task 9 **작성 범위:** no intended writes **Heavy-command
 limit:** sequential Gradle invocations; no parallel benchmark or Testcontainers process
 **Rollback/Rerun:** A failed gate returns to the task that owns the failing file or evidence; rerun that targeted gate, then repeat all Task 10 checks.
 
@@ -1058,7 +1056,7 @@ limit:** sequential Gradle invocations; no parallel benchmark or Testcontainers 
 python3 -m unittest benchmark/serializer-benchmark/scripts/test_summarize_jmh.py -v
 ```
 
-Expected: PASS.
+예상 결과: PASS.
 
 - [ ] **Step 2: Run all affected module tests sequentially**
 
@@ -1071,7 +1069,7 @@ Expected: PASS.
 ./gradlew :bluetape4k-avro:test --no-configuration-cache
 ```
 
-Expected: every command PASS. Investigate any retry-only pass as a lifecycle or environment signal rather than erasing the first failure.
+예상 결과: every command PASS. Investigate any retry-only pass as a lifecycle or environment signal rather than erasing the first failure.
 
 - [ ] **Step 3: Run serializer ABI proof**
 
@@ -1080,7 +1078,7 @@ bash scripts/check-serializer-buffer-abi.sh \
   --build-current --expected-head "$(git rev-parse HEAD)"
 ```
 
-Expected: PASS with current head recorded.
+예상 결과: PASS with current head recorded.
 
 - [ ] **Step 4: Verify module registration and exclusion hazards**
 
@@ -1108,7 +1106,7 @@ Inspect the result. Add root module-map or workflow path updates only when the e
 git diff --check origin/develop...HEAD
 ```
 
-Expected: PASS with no new warnings attributable to changed files.
+예상 결과: PASS with no new warnings attributable to changed files.
 
 - [ ] **Step 6: Verify spec and claim traceability**
 
@@ -1126,17 +1124,17 @@ python3 benchmark/serializer-benchmark/scripts/summarize-jmh.py compare \
 cmp docs/benchmarks/raw/issue-1039/comparison.csv /tmp/issue-1039-comparison-recheck.csv
 ```
 
-Expected: every positive phrase maps to an `accepted` row and regenerated CSV is byte-identical.
+예상 결과: every positive phrase maps to an `accepted` row and regenerated CSV is byte-identical.
 
 ### Task 11: Converge Review And Commit The Durable Lesson
 
-**Complexity:** Medium **Depends on:** Task 10 **Write
+**복잡도:** Medium **의존:** Task 10 **Write
 scope:** `docs/lessons/2026-07-18-issue-1039-serializer-allocation-proof.md` and in-scope blocker fixes only
 **Rollback/Rerun:** Any P0/P1 finding returns to the owning implementation task; after the fix, rerun affected verification and all six review lenses.
 
-**Files:**
+**파일:**
 
-- Create: `docs/lessons/2026-07-18-issue-1039-serializer-allocation-proof.md`
+- 생성: `docs/lessons/2026-07-18-issue-1039-serializer-allocation-proof.md`
 
 - [ ] **Step 1: Run the Type A performance/stability scan and six review lenses**
 
@@ -1187,11 +1185,11 @@ git log -1 --format=full
 git diff --stat origin/develop...HEAD
 ```
 
-Expected: clean branch, Lore-compliant head, intended files only, P0=0, P1=0.
+예상 결과: clean branch, Lore-compliant head, intended files only, P0=0, P1=0.
 
 ### Task 12: Deliver The Exact-Head Pull Request And Stop Before Merge
 
-**Complexity:** Medium **Depends on:** Task 11 and common gates CG-01 through CG-10 **External side
+**복잡도:** Medium **의존:** Task 11 and common gates CG-01 through CG-10 **External side
 effects:** push branch and create/update PR are authorized by the approved design; merge is not
 **Rollback/Rerun:** A push, CI, metadata, or review failure returns to the owning task and exact-head verification; never merge, auto-merge, or delete the branch.
 
@@ -1204,7 +1202,7 @@ git status --short --branch
 git rev-parse HEAD
 ```
 
-Expected: issue OPEN, milestone `1.12.0`, assignee `debop`, labels include
+예상 결과: issue OPEN, milestone `1.12.0`, assignee `debop`, labels include
 `enhancement`, `performance`, and `infra/io`; branch is clean.
 
 - [ ] **Step 2: Push and verify exact remote head**
@@ -1216,7 +1214,7 @@ REMOTE_HEAD=$(git ls-remote --heads origin feat/issue-754-allocation-proof | awk
 test "$LOCAL_HEAD" = "$REMOTE_HEAD"
 ```
 
-Expected: local and remote SHAs match exactly.
+예상 결과: local and remote SHAs match exactly.
 
 - [ ] **Step 3: Render the issue-linked PR body from current evidence**
 
@@ -1276,7 +1274,7 @@ gh pr view "$PR" --repo bluetape4k/bluetape4k-projects \
   --json number,url,state,headRefName,headRefOid,baseRefName,assignees,labels,milestone,body
 ```
 
-Expected: metadata matches and the last Markdown `##` heading is exactly
+예상 결과: metadata matches and the last Markdown `##` heading is exactly
 `## DoD Status`.
 
 - [ ] **Step 6: Wait for exact-head CI and reread reviews**
@@ -1290,7 +1288,7 @@ gh pr view "$PR" --repo bluetape4k/bluetape4k-projects \
 gh api "repos/bluetape4k/bluetape4k-projects/pulls/$PR/comments"
 ```
 
-Expected: required checks succeed on the exact remote head and no unresolved P0/P1 review blocker remains. A failure returns to the owning implementation task and reruns affected verification.
+예상 결과: required checks succeed on the exact remote head and no unresolved P0/P1 review blocker remains. A failure returns to the owning implementation task and reruns affected verification.
 
 - [ ] **Step 7: Report merge readiness and stop**
 

--- a/docs/superpowers/plans/2026-07-18-issue-757-protobuf-buffer-core.md
+++ b/docs/superpowers/plans/2026-07-18-issue-757-protobuf-buffer-core.md
@@ -1,20 +1,18 @@
-# Issue #757 Protobuf Buffer Core Implementation Plan
+# Issue #757 Protobuf Buffer Core 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use `$subagent-driven-development` (recommended) or `$executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 `$subagent-driven-development`(권장) 또는 `$executing-plans`로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** Add caller-owned Protobuf `ByteBuffer` APIs, route strict serializer and contiguous Redisson decode through lower-copy paths, and prove benchmark completeness plus allocation claims with two fail-closed runs.
+**목표:** Add caller-owned Protobuf `ByteBuffer` APIs, route strict serializer and contiguous Redisson decode through lower-copy paths, and prove benchmark completeness plus allocation claims with two fail-closed runs.
 
-**Architecture:** Keep `ByteArray` and trusted fallback behavior intact while adding a shared loader-scoped Protobuf message resolver and explicit buffer overrides. Redisson uses a bounded NIO view only for single-component inputs and retains an isolated copied compatibility path for composite and trusted fallback inputs. The existing protobuf benchmark module becomes a thread-confined allocation harness with a module-local validator and exact-head evidence protocol.
+**아키텍처:** Keep `ByteArray` and trusted fallback behavior intact while adding a shared loader-scoped Protobuf message resolver and explicit buffer overrides. Redisson uses a bounded NIO view only for single-component inputs and retains an isolated copied compatibility path for composite and trusted fallback inputs. The existing protobuf benchmark module becomes a thread-confined allocation harness with a module-local validator and exact-head evidence protocol.
 
-**Tech
-Stack:** Kotlin 2.3, Java 21 `ByteBuffer`, Protobuf 4.35.1 `Any`/`CodedOutputStream`, Netty `ByteBuf`, Redisson codec APIs, JUnit 5, kotlinx-benchmark/JMH, Python 3 `unittest`.
+**기술 스택:** Kotlin 2.3, Java 21 `ByteBuffer`, Protobuf 4.35.1 `Any`/`CodedOutputStream`, Netty `ByteBuf`, Redisson codec APIs, JUnit 5, kotlinx-benchmark/JMH, Python 3 `unittest`.
 
 ---
 
-## File Map
+## 파일 지도
 
-**Create**
+**생성**
 
 - `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufMessageClassResolver.kt` — loader-identity cache and `Message` assignability gate shared by serializer and Redisson.
 - `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/MessageSupportByteBufferTest.kt` — public helper buffer contract.
@@ -37,11 +35,11 @@ Stack:** Kotlin 2.3, Java 21 `ByteBuffer`, Protobuf 4.35.1 `Any`/`CodedOutputStr
 - `docs/benchmarks/raw/issue-757/validation.json` — comparison validation and identity verdict.
 - `docs/benchmarks/raw/issue-757/delivery-manifest.json` — committed relative-path/hash authority for clean-checkout report and delivery validation.
 
-**Move**
+**이동**
 
 - `benchmark/protobuf-codec-benchmark/src/benchmark/proto/protobuf/benchmark-message.proto` → `benchmark/protobuf-codec-benchmark/src/main/proto/protobuf/benchmark-message.proto` so the fixture and its unit tests share one generated payload type.
 
-**Modify**
+**수정**
 
 - `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/MessageSupport.kt`
 - `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt`
@@ -57,7 +55,7 @@ Stack:** Kotlin 2.3, Java 21 `ByteBuffer`, Protobuf 4.35.1 `Any`/`CodedOutputStr
 - `docs/benchmarks/README.md`
 - `CHANGELOG.md`
 
-## Guardrails
+## Guardrail
 
 - Do not edit `LettuceProtobufCodecs.kt`, Kafka, compressor wrappers, Gradle module registration, dependency catalogs, release, or publishing surfaces.
 - Preserve `packMessage(ByteArray)`, `unpackMessage(ByteArray)`, `serialize`, and `deserialize` wire and source/binary compatibility.
@@ -78,12 +76,12 @@ Evidence invalidation is fail-closed:
 
 Initial promotion remains no-clobber. A legitimate post-promotion replacement uses `run-evidence.py replace-promoted --state <new-state> --expected-manifest <tracked-old-manifest> --destination docs/benchmarks/raw/issue-757 --backup-root .omx/tmp/issue-757/evidence-backups`. It verifies the tracked old directory against its manifest, builds/verifies the complete new sibling directory, atomically moves the old canonical directory to a unique ignored backup and the new directory into place, restores the old directory on any failure, and records the one exact backup path in state. Git history plus the ignored backup preserves recovery. Only after the replacement manifest is committed at `HEAD`, `git show HEAD:docs/benchmarks/raw/issue-757/delivery-manifest.json` is byte-identical to the working file, and `validate-committed` succeeds may `cleanup-replacement-backup` remove that state-recorded backup; it rejects an unverified manifest/head, a path outside the configured backup root, or any path other than the recorded backup. Fixtures cover old-manifest drift, destination collision, failure between both renames, successful restore, cleanup refusal, exact single-backup cleanup, and clean-checkout validation of the replacement.
 
-### Task 1: Add the loader-scoped message resolver security boundary
+### Task 1: loader-scoped message resolver security boundary 추가
 
-**Files:**
+**파일:**
 
-- Create: `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufMessageClassResolver.kt`
-- Modify: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerSecurityTest.kt`
+- 생성: `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufMessageClassResolver.kt`
+- 수정: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerSecurityTest.kt`
 
 - [ ] **Step 1: Write failing tests for non-Message classes and loader isolation**
 
@@ -146,7 +144,7 @@ fun `message class cache is isolated by effective class loader identity`() {
 
 - [ ] **Step 2: Run the security tests and verify RED**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-protobuf:test \
@@ -154,7 +152,7 @@ Run:
   --no-configuration-cache
 ```
 
-Expected: FAIL because the existing class-name-only companion cache bypasses the second loader and the unchecked cast does not enforce `Message` assignability before caching.
+예상 결과: FAIL because the existing class-name-only companion cache bypasses the second loader and the unchecked cast does not enforce `Message` assignability before caching.
 
 - [ ] **Step 3: Implement the shared resolver**
 
@@ -360,7 +358,7 @@ Extend the loader tests with a null-TCCL case that restores the original loader 
 
 Run the Step 2 command.
 
-Expected: PASS, including one resolution per distinct loader identity and terminal rejection of `java.lang.String`.
+예상 결과: PASS, including one resolution per distinct loader identity and terminal rejection of `java.lang.String`.
 
 - [ ] **Step 5: Commit the resolver boundary**
 
@@ -381,10 +379,10 @@ Not-tested: Redisson adoption follows in a separate task"
 
 ### Task 2: Add caller-owned MessageSupport ByteBuffer APIs
 
-**Files:**
+**파일:**
 
-- Create: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/MessageSupportByteBufferTest.kt`
-- Modify: `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/MessageSupport.kt`
+- 생성: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/MessageSupportByteBufferTest.kt`
+- 수정: `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/MessageSupport.kt`
 
 - [ ] **Step 1: Write failing public contract tests**
 
@@ -543,7 +541,7 @@ class MessageSupportByteBufferTest {
   --no-configuration-cache
 ```
 
-Expected: compilation FAIL with unresolved `packMessageTo` and `unpackMessage(ByteBuffer)`.
+예상 결과: compilation FAIL with unresolved `packMessageTo` and `unpackMessage(ByteBuffer)`.
 
 - [ ] **Step 3: Implement `packMessageTo` and `unpackMessage(ByteBuffer)`**
 
@@ -603,7 +601,7 @@ Add KDoc that states non-zero position, limit preservation, raw preflight failur
   --no-configuration-cache
 ```
 
-Expected: PASS with ByteArray/ByteBuffer wire equality and preserved input state.
+예상 결과: PASS with ByteArray/ByteBuffer wire equality and preserved input state.
 
 - [ ] **Step 5: Commit the public helper APIs**
 
@@ -623,11 +621,11 @@ Not-tested: Serializer and Redis dispatch are covered by later tasks"
 
 ### Task 3: Override ProtobufSerializer buffer dispatch without weakening fallback security
 
-**Files:**
+**파일:**
 
-- Create: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerByteBufferTest.kt`
-- Modify: `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt`
-- Modify: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerSecurityTest.kt`
+- 생성: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerByteBufferTest.kt`
+- 수정: `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt`
+- 수정: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializerSecurityTest.kt`
 
 - [ ] **Step 1: Write failing serializer buffer tests**
 
@@ -778,7 +776,7 @@ class ProtobufSerializerByteBufferTest {
   --no-configuration-cache
 ```
 
-Expected: the declared-method reflection test fails before the overrides exist.
+예상 결과: the declared-method reflection test fails before the overrides exist.
 
 - [ ] **Step 3: Refactor Protobuf decode once, then override both buffer methods**
 
@@ -1147,7 +1145,7 @@ Together with `terminal security failures never reach trusted fallback`, these t
 
 Run the Step 2 command plus existing `ProtobufSerializerTest`.
 
-Expected: PASS; strict exceptions remain wrapped, trusted fallback remains compatible, and repeated buffer calls do not drift.
+예상 결과: PASS; strict exceptions remain wrapped, trusted fallback remains compatible, and repeated buffer calls do not drift.
 
 - [ ] **Step 6: Commit serializer dispatch**
 
@@ -1168,10 +1166,10 @@ Not-tested: Redisson decode and allocation evidence follow in later tasks"
 
 ### Task 4: Route contiguous Redisson decode through a bounded NIO view
 
-**Files:**
+**파일:**
 
-- Modify: `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt`
-- Modify: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecTest.kt`
+- 수정: `io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt`
+- 수정: `io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodecTest.kt`
 
 - [ ] **Step 1: Write failing contiguous/composite/resource tests**
 
@@ -1353,7 +1351,7 @@ fun `trusted fallback releases its isolated copy on success and failure`() {
   --no-configuration-cache
 ```
 
-Expected: fallback copy remains unreleased, and the bounded-view probe reports zero `nioBuffer` calls because strict decode still performs `getBytes(copy = true)`.
+예상 결과: fallback copy remains unreleased, and the bounded-view probe reports zero `nioBuffer` calls because strict decode still performs `getBytes(copy = true)`.
 
 - [ ] **Step 3: Implement contiguous view, composite copy, shared resolution, and exact fallback cleanup**
 
@@ -1586,7 +1584,7 @@ The `decodeFallback` catch must still throw the original operation sentinel; its
 ./gradlew :bluetape4k-protobuf:test --no-configuration-cache
 ```
 
-Expected: all tests PASS; input indices/refCnt remain unchanged and temporary fallback buffers reach refCnt 0.
+예상 결과: all tests PASS; input indices/refCnt remain unchanged and temporary fallback buffers reach refCnt 0.
 
 - [ ] **Step 6: Commit the Redisson decode boundary**
 
@@ -1606,14 +1604,14 @@ Not-tested: Lettuce remains the second issue 757 pull request"
 
 ### Task 5: Rebuild the protobuf benchmark as a deterministic allocation matrix
 
-**Files:**
+**파일:**
 
-- Move: `benchmark/protobuf-codec-benchmark/src/benchmark/proto/protobuf/benchmark-message.proto` → `benchmark/protobuf-codec-benchmark/src/main/proto/protobuf/benchmark-message.proto`
-- Create: `benchmark/protobuf-codec-benchmark/src/main/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmarkSupport.kt`
-- Create: `benchmark/protobuf-codec-benchmark/src/main/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmarkMetadata.kt`
-- Create: `benchmark/protobuf-codec-benchmark/src/test/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmarkSupportTest.kt`
-- Modify: `benchmark/protobuf-codec-benchmark/build.gradle.kts`
-- Modify: `benchmark/protobuf-codec-benchmark/src/benchmark/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmark.kt`
+- 이동: `benchmark/protobuf-codec-benchmark/src/benchmark/proto/protobuf/benchmark-message.proto` → `benchmark/protobuf-codec-benchmark/src/main/proto/protobuf/benchmark-message.proto`
+- 생성: `benchmark/protobuf-codec-benchmark/src/main/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmarkSupport.kt`
+- 생성: `benchmark/protobuf-codec-benchmark/src/main/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmarkMetadata.kt`
+- 생성: `benchmark/protobuf-codec-benchmark/src/test/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmarkSupportTest.kt`
+- 수정: `benchmark/protobuf-codec-benchmark/build.gradle.kts`
+- 수정: `benchmark/protobuf-codec-benchmark/src/benchmark/kotlin/io/bluetape4k/protobuf/benchmark/ProtobufCodecBenchmark.kt`
 
 - [ ] **Step 1: Move the canonical proto and wire main/test dependencies**
 
@@ -1681,7 +1679,7 @@ class ProtobufCodecBenchmarkSupportTest {
 ./gradlew :protobuf-codec-benchmark:test --no-configuration-cache
 ```
 
-Expected: compilation FAIL until the support fixture and matrix exist.
+예상 결과: compilation FAIL until the support fixture and matrix exist.
 
 - [ ] **Step 4: Implement the deterministic fixture and exact method set**
 
@@ -1993,7 +1991,7 @@ java -cp "$JMH_JARS" io.bluetape4k.protobuf.benchmark.ProtobufCodecBenchmarkMeta
 java -jar "$JMH_JARS" -l
 ```
 
-Expected: tests and tasks PASS; list contains exactly the 13 methods in `ProtobufBenchmarkMatrix.expectedMethods`.
+예상 결과: tests and tasks PASS; list contains exactly the 13 methods in `ProtobufBenchmarkMatrix.expectedMethods`.
 
 - [ ] **Step 7: Commit the deterministic harness**
 
@@ -2011,12 +2009,12 @@ Not-tested: Long GC-profiler evidence runs follow after validation tooling"
 
 ### Task 6: Add the fail-closed JMH validator and two-run verdict gate
 
-**Files:**
+**파일:**
 
-- Create: `benchmark/protobuf-codec-benchmark/scripts/validate-jmh.py`
-- Create: `benchmark/protobuf-codec-benchmark/scripts/test_validate_jmh.py`
-- Create: `benchmark/protobuf-codec-benchmark/scripts/run-evidence.py`
-- Create: `benchmark/protobuf-codec-benchmark/scripts/test_run_evidence.py`
+- 생성: `benchmark/protobuf-codec-benchmark/scripts/validate-jmh.py`
+- 생성: `benchmark/protobuf-codec-benchmark/scripts/test_validate_jmh.py`
+- 생성: `benchmark/protobuf-codec-benchmark/scripts/run-evidence.py`
+- 생성: `benchmark/protobuf-codec-benchmark/scripts/test_run_evidence.py`
 
 - [ ] **Step 1: Write failing validator fixtures**
 
@@ -2063,7 +2061,7 @@ class ValidateJmhTest(unittest.TestCase):
 python3 -m unittest benchmark/protobuf-codec-benchmark/scripts/test_validate_jmh.py
 ```
 
-Expected: FAIL because `validate-jmh.py` does not exist.
+예상 결과: FAIL because `validate-jmh.py` does not exist.
 
 - [ ] **Step 3: Implement the exact matrix and validation primitives**
 
@@ -2189,7 +2187,7 @@ python3 -m unittest benchmark/protobuf-codec-benchmark/scripts/test_validate_jmh
 python3 -m unittest benchmark/protobuf-codec-benchmark/scripts/test_run_evidence.py
 ```
 
-Expected: all tests PASS, including `regressed`, invalid metric, manifest/JAR mismatch, JAR replacement, multiple-JAR, dirty-tree, duplicate-run-ID, failed-process logging, promotion collision, old-manifest drift, failure between the two replacement renames with exact restore, successful replacement, cleanup refusal, exact single-backup cleanup, and clean-checkout replacement validation fixtures.
+예상 결과: all tests PASS, including `regressed`, invalid metric, manifest/JAR mismatch, JAR replacement, multiple-JAR, dirty-tree, duplicate-run-ID, failed-process logging, promotion collision, old-manifest drift, failure between the two replacement renames with exact restore, successful replacement, cleanup refusal, exact single-backup cleanup, and clean-checkout replacement validation fixtures.
 
 - [ ] **Step 5: Commit the unit-validated fail-closed gate**
 
@@ -2220,18 +2218,18 @@ python3 benchmark/protobuf-codec-benchmark/scripts/run-evidence.py run \
 
 The smoke profile is fixed at `-t 1 -f 1 -wi 1 -i 1 -w 1s -r 1s -prof gc -rf json`; the validator's `run` mode validates schema, provenance, and metrics, while final `compare` mode enforces the canonical evidence profile.
 
-Expected: all 13 methods present and validation status `passed`. If the smoke fails, repair the scripts/tests, repeat Step 4, commit the repair with Lore trailers, and rerun the smoke from the new clean head. Do not bypass the runner clean-tree gate. The smoke root/state is never reused for canonical evidence. Task 8 creates the distinct `build/issue-757-evidence/jar.json` only after its fresh clean/JAR build.
+예상 결과: all 13 methods present and validation status `passed`. If the smoke fails, repair the scripts/tests, repeat Step 4, commit the repair with Lore trailers, and rerun the smoke from the new clean head. Do not bypass the runner clean-tree gate. The smoke root/state is never reused for canonical evidence. Task 8 creates the distinct `build/issue-757-evidence/jar.json` only after its fresh clean/JAR build.
 
 ### Task 7: Document the public contract and prepare a clean implementation head
 
-**Files:**
+**파일:**
 
-- Modify: `io/protobuf/README.md`
-- Modify: `io/protobuf/README.ko.md`
-- Modify: `benchmark/protobuf-codec-benchmark/README.md`
-- Modify: `benchmark/protobuf-codec-benchmark/README.ko.md`
-- Modify: `docs/benchmarks/README.md`
-- Modify: `CHANGELOG.md`
+- 수정: `io/protobuf/README.md`
+- 수정: `io/protobuf/README.ko.md`
+- 수정: `benchmark/protobuf-codec-benchmark/README.md`
+- 수정: `benchmark/protobuf-codec-benchmark/README.ko.md`
+- 수정: `docs/benchmarks/README.md`
+- 수정: `CHANGELOG.md`
 
 - [ ] **Step 1: Update English/Korean Protobuf README sections in parity**
 
@@ -2318,7 +2316,7 @@ git diff --check
   --no-configuration-cache
 ```
 
-Expected: locale pairs contain the same contract topics; all targeted tests/compile pass; no whitespace errors.
+예상 결과: locale pairs contain the same contract topics; all targeted tests/compile pass; no whitespace errors.
 
 - [ ] **Step 5: Commit documentation and confirm the measurement head is clean**
 
@@ -2338,20 +2336,20 @@ Not-tested: Final allocation numbers are intentionally deferred to fresh runs"
 repo-status
 ```
 
-Expected: clean tree; branch is ahead of `origin/develop`; record `git rev-parse HEAD` as the measurement commit.
+예상 결과: clean tree; branch is ahead of `origin/develop`; record `git rev-parse HEAD` as the measurement commit.
 
 ### Task 8: Collect two clean exact-head allocation runs and publish only supported conclusions
 
-**Files:**
+**파일:**
 
-- Create: `docs/benchmarks/2026-07-18-protobuf-buffer-allocation.md`
-- Create: `docs/benchmarks/raw/issue-757/run-<UTC>/environment.json`
-- Create: `docs/benchmarks/raw/issue-757/run-<UTC>/argv.json`
-- Create: `docs/benchmarks/raw/issue-757/run-<UTC>/run.log`
-- Create: `docs/benchmarks/raw/issue-757/run-<UTC>/jmh.json`
-- Create: `docs/benchmarks/raw/issue-757/run-<UTC>/summary.csv`
-- Create: `docs/benchmarks/raw/issue-757/run-<UTC>/validation.json`
-- Create: `docs/benchmarks/raw/issue-757/comparison.csv`
+- 생성: `docs/benchmarks/2026-07-18-protobuf-buffer-allocation.md`
+- 생성: `docs/benchmarks/raw/issue-757/run-<UTC>/environment.json`
+- 생성: `docs/benchmarks/raw/issue-757/run-<UTC>/argv.json`
+- 생성: `docs/benchmarks/raw/issue-757/run-<UTC>/run.log`
+- 생성: `docs/benchmarks/raw/issue-757/run-<UTC>/jmh.json`
+- 생성: `docs/benchmarks/raw/issue-757/run-<UTC>/summary.csv`
+- 생성: `docs/benchmarks/raw/issue-757/run-<UTC>/validation.json`
+- 생성: `docs/benchmarks/raw/issue-757/comparison.csv`
 - Modify conditionally: production dispatch files and `CHANGELOG.md` only if the symmetric regression rule requires rollback.
 
 - [ ] **Step 1: Prove the measurement source is clean and capture immutable identity**
@@ -2368,7 +2366,7 @@ sysctl -n machdep.cpu.brand_string
 uname -a
 ```
 
-Expected: clean tree including untracked files. Stop if dirty; do not measure uncommitted implementation. The runner repeats this gate immediately before each launch and writes these command results into the manifest, so this shell inspection is orientation rather than the source of truth.
+예상 결과: clean tree including untracked files. Stop if dirty; do not measure uncommitted implementation. The runner repeats this gate immediately before each launch and writes these command results into the manifest, so this shell inspection is orientation rather than the source of truth.
 
 - [ ] **Step 2: Build one JMH jar before both runs**
 
@@ -2379,7 +2377,7 @@ Expected: clean tree including untracked files. Stop if dirty; do not measure un
   --no-configuration-cache
 ```
 
-Expected: PASS and exactly one runnable JMH jar under `benchmark/protobuf-codec-benchmark/build/benchmarks/benchmark/jars/`.
+예상 결과: PASS and exactly one runnable JMH jar under `benchmark/protobuf-codec-benchmark/build/benchmarks/benchmark/jars/`.
 
 Resolve and pin the artifact once in an ignored, fail-if-exists state file:
 
@@ -2406,7 +2404,7 @@ python3 benchmark/protobuf-codec-benchmark/scripts/run-evidence.py run \
   --output-root benchmark/protobuf-codec-benchmark/build/issue-757-evidence
 ```
 
-Expected: both validations PASS; run IDs differ; all 13 methods and required metrics are present; each directory contains `environment.json`, `argv.json`, `run.log`, `jmh.json`, `summary.csv`, and `validation.json`; the recorded exit code is 0; the tree remains clean because staging is ignored.
+예상 결과: both validations PASS; run IDs differ; all 13 methods and required metrics are present; each directory contains `environment.json`, `argv.json`, `run.log`, `jmh.json`, `summary.csv`, and `validation.json`; the recorded exit code is 0; the tree remains clean because staging is ignored.
 
 - [ ] **Step 4: Compare the two validated runs**
 
@@ -2417,7 +2415,7 @@ python3 benchmark/protobuf-codec-benchmark/scripts/run-evidence.py compare \
   --validation benchmark/protobuf-codec-benchmark/build/issue-757-evidence/validation.json
 ```
 
-Expected: each eligible cell is exactly `accepted`, `inconclusive`, or `regressed`; compatibility/fallback cells are `ineligible`.
+예상 결과: each eligible cell is exactly `accepted`, `inconclusive`, or `regressed`; compatibility/fallback cells are `ineligible`.
 
 - [ ] **Step 5: Apply the symmetric go/no-go rule before writing claims**
 
@@ -2438,7 +2436,7 @@ Rollback 순서는 고정이다: (1) pre-change clean head에서 Gradle clean �
 
 - [ ] **Step 6: Promote validated artifacts atomically only after both runs finish**
 
-Run:
+실행:
 
 ```bash
 test ! -e docs/benchmarks/raw/issue-757
@@ -2505,10 +2503,10 @@ fi
 
 ### Task 9: Run final verification, independent review, and exact-head PR delivery
 
-**Files:**
+**파일:**
 
-- Create: `docs/review/issue-757-protobuf-buffer-core-review.md`
-- Modify: issue #757 DoD and PR metadata only after local verification passes.
+- 생성: `docs/review/issue-757-protobuf-buffer-core-review.md`
+- 수정: issue #757 DoD and PR metadata only after local verification passes.
 
 - [ ] **Step 1: Run final local verification sequentially**
 
@@ -2573,7 +2571,7 @@ git diff --name-status origin/develop...HEAD
 python3 .omx/tmp/issue-757/check_scope.py origin/develop HEAD
 ```
 
-Expected: every command exits 0, the post-test tree is clean including untracked files, the complete `origin/develop...HEAD` name/status list is reviewed, and no module registration, dependency catalog/wrapper, release, tag, publishing, or workflow surface entered the diff. If Detekt task naming differs, discover with `./gradlew :bluetape4k-protobuf:tasks --all` and record the actual equivalent.
+예상 결과: every command exits 0, the post-test tree is clean including untracked files, the complete `origin/develop...HEAD` name/status list is reviewed, and no module registration, dependency catalog/wrapper, release, tag, publishing, or workflow surface entered the diff. If Detekt task naming differs, discover with `./gradlew :bluetape4k-protobuf:tasks --all` and record the actual equivalent.
 
 - [ ] **Step 2: Run independent six-lens review and repair until P0=0/P1=0**
 

--- a/docs/superpowers/plans/2026-07-21-issue-1065-multi-key-ownership-lease-plan.md
+++ b/docs/superpowers/plans/2026-07-21-issue-1065-multi-key-ownership-lease-plan.md
@@ -1,14 +1,12 @@
-# Issue #1065 Multi-Key Ownership Lease Implementation Plan
+# Issue #1065 Multi-Key Ownership Lease 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** 같은 Redis hash slot의 여러 key를 caller-supplied token과 TTL로 원자적으로 점유·검사·갱신·해제하는 stateless Lettuce primitive를 제공한다.
+**목표:** 같은 Redis hash slot의 여러 key를 caller-supplied token과 TTL로 원자적으로 점유·검사·갱신·해제하는 stateless Lettuce primitive를 제공한다.
 
-**Architecture:** standalone/cluster connection을 공통 Redis scripting interface로 축약하고, 입력 검증과 Lua vector decoder를 하나의 internal support에 둔다. sync/`CompletableFuture`/suspend facade는 같은 support를 사용하며 production resilience 정책은 외부 `SuspendDecorators`에 남긴다.
+**아키텍처:** standalone/cluster connection을 공통 Redis scripting interface로 축약하고, 입력 검증과 Lua vector decoder를 하나의 internal support에 둔다. sync/`CompletableFuture`/suspend facade는 같은 support를 사용하며 production resilience 정책은 외부 `SuspendDecorators`에 남긴다.
 
-**Tech
-Stack:** Kotlin 2.3, Java 21, Lettuce 7.6, Redis Lua, Kotlin coroutines, JUnit 5, Kluent-style Bluetape assertions, Testcontainers Redis/Redis Cluster, Resilience4j test integration, Gradle Kotlin DSL.
+**기술 스택:** Kotlin 2.3, Java 21, Lettuce 7.6, Redis Lua, Kotlin coroutines, JUnit 5, Kluent-style Bluetape assertions, Testcontainers Redis/Redis Cluster, Resilience4j test integration, Gradle Kotlin DSL.
 
 ---
 
@@ -62,11 +60,11 @@ Stack:** Kotlin 2.3, Java 21, Lettuce 7.6, Redis Lua, Kotlin coroutines, JUnit 5
 
 ### Task 1: RedisScriptRunner를 cluster-compatible scripting interface로 일반화
 
-**Complexity:** M **Dependency:** 없음 **Pattern skill:** `bluetape-kotlin-patterns`, `test-driven-development`
+**복잡도:** M **Dependency:** 없음 **Pattern skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/script/RedisScript.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/script/RedisScript.kt`
 - Modify/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/script/RedisScriptTest.kt`
 
 - [ ] **Step 1: generalized sync/async/suspend overload가 없어서 compile fail하는 테스트를 추가한다.**
@@ -94,8 +92,8 @@ fun `general scripting interfaces support all runner styles`() = runTest {
 
 - [ ] **Step 2: targeted test를 실행해 generalized overload compile failure를 확인한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.script.RedisScriptTest" --no-parallel --max-workers=1`
-Expected: FAIL at `compileTestKotlin` because runner does not accept `RedisScriptingCommands`/`RedisScriptingAsyncCommands`.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.script.RedisScriptTest" --no-parallel --max-workers=1`
+예상 결과: FAIL at `compileTestKotlin` because runner does not accept `RedisScriptingCommands`/`RedisScriptingAsyncCommands`.
 
 - [ ] **Step 3: 기존 public overload는 유지하고 generalized overload와 private implementation을 추가한다.**
 
@@ -133,8 +131,8 @@ Async는 `RedisScriptingAsyncCommands`로 `evalsha(...).toCompletableFuture().ex
 
 - [ ] **Step 4: 기존 signature와 새 interface fixture를 함께 통과시킨다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.script.RedisScriptTest" --no-parallel --max-workers=1`
-Expected: PASS; 기존 NOSCRIPT sync/async/suspend 테스트도 유지된다.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.script.RedisScriptTest" --no-parallel --max-workers=1`
+예상 결과: PASS; 기존 NOSCRIPT sync/async/suspend 테스트도 유지된다.
 
 - [ ] **Step 5: Lore commit을 만든다.**
 
@@ -149,12 +147,12 @@ Tested: :bluetape4k-lettuce:test --tests RedisScriptTest
 
 ### Task 2: Public result/config/exception 계약을 TDD로 고정
 
-**Complexity:** M **Dependency:** Task 1 **Pattern skill:** `bluetape-kotlin-patterns`, `ecc-kotlin-testing`
+**복잡도:** M **Dependency:** Task 1 **Pattern skill:** `bluetape-kotlin-patterns`, `ecc-kotlin-testing`
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseConfig.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/MultiKeyLeaseResult.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseConfig.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/MultiKeyLeaseResult.kt`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/MultiKeyLeaseResultTest.kt`
 
 - [ ] **Step 1: config validation, exhaustive result properties, serialization round-trip, exception redaction 테스트를
@@ -205,8 +203,8 @@ fun `stable exceptions never expose keys or tokens`() {
 
 - [ ] **Step 2: test compile failure를 확인한다.**
 
-Run: `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.MultiKeyLeaseResultTest"`
-Expected: FAIL because lease public types do not exist.
+실행: `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.MultiKeyLeaseResultTest"`
+예상 결과: FAIL because lease public types do not exist.
 
 - [ ] **Step 3: spec와 동일한 public declarations를 구현한다.**
 
@@ -239,8 +237,8 @@ sealed interface MultiKeyAcquireResult: Serializable {
 
 - [ ] **Step 4: public model test를 통과시킨다.**
 
-Run: `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.MultiKeyLeaseResultTest"`
-Expected: PASS.
+실행: `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.MultiKeyLeaseResultTest"`
+예상 결과: PASS.
 
 - [ ] **Step 5: Lore commit을 만든다.**
 
@@ -255,11 +253,11 @@ Tested: :bluetape4k-lettuce:test --tests MultiKeyLeaseResultTest
 
 ### Task 3: 입력 검증과 vector decoder를 Redis 없이 고정
 
-**Complexity:** L **Dependency:** Task 2 **Pattern skill:** `bluetape-kotlin-patterns`, `ecc-kotlin-testing`
+**복잡도:** L **Dependency:** Task 2 **Pattern skill:** `bluetape-kotlin-patterns`, `ecc-kotlin-testing`
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseSupport.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseSupport.kt`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseSupportTest.kt`
 
 - [ ] **Step 1: bounded snapshot/slot/token/TTL validation RED tests를 작성한다.**
@@ -314,8 +312,8 @@ fun `decoder rejects inconsistent vectors`() {
 
 - [ ] **Step 3: targeted test의 expected compile failure를 확인한다.**
 
-Run: `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseSupportTest"`
-Expected: FAIL because validation/decoder support does not exist.
+실행: `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseSupportTest"`
+예상 결과: FAIL because validation/decoder support does not exist.
 
 - [ ] **Step 4: validation snapshot과 공통 vector invariant를 구현한다.**
 
@@ -342,8 +340,8 @@ decoder는 vector length 7, non-negative counts, `requested == owned + missing +
 
 - [ ] **Step 5: support test를 통과시킨다.**
 
-Run: `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseSupportTest"`
-Expected: PASS.
+실행: `./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseSupportTest"`
+예상 결과: PASS.
 
 - [ ] **Step 6: Lore commit을 만든다.**
 
@@ -358,11 +356,11 @@ Tested: :bluetape4k-lettuce:test --tests LettuceMultiKeyLeaseSupportTest
 
 ### Task 4: Lua state machine을 실제 Redis에서 TDD
 
-**Complexity:** XL **Dependency:** Task 3 **Pattern skill:** `bluetape-kotlin-patterns`, `ecc-kotlin-testing`
+**복잡도:** XL **Dependency:** Task 3 **Pattern skill:** `bluetape-kotlin-patterns`, `ecc-kotlin-testing`
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseSupport.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseSupport.kt`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseScriptTest.kt`
 
 - [ ] **Step 1: acquire/inspect RED matrix를 실제 Redis fixture에 작성한다.**
@@ -408,8 +406,8 @@ full, partial missing, all missing, mismatch-with-zero-owned, external persisten
 
 - [ ] **Step 3: script test가 missing script executor로 실패하는지 확인한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseScriptTest" --no-parallel --max-workers=1`
-Expected: FAIL because operation scripts/executors are absent.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseScriptTest" --no-parallel --max-workers=1`
+예상 결과: FAIL because operation scripts/executors are absent.
 
 - [ ] **Step 4: acquire/inspect Lua를 구현한다.**
 
@@ -441,8 +439,8 @@ renew는 pre-classification 뒤 integrity면 no-op, 아니면 matching key만 `P
 
 - [ ] **Step 6: script matrix를 통과시킨다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseScriptTest" --no-parallel --max-workers=1`
-Expected: PASS; Redis key inspection에서 wrong-owner mutation과 conflict partial write가 없다.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseScriptTest" --no-parallel --max-workers=1`
+예상 결과: PASS; Redis key inspection에서 wrong-owner mutation과 conflict partial write가 없다.
 
 - [ ] **Step 7: Lore commit을 만든다.**
 
@@ -457,11 +455,11 @@ Tested: :bluetape4k-lettuce:test --tests LettuceMultiKeyLeaseScriptTest
 
 ### Task 5: Sync/CompletableFuture facade와 adapter parity
 
-**Complexity:** L **Dependency:** Task 4 **Pattern skill:** `bluetape-kotlin-patterns`, `test-driven-development`
+**복잡도:** L **Dependency:** Task 4 **Pattern skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLease.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLease.kt`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/MultiKeyLeaseContract.kt`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseTest.kt`
 
@@ -495,8 +493,8 @@ Task 5에서는 sync/async adapter가 이 전체 table을 실행하고, Task 6�
 
 - [ ] **Step 2: facade absence failure를 확인한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseTest" --no-parallel --max-workers=1`
-Expected: FAIL because `LettuceMultiKeyLease` does not exist.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseTest" --no-parallel --max-workers=1`
+예상 결과: FAIL because `LettuceMultiKeyLease` does not exist.
 
 - [ ] **Step 3: standalone/cluster secondary constructors와 여덟 public methods를 구현한다.**
 
@@ -528,8 +526,8 @@ inspect/renew/release sync/async도 보유한 `codec`을 각 validation 함수�
 
 - [ ] **Step 4: adapter contract와 validation-before-dispatch를 통과시킨다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseTest" --no-parallel --max-workers=1`
-Expected: PASS.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseTest" --no-parallel --max-workers=1`
+예상 결과: PASS.
 
 - [ ] **Step 5: Lore commit을 만든다.**
 
@@ -544,11 +542,11 @@ Tested: :bluetape4k-lettuce:test --tests LettuceMultiKeyLeaseTest
 
 ### Task 6: Suspend facade와 cancellation contract
 
-**Complexity:** L **Dependency:** Task 5 **Pattern skill:** `kotlin-coroutines-skill`, `ecc-kotlin-testing`
+**복잡도:** L **Dependency:** Task 5 **Pattern skill:** `kotlin-coroutines-skill`, `ecc-kotlin-testing`
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendMultiKeyLease.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendMultiKeyLease.kt`
 - Modify/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/MultiKeyLeaseContract.kt`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendMultiKeyLeaseTest.kt`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseCancellationTest.kt`
@@ -594,8 +592,8 @@ private class TestRedisFuture<T>: CompletableFuture<T>(), RedisFuture<T> {
 
 - [ ] **Step 3: missing suspend facade failure를 확인한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceSuspendMultiKeyLeaseTest" --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseCancellationTest" --no-parallel --max-workers=1`
-Expected: FAIL because suspend facade/test seam is absent.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceSuspendMultiKeyLeaseTest" --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseCancellationTest" --no-parallel --max-workers=1`
+예상 결과: FAIL because suspend facade/test seam is absent.
 
 - [ ] **Step 4: `RedisScriptRunner.runSuspending` 기반 네 suspend method를 구현한다.**
 
@@ -621,7 +619,7 @@ inspect/renew/release도 보유한 `codec`을 validation에 전달해 동일하�
 
 - [ ] **Step 5: cancellation과 suspend parity를 통과시킨다.**
 
-Run: 위 targeted command Expected: PASS; pending future는 cancelled, 실제 Redis fixture는 full-acquired 또는 full-missing만 허용하고 partial은 0건이다.
+실행: 위 targeted command Expected: PASS; pending future는 cancelled, 실제 Redis fixture는 full-acquired 또는 full-missing만 허용하고 partial은 0건이다.
 
 - [ ] **Step 6: Lore commit을 만든다.**
 
@@ -636,9 +634,9 @@ Tested: targeted suspend and cancellation tests
 
 ### Task 7: Redis Cluster·NOSCRIPT·동시성·TTL hostile fixtures
 
-**Complexity:** XL **Dependency:** Task 6 **Pattern skill:** `ecc-kotlin-testing`, `kotlin-coroutines-skill`
+**복잡도:** XL **Dependency:** Task 6 **Pattern skill:** `ecc-kotlin-testing`, `kotlin-coroutines-skill`
 
-**Files:**
+**파일:**
 
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseClusterTest.kt`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseConcurrencyTest.kt`
@@ -676,8 +674,8 @@ fun `cluster routes same-slot scripts and rejects cross-slot before Redis`() {
 
 - [ ] **Step 4: hostile suite를 실행하고 root cause가 없는 retry를 금지한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseClusterTest" --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseConcurrencyTest" --tests "io.bluetape4k.redis.lettuce.script.RedisScriptTest" --no-parallel --max-workers=1`
-Expected: PASS once sequentially; sync/async/suspend NOSCRIPT는 각각 `evalsha=1`, `eval=1`; timing failure는 원인을 수정한 뒤 전체 command를 처음부터 재실행한다.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseClusterTest" --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseConcurrencyTest" --tests "io.bluetape4k.redis.lettuce.script.RedisScriptTest" --no-parallel --max-workers=1`
+예상 결과: PASS once sequentially; sync/async/suspend NOSCRIPT는 각각 `evalsha=1`, `eval=1`; timing failure는 원인을 수정한 뒤 전체 command를 처음부터 재실행한다.
 
 - [ ] **Step 5: Lore commit을 만든다.**
 
@@ -692,11 +690,11 @@ Tested: cluster, concurrency, TTL, NOSCRIPT targeted suites
 
 ### Task 8: Retry + CircuitBreaker + Bulkhead test-only integration
 
-**Complexity:** L **Dependency:** Task 7 **Pattern skill:** `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`
+**복잡도:** L **Dependency:** Task 7 **Pattern skill:** `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/build.gradle.kts`
+- 수정: `infra/lettuce/build.gradle.kts`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseResilience4jTest.kt`
 
 - [ ] **Step 1: test-only project dependency를 추가한다.**
@@ -753,16 +751,16 @@ Retry success-with-retry 1, CircuitBreaker logical success 1, Bulkhead available
 
 - [ ] **Step 4: targeted test를 통과시킨다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseResilience4jTest" --no-parallel --max-workers=1`
-Expected: PASS.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.LettuceMultiKeyLeaseResilience4jTest" --no-parallel --max-workers=1`
+예상 결과: PASS.
 
 - [ ] **Step 5: production dependency 비노출을 증명한다.**
 
-Run: `./gradlew :bluetape4k-lettuce:dependencies --configuration runtimeClasspath`
-Expected: output에 `bluetape4k-resilience4j` 없음.
+실행: `./gradlew :bluetape4k-lettuce:dependencies --configuration runtimeClasspath`
+예상 결과: output에 `bluetape4k-resilience4j` 없음.
 
-Run: `./gradlew :bluetape4k-lettuce:generatePomFileForBluetape4kPublication`
-Expected: `infra/lettuce/build/publications/Bluetape4k/pom-default.xml`에 resilience4j project dependency 없음.
+실행: `./gradlew :bluetape4k-lettuce:generatePomFileForBluetape4kPublication`
+예상 결과: `infra/lettuce/build/publications/Bluetape4k/pom-default.xml`에 resilience4j project dependency 없음.
 
 - [ ] **Step 6: Lore commit을 만든다.**
 
@@ -777,11 +775,11 @@ Tested: resilience integration, runtimeClasspath, generated publication POM
 
 ### Task 9: 성능 characterization task와 evidence
 
-**Complexity:** L **Dependency:** Task 8 **Pattern skill:** `bluetape-kotlin-patterns`, `ecc-kotlin-testing`
+**복잡도:** L **Dependency:** Task 8 **Pattern skill:** `bluetape-kotlin-patterns`, `ecc-kotlin-testing`
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/build.gradle.kts`
+- 수정: `infra/lettuce/build.gradle.kts`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeasePerformanceTest.kt`
 
 - [ ] **Step 1: 기본 test와 분리된 tagged task를 추가한다.**
@@ -819,8 +817,8 @@ fixture 하나가 container, client, workload/probe connections, executor를 명
 
 - [ ] **Step 3: characterization을 단독 실행한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:multiKeyLeasePerformanceTest --no-parallel --max-workers=1`
-Expected: PASS, report에 6개 조합의 p50/p95/throughput 및 probe p95/p99가 출력된다.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:multiKeyLeasePerformanceTest --no-parallel --max-workers=1`
+예상 결과: PASS, report에 6개 조합의 p50/p95/throughput 및 probe p95/p99가 출력된다.
 
 - [ ] **Step 4: maxKeys/script 변경 시 재실행 지침을 test KDoc과 README 작업 목록에 연결한다.**
 
@@ -837,15 +835,15 @@ Tested: :bluetape4k-lettuce:multiKeyLeasePerformanceTest
 
 ### Task 10: English KDoc, bilingual README, diagram을 source-equivalent하게 갱신
 
-**Complexity:** L **Dependency:** Task 9 **Pattern skill:** `bluetape-writer`, `bluetape-diagram`
+**복잡도:** L **Dependency:** Task 9 **Pattern skill:** `bluetape-writer`, `bluetape-diagram`
 
-**Files:**
+**파일:**
 
-- Modify: all new public files under `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/`
-- Modify: `infra/lettuce/README.md`
-- Modify: `infra/lettuce/README.ko.md`
+- 수정: all new public files under `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/`
+- 수정: `infra/lettuce/README.md`
+- 수정: `infra/lettuce/README.ko.md`
 - Create/Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/MultiKeyLeaseDocumentationTest.kt`
-- Modify: `scripts/generate-infra-lettuce-diagram-01.mjs`
+- 수정: `scripts/generate-infra-lettuce-diagram-01.mjs`
 - Regenerate: `docs/images/readme-diagrams/infra-lettuce-diagram-01.svg`
 - Regenerate: `docs/images/readme-diagrams/infra-lettuce-diagram-01.png`
 
@@ -896,14 +894,14 @@ execFileSync(process.env.CAIROSVG ?? "cairosvg", [svgPath, "-o", pngPath, "--sca
 
 - [ ] **Step 4: docs/visual validation을 실행한다.**
 
-Run: `node scripts/generate-infra-lettuce-diagram-01.mjs`
-Expected: SVG와 PNG가 모두 재생성되고 `Multi-Key Lease` label이 존재한다.
+실행: `node scripts/generate-infra-lettuce-diagram-01.mjs`
+예상 결과: SVG와 PNG가 모두 재생성되고 `Multi-Key Lease` label이 존재한다.
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.MultiKeyLeaseDocumentationTest" --no-parallel --max-workers=1`
-Expected: README와 공유한 recovery/decorator policy가 compile되고 실제 Redis smoke가 PASS한다.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.MultiKeyLeaseDocumentationTest" --no-parallel --max-workers=1`
+예상 결과: README와 공유한 recovery/decorator policy가 compile되고 실제 Redis smoke가 PASS한다.
 
-Run: `git diff --check && rg -n "Multi-Key Lease|LettuceMultiKeyLease|ACL|TLS|JWT|PII|operation|result|exception|key/token|single.writer|cutover|rollback|dual.write|durable|manual|namespace" infra/lettuce/README.md infra/lettuce/README.ko.md docs/images/readme-diagrams/infra-lettuce-diagram-01.svg`
-Expected: 양 locale에 bounded telemetry, redaction, same-token recovery, decorator policy, ambiguous completion, cutover/rollback, dual-write 금지, token-loss cleanup heading/marker가 같은 순서로 존재하고 SVG에 새 primitive가 포함된다. test helper는 두 README의 normalized required-heading 목록을 읽어 순서와 source-equivalence도 assertion한다.
+실행: `git diff --check && rg -n "Multi-Key Lease|LettuceMultiKeyLease|ACL|TLS|JWT|PII|operation|result|exception|key/token|single.writer|cutover|rollback|dual.write|durable|manual|namespace" infra/lettuce/README.md infra/lettuce/README.ko.md docs/images/readme-diagrams/infra-lettuce-diagram-01.svg`
+예상 결과: 양 locale에 bounded telemetry, redaction, same-token recovery, decorator policy, ambiguous completion, cutover/rollback, dual-write 금지, token-loss cleanup heading/marker가 같은 순서로 존재하고 SVG에 새 primitive가 포함된다. test helper는 두 README의 normalized required-heading 목록을 읽어 순서와 source-equivalence도 assertion한다.
 
 - [ ] **Step 5: Lore commit을 만든다.**
 
@@ -918,33 +916,33 @@ Tested: diagram regeneration, locale marker scan, git diff --check
 
 ### Task 11: 통합 검증, review, lesson, exact-head PR
 
-**Complexity:** XL **Dependency:** Tasks 1-10 **Pattern
+**복잡도:** XL **Dependency:** Tasks 1-10 **Pattern
 skill:** `verification-before-completion`, `requesting-code-review`, `bluetape-full-feature`
 
-**Files:**
+**파일:**
 
-- Create: `docs/lessons/2026-07-21-multi-key-ownership-lease.md`
+- 생성: `docs/lessons/2026-07-21-multi-key-ownership-lease.md`
 - Create when useful: `docs/review/2026-07-21-issue-1065-multi-key-lease-review.md`
 
 - [ ] **Step 1: targeted tests를 순차 실행한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.*" --tests "io.bluetape4k.redis.lettuce.script.RedisScriptTest" --no-parallel --max-workers=1`
-Expected: PASS.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test --tests "io.bluetape4k.redis.lettuce.lease.*" --tests "io.bluetape4k.redis.lettuce.script.RedisScriptTest" --no-parallel --max-workers=1`
+예상 결과: PASS.
 
 - [ ] **Step 2: full module와 static checks를 실행한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test detekt detektTest --no-parallel --max-workers=1`
-Expected: PASS; Testcontainers-backed tests는 다른 module/worktree와 병렬 실행하지 않는다.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:test detekt detektTest --no-parallel --max-workers=1`
+예상 결과: PASS; Testcontainers-backed tests는 다른 module/worktree와 병렬 실행하지 않는다.
 
 - [ ] **Step 3: performance와 publication boundary를 다시 검증한다.**
 
-Run: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:multiKeyLeasePerformanceTest :bluetape4k-lettuce:generatePomFileForBluetape4kPublication --no-parallel --max-workers=1`
-Expected: performance criteria PASS; POM에 resilience4j dependency 없음.
+실행: `lockf -k -t 900 "$(git rev-parse --git-common-dir)/bluetape-testcontainers.lock" ./gradlew :bluetape4k-lettuce:multiKeyLeasePerformanceTest :bluetape4k-lettuce:generatePomFileForBluetape4kPublication --no-parallel --max-workers=1`
+예상 결과: performance criteria PASS; POM에 resilience4j dependency 없음.
 
 - [ ] **Step 4: repository hygiene를 확인한다.**
 
-Run: `git diff --check && git status --short && git diff --stat`
-Expected: intended lease/test/docs/diagram/lesson files만 존재하고 placeholder·generated drift가 없다.
+실행: `git diff --check && git status --short && git diff --stat`
+예상 결과: intended lease/test/docs/diagram/lesson files만 존재하고 placeholder·generated drift가 없다.
 
 - [ ] **Step 5: spec/plan traceability와 여섯 관점 code review를 실행한다.**
 

--- a/docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md
+++ b/docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md
@@ -1,14 +1,12 @@
-# Issue #755 Caller-Owned ByteBuffer Compressor Implementation Plan
+# Issue #755 Caller-Owned ByteBuffer Compressor 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** `Compressor`에 caller-owned `ByteBuffer` 압축/복원 API를 추가하고 LZ4, Deflate, Snappy, Zstd의 안전한 저할당 경로와 재현 가능한 allocation 증거를 제공한다.
+**목표:** `Compressor`에 caller-owned `ByteBuffer` 압축/복원 API를 추가하고 LZ4, Deflate, Snappy, Zstd의 안전한 저할당 경로와 재현 가능한 allocation 증거를 제공한다.
 
-**Architecture:** 공개 API와 allocating compatibility fallback을 먼저 독립 core slice로 전달한다. 이후 LZ4, Deflate, Snappy, Zstd를 각각 독립 PR로 추가해 backend별 실패 계약과 rollback을 격리하고, 마지막 cross-cutting slice에서 singleton concurrency, caller 예제, benchmark evidence와 문서 parity를 수렴한다. 모든 codec 호출은 source 상태를 보존하고 target position을 성공 시에만 commit하며, native/JDK 경계는 승인 명세의 exact bound와 예외 분류를 따른다.
+**아키텍처:** 공개 API와 allocating compatibility fallback을 먼저 독립 core slice로 전달한다. 이후 LZ4, Deflate, Snappy, Zstd를 각각 독립 PR로 추가해 backend별 실패 계약과 rollback을 격리하고, 마지막 cross-cutting slice에서 singleton concurrency, caller 예제, benchmark evidence와 문서 parity를 수렴한다. 모든 codec 호출은 source 상태를 보존하고 target position을 성공 시에만 commit하며, native/JDK 경계는 승인 명세의 exact bound와 예외 분류를 따른다.
 
-**Tech
-Stack:** Kotlin 2.4.0 / language-api 2.3, Java 21, Gradle 9.x, JUnit 5, `io.bluetape4k.assertions`, lz4-java 1.11.0, snappy-java 1.1.10.8, zstd-jni 1.5.7-11, JDK `Deflater`/`Inflater`, kotlinx-benchmark/JMH 1.37, Python 3 evidence validator.
+**기술 스택:** Kotlin 2.4.0 / language-api 2.3, Java 21, Gradle 9.x, JUnit 5, `io.bluetape4k.assertions`, lz4-java 1.11.0, snappy-java 1.1.10.8, zstd-jni 1.5.7-11, JDK `Deflater`/`Inflater`, kotlinx-benchmark/JMH 1.37, Python 3 evidence validator.
 
 ---
 
@@ -314,7 +312,7 @@ fun decompress(source: ByteBuffer, target: ByteBuffer): Int
 
 ## Task 0: 승인된 plan으로 workflow run과 core slice를 시작한다
 
-**Complexity:** 낮음 **Dependency:** 이 계획의 사용자 승인 **Write
+**복잡도:** 낮음 **Dependency:** 이 계획의 사용자 승인 **Write
 scope:** `.bluetape` coordinator state만 helper가 기록; repository source 변경 없음 **Pattern
 skill:** `bluetape-workflow`, `bluetape-full-feature`
 
@@ -498,7 +496,7 @@ python3 /Users/debop/.codex/skills/bluetape-workflow/scripts/bluetape-flow.py \
   --evidence /Users/debop/work/bluetape4k/.bluetape/inputs/issue755/approval-evidence.json
 ```
 
-Expected: receipt가 `run-start`를 safe next로 반환하고 owner fencing value는 출력하지 않는다.
+예상 결과: receipt가 `run-start`를 safe next로 반환하고 owner fencing value는 출력하지 않는다.
 
 #### Audit Step 0.2 — N/A under WF-04A: 최초 run-start record
 
@@ -517,7 +515,7 @@ git branch --show-current
 git merge-base --is-ancestor origin/develop HEAD
 ```
 
-Expected: branch는 `feat/issue-755-bytebuffer-compressor`, working tree clean, `origin/develop`가 ancestor다. 불일치하면 source edit 전에 중단한다.
+예상 결과: branch는 `feat/issue-755-bytebuffer-compressor`, working tree clean, `origin/develop`가 ancestor다. 불일치하면 source edit 전에 중단한다.
 
 #### Audit Step 0.3 — N/A under WF-04A: 실패한 topology registration record
 
@@ -792,7 +790,7 @@ awk '
 ' "$plan"
 ```
 
-Expected: deliberate failed precondition 뒤 marker mutation은 실행되지 않는다. readiness, approved merge, coordinator, verification, evidence, commit/push block은 모두 첫 명령이
+예상 결과: deliberate failed precondition 뒤 marker mutation은 실행되지 않는다. readiness, approved merge, coordinator, verification, evidence, commit/push block은 모두 첫 명령이
 `set -euo pipefail`이고, standalone script definition만 shebang을 첫 줄로 허용한다.
 
 **Step
@@ -802,25 +800,25 @@ DoD:** WF-04A fallback에서 run의 blocked checksum과 valid receipt chain이 �
 
 ## Task 1: Core RED — public contract와 ABI authority를 먼저 고정한다
 
-**Complexity:** 높음 **Dependency:** Task 0 WF-04A fallback DoD PASS **Write
+**복잡도:** 높음 **Dependency:** Task 0 WF-04A fallback DoD PASS **Write
 scope:** core test/ABI resources와 `scripts/check-compressor-buffer-abi.sh`만 **Pattern
 skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferTestSupport.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferContractTest.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorBufferAbiCompatibilityTest.kt`
-- Create: `io/io/src/test/java/io/bluetape4k/io/compressor/CompressorByteBufferJavaContractTest.java`
-- Create: `io/io/src/test/resources/abi/issue-755/src/java/LegacyCompressorCaller.java`
-- Create: `io/io/src/test/resources/abi/issue-755/src/java/LegacyCompressorImplementation.java`
-- Create: `io/io/src/test/resources/abi/issue-755/src/java/NewCompressorBufferCaller.java`
-- Create: `io/io/src/test/resources/abi/issue-755/src/java/AmbiguousNullCaller.java`
-- Create: `io/io/src/test/resources/abi/issue-755/src/kotlin/LegacyCompressorCaller.kt`
-- Create: `io/io/src/test/resources/abi/issue-755/src/kotlin/LegacyCompressorImplementation.kt`
-- Create: `io/io/src/test/resources/abi/issue-755/pre-change/legacy-compressor-fixtures.jar`
-- Create: `io/io/src/test/resources/abi/issue-755/pre-change/manifest.json`
-- Create: `scripts/check-compressor-buffer-abi.sh`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferTestSupport.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferContractTest.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorBufferAbiCompatibilityTest.kt`
+- 생성: `io/io/src/test/java/io/bluetape4k/io/compressor/CompressorByteBufferJavaContractTest.java`
+- 생성: `io/io/src/test/resources/abi/issue-755/src/java/LegacyCompressorCaller.java`
+- 생성: `io/io/src/test/resources/abi/issue-755/src/java/LegacyCompressorImplementation.java`
+- 생성: `io/io/src/test/resources/abi/issue-755/src/java/NewCompressorBufferCaller.java`
+- 생성: `io/io/src/test/resources/abi/issue-755/src/java/AmbiguousNullCaller.java`
+- 생성: `io/io/src/test/resources/abi/issue-755/src/kotlin/LegacyCompressorCaller.kt`
+- 생성: `io/io/src/test/resources/abi/issue-755/src/kotlin/LegacyCompressorImplementation.kt`
+- 생성: `io/io/src/test/resources/abi/issue-755/pre-change/legacy-compressor-fixtures.jar`
+- 생성: `io/io/src/test/resources/abi/issue-755/pre-change/manifest.json`
+- 생성: `scripts/check-compressor-buffer-abi.sh`
 
 - [ ] **Step 1.1: 공통 buffer fixture와 fallback compressor를 작성한다**
 
@@ -1103,7 +1101,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 ```
 
-Expected: compile FAIL. `Compressor.compress(ByteBuffer, ByteBuffer)`와
+예상 결과: compile FAIL. `Compressor.compress(ByteBuffer, ByteBuffer)`와
 `decompress(ByteBuffer, ByteBuffer)`가 아직 없다. dirty fixture tree에서 ABI checker를 실행하지 않는다. 그 경우 intended descriptor RED가 아니라 dirty-path gate가 먼저 실패하기 때문이다.
 
 - [ ] **Step 1.7: RED fixture를 Lore commit한다**
@@ -1134,7 +1132,7 @@ bash scripts/check-compressor-buffer-abi.sh \
   --build-current --expected-head "$(git rev-parse HEAD)"
 ```
 
-Expected: dirty-path gate와 baseline/current ambiguous-null diagnostic 비교는 PASS하고
+예상 결과: dirty-path gate와 baseline/current ambiguous-null diagnostic 비교는 PASS하고
 `compile_new_callers`에 도달하기 전에 current two-argument JVM default descriptor 부재라는 ABI reason으로 non-zero 종료한다. 다른 이유로 실패하면 Task 2로 진행하지 않고 fixture/checker를 교정해 Lore commit 후 이 step을 재실행한다.
 
 **Step DoD:** 공통 계약과 ABI가 의도한 missing-API 이유로 RED이며 baseline authority가 hash로 고정된다.
@@ -1143,15 +1141,15 @@ Expected: dirty-path gate와 baseline/current ambiguous-null diagnostic 비교�
 
 ## Task 2: Core GREEN — fallback과 상태 commit wrapper를 구현한다
 
-**Complexity:** 높음 **Dependency:** Task 1 **Write
+**복잡도:** 높음 **Dependency:** Task 1 **Write
 scope:** `Compressor.kt`, 신규 `CompressorBufferSupport.kt`, Task 1 test 보정만 **Pattern
 skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/Compressor.kt`
-- Create: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/CompressorBufferSupport.kt`
-- Modify: Task 1의 test/fixture files only when RED expectation needs exact import or generated hash update
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/Compressor.kt`
+- 생성: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/CompressorBufferSupport.kt`
+- 수정: Task 1의 test/fixture files only when RED expectation needs exact import or generated hash update
 
 - [ ] **Step 2.1: preflight와 fallback helper를 최소 구현한다**
 
@@ -1298,7 +1296,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 ```
 
-Expected: all contract cases PASS. Java null은 raw NPE, fallback overflow는 raw
+예상 결과: all contract cases PASS. Java null은 raw NPE, fallback overflow는 raw
 `BufferOverflowException`, source/target mark reset assertion도 PASS한다.
 
 - [ ] **Step 2.4: helper/default implementation을 Lore commit한다**
@@ -1332,7 +1330,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 ```
 
-Expected: legacy source와 classfile caller/implementor, new callers, manifest/hash, JVM default reflection PASS. ambiguous null fixture만 예상한 compiler diagnostic으로 실패한다.
+예상 결과: legacy source와 classfile caller/implementor, new callers, manifest/hash, JVM default reflection PASS. ambiguous null fixture만 예상한 compiler diagnostic으로 실패한다.
 
 **Step DoD:** 모든 compressor가 default fallback으로 공통 contract를 통과하고 legacy ABI가 exact baseline에 대해 증명된다.
 
@@ -1340,16 +1338,16 @@ Expected: legacy source와 classfile caller/implementor, new callers, manifest/h
 
 ## Task 3: Core slice 문서·검증·PR을 수렴한다
 
-**Complexity:** 중간 **Dependency:** Task 2 **Write scope:** 양쪽 README, CHANGELOG, issue lesson, core test/ABI artifact
+**복잡도:** 중간 **Dependency:** Task 2 **작성 범위:** 양쪽 README, CHANGELOG, issue lesson, core test/ABI artifact
 **Pattern skill:** `bluetape-writer`, `verification-before-completion`, `requesting-code-review`
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/README.md`
-- Modify: `io/io/README.ko.md`
-- Modify: `CHANGELOG.md`
-- Create: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
-- Create: `scripts/check-compressor-buffer-docs.py`
+- 수정: `io/io/README.md`
+- 수정: `io/io/README.ko.md`
+- 수정: `CHANGELOG.md`
+- 생성: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
+- 생성: `scripts/check-compressor-buffer-docs.py`
 
 - [ ] **Step 3.1: provisional fallback matrix와 sizing/retry 경계를 양쪽 README에 기록한다**
 
@@ -1414,7 +1412,7 @@ python3 scripts/check-compressor-buffer-docs.py
 git diff --check
 ```
 
-Expected: module tests 1,109 baseline + 신규 core tests PASS, compile/Detekt/ABI PASS, diff check clean. ABI script가 commit-only tested paths를 요구하므로 docs/lesson commit 뒤 exact head에서 다시 실행한다.
+예상 결과: module tests 1,109 baseline + 신규 core tests PASS, compile/Detekt/ABI PASS, diff check clean. ABI script가 commit-only tested paths를 요구하므로 docs/lesson commit 뒤 exact head에서 다시 실행한다.
 
 - [ ] **Step 3.4: core 문서와 lesson을 Lore commit한다**
 
@@ -1472,17 +1470,17 @@ PR body는 English이며 issue #755를 연결하고 final `##` heading을 `## Do
 
 ## Task 4: LZ4 slice — bounded payload를 사용하는 전체 storage override를 전달한다
 
-**Complexity:** 높음 **Dependency:** core PR merge + updated `develop` sync **Write
+**복잡도:** 높음 **Dependency:** core PR merge + updated `develop` sync **Write
 scope:** `LZ4Compressor.kt`, LZ4 test, README locale rows, shared lesson LZ4 section **Pattern
 skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/LZ4CompressorByteBufferTest.kt`
-- Modify: `io/io/README.md`
-- Modify: `io/io/README.ko.md`
-- Modify: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/LZ4Compressor.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/LZ4CompressorByteBufferTest.kt`
+- 수정: `io/io/README.md`
+- 수정: `io/io/README.ko.md`
+- 수정: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
 
 - [ ] **Step 4.1: merge된 core에서 isolated worktree를 만든다**
 
@@ -1496,7 +1494,7 @@ git -C /Users/debop/work/bluetape4k/bluetape4k-projects worktree add \
   -b feat/issue-755-bytebuffer-lz4 origin/develop
 ```
 
-Expected: 새 worktree clean, core default/API/ABI commit이 `HEAD` ancestor다.
+예상 결과: 새 worktree clean, core default/API/ABI commit이 `HEAD` ancestor다.
 
 - [ ] **Step 4.2: LZ4 exact failure/boundary RED를 작성한다**
 
@@ -1559,7 +1557,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 ```
 
-Expected: default fallback 때문에 correctness 일부는 PASS하지만 native dispatch seam, capacity-tail regression, payload-sized allocation avoidance assertion은 FAIL한다.
+예상 결과: default fallback 때문에 correctness 일부는 PASS하지만 native dispatch seam, capacity-tail regression, payload-sized allocation avoidance assertion은 FAIL한다.
 
 - [ ] **Step 4.4: injectable operation과 optimized override를 구현한다**
 
@@ -1650,7 +1648,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test --no-build-cache --rerun-task
 git diff --check
 ```
 
-Expected: capacity-tail/trailing test가 LZ4Exception으로 PASS하고 heap/direct 네 조합, wire interop, target rollback, sentinel, module suite, Detekt가 PASS한다.
+예상 결과: capacity-tail/trailing test가 LZ4Exception으로 PASS하고 heap/direct 네 조합, wire interop, target rollback, sentinel, module suite, Detekt가 PASS한다.
 
 - [ ] **Step 4.6: README matrix와 lesson을 LZ4 증거로 갱신하고 Lore commit한다**
 
@@ -1694,16 +1692,16 @@ Six-perspective review, CI, live threads가 P0=0/P1=0일 때 exact PR/head를 �
 
 ## Task 5: Deflate slice — bounded JDK loop와 deterministic cleanup을 전달한다
 
-**Complexity:** 높음 **Dependency:** LZ4 PR merge + updated `develop` sync **Write
+**복잡도:** 높음 **Dependency:** LZ4 PR merge + updated `develop` sync **Write
 scope:** `DeflateCompressor.kt`, Deflate test, README locale rows, lesson lifecycle section **Pattern
 skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/DeflateCompressorByteBufferTest.kt`
-- Modify: `io/io/README.md`, `io/io/README.ko.md`
-- Modify: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/DeflateCompressorByteBufferTest.kt`
+- 수정: `io/io/README.md`, `io/io/README.ko.md`
+- 수정: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
 
 - [ ] **Step 5.1: merge된 develop에서 Deflate worktree를 만든다**
 
@@ -1717,7 +1715,7 @@ git -C /Users/debop/work/bluetape4k/bluetape4k-projects worktree add \
   -b feat/issue-755-bytebuffer-deflate origin/develop
 ```
 
-Expected: core와 LZ4 merge commit이 ancestor이며 worktree clean.
+예상 결과: core와 LZ4 merge commit이 ancestor이며 worktree clean.
 
 - [ ] **Step 5.2: Deflate state table와 cleanup RED를 작성한다**
 
@@ -1784,7 +1782,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 ```
 
-Expected: test seam/optimized override가 없어 compile 또는 dispatch assertion FAIL.
+예상 결과: test seam/optimized override가 없어 compile 또는 dispatch assertion FAIL.
 
 - [ ] **Step 5.4: per-call factories, operation-primary cleanup helper와 compression loop를 구현한다**
 
@@ -1894,7 +1892,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test --no-build-cache --rerun-task
 git diff --check
 ```
 
-Expected: state table, exact-fit, dictionary/zero-target precedence, no-progress, end-once와 suppressed identity가 PASS하고 전체 module regression이 없다.
+예상 결과: state table, exact-fit, dictionary/zero-target precedence, no-progress, end-once와 suppressed identity가 PASS하고 전체 module regression이 없다.
 
 - [ ] **Step 5.7: docs/lesson/Lore commit과 Deflate PR을 수렴한다**
 
@@ -1919,16 +1917,16 @@ gh pr create --repo bluetape4k/bluetape4k-projects \
 
 ## Task 6: Snappy slice — validation-first matched-storage native path를 전달한다
 
-**Complexity:** 높음 **Dependency:** Deflate PR merge + updated `develop` sync **Write
+**복잡도:** 높음 **Dependency:** Deflate PR merge + updated `develop` sync **Write
 scope:** `SnappyCompressor.kt`, Snappy test, README locale rows, lesson native-validation section **Pattern
 skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyCompressorByteBufferTest.kt`
-- Modify: `io/io/README.md`, `io/io/README.ko.md`
-- Modify: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyCompressorByteBufferTest.kt`
+- 수정: `io/io/README.md`, `io/io/README.ko.md`
+- 수정: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
 
 - [ ] **Step 6.1: merge된 develop에서 Snappy worktree를 만든다**
 
@@ -1942,7 +1940,7 @@ git -C /Users/debop/work/bluetape4k/bluetape4k-projects worktree add \
   -b feat/issue-755-bytebuffer-snappy origin/develop
 ```
 
-Expected: core/LZ4/Deflate merge commits가 ancestor이고 worktree clean.
+예상 결과: core/LZ4/Deflate merge commits가 ancestor이고 worktree clean.
 
 - [ ] **Step 6.2: dispatch와 native validation ordering RED를 작성한다**
 
@@ -2013,7 +2011,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 ```
 
-Expected: `forTesting`과 native dispatch가 없어 compile/ordering assertion FAIL.
+예상 결과: `forTesting`과 native dispatch가 없어 compile/ordering assertion FAIL.
 
 - [ ] **Step 6.4: exact storage dispatch와 compression을 구현한다**
 
@@ -2114,7 +2112,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test --no-build-cache --rerun-task
 git diff --check
 ```
 
-Expected: invalid heap/direct payload는 native decode 미호출, max-size preflight와 mixed fallback, 원본 limit 보존, 전체 suite와 Detekt PASS.
+예상 결과: invalid heap/direct payload는 native decode 미호출, max-size preflight와 mixed fallback, 원본 limit 보존, 전체 suite와 Detekt PASS.
 
 - [ ] **Step 6.7: docs/lesson/Lore commit과 Snappy PR을 수렴한다**
 
@@ -2139,16 +2137,16 @@ gh pr create --repo bluetape4k/bluetape4k-projects \
 
 ## Task 7: Zstd slice — declared-size destination bound와 예외 의미를 전달한다
 
-**Complexity:** 높음 **Dependency:** Snappy PR merge + updated `develop` sync **Write
+**복잡도:** 높음 **Dependency:** Snappy PR merge + updated `develop` sync **Write
 scope:** `ZstdCompressor.kt`, Zstd test, README locale rows, lesson native-bound section **Pattern
 skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZstdCompressorByteBufferTest.kt`
-- Modify: `io/io/README.md`, `io/io/README.ko.md`
-- Modify: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZstdCompressorByteBufferTest.kt`
+- 수정: `io/io/README.md`, `io/io/README.ko.md`
+- 수정: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
 
 - [ ] **Step 7.1: merge된 develop에서 Zstd worktree를 만든다**
 
@@ -2162,7 +2160,7 @@ git -C /Users/debop/work/bluetape4k/bluetape4k-projects worktree add \
   -b feat/issue-755-bytebuffer-zstd origin/develop
 ```
 
-Expected: 앞선 네 slice merge commits가 ancestor이고 worktree clean.
+예상 결과: 앞선 네 slice merge commits가 ancestor이고 worktree clean.
 
 - [ ] **Step 7.2: destination bound와 exact taxonomy RED를 작성한다**
 
@@ -2263,7 +2261,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 ```
 
-Expected: operation seam/optimized dispatch가 없어 compile/target-length/taxonomy assertion FAIL.
+예상 결과: operation seam/optimized dispatch가 없어 compile/target-length/taxonomy assertion FAIL.
 
 - [ ] **Step 7.4: matched storage compression과 error normalization을 구현한다**
 
@@ -2354,7 +2352,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test --no-build-cache --rerun-task
 git diff --check
 ```
 
-Expected: under-declared large target의 native target length가 declared size이고 stable cause-less ISE, compression overflow와 기타 ZstdException identity, mixed fallback, full suite/Detekt가 PASS한다.
+예상 결과: under-declared large target의 native target length가 declared size이고 stable cause-less ISE, compression overflow와 기타 ZstdException identity, mixed fallback, full suite/Detekt가 PASS한다.
 
 - [ ] **Step 7.7: docs/lesson/Lore commit과 Zstd PR을 수렴한다**
 
@@ -2381,15 +2379,15 @@ gh pr create --repo bluetape4k/bluetape4k-projects \
 
 ## Task 8: Adoption RED/GREEN — singleton concurrency와 caller examples를 수렴한다
 
-**Complexity:** 높음 **Dependency:** Zstd PR merge + updated `develop` sync **Write
+**복잡도:** 높음 **Dependency:** Zstd PR merge + updated `develop` sync **Write
 scope:** cross-codec integration tests와 public examples only **Pattern
 skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferIntegrationTest.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferKotlinExampleTest.kt`
-- Create: `io/io/src/test/java/io/bluetape4k/io/compressor/CompressorByteBufferJavaExampleTest.java`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferIntegrationTest.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/CompressorByteBufferKotlinExampleTest.kt`
+- 생성: `io/io/src/test/java/io/bluetape4k/io/compressor/CompressorByteBufferJavaExampleTest.java`
 
 - [ ] **Step 8.1: evidence worktree를 merged develop에서 만든다**
 
@@ -2403,7 +2401,7 @@ git -C /Users/debop/work/bluetape4k/bluetape4k-projects worktree add \
   -b perf/issue-755-bytebuffer-compressor-evidence origin/develop
 ```
 
-Expected: core와 네 backend merge commit이 모두 ancestor이고 worktree clean.
+예상 결과: core와 네 backend merge commit이 모두 ancestor이고 worktree clean.
 
 - [ ] **Step 8.2: built-in singleton concurrency/integration RED를 작성한다**
 
@@ -2567,7 +2565,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 ```
 
-Expected: merged backend 구현이 정확하면 first run부터 GREEN이다. 실패하면 timing retry로 넘기지 않고 해당 backend slice의 lifecycle/state bug를 진단해 수정하고 전체 세 test를 처음부터 재실행한다.
+예상 결과: merged backend 구현이 정확하면 first run부터 GREEN이다. 실패하면 timing retry로 넘기지 않고 해당 backend slice의 lifecycle/state bug를 진단해 수정하고 전체 세 test를 처음부터 재실행한다.
 
 - [ ] **Step 8.6: integration/examples를 Lore commit한다**
 
@@ -2592,15 +2590,15 @@ Not-tested: Allocation evidence is produced by the next task'
 
 ## Task 9: Benchmark RED/GREEN — thread-local harness와 fail-closed evidence tool을 만든다
 
-**Complexity:** 높음 **Dependency:** Task 8 **Write scope:** io existing benchmark source와 `io/io/scripts` only **Pattern
+**복잡도:** 높음 **Dependency:** Task 8 **작성 범위:** io existing benchmark source와 `io/io/scripts` only **Pattern
 skill:** `bluetape-kotlin-patterns`, `test-driven-development`
 
-**Files:**
+**파일:**
 
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/benchmark/CallerOwnedByteBufferCompressorBenchmark.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/benchmark/CallerOwnedByteBufferCompressorBenchmarkTest.kt`
-- Create: `io/io/scripts/run-bytebuffer-compressor-evidence.py`
-- Create: `io/io/scripts/test_run_bytebuffer_compressor_evidence.py`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/benchmark/CallerOwnedByteBufferCompressorBenchmark.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/benchmark/CallerOwnedByteBufferCompressorBenchmarkTest.kt`
+- 생성: `io/io/scripts/run-bytebuffer-compressor-evidence.py`
+- 생성: `io/io/scripts/test_run_bytebuffer_compressor_evidence.py`
 
 이 harness는 production module에 새 dependency를 넣지 않고 이미 `kotlinx.benchmark` plugin이 적용된 `:bluetape4k-io`의 `testBenchmarkJar`를 재사용한다. repository benchmark hazard의 “existing benchmark module” branch다.
 
@@ -2612,7 +2610,7 @@ set -euo pipefail
   grep -E '^(testBenchmark|testBenchmarkCompile|testBenchmarkJar)'
 ```
 
-Expected: `testBenchmark`, `testBenchmarkCompile`, `testBenchmarkJar`가 존재한다. task 이름이 바뀌면 plan/spec의 command를 먼저 갱신하고 plan review를 재실행한다.
+예상 결과: `testBenchmark`, `testBenchmarkCompile`, `testBenchmarkJar`가 존재한다. task 이름이 바뀌면 plan/spec의 command를 먼저 갱신하고 plan review를 재실행한다.
 
 - [ ] **Step 9.2: benchmark dispatch/state unit RED를 작성한다**
 
@@ -2801,7 +2799,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
 ./gradlew :bluetape4k-io:testBenchmarkJar --no-build-cache --rerun-tasks
 ```
 
-Expected: unit test, generated JMH compile, exactly one `*-JMH.jar` build PASS.
+예상 결과: unit test, generated JMH compile, exactly one `*-JMH.jar` build PASS.
 
 - [ ] **Step 9.5: evidence validator unit RED를 작성한다**
 
@@ -3129,7 +3127,7 @@ python3 io/io/scripts/run-bytebuffer-compressor-evidence.py smoke \
   --param compressorName=lz4 --param payloadSize=small --param storagePath=heap
 ```
 
-Expected: Python tests PASS. Smoke는 `gc.alloc.rate.norm` B/op와 primary throughput을 가진 valid JMH JSON을 생성하지만 `docs/benchmarks/raw`에는 아직 promotion하지 않는다.
+예상 결과: Python tests PASS. Smoke는 `gc.alloc.rate.norm` B/op와 primary throughput을 가진 valid JMH JSON을 생성하지만 `docs/benchmarks/raw`에는 아직 promotion하지 않는다.
 
 - [ ] **Step 9.8: harness와 runner를 Lore commit한다**
 
@@ -3156,21 +3154,21 @@ DoD:** committed harness는 `Scope.Thread`, measured allocation-free setup disci
 
 ## Task 10: Canonical evidence·문서·최종 PR을 exact head에서 수렴한다
 
-**Complexity:** 높음 **Dependency:** Task 9 commit **Write
+**복잡도:** 높음 **Dependency:** Task 9 commit **Write
 scope:** raw evidence, benchmark report/index, module benchmark/readmes, CHANGELOG, shared lesson **Pattern
 skill:** `bluetape-writer`, `verification-before-completion`, `requesting-code-review`
 
-**Files:**
+**파일:**
 
-- Create: `docs/benchmarks/raw/issue-755/run-<UTC>-<id>/` exactly twice
-- Create: `docs/benchmarks/raw/issue-755/comparison.csv`
-- Create: `docs/benchmarks/2026-07-21-bytebuffer-compressor-allocation.md`
-- Modify: `docs/benchmarks/README.md`
-- Modify: `io/io/Benchmark.md`
-- Modify: `io/io/README.md`
-- Modify: `io/io/README.ko.md`
-- Modify: `CHANGELOG.md`
-- Modify: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
+- 생성: `docs/benchmarks/raw/issue-755/run-<UTC>-<id>/` exactly twice
+- 생성: `docs/benchmarks/raw/issue-755/comparison.csv`
+- 생성: `docs/benchmarks/2026-07-21-bytebuffer-compressor-allocation.md`
+- 수정: `docs/benchmarks/README.md`
+- 수정: `io/io/Benchmark.md`
+- 수정: `io/io/README.md`
+- 수정: `io/io/README.ko.md`
+- 수정: `CHANGELOG.md`
+- 수정: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
 
 - [ ] **Step 10.1: committed exact JMH jar와 clean tracked tree를 고정한다**
 
@@ -3309,7 +3307,7 @@ rg -n 'TBD|TODO|PLACEHOLDER|implement later|fill in later' \
   io/io/Benchmark.md CHANGELOG.md docs/lessons && exit 1 || true
 ```
 
-Expected: 모든 unit/integration/benchmark compile/Detekt/ABI/Python/evidence validation PASS, placeholder와 whitespace error 0. ABI script의 dirty-path gate를 위해 production/test/script를 먼저 commit한 뒤 exact-head ABI를 실행한다. evidence validation은 canonical metadata의
+예상 결과: 모든 unit/integration/benchmark compile/Detekt/ABI/Python/evidence validation PASS, placeholder와 whitespace error 0. ABI script의 dirty-path gate를 위해 production/test/script를 먼저 commit한 뒤 exact-head ABI를 실행한다. evidence validation은 canonical metadata의
 `$evidence_head`를 계속 사용한다.
 
 - [ ] **Step 10.6: evidence와 최종 문서를 Lore commit한다**
@@ -3394,7 +3392,7 @@ CI와 current review/thread가 exact head에서 수렴하면 PR number/head SHA�
 
 ## Task 11: final merge 승인 후 documented checklist를 닫고 cleanup gate에서 멈춘다
 
-**Complexity:** 중간 **Dependency:** final PR exact-head fresh merge approval **Write
+**복잡도:** 중간 **Dependency:** final PR exact-head fresh merge approval **Write
 scope:** approved GitHub merge와 local sync only; terminal blocked `.bluetape` receipt는 read-only **Pattern
 skill:** `bluetape-workflow`, `finishing-a-development-branch`
 

--- a/docs/superpowers/plans/2026-07-22-issue-1055-http-idempotency-conformance-plan.md
+++ b/docs/superpowers/plans/2026-07-22-issue-1055-http-idempotency-conformance-plan.md
@@ -1,14 +1,12 @@
-# Issue #1055 HTTP Idempotency Conformance Implementation Plan
+# Issue #1055 HTTP Idempotency Conformance 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** `bluetape4k-junit5`에 bounded-wait HTTP idempotency 공통 runner를 추가하고 Ktor `testApplication`과 Spring MockMvc가 같은 17개 black-box scenario를 통과하게 한다.
+**목표:** `bluetape4k-junit5`에 bounded-wait HTTP idempotency 공통 runner를 추가하고 Ktor `testApplication`과 Spring MockMvc가 같은 17개 black-box scenario를 통과하게 한다.
 
-**Architecture:** 공용 module은 serializable value, framework-neutral adapter contract, deterministic scenario runner만 제공한다. Ktor와 Spring test source는 같은 config를 HTTP ingress와 test control에 연결하는 독립 in-memory reference application을 가지며, persistence/store/filter/plugin/telemetry API는 추가하지 않는다. Runner는 caller structured scope에서 실행하고 자체 monotonic watchdog scheduler만 `finally`에서 닫는다.
+**아키텍처:** 공용 module은 serializable value, framework-neutral adapter contract, deterministic scenario runner만 제공한다. Ktor와 Spring test source는 같은 config를 HTTP ingress와 test control에 연결하는 독립 in-memory reference application을 가지며, persistence/store/filter/plugin/telemetry API는 추가하지 않는다. Runner는 caller structured scope에서 실행하고 자체 monotonic watchdog scheduler만 `finally`에서 닫는다.
 
-**Tech
-Stack:** Kotlin 2.3, Java 21, JUnit 5, kotlinx-coroutines, bluetape4k-assertions, Ktor `testApplication`, Spring MockMvc.
+**기술 스택:** Kotlin 2.3, Java 21, JUnit 5, kotlinx-coroutines, bluetape4k-assertions, Ktor `testApplication`, Spring MockMvc.
 
 ---
 
@@ -36,14 +34,14 @@ Stack:** Kotlin 2.3, Java 21, JUnit 5, kotlinx-coroutines, bluetape4k-assertions
 
 ## Task 1: Public serializable values와 validation
 
-**Complexity:** Medium **Depends on:** 승인된 spec commits `996776195`, `2c055437c`
+**복잡도:** Medium **의존:** 승인된 spec commits `996776195`, `2c055437c`
 **Pattern skills:** `bluetape-kotlin-patterns`, `test-driven-development`
 **Rollback:** 이 task commit만 revert하면 public API가 생기기 전 상태로 돌아간다.
 
-**Files:**
+**파일:**
 
-- Create: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyValues.kt`
-- Create: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyValuesTest.kt`
+- 생성: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyValues.kt`
+- 생성: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyValuesTest.kt`
 
 - [ ] **Step 1: constructor, redaction, content equality 실패 test 작성**
 
@@ -86,8 +84,8 @@ fun `request deep copies duplicate header values`() {
 
 - [ ] **Step 2: targeted test가 unresolved symbol로 실패하는지 확인**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyValuesTest' --no-configuration-cache`
-Expected: `HttpIdempotencyRequest`, `HttpIdempotencyResponse` unresolved로 FAIL.
+실행: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyValuesTest' --no-configuration-cache`
+예상 결과: `HttpIdempotencyRequest`, `HttpIdempotencyResponse` unresolved로 FAIL.
 
 - [ ] **Step 3: value class 최소 구현 작성**
 
@@ -550,8 +548,8 @@ RED/GREEN parameterized matrix는 identity `512/513`, operation/resource `1,024/
 
 - [ ] **Step 7: values test와 detekt 실행**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyValuesTest' :bluetape4k-junit5:detekt :bluetape4k-junit5:detektTest --no-configuration-cache`
-Expected: value tests PASS, detekt 0 violations. Assertion은 `assertFailsWith`, `shouldBeEqualTo`, `shouldNotContain`을 사용하고 Boolean wrapper를 남기지 않는다.
+실행: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyValuesTest' :bluetape4k-junit5:detekt :bluetape4k-junit5:detektTest --no-configuration-cache`
+예상 결과: value tests PASS, detekt 0 violations. Assertion은 `assertFailsWith`, `shouldBeEqualTo`, `shouldNotContain`을 사용하고 Boolean wrapper를 남기지 않는다.
 
 - [ ] **Step 8: Lore commit**
 
@@ -566,16 +564,16 @@ git commit -m "Keep idempotency test values bounded and safe to serialize" \
 
 ## Task 2: Adapter contract, watchdog와 runner lifecycle
 
-**Complexity:** High **Depends on:** Task 1 **Pattern
+**복잡도:** High **의존:** Task 1 **Pattern
 skills:** `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`, `test-driven-development`
 **Rollback:** runner commit을 revert해도 Task 1 values는 독립적으로 제거 가능하다.
 
-**Files:**
+**파일:**
 
-- Create: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/BoundedWaitHttpIdempotencyAdapter.kt`
-- Create: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/BoundedWaitHttpIdempotencyConformance.kt`
-- Create: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyScenarioFixtures.kt`
-- Create: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/BoundedWaitHttpIdempotencyConformanceLifecycleTest.kt`
+- 생성: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/BoundedWaitHttpIdempotencyAdapter.kt`
+- 생성: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/BoundedWaitHttpIdempotencyConformance.kt`
+- 생성: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyScenarioFixtures.kt`
+- 생성: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/BoundedWaitHttpIdempotencyConformanceLifecycleTest.kt`
 
 - [ ] **Step 1: watchdog timeout/cancellation/cleanup 실패 test 작성**
 
@@ -623,8 +621,8 @@ fun `runner rejects fan-in workload above the shared proof budget before exchang
 
 - [ ] **Step 2: lifecycle test가 entrypoint unresolved로 실패하는지 확인**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*BoundedWaitHttpIdempotencyConformanceLifecycleTest' --no-configuration-cache`
-Expected: adapter/lifecycle runner symbol unresolved로 FAIL.
+실행: `./gradlew :bluetape4k-junit5:test --tests '*BoundedWaitHttpIdempotencyConformanceLifecycleTest' --no-configuration-cache`
+예상 결과: adapter/lifecycle runner symbol unresolved로 FAIL.
 
 - [ ] **Step 3: public adapter contract 작성**
 
@@ -837,8 +835,8 @@ private fun validateReplaySnapshot(
 
 - [ ] **Step 5: watchdog success/timeout/reset/cancellation failure matrix 통과**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*BoundedWaitHttpIdempotencyConformanceLifecycleTest' --no-configuration-cache`
-Expected: 정상, scenario timeout, caller cancellation, reset exception, reset의 `awaitCancellation()`, quiescence mismatch를 각각 실행해 원래 failure와 suppressed cleanup failure가 redacted 상태로 보존된다. 모든 case에서 `http-idempotency-watchdog` live thread와 adapter child job은 0이다. Adapter contract test는
+실행: `./gradlew :bluetape4k-junit5:test --tests '*BoundedWaitHttpIdempotencyConformanceLifecycleTest' --no-configuration-cache`
+예상 결과: 정상, scenario timeout, caller cancellation, reset exception, reset의 `awaitCancellation()`, quiescence mismatch를 각각 실행해 원래 failure와 suppressed cleanup failure가 redacted 상태로 보존된다. 모든 case에서 `http-idempotency-watchdog` live thread와 adapter child job은 0이다. Adapter contract test는
 `resetScenario`가 cancellation-cooperative suspend function이어야 하며 blocking I/O를 직접 수행하지 않는다는 전제를 확인한다.
 
 - [ ] **Step 6: public adapter English KDoc에 caller scope와 ownership 추가**
@@ -867,15 +865,15 @@ git commit -m "Bound every idempotency scenario without owning caller coroutines
 
 ## Task 3: Terminal, scope와 authorization scenarios
 
-**Complexity:** High **Depends on:** Task 2 **Pattern skills:** `bluetape-kotlin-patterns`, `test-driven-development`
+**복잡도:** High **의존:** Task 2 **Pattern skills:** `bluetape-kotlin-patterns`, `test-driven-development`
 **Rollback:** terminal scenario file와 test double commit을 함께 revert한다.
 
-**Files:**
+**파일:**
 
-- Create: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyTerminalScenarios.kt`
-- Modify: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyScenarioFixtures.kt`
-- Create: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/InMemoryBoundedWaitHttpIdempotencyAdapter.kt`
-- Create: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyTerminalScenariosTest.kt`
+- 생성: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyTerminalScenarios.kt`
+- 수정: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyScenarioFixtures.kt`
+- 생성: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/InMemoryBoundedWaitHttpIdempotencyAdapter.kt`
+- 생성: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyTerminalScenariosTest.kt`
 
 - [ ] **Step 1: first/replay/conflict/tenant/auth/terminal failure test 작성**
 
@@ -893,8 +891,8 @@ fun `terminal scenario group preserves one execution and tenant isolation`() = r
 
 - [ ] **Step 2: scenario test가 missing implementation으로 실패하는지 확인**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyTerminalScenariosTest' --no-configuration-cache`
-Expected: `terminalScenarios`와 test adapter unresolved로 FAIL.
+실행: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyTerminalScenariosTest' --no-configuration-cache`
+예상 결과: `terminalScenarios`와 test adapter unresolved로 FAIL.
 
 - [ ] **Step 3: test-only independent state machine 최소 구현**
 
@@ -973,8 +971,8 @@ private suspend fun assertDifferentPayloadConflictIsImmediate(
 
 - [ ] **Step 5: terminal group와 전체 junit5 test 실행**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyTerminalScenariosTest' --no-configuration-cache`
-Expected: all terminal scenarios PASS; raw sentinel values absent from failure diagnostics.
+실행: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyTerminalScenariosTest' --no-configuration-cache`
+예상 결과: all terminal scenarios PASS; raw sentinel values absent from failure diagnostics.
 
 - [ ] **Step 6: Lore commit**
 
@@ -989,15 +987,15 @@ git commit -m "Prove terminal replay without leaking security scope" \
 
 ## Task 4: In-flight race, cancellation과 abandon scenarios
 
-**Complexity:** High **Depends on:** Task 3 **Pattern
+**복잡도:** High **의존:** Task 3 **Pattern
 skills:** `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`, `test-driven-development`
 **Rollback/rerun:** race failure 시 이 task의 virtual clock/gate test만 반복하고 framework task로 진행하지 않는다.
 
-**Files:**
+**파일:**
 
-- Create: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyInFlightScenarios.kt`
-- Create: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyInFlightScenariosTest.kt`
-- Modify: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/InMemoryBoundedWaitHttpIdempotencyAdapter.kt`
+- 생성: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyInFlightScenarios.kt`
+- 생성: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyInFlightScenariosTest.kt`
+- 수정: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/InMemoryBoundedWaitHttpIdempotencyAdapter.kt`
 
 - [ ] **Step 1: deadline exact boundary와 slot recovery 실패 test 작성**
 
@@ -1030,8 +1028,8 @@ fun `one nanosecond timeout preserves before exact and after ordering`() = runSu
 
 - [ ] **Step 2: 새 scenario가 unresolved로 실패하는지 확인**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyInFlightScenariosTest' --no-configuration-cache`
-Expected: `inFlightScenarios` unresolved로 FAIL.
+실행: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyInFlightScenariosTest' --no-configuration-cache`
+예상 결과: `inFlightScenarios` unresolved로 FAIL.
 
 - [ ] **Step 3: wait, exact deadline, timeout/overflow immediate assertion 구현**
 
@@ -1090,8 +1088,8 @@ catch (e: CancellationException) {
 
 - [ ] **Step 5: concurrency test를 20회 반복 실행**
 
-Run: `for i in {1..20}; do ./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyInFlightScenariosTest' --no-configuration-cache --rerun-tasks || exit 1; done`
-Expected: 20/20 PASS, timeout, cancellation 또는 lingering job 없음.
+실행: `for i in {1..20}; do ./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyInFlightScenariosTest' --no-configuration-cache --rerun-tasks || exit 1; done`
+예상 결과: 20/20 PASS, timeout, cancellation 또는 lingering job 없음.
 
 - [ ] **Step 6: Lore commit**
 
@@ -1107,16 +1105,16 @@ git commit -m "Make bounded waiting deterministic at every lifecycle edge" \
 
 ## Task 5: Retention, ingress safety, replay bounds와 fan-in stress
 
-**Complexity:** High **Depends on:** Task 4 **Pattern
+**복잡도:** High **의존:** Task 4 **Pattern
 skills:** `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`, `test-driven-development`
 **Rollback/rerun:** stress가 불안정하면 round/worker를 낮추지 말고 barrier 또는 cleanup 원인을 수정한 뒤 같은 명령을 재실행한다.
 
-**Files:**
+**파일:**
 
-- Create: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenarios.kt`
-- Modify: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/BoundedWaitHttpIdempotencyConformance.kt`
-- Create: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenariosTest.kt`
-- Modify: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/InMemoryBoundedWaitHttpIdempotencyAdapter.kt`
+- 생성: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenarios.kt`
+- 수정: `testing/junit5/src/main/kotlin/io/bluetape4k/junit5/http/idempotency/BoundedWaitHttpIdempotencyConformance.kt`
+- 생성: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenariosTest.kt`
+- 수정: `testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/InMemoryBoundedWaitHttpIdempotencyAdapter.kt`
 
 - [ ] **Step 1: expiry, oversized ingress와 unsafe replay 실패 test 작성**
 
@@ -1135,8 +1133,8 @@ fun `boundary scenarios reject unsafe snapshots and elect one owner after expiry
 
 - [ ] **Step 2: boundary test가 missing scenario로 실패하는지 확인**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyBoundaryScenariosTest' --no-configuration-cache`
-Expected: `boundaryScenarios` unresolved로 FAIL.
+실행: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyBoundaryScenariosTest' --no-configuration-cache`
+예상 결과: `boundaryScenarios` unresolved로 FAIL.
 
 - [ ] **Step 3: expiry/key/body/header boundary scenario 구현**
 
@@ -1245,8 +1243,8 @@ completion과 key별 waiter-registration barrier를 노출하지 않아 exact ad
 
 - [ ] **Step 5: boundary와 repeated stress 실행**
 
-Run: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyBoundaryScenariosTest' --no-configuration-cache`
-Expected: expiry exact boundary, oversized request via `exchange`, unsafe headers/body, 5-round fan-in에서 key별 owner 1, admitted `maxWaitersPerKey`, overflow 2, cross-key blocking isolation, slot 회수와 bounded termination이 모두 PASS.
+실행: `./gradlew :bluetape4k-junit5:test --tests '*HttpIdempotencyBoundaryScenariosTest' --no-configuration-cache`
+예상 결과: expiry exact boundary, oversized request via `exchange`, unsafe headers/body, 5-round fan-in에서 key별 owner 1, admitted `maxWaitersPerKey`, overflow 2, cross-key blocking isolation, slot 회수와 bounded termination이 모두 PASS.
 
 - [ ] **Step 6: public entrypoint에 세 scenario group 연결하고 KDoc 작성**
 
@@ -1273,8 +1271,8 @@ suspend fun assertBoundedWaitHttpIdempotencyConformance(
 
 - [ ] **Step 7: 전체 shared runner unit proof 실행**
 
-Run: `./gradlew :bluetape4k-junit5:test --no-configuration-cache`
-Expected: 기존 281 baseline tests와 신규 fixture tests 전부 PASS; no leaked thread/job warning.
+실행: `./gradlew :bluetape4k-junit5:test --no-configuration-cache`
+예상 결과: 기존 281 baseline tests와 신규 fixture tests 전부 PASS; no leaked thread/job warning.
 
 - [ ] **Step 8: Lore commit**
 
@@ -1289,13 +1287,13 @@ git commit -m "Bound idempotency retention and replay under hostile fan-in" \
 
 ## Task 6: Ktor `testApplication` reference proof
 
-**Complexity:** High **Depends on:** Task 5 **Pattern
+**복잡도:** High **의존:** Task 5 **Pattern
 skills:** `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`, `test-driven-development`
 **Rollback:** Ktor test file만 제거하면 shared public fixture는 유지된다.
 
-**Files:**
+**파일:**
 
-- Create: `ktor/testing/src/test/kotlin/io/bluetape4k/ktor/testing/idempotency/KtorHttpIdempotencyConformanceTest.kt`
+- 생성: `ktor/testing/src/test/kotlin/io/bluetape4k/ktor/testing/idempotency/KtorHttpIdempotencyConformanceTest.kt`
 
 - [ ] **Step 1: same runner 호출 test 작성**
 
@@ -1313,8 +1311,8 @@ fun `Ktor testApplication satisfies bounded wait HTTP idempotency conformance`()
 
 - [ ] **Step 2: Ktor test가 missing adapter/routes로 실패하는지 확인**
 
-Run: `./gradlew :bluetape4k-ktor-testing:test --tests '*KtorHttpIdempotencyConformanceTest' --no-configuration-cache`
-Expected: Ktor fake application/adapter unresolved로 FAIL.
+실행: `./gradlew :bluetape4k-ktor-testing:test --tests '*KtorHttpIdempotencyConformanceTest' --no-configuration-cache`
+예상 결과: Ktor fake application/adapter unresolved로 FAIL.
 
 - [ ] **Step 3: 실제 HTTP route와 server-resolved auth profile 구현**
 
@@ -1380,8 +1378,8 @@ override suspend fun exchange(request: HttpIdempotencyRequest): HttpIdempotencyR
 
 - [ ] **Step 5: Ktor reference test와 module test 실행**
 
-Run: `./gradlew :bluetape4k-ktor-testing:test --no-configuration-cache`
-Expected: 동일 17 scenario가 skip/override 없이 PASS; transport-legal malformed value는 route를 통과해 application `400`, C0는 client boundary에서 거절되고 test application 종료 후 quiescence 0.
+실행: `./gradlew :bluetape4k-ktor-testing:test --no-configuration-cache`
+예상 결과: 동일 17 scenario가 skip/override 없이 PASS; transport-legal malformed value는 route를 통과해 application `400`, C0는 client boundary에서 거절되고 test application 종료 후 quiescence 0.
 
 - [ ] **Step 6: Lore commit**
 
@@ -1395,13 +1393,13 @@ git commit -m "Prove the bounded idempotency contract through real Ktor HTTP" \
 
 ## Task 7: Spring MockMvc reference proof
 
-**Complexity:** High **Depends on:** Task 6 **Pattern
+**복잡도:** High **의존:** Task 6 **Pattern
 skills:** `bluetape-kotlin-patterns`, `kotlin-spring`, `kotlin-coroutines-skill`, `test-driven-development`
 **Rollback/rerun:** MockMvc executor/thread leak가 있으면 Spring task만 반복하며 Ktor/shared proof를 변경하지 않는다.
 
-**Files:**
+**파일:**
 
-- Create: `spring-boot/core/src/test/kotlin/io/bluetape4k/spring/idempotency/SpringHttpIdempotencyConformanceTest.kt`
+- 생성: `spring-boot/core/src/test/kotlin/io/bluetape4k/spring/idempotency/SpringHttpIdempotencyConformanceTest.kt`
 
 - [ ] **Step 1: same runner + outer executor ownership test 작성**
 
@@ -1422,8 +1420,8 @@ fun `Spring MockMvc satisfies bounded wait HTTP idempotency conformance`() = run
 
 - [ ] **Step 2: Spring test가 missing controller/adapter로 실패하는지 확인**
 
-Run: `./gradlew :bluetape4k-spring-boot-core:test --tests '*SpringHttpIdempotencyConformanceTest' --no-configuration-cache`
-Expected: Spring fake application/controller/adapter unresolved로 FAIL.
+실행: `./gradlew :bluetape4k-spring-boot-core:test --tests '*SpringHttpIdempotencyConformanceTest' --no-configuration-cache`
+예상 결과: Spring fake application/controller/adapter unresolved로 FAIL.
 
 - [ ] **Step 3: standalone controller와 server-resolved auth 구현**
 
@@ -1470,8 +1468,8 @@ dedicated lifecycle test는 test controller가 `CountDownLatch.await()`에서 �
 
 - [ ] **Step 5: Spring reference test와 module test 실행**
 
-Run: `./gradlew :bluetape4k-spring-boot-core:test --no-configuration-cache`
-Expected: 동일 17 scenario PASS; deliberately blocked exchange가 timeout 안에 interrupt되고 outer dispatcher/executor close 후 live owned thread 0.
+실행: `./gradlew :bluetape4k-spring-boot-core:test --no-configuration-cache`
+예상 결과: 동일 17 scenario PASS; deliberately blocked exchange가 timeout 안에 interrupt되고 outer dispatcher/executor close 후 live owned thread 0.
 
 - [ ] **Step 6: Lore commit**
 
@@ -1485,19 +1483,19 @@ git commit -m "Prove the bounded idempotency contract through Spring MockMvc" \
 
 ## Task 8: Bilingual docs, caller guidance와 release note
 
-**Complexity:** Medium **Depends on:** Tasks 6-7의 실제 compile-checked examples **Pattern
+**복잡도:** Medium **의존:** Tasks 6-7의 실제 compile-checked examples **Pattern
 skills:** `bluetape-writer`, `bluetape-kotlin-patterns`
 **Rollback:** repository docs는 이 task commit만 revert한다. adopter는 fixture 호출 제거 또는 이전 library version pin으로 opt-out하며 production data rollback은 없다. 정책 자체를 바꾸면 API version과 client migration 안내를 먼저 제공한다.
 
-**Files:**
+**파일:**
 
-- Modify: `testing/junit5/README.md`
-- Modify: `testing/junit5/README.ko.md`
-- Create: `docs/manual/en/modules/bluetape4k-junit5/http-idempotency-conformance.md`
-- Create: `docs/manual/ko/modules/bluetape4k-junit5/http-idempotency-conformance.md`
-- Modify: `docs/manual/en/modules/bluetape4k-junit5.md`
-- Modify: `docs/manual/ko/modules/bluetape4k-junit5.md`
-- Modify: `CHANGELOG.md`
+- 수정: `testing/junit5/README.md`
+- 수정: `testing/junit5/README.ko.md`
+- 생성: `docs/manual/en/modules/bluetape4k-junit5/http-idempotency-conformance.md`
+- 생성: `docs/manual/ko/modules/bluetape4k-junit5/http-idempotency-conformance.md`
+- 수정: `docs/manual/en/modules/bluetape4k-junit5.md`
+- 수정: `docs/manual/ko/modules/bluetape4k-junit5.md`
+- 수정: `CHANGELOG.md`
 
 - [ ] **Step 1: README English/Korean에 같은 결과표와 config example 추가**
 
@@ -1562,7 +1560,7 @@ Korean sections: `문제`, `정책 선택`, `적합성 gate`, `호출자 key lif
 
 - [ ] **Step 6: locale/source link 검증**
 
-Run:
+실행:
 
 ```bash
 for file in \
@@ -1589,7 +1587,7 @@ for landing in docs/manual/en/modules/bluetape4k-junit5.md \
 done
 ```
 
-Expected: first loop output 0, 각 file의 required term 11/11. 두 source test link는 README/manual 네 파일에 각각 존재해 nested loop 8/8이 통과하며, landing page 양쪽은 새 chapter link 1개씩을 가진다. reviewer는 caller action 5행, support 4행, signals/actions 6행의 EN/KO 순서와 의미 parity를 확인한다.
+예상 결과: first loop output 0, 각 file의 required term 11/11. 두 source test link는 README/manual 네 파일에 각각 존재해 nested loop 8/8이 통과하며, landing page 양쪽은 새 chapter link 1개씩을 가진다. reviewer는 caller action 5행, support 4행, signals/actions 6행의 EN/KO 순서와 의미 parity를 확인한다.
 
 - [ ] **Step 7: Lore commit**
 
@@ -1605,47 +1603,47 @@ git commit -m "Make bounded idempotency adoption limits explicit" \
 
 ## Task 9: Cross-module verification와 delivery readiness
 
-**Complexity:** Medium **Depends on:** Tasks 1-8 **Pattern
+**복잡도:** Medium **의존:** Tasks 1-8 **Pattern
 skills:** `verification-before-completion`, `requesting-code-review`, `bluetape-kotlin-patterns`
 **Rollback/rerun:** 실패한 가장 작은 module/task로 돌아가 수정하고 해당 targeted test부터 순서대로 재실행한다.
 
-**Files:**
+**파일:**
 
 - Modify only if verification exposes a defect in the files owned by Tasks 1-8.
 
 - [ ] **Step 1: exact changed-file scope 확인**
 
-Run: `repo-status && git diff --name-status origin/develop...HEAD`
-Expected: 승인된 spec/plan과 plan에 열거한 junit5/Ktor/Spring/docs/changelog 파일만 변경되고 build/dependency/production adapter 파일은 없다.
+실행: `repo-status && git diff --name-status origin/develop...HEAD`
+예상 결과: 승인된 spec/plan과 plan에 열거한 junit5/Ktor/Spring/docs/changelog 파일만 변경되고 build/dependency/production adapter 파일은 없다.
 
-Run: `git diff --name-status origin/develop...HEAD -- testing/junit5/src/main/kotlin | awk '$1 != "A" { print; bad=1 } END { exit bad }'`
-Expected: output 0, exit 0. 기존 `bluetape4k-junit5` main source를 수정/삭제하지 않고 새 package/file만 추가했으므로 existing JVM ABI는 exact unchanged이고 새 surface만 additive다. 저장소에는 module-wide baseline API validator가 없으므로 이 additive-only diff gate와 아래 compiled JVM surface를 authority로 사용하며 generic `apiCheck` task가 있다고 가정하지 않는다.
+실행: `git diff --name-status origin/develop...HEAD -- testing/junit5/src/main/kotlin | awk '$1 != "A" { print; bad=1 } END { exit bad }'`
+예상 결과: output 0, exit 0. 기존 `bluetape4k-junit5` main source를 수정/삭제하지 않고 새 package/file만 추가했으므로 existing JVM ABI는 exact unchanged이고 새 surface만 additive다. 저장소에는 module-wide baseline API validator가 없으므로 이 additive-only diff gate와 아래 compiled JVM surface를 authority로 사용하며 generic `apiCheck` task가 있다고 가정하지 않는다.
 
 - [ ] **Step 2: 세 module targeted test를 순차 실행**
 
-Run: `repo-test-summary -- ./gradlew :bluetape4k-junit5:test --no-configuration-cache`
-Expected: PASS. Run: `repo-test-summary -- ./gradlew :bluetape4k-ktor-testing:test --no-configuration-cache`
-Expected: PASS. Run: `repo-test-summary -- ./gradlew :bluetape4k-spring-boot-core:test --no-configuration-cache`
-Expected: PASS.
+실행: `repo-test-summary -- ./gradlew :bluetape4k-junit5:test --no-configuration-cache`
+예상 결과: PASS. Run: `repo-test-summary -- ./gradlew :bluetape4k-ktor-testing:test --no-configuration-cache`
+예상 결과: PASS. Run: `repo-test-summary -- ./gradlew :bluetape4k-spring-boot-core:test --no-configuration-cache`
+예상 결과: PASS.
 
 - [ ] **Step 3: affected modules broader build**
 
-Run: `repo-test-summary -- ./gradlew :bluetape4k-junit5:build :bluetape4k-ktor-testing:build :bluetape4k-spring-boot-core:build --no-configuration-cache`
-Expected: BUILD SUCCESSFUL; compile/test/jar tasks pass.
+실행: `repo-test-summary -- ./gradlew :bluetape4k-junit5:build :bluetape4k-ktor-testing:build :bluetape4k-spring-boot-core:build --no-configuration-cache`
+예상 결과: BUILD SUCCESSFUL; compile/test/jar tasks pass.
 
 - [ ] **Step 4: detekt/static analysis**
 
-Run: `./gradlew :bluetape4k-junit5:detekt :bluetape4k-junit5:detektTest :bluetape4k-ktor-testing:detektTest :bluetape4k-spring-boot-core:detektTest --no-configuration-cache`
-Expected: 0 detekt violations. Task name이 존재하지 않으면 `./gradlew tasks --all | rg 'detekt(Test)?'`로 실제 affected task를 확인하고 같은 module scope로 실행한다.
+실행: `./gradlew :bluetape4k-junit5:detekt :bluetape4k-junit5:detektTest :bluetape4k-ktor-testing:detektTest :bluetape4k-spring-boot-core:detektTest --no-configuration-cache`
+예상 결과: 0 detekt violations. Task name이 존재하지 않으면 `./gradlew tasks --all | rg 'detekt(Test)?'`로 실제 affected task를 확인하고 같은 module scope로 실행한다.
 
 - [ ] **Step 5: assertion 전수조사**
 
-Run: `rg -n '(assertTrue|assertFalse|assertEquals|kotlin\.test\.assert|org\.junit\.jupiter\.api\.Assertions|\.shouldBe(True|False)\(\))' testing/junit5/src/{main,test}/kotlin/io/bluetape4k/junit5/http/idempotency ktor/testing/src/test/kotlin/io/bluetape4k/ktor/testing/idempotency spring-boot/core/src/test/kotlin/io/bluetape4k/spring/idempotency`
-Expected: no output. Exact matcher가 없는 fallback이 있으면 code comment와 review evidence에 이유가 있어야 한다.
+실행: `rg -n '(assertTrue|assertFalse|assertEquals|kotlin\.test\.assert|org\.junit\.jupiter\.api\.Assertions|\.shouldBe(True|False)\(\))' testing/junit5/src/{main,test}/kotlin/io/bluetape4k/junit5/http/idempotency ktor/testing/src/test/kotlin/io/bluetape4k/ktor/testing/idempotency spring-boot/core/src/test/kotlin/io/bluetape4k/spring/idempotency`
+예상 결과: no output. Exact matcher가 없는 fallback이 있으면 code comment와 review evidence에 이유가 있어야 한다.
 
 - [ ] **Step 6: serialization/KDoc/compiled public API audit**
 
-Run:
+실행:
 
 ```bash
 rg -n '^(data )?class |^interface |^suspend fun |^fun ' \
@@ -1664,13 +1662,13 @@ for class_name in \
 done
 ```
 
-Expected: 모든 public value는 `java.io.Serializable`, private `serialVersionUID`는
+예상 결과: 모든 public value는 `java.io.Serializable`, private `serialVersionUID`는
 `HttpIdempotencyValuesTest`의 `ObjectStreamClass.lookup(...).serialVersionUID shouldBeEqualTo 1L`로 검증된다. `javap`에는 승인된 constructor/copy, adapter suspend contract와 runner entrypoint만 있고 Spring/Ktor/store/dispatcher/executor type이 없다. 모든 public declaration 앞 English KDoc을 source review로 확인한다. Task 2 lifecycle test와 Tasks 6-7의 실제 compile된 test가 config 생성, adapter override, runner 호출, caller-owned cleanup을 사용하므로 별도 복사된 문서 sample 대신 동일 source link를 README/KDoc에 연결한다.
 
 - [ ] **Step 7: final hygiene**
 
-Run: `git diff --check && git status --short --branch`
-Expected: whitespace error 없음; branch는 commit 후 clean.
+실행: `git diff --check && git status --short --branch`
+예상 결과: whitespace error 없음; branch는 commit 후 clean.
 
 - [ ] **Step 8: Type A code review와 PR gate 준비**
 

--- a/docs/superpowers/plans/2026-07-22-issue-1068-fencing-lease-plan.md
+++ b/docs/superpowers/plans/2026-07-22-issue-1068-fencing-lease-plan.md
@@ -1,14 +1,12 @@
 # Redis Fencing Lease Implementation Plan
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** `bluetape4k-lettuce`에 `(epoch, sequence)`로 정렬 가능한 fencing lease를 추가하고, Redis history loss·모호한 완료·취소·Cluster routing·외부 resilience 조합의 경계를 실행 가능한 test와 영문/한글 문서로 고정한다.
+**목표:** `bluetape4k-lettuce`에 `(epoch, sequence)`로 정렬 가능한 fencing lease를 추가하고, Redis history loss·모호한 완료·취소·Cluster routing·외부 resilience 조합의 경계를 실행 가능한 test와 영문/한글 문서로 고정한다.
 
-**Architecture:** 한 instance가 `LettuceFencingLeaseConfig(namespace, resourceName, epoch)` 하나를 소유하고, 파생된 lease/counter 두 key만 동일 slot에서 Lua로 다룬다. public model과 result는 Java serialization invariant를 지키며, sync/`CompletableFuture`/suspend facade는 같은 validation·script·wire decoder·backend classifier를 공유한다. primitive 내부에는 retry/CB/bulkhead를 넣지 않고, 테스트와 README에서 `bluetape4k-resilience4j` decorator 및 downstream tuple CAS를 보여준다.
+**아키텍처:** 한 instance가 `LettuceFencingLeaseConfig(namespace, resourceName, epoch)` 하나를 소유하고, 파생된 lease/counter 두 key만 동일 slot에서 Lua로 다룬다. public model과 result는 Java serialization invariant를 지키며, sync/`CompletableFuture`/suspend facade는 같은 validation·script·wire decoder·backend classifier를 공유한다. primitive 내부에는 retry/CB/bulkhead를 넣지 않고, 테스트와 README에서 `bluetape4k-resilience4j` decorator 및 downstream tuple CAS를 보여준다.
 
-**Tech
-Stack:** Kotlin 2.3, Java 21, Lettuce, Redis Lua/EVALSHA/EVAL/EVAL_RO, Kotlin Coroutines, JUnit 5, bluetape4k-assertions, bluetape4k-junit5, bluetape4k-testcontainers, bluetape4k-resilience4j, Resilience4j 2.4.0.
+**기술 스택:** Kotlin 2.3, Java 21, Lettuce, Redis Lua/EVALSHA/EVAL/EVAL_RO, Kotlin Coroutines, JUnit 5, bluetape4k-assertions, bluetape4k-junit5, bluetape4k-testcontainers, bluetape4k-resilience4j, Resilience4j 2.4.0.
 
 ---
 
@@ -75,12 +73,12 @@ Not-tested: <known gap>
 
 ## 2. Task 1 — Public value와 sealed result를 먼저 고정
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValueTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResultTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValueTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResultTest.kt`
 
 ### 2.1 RED — invariant, ordering, serialization test
 
@@ -105,7 +103,7 @@ Not-tested: <known gap>
 ./gradlew :bluetape4k-lettuce:test --tests '*FencingLeaseValueTest' --tests '*FencingLeaseResultTest'
 ```
 
-Expected: 새 type이 없어 Kotlin test compilation이 실패한다.
+예상 결과: 새 type이 없어 Kotlin test compilation이 실패한다.
 
 ### 2.2 GREEN — public model 구현
 
@@ -270,7 +268,7 @@ sealed interface FencingBootstrapResult : Serializable {
 ./gradlew :bluetape4k-lettuce:test --tests '*FencingLeaseValueTest' --tests '*FencingLeaseResultTest'
 ```
 
-Expected: 모든 ordering/invariant/serialization/redaction test가 통과한다.
+예상 결과: 모든 ordering/invariant/serialization/redaction test가 통과한다.
 
 ### 2.3 Commit
 
@@ -290,10 +288,10 @@ Not-tested: Redis execution is introduced in later tasks
 
 ## 3. Task 2 — `RedisScriptRunner`의 현재 upstream future 취소 전파
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/script/RedisScript.kt`
-- Modify: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/script/RedisScriptTest.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/script/RedisScript.kt`
+- 수정: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/script/RedisScriptTest.kt`
 
 ### 3.1 RED — EVALSHA/NOSCRIPT race contract
 
@@ -311,7 +309,7 @@ Not-tested: Redis execution is introduced in later tasks
 ./gradlew :bluetape4k-lettuce:test --tests 'io.bluetape4k.redis.lettuce.script.RedisScriptTest'
 ```
 
-Expected: 새 cancellation assertion이 실패한다.
+예상 결과: 새 cancellation assertion이 실패한다.
 
 ### 3.2 GREEN — cancellable bridge 구현
 
@@ -380,7 +378,7 @@ private fun Throwable.unwrapCompletionCause(): Throwable =
 ./gradlew :bluetape4k-lettuce:test --tests 'io.bluetape4k.redis.lettuce.script.RedisScriptTest' --rerun-tasks
 ```
 
-Expected: 기존 sync/async/suspend/NOSCRIPT test와 새 cancellation test가 모두 통과한다.
+예상 결과: 기존 sync/async/suspend/NOSCRIPT test와 새 cancellation test가 모두 통과한다.
 
 ### 3.3 Commit
 
@@ -400,10 +398,10 @@ Not-tested: fencing lease integration is introduced later
 
 ## 4. Task 3 — Key derivation, validation, wire protocol, backend classifier
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupportTest.kt`
 
 ### 4.1 RED — pure support contract
 
@@ -423,7 +421,7 @@ Not-tested: fencing lease integration is introduced later
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseSupportTest'
 ```
 
-Expected: support symbol이 없어 test compilation이 실패한다.
+예상 결과: support symbol이 없어 test compilation이 실패한다.
 
 ### 4.2 GREEN — 고정 내부 계약 구현
 
@@ -515,7 +513,7 @@ internal fun Duration.requireFencingLeaseMillis(): Long {
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseSupportTest'
 ```
 
-Expected: key/codec/decimal/TTL/classifier/protocol/redaction unit test가 모두 통과한다.
+예상 결과: key/codec/decimal/TTL/classifier/protocol/redaction unit test가 모두 통과한다.
 
 ### 4.3 Commit
 
@@ -535,10 +533,10 @@ Not-tested: real Redis state transitions are introduced next
 
 ## 5. Task 4 — Lua state machine와 hostile standalone Redis
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseScriptTest.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseScriptTest.kt`
 
 ### 5.1 RED — operation matrix와 hostile state
 
@@ -561,7 +559,7 @@ Not-tested: real Redis state transitions are introduced next
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseScriptTest'
 ```
 
-Expected: script runner/decoder operation이 없어 test compilation 또는 assertion이 실패한다.
+예상 결과: script runner/decoder operation이 없어 test compilation 또는 assertion이 실패한다.
 
 ### 5.2 GREEN — fixed O (1) Lua protocol
 
@@ -603,7 +601,7 @@ return {'ACQUIRED', ARGV[2], nextSequenceText, '-1'}
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseScriptTest'
 ```
 
-Expected: 정상 state machine, hostile state fail-closed, overflow, NOSCRIPT, structural O (1) test가 통과한다.
+예상 결과: 정상 state machine, hostile state fail-closed, overflow, NOSCRIPT, structural O (1) test가 통과한다.
 
 ### 5.3 Commit
 
@@ -623,13 +621,13 @@ Not-tested: facade parity, Cluster routing, and cancellation follow
 
 ## 6. Task 5 — Sync, future, suspend facade와 shared contract
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseContract.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLeaseTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseContract.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLeaseTest.kt`
 
 ### 6.1 RED — 공통 adapter contract
 
@@ -664,7 +662,7 @@ internal interface FencingLeaseAdapter {
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseTest' --tests '*LettuceSuspendFencingLeaseTest'
 ```
 
-Expected: facade type이 없어 compilation이 실패한다.
+예상 결과: facade type이 없어 compilation이 실패한다.
 
 ### 6.2 GREEN — facade는 validation과 support에만 위임
 
@@ -781,7 +779,7 @@ class LettuceSuspendFencingLease private constructor(
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseTest' --tests '*LettuceSuspendFencingLeaseTest'
 ```
 
-Expected: sync/future/suspend가 동일 result와 validation/backend failure boundary를 보인다.
+예상 결과: sync/future/suspend가 동일 result와 validation/backend failure boundary를 보인다.
 
 ### 6.3 Commit
 
@@ -801,12 +799,12 @@ Not-tested: bounded contention and Cluster stress follow
 
 ## 7. Task 6 — Cancellation과 모호한 완료를 결정적으로 재현
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseCancellationTest.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseCancellationTest.kt`
 
 ### 7.1 RED — apply 전/후 fault injection
 
@@ -860,7 +858,7 @@ internal interface FencingScriptExecutor {
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseCancellationTest'
 ```
 
-Expected: fault seam과 cancellation reconciliation이 없어 실패한다.
+예상 결과: fault seam과 cancellation reconciliation이 없어 실패한다.
 
 ### 7.2 GREEN — cancellation 우선 전파
 
@@ -885,7 +883,7 @@ try {
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseCancellationTest' --rerun-tasks
 ```
 
-Expected: before/after apply와 EVALSHA/EVAL 전환 모든 case가 deterministic하게 통과한다.
+예상 결과: before/after apply와 EVALSHA/EVAL 전환 모든 case가 deterministic하게 통과한다.
 
 ### 7.3 Commit
 
@@ -905,10 +903,10 @@ Not-tested: external topology promotion remains opt-in
 
 ## 8. Task 7 — Bounded contention과 Redis Cluster routing
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseConcurrencyTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseClusterTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseConcurrencyTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseClusterTest.kt`
 
 ### 8.1 RED — duplicate generation과 wrong-slot 방어
 
@@ -926,7 +924,7 @@ Not-tested: external topology promotion remains opt-in
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseClusterTest'
 ```
 
-Expected: contention/Cluster contract 중 누락된 동작이 실패한다.
+예상 결과: contention/Cluster contract 중 누락된 동작이 실패한다.
 
 ### 8.2 GREEN — 발견된 race/routing만 최소 수정
 
@@ -939,7 +937,7 @@ Expected: contention/Cluster contract 중 누락된 동작이 실패한다.
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceFencingLeaseClusterTest' --rerun-tasks
 ```
 
-Expected: bounded contention과 Cluster test가 각각 30초 안에 통과한다.
+예상 결과: bounded contention과 Cluster test가 각각 30초 안에 통과한다.
 
 ### 8.3 Commit
 
@@ -959,12 +957,12 @@ Not-tested: production-scale latency is intentionally outside this issue
 
 ## 9. Task 8 — 외부 resilience, downstream CAS, epoch recovery 예제
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/build.gradle.kts`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseResilience4jTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTopologyRecoveryTest.kt`
+- 수정: `infra/lettuce/build.gradle.kts`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseResilience4jTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseRecoveryTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseTopologyRecoveryTest.kt`
 
 ### 9.1 RED — caller-layer policy contract
 
@@ -1043,7 +1041,7 @@ bootstrap -> verify readiness and tuple guard -> rollout -> confirm old absence 
 ./gradlew :bluetape4k-lettuce:fencingLeaseTopologyRecoveryTest
 ```
 
-Expected: caller policy/recovery fixture와 tagged topology task가 없어 실패한다.
+예상 결과: caller policy/recovery fixture와 tagged topology task가 없어 실패한다.
 
 ### 9.2 GREEN — test/example layer에서만 policy 구현
 
@@ -1065,7 +1063,7 @@ private fun isBackendFailure(result: FencingAcquireResult): Boolean =
 ./gradlew :bluetape4k-lettuce:fencingLeaseTopologyRecoveryTest --rerun-tasks
 ```
 
-Expected: decorator topology, exception boundary, strict tuple acceptance, simulated recovery와 실제 tagged promotion/restore contract가 통과한다.
+예상 결과: decorator topology, exception boundary, strict tuple acceptance, simulated recovery와 실제 tagged promotion/restore contract가 통과한다.
 
 ### 9.3 Commit
 
@@ -1085,15 +1083,15 @@ Not-tested: production-managed Redis topology remains outside the Testcontainers
 
 ## 10. Task 9 — English KDoc, bilingual README, executable documentation
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
-- Modify: `infra/lettuce/README.md`
-- Modify: `infra/lettuce/README.ko.md`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseDocumentationTest.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseValue.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseResult.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLease.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceSuspendFencingLease.kt`
+- 수정: `infra/lettuce/README.md`
+- 수정: `infra/lettuce/README.ko.md`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/FencingLeaseDocumentationTest.kt`
 
 ### 10.1 RED — KDoc와 locale parity contract
 
@@ -1132,7 +1130,7 @@ Not-tested: production-managed Redis topology remains outside the Testcontainers
 ./gradlew :bluetape4k-lettuce:test --tests '*FencingLeaseDocumentationTest'
 ```
 
-Expected: README section/marker가 없어 실패한다.
+예상 결과: README section/marker가 없어 실패한다.
 
 ### 10.2 GREEN — 문서와 KDoc를 구현에 맞춤
 
@@ -1162,7 +1160,7 @@ WHERE id = :id
 git diff --check
 ```
 
-Expected: bilingual marker/source parity와 executable example이 통과한다.
+예상 결과: bilingual marker/source parity와 executable example이 통과한다.
 
 ### 10.3 Commit
 
@@ -1182,7 +1180,7 @@ Not-tested: rendered website is outside this module README change
 
 ## 11. Task 10 — Regression, static analysis, acceptance 추적
 
-**Files:**
+**파일:**
 
 - Verify only; source 변경은 실패 수정에 한정한다.
 
@@ -1210,7 +1208,7 @@ Not-tested: rendered website is outside this module README change
 ./gradlew :bluetape4k-lettuce:fencingLeaseTopologyRecoveryTest
 ```
 
-Expected: 모든 targeted test가 통과하고 Testcontainers test가 서로 겹치지 않는다.
+예상 결과: 모든 targeted test가 통과하고 Testcontainers test가 서로 겹치지 않는다.
 
 ### 11.2 기존 API 회귀
 
@@ -1223,7 +1221,7 @@ Expected: 모든 targeted test가 통과하고 Testcontainers test가 서로 겹
   --tests '*MultiKeyLease*'
 ```
 
-Expected: 기존 RedisScriptRunner와 multi-key lease contract가 그대로 통과한다.
+예상 결과: 기존 RedisScriptRunner와 multi-key lease contract가 그대로 통과한다.
 
 ### 11.3 Module gate와 static analysis
 
@@ -1235,7 +1233,7 @@ repo-test-summary -- ./gradlew :bluetape4k-lettuce:test
 git diff --check
 ```
 
-Expected: `:bluetape4k-lettuce:test` 0 failures, detekt 0 findings, whitespace error 0.
+예상 결과: `:bluetape4k-lettuce:test` 0 failures, detekt 0 findings, whitespace error 0.
 
 - [ ] changed Kotlin test 전체를 검색해 assertion/style invariant를 확인한다.
 
@@ -1246,7 +1244,7 @@ rg -n 'assertThrows|kotlin\.test\.assertFailsWith|\)\.shouldBeFalse\(\)|TO''DO|F
   infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/script/RedisScriptTest.kt
 ```
 
-Expected: 허용되지 않은 assertion/작업 marker 0. 의도적 `shouldBeFalse()`가 있다면 boolean 상태 자체를 검증하는 경우인지 수동 확인하고 equality 대체가 가능하면 intent matcher로 바꾼다.
+예상 결과: 허용되지 않은 assertion/작업 marker 0. 의도적 `shouldBeFalse()`가 있다면 boolean 상태 자체를 검증하는 경우인지 수동 확인하고 equality 대체가 가능하면 intent matcher로 바꾼다.
 
 ### 11.4 Acceptance traceability
 

--- a/docs/superpowers/plans/2026-07-22-issue-756-lettuce-buffer-codecs-plan.md
+++ b/docs/superpowers/plans/2026-07-22-issue-756-lettuce-buffer-codecs-plan.md
@@ -1,14 +1,12 @@
-# Issue #756 Lettuce Buffer Codec Implementation Plan
+# Issue #756 Lettuce Buffer Codec 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to execute this plan task-by-task. Apply `bluetape-kotlin-patterns` to every Kotlin production and test change.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 superpowers:subagent-driven-development(권장) 또는 superpowers:executing-plans로 task별 실행한다. 모든 Kotlin production/test 변경에는 `bluetape-kotlin-patterns`를 적용한다.
 
-**Goal:** `BinarySerializer`/`JsonSerializer`에 source·binary compatible한 caller-owned `OutputStream` capability를 추가하고, Lettuce built-in codec 계층의 unconditional `ByteArray` copy를 bounded `ByteBuf`/`ByteBuffer` dispatch로 제거한다. payload-sized handoff allocation 제거 주장은 two-run evidence에서 accepted된 direct backend와 target cell에만 한정하며 compatibility fallback은 계속 allocation할 수 있다.
+**목표:** `BinarySerializer`/`JsonSerializer`에 source·binary compatible한 caller-owned `OutputStream` capability를 추가하고, Lettuce built-in codec 계층의 unconditional `ByteArray` copy를 bounded `ByteBuf`/`ByteBuffer` dispatch로 제거한다. payload-sized handoff allocation 제거 주장은 two-run evidence에서 accepted된 direct backend와 target cell에만 한정하며 compatibility fallback은 계속 allocation할 수 있다.
 
-**Architecture:** serializer interface default는 기존 `ByteArray` API에 위임하는 allocating compatibility fallback으로 남긴다. 검증된 JDK/Kryo/Jackson 2/Jackson 3만 caller-owned stream 직접 기록 후보를 제공하고, Lettuce는 NIO writable view 대신 absolute-index 기반 `BoundedByteBufOutputStream`으로 성공 시에만 `writerIndex`를 commit한다. 성능 주장은 exact matrix의 two-run JMH evidence와 fail-closed validator가 결정한다.
+**아키텍처:** serializer interface default는 기존 `ByteArray` API에 위임하는 allocating compatibility fallback으로 남긴다. 검증된 JDK/Kryo/Jackson 2/Jackson 3만 caller-owned stream 직접 기록 후보를 제공하고, Lettuce는 NIO writable view 대신 absolute-index 기반 `BoundedByteBufOutputStream`으로 성공 시에만 `writerIndex`를 commit한다. 성능 주장은 exact matrix의 two-run JMH evidence와 fail-closed validator가 결정한다.
 
-**Tech
-Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty `ByteBuf`, Lettuce `ToByteBufEncoder`, JDK serialization, Kryo 5, Jackson 2/3, kotlinx-benchmark/JMH, Python 3 standard library.
+**기술 스택:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty `ByteBuf`, Lettuce `ToByteBufEncoder`, JDK serialization, Kryo 5, Jackson 2/3, kotlinx-benchmark/JMH, Python 3 standard library.
 
 ---
 
@@ -82,12 +80,12 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 1: serializer interface default를 test-first로 추가
 
-**Files:**
+**파일:**
 
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/BinarySerializerOutputStreamContractTest.kt`
-- Create: `io/json/src/test/kotlin/io/bluetape4k/json/JsonSerializerOutputStreamContractTest.kt`
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializer.kt`
-- Modify: `io/json/src/main/kotlin/io/bluetape4k/json/JsonSerializer.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/BinarySerializerOutputStreamContractTest.kt`
+- 생성: `io/json/src/test/kotlin/io/bluetape4k/json/JsonSerializerOutputStreamContractTest.kt`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializer.kt`
+- 수정: `io/json/src/main/kotlin/io/bluetape4k/json/JsonSerializer.kt`
 
 - [ ] **1.1 RED — allocating default와 caller lifecycle 계약을 고정한다.**
 
@@ -184,20 +182,20 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 2: release/base/current ABI와 dual-interface source compatibility를 증명
 
-**Files:**
+**파일:**
 
-- Create: `io/io/src/test/resources/compat/issue-756/src/java/LegacyBinaryStreamCaller.java`
-- Create: `io/io/src/test/resources/compat/issue-756/src/java/LegacyBinaryImplementation.java`
-- Create: `io/io/src/test/resources/compat/issue-756/src/kotlin/LegacyBinaryStreamCaller.kt`
-- Create: `io/io/src/test/resources/compat/issue-756/src/java/LegacyBinaryDecorator.java`
-- Create: `io/io/src/test/resources/compat/issue-756/src/kotlin/LegacyBinaryDecorator.kt`
-- Create: `io/io/src/test/resources/compat/issue-756/src/java/ConcreteSerializerStreamCaller.java`
-- Create: `io/json/src/test/resources/compat/issue-756/src/java/LegacyJsonStreamCaller.java`
-- Create: `io/json/src/test/resources/compat/issue-756/src/java/LegacyJsonImplementation.java`
-- Create: `io/json/src/test/resources/compat/issue-756/src/kotlin/LegacyJsonStreamCaller.kt`
-- Create: `io/json/src/test/resources/compat/issue-756/src/java/LegacyDualSerializer.java`
-- Create: `io/json/src/test/resources/compat/issue-756/src/kotlin/LegacyDualSerializer.kt`
-- Modify: `scripts/check-serializer-buffer-abi.sh`
+- 생성: `io/io/src/test/resources/compat/issue-756/src/java/LegacyBinaryStreamCaller.java`
+- 생성: `io/io/src/test/resources/compat/issue-756/src/java/LegacyBinaryImplementation.java`
+- 생성: `io/io/src/test/resources/compat/issue-756/src/kotlin/LegacyBinaryStreamCaller.kt`
+- 생성: `io/io/src/test/resources/compat/issue-756/src/java/LegacyBinaryDecorator.java`
+- 생성: `io/io/src/test/resources/compat/issue-756/src/kotlin/LegacyBinaryDecorator.kt`
+- 생성: `io/io/src/test/resources/compat/issue-756/src/java/ConcreteSerializerStreamCaller.java`
+- 생성: `io/json/src/test/resources/compat/issue-756/src/java/LegacyJsonStreamCaller.java`
+- 생성: `io/json/src/test/resources/compat/issue-756/src/java/LegacyJsonImplementation.java`
+- 생성: `io/json/src/test/resources/compat/issue-756/src/kotlin/LegacyJsonStreamCaller.kt`
+- 생성: `io/json/src/test/resources/compat/issue-756/src/java/LegacyDualSerializer.java`
+- 생성: `io/json/src/test/resources/compat/issue-756/src/kotlin/LegacyDualSerializer.kt`
+- 수정: `scripts/check-serializer-buffer-abi.sh`
 
 - [ ] **2.1 Compatibility fixture와 fail-closed matrix를 작성한다.**
 
@@ -247,12 +245,12 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 3: decorator subclass semantics와 compressed wire를 명시적으로 보존
 
-**Files:**
+**파일:**
 
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/BinarySerializerDecoratorOutputStreamTest.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializerOutputStreamTest.kt`
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializerDecorator.kt`
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializer.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/BinarySerializerDecoratorOutputStreamTest.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializerOutputStreamTest.kt`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializerDecorator.kt`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializer.kt`
 
 - [ ] **3.1 RED — public decorator와 compression의 Kotlin delegation bypass regression을 고정한다.**
 
@@ -306,11 +304,11 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 4: JDK와 Kryo direct stream 후보를 검증
 
-**Files:**
+**파일:**
 
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerOutputStreamTest.kt`
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/JdkBinarySerializer.kt`
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerOutputStreamTest.kt`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/JdkBinarySerializer.kt`
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt`
 
 - [ ] **4.1 RED — backend parity와 resource lifecycle을 고정한다.**
 
@@ -388,12 +386,12 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 5: Jackson 2/3 direct stream 후보를 검증
 
-**Files:**
+**파일:**
 
-- Create: `io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonSerializerOutputStreamTest.kt`
-- Create: `io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonSerializerOutputStreamTest.kt`
-- Modify: `io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt`
-- Modify: `io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt`
+- 생성: `io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonSerializerOutputStreamTest.kt`
+- 생성: `io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonSerializerOutputStreamTest.kt`
+- 수정: `io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt`
+- 수정: `io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt`
 
 - [ ] **5.1 RED — mapper/wire/security/failure parity를 각 major line에서 고정한다.**
 
@@ -474,10 +472,10 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 6: bounded absolute-index ByteBuf writer를 TDD로 구현
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/BoundedByteBufOutputStreamTest.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/BoundedByteBufOutputStream.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/BoundedByteBufOutputStreamTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/BoundedByteBufOutputStream.kt`
 
 - [ ] **6.1 RED — ownership, bounds, hostile state matrix를 고정한다.**
 
@@ -556,12 +554,12 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 7: Lettuce built-in target encode를 success-only commit으로 전환
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecBufferContractTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodecBufferContractTest.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecBufferContractTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodecBufferContractTest.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt`
 
 - [ ] **7.1 RED — binary/json 공통 target 계약을 고정한다.**
 
@@ -623,17 +621,17 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 8: bounded decode dispatch로 unconditional copy를 제거
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecBufferContractTest.kt`
-- Modify: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodecBufferContractTest.kt`
-- Modify: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerOutputStreamTest.kt`
-- Create: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/JdkGlobalObjectInputFilterForkTest.kt`
-- Create: `io/io/src/test/java/io/bluetape4k/io/serializer/JdkGlobalObjectInputFilterFixture.java`
-- Modify: `io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonSerializerOutputStreamTest.kt`
-- Modify: `io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonSerializerOutputStreamTest.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt`
+- 수정: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecBufferContractTest.kt`
+- 수정: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodecBufferContractTest.kt`
+- 수정: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerOutputStreamTest.kt`
+- 생성: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/JdkGlobalObjectInputFilterForkTest.kt`
+- 생성: `io/io/src/test/java/io/bluetape4k/io/serializer/JdkGlobalObjectInputFilterFixture.java`
+- 수정: `io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonSerializerOutputStreamTest.kt`
+- 수정: `io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonSerializerOutputStreamTest.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt`
 
 - [ ] **8.1 RED — source view와 synchronous borrow 계약을 고정한다.**
 
@@ -703,14 +701,14 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 9: exact benchmark matrix와 fail-closed validator를 TDD로 구축
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/benchmark/kotlin/io/bluetape4k/redis/lettuce/benchmark/LettuceCodecBenchmark.kt`
-- Create: `infra/lettuce/src/benchmark/kotlin/io/bluetape4k/redis/lettuce/benchmark/LettuceCodecBenchmarkPreflight.kt`
-- Create: `infra/lettuce/scripts/test_validate_issue756_jmh.py`
-- Create: `infra/lettuce/scripts/validate-issue756-jmh.py`
-- Create: `infra/lettuce/scripts/test_run_issue756_evidence.py`
-- Create: `infra/lettuce/scripts/run-issue756-evidence.py`
+- 수정: `infra/lettuce/src/benchmark/kotlin/io/bluetape4k/redis/lettuce/benchmark/LettuceCodecBenchmark.kt`
+- 생성: `infra/lettuce/src/benchmark/kotlin/io/bluetape4k/redis/lettuce/benchmark/LettuceCodecBenchmarkPreflight.kt`
+- 생성: `infra/lettuce/scripts/test_validate_issue756_jmh.py`
+- 생성: `infra/lettuce/scripts/validate-issue756-jmh.py`
+- 생성: `infra/lettuce/scripts/test_run_issue756_evidence.py`
+- 생성: `infra/lettuce/scripts/run-issue756-evidence.py`
 
 - [ ] **9.1 RED — validator fixture tests를 먼저 작성한다.**
 
@@ -823,12 +821,12 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 10: benchmark input commit을 고정하고 two-run 판정을 코드에 반영
 
-**Files:**
+**파일:**
 
 - Potentially modify only when evidence rejects a direct backend: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/JdkBinarySerializer.kt`, `io/io/src/main/kotlin/io/bluetape4k/io/serializer/KryoBinarySerializer.kt`, `io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt`, `io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt`
 - Potentially modify with the rejected backend: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerOutputStreamTest.kt`, `io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonSerializerOutputStreamTest.kt`, `io/jackson3/src/test/kotlin/io/bluetape4k/jackson3/JacksonSerializerOutputStreamTest.kt`
 - Create after final accepted input: `docs/benchmarks/raw/issue-756/**`
-- Create: `docs/benchmarks/2026-07-22-issue-756-lettuce-buffer-codec-allocation.md`
+- 생성: `docs/benchmarks/2026-07-22-issue-756-lettuce-buffer-codec-allocation.md`
 
 - [ ] **10.1 Pre-measurement full gate와 clean input SHA freeze.**
 
@@ -896,13 +894,13 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 11: bilingual docs와 운영 경계를 동기화
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/README.md`, `io/io/README.ko.md`
-- Modify: `io/json/README.md`, `io/json/README.ko.md`
-- Modify: `io/jackson2/README.md`, `io/jackson2/README.ko.md`
-- Modify: `io/jackson3/README.md`, `io/jackson3/README.ko.md`
-- Modify: `infra/lettuce/README.md`, `infra/lettuce/README.ko.md`
+- 수정: `io/io/README.md`, `io/io/README.ko.md`
+- 수정: `io/json/README.md`, `io/json/README.ko.md`
+- 수정: `io/jackson2/README.md`, `io/jackson2/README.ko.md`
+- 수정: `io/jackson3/README.md`, `io/jackson3/README.ko.md`
+- 수정: `infra/lettuce/README.md`, `infra/lettuce/README.ko.md`
 
 - [ ] **11.1 RED — exact terminology/parity check를 실행한다.**
 
@@ -959,7 +957,7 @@ Stack:** Kotlin 2.3, Java 21, Gradle, JUnit 5, `io.bluetape4k.assertions`, Netty
 
 ## Task 12: 독립 review, 최종 검증, PR 생성, merge 승인 대기
 
-**Files:**
+**파일:**
 
 - Review all files changed from `b00cc5440e47ad803e5aac21528b560fdd3b0474`
 - Create transiently for PR body: `.codex/compat/issue-756/pr-body.md` (gitignored)

--- a/docs/superpowers/plans/2026-07-23-issue-756-fory-codec-followup-plan.md
+++ b/docs/superpowers/plans/2026-07-23-issue-756-fory-codec-followup-plan.md
@@ -1,14 +1,12 @@
-# #756 Fory/FastFory Raw Codec Allocation Implementation Plan
+# #756 Fory/FastFory Raw Codec Allocation 구현 계획
 
-> **For agentic
-workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 `superpowers:subagent-driven-development`(권장) 또는 `superpowers:executing-plans`로 task별 구현한다. 진행 상태는 checkbox(`- [ ]`) syntax로 추적한다.
 
-**Goal:** Remove only the warmed steady-state caller-return/handoff `ByteArray` from raw Fory/FastFory codec paths while preserving Fory's internal reusable `MemoryBuffer`, all serializer and codec fallback contracts, and caller-owned `ByteBuf` state.
+**목표:** Fory 내부 reusable `MemoryBuffer`, 모든 serializer/codec fallback contract, caller-owned `ByteBuf` state를 보존하면서 raw Fory/FastFory codec path에서 warmed steady-state caller-return/handoff `ByteArray`만 제거한다.
 
-**Architecture:** `ForyBinarySerializer` gains the existing caller-owned `OutputStream` fast-path seam. Lettuce continues to own bounded absolute-index writing through `BoundedByteBufOutputStream`. Redisson decode receives a narrowly scoped read-only NIO view with exactly-one copied-primary fallback; Redisson encode is guarded by a benchmark-only feasibility probe and is implemented only when that probe accepts it. Evidence promotion, charts, and README claims are disposition-gated.
+**아키텍처:** `ForyBinarySerializer` gains the existing caller-owned `OutputStream` fast-path seam. Lettuce continues to own bounded absolute-index writing through `BoundedByteBufOutputStream`. Redisson decode receives a narrowly scoped read-only NIO view with exactly-one copied-primary fallback; Redisson encode is guarded by a benchmark-only feasibility probe and is implemented only when that probe accepts it. Evidence promotion, charts, and README claims are disposition-gated.
 
-**Tech
-Stack:** Kotlin 2.3, Java 21, Apache Fory/FastFory, Netty `ByteBuf`, Lettuce, Redisson, JUnit 5, `bluetape4k-assertions`, JMH, Python evidence validators.
+**기술 스택:** Kotlin 2.3, Java 21, Apache Fory/FastFory, Netty `ByteBuf`, Lettuce, Redisson, JUnit 5, `bluetape4k-assertions`, JMH, Python evidence validators.
 
 **Required
 pattern:** Follow `bluetape4k-kotlin-patterns`: immutable local state, JUnit 5 plus `bluetape4k-assertions` (`assertFailsWith` for failure contracts), explicit `finally` cleanup, no broad exception swallowing, KDoc at public behavior boundaries, and repository formatter/import conventions.
@@ -37,30 +35,30 @@ pattern:** Follow `bluetape4k-kotlin-patterns`: immutable local state, JUnit 5 p
 
 ## Task 1: Lock Fory caller-owned stream behavior with failing tests
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerByteBufferTest.kt`
-- Modify: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializerTest.kt`
-- Modify: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/SecureForyBinarySerializerTest.kt`
+- 수정: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/CoreBinarySerializerByteBufferTest.kt`
+- 수정: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializerTest.kt`
+- 수정: `io/io/src/test/kotlin/io/bluetape4k/io/serializer/SecureForyBinarySerializerTest.kt`
 
 - [ ] Extend the existing `RecordingForyHandler` proxy with a `serialize(OutputStream, value)` branch that records the stream overload, writes fixed bytes, and rejects the one-argument `serialize(value)` branch for this contract test. Serialize to `ByteArrayOutputStream` through `serializeBinaryToStream`, then assert the returned count, bytes, and exactly one stream-overload call.
 - [ ] Add byte-for-byte stream-versus-`serialize()` parity tests for default, `fast()`, and secure/registration-required Fory; preserve existing registration configuration rather than adding a new policy.
 - [ ] Add a failure table and tests that distinguish primary Fory serialization failure from borrowed-target failure: primary failure follows existing `serialize(graph)` normalization, while target `IOException`, runtime failure, and `Error` each propagate with their original identity unchanged as required by `BinarySerializer.serializeBinaryToStream`. Cover counter overflow, partial write (count advances only after a successful delegate write), and tracking-target no-`flush()`/no-`close()` behavior.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-io:test --tests '*CoreBinarySerializerByteBufferTest' --tests '*ForyBinarySerializerTest' --tests '*SecureForyBinarySerializerTest'
 ```
 
-Expected: the stream-overload contract test fails before Task 2 because Fory uses the default allocating `BinarySerializer` implementation, which calls the proxy's deliberately rejected one-argument `serialize(value)` branch.
+예상 결과: the stream-overload contract test fails before Task 2 because Fory uses the default allocating `BinarySerializer` implementation, which calls the proxy's deliberately rejected one-argument `serialize(value)` branch.
 
 ## Task 2: Implement the Fory stream seam without changing policy
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt`
-- Modify: Task 1 tests as needed for exact exception assertions
+- 수정: `io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt`
+- 수정: Task 1 tests as needed for exact exception assertions
 
 - [ ] Override `serializeBinaryToStream(graph, target)` in `ForyBinarySerializer`.
 - [ ] For `null`, return `0` and perform no write, matching existing serializer semantics.
@@ -69,7 +67,7 @@ Expected: the stream-overload contract test fails before Task 2 because Fory use
 - [ ] Normalize only primary Fory serialization failures with the existing `serialize(graph)` policy; rethrow borrowed-target failures unchanged. Do not change `BinarySerializer` public stream KDoc or `serializeTo(ByteBuffer)` compatibility behavior.
 - [ ] Update public KDoc to say the stream path avoids the returned/handoff payload array but Fory may retain its own reusable internal buffer.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-io:test --tests '*CoreBinarySerializerByteBufferTest' --tests '*ForyBinarySerializerTest' --tests '*SecureForyBinarySerializerTest'
@@ -77,7 +75,7 @@ Run:
 git diff --check
 ```
 
-Expected: tests pass; no serializer policy, registration mode, flush, or close side effect changes.
+예상 결과: tests pass; no serializer policy, registration mode, flush, or close side effect changes.
 
 Commit after green (Lore protocol):
 
@@ -95,11 +93,11 @@ Not-tested: codec integration and JMH evidence
 
 ## Task 3: Prove Lettuce raw codec dispatch and preserve compressed behavior
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecTest.kt` (or the existing focused codec test)
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt` only if a failing contract proves a minimal adjustment is needed
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt` only for KDoc/factory documentation
+- 수정: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecTest.kt` (or the existing focused codec test)
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt` only if a failing contract proves a minimal adjustment is needed
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt` only for KDoc/factory documentation
 
 - [ ] Add `LettuceBinaryCodecBufferContractTest` cases for raw `fory()` and `fastFory()` on heap and direct pooled targets with nonzero `readerIndex`/`writerIndex`, marks, refcount checks, bounded max capacity, and sentinel bytes before/after the write range.
 - [ ] Assert reported bytes equal committed bytes, bytes round-trip, prefix/suffix sentinels remain unchanged, and writer index advances exactly once on success.
@@ -107,7 +105,7 @@ Not-tested: codec integration and JMH evidence
 - [ ] Assert compressed Fory/FastFory constructors remain on their existing byte-array/compression route; do not add a compression streaming path.
 - [ ] Keep `BoundedByteBufOutputStream` as the only Netty-aware writer. Do not introduce NIO views into Lettuce.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceBinaryCodec*' --tests '*Fory*'
@@ -115,15 +113,15 @@ Run:
 git diff --check
 ```
 
-Expected: raw codecs use the already-established bounded stream dispatch; compressed codecs retain prior behavior.
+예상 결과: raw codecs use the already-established bounded stream dispatch; compressed codecs retain prior behavior.
 
 ## Task 4: Add Redisson decode contract tests before implementation
 
-**Files:**
+**파일:**
 
-- Modify: `infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/ForyCodecTest.kt`
-- Modify: `infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/FastForyCompatibilityTest.kt`
-- Modify: package-local internal constructor/factory seams for Fory serializer, fallback codec, readable-view creation, and owned output buffer allocation; all public constructors keep their current ABI/default behavior
+- 수정: `infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/ForyCodecTest.kt`
+- 수정: `infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/codec/FastForyCompatibilityTest.kt`
+- 수정: package-local internal constructor/factory seams for Fory serializer, fallback codec, readable-view creation, and owned output buffer allocation; all public constructors keep their current ABI/default behavior
 
 - [ ] Replace weak `runCatching(...).shouldNotBeNull()` assertions in touched Fory codec tests with value, type, and fallback assertions.
 - [ ] Establish fixtures with nonzero `readerIndex`, unread suffix, marks, and reference-count checks.
@@ -132,21 +130,21 @@ Expected: raw codecs use the already-established bounded stream dispatch; compre
 - [ ] Preserve trusted-Redis payload test coverage for default registration-off Fory and add KDoc-warning expectation coverage if the project convention supports it.
 - [ ] Add a failure matrix for Fory and FastFory: ordinary semantic failure, raw and nested `CancellationException`, raw and nested `Error`, view/precondition failure, direct destination failure, fallback-terminal failure, fallback log count, and cleanup suppression. Establish the existing `deserialize(ByteArray)` result as the oracle for fallback invocation count, logger count, terminal type/identity/cause, and zero duplicate primary attempts.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-redisson:test --tests '*ForyCodecTest' --tests '*FastForyCompatibilityTest'
 ```
 
-Expected: new direct-path cases fail before Task 5; old byte-array fallback behavior remains green.
+예상 결과: new direct-path cases fail before Task 5; old byte-array fallback behavior remains green.
 
 ## Task 5: Implement Redisson decode with exactly-one-copy fallback
 
-**Files:**
+**파일:**
 
-- Modify: `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/ForyCodec.kt`
-- Modify: `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/FastForyCodec.kt`
-- Modify: Task 4 tests
+- 수정: `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/ForyCodec.kt`
+- 수정: `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/FastForyCodec.kt`
+- 수정: Task 4 tests
 
 - [ ] Build a read-only duplicate/slice over exactly `readerIndex..writerIndex`; never mutate the supplied `ByteBuf` indices, marks, or refcount.
 - [ ] Decode direct NIO only when the readable range can be represented safely. If view construction/preconditions fail, materialize copied bytes and perform the original primary decode exactly once.
@@ -157,7 +155,7 @@ Expected: new direct-path cases fail before Task 5; old byte-array fallback beha
 - [ ] The Task 4 matrix must prove the normalizer preserves byte-array oracle behavior for semantic, raw/nested cancellation, raw/nested `Error`, destination, fallback-terminal, and cleanup behavior; it must not duplicate direct primary attempts.
 - [ ] Add KDoc that default registration-off decoding is for trusted Redis payloads only; do not claim it is a security hardening change.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-redisson:test --tests '*ForyCodecTest' --tests '*FastForyCompatibilityTest'
@@ -165,7 +163,7 @@ Run:
 git diff --check
 ```
 
-Expected: direct decode succeeds for readable NIO buffers and every forced fallback follows the old externally visible codec contract.
+예상 결과: direct decode succeeds for readable NIO buffers and every forced fallback follows the old externally visible codec contract.
 
 Commit after green (Lore protocol):
 
@@ -183,7 +181,7 @@ Not-tested: conditional encode path and JMH evidence
 
 ## Task 6: Run the Redisson encode feasibility probe before production encode work
 
-**Files:**
+**파일:**
 
 - Add: `infra/redisson/src/benchmark/.../Issue756ForyEncodeFeasibilityBenchmark.kt`
 - Add: `infra/redisson/scripts/run-issue756-fory-feasibility.py`
@@ -200,7 +198,7 @@ Not-tested: conditional encode path and JMH evidence
 - [ ] Add negative validator fixtures for missing/duplicate/unexpected methods, invalid allocation metric/unit, NaN, error-bar overlap, dirty tree/hash drift, malformed provenance, process-environment capture, and sensitive argv tokens/passwords/proxy URLs. The runner redacts or rejects sensitive argv; a repository scan gate runs before artifact or documentation promotion.
 - [ ] Write only `probeDisposition=accepted|rejected` and its reason. A rejected probe is terminal for encode: record final `encodeDisposition=rejected` with reason, commit evidence, and skip Task 7 production edits.
 
-Run:
+실행:
 
 ```bash
 python3 infra/redisson/scripts/run-issue756-fory-feasibility.py
@@ -208,7 +206,7 @@ python3 infra/redisson/scripts/validate-issue756-fory-feasibility.py
 python3 infra/redisson/scripts/test_validate_issue756_fory_feasibility.py
 ```
 
-Expected: a reproducible disposition artifact, not a presumed optimization result.
+예상 결과: a reproducible disposition artifact, not a presumed optimization result.
 
 ## Task 7: Conditional Redisson encode implementation
 
@@ -216,9 +214,9 @@ Expected: a reproducible disposition artifact, not a presumed optimization resul
 
 **Files when accepted:**
 
-- Modify: `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/ForyCodec.kt`
-- Modify: `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/FastForyCodec.kt`
-- Modify: focused codec tests
+- 수정: `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/ForyCodec.kt`
+- 수정: `infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/codec/FastForyCodec.kt`
+- 수정: focused codec tests
 
 - [ ] First write failing encode tests for a fresh owned output `ByteBuf`: round-trip values, encoder index correctness, release ownership, injected-factory copy preservation, and unchanged Fory/FastFory fallback behavior.
 - [ ] Cover backend semantic failure, candidate-only setup/destination failure, baseline success/failure, terminal fallback failure (type, identity, cause, and log count), cleanup failure suppression, cancellation/`Error` behavior, and exactly-once release/refcount.
@@ -230,7 +228,7 @@ Commit accepted implementation or rejected feasibility evidence separately using
 
 ## Task 8: Generate canonical benchmark evidence and validate all disposition cells
 
-**Files:**
+**파일:**
 
 - Modify/add: `infra/lettuce/src/benchmark/kotlin/io/bluetape4k/redis/lettuce/benchmark/LettuceCodecBenchmark.kt`, `LettuceCodecBenchmarkPreflight.kt`, `infra/lettuce/scripts/run-issue756-evidence.py`, `validate-issue756-jmh.py`, and their Python tests
 - Add: Redisson issue-756 benchmark/preflight/runner/validator scripts and their Python tests
@@ -248,7 +246,7 @@ Commit accepted implementation or rejected feasibility evidence separately using
 - [ ] Validate 20 canonical methods when encode is rejected or 24 when implemented. Feasibility output remains raw supporting evidence and is never silently promoted to canonical results.
 - [ ] Classify every cell `accepted`, `fallback`, `inconclusive`, or `rejected`; issue completion requires a terminal documented disposition for every in-scope cell.
 
-Run:
+실행:
 
 ```bash
 python3 infra/lettuce/scripts/run-issue756-evidence.py
@@ -260,15 +258,15 @@ python3 docs/benchmarks/raw/issue-756-fory-followup/validate-issue756-fory-follo
 git diff --check
 ```
 
-Expected: aggregate validation rejects absent forks, inconsistent manifests, undocumented cells, and a count that conflicts with `encodeDisposition`.
+예상 결과: aggregate validation rejects absent forks, inconsistent manifests, undocumented cells, and a count that conflicts with `encodeDisposition`.
 
 ## Task 9: Publish evidence-backed documentation, charts, and release handoff
 
-**Files:**
+**파일:**
 
-- Modify: `io/io/README.md`, `io/io/README.ko.md`, `infra/lettuce/README.md`, `infra/lettuce/README.ko.md`, `infra/redisson/README.md`, and `infra/redisson/README.ko.md`
+- 수정: `io/io/README.md`, `io/io/README.ko.md`, `infra/lettuce/README.md`, `infra/lettuce/README.ko.md`, `infra/redisson/README.md`, and `infra/redisson/README.ko.md`
 - Add: `docs/benchmarks/2026-07-23-issue-756-fory-codec-followup.md`; preserve `2026-07-22-issue-756-lettuce-buffer-codec-allocation.md` and its raw authority unchanged
-- Modify: public KDoc for `ForyBinarySerializer`, `LettuceBinaryCodec`, `LettuceBinaryCodecs`, `ForyCodec`, and `FastForyCodec`
+- 수정: public KDoc for `ForyBinarySerializer`, `LettuceBinaryCodec`, `LettuceBinaryCodecs`, `ForyCodec`, and `FastForyCodec`
 - Add: chart source and rendered assets under `docs/images/readme-charts/`
 - Add: `docs/benchmarks/raw/issue-756-fory-followup/validate-chart-source.py`
 - Add: `docs/superpowers/checklists/2026-07-23-issue-756-fory-followup-release.md`
@@ -283,7 +281,7 @@ Expected: aggregate validation rejects absent forks, inconsistent manifests, und
 - [ ] `run-issue756-fory-compatibility.py` resolves the checklist-pinned known-good JARs through an explicit repository URL, checksum-gates every loaded JAR against its coordinate/version/SHA-256 before execution, and stores coordinate/version/SHA/repository URL/classpath manifests. It records old-write/new-read plus new-write/old-read Fory/FastFory fixtures and has a checksum-mismatch negative test. `run-issue756-fory-rollback-smoke.py` executes and records the rollback Redis smoke procedure without publishing; either failure blocks documentation promotion.
 - [ ] Validate links/assets, chart source data, Korean/English parity, explicit trusted-input/no-migration/raw-only/fallback/zero-copy wording, and markdown rendering conventions.
 
-Run:
+실행:
 
 ```bash
 git diff --check
@@ -294,7 +292,7 @@ python3 infra/redisson/scripts/run-issue756-fory-compatibility.py
 python3 infra/redisson/scripts/run-issue756-fory-rollback-smoke.py
 ```
 
-Expected: no unsupported zero-copy claim; only validated measurements appear in reader-facing materials.
+예상 결과: no unsupported zero-copy claim; only validated measurements appear in reader-facing materials.
 
 ## Task 10: Final verification, review, and handoff
 

--- a/docs/superpowers/plans/2026-07-25-issue-1080-lettuce-lock-family-plan.md
+++ b/docs/superpowers/plans/2026-07-25-issue-1080-lettuce-lock-family-plan.md
@@ -1,12 +1,12 @@
-# Issue #1080 Lettuce Lock Family Implementation Plan
+# Issue #1080 Lettuce Lock Family 구현 계획
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development` (recommended) or `executing-plans` to implement this plan task-by-task. Follow `bluetape-full-feature`, `bluetape-workflow`, `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`, `test-driven-development`, `bluetape-writer`, and `bluetape-diagram`. Testcontainers-backed Redis tasks are serialized across worktrees.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 `subagent-driven-development`(권장) 또는 `executing-plans`로 task별 구현한다. `bluetape-full-feature`, `bluetape-workflow`, `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`, `test-driven-development`, `bluetape-writer`, `bluetape-diagram`을 따른다. Testcontainers-backed Redis task는 worktree 전체에서 직렬화한다.
 
-**Goal:** Deliver the first approved #1080 PR as an additive, Redisson-shaped Lettuce Lock family with six lock objects, logical-owner reentrancy, generation-safe handles, fixed/watchdog leases, bounded waiting, typed failure/reconciliation, Redis Cluster safety, and blocking/async/suspend semantic parity.
+**목표:** Deliver the first approved #1080 PR as an additive, Redisson-shaped Lettuce Lock family with six lock objects, logical-owner reentrancy, generation-safe handles, fixed/watchdog leases, bounded waiting, typed failure/reconciliation, Redis Cluster safety, and blocking/async/suspend semantic parity.
 
-**Architecture:** Public identity, handle, config, result, and six lock objects live under `io.bluetape4k.redis.lettuce.lock`. Redis-neutral key, script, deadline, runtime, task-registry, and sanitized protocol support lives under `io.bluetape4k.redis.lettuce.coordination.internal` without leaking into public signatures. Lock-specific Lua, result decoding, wait loops, fair/read-write admission, fencing, and multi-lock composition live under `lock.internal`. Existing `LettuceLock`, fencing lease, multi-key lease, and semaphore APIs remain source/binary compatible and unchanged in this delivery.
+**아키텍처:** Public identity, handle, config, result, and six lock objects live under `io.bluetape4k.redis.lettuce.lock`. Redis-neutral key, script, deadline, runtime, task-registry, and sanitized protocol support lives under `io.bluetape4k.redis.lettuce.coordination.internal` without leaking into public signatures. Lock-specific Lua, result decoding, wait loops, fair/read-write admission, fencing, and multi-lock composition live under `lock.internal`. Existing `LettuceLock`, fencing lease, multi-key lease, and semaphore APIs remain source/binary compatible and unchanged in this delivery.
 
-**Tech Stack:** Kotlin 2.3, Java 21, Lettuce, Redis Lua, Kotlin Coroutines, `CompletableFuture`, JUnit 5, `bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-testcontainers`, Gradle Kotlin DSL, SVG, CairoSVG.
+**기술 스택:** Kotlin 2.3, Java 21, Lettuce, Redis Lua, Kotlin Coroutines, `CompletableFuture`, JUnit 5, `bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-testcontainers`, Gradle Kotlin DSL, SVG, CairoSVG.
 
 **Approved design:** `docs/superpowers/specs/2026-07-25-issue-1080-lettuce-locks-synchronizers-design.md`
 
@@ -840,17 +840,17 @@ assigned file set, and report a shared-file conflict instead of reverting anothe
 
 ## Task 1: Lock the public model and validation contract
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockIdentity.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockConfig.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockFailure.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockResult.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockObservation.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockIdentityTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockConfigTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockResultTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockObservationTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockIdentity.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockConfig.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockFailure.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockResult.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LockObservation.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockIdentityTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockConfigTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockResultTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockObservationTest.kt`
 
 - [ ] Write failing serialization/validation/redaction tests for every public value and result variant.
 - [ ] Prove generated owner/request values contain at least 128 bits of CSPRNG entropy through decoded byte length and
@@ -909,14 +909,14 @@ Not-tested: Redis scripts and lifecycle behavior
 
 ## Task 2: Build the neutral coordination substrate with pure tests
 
-**Files:**
+**파일:**
 
-- Create: the six `coordination/internal` files listed in §3.1
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationKeyspaceTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationDeadlineTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationProtocolTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationRuntimeTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationObservationTest.kt`
+- 생성: the six `coordination/internal` files listed in §3.1
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationKeyspaceTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationDeadlineTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationProtocolTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationRuntimeTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/coordination/internal/CoordinationObservationTest.kt`
 
 - [ ] Write failing codec-wire key-slot tests using `StringCodec` and a custom key codec whose encoded bytes differ
       from source text.
@@ -963,7 +963,7 @@ if rg -n '^import io\\.bluetape4k\\.redis\\.lettuce\\.(lock|lease|semaphore|sync
 fi
 ```
 
-Expected: no matches.
+예상 결과: no matches.
 
 Commit:
 
@@ -981,17 +981,17 @@ Not-tested: Redis lock state transitions
 
 ## Task 3: Implement the reentrant distributed lock contract
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/LockProtocol.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/LockCommandExecutor.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/LockWaitSupport.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/DistributedLockScript.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceDistributedLock.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendDistributedLock.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockContract.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/DistributedLockScriptTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceDistributedLockTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/LockProtocol.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/LockCommandExecutor.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/LockWaitSupport.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/DistributedLockScript.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceDistributedLock.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendDistributedLock.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockContract.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/DistributedLockScriptTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceDistributedLockTest.kt`
 
 - [ ] Define one `LockContract` adapter for blocking, async, and suspend surfaces.
 - [ ] Write RED cases for immediate acquire, contention, bounded timeout, same-owner reentry, same generation,
@@ -1010,7 +1010,7 @@ Not-tested: Redis lock state transitions
       `delay` plus `ensureActive`.
 - [ ] Preserve the same owner/request identity across every retry and reconciliation.
 
-Run:
+실행:
 
 ```bash
 repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
@@ -1037,13 +1037,13 @@ Not-tested: Watchdog and specialized lock algorithms
 
 ## Task 4: Add watchdog, cancellation, reconciliation, and lifecycle safety
 
-**Files:**
+**파일:**
 
-- Modify: `CoordinationRuntime.kt`, `LockCommandExecutor.kt`, `LockWaitSupport.kt`
-- Modify: `LettuceDistributedLock.kt`, `LettuceSuspendDistributedLock.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockWatchdogTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockCancellationTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockLifecycleTest.kt`
+- 수정: `CoordinationRuntime.kt`, `LockCommandExecutor.kt`, `LockWaitSupport.kt`
+- 수정: `LettuceDistributedLock.kt`, `LettuceSuspendDistributedLock.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockWatchdogTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockCancellationTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockLifecycleTest.kt`
 
 - [ ] Write RED cases for fixed lease without renewal, watchdog renewal cadence/jitter, maximum lifetime, 10,000
       registration cap, 256-per-tick cap, 25-ms backlog drain, the worst-case 10,000-watchdog service formula,
@@ -1061,7 +1061,7 @@ Not-tested: Watchdog and specialized lock algorithms
 - [ ] Implement watchdog registration only after successful acquisition and cancel it after final release/loss/close.
 - [ ] Never use `runCatching` around suspend calls; rethrow `CancellationException`.
 
-Run:
+실행:
 
 ```bash
 repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
@@ -1071,7 +1071,7 @@ repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
   --tests '*LettuceDistributedLockTest'
 ```
 
-Expected: all lifecycle registries reach zero after each test; no real-delay scheduler test is used where virtual time
+예상 결과: all lifecycle registries reach zero after each test; no real-delay scheduler test is used where virtual time
 can prove the transition.
 
 Commit:
@@ -1090,13 +1090,13 @@ Not-tested: Fair, read-write, fenced, spin, and multi-lock behavior
 
 ## Task 5: Implement bounded FIFO fair lock
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/FairLockScript.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFairLock.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendFairLock.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/FairLockScriptTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFairLockTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/FairLockScript.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFairLock.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendFairLock.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/FairLockScriptTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFairLockTest.kt`
 
 - [ ] Write RED cases for Redis enqueue sequence FIFO, reentrancy without a second queue entry, timeout/cancellation
       removal, stale head without process cooperation, cleanup batch 64/default and 256/max, `CleanupPending` no-bypass,
@@ -1110,7 +1110,7 @@ Not-tested: Fair, read-write, fenced, spin, and multi-lock behavior
 - [ ] Keep Redis queue state authoritative. Polling must recover if an optional wakeup hint is lost.
 - [ ] Use same request identity for queue removal and reconcile.
 
-Run:
+실행:
 
 ```bash
 repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
@@ -1118,7 +1118,7 @@ repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
   --tests '*LettuceFairLockTest'
 ```
 
-Expected: FIFO/state assertions pass without timing-only sleeps.
+예상 결과: FIFO/state assertions pass without timing-only sleeps.
 
 Commit:
 
@@ -1136,13 +1136,13 @@ Not-tested: Read-write phase fairness
 
 ## Task 6: Implement fenced lock on the proven fencing invariant
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/FencedLockScript.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFencedLock.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendFencedLock.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/FencedLockScriptTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFencedLockTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/FencedLockScript.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFencedLock.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendFencedLock.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/FencedLockScriptTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFencedLockTest.kt`
 - Modify only if extraction proves smaller and behavior-neutral:
   `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceFencingLeaseSupport.kt`
 - Modify only with that extraction:
@@ -1158,7 +1158,7 @@ Not-tested: Read-write phase fairness
 - [ ] Never claim Redis fencing alone gives exactly-once or stops stale work.
 - [ ] Run every existing fencing lease test if its support file changes.
 
-Run:
+실행:
 
 ```bash
 repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
@@ -1166,7 +1166,7 @@ repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
   --tests '*FencingLease*'
 ```
 
-Expected: new fenced lock and all existing fencing lease regressions pass.
+예상 결과: new fenced lock and all existing fencing lease regressions pass.
 
 Commit:
 
@@ -1184,13 +1184,13 @@ Not-tested: Read-write and multi-lock algorithms
 
 ## Task 7: Implement phase-fair read-write lock
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/ReadWriteLockScript.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceReadWriteLock.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendReadWriteLock.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/ReadWriteLockScriptTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceReadWriteLockTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/ReadWriteLockScript.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceReadWriteLock.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendReadWriteLock.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/ReadWriteLockScriptTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceReadWriteLockTest.kt`
 
 - [ ] Write RED cases for concurrent compatible readers, exclusive writer, same-owner reentry per mode, blocked writer
       boundary, bounded reader phase, one-writer admission, both-side starvation prevention, expired holder cleanup,
@@ -1203,7 +1203,7 @@ Not-tested: Read-write and multi-lock algorithms
 - [ ] Perform write-to-read downgrade in one Lua script. Do not expose or implement read-to-write upgrade.
 - [ ] Apply the fair cleanup cap and `CleanupPending` no-bypass rule.
 
-Run:
+실행:
 
 ```bash
 repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
@@ -1211,7 +1211,7 @@ repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
   --tests '*LettuceReadWriteLockTest'
 ```
 
-Expected: read/write compatibility and phase progress pass under blocking, async, and suspend views.
+예상 결과: read/write compatibility and phase progress pass under blocking, async, and suspend views.
 
 Commit:
 
@@ -1229,12 +1229,12 @@ Not-tested: Spin and multi-lock behavior
 
 ## Task 8: Implement bounded spin lock as a wait policy
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSpinLock.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendSpinLock.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSpinLockTest.kt`
-- Modify: `LockWaitSupport.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSpinLock.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendSpinLock.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSpinLockTest.kt`
+- 수정: `LockWaitSupport.kt`
 
 - [ ] Write RED pure tests using injected jitter source/ticker for delay sequence 10 ms, 20 ms, 40 ms up to 1 second,
       multiplier validation, jitter 0..25%, jitter disabled at zero, deadline clipping, max 100 attempts/second, and
@@ -1244,13 +1244,13 @@ Not-tested: Spin and multi-lock behavior
 - [ ] Use scheduled Redis retries, never CPU busy looping, pub/sub, or a fair queue.
 - [ ] Apply the same request identity and result/failure contract as distributed lock.
 
-Run:
+실행:
 
 ```bash
 repo-test-summary -- ./gradlew :bluetape4k-lettuce:test --tests '*LettuceSpinLockTest'
 ```
 
-Expected: virtual-time backoff tests and Redis semantic tests pass.
+예상 결과: virtual-time backoff tests and Redis semantic tests pass.
 
 Commit:
 
@@ -1268,13 +1268,13 @@ Not-tested: Multi-lock atomicity
 
 ## Task 9: Implement same-slot atomic multi-lock
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/MultiLockScript.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceMultiLock.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendMultiLock.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/MultiLockScriptTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceMultiLockTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/MultiLockScript.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceMultiLock.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceSuspendMultiLock.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/MultiLockScriptTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceMultiLockTest.kt`
 - Modify only if extraction proves smaller and behavior-neutral:
   `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeaseSupport.kt`
 - Modify only with that extraction:
@@ -1292,7 +1292,7 @@ Not-tested: Multi-lock atomicity
 - [ ] Reject different-slot input; never implement sequential best-effort locking.
 - [ ] Run every existing multi-key lease test if its support file changes.
 
-Run:
+실행:
 
 ```bash
 repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
@@ -1300,7 +1300,7 @@ repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
   --tests '*MultiKeyLease*'
 ```
 
-Expected: multi-lock and existing multi-key lease regressions pass.
+예상 결과: multi-lock and existing multi-key lease regressions pass.
 
 Commit:
 
@@ -1318,14 +1318,14 @@ Not-tested: Cross-family synchronizer reuse
 
 ## Task 10: Prove cross-cutting Cluster, ambiguity, concurrency, and protocol behavior
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockClusterTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockTopologyRecoveryTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockConcurrencyTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockFailureTest.kt`
-- Modify: `infra/lettuce/build.gradle.kts`
-- Modify: focused production/internal files only when a failing case proves a defect
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockClusterTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockTopologyRecoveryTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockConcurrencyTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockFailureTest.kt`
+- 수정: `infra/lettuce/build.gradle.kts`
+- 수정: focused production/internal files only when a failing case proves a defect
 
 - [ ] Add literal `coordination-lock-topology` to the default test exclusions, annotate only
       `LockTopologyRecoveryTest` with `@Tag("coordination-lock-topology")`, and register
@@ -1354,7 +1354,7 @@ repo-test-summary -- ./gradlew :bluetape4k-lettuce:test \
 repo-test-summary -- ./gradlew :bluetape4k-lettuce:coordinationLockTopologyRecoveryTest
 ```
 
-Expected: all fault and concurrency cases pass with no raw secret/key output.
+예상 결과: all fault and concurrency cases pass with no raw secret/key output.
 
 Commit:
 
@@ -1372,12 +1372,12 @@ Not-tested: Characterization workload
 
 ## Task 11: Add command-budget and bounded performance characterization
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/build.gradle.kts`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockPerformanceTest.kt`
-- Create: `infra/lettuce/scripts/validate-lock-performance.py`
-- Create: `infra/lettuce/scripts/test_validate_lock_performance.py`
+- 수정: `infra/lettuce/build.gradle.kts`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockPerformanceTest.kt`
+- 생성: `infra/lettuce/scripts/validate-lock-performance.py`
+- 생성: `infra/lettuce/scripts/test_validate_lock_performance.py`
 - Generated, not committed unless repository convention requires:
   `infra/lettuce/build/reports/coordination-lock-performance/results.json`
 
@@ -1413,7 +1413,7 @@ Not-tested: Characterization workload
       flakiness; the second proves the report/alert path with zero late or missed renewal.
 - [ ] Verify the task names through Gradle task listing before executing them.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-lettuce:tasks --all | \
@@ -1424,7 +1424,7 @@ python3 infra/lettuce/scripts/validate-lock-performance.py \
   infra/lettuce/build/reports/coordination-lock-performance/results.json
 ```
 
-Expected: both task names exist; characterization passes and writes non-empty JSON.
+예상 결과: both task names exist; characterization passes and writes non-empty JSON.
 
 Commit:
 
@@ -1442,27 +1442,27 @@ Not-tested: Long-duration production traffic
 
 ## Task 12: Publish English/Korean guidance and compile-tested examples
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/README.md`
-- Modify: `infra/lettuce/README.ko.md`
-- Create: `infra/lettuce/CoordinationLocks.md`
-- Create: `infra/lettuce/CoordinationLocks.ko.md`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockDocumentationTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockApiSurfaceTest.kt`
-- Create: `infra/lettuce/src/test/java/io/bluetape4k/redis/lettuce/lock/LettuceLockJavaDocumentationTest.java`
-- Create: `docs/images/readme-diagrams/infra-lettuce-diagram-03.svg`
-- Create: `docs/images/readme-diagrams/infra-lettuce-diagram-03.png`
-- Create: `docs/images/readme-diagrams/infra-lettuce-diagram-03-ko.svg`
-- Create: `docs/images/readme-diagrams/infra-lettuce-diagram-03-ko.png`
-- Create: `docs/images/readme-diagrams/infra-lettuce-sequence-02.svg`
-- Create: `docs/images/readme-diagrams/infra-lettuce-sequence-02.png`
-- Create: `docs/images/readme-diagrams/infra-lettuce-sequence-02-ko.svg`
-- Create: `docs/images/readme-diagrams/infra-lettuce-sequence-02-ko.png`
-- Create: `docs/superpowers/reviews/2026-07-25-issue-1080-lock-diagram-review.md`
-- Modify: `scripts/validate-readme-diagram-assets.mjs`
-- Modify: `scripts/validate-readme-diagram-assets_test.mjs`
-- Modify: all new public Kotlin files for final English KDoc
+- 수정: `infra/lettuce/README.md`
+- 수정: `infra/lettuce/README.ko.md`
+- 생성: `infra/lettuce/CoordinationLocks.md`
+- 생성: `infra/lettuce/CoordinationLocks.ko.md`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockDocumentationTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockApiSurfaceTest.kt`
+- 생성: `infra/lettuce/src/test/java/io/bluetape4k/redis/lettuce/lock/LettuceLockJavaDocumentationTest.java`
+- 생성: `docs/images/readme-diagrams/infra-lettuce-diagram-03.svg`
+- 생성: `docs/images/readme-diagrams/infra-lettuce-diagram-03.png`
+- 생성: `docs/images/readme-diagrams/infra-lettuce-diagram-03-ko.svg`
+- 생성: `docs/images/readme-diagrams/infra-lettuce-diagram-03-ko.png`
+- 생성: `docs/images/readme-diagrams/infra-lettuce-sequence-02.svg`
+- 생성: `docs/images/readme-diagrams/infra-lettuce-sequence-02.png`
+- 생성: `docs/images/readme-diagrams/infra-lettuce-sequence-02-ko.svg`
+- 생성: `docs/images/readme-diagrams/infra-lettuce-sequence-02-ko.png`
+- 생성: `docs/superpowers/reviews/2026-07-25-issue-1080-lock-diagram-review.md`
+- 수정: `scripts/validate-readme-diagram-assets.mjs`
+- 수정: `scripts/validate-readme-diagram-assets_test.mjs`
+- 수정: all new public Kotlin files for final English KDoc
 
 - [ ] Add the six Lock types and suspend counterparts to both feature tables.
 - [ ] Add a capability/selection matrix covering distributed, fair, fenced, read-write, spin, and multi-lock.
@@ -1525,7 +1525,7 @@ Not-tested: Long-duration production traffic
 - [ ] State non-goals: no Java thread ownership, no indefinite wait/watchdog, no cross-slot best effort, no read upgrade,
       no exactly-once/stale-work-stop claim, and no implicit unlock on close.
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-lettuce:test \
@@ -1603,7 +1603,7 @@ python3 "$DIAGRAM_SKILLS_ROOT/diagram-sequence-style-audit.py" \
 git diff --check
 ```
 
-Expected: examples compile/run, Dokka succeeds, locale content has the same capability rows, and Markdown has no
+예상 결과: examples compile/run, Dokka succeeds, locale content has the same capability rows, and Markdown has no
 whitespace errors. All four SVGs parse and pass the triggered audits, all four canonical `-s 2` PNGs exist and were
 inspected full-size after the last coordinate change, README/guides embed the correct locale assets, the repository
 diagram validator's exact four-file target reports `total=4 failed=0`, its default full-scan behavior remains
@@ -1625,10 +1625,10 @@ Not-tested: External documentation rendering
 
 ## Task 13: Run complete verification and six-lens implementation review
 
-**Files:**
+**파일:**
 
 - Modify only defects proven by verification/review.
-- Create:
+- 생성:
   `docs/superpowers/reviews/2026-07-25-issue-1080-lock-implementation-review.md`
 
 Run the smallest proof first, then the full affected module:
@@ -1649,7 +1649,7 @@ rg -n 'Required checks: [1-9][0-9]*/[1-9][0-9]*; N/A: [0-9]+; Blocked: 0' \
 git diff --check
 ```
 
-Expected:
+예상 결과:
 
 - targeted and full module tests pass;
 - topology and performance evidence tasks pass sequentially;
@@ -1806,7 +1806,7 @@ DIAGRAM_VALIDATION_TARGETS='infra-lettuce-diagram-03.svg,infra-lettuce-diagram-0
   node scripts/validate-readme-diagram-assets.mjs
 ```
 
-Expected:
+예상 결과:
 
 - no Synchronizer implementation path;
 - no unrelated module path;
@@ -1841,7 +1841,7 @@ git -C /Users/debop/work/bluetape4k/bluetape4k-projects rev-parse origin/develop
 worktree-list
 ```
 
-Expected: local root `develop` equals `origin/develop`; the Delivery 1 worktree/branch cleanup target is identified.
+예상 결과: local root `develop` equals `origin/develop`; the Delivery 1 worktree/branch cleanup target is identified.
 Destructive worktree/branch deletion is performed only after merged-state and clean-tree proof.
 
 ---

--- a/docs/superpowers/plans/2026-07-27-issue-1080-lettuce-synchronizers-plan.md
+++ b/docs/superpowers/plans/2026-07-27-issue-1080-lettuce-synchronizers-plan.md
@@ -1,12 +1,12 @@
-# Issue #1080 Lettuce Synchronizers Implementation Plan
+# Issue #1080 Lettuce Synchronizers 구현 계획
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development` or `executing-plans` to implement this plan task-by-task. Follow `bluetape-workflow`, `bluetape-full-feature`, `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`, `test-driven-development`, `bluetape-writer`, and `bluetape-diagram`. Redis/Testcontainers and diagram rendering commands are serialized.
+> **agentic worker용:** 필수 sub-skill: 이 계획은 `subagent-driven-development` 또는 `executing-plans`로 task별 구현한다. `bluetape-workflow`, `bluetape-full-feature`, `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`, `test-driven-development`, `bluetape-writer`, `bluetape-diagram`을 따른다. Redis/Testcontainers와 diagram rendering 명령은 직렬화한다.
 
-**Goal:** Deliver issue #1080 Delivery 2 as additive Lettuce implementations of a generation-safe distributed semaphore, a fixed-lease expirable permit semaphore, and a monotonic-generation count-down latch with blocking, async, and suspend semantic parity.
+**목표:** Deliver issue #1080 Delivery 2 as additive Lettuce implementations of a generation-safe distributed semaphore, a fixed-lease expirable permit semaphore, and a monotonic-generation count-down latch with blocking, async, and suspend semantic parity.
 
-**Architecture:** Public identities, handles, configs, outcomes, and six caller-facing objects live under `io.bluetape4k.redis.lettuce.synchronizer`. Internal key layouts, Lua scripts, reply decoding, bounded polling, cancellation, and standalone/Cluster command adapters reuse `RedisScriptRunner` and the merged Lock-family conventions. Redis is the authority for capacity, permit ownership, expiry, latch count, and non-reused generation; legacy `LettuceSemaphore` remains unchanged.
+**아키텍처:** Public identities, handles, configs, outcomes, and six caller-facing objects live under `io.bluetape4k.redis.lettuce.synchronizer`. Internal key layouts, Lua scripts, reply decoding, bounded polling, cancellation, and standalone/Cluster command adapters reuse `RedisScriptRunner` and the merged Lock-family conventions. Redis is the authority for capacity, permit ownership, expiry, latch count, and non-reused generation; legacy `LettuceSemaphore` remains unchanged.
 
-**Tech Stack:** Kotlin 2.3, Java 21, Lettuce, Redis Lua, Kotlin Coroutines, `CompletableFuture`, JUnit 5, Testcontainers Redis, Gradle Kotlin DSL, SVG, CairoSVG.
+**기술 스택:** Kotlin 2.3, Java 21, Lettuce, Redis Lua, Kotlin Coroutines, `CompletableFuture`, JUnit 5, Testcontainers Redis, Gradle Kotlin DSL, SVG, CairoSVG.
 
 **Approved design:** `docs/superpowers/specs/2026-07-25-issue-1080-lettuce-locks-synchronizers-design.md`
 
@@ -41,10 +41,10 @@ The copied `SynchronizerTypes.kt` and `SynchronizerScripts.kt` are prior user wo
 
 ### 2.1 Identity, handles, configuration, and results
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerTypes.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerObservation.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerTypes.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerObservation.kt`
 - Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerTypesTest.kt`
 
 The public contract uses opaque, serializable identities with redacted `toString()`:
@@ -152,10 +152,10 @@ Each public object has no-config/config standalone and Cluster `@JvmStatic creat
 
 ### 2.2 Key layout and Redis protocol
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/SynchronizerProtocol.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerScripts.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/SynchronizerProtocol.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerScripts.kt`
 - Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerProtocolTest.kt`
 
 All keys for one object share one Redis Cluster hash tag:
@@ -180,11 +180,11 @@ The semaphore generation key is incremented only when a previously absent logica
 
 ### Task 1: Freeze the public contract
 
-**Files:**
+**파일:**
 
 - Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerTypesTest.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerTypes.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerObservation.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerTypes.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerObservation.kt`
 
 - [ ] **Step 1 — Write the failing type and validation tests**
 
@@ -208,13 +208,13 @@ fun `configs reject overflow and out of range durations before dispatch`() {
 
 - [ ] **Step 2 — Verify RED**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-lettuce:test --tests '*SynchronizerTypesTest' --no-parallel --max-workers=1
 ```
 
-Expected: FAIL because the final config bounds/result types are missing or inconsistent.
+예상 결과: FAIL because the final config bounds/result types are missing or inconsistent.
 
 - [ ] **Step 3 — Implement the minimal types**
 
@@ -226,11 +226,11 @@ Run the same targeted command. Expected: PASS with no new compiler warning.
 
 ### Task 2: Lock the key and Lua protocol
 
-**Files:**
+**파일:**
 
 - Test: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerProtocolTest.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/SynchronizerProtocol.kt`
-- Modify: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerScripts.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/SynchronizerProtocol.kt`
+- 수정: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerScripts.kt`
 
 - [ ] **Step 1 — Write failing protocol tests**
 
@@ -262,13 +262,13 @@ fun `three expirable unit leases restore exactly three permits`() {
 
 - [ ] **Step 2 — Verify RED**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-lettuce:test --tests '*SynchronizerProtocolTest' --no-parallel --max-workers=1
 ```
 
-Expected: FAIL on missing key layout/decoder and the copied latch delete bug.
+예상 결과: FAIL on missing key layout/decoder and the copied latch delete bug.
 
 - [ ] **Step 3 — Implement minimal protocol and repair scripts**
 
@@ -280,13 +280,13 @@ Run the same targeted command. Expected: PASS.
 
 ### Task 3: Implement `LettuceDistributedSemaphore`
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/DistributedSemaphoreClient.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceDistributedSemaphore.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceSuspendDistributedSemaphore.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/DistributedSemaphoreContract.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceDistributedSemaphoreTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/DistributedSemaphoreClient.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceDistributedSemaphore.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceSuspendDistributedSemaphore.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/DistributedSemaphoreContract.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceDistributedSemaphoreTest.kt`
 
 Public operations:
 
@@ -308,13 +308,13 @@ Tests must cover initialization result variants, forbidden capacity shrink while
 
 - [ ] **Step 2 — Verify RED**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceDistributedSemaphoreTest' --no-parallel --max-workers=1
 ```
 
-Expected: compilation/test failure because the public objects do not exist.
+예상 결과: compilation/test failure because the public objects do not exist.
 
 - [ ] **Step 3 — Implement minimal blocking/async/suspend surfaces**
 
@@ -326,13 +326,13 @@ Run the same targeted command. Expected: all blocking, future, suspend, standalo
 
 ### Task 4: Implement `LettucePermitExpirableSemaphore`
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/ExpirableSemaphoreClient.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettucePermitExpirableSemaphore.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceSuspendPermitExpirableSemaphore.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/ExpirableSemaphoreContract.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettucePermitExpirableSemaphoreTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/ExpirableSemaphoreClient.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettucePermitExpirableSemaphore.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceSuspendPermitExpirableSemaphore.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/ExpirableSemaphoreContract.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettucePermitExpirableSemaphoreTest.kt`
 
 Additional public operation:
 
@@ -348,13 +348,13 @@ Cover `N > 1` unique permit IDs and per-entry deadlines, fixed lease expiry, cle
 
 - [ ] **Step 2 — Verify RED**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-lettuce:test --tests '*LettucePermitExpirableSemaphoreTest' --no-parallel --max-workers=1
 ```
 
-Expected: FAIL because expirable public/client behavior is absent.
+예상 결과: FAIL because expirable public/client behavior is absent.
 
 - [ ] **Step 3 — Implement minimal expirable behavior**
 
@@ -366,13 +366,13 @@ Run the same targeted command. Expected: PASS.
 
 ### Task 5: Implement `LettuceCountDownLatch`
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/CountDownLatchClient.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceCountDownLatch.kt`
-- Create: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceSuspendCountDownLatch.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/CountDownLatchContract.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceCountDownLatchTest.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/internal/CountDownLatchClient.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceCountDownLatch.kt`
+- 생성: `infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceSuspendCountDownLatch.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/CountDownLatchContract.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceCountDownLatchTest.kt`
 
 Public operations:
 
@@ -393,13 +393,13 @@ Cover request-idempotent create after ambiguous completion, active-generation re
 
 - [ ] **Step 2 — Verify RED**
 
-Run:
+실행:
 
 ```bash
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceCountDownLatchTest' --no-parallel --max-workers=1
 ```
 
-Expected: FAIL because latch objects and corrected monotonic-generation protocol do not exist.
+예상 결과: FAIL because latch objects and corrected monotonic-generation protocol do not exist.
 
 - [ ] **Step 3 — Implement minimal latch behavior**
 
@@ -411,13 +411,13 @@ Run the same targeted command. Expected: PASS.
 
 ### Task 6: Sequential Redis, Cluster, protocol, and lifecycle verification
 
-**Files:**
+**파일:**
 
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerRedisProtocolTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerCancellationTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerClusterTest.kt`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerPerformanceStabilityTest.kt`
-- Create: `infra/lettuce/src/test/java/io/bluetape4k/redis/lettuce/synchronizer/LettuceSynchronizerJavaDocumentationTest.java`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerRedisProtocolTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerCancellationTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerClusterTest.kt`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerPerformanceStabilityTest.kt`
+- 생성: `infra/lettuce/src/test/java/io/bluetape4k/redis/lettuce/synchronizer/LettuceSynchronizerJavaDocumentationTest.java`
 
 - [ ] **Step 1 — Run Redis protocol tests alone**
 
@@ -425,7 +425,7 @@ Run the same targeted command. Expected: PASS.
 ./gradlew :bluetape4k-lettuce:test --tests '*SynchronizerRedisProtocolTest' --no-parallel --max-workers=1
 ```
 
-Expected: PASS for EVALSHA, NOSCRIPT fallback, malformed replies, generation persistence, expiry cleanup, and atomic contention.
+예상 결과: PASS for EVALSHA, NOSCRIPT fallback, malformed replies, generation persistence, expiry cleanup, and atomic contention.
 
 The command observer must prove warm immediate operations use one Redis command and cold `NOSCRIPT` uses exactly two. Cleanup work is bounded by capacity/batch limits and malformed or oversized responses fail closed.
 
@@ -435,7 +435,7 @@ The command observer must prove warm immediate operations use one Redis command 
 ./gradlew :bluetape4k-lettuce:test --tests '*SynchronizerCancellationTest' --no-parallel --max-workers=1
 ```
 
-Expected: PASS; cancelled future/coroutine leaves Redis ownership/count unchanged and cancels the leaf command/wait.
+예상 결과: PASS; cancelled future/coroutine leaves Redis ownership/count unchanged and cancels the leaf command/wait.
 
 - [ ] **Step 3 — Run Cluster tests alone**
 
@@ -443,7 +443,7 @@ Expected: PASS; cancelled future/coroutine leaves Redis ownership/count unchange
 ./gradlew :bluetape4k-lettuce:test --tests '*SynchronizerClusterTest' --no-parallel --max-workers=1
 ```
 
-Expected: PASS without CROSSSLOT or redirect-loop failure. Cover standalone and Cluster dispatch for semaphore, expirable semaphore, and latch. For every multi-key family, add a custom `RedisCodec` fixture that encodes otherwise similar derived keys into different wire-byte hash slots; construction or pre-dispatch validation must return a sanitized cross-slot failure before Redis receives a command.
+예상 결과: PASS without CROSSSLOT or redirect-loop failure. Cover standalone and Cluster dispatch for semaphore, expirable semaphore, and latch. For every multi-key family, add a custom `RedisCodec` fixture that encodes otherwise similar derived keys into different wire-byte hash slots; construction or pre-dispatch validation must return a sanitized cross-slot failure before Redis receives a command.
 
 - [ ] **Step 4 — Compile Java public usage**
 
@@ -451,7 +451,7 @@ Expected: PASS without CROSSSLOT or redirect-loop failure. Cover standalone and 
 ./gradlew :bluetape4k-lettuce:test --tests '*LettuceSynchronizerJavaDocumentationTest' --no-parallel --max-workers=1
 ```
 
-Expected: PASS for no-config/config standalone/Cluster factories and handle lifecycle.
+예상 결과: PASS for no-config/config standalone/Cluster factories and handle lifecycle.
 
 - [ ] **Step 5 — Run bounded performance/stability checks alone**
 
@@ -459,22 +459,22 @@ Expected: PASS for no-config/config standalone/Cluster factories and handle life
 ./gradlew :bluetape4k-lettuce:test --tests '*SynchronizerPerformanceStabilityTest' --no-parallel --max-workers=1
 ```
 
-Expected: PASS for 100 concurrent contenders without capacity drift, 10,000 waiter/task cap fail-closed behavior, bounded cleanup batches, no scheduler-thread blocking, and five sequential Testcontainers lifecycle repetitions without leaked objects or tasks.
+예상 결과: PASS for 100 concurrent contenders without capacity drift, 10,000 waiter/task cap fail-closed behavior, bounded cleanup batches, no scheduler-thread blocking, and five sequential Testcontainers lifecycle repetitions without leaked objects or tasks.
 
 ### Task 7: English/Korean KDoc, selection docs, and diagram
 
-**Files:**
+**파일:**
 
-- Modify: `infra/lettuce/README.md`
-- Modify: `infra/lettuce/README.ko.md`
-- Modify: `infra/lettuce/CoordinationLocks.md`
-- Modify: `infra/lettuce/CoordinationLocks.ko.md`
-- Create: `infra/lettuce/images/coordination-synchronizers-architecture.svg`
-- Create: `infra/lettuce/images/coordination-synchronizers-architecture.png`
-- Create: `infra/lettuce/images/coordination-synchronizers-architecture.ko.svg`
-- Create: `infra/lettuce/images/coordination-synchronizers-architecture.ko.png`
-- Create: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerDocumentationTest.kt`
-- Create: `docs/superpowers/reviews/2026-07-27-issue-1080-synchronizer-diagram-review.md`
+- 수정: `infra/lettuce/README.md`
+- 수정: `infra/lettuce/README.ko.md`
+- 수정: `infra/lettuce/CoordinationLocks.md`
+- 수정: `infra/lettuce/CoordinationLocks.ko.md`
+- 생성: `infra/lettuce/images/coordination-synchronizers-architecture.svg`
+- 생성: `infra/lettuce/images/coordination-synchronizers-architecture.png`
+- 생성: `infra/lettuce/images/coordination-synchronizers-architecture.ko.svg`
+- 생성: `infra/lettuce/images/coordination-synchronizers-architecture.ko.png`
+- 생성: `infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerDocumentationTest.kt`
+- 생성: `docs/superpowers/reviews/2026-07-27-issue-1080-synchronizer-diagram-review.md`
 
 The selection table must distinguish:
 
@@ -495,7 +495,7 @@ Tests assert English/Korean class rows, equivalent headings, selection-table ter
 ./gradlew :bluetape4k-lettuce:test --tests '*SynchronizerDocumentationTest' --no-parallel --max-workers=1
 ```
 
-Expected: FAIL because new docs/assets are absent.
+예상 결과: FAIL because new docs/assets are absent.
 
 - [ ] **Step 3 — Write English KDoc/docs from final APIs**
 
@@ -515,11 +515,11 @@ Run the same documentation test. Expected: PASS.
 
 ### Task 8: Final review, lessons, Lore commit, PR, and CI
 
-**Files:**
+**파일:**
 
-- Create: `docs/superpowers/reviews/2026-07-27-issue-1080-synchronizer-implementation-review.md`
+- 생성: `docs/superpowers/reviews/2026-07-27-issue-1080-synchronizer-implementation-review.md`
 - Create or update after lesson gate: `docs/lessons/2026-07-27-lettuce-synchronizer-generation-and-cancellation.md`
-- Modify: `docs/superpowers/checklists/2026-07-27-issue-1080-lettuce-synchronizers.md`
+- 수정: `docs/superpowers/checklists/2026-07-27-issue-1080-lettuce-synchronizers.md`
 
 - [ ] **Step 1 — Run final sequential verification**
 
@@ -529,7 +529,7 @@ Run the same documentation test. Expected: PASS.
 git diff --check
 ```
 
-Expected: PASS with no new diagnostics attributable to this delivery.
+예상 결과: PASS with no new diagnostics attributable to this delivery.
 
 - [ ] **Step 2 — Run independent reviews**
 

--- a/docs/superpowers/research/2026-04-25-netcdf-support-research.md
+++ b/docs/superpowers/research/2026-04-25-netcdf-support-research.md
@@ -1,4 +1,4 @@
-# NetCdfCatalogService UCAR netCDF-Java 통합 — Pre-Spec Research
+# NetCdfCatalogService UCAR netCDF-Java 통합 — Pre-Spec 조사
 
 - **일자**: 2026-04-25 (v2 refresh)
 - **이슈**: #107 (utils/science — NetCdf 지원 완성)

--- a/docs/superpowers/reviews/2026-05-11-coroutines-6tier-gate.md
+++ b/docs/superpowers/reviews/2026-05-11-coroutines-6tier-gate.md
@@ -1,4 +1,4 @@
-# bluetape4k-coroutines 6-Tier Review Gate
+# bluetape4k-coroutines 6-Tier 검토 Gate
 
 **날짜**: 2026-05-11 **모듈**: `bluetape4k-coroutines`
 **결론**: PASS **P0/P1**: 0

--- a/docs/superpowers/reviews/2026-05-11-io-6tier-gate.md
+++ b/docs/superpowers/reviews/2026-05-11-io-6tier-gate.md
@@ -1,4 +1,4 @@
-# bluetape4k-io 6-Tier Review Gate
+# bluetape4k-io 6-Tier 검토 Gate
 
 **날짜**: 2026-05-11 **모듈**: `bluetape4k-io`
 **결론**: PASS **P0/P1**: 0

--- a/docs/superpowers/reviews/2026-07-25-issue-1080-lock-diagram-review.md
+++ b/docs/superpowers/reviews/2026-07-25-issue-1080-lock-diagram-review.md
@@ -1,4 +1,4 @@
-# Issue #1080 Lock Diagram Review
+# Issue #1080 Lock Diagram 검토
 
 ## 범위와 공통 근거
 

--- a/docs/superpowers/specs/2026-07-12-logging-connector-repair-design.md
+++ b/docs/superpowers/specs/2026-07-12-logging-connector-repair-design.md
@@ -1,4 +1,4 @@
-# Logging Diagram Connector Repair Design
+# Logging Diagram Connector Repair 설계
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-16-issue-754-bytebuffer-serializer-stack-design.md
+++ b/docs/superpowers/specs/2026-07-16-issue-754-bytebuffer-serializer-stack-design.md
@@ -1,4 +1,4 @@
-# Issue #754 ByteBuffer Serializer Stack Design
+# Issue #754 ByteBuffer Serializer Stack 설계
 
 - Issue: [#754 Add ByteBuffer-oriented serializer APIs to reduce allocation pressure](https://github.com/bluetape4k/bluetape4k-projects/issues/754)
 - Milestone: `1.12.0`

--- a/docs/superpowers/specs/2026-07-18-issue-1039-serializer-allocation-benchmark-design.md
+++ b/docs/superpowers/specs/2026-07-18-issue-1039-serializer-allocation-benchmark-design.md
@@ -1,4 +1,4 @@
-# Issue #1039 Serializer Allocation Benchmark Design
+# Issue #1039 Serializer Allocation Benchmark 설계
 
 - Issue: [#1039 Prove ByteBuffer serializer allocation reductions and document limits](https://github.com/bluetape4k/bluetape4k-projects/issues/1039)
 - Parent: [#754 Add ByteBuffer-oriented serializer APIs to reduce allocation pressure](https://github.com/bluetape4k/bluetape4k-projects/issues/754)

--- a/docs/superpowers/specs/2026-07-18-issue-757-protobuf-buffer-core-design.md
+++ b/docs/superpowers/specs/2026-07-18-issue-757-protobuf-buffer-core-design.md
@@ -1,4 +1,4 @@
-# Issue #757 Protobuf Buffer Core Design
+# Issue #757 Protobuf Buffer Core 설계
 
 - Issue: [#757 Add ByteBuffer-oriented Protobuf serializer and codec APIs](https://github.com/bluetape4k/bluetape4k-projects/issues/757)
 - Parent delivery tracker: [#898 Epic: 1.12.0 delivery tracking](https://github.com/bluetape4k/bluetape4k-projects/issues/898)

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/SharedFlowAsEventBus.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/SharedFlowAsEventBus.kt
@@ -24,7 +24,7 @@ class SharedFlowAsEventBus {
     companion object: KLoggingChannel()
 
     /**
-     * An event bus implementation that uses a shared flow to broadcast events to multiple listeners.
+     * shared flow로 여러 listener에 event를 broadcast하는 event bus 구현입니다.
      */
     class EventBus<T> {
         // The shared flow that will be used to broadcast events to multiple listeners.

--- a/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/AbstractBlazePersistenceTest.kt
+++ b/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/AbstractBlazePersistenceTest.kt
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 /**
- * Base Spring Boot test configuration for the Blaze Persistence examples.
+ * Blaze Persistence example을 위한 base Spring Boot test configuration입니다.
  */
 @SpringBootTest(
     classes = [BlazePersistenceApplication::class],

--- a/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/BlazePersistenceApplication.kt
+++ b/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/BlazePersistenceApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 /**
- * Spring Boot test application for the Blaze Persistence JPA examples.
+ * Blaze Persistence JPA example용 Spring Boot test application입니다.
  */
 @SpringBootApplication
 @EnableJpaAuditing(modifyOnCreate = true)

--- a/examples/ktor/idgenerator-ktor-demo/src/main/kotlin/io/bluetape4k/examples/ktor/idgenerator/IdGeneratorKtorApplication.kt
+++ b/examples/ktor/idgenerator-ktor-demo/src/main/kotlin/io/bluetape4k/examples/ktor/idgenerator/IdGeneratorKtorApplication.kt
@@ -25,12 +25,12 @@ private const val DEFAULT_BATCH_SIZE = 10
 private const val MAX_BATCH_SIZE = 100
 
 /**
- * Configures the Ktor idgenerator example application.
+ * Ktor idgenerator example application을 설정합니다.
  *
- * ## Contract
- * - Explicit `/ids/{type}` routes and generic `/idgen/{type}` routes share the same registry.
- * - Batch generation accepts `size` in `1..100`; omitted `size` defaults to `10`.
- * - Unsupported generator types and invalid batch sizes return HTTP 400 JSON errors.
+ * ## 계약
+ * - 명시적 `/ids/{type}` route와 generic `/idgen/{type}` route는 같은 registry를 공유합니다.
+ * - batch generation은 `1..100` 범위의 `size`를 허용하며, `size`를 생략하면 기본값 `10`을 사용합니다.
+ * - 지원하지 않는 generator type과 잘못된 batch size는 HTTP 400 JSON error를 반환합니다.
  *
  * ```kotlin
  * embeddedServer(CIO, port = 8080) {

--- a/examples/ktor/observability-ktor-demo/src/main/kotlin/io/bluetape4k/examples/ktor/observability/ObservabilityKtorApplication.kt
+++ b/examples/ktor/observability-ktor-demo/src/main/kotlin/io/bluetape4k/examples/ktor/observability/ObservabilityKtorApplication.kt
@@ -31,12 +31,12 @@ import kotlinx.serialization.Serializable
 import java.io.Serializable as JavaSerializable
 
 /**
- * Configures the Ktor observability example application.
+ * Ktor observability example application을 설정합니다.
  *
- * ## Contract
- * - The application owns the Prometheus registry and exposes it at `/metrics`.
- * - OpenTelemetry tracing is installed only when an [OpenTelemetry] instance is supplied.
- * - Application event telemetry is recorded with bounded low-cardinality dimensions.
+ * ## 계약
+ * - application이 Prometheus registry를 소유하고 `/metrics`에서 노출합니다.
+ * - [OpenTelemetry] instance가 제공된 경우에만 OpenTelemetry tracing을 설치합니다.
+ * - application event telemetry는 bounded low-cardinality dimension으로 기록합니다.
  */
 internal fun Application.observabilityKtorModule(
     meterRegistry: PrometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 /**
- * Spring Boot demo application for bluetape4k idgenerators.
+ * bluetape4k idgenerator용 Spring Boot demo application입니다.
  *
  * ## Behavior
  * - Registers `IdGenerator` implementations as Spring beans and injects them into the REST controller.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 /**
- * Example configuration that registers idgenerator implementations as Spring beans.
+ * idgenerator 구현체를 Spring bean으로 등록하는 example configuration입니다.
  *
  * ## Behavior
  * - UUID generators of the same type are distinguished by bean name.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.support.requirePositiveNumber
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * Configuration properties for the ID batch example.
+ * ID batch example 설정 property입니다.
  *
  * ## Behavior
  * - `defaultBatchSize` is used when the `size` query parameter is omitted.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * REST controller for the idgenerator Spring Boot demo.
+ * idgenerator Spring Boot demo용 REST controller입니다.
  *
  * ## Behavior
  * - The `/ids/{type}` family provides explicit endpoints that are easy to copy.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 /**
- * Converts input validation errors from the idgenerator REST demo into JSON responses.
+ * idgenerator REST demo의 input validation error를 JSON response로 변환합니다.
  *
  * ## Behavior
  * - Unsupported generator types and batch size errors return HTTP 400.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
@@ -43,7 +43,7 @@ data class GeneratorResponse(
 )
 
 /**
- * Example application health response.
+ * example application health response입니다.
  */
 data class HealthResponse(
     val status: String,

--- a/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
+++ b/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
@@ -23,7 +23,7 @@ import java.io.Serializable
 private const val REQUEST_ID_HEADER = "X-Request-Id"
 
 /**
- * Spring Boot observability example for Prometheus metrics and OTLP tracing configuration.
+ * Prometheus metric과 OTLP tracing configuration을 보여 주는 Spring Boot observability example입니다.
  *
  * ## Behavior
  * - Exposes application metrics through Spring Boot Actuator's Prometheus endpoint.

--- a/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt
+++ b/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt
@@ -241,12 +241,12 @@ data class BulkListenerHandle<Context>(
 }
 
 /**
- * Creates a [BulkListener] and [Flow] pair for bulk progress callbacks.
+ * bulk progress callback을 위한 [BulkListener]와 [Flow] pair를 생성합니다.
  *
  * Register the returned [BulkListener] with a [BulkIngester] to stream `beforeBulk`,
  * successful `afterBulk`, and failed `afterBulk` callbacks as [BulkProgressEvent] values.
  *
- * The callback path never suspends or blocks Elasticsearch client threads. Events are
+ * callback 경로는 Elasticsearch client thread를 suspend하거나 block하지 않습니다. event는
  * offered to a bounded [Channel] with [bufferCapacity] and [onBufferOverflow]. With the
  * default [BufferOverflow.SUSPEND] policy, `trySend` failures are logged and the event is
  * dropped when collectors are too slow or absent.

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -74,7 +74,7 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         /**
          * Sentinel value for [allowedTypePackages] that bypasses all package checks.
          *
-         * Use only in fully trusted, internal deployments where all Kafka producers are
+         * 모든 Kafka producer가 완전히 신뢰되는 internal deployment에서만 사용합니다
          * controlled. Assigning this constant re-enables the pre-1.8.0 allow-all behavior.
          *
          * ```kotlin

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -110,7 +110,7 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     fun receiveAutoAck(): Flow<ConsumerRecord<K, V>> = receiver.receiveAutoAck().concatMap { it }.asFlow()
 
     /**
-     * Returns a {@link Flux} of consumer record batches that may be used for exactly once
+     * exactly once 처리에 사용할 수 있는 consumer record batch의 {@link Flux}를 반환합니다
      * delivery semantics. A new transaction is started for each inner Flux and it is the
      * responsibility of the consuming application to commit or abort the transaction
      * using {@link TransactionManager#commit()} or {@link TransactionManager#abort()}

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -53,7 +53,7 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
 
     companion object: KLoggingChannel() {
         /**
-         * Create an instance of [SuspendKafkaProducerTemplate] with the provided configuration.
+         * 제공된 configuration으로 [SuspendKafkaProducerTemplate] instance를 생성합니다.
          *
          * @param senderOptions [SenderOptions] instance.
          * @param messageConverter [RecordMessageConverter] instance.

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
@@ -8,9 +8,9 @@ import org.apache.kafka.common.header.internals.RecordHeaders
 import org.junit.jupiter.api.Test
 
 /**
- * Security tests for [JacksonKafkaCodec] type allowlist enforcement.
+ * [JacksonKafkaCodec] type allowlist 강제를 검증하는 security test입니다.
  *
- * Verifies that:
+ * 다음을 검증합니다:
  * - Untrusted class names in the `VALUE_TYPE_KEY` header are rejected by default (empty allowedTypePackages)
  * - Explicitly allowed packages are deserialized correctly
  * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE] opt-in restores legacy allow-all behavior

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -151,7 +151,7 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         /**
          * Sentinel value for [allowedTypePackages] that bypasses all package checks.
          *
-         * Use only in fully trusted, internal deployments where all Kafka producers are
+         * 모든 Kafka producer가 완전히 신뢰되는 internal deployment에서만 사용합니다
          * controlled. Assigning this constant re-enables the pre-1.8.0 allow-all behavior.
          *
          * ```kotlin

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -110,7 +110,7 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     fun receiveAutoAck(): Flow<ConsumerRecord<K, V>> = receiver.receiveAutoAck().concatMap { it }.asFlow()
 
     /**
-     * Returns a {@link Flux} of consumer record batches that may be used for exactly once
+     * exactly once 처리에 사용할 수 있는 consumer record batch의 {@link Flux}를 반환합니다
      * delivery semantics. A new transaction is started for each inner Flux and it is the
      * responsibility of the consuming application to commit or abort the transaction
      * using {@link TransactionManager#commit()} or {@link TransactionManager#abort()}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -53,7 +53,7 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
 
     companion object: KLoggingChannel() {
         /**
-         * Create an instance of [SuspendKafkaProducerTemplate] with the provided configuration.
+         * 제공된 configuration으로 [SuspendKafkaProducerTemplate] instance를 생성합니다.
          *
          * @param senderOptions [SenderOptions] instance.
          * @param messageConverter [RecordMessageConverter] instance.

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
@@ -12,9 +12,9 @@ import org.apache.kafka.common.header.internals.RecordHeaders
 import org.junit.jupiter.api.Test
 
 /**
- * Security tests for [JacksonKafkaCodec] type allowlist enforcement.
+ * [JacksonKafkaCodec] type allowlist 강제를 검증하는 security test입니다.
  *
- * Verifies that:
+ * 다음을 검증합니다:
  * - Untrusted class names in the `VALUE_TYPE_KEY` header are rejected by default (empty allowedTypePackages)
  * - Explicitly allowed packages are deserialized correctly
  * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE] opt-in restores legacy allow-all behavior

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt
@@ -12,7 +12,7 @@ import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
 
 /**
- * A Lettuce [RedisCodec] that serializes values with a [BinarySerializer].
+ * [BinarySerializer]로 값을 직렬화하는 Lettuce [RedisCodec]입니다.
  *
  * ```kotlin
  * val codec = LettuceBinaryCodec<MyData>(BinarySerializers.LZ4Kryo)
@@ -23,7 +23,7 @@ import java.nio.ReadOnlyBufferException
  * // value == myData
  * ```
  *
- * The nullable target-taking [encodeValue] overload is the only supported source extension seam. Ordinary codec
+ * nullable target을 받는 [encodeValue] overload가 유일하게 지원되는 source extension 지점입니다. 일반 codec
  * methods remain final. Opening this class also makes compiler-generated JVM bridge methods bytecode-overrideable;
  * those bridges are not a supported extension API. Subclasses must override only the target overload and preserve
  * the configured [serializer] contract.
@@ -59,7 +59,7 @@ open class LettuceBinaryCodec<V: Any>(
     /**
      * Encodes [value] into the caller-owned [target].
      *
-     * A null target is a no-op. A read-only target fails before serializer dispatch and preserves its observable
+     * null target은 no-op입니다. 읽기 전용 target은 serializer dispatch 전에 실패하며 관찰 가능한 상태를 보존합니다
      * indices, marks, and reference count. The caller owns the target and its lifetime. A successful override must
      * commit the writer index only after the complete value has been written. A failed override may leave attempted
      * bytes or capacity changes behind, but it must not advance the writer index. Subclasses are responsible for

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
@@ -51,7 +51,7 @@ object LettuceBinaryCodecs {
     fun <V: Any> kryo(): LettuceBinaryCodec<V> = codec(BinarySerializers.Kryo)
 
     /**
-     * Creates a [LettuceBinaryCodec] with the raw Fory serializer.
+     * raw Fory serializer를 사용하는 [LettuceBinaryCodec]을 생성합니다.
      *
      * One-argument encode still creates a [ByteArray]. Caller-owned target encode uses the bounded stream path to
      * avoid the codec-level handoff array and commits the writer index only after success. Fory retains its internal
@@ -144,7 +144,7 @@ object LettuceBinaryCodecs {
     // -------------------------------------------------------------------------
 
     /**
-     * Creates a [LettuceBinaryCodec] with the raw FastFory serializer.
+     * raw FastFory serializer를 사용하는 [LettuceBinaryCodec]을 생성합니다.
      *
      * FastFory uses `CompatibleMode.SCHEMA_CONSISTENT`. One-argument encode still creates a [ByteArray].
      * Caller-owned target encode avoids only the codec-level handoff array; Fory's internal buffer remains, so this

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt
@@ -61,7 +61,7 @@ class LettuceJsonCodec<V: Any>(
     /**
      * Encodes [value] into the caller-owned [target].
      *
-     * A null target is a no-op. A read-only target fails before serializer dispatch and preserves its observable
+     * null target은 no-op입니다. 읽기 전용 target은 serializer dispatch 전에 실패하며 관찰 가능한 상태를 보존합니다
      * indices, marks, and reference count. Success commits the writer index only after the complete wire is written;
      * failure may leave attempted content or capacity changes but does not commit the writer index.
      */

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeasePerformanceTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeasePerformanceTest.kt
@@ -38,11 +38,11 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.ceil
 
 /**
- * Characterizes Redis-side multi-key lease cost outside the default test task.
+ * 기본 test task 밖에서 Redis-side multi-key lease 비용을 특성화합니다.
  *
- * Re-run `:bluetape4k-lettuce:multiKeyLeasePerformanceTest` after changing the Lua scripts or the default `maxKeys`.
- * Absolute latency is environment-dependent; the regression assertion compares normalized p95 values within one run.
- * This test deliberately owns a dedicated Redis server and explicit executors: a shared launcher would contaminate
+ * Lua script 또는 기본 `maxKeys`를 변경한 뒤 `:bluetape4k-lettuce:multiKeyLeasePerformanceTest`를 다시 실행합니다.
+ * 절대 latency는 환경 의존적이므로 regression assertion은 한 run 안의 normalized p95 값을 비교합니다.
+ * 이 test는 전용 Redis server와 explicit executor를 의도적으로 소유합니다. shared launcher는 오염시킬 수 있습니다
  * latency samples, while `MultithreadingTester` cannot preserve per-attempt timing, persistent connections, and the
  * independently scheduled PING probe that this characterization requires.
  */

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockPerformanceTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockPerformanceTest.kt
@@ -44,9 +44,9 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Characterizes coordination lock command, scheduler, latency, and retained-state bounds.
+ * coordination lock command, scheduler, latency, retained-state 한계를 특성화합니다.
  *
- * Absolute timings vary by host. This suite therefore asserts exact command budgets, hard caps, cleanup invariants,
+ * 절대 시간은 host마다 달라집니다. 따라서 이 suite는 정확한 command budget, hard cap, cleanup invariant,
  * and normalized within-run relationships. It is intentionally isolated from the default test task.
  */
 @Tag("coordination-lock-performance")

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroGenericRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroGenericRecordSerializer.kt
@@ -44,7 +44,7 @@ interface AvroGenericRecordSerializer {
     fun serialize(schema: Schema, graph: GenericRecord?): ByteArray?
 
     /**
-     * Serializes [graph] under [schema] into the caller-owned [target] from its current position.
+     * [schema] 아래의 [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating fallback that calls [serialize] first. A read-only target fails with
      * `ReadOnlyBufferException` before serializer code runs. A null result writes nothing and returns `0`; insufficient
@@ -78,7 +78,7 @@ interface AvroGenericRecordSerializer {
     fun deserialize(schema: Schema, avroBytes: ByteArray?): GenericData.Record?
 
     /**
-     * Deserializes trusted, caller-bounded bytes in `[source.position(), source.limit())` under [schema].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [schema] 아래에서 역직렬화합니다.
      *
      * This allocating fallback copies the remaining bytes to a new [ByteArray] before calling [deserialize]. Heap,
      * direct, sliced, and read-only sources are supported. Position, limit, mark, and byte order are preserved on every
@@ -130,9 +130,9 @@ interface AvroGenericRecordSerializer {
 }
 
 /**
- * Deserializes the remaining trusted, caller-bounded bytes in [source] under [schema].
+ * [source]에 남은 신뢰된 호출자 한정 바이트를 [schema] 아래에서 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, thread-confinement, and source-state preservation rules of
+ * 할당 기반 fallback, 호출자 소유권, 스레드 한정, source 상태 보존 규칙은
  * [AvroGenericRecordSerializer.deserializeFrom] apply.
  */
 fun AvroGenericRecordSerializer.deserialize(schema: Schema, source: ByteBuffer): GenericData.Record? =

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroReflectSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroReflectSerializer.kt
@@ -42,7 +42,7 @@ interface AvroReflectSerializer {
     fun <T> serialize(graph: T?): ByteArray?
 
     /**
-     * Serializes [graph] into the caller-owned [target] from its current position.
+     * [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating fallback that calls [serialize] first. A read-only target fails with
      * `ReadOnlyBufferException` before serializer code runs. A null [serialize] result writes nothing and returns `0`;
@@ -76,7 +76,7 @@ interface AvroReflectSerializer {
     fun <T> deserialize(avroBytes: ByteArray?, clazz: Class<T>): T?
 
     /**
-     * Deserializes trusted, caller-bounded bytes in `[source.position(), source.limit())` as [clazz].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [clazz]로 역직렬화합니다.
      *
      * This allocating fallback copies the remaining bytes to a new [ByteArray] before calling [deserialize]. Heap,
      * direct, sliced, and read-only sources are supported. Position, limit, mark, and byte order are preserved on every
@@ -146,15 +146,15 @@ inline fun <reified T: Any> AvroReflectSerializer.deserialize(avroBytes: ByteArr
 }
 
 /**
- * Deserializes the remaining bytes in [source] as [clazz] through [AvroReflectSerializer.deserializeFrom].
+ * [source]에 남은 바이트를 [AvroReflectSerializer.deserializeFrom]을 통해 [clazz]로 역직렬화합니다.
  */
 fun <T> AvroReflectSerializer.deserialize(source: ByteBuffer, clazz: Class<T>): T? =
     deserializeFrom(source, clazz)
 
 /**
- * Deserializes the remaining trusted, caller-bounded bytes in [source] as reified [T].
+ * [source]에 남은 신뢰된 호출자 한정 바이트를 reified [T]로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, thread-confinement, and source-state preservation rules of
+ * 할당 기반 fallback, 호출자 소유권, 스레드 한정, source 상태 보존 규칙은
  * [AvroReflectSerializer.deserializeFrom] apply.
  */
 inline fun <reified T: Any> AvroReflectSerializer.deserialize(source: ByteBuffer): T? =

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroSpecificRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroSpecificRecordSerializer.kt
@@ -40,7 +40,7 @@ interface AvroSpecificRecordSerializer {
     fun <T: SpecificRecord> serialize(graph: T?): ByteArray?
 
     /**
-     * Serializes [graph] into the caller-owned [target] from its current position.
+     * [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating fallback that calls [serialize] first. A read-only target fails with
      * `ReadOnlyBufferException` before serializer code runs. A null result writes nothing and returns `0`; insufficient
@@ -74,7 +74,7 @@ interface AvroSpecificRecordSerializer {
     fun <T: SpecificRecord> deserialize(avroBytes: ByteArray?, clazz: Class<T>): T?
 
     /**
-     * Deserializes trusted, caller-bounded bytes in `[source.position(), source.limit())` as [clazz].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [clazz]로 역직렬화합니다.
      *
      * This allocating fallback copies the remaining bytes to a new [ByteArray] before calling [deserialize]. Heap,
      * direct, sliced, and read-only sources are supported. Position, limit, mark, and byte order are preserved on every
@@ -142,7 +142,7 @@ interface AvroSpecificRecordSerializer {
     fun <T: SpecificRecord> serializeList(collection: List<T>?): ByteArray?
 
     /**
-     * Serializes [collection] into the caller-owned [target] from its current position.
+     * [collection]을 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This allocating fallback delegates to [serializeList]. Null or empty collections retain that method's policy; a
      * null result writes nothing and returns `0`. Read-only validation occurs before serializer code, and insufficient
@@ -175,7 +175,7 @@ interface AvroSpecificRecordSerializer {
     fun <T: SpecificRecord> deserializeList(avroBytes: ByteArray?, clazz: Class<T>): List<T>
 
     /**
-     * Deserializes trusted, caller-bounded bytes in `[source.position(), source.limit())` as a list of [clazz].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [clazz] 목록으로 역직렬화합니다.
      *
      * This allocating fallback copies the remaining bytes to a new [ByteArray] before calling [deserializeList]. Heap,
      * direct, sliced, and read-only sources are supported. Position, limit, mark, and byte order are preserved on every
@@ -205,15 +205,15 @@ inline fun <reified T: SpecificRecord> AvroSpecificRecordSerializer.deserialize(
 }
 
 /**
- * Deserializes the remaining bytes in [source] as [clazz] through [AvroSpecificRecordSerializer.deserializeFrom].
+ * [source]에 남은 바이트를 [AvroSpecificRecordSerializer.deserializeFrom]을 통해 [clazz]로 역직렬화합니다.
  */
 fun <T: SpecificRecord> AvroSpecificRecordSerializer.deserialize(source: ByteBuffer, clazz: Class<T>): T? =
     deserializeFrom(source, clazz)
 
 /**
- * Deserializes the remaining trusted, caller-bounded bytes in [source] as reified [T].
+ * [source]에 남은 신뢰된 호출자 한정 바이트를 reified [T]로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, thread-confinement, and source-state preservation rules of
+ * 할당 기반 fallback, 호출자 소유권, 스레드 한정, source 상태 보존 규칙은
  * [AvroSpecificRecordSerializer.deserializeFrom] apply.
  */
 inline fun <reified T: SpecificRecord> AvroSpecificRecordSerializer.deserialize(source: ByteBuffer): T? =
@@ -258,15 +258,15 @@ inline fun <reified T: SpecificRecord> AvroSpecificRecordSerializer.deserializeL
 }
 
 /**
- * Deserializes the remaining bytes in [source] as [clazz] through [AvroSpecificRecordSerializer.deserializeListFrom].
+ * [source]에 남은 바이트를 [AvroSpecificRecordSerializer.deserializeListFrom]을 통해 [clazz] 목록으로 역직렬화합니다.
  */
 fun <T: SpecificRecord> AvroSpecificRecordSerializer.deserializeList(source: ByteBuffer, clazz: Class<T>): List<T> =
     deserializeListFrom(source, clazz)
 
 /**
- * Deserializes the remaining trusted, caller-bounded bytes in [source] as a list of reified [T].
+ * [source]에 남은 신뢰된 호출자 한정 바이트를 reified [T] 목록으로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, thread-confinement, and source-state preservation rules of
+ * 할당 기반 fallback, 호출자 소유권, 스레드 한정, source 상태 보존 규칙은
  * [AvroSpecificRecordSerializer.deserializeListFrom] apply.
  */
 inline fun <reified T: SpecificRecord> AvroSpecificRecordSerializer.deserializeList(source: ByteBuffer): List<T> =

--- a/io/fastjson2/src/main/kotlin/io/bluetape4k/fastjson2/FastjsonSerializer.kt
+++ b/io/fastjson2/src/main/kotlin/io/bluetape4k/fastjson2/FastjsonSerializer.kt
@@ -81,7 +81,7 @@ class FastjsonSerializer: JsonSerializer {
     }
 
     /**
-     * Serializes through `JSONB.toBytes` and copies the result into [target].
+     * `JSONB.toBytes`로 직렬화한 뒤 결과를 [target]에 복사합니다.
      * This compatibility path commits the target position only on success and does not claim allocation reduction.
      */
     override fun serializeTo(graph: Any?, target: ByteBuffer): Int {

--- a/io/http/src/main/kotlin/io/bluetape4k/http/vertx/VertxHttpClientSupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/vertx/VertxHttpClientSupport.kt
@@ -15,7 +15,7 @@ private val defaultVertxHttpClientLock = ReentrantLock()
 private var defaultVertxHttpClientRef: HttpClient? = null
 
 /**
- * Default Vert.x [HttpClientOptions].
+ * 기본 Vert.x [HttpClientOptions]입니다.
  *
  * Security note: `trustAll = false` keeps TLS certificate verification enabled.
  * Use custom options with `trustAll = true` only for controlled test environments.
@@ -30,12 +30,12 @@ val defaultVertxHttpClientOptions: HttpClientOptions = httpClientOptionsOf(
 )
 
 /**
- * Managed default Vert.x [HttpClient].
+ * 관리되는 기본 Vert.x [HttpClient]입니다.
  *
  * ## Behaviour / Contract
  * - The client is created lazily from `bluetape4k-vertx`'s managed [defaultVertx].
  * - The client is reused across calls to this property.
- * - Call [closeDefaultVertxHttpClient] before closing the managed default Vert.x during shutdown.
+ * - shutdown 중 관리되는 기본 Vert.x를 닫기 전에 [closeDefaultVertxHttpClient]를 호출합니다.
  *
  * ```kotlin
  * val client = defaultVertxHttpClient
@@ -49,7 +49,7 @@ val defaultVertxHttpClient: HttpClient
     }
 
 /**
- * Closes and clears the managed default Vert.x [HttpClient], if it was created.
+ * 관리되는 기본 Vert.x [HttpClient]가 생성되어 있으면 닫고 지웁니다.
  */
 fun closeDefaultVertxHttpClient(): Future<Void> {
     val client = defaultVertxHttpClientLock.withLock {

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -62,7 +62,7 @@ import okhttp3.Dispatcher as OkHttpDispatcher
  * - Ktor CIO + Coroutines
  * - Vert.x WebClient + Coroutines
  *
- * Ktor CIO 3.5 opens dedicated HTTP/1 connections when its pipeline path is
+ * Ktor CIO 3.5는 pipeline 경로가 사용될 때 전용 HTTP/1 connection을 엽니다
  * disabled. The benchmark therefore keeps a short equal-thread measurement
  * window for every client instead of limiting only the CIO row to one thread.
  */

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -55,11 +55,11 @@ import okhttp3.Dispatcher as OkHttpDispatcher
  * 동기 클라이언트 이론 상한: threads × (1000 / 50ms) = 2,000 ops/s
  * 비동기는 스레드 블로킹 없이 더 높은 동시성 확보 가능.
  *
- * Vert.x 5 defaults to a 5-connection HTTP/1 pool. This benchmark configures
+ * Vert.x 5는 기본적으로 5개 connection의 HTTP/1 pool을 사용합니다. 이 benchmark는
  * the pool to match the other clients so the high-latency test compares client
- * behavior instead of the default connection cap.
+ * 기본 connection cap 대신 동작 자체를 측정하도록 설정합니다.
  *
- * Ktor CIO 3.5 opens dedicated HTTP/1 connections when its pipeline path is
+ * Ktor CIO 3.5는 pipeline 경로가 사용될 때 전용 HTTP/1 connection을 엽니다
  * disabled. The benchmark therefore keeps a short equal-thread measurement
  * window for every client instead of limiting only the CIO row to one thread.
  */

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializer.kt
@@ -19,7 +19,7 @@ import java.nio.ByteBuffer
  * val text = serializer.deserialize<String>(bytes)  // "Hello, World!"
  * ```
  *
- * The interface-default ByteBuffer methods are allocating compatibility fallbacks. See the
+ * interface default ByteBuffer 메서드는 할당 기반 호환성 fallback입니다. 자세한 내용은
  * [issue #1039 allocation evidence](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/docs/benchmarks/2026-07-18-bytebuffer-serializer-allocation.md)
  * before making backend-specific allocation claims.
  *
@@ -37,13 +37,13 @@ interface BinarySerializer {
     fun serialize(graph: Any?): ByteArray
 
     /**
-     * Serializes [graph] and writes the resulting bytes to the caller-owned [target].
+     * [graph]를 직렬화하고 결과 바이트를 호출자 소유 [target]에 씁니다.
      *
      * This interface default is an allocating fallback: it first obtains a [ByteArray] from [serialize], then writes
      * that array to [target]. Null input and zero-byte results retain [serialize]'s existing policy. On success, the
      * returned count is exactly the number of bytes written and is bounded by [Int.MAX_VALUE].
      *
-     * The target is borrowed synchronously and is not retained after the call. This method neither flushes nor closes
+     * target은 동기적으로 빌려 쓰며 호출 뒤 보관하지 않습니다. 이 메서드는 flush 또는 close를 수행하지 않습니다
      * it. Serializer and destination failures propagate unchanged; a failed destination may already contain partial
      * output.
      *
@@ -57,7 +57,7 @@ interface BinarySerializer {
     }
 
     /**
-     * Serializes [graph] into the caller-owned [target], starting at its current position.
+     * [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating compatibility fallback: it first calls [serialize] to create a [ByteArray], then
      * copies that array into [target]. A read-only target fails with `ReadOnlyBufferException` before [serialize] is
@@ -84,7 +84,7 @@ interface BinarySerializer {
     fun <T: Any> deserialize(bytes: ByteArray?): T?
 
     /**
-     * Deserializes the trusted, caller-bounded bytes in `[source.position(), source.limit())`.
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 역직렬화합니다.
      *
      * This default is an allocating compatibility fallback: it copies the remaining bytes to a new [ByteArray] and
      * delegates to [deserialize]. The source position, limit, mark, and byte order are preserved on success and failure;

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializerDecorator.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializerDecorator.kt
@@ -34,9 +34,9 @@ open class BinarySerializerDecorator(
     companion object: KLogging()
 
     /**
-     * Serializes through this decorator's virtual [serialize] contract before writing to caller-owned [target].
+     * 호출자 소유 [target]에 쓰기 전에 이 decorator의 virtual [serialize] 계약을 통해 직렬화합니다.
      *
-     * The allocating compatibility path is intentional: Kotlin interface delegation would otherwise bypass
+     * 할당 기반 호환성 경로는 의도된 것입니다. 그렇지 않으면 Kotlin interface delegation이
      * serializer transforms supplied by subclasses of this decorator.
      */
     @Throws(IOException::class)

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializer.kt
@@ -66,7 +66,7 @@ open class CompressableBinarySerializer(
     }
 
     /**
-     * Serializes and compresses [graph] before writing the compressed wire bytes into caller-owned [target].
+     * [graph]를 직렬화하고 압축한 뒤 압축된 wire byte를 호출자 소유 [target]에 씁니다.
      *
      * This allocating compatibility path intentionally preserves compression and restores nested control-flow
      * failures that standard-array serializer wrappers may hide.
@@ -80,7 +80,7 @@ open class CompressableBinarySerializer(
         }
 
     /**
-     * Serializes and compresses [graph] before copying the compressed wire bytes into caller-owned [target].
+     * [graph]를 직렬화하고 압축한 뒤 압축된 wire byte를 호출자 소유 [target]에 복사합니다.
      *
      * This allocating compatibility path is intentional: decorator semantics take precedence over bypassing compression.
      * Nested cancellation and fatal failures are restored from standard-array serializer wrappers.

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt
@@ -117,7 +117,7 @@ class ForyBinarySerializer(
         }
 
         /**
-         * Returns a [ForyBinarySerializer] configured with `SCHEMA_CONSISTENT` and reference tracking disabled.
+         * `SCHEMA_CONSISTENT`와 비활성화된 reference tracking으로 설정된 [ForyBinarySerializer]를 반환합니다.
          *
          * Throughput depends on the payload and runtime profile. Use committed benchmark evidence for the exact
          * workload instead of assuming a fixed uplift over the default serializer.

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/SerializationTrustProfile.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/SerializationTrustProfile.kt
@@ -24,7 +24,7 @@ enum class SerializationTrustProfile(
     ALLOW_LISTED_TYPES("AllowListedTypes"),
 
     /**
-     * The caller supplies the target type statically; serialized data does not
+     * 호출자는 target 타입을 정적으로 제공합니다. 직렬화된 데이터는
      * choose the class to instantiate.
      */
     NO_DYNAMIC_TYPE_LOADING("NoDynamicTypeLoading"),

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
@@ -67,7 +67,7 @@ object Jackson: KLogging() {
     }
 
     /**
-     * Creates a [JsonMapper] that writes property-based type information and allows only trusted
+     * property 기반 타입 정보를 기록하고 신뢰된 타입만 허용하는 [JsonMapper]를 생성합니다
      * subtype packages.
      *
      * ## Security contract

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt
@@ -118,8 +118,8 @@ open class JacksonSerializer(
     }
 
     /**
-     * Serializes into [target] through the configured mapper instead of the compatibility [serialize] method.
-     * The target position is committed only on success; read-only and overflow failures remain raw buffer exceptions.
+     * 호환성 [serialize] 메서드 대신 설정된 mapper를 통해 [target]으로 직렬화합니다.
+     * target 위치는 성공할 때만 커밋됩니다. 읽기 전용과 overflow 실패는 원래 buffer 예외로 유지합니다.
      */
     override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
         if (target.isReadOnly) throw ReadOnlyBufferException()
@@ -169,7 +169,7 @@ open class JacksonSerializer(
     }
 
     /**
-     * Deserializes the remaining [source] range through a duplicate-backed stream and preserves caller state.
+     * 남은 [source] 범위를 duplicate 기반 stream으로 역직렬화하고 호출자 상태를 보존합니다.
      */
     override fun <T: Any> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? =
         try {
@@ -228,7 +228,7 @@ open class JacksonSerializer(
 }
 
 /**
- * Deserializes the remaining [source] range with a Jackson type reference, preserving generic type arguments.
+ * 남은 [source] 범위를 Jackson type reference로 역직렬화하여 generic type argument를 보존합니다.
  *
  * This stays an extension so adding it does not introduce a final JVM method on the open [JacksonSerializer] class.
  */

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/crypto/TinkEncryptAlgorithm.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/crypto/TinkEncryptAlgorithm.kt
@@ -34,7 +34,7 @@ enum class TinkEncryptAlgorithm {
     DETERMINISTIC_AES256_SIV;
 
     /**
-     * Returns the singleton [TinkEncryptor] mapped to this algorithm.
+     * 이 알고리즘에 매핑된 singleton [TinkEncryptor]를 반환합니다.
      *
      * @return preconfigured singleton [TinkEncryptor].
      */

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt
@@ -101,7 +101,7 @@ open class JacksonSerializer(
     }
 
     /**
-     * Serializes [graph] directly through this serializer's configured mapper while preserving caller ownership of
+     * 호출자 소유권을 보존하면서 이 serializer에 설정된 mapper로 [graph]를 직접 직렬화합니다
      * [target]. Encoder close drains buffered wire bytes without flushing or closing the caller stream.
      */
     @Throws(IOException::class)
@@ -121,8 +121,8 @@ open class JacksonSerializer(
     }
 
     /**
-     * Serializes into [target] through the configured mapper instead of the compatibility [serialize] method.
-     * The target position is committed only on success; read-only and overflow failures remain raw buffer exceptions.
+     * 호환성 [serialize] 메서드 대신 설정된 mapper를 통해 [target]으로 직렬화합니다.
+     * target 위치는 성공할 때만 커밋됩니다. 읽기 전용과 overflow 실패는 원래 buffer 예외로 유지합니다.
      */
     override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
         if (target.isReadOnly) throw ReadOnlyBufferException()
@@ -172,7 +172,7 @@ open class JacksonSerializer(
     }
 
     /**
-     * Deserializes the remaining [source] range through a duplicate-backed stream and preserves caller state.
+     * 남은 [source] 범위를 duplicate 기반 stream으로 역직렬화하고 호출자 상태를 보존합니다.
      */
     override fun <T: Any> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? =
         try {
@@ -233,7 +233,7 @@ open class JacksonSerializer(
 }
 
 /**
- * Deserializes the remaining [source] range with a Jackson type reference, preserving generic type arguments.
+ * 남은 [source] 범위를 Jackson type reference로 역직렬화하여 generic type argument를 보존합니다.
  *
  * This stays an extension so adding it does not introduce a final JVM method on the open [JacksonSerializer] class.
  */

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/TinkEncryptAlgorithm.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/TinkEncryptAlgorithm.kt
@@ -34,7 +34,7 @@ enum class TinkEncryptAlgorithm {
     DETERMINISTIC_AES256_SIV;
 
     /**
-     * Returns the singleton [TinkEncryptor] mapped to this algorithm.
+     * 이 알고리즘에 매핑된 singleton [TinkEncryptor]를 반환합니다.
      *
      * @return preconfigured singleton [TinkEncryptor].
      */

--- a/io/json/src/main/kotlin/io/bluetape4k/json/JsonSerializer.kt
+++ b/io/json/src/main/kotlin/io/bluetape4k/json/JsonSerializer.kt
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer
  * // value?.get("id") == 1
  * ```
  *
- * The interface-default ByteBuffer methods are allocating compatibility fallbacks. Concrete backend verdicts are in
+ * interface default ByteBuffer 메서드는 할당 기반 호환성 fallback입니다. 구체 backend 판정은
  * the [issue #1039 allocation evidence](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/docs/benchmarks/2026-07-18-bytebuffer-serializer-allocation.md).
  */
 interface JsonSerializer {
@@ -41,13 +41,13 @@ interface JsonSerializer {
     fun serialize(graph: Any?): ByteArray
 
     /**
-     * Serializes [graph] and writes the resulting bytes to the caller-owned [target].
+     * [graph]를 직렬화하고 결과 바이트를 호출자 소유 [target]에 씁니다.
      *
      * This interface default is an allocating fallback: it first obtains a [ByteArray] from [serialize], then writes
      * that array to [target]. Null input and zero-byte results retain [serialize]'s existing policy. On success, the
      * returned count is exactly the number of bytes written and is bounded by [Int.MAX_VALUE].
      *
-     * The target is borrowed synchronously and is not retained after the call. This method neither flushes nor closes
+     * target은 동기적으로 빌려 쓰며 호출 뒤 보관하지 않습니다. 이 메서드는 flush 또는 close를 수행하지 않습니다
      * it. Serializer and destination failures propagate unchanged; a failed destination may already contain partial
      * output.
      *
@@ -61,10 +61,10 @@ interface JsonSerializer {
     }
 
     /**
-     * Serializes [graph] into the caller-owned [target], beginning at its current position.
+     * [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating fallback: it obtains a [ByteArray] from [serialize] before copying it into [target].
-     * A read-only target fails with `ReadOnlyBufferException` before serializer code runs. Null input retains the
+     * 읽기 전용 target은 serializer 코드 실행 전 `ReadOnlyBufferException`으로 실패합니다. null 입력은
      * existing [serialize] policy, and a zero-byte result returns `0`. Insufficient remaining space fails with the raw
      * `BufferOverflowException`.
      *
@@ -94,7 +94,7 @@ interface JsonSerializer {
     fun <T: Any> deserialize(bytes: ByteArray?, clazz: Class<T>): T?
 
     /**
-     * Deserializes the trusted, caller-bounded bytes in `[source.position(), source.limit())` as [clazz].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [clazz]로 역직렬화합니다.
      *
      * This default is an allocating fallback that copies the remaining bytes to a new [ByteArray] before delegating to
      * [deserialize]. It supports heap, direct, sliced, and read-only sources while preserving the source position,
@@ -154,18 +154,18 @@ inline fun <reified T: Any> JsonSerializer.deserialize(bytes: ByteArray?): T? =
     deserialize(bytes, T::class.java)
 
 /**
- * Deserializes the remaining bytes in [source] as [clazz] through [JsonSerializer.deserializeFrom].
+ * [source]에 남은 바이트를 [JsonSerializer.deserializeFrom]을 통해 [clazz]로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, trusted bounded-input, thread-confinement, and source-state preservation
+ * 할당 기반 fallback, 호출자 소유권, 신뢰된 bounded-input, 스레드 한정, source 상태 보존
  * rules of [JsonSerializer.deserializeFrom] apply.
  */
 fun <T: Any> JsonSerializer.deserialize(source: ByteBuffer, clazz: Class<T>): T? =
     deserializeFrom(source, clazz)
 
 /**
- * Deserializes the remaining bytes in [source] as reified [T] through [JsonSerializer.deserializeFrom].
+ * [source]에 남은 바이트를 [JsonSerializer.deserializeFrom]을 통해 reified [T]로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, trusted bounded-input, thread-confinement, and source-state preservation
+ * 할당 기반 fallback, 호출자 소유권, 신뢰된 bounded-input, 스레드 한정, source 상태 보존
  * rules of [JsonSerializer.deserializeFrom] apply.
  */
 inline fun <reified T: Any> JsonSerializer.deserialize(source: ByteBuffer): T? =

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/PipeTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/PipeTest.kt
@@ -166,7 +166,7 @@ class PipeTest: AbstractOkioTest() {
     }
 
     /**
-     * The writer is writing 12 bytes as fast as it can to a 3 byte buffer. The reader alternates
+     * writer는 12바이트를 3바이트 buffer에 가능한 한 빠르게 씁니다. reader는 번갈아
      * sleeping 1000 ms, then reading 3 bytes. That should make for an approximate timeline like
      * this:
      *
@@ -177,12 +177,12 @@ class PipeTest: AbstractOkioTest() {
      * 2000: reader reads 'def', sleeps until 3000
      * 2000: writer writes 'ghi', blocks
      * 3000: reader reads 'ghi', sleeps until 4000
-     * 3000: writer writes 'jkl', returns
-     * 4000: reader reads 'jkl', returns
+     * 3000: writer가 'jkl'을 쓰고 반환합니다
+     * 4000: reader가 'jkl'을 읽고 반환합니다
      * ```
      *
      *
-     * Because the writer is writing to a buffer, it finishes before the reader does.
+     * writer가 buffer에 쓰기 때문에 reader보다 먼저 완료됩니다.
      */
     @Test
     fun `sink blocks on slow reader`() {
@@ -311,7 +311,7 @@ class PipeTest: AbstractOkioTest() {
 
 
     /**
-     * The writer has 12 bytes to write. It alternates sleeping 1000 ms, then writing 3 bytes. The
+     * writer는 12바이트를 써야 합니다. 1000 ms sleep 후 3바이트 쓰기를 반복합니다.
      * reader is reading as fast as it can. That should make for an approximate timeline like this:
      *
      * ```
@@ -323,8 +323,8 @@ class PipeTest: AbstractOkioTest() {
      * 2000: reader reads 'def'
      * 3000: writer writes 'ghi', sleeps until 4000
      * 3000: reader reads 'ghi'
-     * 4000: writer writes 'jkl', returns
-     * 4000: reader reads 'jkl', returns
+     * 4000: writer가 'jkl'을 쓰고 반환합니다
+     * 4000: reader가 'jkl'을 읽고 반환합니다
      * ```
      */
     @Test
@@ -374,7 +374,7 @@ class PipeTest: AbstractOkioTest() {
     }
 
     /**
-     * The writer has 12 bytes to write. It alternates sleeping 1000 ms, then writing 3 bytes. The
+     * writer는 12바이트를 써야 합니다. 1000 ms sleep 후 3바이트 쓰기를 반복합니다.
      * reader is reading as fast as it can. That should make for an approximate timeline like this:
      *
      * ```
@@ -386,8 +386,8 @@ class PipeTest: AbstractOkioTest() {
      * 2000: reader reads 'def'
      * 3000: writer writes 'ghi', sleeps until 4000
      * 3000: reader reads 'ghi'
-     * 4000: writer writes 'jkl', returns
-     * 4000: reader reads 'jkl', returns
+     * 4000: writer가 'jkl'을 쓰고 반환합니다
+     * 4000: reader가 'jkl'을 읽고 반환합니다
      * ```
      */
     @Test

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/MessageSupport.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/MessageSupport.kt
@@ -28,13 +28,13 @@ fun <T: Message> packMessage(message: T): ByteArray {
 /**
  * Packs [message] as protobuf `Any` wire bytes into [target].
  *
- * The bytes are identical to [packMessage]. Writing begins at the target's current position, so callers may use a
+ * [packMessage]와 동일한 바이트입니다. 쓰기는 target의 현재 위치에서 시작하므로 호출자는
  * nonzero position and a bounded limit. On success, the target's byte order, limit, and capacity are preserved, and
  * its position advances by the returned byte count. The exact encoded size is preflighted against
  * [ByteBuffer.remaining]; a read-only target is rejected before packing or checking the encoded size. These preflight
  * failures leave the target state and content unchanged.
  *
- * A later write failure restores only the target position; already-written content is intentionally unspecified. After
+ * 나중의 쓰기 실패는 target 위치만 복구합니다. 이미 기록된 내용은 의도적으로 지정하지 않습니다. 이후
  * such a failure, callers must clear, reinitialize, or discard the target before reusing it. The target remains
  * caller-owned and must be thread-confined or otherwise synchronized by its caller.
  *
@@ -74,7 +74,7 @@ inline fun <reified T: Message> unpackMessage(bytes: ByteArray): T? {
  *
  * Parsing uses a short-lived duplicate, so the caller's source position, limit, mark, and byte order are preserved;
  * this also supports nonzero positions and bounded sources. No buffer view is retained after this function returns.
- * A mismatched `Any` type returns `null`; malformed wire bytes propagate their parse failure.
+ * 일치하지 않는 `Any` 타입은 `null`을 반환합니다. 잘못된 wire byte는 parse 실패를 그대로 전파합니다.
  */
 inline fun <reified T: Message> unpackMessage(source: ByteBuffer): T? {
     val any = ProtoAny.parseFrom(source.duplicate())

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt
@@ -64,7 +64,7 @@ class ProtobufSerializer(
         )
 
         /**
-         * Creates the trusted-internal mixed Protobuf + fallback serializer.
+         * trusted-internal 혼합 Protobuf + fallback serializer를 생성합니다.
          *
          * Use this profile only for internal stores whose historical bytes may contain fallback-encoded payloads.
          */

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/LettuceProtobufCodecs.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/LettuceProtobufCodecs.kt
@@ -110,13 +110,13 @@ object LettuceProtobufCodecs {
     }
 
     /**
-     * Creates a strict Protobuf codec optimized for a direct ByteBuf target.
+     * direct ByteBuf target에 최적화된 strict Protobuf codec을 생성합니다.
      *
-     * The target remains caller-owned. This removes the payload-sized handoff for uncompressed Protobuf values but
+     * target은 계속 호출자 소유입니다. 압축되지 않은 Protobuf 값에서 payload 크기 handoff를 제거하지만
      * does not promise zero-copy operation. The unchanged ByteBuffer API and all compressed or custom-prefix codecs
      * retain their compatibility path. On failure, failure-aftercare belongs to the caller because attempted bytes or
      * capacity growth may remain even though the writer index is not advanced.
-     * The default allowlist accepts Bluetape and Google Protobuf message packages. Callers that need another package
+     * 기본 allowlist는 Bluetape 및 Google Protobuf message package를 허용합니다. 다른 package가 필요한 호출자는
      * prefix must construct [ProtobufSerializer] and [LettuceBinaryCodec] directly; that custom-prefix path retains
      * the allocating compatibility implementation.
      *
@@ -184,43 +184,43 @@ object LettuceProtobufCodecs {
         LettuceBinaryCodec(CompressableBinarySerializer(strictSerializer, Compressors.Zstd))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec optimized for a direct ByteBuf target.
+     * direct ByteBuf target에 최적화된 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      *
      * Use this factory only for internal stores where every producer and stored payload is trusted. Do not use it at
      * a shared or untrusted boundary.
      *
-     * The target is caller-owned and has the same failure-aftercare contract as [protobuf]. The unchanged ByteBuffer
+     * target은 호출자 소유이며 [protobuf]와 동일한 failure-aftercare 계약을 가집니다. 변경되지 않은 ByteBuffer
      * API, compressed factories, and any caller-configured custom-prefix serializer retain the compatibility path.
      */
     fun <V: Any> trustedInternalProtobuf(): LettuceBinaryCodec<V> =
         DirectProtobufLettuceCodec.create(trustedInternalSerializer)
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Gzip compression.
+     * Gzip 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalGzipProtobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.GZip))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Deflate compression.
+     * Deflate 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalDeflateProtobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Deflate))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with LZ4 compression.
+     * LZ4 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalLz4Protobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.LZ4))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Snappy compression.
+     * Snappy 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalSnappyProtobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Snappy))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Zstd compression.
+     * Zstd 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalZstdProtobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Zstd))

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
@@ -93,7 +93,7 @@ class RedissonProtobufCodec private constructor(
         val ALLOW_ALL_CLASSES_UNSAFE: Set<String> = setOf("*")
 
         /**
-         * Creates a trusted-internal mixed Protobuf + fallback codec.
+         * trusted-internal 혼합 Protobuf + fallback codec을 생성합니다.
          *
          * Use this profile only for internal Redis stores whose historical bytes may contain fallback-encoded payloads.
          */

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kStatusPages.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kStatusPages.kt
@@ -8,7 +8,7 @@ import io.ktor.server.response.respond
 import kotlinx.coroutines.CancellationException
 
 /**
- * Registers default JSON error responses for common application exceptions.
+ * 일반 application exception에 대한 기본 JSON error response를 등록합니다.
  *
  * ## Contract
  * - [IllegalArgumentException] is mapped to HTTP 400.
@@ -42,7 +42,7 @@ fun StatusPagesConfig.bluetape4kErrorResponses() {
 }
 
 /**
- * Responds with the standard bluetape4k JSON error payload.
+ * 표준 bluetape4k JSON error payload로 응답합니다.
  */
 suspend fun ApplicationCall.respondApiError(
     status: HttpStatusCode,

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorRequestParameters.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorRequestParameters.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.support.requireNotBlank
 import io.ktor.server.application.ApplicationCall
 
 /**
- * Returns a required path parameter or throws [IllegalArgumentException].
+ * 필수 path parameter를 반환하거나 [IllegalArgumentException]을 던집니다.
  */
 fun ApplicationCall.requiredPathParameter(name: String): String {
     name.requireNotBlank("name")
@@ -14,7 +14,7 @@ fun ApplicationCall.requiredPathParameter(name: String): String {
 }
 
 /**
- * Returns a required query parameter or throws [IllegalArgumentException].
+ * 필수 query parameter를 반환하거나 [IllegalArgumentException]을 던집니다.
  */
 fun ApplicationCall.requiredQueryParameter(name: String): String {
     name.requireNotBlank("name")

--- a/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceStatusPages.kt
+++ b/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceStatusPages.kt
@@ -8,7 +8,7 @@ import io.ktor.server.plugins.statuspages.StatusPagesConfig
 import java.util.concurrent.TimeoutException
 
 /**
- * Registers generic JSON error responses for Resilience4j route failures.
+ * Resilience4j route failure에 대한 generic JSON error response를 등록합니다.
  *
  * ## Contract
  * - Open circuit failures map to HTTP 503.

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTesting.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTesting.kt
@@ -39,7 +39,7 @@ fun ApplicationTestBuilder.installBluetape4kKtorCoreForTest(
 }
 
 /**
- * Creates a Ktor test client with bluetape4k JSON defaults.
+ * bluetape4k JSON 기본값을 사용하는 Ktor test client를 생성합니다.
  *
  * ## Contract
  * - Uses [Bluetape4kKtorJson.defaultJson] unless a custom [jsonFormat] is supplied.

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorResponseAssertions.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorResponseAssertions.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 /**
- * Verifies the HTTP status and returns the same response for chaining.
+ * HTTP status를 검증하고 chaining할 수 있도록 같은 response를 반환합니다.
  */
 infix fun HttpResponse.shouldHaveStatus(expected: HttpStatusCode): HttpResponse {
     status shouldBeEqualTo expected
@@ -53,7 +53,7 @@ suspend inline fun <reified T> HttpResponse.shouldHaveJsonBody(
 }
 
 /**
- * Verifies a standard bluetape4k [ApiErrorResponse].
+ * 표준 bluetape4k [ApiErrorResponse]를 검증합니다.
  */
 suspend fun HttpResponse.shouldHaveApiError(
     expected: ExpectedApiError,

--- a/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/basic/BasicUserRepository.kt
+++ b/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/basic/BasicUserRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
 
     /**
-     * Sample method annotated with {@link Query}. This method executes the CQL from the {@link Query} value.
+     * {@link Query}가 붙은 sample method입니다. 이 method는 {@link Query} 값의 CQL을 실행합니다.
      *
      * @param id
      * @return
@@ -16,7 +16,7 @@ interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
     suspend fun findUserByIdIn(id: Long): BasicUser?
 
     /**
-     * Derived query method. This query corresponds with {@code SELECT * FROM users WHERE uname = ?0}.
+     * derived query method입니다. 이 query는 {@code SELECT * FROM users WHERE uname = ?0}에 대응합니다.
      * {@link User#username} is not part of the primary so it requires a secondary index.
      *
      * @param username
@@ -25,7 +25,7 @@ interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
     suspend fun findByUsername(username: String): BasicUser?
 
     /**
-     * Derived query method using SASI (SSTable Attached Secondary Index) features through the `LIKE` keyword. This
+     * `LIKE` keyword를 통해 SASI(SSTable Attached Secondary Index) 기능을 사용하는 derived query method입니다. 이
      * query corresponds with `SELECT * FROM users WHERE lname LIKE '?0'`}`. `User.lastname` is not part of the
      * primary key so it requires a secondary index.
      *

--- a/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/kotlin/PersonRepository.kt
+++ b/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/kotlin/PersonRepository.kt
@@ -12,7 +12,7 @@ interface PersonRepository: CoroutineCrudRepository<Person, String> {
     fun findByFirstname(firstname: String): Flow<Person>
 
     /**
-     * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
+     * 결과가 필요한 query method입니다. 결과를 찾지 못하면 [org.springframework.dao.EmptyResultDataAccessException]을 던집니다.
      * NOTE: suspend 메소드일 때에는 발생하지 않습니다.
      */
     suspend fun findOneByFirstname(firstname: String): Person?

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
@@ -6,9 +6,9 @@ import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Base controller that exposes a virtual-thread-per-task executor.
+ * virtual-thread-per-task executor를 노출하는 base controller입니다.
  *
- * Use this base class only when a controller needs an explicit
+ * controller가 explicit
  * [ExecutorService] for virtual-thread task submission. Spring calls
  * [closeVirtualThreadExecutor] when the controller bean is destroyed, and the
  * shared executor is recreated on the next access if a later context needs it.

--- a/spring-boot/r2dbc/src/test/kotlin/io/bluetape4k/spring/r2dbc/coroutines/blog/DatabaseInitializer.kt
+++ b/spring-boot/r2dbc/src/test/kotlin/io/bluetape4k/spring/r2dbc/coroutines/blog/DatabaseInitializer.kt
@@ -18,7 +18,7 @@ class DatabaseInitializer(
     companion object: KLoggingChannel()
 
     /**
-     * Spring Boot Application이 준비되면 호출되는 Event Listener
+     * Spring Boot application이 준비되면 호출되는 event listener입니다.
      */
     @EventListener(value = [ApplicationReadyEvent::class])
     fun init() {

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CancellationContracts.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CancellationContracts.kt
@@ -14,18 +14,17 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Default timeout for coroutine cancellation contract checks.
+ * coroutine cancellation contract 검증에 사용하는 기본 timeout입니다.
  */
 val DEFAULT_CANCELLATION_CONTRACT_TIMEOUT: Duration = 5.seconds
 
 /**
- * Runs [block] and captures non-cancellation failures as [Result.failure].
+ * [block]을 실행하고 cancellation이 아닌 실패를 [Result.failure]로 포착합니다.
  *
- * ## Behaviour / Contract
- * - Returns [Result.success] when [block] completes normally.
- * - Returns [Result.failure] for non-cancellation exceptions.
- * - Rethrows [CancellationException] so structured coroutine cancellation is
- *   preserved.
+ * ## 동작 계약
+ * - [block]이 정상 완료되면 [Result.success]를 반환합니다.
+ * - cancellation이 아닌 예외는 [Result.failure]로 반환합니다.
+ * - structured coroutine cancellation이 보존되도록 [CancellationException]은 다시 던집니다.
  *
  * ```kotlin
  * val result = resultOfNonCancellation { parseValue() }
@@ -42,13 +41,13 @@ inline fun <T> resultOfNonCancellation(block: () -> T): Result<T> {
 }
 
 /**
- * Runs suspend [block] and captures non-cancellation failures as [Result.failure].
+ * suspend [block]을 실행하고 cancellation이 아닌 실패를 [Result.failure]로 포착합니다.
  *
- * ## Behaviour / Contract
- * - Returns [Result.success] when [block] completes normally.
- * - Returns [Result.failure] for non-cancellation exceptions.
- * - Rethrows [CancellationException]. Use this instead of plain `runCatching`
- *   around suspend APIs that must preserve structured cancellation.
+ * ## 동작 계약
+ * - [block]이 정상 완료되면 [Result.success]를 반환합니다.
+ * - cancellation이 아닌 예외는 [Result.failure]로 반환합니다.
+ * - [CancellationException]은 다시 던집니다. structured cancellation을 보존해야 하는 suspend API 주변에서는
+ *   일반 `runCatching` 대신 이 helper를 사용합니다.
  *
  * ```kotlin
  * val result = runCatchingNonCancellation { client.fetch() }
@@ -67,14 +66,12 @@ suspend inline fun <T> runCatchingNonCancellation(
 }
 
 /**
- * Asserts that cancelling the launched coroutine is observed as
- * [CancellationException] inside [operation].
+ * 시작한 coroutine을 취소했을 때 [operation] 내부에서 [CancellationException]으로 관측되는지 검증합니다.
  *
- * ## Behaviour / Contract
- * - Starts [operation] immediately in a child coroutine.
- * - Cancels the child after it reaches the first suspension point.
- * - Fails if [operation] completes normally or turns cancellation into another
- *   result/exception type.
+ * ## 동작 계약
+ * - [operation]을 child coroutine에서 즉시 시작합니다.
+ * - child가 첫 suspension point에 도달한 뒤 취소합니다.
+ * - [operation]이 정상 완료되거나 cancellation을 다른 result/exception type으로 바꾸면 실패합니다.
  *
  * ```kotlin
  * assertCancellationPropagates {
@@ -112,13 +109,11 @@ suspend fun <T> assertCancellationPropagates(
 }
 
 /**
- * Asserts that cancelling one suspended waiter clears its registration and does
- * not block the next waiter.
+ * suspended waiter 하나를 취소하면 등록이 해제되고 다음 waiter를 막지 않는지 검증합니다.
  *
- * ## Behaviour / Contract
- * - Starts [awaiter] once and cancels it while suspended.
- * - Starts [awaiter] again, calls [releaser], and verifies that the second
- *   waiter completes within [timeout].
+ * ## 동작 계약
+ * - [awaiter]를 한 번 시작하고 suspended 상태에서 취소합니다.
+ * - [awaiter]를 다시 시작한 뒤 [releaser]를 호출하고, 두 번째 waiter가 [timeout] 안에 완료되는지 확인합니다.
  *
  * ```kotlin
  * assertCancellationClearsWaiter(
@@ -155,15 +150,13 @@ suspend fun assertCancellationClearsWaiter(
 }
 
 /**
- * Asserts that cancelling a coroutine also cancels the underlying resource used
- * by [operation].
+ * coroutine 취소가 [operation]이 사용하는 underlying resource도 취소하는지 검증합니다.
  *
- * ## Behaviour / Contract
- * - Starts [operation] immediately in a child coroutine.
- * - Runs [beforeCancel] so tests can wait until a future, HTTP call, or callback
- *   registration is known to have started.
- * - Cancels the coroutine and verifies [resourceCancelled].
- * - Fails if cancellation is converted to a non-cancellation outcome.
+ * ## 동작 계약
+ * - [operation]을 child coroutine에서 즉시 시작합니다.
+ * - test가 future, HTTP call, callback registration 시작을 확인할 수 있도록 [beforeCancel]을 실행합니다.
+ * - coroutine을 취소하고 [resourceCancelled]가 참인지 확인합니다.
+ * - cancellation이 non-cancellation outcome으로 변환되면 실패합니다.
  *
  * ```kotlin
  * assertResourceCancelledOnCoroutineCancellation(

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CoroutineSupport.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/coroutines/CoroutineSupport.kt
@@ -134,9 +134,9 @@ inline fun runSuspendVT(
 }
 
 /**
- * Creates a single-thread dispatcher for the duration of [block].
+ * [block] 실행 동안 사용할 single-thread dispatcher를 생성합니다.
  *
- * The backing executor is shut down after [block] returns or throws.
+ * backing executor는 [block]이 정상 반환하거나 예외를 던진 뒤 종료됩니다.
  */
 suspend inline fun withSingleThread(crossinline block: suspend (dispatcher: CoroutineDispatcher) -> Unit) {
     val executor = Executors.newSingleThreadExecutor()
@@ -151,9 +151,9 @@ suspend inline fun withSingleThread(crossinline block: suspend (dispatcher: Coro
 }
 
 /**
- * Creates [parallelism] single-thread dispatchers for the duration of [block].
+ * [block] 실행 동안 사용할 [parallelism]개의 single-thread dispatcher를 생성합니다.
  *
- * The backing executors are shut down after [block] returns or throws.
+ * backing executor들은 [block]이 정상 반환하거나 예외를 던진 뒤 종료됩니다.
  */
 suspend inline fun withParallels(
     parallelism: Int = Runtime.getRuntime().availableProcessors(),

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
@@ -5,9 +5,9 @@ import java.io.Serializable
 private const val REDACTED_MARKER_VALUE = "values redacted"
 
 /**
- * Identifies a framework boundary covered by a context propagation proof.
+ * context propagation proof가 다루는 framework boundary를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -22,9 +22,9 @@ enum class ContextPropagationBoundary {
 }
 
 /**
- * Identifies the lifecycle scenario exercised by a context propagation proof.
+ * context propagation proof가 실행하는 lifecycle scenario를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -39,9 +39,9 @@ enum class ContextPropagationScenario {
 }
 
 /**
- * Identifies the terminal outcome observed after crossing a context boundary.
+ * context boundary를 지난 뒤 관찰된 terminal outcome을 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -55,9 +55,9 @@ enum class ContextPropagationTerminal {
 }
 
 /**
- * Identifies where cleanup was probed after a boundary completed.
+ * boundary 완료 후 cleanup을 probe한 위치를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -72,7 +72,7 @@ enum class ContextProbeLocation {
 /**
  * Supplies a stable test-owned alias for one request or probe.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -88,7 +88,7 @@ enum class ContextRequestAlias {
 /**
  * Identifies a stable observation point inside a propagation lifecycle.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -103,7 +103,7 @@ enum class ContextObservationPoint {
 /**
  * Defines the relation applied to an isolation sample.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenariosTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenariosTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 class HttpIdempotencyBoundaryScenariosTest {
 
     /**
-     * Uses a custom barrier-aligned harness because `SuspendedJobTester` does not expose each
+     * `SuspendedJobTester`가 각 항목을 노출하지 않으므로 custom barrier-aligned harness를 사용합니다
      * attempt's result together with the per-key waiter-registration barrier. The bounded workload
      * is five rounds, three keys per round, and at most 105 concurrent requests per round.
      */

--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/MockServerApplication.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/MockServerApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 /**
- * Bluetape4k Mock Server 애플리케이션.
+ * Bluetape4k Mock Server 애플리케이션입니다.
  *
  * httpbin, jsonplaceholder 등 다양한 HTTP 테스트용 mock 엔드포인트를 제공하는 Spring Boot 애플리케이션.
  * 포트 80(HTTP)/443(HTTPS)에서 실행되며, Testcontainers 환경에서 외부 HTTP 의존성을 대체할 수 있다.

--- a/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
+++ b/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
@@ -9,7 +9,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 
 /**
- * README HTTPS port documentation must match runtime and container metadata.
+ * README HTTPS port 문서는 runtime 및 container metadata와 일치해야 합니다.
  */
 class ReadmeHttpsPortContractTest {
 

--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/MockWebfluxServerApplication.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/MockWebfluxServerApplication.kt
@@ -6,8 +6,8 @@ import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 
 /**
- * Mock WebFlux 서버 애플리케이션.
- * Spring Boot 4 WebFlux + Kotlin Coroutines 기반 테스트용 HTTP 서버.
+ * Mock WebFlux 서버 애플리케이션입니다.
+ * Spring Boot 4 WebFlux + Kotlin Coroutines 기반 테스트용 HTTP 서버입니다.
  */
 @EnableCaching
 @SpringBootApplication

--- a/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
+++ b/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
@@ -8,7 +8,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 
 /**
- * README endpoint rows must describe implemented mock-webflux routes only.
+ * README endpoint row는 구현된 mock-webflux route만 설명해야 합니다.
  */
 class ReadmeRouteContractTest {
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
@@ -11,7 +11,7 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
 
 /**
- * Runs a single-node [etcd](https://etcd.io/) server with Testcontainers.
+ * Testcontainers로 single-node [etcd](https://etcd.io/) server를 실행합니다.
  *
  * ## Behavior / Contract
  * - Exposes the etcd client API on [CLIENT_PORT] and the peer API on [PEER_PORT].
@@ -50,7 +50,7 @@ class EtcdServer private constructor(
         val EXPORT_PORTS = intArrayOf(CLIENT_PORT, PEER_PORT)
 
         /**
-         * Creates an [EtcdServer] from a [DockerImageName].
+         * [DockerImageName]으로 [EtcdServer]를 생성합니다.
          *
          * @param imageName Docker image name.
          * @param useDefaultPort binds 2379/2380 to the same host ports when `true`.
@@ -66,7 +66,7 @@ class EtcdServer private constructor(
         }
 
         /**
-         * Creates an [EtcdServer] from an image name and tag.
+         * image name과 tag로 [EtcdServer]를 생성합니다.
          *
          * @param image Docker image name; blank values are rejected.
          * @param tag Docker image tag; blank values are rejected.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
@@ -16,7 +16,7 @@ import java.time.Duration
 import java.util.Base64
 
 /**
- * Runs a [Grafana](https://grafana.com/) server in Docker for integration tests.
+ * integration test를 위해 Docker에서 [Grafana](https://grafana.com/) server를 실행합니다.
  *
  * Follows the same `GenericServer + Launcher` pattern as [PrometheusServer].
  *
@@ -62,7 +62,7 @@ class GrafanaServer private constructor(
         const val ADMIN_PASSWORD = "admin"
 
         /**
-         * Creates a [GrafanaServer] from a pre-built [DockerImageName].
+         * 미리 구성된 [DockerImageName]으로 [GrafanaServer]를 생성합니다.
          *
          * @param imageName      Fully qualified Docker image name with tag.
          * @param useDefaultPort When `true`, binds port [PORT] to the same fixed host port.
@@ -76,7 +76,7 @@ class GrafanaServer private constructor(
         ): GrafanaServer = GrafanaServer(imageName, useDefaultPort, reuse)
 
         /**
-         * Creates a [GrafanaServer] by image name and tag.
+         * image name과 tag로 [GrafanaServer]를 생성합니다.
          *
          * @param image          Docker image name; blank value throws [IllegalArgumentException].
          * @param tag            Docker image tag; blank value throws [IllegalArgumentException].

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
@@ -13,7 +13,7 @@ import org.testcontainers.k3s.K3sContainer
 import org.testcontainers.utility.DockerImageName
 
 /**
- * Runs a [K3s](https://k3s.io/) lightweight Kubernetes cluster in Docker for integration tests.
+ * integration test를 위해 Docker에서 [K3s](https://k3s.io/) lightweight Kubernetes cluster를 실행합니다.
  *
  * Extends the native testcontainers [K3sContainer] and adds the bluetape4k
  * `GenericServer + Launcher` pattern.
@@ -53,7 +53,7 @@ class K3sServer private constructor(
         const val API_PORT = 6443
 
         /**
-         * Creates a [K3sServer] from a pre-built [DockerImageName].
+         * 미리 구성된 [DockerImageName]으로 [K3sServer]를 생성합니다.
          *
          * @param imageName      Fully qualified Docker image name with tag.
          * @param useDefaultPort When `true`, binds port [API_PORT] to the same fixed host port.
@@ -67,7 +67,7 @@ class K3sServer private constructor(
         ): K3sServer = K3sServer(imageName, useDefaultPort, reuse)
 
         /**
-         * Creates a [K3sServer] by image name and tag.
+         * image name과 tag로 [K3sServer]를 생성합니다.
          *
          * @param image          Docker image name; blank value throws [IllegalArgumentException].
          * @param tag            Docker image tag; blank value throws [IllegalArgumentException].
@@ -118,7 +118,7 @@ class K3sServer private constructor(
     }
 
     /**
-     * Returns a fabric8 [KubernetesClient] pre-configured for this K3s cluster.
+     * 이 K3s cluster에 맞게 미리 설정된 fabric8 [KubernetesClient]를 반환합니다.
      *
      * Must be called **after** [start]. Each call returns a **new** client instance
      * registered in [ShutdownQueue] — it will be closed on JVM shutdown automatically.

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
@@ -6,8 +6,8 @@ import io.bluetape4k.testcontainers.AbstractContainerTest
 import org.junit.jupiter.api.Test
 
 /**
- * Validation tests for [K3sServer] that do not require a running container.
- * These run in regular CI without a privileged Docker runner.
+ * 실행 중인 container가 필요 없는 [K3sServer] validation test입니다.
+ * privileged Docker runner 없이 일반 CI에서 실행됩니다.
  */
 class K3sServerValidationTest: AbstractContainerTest() {
 

--- a/utils/geo/src/main/kotlin/io/bluetape4k/geohash/queries/GeoHashBoundingBoxQuery.kt
+++ b/utils/geo/src/main/kotlin/io/bluetape4k/geohash/queries/GeoHashBoundingBoxQuery.kt
@@ -176,7 +176,7 @@ class GeoHashBoundingBoxQuery(
     }
 
     /**
-     * Checks if the provided hash completely(!) contains the provided bounding box
+     * 제공된 hash가 제공된 bounding box를 완전히(!) 포함하는지 확인합니다
      */
     private fun hashContainsBoundingBox(
         hash: GeoHash,

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geohash/tests/RandomGeoHashes.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geohash/tests/RandomGeoHashes.kt
@@ -25,16 +25,16 @@ object RandomGeoHashes: KLogging() {
     }
 
     /**
-     * Create a completely random [GeoHash] with a random number of bits.
+     * random bit 수를 가진 완전 random [GeoHash]를 생성합니다.
      *
-     * Precision will be between [5,64] bits.
+     * precision은 [5,64] bit 사이입니다.
      */
     fun create(): GeoHash {
         return geoHashWithBits(randomLatitude(), randomLongitude(), randomPrecision())
     }
 
     /**
-     * Create a completely random geohash with
+     * 완전 random geohash를 생성합니다
      * a precision that is a multiple of 5 and in [5,60] bits.
      */
     fun createWith5BitsPrecision(): GeoHash {

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geohash/utils/GeoHashSizeTableTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geohash/utils/GeoHashSizeTableTest.kt
@@ -43,7 +43,7 @@ class GeoHashSizeTableTest {
         fun generate(bits: Int): BoundingBox
 
         /**
-         * Get expected bits
+         * expected bit를 가져옵니다.
          */
         fun getExpectedBits(bits: Int): Int
     }

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/hashids/Hashids.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/hashids/Hashids.kt
@@ -236,7 +236,7 @@ class Hashids(
         (numbersHash + returnStr[index].code) % guards.length
 
     /**
-     * Encode hexadecimal formatted string
+     * hexadecimal formatted string을 encode합니다.
      *
      * @param hexStr hexadecimal formatted string to encode
      * @return encoded string as hash
@@ -256,7 +256,7 @@ class Hashids(
     }
 
     /**
-     * Decode hash to hexadecimal formatted string
+     * hash를 hexadecimal formatted string으로 decode합니다.
      *
      * @param hash encoded string
      * @return hexadecimal formatted string

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/snowflake/SnowflakeId.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/snowflake/SnowflakeId.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.support.publicLazy
 import java.io.Serializable
 
 /**
- * Snowflake id
+ * Snowflake id입니다.
  *
  * ```kotlin
  * val snowflake = DefaultSnowflake()

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/ulid/utils/TestConstants.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/ulid/utils/TestConstants.kt
@@ -56,6 +56,6 @@ val PatternBytes =
     ).map { it.toByte() }.toByteArray()
 
 /**
- * Get timestamp and random part of ULID string.
+ * ULID string에서 timestamp와 random part를 가져옵니다.
  */
 fun partsOf(ulid: String): Pair<String, String> = ulid.substring(0, 10) to ulid.substring(10)

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
@@ -38,7 +38,7 @@ class JwtReader(
         get() = header<String>("kid")
 
     /**
-     * JWT expiration time as epoch milliseconds.
+     * JWT 만료 시각을 epoch milliseconds로 표현한 값입니다.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 `null`을 반환합니다.
@@ -47,7 +47,7 @@ class JwtReader(
         get() = expiration?.time
 
     /**
-     * Expiration TTL (Time To Live) in milliseconds.
+     * 만료 TTL(Time To Live)을 milliseconds로 표현한 값입니다.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 [Long.MAX_VALUE]를 반환합니다.
@@ -65,7 +65,7 @@ class JwtReader(
         get() = expiresAtMillis?.let { (it - System.currentTimeMillis()).coerceAtLeast(0L) } ?: Long.MAX_VALUE
 
     /**
-     * Expiration TTL (Time To Live) in milliseconds.
+     * 만료 TTL(Time To Live)을 milliseconds로 표현한 값입니다.
      *
      * @see remainingTtlMillis
      */

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/GroupingSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/GroupingSupport.kt
@@ -81,7 +81,7 @@ inline fun <T: Any, K: Any> Iterable<T>.groupingCount(crossinline keySelector: (
 /**
  * Groups elements from the [Grouping] source by key and applies [operation] to the elements of each group sequentially,
  * passing the previously accumulated value and the current element as arguments, and stores the results in a new map.
- * An initial value of accumulator is the same [initialValue] for each group.
+ * accumulator의 initial value는 각 group마다 같은 [initialValue]입니다.
  *
  * ```kotlin
  * val data = sequenceOf("apple" to 3, "banana" to 5, "apple" to 7)
@@ -110,7 +110,7 @@ inline fun <T: Any, K: Any, R: Any> Sequence<T>.groupingFold(
 /**
  * Groups elements from the [Grouping] source by key and applies [operation] to the elements of each group sequentially,
  * passing the previously accumulated value and the current element as arguments, and stores the results in a new map.
- * An initial value of accumulator is the same [initialValue] for each group.
+ * accumulator의 initial value는 각 group마다 같은 [initialValue]입니다.
  *
  * ```kotlin
  * val data = listOf("apple" to 3, "banana" to 5, "apple" to 7)
@@ -138,7 +138,7 @@ inline fun <T: Any, K: Any, R: Any> Iterable<T>.groupingFold(
  * sequentially starting from the second element of the group,
  * passing the previously accumulated value and the current element as arguments,
  * and stores the results in a new map.
- * An initial value of accumulator is the first element of the group.
+ * accumulator의 initial value는 group의 첫 번째 element입니다.
  *
  * ```kotlin
  * val data = sequenceOf("apple" to 1, "banana" to 2, "apple" to 3)
@@ -170,7 +170,7 @@ inline fun <T: S, K: Any, S: Any> Sequence<T>.groupingReduce(
  * sequentially starting from the second element of the group,
  * passing the previously accumulated value and the current element as arguments,
  * and stores the results in a new map.
- * An initial value of accumulator is the first element of the group.
+ * accumulator의 initial value는 group의 첫 번째 element입니다.
  *
  * ```kotlin
  * val data = listOf("apple" to 1, "banana" to 2, "apple" to 3)

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/MathConsts.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/MathConsts.kt
@@ -47,14 +47,14 @@ object MathConsts {
 
     /**
      * ln(10) / 20 - Power Decibel (dB) 를 Neper (Np) 로 변환할 때의 factor
-     * Use this version when the Decibel represent a power gain
+     * Decibel이 power gain을 나타낼 때 이 version을 사용합니다
      * but the compared values are not powers (e.g. amplitude, current, voltage).
      */
     val powerDecibel: Double get() = ln(10.0) / 20.0
 
     /**
      * ln(10) / 10 - Neutral Decibel (dB)를 Neper (Np)로 변환할 때의 factor
-     * Use this version when the Decibel represent a power gain
+     * Decibel이 power gain을 나타낼 때 이 version을 사용합니다
      * but the compared values are not powers (e.g. amplitude, current, voltage).
      */
     val neutralDecibel: Double get() = ln(10.0) / 10.0
@@ -65,25 +65,25 @@ object MathConsts {
     val goldenRatio: Double = (1.0 + sqrt(5.0)) / 2.0
 
     /**
-     * The Catalan constant
+     * Catalan constant입니다.
      * `Sum(k=0 -> inf){ (-1)^k/(2*k + 1)2 }`
      */
     const val CATALAN: Double = 0.9159655941772190150546035149323841107741493742816721342664981196217630197762547694794
 
     /**
-     * The Euler-Mascheroni constant
+     * Euler-Mascheroni constant입니다.
      * `lim(n -> inf){ Sum(k=1 -> n) { 1/k - log(n) } }`
      */
     const val EULER_MASCHERONI = 0.5772156649015328606065120900824024310421593359399235988057672348849
 
     /**
-     * The Glaisher constant
+     * Glaisher constant입니다.
      * `e^(1/12 - Zeta(-1))`
      */
     const val GLAISHER = 1.2824271291006226368753425688697917277676889273250011920637400217404063088588264611297
 
     /**
-     * The Khinchin constant
+     * Khinchin constant입니다.
      * `prod(k=1 -> inf){1+1/(k*(k+2))^log(k,2)}`</remarks>`
      */
     const val KHINCHIN = 2.6854520010653064453097148354817956938203822939944629530511523455572188595371520028011

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/RandomSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/RandomSupport.kt
@@ -141,7 +141,7 @@ fun <T: Any> Sequence<T>.random(sampleSize: Int): List<T> = toList().random(samp
 fun <T: Any> Iterable<T>.random(sampleSize: Int): List<T> = toList().random(sampleSize)
 
 /**
- * Simulates a weighted TRUE/FALSE coin flip, with a percentage of probability towards TRUE
+ * TRUE 쪽 probability percentage를 가진 weighted TRUE/FALSE coin flip을 시뮬레이션합니다
  * In other words, this is a Probability Density Function (PDF) for discrete TRUE/FALSE values
  *
  * ```kotlin
@@ -169,7 +169,7 @@ class WeightedCoin(val trueProbability: Double) {
 }
 
 /**
- * Simulates a weighted TRUE/FALSE coin flip, with a percentage of probability towards TRUE
+ * TRUE 쪽 probability percentage를 가진 weighted TRUE/FALSE coin flip을 시뮬레이션합니다
  * In other words, this is a Probability Density Function (PDF) for discrete TRUE/FALSE values
  *
  * ```kotlin

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.states.core
 import java.io.Serializable
 
 /**
- * Identifies an inherited transition registered for a state family.
+ * state family에 등록된 inherited transition을 식별합니다.
  *
  * Exact state transitions still have precedence. Parent transitions are used
  * when the current state is an instance of [stateType] and no exact transition

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
@@ -99,7 +99,7 @@ class StateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
-     * Registers an inherited transition for every state matching [from].
+     * [from]과 일치하는 모든 state에 inherited transition을 등록합니다.
      *
      * Exact state transitions have precedence over inherited transitions.
      */
@@ -212,7 +212,7 @@ class SuspendStateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
-     * Registers an inherited transition for every state matching [from].
+     * [from]과 일치하는 모든 state에 inherited transition을 등록합니다.
      *
      * Exact state transitions have precedence over inherited transitions.
      */
@@ -317,7 +317,7 @@ fun <S: Any, E: Any> suspendStateMachine(
 inline fun <reified E: Any> on(): Class<E> = E::class.java
 
 /**
- * Returns a state class for inherited transition registration.
+ * inherited transition 등록에 사용할 state class를 반환합니다.
  *
  * ```kotlin
  * transition(state<OrderState.Payable>(), on<OrderEvent.Cancel>(), to = OrderState.Cancelled)

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/ReactiveStateMachineDsl.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/reactive/ReactiveStateMachineDsl.kt
@@ -9,11 +9,11 @@ import io.bluetape4k.states.core.TransitionTarget
 import kotlinx.coroutines.CoroutineScope
 
 /**
- * Configures a reactive transition.
+ * reactive transition을 설정합니다.
  *
- * @param S state type
- * @param E event type
- * @param F effect type
+ * @param S state 타입입니다.
+ * @param E event 타입입니다.
+ * @param F effect 타입입니다.
  */
 @StateMachineDsl
 class ReactiveTransitionBuilder<S: Any, E: Any, F: Any> {
@@ -25,14 +25,14 @@ class ReactiveTransitionBuilder<S: Any, E: Any, F: Any> {
         private set
 
     /**
-     * Sets a guard condition for this transition.
+     * 이 transition의 guard 조건을 설정합니다.
      */
     fun guard(predicate: (S, E) -> Boolean) {
         guardFunction = predicate
     }
 
     /**
-     * Sets an effect handler that runs after a successful transition.
+     * transition 성공 후 실행할 effect handler를 설정합니다.
      */
     fun effect(handler: suspend ReactiveEffectScope<E, F>.(S, E, S) -> Unit) {
         effectHandler = handler
@@ -40,7 +40,7 @@ class ReactiveTransitionBuilder<S: Any, E: Any, F: Any> {
 }
 
 /**
- * Configures lifecycle side effects for a state or state family.
+ * state 또는 state family에 대한 lifecycle side effect를 설정합니다.
  */
 @StateMachineDsl
 class ReactiveStateBuilder<S: Any, E: Any, F: Any> internal constructor(
@@ -49,15 +49,14 @@ class ReactiveStateBuilder<S: Any, E: Any, F: Any> internal constructor(
 ) {
 
     /**
-     * Starts [block] whenever the matching state is active.
+     * matching state가 active일 때마다 [block]을 시작합니다.
      */
     fun sideEffect(block: suspend ReactiveEffectScope<E, F>.(S) -> Unit) {
         sideEffect(key = { it }, block = block)
     }
 
     /**
-     * Starts [block] whenever the matching state is active and restarts it only
-     * when [key] changes.
+     * matching state가 active일 때마다 [block]을 시작하고 [key]가 바뀔 때만 다시 시작합니다.
      */
     fun sideEffect(
         key: (S) -> Any?,
@@ -68,7 +67,7 @@ class ReactiveStateBuilder<S: Any, E: Any, F: Any> internal constructor(
 }
 
 /**
- * Builder for [ReactiveStateMachine].
+ * [ReactiveStateMachine]을 구성하는 builder입니다.
  */
 @StateMachineDsl
 class ReactiveStateMachineBuilder<S: Any, E: Any, F: Any> internal constructor(
@@ -87,7 +86,7 @@ class ReactiveStateMachineBuilder<S: Any, E: Any, F: Any> internal constructor(
     private val sideEffects = mutableListOf<ReactiveSideEffect<S, E, F>>()
 
     /**
-     * Registers an exact state transition.
+     * 정확히 일치하는 state transition을 등록합니다.
      */
     fun transition(
         from: S,
@@ -102,7 +101,7 @@ class ReactiveStateMachineBuilder<S: Any, E: Any, F: Any> internal constructor(
     }
 
     /**
-     * Registers an inherited transition for a state family.
+     * state family에 대한 inherited transition을 등록합니다.
      */
     fun transition(
         from: Class<out S>,
@@ -117,7 +116,7 @@ class ReactiveStateMachineBuilder<S: Any, E: Any, F: Any> internal constructor(
     }
 
     /**
-     * Configures side effects for one exact state value.
+     * 하나의 정확한 state 값에 대한 side effect를 설정합니다.
      */
     fun onState(
         state: S,
@@ -127,7 +126,7 @@ class ReactiveStateMachineBuilder<S: Any, E: Any, F: Any> internal constructor(
     }
 
     /**
-     * Configures side effects for every state matching [stateType].
+     * [stateType]과 일치하는 모든 state에 대한 side effect를 설정합니다.
      */
     fun onState(
         stateType: Class<out S>,
@@ -137,7 +136,7 @@ class ReactiveStateMachineBuilder<S: Any, E: Any, F: Any> internal constructor(
     }
 
     /**
-     * Creates a reactive state machine.
+     * reactive state machine을 생성합니다.
      */
     fun build(): ReactiveStateMachine<S, E, F> {
         val exactTransitions = transitions.toMap()
@@ -173,7 +172,7 @@ class ReactiveStateMachineBuilder<S: Any, E: Any, F: Any> internal constructor(
 }
 
 /**
- * Creates a [ReactiveStateMachine].
+ * [ReactiveStateMachine]을 생성합니다.
  */
 fun <S: Any, E: Any, F: Any> reactiveStateMachine(
     scope: CoroutineScope,

--- a/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/api/WorkAdapters.kt
+++ b/utils/workflow/src/main/kotlin/io/bluetape4k/workflow/api/WorkAdapters.kt
@@ -20,17 +20,17 @@ fun Work.asSuspend(): SuspendWork = SuspendWork { ctx ->
 }
 
 /**
- * Converts a coroutine [SuspendWork] to a blocking [Work].
+ * coroutine [SuspendWork]를 blocking [Work]로 변환합니다.
  *
- * Uses [runBlocking] internally. **Do not call from a coroutine context** —
- * doing so may cause deadlocks or thread starvation. Use [SuspendWork] directly
- * in coroutine contexts instead.
+ * 내부적으로 [runBlocking]을 사용합니다. **coroutine context에서는 호출하지 마십시오.**
+ * 그렇게 하면 deadlock 또는 thread starvation이 발생할 수 있습니다. coroutine context에서는
+ * [SuspendWork]를 직접 사용하십시오.
  *
  * ```kotlin
  * val blockingWork = suspendWork.asBlocking()
  * ```
  *
- * @return converted [Work]
+ * @return 변환된 [Work]입니다.
  */
 @Deprecated(
     message = "asBlocking() uses runBlocking and risks deadlock in coroutine contexts. Use SuspendWork directly instead.",


### PR DESCRIPTION
## Summary

Closes #1106

- PR 제목: docs: Koreanize testing coroutine KDoc

- Koreanizes selected JUnit coroutine testing KDoc.
- Preserves cancellation contract behavior and examples while moving prose into Korean.
- Keeps Testcontainers and broader testing fixture localization for follow-up #1106 batches.

Refs #1106

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Koreanizes selected JUnit coroutine testing KDoc.
- Preserves cancellation contract behavior and examples while moving prose into Korean.
- Keeps Testcontainers and broader testing fixture localization for follow-up #1106 batches.

Refs #1106

### Validation
- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`
- Targeted KDoc drift search on changed testing surfaces

### DoD Status
| Gate | Status | Evidence |
| --- | --- | --- |
| Type E scope | PASS | KDoc/comment-only localization; no production behavior changed. |
| Scope exclusions | PASS | README and LLM-facing operating docs were not changed. |
| KDoc Koreanization | PASS | Selected JUnit coroutine testing KDoc is Korean. |
| Guardrails | PASS | `python3 scripts/docs-localization-inventory.py --check` reports zero manual parity and English-KDoc policy drift. |
| Diff hygiene | PASS | `git diff --check` passed. |
| Build/test | N/A | No Gradle build; KDoc/comment-only change. |
| Merge | PENDING | PR-only per current project-translation instruction. |

## Validation

- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`
- Targeted KDoc drift search on changed testing surfaces

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1106, milestone `1.12.0`, assignee `debop`
- PR: #1126, head `4b7d1fcc666118b926975614d16972496831e3da`, milestone `1.12.0`, assignee `debop`
- Base: `kdoc/issue-1105-frameworks-kdoc-batch`, head branch `kdoc/issue-1106-testing-kdoc-batch`
- Labels: `documentation`, `tech-debt`
- State: `MERGED`, merge commit `462119ccc2225a718c413a90443cde0abe0d00ba`
- CI: | Scope exclusions | PASS | README and LLM-facing operating docs were not changed. | / | Build/test | N/A | No Gradle build; KDoc/comment-only change. |

## DoD Status

| Gate | Status | Evidence |
| --- | --- | --- |
| Type E scope | PASS | KDoc/comment-only localization; no production behavior changed. |
| Scope exclusions | PASS | README and LLM-facing operating docs were not changed. |
| KDoc Koreanization | PASS | Selected JUnit coroutine testing KDoc is Korean. |
| Guardrails | PASS | `python3 scripts/docs-localization-inventory.py --check` reports zero manual parity and English-KDoc policy drift. |
| Diff hygiene | PASS | `git diff --check` passed. |
| Build/test | N/A | No Gradle build; KDoc/comment-only change. |
| Merge | PENDING | PR-only per current project-translation instruction. |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1126 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `462119ccc2225a718c413a90443cde0abe0d00ba`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
