### PR TITLE
kdoc(core): Koreanize core support KDoc

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/DefaultFields.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/DefaultFields.kt
@@ -37,19 +37,19 @@ val DefaultLocale: Locale = Locale.getDefault()
 val DefaultCharset: Charset = Charsets.UTF_8
 
 /**
- * System default charset name ("UTF-8")
+ * 시스템 기본 문자 집합 이름입니다("UTF-8").
  */
 @JvmField
 val DefaultCharsetName: String = DefaultCharset.name()
 
 /**
- * System Default Charactor encoding ("utf-8")
+ * 시스템 기본 문자 인코딩 이름입니다("utf-8").
  */
 @JvmField
 val DefaultEncoding: String = DefaultCharsetName.lowercase()
 
 /**
- * System default [ZoneId]
+ * 시스템 기본 [ZoneId]입니다.
  *
  * @see DefaultZoneOffset
  * @see ZoneId.systemDefault()
@@ -67,7 +67,7 @@ val DefaultZoneId: ZoneId = ZoneId.systemDefault()
 val UtcZoneId: ZoneId = ZoneId.of("UTC")
 
 /**
- * System default [ZoneOffset]
+ * 시스템 기본 [ZoneOffset]입니다.
  *
  * @see DefaultZoneId
  */

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/apache/ApacheClassUtils.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/apache/ApacheClassUtils.kt
@@ -130,7 +130,7 @@ fun KClass<*>.isAssignable(toClass: KClass<*>, autoboxing: Boolean = true): Bool
     ClassUtils.isAssignable(this.java, toClass.java, autoboxing)
 
 /**
- * Is the specified class an inner class or static nested class?
+ * 지정한 클래스가 내부 클래스 또는 정적 중첩 클래스인지 확인합니다.
  *
  * @receiver the class to check may be null
  * @return {@code true} if the class is an inner or static nested class, false if not or `null`

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/apache/ApacheStringUtils.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/apache/ApacheStringUtils.kt
@@ -4,16 +4,16 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.Strings
 
 /**
- * Abbreviates a String using a given replacement marker. This will turn
+ * 지정한 대체 마커로 문자열을 축약합니다. 예를 들어
  * "Now is the time for all good men" into "...is the time for..." if "..." was defined
  * as the replacement marker.
  *
- * Works like `String.abbr(String, int)`, but allows you to specify
- * a "left edge" offset.  Note that this left edge is not necessarily going to
- * be the leftmost character in the result, or the first character following the
- * replacement marker, but it will appear somewhere in the result.
+ * `String.abbr(String, int)`처럼 동작하지만
+ * "왼쪽 경계" 오프셋을 지정할 수 있습니다. 이 경계가 반드시
+ * 결과의 가장 왼쪽 문자나 대체 마커 바로 뒤의 첫 문자가 되는 것은 아니지만,
+ * 결과 어딘가에는 포함됩니다.
  *
- * In no case will it return a String of length greater than {@code maxWidth}.
+ * 어떤 경우에도 {@code maxWidth\}보다 긴 문자열은 반환하지 않습니다.
  *
  * ```
  * StringUtils.abbreviate(null, null, *, *)                 = null
@@ -32,27 +32,27 @@ import org.apache.commons.lang3.Strings
  * StringUtils.abbreviate("abcdefghij", "...", 5, 6)        = IllegalArgumentException
  * ```
  *
- * @receiver  the String to check, may be null
- * @param abbrMarker  the String used as replacement marker
- * @param offset  left edge of source String
- * @param maxWidth  maximum length of result String, must be at least 4
- * @return abbreviated String, `null` if null String input
+ * @receiver 검사할 문자열입니다. `null`일 수 있습니다.
+ * @param abbrMarker 대체 마커로 사용할 문자열입니다.
+ * @param offset 원본 문자열의 왼쪽 경계입니다.
+ * @param maxWidth 결과 문자열의 최대 길이입니다. 4 이상이어야 합니다.
+ * @return 축약된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.abbr(maxWidth: Int, abbrMarker: String = "...", offset: Int = 0): String =
     StringUtils.abbreviate(this, abbrMarker, offset, maxWidth)
 
 /**
- * Abbreviates a String to the length passed, replacing the middle characters with the supplied
- * replacement String.
+ * 문자열을 지정한 길이로 축약하고 가운데 문자를 제공된
+ * 대체 문자열로 바꿉니다.
  *
- * This abbreviation only occurs if the following criteria is met:
- * - Neither the String for abbreviation nor the replacement String are null or empty
- * - The length to truncate to is less than the length of the supplied String
- * - The length to truncate to is greater than 0
- * - The abbreviated String will have enough room for the length supplied replacement String
- * and the first and last characters of the supplied String for abbreviation
+ * 이 축약은 다음 조건을 모두 만족할 때만 수행됩니다:
+ * - 축약 대상 문자열과 대체 문자열이 모두 `null` 또는 빈 값이 아닙니다
+ * - 축약할 길이가 제공된 문자열 길이보다 작습니다
+ * - 축약할 길이가 0보다 큽니다
+ * - 축약 결과가 제공된 대체 문자열 길이와
+ * 축약 대상 문자열의 첫 문자와 마지막 문자를 담을 만큼 충분한 공간을 가집니다
  *
- * Otherwise, the returned String will be the same as the supplied String for abbreviation.
+ * 그 외의 경우에는 축약 대상 문자열을 그대로 반환합니다.
  *
  *
  * ```
@@ -63,17 +63,17 @@ fun String.abbr(maxWidth: Int, abbrMarker: String = "...", offset: Int = 0): Str
  * StringUtils.abbreviateMiddle("abcdef", ".", 4)     = "ab.f"
  * ```
  *
- * @receiver  the String to abbreviate, may be null
- * @param middle the String to replace the middle characters with, may be null
- * @param length the length to abbreviate {@code str} to.
- * @return the abbreviated String if the above criteria is met, or the original String supplied for abbreviation.
+ * @receiver 축약할 문자열입니다. `null`일 수 있습니다.
+ * @param middle 가운데 문자를 대체할 문자열입니다. `null`일 수 있습니다.
+ * @param length {@code str\}를 축약할 길이입니다.
+ * @return 위 조건을 만족하면 축약된 문자열, 그렇지 않으면 축약 대상 원본 문자열입니다.
  */
 fun String.abbrMiddle(length: Int, middle: String = "..."): String =
     StringUtils.abbreviateMiddle(this, middle, length)
 
 /**
- * Appends the suffix to the end of the string if the string does not
- * already end with any of the suffixes.
+ * 문자열이 지정한 접미사 중 하나로 끝나지 않으면
+ * 문자열 끝에 접미사를 추가합니다.
  *
  * ```
  * StringUtils.appendIfMissing(null, null) = null
@@ -83,7 +83,7 @@ fun String.abbrMiddle(length: Int, middle: String = "..."): String =
  * StringUtils.appendIfMissing("abcxyz", "xyz") = "abcxyz"
  * StringUtils.appendIfMissing("abcXYZ", "xyz") = "abcXYZxyz"
  * ```
- * With additional suffixes,
+ * 추가 접미사를 지정한 경우,
  * ```
  * StringUtils.appendIfMissing(null, null, null) = null
  * StringUtils.appendIfMissing("abc", null, null) = "abc"
@@ -97,18 +97,18 @@ fun String.abbrMiddle(length: Int, middle: String = "..."): String =
  * StringUtils.appendIfMissing("abcMNO", "xyz", "mno") = "abcMNOxyz"
  * ```
  *
- * @receiver The string.
- * @param suffix The suffix to append to the end of the string.
- * @param suffixes Additional suffixes that are valid terminators.
+ * @receiver 대상 문자열입니다.
+ * @param suffix 문자열 끝에 추가할 접미사입니다.
+ * @param suffixes 이미 유효한 끝으로 인정할 추가 접미사입니다.
  *
- * @return A new String if suffix was appended, the same string otherwise.
+ * @return 접미사가 추가되면 새 문자열, 그렇지 않으면 기존 문자열입니다.
  */
 fun String.appendIfMissing(suffix: CharSequence, vararg suffixes: CharSequence): String =
     Strings.CS.appendIfMissing(this, suffix, *suffixes)
 
 /**
- * Appends the suffix to the end of the string if the string does not
- * already end, case-insensitive, with any of the suffixes.
+ * 대소문자를 무시했을 때 문자열이 지정한 접미사 중 하나로 끝나지 않으면
+ * 문자열 끝에 접미사를 추가합니다.
  *
  * ```
  * StringUtils.appendIfMissingIgnoreCase(null, null) = null
@@ -118,7 +118,7 @@ fun String.appendIfMissing(suffix: CharSequence, vararg suffixes: CharSequence):
  * StringUtils.appendIfMissingIgnoreCase("abcxyz", "xyz") = "abcxyz"
  * StringUtils.appendIfMissingIgnoreCase("abcXYZ", "xyz") = "abcXYZ"
  * ```
- * With additional suffixes,
+ * 추가 접미사를 지정한 경우,
  * ```
  * StringUtils.appendIfMissingIgnoreCase(null, null, null) = null
  * StringUtils.appendIfMissingIgnoreCase("abc", null, null) = "abc"
@@ -132,24 +132,24 @@ fun String.appendIfMissing(suffix: CharSequence, vararg suffixes: CharSequence):
  * StringUtils.appendIfMissingIgnoreCase("abcMNO", "xyz", "mno") = "abcMNO"
  * ```
  *
- * @receiver The string.
- * @param suffix The suffix to append to the end of the string.
- * @param suffixes Additional suffixes that are valid terminators.
+ * @receiver 대상 문자열입니다.
+ * @param suffix 문자열 끝에 추가할 접미사입니다.
+ * @param suffixes 이미 유효한 끝으로 인정할 추가 접미사입니다.
  *
- * @return A new String if suffix was appended, the same string otherwise.
+ * @return 접미사가 추가되면 새 문자열, 그렇지 않으면 기존 문자열입니다.
  */
 fun String.appendIfMissingIgnoreCase(suffix: CharSequence, vararg suffixes: CharSequence): String =
     Strings.CI.appendIfMissing(this, suffix, *suffixes)
 
 /**
- * Centers a String in a larger String of size {@code size}
- * using the space character (' ').
+ * {@code size\} 크기의 더 큰 문자열 안에서 문자열을 가운데 정렬합니다
+ * 공백 문자(' ')로 채웁니다.
  *
- * If the size is less than the String length, the original String is returned.
- * A `null` String returns `null`.
- * A negative size is treated as zero.</p>
+ * 지정 크기가 문자열 길이보다 작으면 원래 문자열을 반환합니다.
+ * `null` 문자열은 `null`을 반환합니다.
+ * 음수 크기는 0으로 처리합니다.</p>
  *
- * Equivalent to `center(str, size, " ")`.
+ * `center(str, size, " ")`와 동일합니다.
  *
  * ```
  * StringUtils.center(null, *)   = null
@@ -160,20 +160,20 @@ fun String.appendIfMissingIgnoreCase(suffix: CharSequence, vararg suffixes: Char
  * StringUtils.center("a", 4)    = " a  "
  * ```
  *
- * @receiver  the String to center, may be null
- * @param size  the int size of new String, negative treated as zero
- * @return centered String, `null` if null String input
+ * @receiver 가운데 정렬할 문자열입니다. `null`일 수 있습니다.
+ * @param size 새 문자열 크기입니다. 음수는 0으로 처리합니다.
+ * @return 가운데 정렬된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.center(size: Int, padChar: Char = ' '): String =
     StringUtils.center(this, size, padChar)
 
 /**
- * Centers a String in a larger String of size {@code size}.
- * Uses a supplied String as the value to pad the String with.
+ * {@code size\} 크기의 더 큰 문자열 안에서 문자열을 가운데 정렬합니다.
+ * 제공된 문자열을 채움 값으로 사용합니다.
  *
- * If the size is less than the String length, the String is returned.
- * A `null` String returns `null`.
- * A negative size is treated as zero.
+ * 지정 크기가 문자열 길이보다 작으면 문자열을 그대로 반환합니다.
+ * `null` 문자열은 `null`을 반환합니다.
+ * 음수 크기는 0으로 처리합니다.
  *
  * ```
  * StringUtils.center(null, *, *)     = null
@@ -187,19 +187,19 @@ fun String.center(size: Int, padChar: Char = ' '): String =
  * StringUtils.center("abc", 7, "")   = "  abc  "
  * ```
  *
- * @receiver  the String to center, may be null
- * @param size  the int size of new String, negative treated as zero
- * @param padStr  the String to pad the new String with, must not be null or empty
- * @return centered String, `null` if null String input
- * @throws IllegalArgumentException if padStr is `null` or empty
+ * @receiver 가운데 정렬할 문자열입니다. `null`일 수 있습니다.
+ * @param size 새 문자열 크기입니다. 음수는 0으로 처리합니다.
+ * @param padStr 새 문자열을 채울 문자열입니다. `null`이거나 비어 있으면 안 됩니다.
+ * @return 가운데 정렬된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
+ * @throws IllegalArgumentException `padStr`가 `null`이거나 비어 있으면 발생합니다.
  */
 fun String.center(size: Int, padStr: String): String =
     StringUtils.center(this, size, padStr)
 
 /**
- * Remove the last character from a String.
+ * 문자열의 마지막 문자를 제거합니다.
  *
- * If the String ends in {@code \r\n}, then remove both of them.
+ * 문자열이 {@code \r\n}로 끝나면 두 문자를 모두 제거합니다.
  *
  * ```
  * StringUtils.chop(null)          = null
@@ -215,16 +215,16 @@ fun String.center(size: Int, padStr: String): String =
  * StringUtils.chop("\r\n")        = ""
  * ```
  *
- * @receiver  the String to chop last character from, may be null
- * @return String without last character, `null` if null String input
+ * @receiver 마지막 문자를 제거할 문자열입니다. `null`일 수 있습니다.
+ * @return 마지막 문자가 제거된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.chop(): String =
     StringUtils.chop(this)
 
 
 /**
- * Checks if the CharSequence contains any character in the given
- * set of characters.
+ * CharSequence가 지정한 문자 집합의 문자 중 하나라도 포함하는지
+ * 확인합니다.
  *
  * <p>A `null` CharSequence will return {@code false}.
  * A `null` or zero length search array will return {@code false}.</p>
@@ -240,15 +240,15 @@ fun String.chop(): String =
  * StringUtils.containsAny("aba", ['z'])             = false
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param searchChars  the chars to search for, may be null
- * @return the {@code true} if any of the chars are found, {@code false} if no match or null input
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param searchChars 검색할 문자입니다. `null`일 수 있습니다.
+ * @return 문자를 하나라도 찾으면 {@code true\}, 매치가 없거나 입력이 `null`이면 {@code false\}입니다.
  */
 fun CharSequence.containsAny(vararg searchChars: Char): Boolean =
     StringUtils.containsAny(this, *searchChars)
 
 /**
- * Checks if the CharSequence contains any of the CharSequences in the given array.
+ * CharSequence가 지정한 배열의 CharSequence 중 하나라도 포함하는지 확인합니다.
  *
  * A `null` or zero length search array will return `false`.
  *
@@ -262,17 +262,17 @@ fun CharSequence.containsAny(vararg searchChars: Char): Boolean =
  * StringUtils.containsAny("abc", "d", "abc")  = true
  * ```
  *
- * @receiver The CharSequence to check, may be null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
  * @param searchCharSequences The array of CharSequences to search for, may be null. Individual CharSequences may be
  *        null as well.
- * @return `true` if any of the search CharSequences are found, `false` otherwise
+ * @return 검색 CharSequence를 하나라도 찾으면 `true`, 그렇지 않으면 `false`입니다.
  */
 fun CharSequence.containsAny(vararg searchCharSequences: CharSequence): Boolean =
     Strings.CS.containsAny(this, *searchCharSequences)
 
 
 /**
- * Checks if the CharSequence contains any of the CharSequences in the given array, ignoring case.
+ * 대소문자를 무시하고 CharSequence가 지정한 배열의 CharSequence 중 하나라도 포함하는지 확인합니다.
  *
  * A `null` {@code cs} CharSequence will return {@code false}. A `null` or zero length search array will
  * return {@code false}.
@@ -290,16 +290,16 @@ fun CharSequence.containsAny(vararg searchCharSequences: CharSequence): Boolean 
  * StringUtils.containsAny("ABC", "d", "abc")  = true
  * ```
  *
- * @receiver The CharSequence to check, may be null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
  * @param searchCharSequences The array of CharSequences to search for, may be null. Individual CharSequences may be
  *        null as well.
- * @return `true` if any of the search CharSequences are found, `false` otherwise
+ * @return 검색 CharSequence를 하나라도 찾으면 `true`, 그렇지 않으면 `false`입니다.
  */
 fun CharSequence.containsAnyIgnoreCase(vararg searchCharSequences: CharSequence): Boolean =
     Strings.CI.containsAny(this, *searchCharSequences)
 
 /**
- * Checks if CharSequence contains a search CharSequence irrespective of case,
+ * 대소문자와 관계없이 CharSequence가 검색 CharSequence를 포함하는지 확인합니다,
  * handling `null`. Case-insensitivity is defined as by
  * `String#equalsIgnoreCase(String)`
  *
@@ -316,15 +316,15 @@ fun CharSequence.containsAnyIgnoreCase(vararg searchCharSequences: CharSequence)
  * StringUtils.containsIgnoreCase("abc", "Z") = false
  * ```
  *
- * @receiver the CharSequence to check, may be null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
  * @param searchStr  the CharSequence to find, may be null
- * @return true if the CharSequence contains the search CharSequence irrespective of case or false if not or `null` string input
+ * @return 대소문자와 관계없이 검색 CharSequence를 포함하면 true, 그렇지 않거나 입력이 `null`이면 false입니다.
  */
 fun CharSequence.containsIgnoreCase(searchStr: CharSequence): Boolean =
     Strings.CI.contains(this, searchStr)
 
 /**
- * Checks that the CharSequence does not contain certain characters.
+ * CharSequence가 특정 문자를 포함하지 않는지 확인합니다.
  *
  * <p>A `null` CharSequence will return {@code true}.
  * A `null` invalid character array will return {@code true}.
@@ -339,19 +339,19 @@ fun CharSequence.containsIgnoreCase(searchStr: CharSequence): Boolean =
  * StringUtils.containsNone("abz", 'xyz')  = false
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param searchChars  an array of invalid chars, may be null
- * @return true if it contains none of the invalid chars, or is null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param searchChars 허용하지 않는 문자 배열입니다. `null`일 수 있습니다.
+ * @return 허용하지 않는 문자를 포함하지 않거나 `null`이면 true입니다.
  */
 fun CharSequence.containsNone(vararg searchChars: Char): Boolean =
     StringUtils.containsNone(this, *searchChars)
 
 /**
- * Checks that the CharSequence does not contain certain characters.
+ * CharSequence가 특정 문자를 포함하지 않는지 확인합니다.
  *
  * A `null` CharSequence will return {@code true}.
  * A `null` invalid character array will return `true`.
- * An empty String ("") always returns true.
+ * 빈 문자열("")은 항상 true를 반환합니다.
  *
  * ```
  * StringUtils.containsNone(*, null)       = true
@@ -362,9 +362,9 @@ fun CharSequence.containsNone(vararg searchChars: Char): Boolean =
  * StringUtils.containsNone("abz", "xyz")  = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @param invalidStr  a String of invalid chars, may be null
- * @return true if it contains none of the invalid chars, or is null
+ * @receiver 검사할 CharSequence입니다.
+ * @param invalidStr 허용하지 않는 문자 문자열입니다. `null`일 수 있습니다.
+ * @return 허용하지 않는 문자를 포함하지 않거나 `null`이면 true입니다.
  * @since 2.0
  * @since 3.0 Changed signature from containsNone(String, String) to containsNone(CharSequence, String)
  */
@@ -373,11 +373,11 @@ fun CharSequence.containsNone(invalidStr: String?): Boolean =
 
 
 /**
- * Checks if the CharSequence contains only certain characters.
+ * CharSequence가 특정 문자만 포함하는지 확인합니다.
  *
  * A `null` CharSequence will return {@code false}.
  * A `null` valid character array will return `false`.
- * An empty CharSequence (length()=0) always returns `true`.
+ * 빈 CharSequence(length()=0)는 항상 `true`를 반환합니다.
  *
  * ```
  * StringUtils.containsOnly("", *)         = true
@@ -388,14 +388,14 @@ fun CharSequence.containsNone(invalidStr: String?): Boolean =
  * ```
  *
  * @receiver  the String to check
- * @param validChars  an array of valid chars
- * @return true if it only contains valid chars and is non-null
+ * @param validChars 허용할 문자 배열입니다.
+ * @return `null`이 아니고 허용 문자만 포함하면 true입니다.
  */
 fun CharSequence.containsOnly(vararg validChars: Char): Boolean =
     StringUtils.containsOnly(this, *validChars)
 
 /**
- * Checks if the CharSequence contains only certain characters.
+ * CharSequence가 특정 문자만 포함하는지 확인합니다.
  *
  * A `null` valid character String will return `false`.
  * An empty String (length()=0) always returns `true`.
@@ -409,9 +409,9 @@ fun CharSequence.containsOnly(vararg validChars: Char): Boolean =
  * StringUtils.containsOnly("abz", "abc")  = false
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param validStr  a String of valid chars, may be null
- * @return true if it only contains valid chars and is non-null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param validStr 허용할 문자 문자열입니다. `null`일 수 있습니다.
+ * @return `null`이 아니고 허용 문자만 포함하면 true입니다.
  * @since 2.0
  * @since 3.0 Changed signature from containsOnly(String, String) to containsOnly(CharSequence, String)
  */
@@ -419,11 +419,11 @@ fun CharSequence.containsOnly(validStr: String?): Boolean =
     StringUtils.containsOnly(this, validStr)
 
 /**
- * Check whether the given CharSequence contains any whitespace characters.
+ * 주어진 CharSequence가 공백 문자를 포함하는지 확인합니다.
  *
- * Whitespace is defined by [Character#isWhitespace(char)].
+ * 공백은 [Character#isWhitespace(char)] 기준으로 정의합니다.
  *
- * @receiver the CharSequence to check (may be `null`)
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
  * @return `true` if the CharSequence is not empty and
  * contains at least 1 (breaking) whitespace character
  */
@@ -431,7 +431,7 @@ fun CharSequence.containsWhitespace(): Boolean =
     StringUtils.containsWhitespace(this)
 
 /**
- * Counts how many times the char appears in the given string.
+ * 지정한 문자열에 문자가 몇 번 등장하는지 셉니다.
  *
  * A `null` or empty ("") String input returns `0`.
  *
@@ -444,16 +444,16 @@ fun CharSequence.containsWhitespace(): Boolean =
  * StringUtils.countMatches("abba", 'x') = 0
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param ch  the char to count
- * @return the number of occurrences, 0 if the CharSequence is `null`
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param ch 셀 문자입니다.
+ * @return 등장 횟수입니다. CharSequence가 `null`이면 0입니다.
  */
 fun CharSequence.countMatches(ch: Char): Int =
     StringUtils.countMatches(this, ch)
 
 /**
- * Counts how many times the substring appears in the larger string.
- * Note that the code only counts non-overlapping matches.
+ * 큰 문자열 안에 부분 문자열이 몇 번 등장하는지 셉니다.
+ * 겹치지 않는 매치만 셉니다.
  *
  * A `null` or empty ("") String input returns {@code 0}.
  *
@@ -468,9 +468,9 @@ fun CharSequence.countMatches(ch: Char): Int =
  * StringUtils.countMatches("ababa", "aba") = 1
  * ```
  *
- * @receiver the CharSequence to check, may be null
- * @param sub  the substring to count, may be null
- * @return the number of occurrences, 0 if either CharSequence is `null`
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param sub 셀 부분 문자열입니다. `null`일 수 있습니다.
+ * @return 등장 횟수입니다. 어느 CharSequence라도 `null`이면 0입니다.
  */
 fun CharSequence.countMatches(sub: CharSequence): Int =
     StringUtils.countMatches(this, sub)
@@ -516,13 +516,13 @@ fun <T: CharSequence> T.defaultIfEmpty(defaultValue: T): T = this.ifEmpty { defa
  * StringUtils.deleteWhitespace("   ab  c  ") = "abc"
  * ```
  *
- * @receiver  the String to delete whitespace from, may be null
+ * @receiver 공백을 제거할 문자열입니다. `null`일 수 있습니다.
  * @return the String without whitespaces, `null` if null String input
  */
 fun String.deleteWhitespace(): String = StringUtils.deleteWhitespace(this)
 
 /**
- * Compares two Strings, and returns the portion where they differ.
+ * 두 문자열을 비교하고 서로 달라지는 부분을 반환합니다.
  * More precisely, return the remainder of the second String,
  * starting from where it's different from the first. This means that
  * the difference between "abc" and "ab" is the empty String and not "c".
@@ -544,9 +544,9 @@ fun String.deleteWhitespace(): String = StringUtils.deleteWhitespace(this)
  * StringUtils.difference("abcde", "xyz")   = "xyz"
  * ```
  *
- * @receiver  the first String
- * @param other  the second String, may be null
- * @return the portion of str2 where it differs from str1; returns the empty String if they are equal
+ * @receiver 첫 번째 문자열입니다.
+ * @param other 두 번째 문자열입니다. `null`일 수 있습니다.
+ * @return `str1`과 다른 `str2`의 부분입니다. 같으면 빈 문자열을 반환합니다.
  */
 fun String.deference(other: String): String = StringUtils.difference(this, other)
 
@@ -582,10 +582,10 @@ fun String.endsWithAny(vararg searchStrings: String): Boolean = Strings.CS.endsW
 fun String.endsWithIgnoreCase(suffix: CharSequence): Boolean = Strings.CI.endsWith(this, suffix)
 
 /**
- * Checks if a String contains Unicode digits,
+ * 문자열이 유니코드 숫자를 포함하는지 확인하고,
  * if yes then concatenate all the digits in String and return it as a String.
  *
- * An empty ("") String will be returned if no digits found in {@code str}.
+ * {@code str\}에서 숫자를 찾지 못하면 빈 문자열("")을 반환합니다.
  *
  * ```
  * StringUtils.getDigits("")                   = ""
@@ -596,8 +596,8 @@ fun String.endsWithIgnoreCase(suffix: CharSequence): Boolean = Strings.CI.endsWi
  * StringUtils.getDigits("\u0967\u0968\u0969") = "\u0967\u0968\u0969"
  * ```
  *
- * @receiver the String to extract digits from
- * @return String with only digits,
+ * @receiver 숫자만 추출할 문자열입니다.
+ * @return 숫자만 포함한 문자열입니다,
  *           or an empty ("") String if no digits found,
  *           or `null` String if {@code str} is null
  */
@@ -605,7 +605,7 @@ fun String.getDigits(): String = StringUtils.getDigits(this)
 
 
 /**
- * Find the first index of any of a set of potential substrings.
+ * 후보 부분 문자열 집합 중 하나가 처음 나타나는 인덱스를 찾습니다.
  *
  * A `null` CharSequence will return `-1`.
  * A `null` or zero length search array will return `-1`.
@@ -625,15 +625,15 @@ fun String.getDigits(): String = StringUtils.getDigits(this)
  * StringUtils.indexOfAny("", ["a"])                    = -1
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param searchStrs  the CharSequences to search for, may be null
- * @return the first index of any of the searchStrs in str, -1 if no match
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param searchStrs 검색할 CharSequence입니다. `null`일 수 있습니다.
+ * @return `str`에서 `searchStrs` 중 하나가 처음 나타나는 인덱스입니다. 매치가 없으면 -1입니다.
  */
 fun CharSequence.indexOfAny(vararg searchStrs: CharSequence): Int = StringUtils.indexOfAny(this, *searchStrs)
 
 /**
  * Search a CharSequence to find the first index of any
- * character in the given set of characters.
+ * character in the given 확인합니다.
  *
  * A `null` String will return `-1`.
  * A `null` search string will return `-1`.
@@ -647,15 +647,15 @@ fun CharSequence.indexOfAny(vararg searchStrs: CharSequence): Int = StringUtils.
  * StringUtils.indexOfAny("aba", "z")         = -1
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @param searchStr  the chars to search for, may be null
- * @return the index of any of the chars, -1 if no match or null input
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param searchStr 검색할 문자입니다. `null`일 수 있습니다.
+ * @return 문자 중 하나의 인덱스입니다. 매치가 없거나 입력이 `null`이면 -1입니다.
  */
 fun CharSequence.indexOfAny(searchStr: String?): Int = StringUtils.indexOfAny(this, searchStr)
 
 
 /**
- * Compares all CharSequences in an array and returns the index at which the
+ * 배열의 모든 CharSequence를 비교하고
  * CharSequences begin to differ.
  *
  * For example,
@@ -683,14 +683,14 @@ fun CharSequence.indexOfAny(searchStr: String?): Int = StringUtils.indexOfAny(th
  * StringUtils.indexOfDifference(new String[] {"i am a machine", "i am a robot"}) = 7
  * ```
  *
- * @param css  array of CharSequences, entries may be null
- * @return the index where the strings begin to differ; -1 if they are all equal
+ * @param css CharSequence 배열입니다. 각 항목은 `null`일 수 있습니다.
+ * @return 문자열들이 달라지기 시작하는 인덱스입니다. 모두 같으면 -1입니다.
  */
 fun indexOfDifference(vararg css: CharSequence): Int = StringUtils.indexOfDifference(*css)
 
 
 /**
- * Compares two CharSequences, and returns the index at which the
+ * 두 CharSequence를 비교하고
  * CharSequences begin to differ.
  *
  * For example,
@@ -708,9 +708,9 @@ fun indexOfDifference(vararg css: CharSequence): Int = StringUtils.indexOfDiffer
  * StringUtils.indexOfDifference("abcde", "xyz")   = 0
  * ```
  *
- * @receiver  the first CharSequence
- * @param other  the second CharSequence, may be null
- * @return the index where cs1 and cs2 begin to differ; -1 if they are equal
+ * @receiver 첫 번째 CharSequence입니다.
+ * @param other 두 번째 CharSequence입니다. `null`일 수 있습니다.
+ * @return `cs1`과 `cs2`가 달라지기 시작하는 인덱스입니다. 같으면 -1입니다.
  */
 fun CharSequence.indexOfDifference(other: CharSequence?): Int = StringUtils.indexOfDifference(this, other)
 
@@ -731,9 +731,9 @@ fun CharSequence.indexOfIgnoreCase(searchStr: CharSequence, startPos: Int = 0): 
     Strings.CI.indexOf(this, searchStr, startPos)
 
 /**
- * Checks if the CharSequence contains only Unicode letters.
+ * CharSequence가 유니코드 문자만 포함하는지 확인합니다.
  *
- * An empty CharSequence (length()=0) will return `false`.
+ * 빈 CharSequence(length()=0)는 `false`를 반환합니다.
  *
  * ```
  * StringUtils.isAlpha("")     = false
@@ -743,15 +743,15 @@ fun CharSequence.indexOfIgnoreCase(searchStr: CharSequence, startPos: Int = 0): 
  * StringUtils.isAlpha("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check, may be null
- * @return `true` if only contains letters, and is non-null
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @return `null`이 아니고 문자만 포함하면 `true`입니다.
  */
 fun CharSequence.isAlpha(): Boolean = StringUtils.isAlpha(this)
 
 /**
- * Checks if the CharSequence contains only Unicode letters or digits.
+ * CharSequence가 유니코드 문자 또는 숫자만 포함하는지 확인합니다.
  *
- * An empty CharSequence (length()=0) will return `false`.
+ * 빈 CharSequence(length()=0)는 `false`를 반환합니다.
  *
  * ```
  * StringUtils.isAlphanumeric("")     = false
@@ -762,16 +762,16 @@ fun CharSequence.isAlpha(): Boolean = StringUtils.isAlpha(this)
  * StringUtils.isAlphanumeric("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return {@code true} if only contains letters or digits, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 문자 또는 숫자만 포함하면 {@code true\}입니다.
  */
 fun CharSequence.isAlphaNumeric(): Boolean = StringUtils.isAlphanumeric(this)
 
 /**
- * Checks if the CharSequence contains only Unicode letters, digits
+ * CharSequence가 유니코드 문자, 숫자
  * or space ({@code ' '}).
  *
- * An empty CharSequence (length()=0) will return `true`.
+ * 빈 CharSequence(length()=0)는 `true`를 반환합니다.
  *
  * ```
  * StringUtils.isAlphanumericSpace("")     = true
@@ -782,16 +782,16 @@ fun CharSequence.isAlphaNumeric(): Boolean = StringUtils.isAlphanumeric(this)
  * StringUtils.isAlphanumericSpace("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains letters, digits or space, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 문자, 숫자 또는 공백만 포함하면 `true`입니다.
  */
 fun CharSequence.isAlphaNumericSpace(): Boolean = StringUtils.isAlphanumericSpace(this)
 
 /**
- * Checks if the CharSequence contains only Unicode letters or space
+ * CharSequence가 유니코드 문자 또는 공백만 포함하는지 확인합니다
  * ({@code ' '}).
  *
- * An empty CharSequence (length()=0) will return `true`.
+ * 빈 CharSequence(length()=0)는 `true`를 반환합니다.
  *
  * ```
  * StringUtils.isAlphaSpace("")     = true
@@ -802,14 +802,14 @@ fun CharSequence.isAlphaNumericSpace(): Boolean = StringUtils.isAlphanumericSpac
  * StringUtils.isAlphaSpace("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains letters or space, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 문자 또는 공백만 포함하면 `true`입니다.
  */
 fun CharSequence.isAlphaSpace(): Boolean = StringUtils.isAlphaSpace(this)
 
 
 /**
- * Checks if the CharSequence contains only ASCII printable characters.
+ * CharSequence가 출력 가능한 ASCII 문자만 포함하는지 확인합니다.
  *
  * An empty CharSequence (length()=0) will return `true`
  *
@@ -826,13 +826,13 @@ fun CharSequence.isAlphaSpace(): Boolean = StringUtils.isAlphaSpace(this)
  * StringUtils.isAsciiPrintable("Ceki G\u00fclc\u00fc") = false
  * ```
  *
- * @receiver the CharSequence to check
- * @return `true` if every character is in the range 32 through 126
+ * @receiver 검사할 CharSequence입니다.
+ * @return 모든 문자가 32부터 126 범위에 있으면 `true`입니다.
  */
 fun CharSequence.isAsciiPrintable(): Boolean = StringUtils.isAsciiPrintable(this)
 
 /**
- * Checks if the CharSequence contains mixed casing of both uppercase and lowercase characters.
+ * CharSequence가 대문자와 소문자를 모두 포함하는지 확인합니다.
  *
  * An empty CharSequence ({@code length()=0}) will return `false`
  *
@@ -848,13 +848,13 @@ fun CharSequence.isAsciiPrintable(): Boolean = StringUtils.isAsciiPrintable(this
  * StringUtils.isMixedCase("aC\t")  = true
  * ```
  *
- * @receiver the CharSequence to check
- * @return `true` if the CharSequence contains both uppercase and lowercase characters
+ * @receiver 검사할 CharSequence입니다.
+ * @return CharSequence가 대문자와 소문자를 모두 포함하면 `true`입니다.
  */
 fun CharSequence.isMixedCase(): Boolean = StringUtils.isMixedCase(this)
 
 /**
- * Checks if the CharSequence contains only Unicode digits.
+ * CharSequence가 유니코드 숫자만 포함하는지 확인합니다.
  * A decimal point is not a Unicode digit and returns false.
  *
  * <p>`null` will return {@code false}.
@@ -878,16 +878,16 @@ fun CharSequence.isMixedCase(): Boolean = StringUtils.isMixedCase(this)
  * StringUtils.isNumeric("+123") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains digits, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 숫자만 포함하면 `true`입니다.
  */
 fun CharSequence.isNumeric(): Boolean = StringUtils.isNumeric(this)
 
 /**
- * Checks if the CharSequence contains only Unicode digits or space (`' '`).
+ * CharSequence가 유니코드 숫자 또는 공백(`' '`)만 포함하는지 확인합니다.
  * A decimal point is not a Unicode digit and returns false.
  *
- * An empty CharSequence (length()=0) will return `true`.
+ * 빈 CharSequence(length()=0)는 `true`를 반환합니다.
  *
  * ```
  * StringUtils.isNumericSpace(null)   = false
@@ -902,15 +902,15 @@ fun CharSequence.isNumeric(): Boolean = StringUtils.isNumeric(this)
  * StringUtils.isNumericSpace("12.3") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains digits or space, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 숫자 또는 공백만 포함하면 `true`입니다.
  */
 fun CharSequence.isNumericSpace(): Boolean = StringUtils.isNumericSpace(this)
 
 /**
- * Checks if the CharSequence contains only whitespace.
+ * CharSequence가 공백만 포함하는지 확인합니다.
  *
- * Whitespace is defined by {@link Character#isWhitespace(char)}.
+ * 공백은 \{@link Character#isWhitespace(char)\} 기준으로 정의합니다.
  *
  * An empty CharSequence (length()=0) will return `true`
  *
@@ -922,13 +922,13 @@ fun CharSequence.isNumericSpace(): Boolean = StringUtils.isNumericSpace(this)
  * StringUtils.isWhitespace("ab-c") = false
  * ```
  *
- * @receiver  the CharSequence to check
- * @return `true` if only contains whitespace, and is non-null
+ * @receiver 검사할 CharSequence입니다.
+ * @return `null`이 아니고 공백만 포함하면 `true`입니다.
  */
 fun CharSequence.isWhiteSpace(): Boolean = StringUtils.isWhitespace(this)
 
 /**
- * Find the latest index of any substring in a set of potential substrings.
+ * 후보 부분 문자열 집합 중 하나가 마지막으로 나타나는 인덱스를 찾습니다.
  *
  * <p>A `null` CharSequence will return {@code -1}.
  * A `null` search array will return {@code -1}.
@@ -945,9 +945,9 @@ fun CharSequence.isWhiteSpace(): Boolean = StringUtils.isWhitespace(this)
  * StringUtils.lastIndexOfAny("zzabyycdxx", ["mn", ""])   = 10
  * ```
  *
- * @receiver  the CharSequence to check
- * @param searchStrs  the CharSequences to search for, may be null
- * @return the last index of any of the CharSequences, -1 if no match
+ * @receiver 검사할 CharSequence입니다.
+ * @param searchStrs 검색할 CharSequence입니다. `null`일 수 있습니다.
+ * @return CharSequence 중 하나가 마지막으로 나타나는 인덱스입니다. 매치가 없으면 -1입니다.
  */
 fun CharSequence.lastIndexOfAny(vararg searchStrs: CharSequence): Int =
     StringUtils.lastIndexOfAny(this, *searchStrs)
@@ -957,7 +957,7 @@ fun CharSequence.lastIndexOfAny(vararg searchStrs: CharSequence): Int =
  * from the specified position.
  *
  * A negative start position returns {@code -1}.
- * An empty ("") search CharSequence always matches unless the start position is negative.
+ * 빈 검색 CharSequence("")는 시작 위치가 음수가 아니면 항상 일치합니다.
  * A start position greater than the string length searches the whole string.
  * The search starts at the startPos and works backwards; matches starting after the start
  * position are ignored.
@@ -972,16 +972,16 @@ fun CharSequence.lastIndexOfAny(vararg searchStrs: CharSequence): Int =
  * StringUtils.lastIndexOfIgnoreCase("aabaabaa", "B", 0)  = -1
  * ```
  *
- * @receiver  the CharSequence to check
+ * @receiver 검사할 CharSequence입니다.
  * @param searchStr  the CharSequence to find, may be null
  * @param startPos  the start position
- * @return the last index of the search CharSequence (always <= startPos), -1 if no match
+ * @return 검색 CharSequence의 마지막 인덱스입니다(항상 startPos 이하). 매치가 없으면 -1입니다.
  */
 fun CharSequence.lastIndexOfIgnoreCase(searchStr: CharSequence?, startPos: Int = length): Int =
     Strings.CI.lastIndexOf(this, searchStr, startPos)
 
 /**
- * Left pad a String with a specified character.
+ * 지정한 문자로 문자열 왼쪽을 채웁니다.
  *
  * <p>Pad to a size of {@code size}.</p>
  *
@@ -993,10 +993,10 @@ fun CharSequence.lastIndexOfIgnoreCase(searchStr: CharSequence?, startPos: Int =
  * StringUtils.leftPad("bat", -1, 'z') = "bat"
  * ```
  *
- * @receiver  the String to pad out
- * @param size  the size to pad to
- * @param padChar  the character to pad with
- * @return left padded String or original String if no padding is necessary,
+ * @receiver 채울 대상 문자열입니다.
+ * @param size 채운 뒤의 크기입니다.
+ * @param padChar 채움에 사용할 문자입니다.
+ * @return 왼쪽이 채워진 문자열입니다. 채움이 필요 없으면 원래 문자열입니다,
  *  `null` if null String input
  * @since 2.0
  */
@@ -1004,9 +1004,9 @@ fun String.leftPad(size: Int, padChar: Char = ' '): String =
     StringUtils.leftPad(this, size, padChar)
 
 /**
- * Left pad a String with a specified String.
+ * 지정한 문자열로 문자열 왼쪽을 채웁니다.
  *
- * Pad to a size of `size`.
+ * `size` 크기가 되도록 채웁니다.
  *
  * ```
  * StringUtils.leftPad("", 3, "z")      = "zzz"
@@ -1018,10 +1018,10 @@ fun String.leftPad(size: Int, padChar: Char = ' '): String =
  * StringUtils.leftPad("bat", 5, "")    = "  bat"
  * ```
  *
- * @receiver the String to pad out
- * @param size  the size to pad to
- * @param padStr  the String to pad with, null or empty treated as single space
- * @return left padded String or original String if no padding is necessary,
+ * @receiver 채울 대상 문자열입니다.
+ * @param size 채운 뒤의 크기입니다.
+ * @param padStr 채움에 사용할 문자열입니다. `null` 또는 빈 값은 단일 공백으로 처리합니다.
+ * @return 왼쪽이 채워진 문자열입니다. 채움이 필요 없으면 원래 문자열입니다,
  *  `null` if null String input
  */
 fun String.leftPad(size: Int, padStr: String): String =
@@ -1029,11 +1029,11 @@ fun String.leftPad(size: Int, padStr: String): String =
 
 
 /**
- * Removes all occurrences of a substring from within the source string.
+ * 원본 문자열 안의 모든 부분 문자열 등장 위치를 제거합니다.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` remove string will return the source string.
- * An empty ("") remove string will return the source string.
+ * 빈 제거 문자열("")은 원본 문자열을 반환합니다.
  *
  * ```
  * StringUtils.remove("", *)          = ""
@@ -1043,9 +1043,9 @@ fun String.leftPad(size: Int, padStr: String): String =
  * StringUtils.remove("queued", "zz") = "queued"
  * ```
  *
- * @receiver  the source String to search
- * @param remove  the String to search for and remove, may be null
- * @return the substring with the string removed if found, `null` if null String input
+ * @receiver 검색할 원본 문자열입니다.
+ * @param remove 검색 후 제거할 문자열입니다. `null`일 수 있습니다.
+ * @return 문자열을 찾으면 제거한 부분 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.remove(remove: String?): String = Strings.CS.remove(this, remove)
 
@@ -1053,7 +1053,7 @@ fun String.remove(remove: String?): String = Strings.CS.remove(this, remove)
  * Removes a substring only if it is at the end of a source string,
  * otherwise returns the source string.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` search string will return the source string.</p>
  *
  * ```
@@ -1065,17 +1065,17 @@ fun String.remove(remove: String?): String = Strings.CS.remove(this, remove)
  * StringUtils.removeEnd("abc", "")    = "abc"
  * ```
  *
- * @receiver  the source String to search, may be null
- * @param remove  the String to search for and remove, may be null
- * @return the substring with the string removed if found, `null` if null String input
+ * @receiver 검색할 원본 문자열입니다. `null`일 수 있습니다.
+ * @param remove 검색 후 제거할 문자열입니다. `null`일 수 있습니다.
+ * @return 문자열을 찾으면 제거한 부분 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.removeEnd(remove: String): String = Strings.CS.removeEnd(this, remove)
 
 /**
- * Case insensitive removal of a substring if it is at the end of a source string,
+ * 원본 문자열 끝에 있는 부분 문자열을 대소문자 구분 없이 제거합니다,
  * otherwise returns the source string.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` search string will return the source string.
  *
  * ```
@@ -1089,9 +1089,9 @@ fun String.removeEnd(remove: String): String = Strings.CS.removeEnd(this, remove
  * StringUtils.removeEndIgnoreCase("www.domain.COM", ".com") = "www.domain")
  * ```
  *
- * @receiver  the source String to search, may be null
+ * @receiver 검색할 원본 문자열입니다. `null`일 수 있습니다.
  * @param remove  the String to search for (case-insensitive) and remove, may be null
- * @return the substring with the string removed if found, `null` if null String input
+ * @return 문자열을 찾으면 제거한 부분 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.removeEndIgnoreCase(remove: String): String = Strings.CI.removeEnd(this, remove)
 
@@ -1099,7 +1099,7 @@ fun String.removeEndIgnoreCase(remove: String): String = Strings.CI.removeEnd(th
  * Removes a substring only if it is at the beginning of a source string,
  * otherwise returns the source string.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` search string will return the source string.
  *
  * ```
@@ -1112,17 +1112,17 @@ fun String.removeEndIgnoreCase(remove: String): String = Strings.CI.removeEnd(th
  * StringUtils.removeStart("abc", "")    = "abc"
  * ```
  *
- * @receiver  the source String to search
- * @param remove  the String to search for and remove, may be null
- * @return the substring with the string removed if found, `null` if null String input
+ * @receiver 검색할 원본 문자열입니다.
+ * @param remove 검색 후 제거할 문자열입니다. `null`일 수 있습니다.
+ * @return 문자열을 찾으면 제거한 부분 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.removeStart(remove: String): String = Strings.CS.removeStart(this, remove)
 
 /**
- * Case insensitive removal of a substring if it is at the beginning of a source string,
+ * 원본 문자열 시작에 있는 부분 문자열을 대소문자 구분 없이 제거합니다,
  * otherwise returns the source string.
  *
- * An empty ("") source string will return the empty string.
+ * 빈 원본 문자열("")은 빈 문자열을 반환합니다.
  * A `null` search string will return the source string.
  *
  * ```
@@ -1136,7 +1136,7 @@ fun String.removeStart(remove: String): String = Strings.CS.removeStart(this, re
  * StringUtils.removeStartIgnoreCase("abc", "")    = "abc"
  * ```
  *
- * @receiver  the source String to search, may be null
+ * @receiver 검색할 원본 문자열입니다. `null`일 수 있습니다.
  * @param remove  the String to search for (case-insensitive) and remove, may be null
  * @return the substring with the string removed if found,
  *  `null` if null String input
@@ -1163,7 +1163,7 @@ fun String.removeStartIgnoreCase(remove: String): String = Strings.CI.removeStar
 fun String.repeat(separator: String?, repeat: Int): String = StringUtils.repeat(this, separator, repeat)
 
 /**
- * Case insensitively replaces a String with another String inside a larger String,
+ * 대소문자를 무시하고 큰 문자열 안의 문자열을 다른 문자열로 교체합니다,
  * for the first {@code max} values of the search String.
  *
  *
@@ -1181,17 +1181,17 @@ fun String.repeat(separator: String?, repeat: Int): String = StringUtils.repeat(
  * StringUtils.replaceIgnoreCase("abAa", "a", "z", -1)  = "zbzz"
  * ```
  *
- * @receiver  text to search and replace in
- * @param searchStr  the String to search for (case-insensitive), may be null
- * @param replacement  the String to replace it with, may be null
+ * @receiver 검색하고 치환할 텍스트입니다.
+ * @param searchStr 대소문자를 무시하고 검색할 문자열입니다. `null`일 수 있습니다.
+ * @param replacement 치환에 사용할 문자열입니다. `null`일 수 있습니다.
  * @param max  maximum number of values to replace, or {@code -1} if no maximum
- * @return the text with any replacements processed, `null` if null String input
+ * @return 치환을 처리한 텍스트입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.replaceIgnoreCase(searchStr: String?, replacement: String?, max: Int = -1): String =
     Strings.CI.replace(this, searchStr, replacement, max)
 
 /**
- * Replaces a String with another String inside a larger String, once.
+ * 큰 문자열 안의 문자열을 다른 문자열로 한 번 교체합니다.
  *
  * ```
  * StringUtils.replaceOnce(null, *, *)        = null
@@ -1204,17 +1204,17 @@ fun String.replaceIgnoreCase(searchStr: String?, replacement: String?, max: Int 
  * StringUtils.replaceOnce("aba", "a", "z")   = "zba"
  * ```
  *
- * @receiver text to search and replace in
- * @param searchString  the String to search for, may be null
- * @param replacement  the String to replace with, may be null
- * @return the text with any replacements processed, `null` if null String input
+ * @receiver 검색하고 치환할 텍스트입니다.
+ * @param searchString 검색할 문자열입니다. `null`일 수 있습니다.
+ * @param replacement 치환에 사용할 문자열입니다. `null`일 수 있습니다.
+ * @return 치환을 처리한 텍스트입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.replaceOnce(searchString: String?, replacement: String?): String {
     return Strings.CS.replace(this, searchString, replacement, 1)
 }
 
 /**
- * Case insensitively replaces a String with another String inside a larger String, once.
+ * 대소문자를 무시하고 큰 문자열 안의 문자열을 다른 문자열로 한 번 교체합니다.
  *
  * ```
  * StringUtils.replaceOnceIgnoreCase(null, *, *)        = null
@@ -1229,17 +1229,17 @@ fun String.replaceOnce(searchString: String?, replacement: String?): String {
  * ```
  *
  * @see replaceIgnoreCase
- * @receiver  text to search and replace in
- * @param searchString  the String to search for (case-insensitive), may be null
- * @param replacement  the String to replace with, may be null
- * @return the text with any replacements processed, `null` if null String input
+ * @receiver 검색하고 치환할 텍스트입니다.
+ * @param searchString 대소문자를 무시하고 검색할 문자열입니다. `null`일 수 있습니다.
+ * @param replacement 치환에 사용할 문자열입니다. `null`일 수 있습니다.
+ * @return 치환을 처리한 텍스트입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.replaceOnceIgnoreCase(searchString: String?, replacement: String?): String {
     return Strings.CI.replace(this, searchString, replacement, 1)
 }
 
 /**
- * Gets the rightmost {@code len} characters of a String.
+ * 문자열의 오른쪽 끝 {@code len\}개 문자를 가져옵니다.
  *
  * If `len` characters are not available, or the String
  * is `null`, the String will be returned without an
@@ -1253,16 +1253,16 @@ fun String.replaceOnceIgnoreCase(searchString: String?, replacement: String?): S
  * StringUtils.right("abc", 4)   = "abc"
  * ```
  *
- * @receiver  the String to get the rightmost characters from, may be null
- * @param len  the length of the required String
- * @return the rightmost characters, `null` if null String input
+ * @receiver 오른쪽 끝 문자를 가져올 문자열입니다. `null`일 수 있습니다.
+ * @param len 필요한 문자열 길이입니다.
+ * @return 오른쪽 끝 문자입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.right(len: Int): String = StringUtils.right(this, len)
 
 /**
- * Right pad a String with a specified character.
+ * 지정한 문자로 문자열 오른쪽을 채웁니다.
  *
- * The String is padded to the size of `size`.
+ * 문자열을 `size` 크기가 되도록 채웁니다.
  *
  * ```
  * StringUtils.rightPad("", 3, 'z')     = "zzz"
@@ -1272,17 +1272,17 @@ fun String.right(len: Int): String = StringUtils.right(this, len)
  * StringUtils.rightPad("bat", -1, 'z') = "bat"
  * ```
  *
- * @receiver  the String to pad out
- * @param size  the size to pad to
- * @param padChar  the character to pad with
- * @return right padded String or original String if no padding is necessary, `null` if null String input
+ * @receiver 채울 대상 문자열입니다.
+ * @param size 채운 뒤의 크기입니다.
+ * @param padChar 채움에 사용할 문자입니다.
+ * @return 오른쪽이 채워진 문자열입니다. 채움이 필요 없으면 원래 문자열, 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.rightPad(size: Int, padChar: Char = ' '): String = StringUtils.rightPad(this, size, padChar)
 
 /**
- * Right pad a String with a specified String.
+ * 지정한 문자열로 문자열 오른쪽을 채웁니다.
  *
- * The String is padded to the size of `size`.
+ * 문자열을 `size` 크기가 되도록 채웁니다.
  *
  * ```
  * StringUtils.rightPad("", 3, "z")      = "zzz"
@@ -1295,15 +1295,15 @@ fun String.rightPad(size: Int, padChar: Char = ' '): String = StringUtils.rightP
  * StringUtils.rightPad("bat", 5, "")    = "bat  "
  * ```
  *
- * @receiver the String to pad out
- * @param size  the size to pad to
- * @param padStr  the String to pad with, null or empty treated as single space
- * @return right padded String or original String if no padding is necessary, `null` if null String input
+ * @receiver 채울 대상 문자열입니다.
+ * @param size 채운 뒤의 크기입니다.
+ * @param padStr 채움에 사용할 문자열입니다. `null` 또는 빈 값은 단일 공백으로 처리합니다.
+ * @return 오른쪽이 채워진 문자열입니다. 채움이 필요 없으면 원래 문자열, 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.rightPad(size: Int, padStr: String): String = StringUtils.rightPad(this, size, padStr)
 
 /**
- * Check if a CharSequence starts with any of the provided case-sensitive prefixes.
+ * CharSequence가 제공된 대소문자 구분 접두사 중 하나로 시작하는지 확인합니다.
  *
  * ```
  * StringUtils.startsWithAny(null, new String[] {"abc"})  = false
@@ -1315,17 +1315,17 @@ fun String.rightPad(size: Int, padStr: String): String = StringUtils.rightPad(th
  * StringUtils.startsWithAny("ABCXYZ", null, "xyz", "abc") = false
  * ```
  *
- * @receiver the CharSequence to check
- * @param searchStrs the case-sensitive CharSequence prefixes, may be empty or `null`
+ * @receiver 검사할 CharSequence입니다.
+ * @param searchStrs 대소문자를 구분하는 CharSequence 접두사입니다. 비어 있거나 `null`일 수 있습니다.
  * @see StringUtils#startsWith(CharSequence, CharSequence)
- * @return {@code true} if the input {@code sequence} is `null` AND no {@code searchStrings} are provided, or
+ * @return 입력 {@code sequence\}가 `null`이고 {@code searchStrings\}가 제공되지 않았거나,
  *   the input {@code sequence} begins with any of the provided case-sensitive {@code searchStrings}.
  */
 fun CharSequence.startsWithAny(vararg searchStrs: CharSequence?): Boolean =
     Strings.CS.startsWithAny(this, *searchStrs)
 
 /**
- * Case insensitive check if a CharSequence starts with a specified prefix.
+ * 대소문자를 무시하고 CharSequence가 지정한 접두사로 시작하는지 확인합니다.
  *
  * references are considered to be equal. The comparison is case insensitive.
  *
@@ -1337,23 +1337,23 @@ fun CharSequence.startsWithAny(vararg searchStrs: CharSequence?): Boolean =
  * ```
  *
  * @see String#startsWith(String)
- * @receiver  the CharSequence to check, may be null
- * @param prefix the prefix to find, may be null
- * @return {@code true} if the CharSequence starts with the prefix, case-insensitive, or both `null`
+ * @receiver 검사할 CharSequence입니다. `null`일 수 있습니다.
+ * @param prefix 찾을 접두사입니다. `null`일 수 있습니다.
+ * @return 대소문자를 무시하고 CharSequence가 접두사로 시작하거나 둘 다 `null`이면 {@code true\}입니다.
  */
 fun CharSequence.startsWithIgnoreCase(prefix: CharSequence?): Boolean =
     Strings.CI.startsWith(this, prefix)
 
 /**
- * Strips any of a set of characters from the start and end of a String.
+ * 문자열의 시작과 끝에서 지정한 문자 집합을 제거합니다.
  * This is similar to {@link String#trim()} but allows the characters
  * to be stripped to be controlled.
  *
- * An empty string ("") input returns the empty string.
+ * 빈 문자열("") 입력은 빈 문자열을 반환합니다.
  *
  * If the stripChars String is `null`, whitespace is
  * stripped as defined by `Character#isWhitespace(char)`.
- * Alternatively use `String.strip(String)`.
+ * 또는 `String.strip(String)`을 사용합니다.
  *
  * ```
  * StringUtils.strip("", *)            = ""
@@ -1364,16 +1364,16 @@ fun CharSequence.startsWithIgnoreCase(prefix: CharSequence?): Boolean =
  * StringUtils.strip("  abcyx", "xyz") = "  abc"
  * ```
  *
- * @receiver the String to remove characters from, may be null
- * @param stripStr  the characters to remove, null treated as whitespace
- * @return the stripped String, `null` if null String input
+ * @receiver 문자를 제거할 문자열입니다. `null`일 수 있습니다.
+ * @param stripStr 제거할 문자입니다. `null`은 공백으로 처리합니다.
+ * @return 제거 처리된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.strip(stripStr: String? = null): String = StringUtils.strip(this, stripStr)
 
 /**
- * Strips any of a set of characters from the end of a String.
+ * 문자열 끝에서 지정한 문자 집합을 제거합니다.
  *
- * An empty string ("") input returns the empty string.
+ * 빈 문자열("") 입력은 빈 문자열을 반환합니다.
  *
  * If the stripStr String is `null`, whitespace is
  * stripped as defined by `Character#isWhitespace(char)`.
@@ -1389,16 +1389,16 @@ fun String.strip(stripStr: String? = null): String = StringUtils.strip(this, str
  * StringUtils.stripEnd("120.00", ".0")   = "12"
  * ```
  *
- * @receiver  the String to remove characters from, may be null
- * @param stripStr  the set of characters to remove, null treated as whitespace
- * @return the stripped String, `null` if null String input
+ * @receiver 문자를 제거할 문자열입니다. `null`일 수 있습니다.
+ * @param stripStr 제거할 문자 집합입니다. `null`은 공백으로 처리합니다.
+ * @return 제거 처리된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.stripEnd(stripStr: String? = null): String = StringUtils.stripEnd(this, stripStr)
 
 /**
- * Strips any of a set of characters from the start of a String.
+ * 문자열 시작에서 지정한 문자 집합을 제거합니다.
  *
- * An empty string ("") input returns the empty string.
+ * 빈 문자열("") 입력은 빈 문자열을 반환합니다.
  *
  * If the stripChars String is `null`, whitespace is
  * stripped as defined by `Character#isWhitespace(char)`.
@@ -1413,15 +1413,15 @@ fun String.stripEnd(stripStr: String? = null): String = StringUtils.stripEnd(thi
  * StringUtils.stripStart("yxabc  ", "xyz") = "abc  "
  * ```
  *
- * @receiver  the String to remove characters from, may be null
- * @param stripStr  the characters to remove, null treated as whitespace
- * @return the stripped String, `null` if null String input
+ * @receiver 문자를 제거할 문자열입니다. `null`일 수 있습니다.
+ * @param stripStr 제거할 문자입니다. `null`은 공백으로 처리합니다.
+ * @return 제거 처리된 문자열입니다. 입력 문자열이 `null`이면 `null`입니다.
  */
 fun String.stripStart(stripStr: String? = null): String = StringUtils.stripStart(this, stripStr)
 
 /**
- * Gets the String that is nested in between two Strings.
- * Only the first match is returned.
+ * 두 문자열 사이에 중첩된 문자열을 가져옵니다.
+ * 첫 번째 매치만 반환합니다.
  *
  * A `null` open/close returns `null` (no match).
  * An empty ("") open and close returns an empty string.</p>
@@ -1438,10 +1438,10 @@ fun String.stripStart(stripStr: String? = null): String = StringUtils.stripStart
  * StringUtils.substringBetween("yabczyabcz", "y", "z")   = "abc"
  * ```
  *
- * @receiver  the String containing the substring, may be null
- * @param open  the String before the substring, may be null
- * @param close  the String after the substring, may be null
- * @return the substring, `null` if no match
+ * @receiver 부분 문자열을 포함하는 문자열입니다. `null`일 수 있습니다.
+ * @param open 부분 문자열 앞의 문자열입니다. `null`일 수 있습니다.
+ * @param close 부분 문자열 뒤의 문자열입니다. `null`일 수 있습니다.
+ * @return 부분 문자열입니다. 매치가 없으면 `null`입니다.
  */
 fun String.substringBetween(open: String?, close: String?): String =
     StringUtils.substringBetween(this, open, close)
@@ -1451,7 +1451,7 @@ fun String.substringBetween(open: String?, close: String?): String =
  * returning all matching substrings in an array.
  *
  * A `null` open/close returns `null` (no match).
- * An empty ("") open/close returns `null` (no match).
+ * 빈 open/close 문자열("")은 `null`을 반환합니다(매치 없음).
  *
  * ```
  * StringUtils.substringsBetween("[a][b][c]", "[", "]") = ["a","b","c"]
@@ -1460,16 +1460,16 @@ fun String.substringBetween(open: String?, close: String?): String =
  * StringUtils.substringsBetween("", "[", "]")          = []
  * ```
  *
- * @receiver  the String containing the substrings, null returns null, empty returns empty
- * @param open  the String identifying the start of the substring, empty returns null
- * @param close  the String identifying the end of the substring, empty returns null
- * @return a String Array of substrings, or `null` if no match
+ * @receiver 부분 문자열들을 포함하는 문자열입니다. `null`이면 `null`, 빈 값이면 빈 값을 반환합니다.
+ * @param open 부분 문자열 시작을 식별하는 문자열입니다. 빈 값이면 `null`을 반환합니다.
+ * @param close 부분 문자열 끝을 식별하는 문자열입니다. 빈 값이면 `null`을 반환합니다.
+ * @return 부분 문자열의 String 배열입니다. 매치가 없으면 `null`입니다.
  */
 fun String.substringsBetween(open: String?, close: String?): Array<String> =
     StringUtils.substringsBetween(this, open, close)
 
 /**
- * Unwraps a given string from another string.
+ * 주어진 문자열에서 감싸는 문자열을 제거합니다.
  *
  * ```
  * StringUtils.unwrap("a", "a")           = "a"
@@ -1482,14 +1482,14 @@ fun String.substringsBetween(open: String?, close: String?): Array<String> =
  * StringUtils.unwrap("A#", "#")          = "A#"
  * ```
  *
- * @receiver the String to be unwrapped, can be null
- * @param wrapToken the String used to unwrap
- * @return unwrapped String or the original string if it is not quoted properly with the wrapToken
+ * @receiver 감싸는 토큰을 제거할 문자열입니다. `null`일 수 있습니다.
+ * @param wrapToken 감싸는 토큰을 제거하는 데 사용할 문자열입니다.
+ * @return 감싸는 토큰을 제거한 문자열입니다. `wrapToken`으로 올바르게 감싸져 있지 않으면 원래 문자열입니다.
  */
 fun String.unwrap(wrapToken: String): String = StringUtils.unwrap(this, wrapToken)
 
 /**
- * Wraps a String with another String.
+ * 문자열을 다른 문자열로 감쌉니다.
  *
  * ```
  * StringUtils.wrap("", *)           = ""
@@ -1503,8 +1503,8 @@ fun String.unwrap(wrapToken: String): String = StringUtils.unwrap(this, wrapToke
  * StringUtils.wrap("'abcd'", "\"")  = "\"'abcd'\""
  * ```
  *
- * @receiver the String to be wrapper, may be null
- * @param wrapWith the String that will wrap str
- * @return wrapped String
+ * @receiver 감쌀 문자열입니다. `null`일 수 있습니다.
+ * @param wrapWith `str`를 감쌀 문자열입니다.
+ * @return 감싸진 문자열입니다.
  */
 fun String.wrap(wrapWith: String): String = StringUtils.wrap(this, wrapWith)

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/CheckSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/support/CheckSupport.kt
@@ -7,12 +7,12 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
 /**
- * Provides the `checkNotNull` invariant check.
+ * `checkNotNull` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkNotNull("text")
@@ -31,12 +31,12 @@ inline fun <T: Any> T?.checkNotNull(lazyMessage: () -> Any): T {
 }
 
 /**
- * Provides the `checkNull` invariant check.
+ * `checkNull` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = (null as String?).checkNull("text")
@@ -55,12 +55,12 @@ inline fun <T: Any> T?.checkNull(lazyMessage: () -> Any): T? {
 }
 
 /**
- * Provides the `checkNotEmpty` invariant check.
+ * `checkNotEmpty` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkNotEmpty("text")
@@ -80,12 +80,12 @@ inline fun <T: CharSequence> T?.checkNotEmpty(lazyMessage: () -> Any): T {
 }
 
 /**
- * Provides the `checkNullOrEmpty` invariant check.
+ * `checkNullOrEmpty` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("" as String?).checkNullOrEmpty("text")
@@ -101,12 +101,12 @@ inline fun <T: CharSequence> T?.checkNullOrEmpty(lazyMessage: () -> Any): T? {
 }
 
 /**
- * Provides the `checkNotBlank` invariant check.
+ * `checkNotBlank` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkNotBlank("text")
@@ -126,12 +126,12 @@ inline fun <T: CharSequence> T?.checkNotBlank(lazyMessage: () -> Any): T {
 }
 
 /**
- * Provides the `checkNullOrBlank` invariant check.
+ * `checkNullOrBlank` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("   " as String?).checkNullOrBlank("text")
@@ -148,12 +148,12 @@ inline fun <T: CharSequence> T?.checkNullOrBlank(lazyMessage: () -> Any): T? {
 
 
 /**
- * Provides the `checkContains` invariant check.
+ * `checkContains` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkContains("lu", "text")
@@ -171,12 +171,12 @@ inline fun <T: CharSequence> T?.checkContains(other: CharSequence, lazyMessage: 
 
 
 /**
- * Provides the `checkStartsWith` invariant check.
+ * `checkStartsWith` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkStartsWith("bl", "text")
@@ -201,12 +201,12 @@ inline fun <T: CharSequence> T?.checkStartsWith(
 }
 
 /**
- * Provides the `checkEndsWith` invariant check.
+ * `checkEndsWith` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = ("blue" as String?).checkEndsWith("ue", "text")
@@ -231,12 +231,12 @@ inline fun <T: CharSequence> T?.checkEndsWith(
 }
 
 /**
- * Provides the `checkEquals` invariant check.
+ * `checkEquals` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 10.checkEquals(10, "value")
@@ -252,12 +252,12 @@ inline fun <T> T.checkEquals(expected: T, lazyMessage: () -> Any): T {
 }
 
 /**
- * Provides the `checkGt` invariant check.
+ * `checkGt` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 10.checkGt(1, "value")
@@ -272,12 +272,12 @@ inline fun <T: Comparable<T>> T.checkGt(expected: T, lazyMessage: () -> Any): T 
 }
 
 /**
- * Provides the `checkGe` invariant check.
+ * `checkGe` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 10.checkGe(10, "value")
@@ -292,12 +292,12 @@ inline fun <T: Comparable<T>> T.checkGe(expected: T, lazyMessage: () -> Any): T 
 }
 
 /**
- * Provides the `checkLt` invariant check.
+ * `checkLt` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 1.checkLt(10, "value")
@@ -312,12 +312,12 @@ inline fun <T: Comparable<T>> T.checkLt(expected: T, lazyMessage: () -> Any): T 
 }
 
 /**
- * Provides the `checkLe` invariant check.
+ * `checkLe` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 10.checkLe(10, "value")
@@ -332,12 +332,12 @@ inline fun <T: Comparable<T>> T.checkLe(expected: T, lazyMessage: () -> Any): T 
 }
 
 /**
- * Provides the `checkInRange` invariant check.
+ * `checkInRange` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 5.checkInRange(1, 10, "value")
@@ -352,12 +352,12 @@ inline fun <T: Comparable<T>> T.checkInRange(start: T, endInclusive: T, lazyMess
 }
 
 /**
- * Provides the `checkInOpenRange` invariant check.
+ * `checkInOpenRange` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 5.checkInOpenRange(1, 10, "value")
@@ -372,12 +372,12 @@ inline fun <T: Comparable<T>> T.checkInOpenRange(start: T, endExclusive: T, lazy
 }
 
 /**
- * Provides the `checkZeroOrPositiveNumber` invariant check.
+ * `checkZeroOrPositiveNumber` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 0.checkZeroOrPositiveNumber("value")
@@ -393,12 +393,12 @@ inline fun <T> T.checkZeroOrPositiveNumber(lazyMessage: () -> Any): T where T: N
 }
 
 /**
- * Provides the `checkPositiveNumber` invariant check.
+ * `checkPositiveNumber` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 1.checkPositiveNumber("value")
@@ -414,12 +414,12 @@ inline fun <T> T.checkPositiveNumber(lazyMessage: () -> Any): T where T: Number,
 }
 
 /**
- * Provides the `checkZeroOrNegativeNumber` invariant check.
+ * `checkZeroOrNegativeNumber` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = 0.checkZeroOrNegativeNumber("value")
@@ -435,12 +435,12 @@ inline fun <T> T.checkZeroOrNegativeNumber(lazyMessage: () -> Any): T where T: N
 }
 
 /**
- * Provides the `checkNegativeNumber` invariant check.
+ * `checkNegativeNumber` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = (-1).checkNegativeNumber("value")
@@ -458,10 +458,10 @@ inline fun <T> T.checkNegativeNumber(lazyMessage: () -> Any): T where T: Number,
 /**
  * Requires this array to be non-null and non-empty, then returns the same array.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = arrayOf(1, 2).checkNotEmpty("items")
@@ -480,10 +480,10 @@ inline fun <T> Array<T>?.checkNotEmpty(lazyMessage: () -> Any): Array<T> {
 /**
  * Requires this collection to be non-null and non-empty, then returns the same collection.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = listOf(1, 2).checkNotEmpty("items")
@@ -502,10 +502,10 @@ inline fun <T> Collection<T>?.checkNotEmpty(lazyMessage: () -> Any): Collection<
 /**
  * Requires this map to be non-null and non-empty, then returns the same map.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).checkNotEmpty("map")
@@ -522,12 +522,12 @@ inline fun <K, V> Map<K, V>?.checkNotEmpty(lazyMessage: () -> Any): Map<K, V> {
 }
 
 /**
- * Provides the `checkHasKey` invariant check.
+ * `checkHasKey` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).checkHasKey("a", "map")
@@ -545,12 +545,12 @@ inline fun <K, V> Map<K, V>?.checkHasKey(key: K, lazyMessage: () -> Any): Map<K,
 }
 
 /**
- * Provides the `checkHasValue` invariant check.
+ * `checkHasValue` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).checkHasValue(1, "map")
@@ -568,12 +568,12 @@ inline fun <K, V> Map<K, V>?.checkHasValue(value: V, lazyMessage: () -> Any): Ma
 }
 
 /**
- * Provides the `checkContains` invariant check.
+ * `checkContains` 불변 조건 검사를 제공합니다.
  *
- * ## Contract
- * - Throws [IllegalStateException] when the invariant is not satisfied.
- * - Returns the original receiver when the invariant is satisfied.
- * - Does not mutate the receiver.
+ * ## 계약
+ * - 불변 조건을 만족하지 않으면 [IllegalStateException]이 발생합니다.
+ * - 불변 조건을 만족하면 원래 수신 값을 반환합니다.
+ * - 수신 객체를 변경하지 않습니다.
  *
  * ```kotlin
  * val result = mapOf("a" to 1).checkContains("a", 1, "map")
@@ -591,7 +591,7 @@ inline fun <K, V> Map<K, V>?.checkContains(key: K, value: V, lazyMessage: () -> 
 }
 
 /**
- * Checks that a nullable character sequence has a length within the inclusive range.
+ * nullable 문자 시퀀스의 길이가 닫힌 범위 안에 있는지 확인합니다.
  *
  * ```kotlin
  * val id = ("order-42" as String?).checkLengthInRange(1, 80, "id")
@@ -614,7 +614,7 @@ inline fun <T: CharSequence> T?.checkLengthInRange(
 }
 
 /**
- * Checks that a nullable collection has a size within the inclusive range.
+ * nullable 컬렉션의 크기가 닫힌 범위 안에 있는지 확인합니다.
  *
  * ```kotlin
  * val items = (listOf(1, 2) as List<Int>?).checkSizeInRange(1, 50, "items")
@@ -637,7 +637,7 @@ inline fun <T> Collection<T>?.checkSizeInRange(
 }
 
 /**
- * Checks that a nullable map has a size within the inclusive range.
+ * nullable 맵의 크기가 닫힌 범위 안에 있는지 확인합니다.
  *
  * ```kotlin
  * val attributes = (mapOf("state" to "ready") as Map<String, String>?)
@@ -661,7 +661,7 @@ inline fun <K, V> Map<K, V>?.checkSizeInRange(
 }
 
 /**
- * Checks that a nullable array has a size within the inclusive range.
+ * nullable 배열의 크기가 닫힌 범위 안에 있는지 확인합니다.
  *
  * ```kotlin
  * val values = (arrayOf(1, 2) as Array<Int>?).checkSizeInRange(1, 10, "values")
@@ -684,7 +684,7 @@ inline fun <T> Array<T>?.checkSizeInRange(
 }
 
 /**
- * Checks that a nullable character sequence matches [regex].
+ * nullable 문자 시퀀스가 [regex]와 일치하는지 확인합니다.
  *
  * ```kotlin
  * val sku = ("SKU-42" as String?).checkMatches(Regex("SKU-\\d+"), "sku")
@@ -706,7 +706,7 @@ inline fun <T: CharSequence> T?.checkMatches(
 }
 
 /**
- * Checks that a `Float` value is finite.
+ * `Float` 값이 유한한지 확인합니다.
  *
  * ```kotlin
  * val ratio = 0.5f.checkFinite("ratio")
@@ -719,7 +719,7 @@ inline fun Float.checkFinite(parameterName: String, noinline lazyMessage: (() ->
 }
 
 /**
- * Checks that a `Double` value is finite.
+ * `Double` 값이 유한한지 확인합니다.
  *
  * ```kotlin
  * val ratio = 0.5.checkFinite("ratio")

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/FlowEvent.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/FlowEvent.kt
@@ -18,7 +18,7 @@ import io.bluetape4k.coroutines.flow.exceptions.FlowNoElementException
 sealed interface FlowEvent<out T> {
 
     /**
-     * Event containing a value.
+     * 값을 담는 이벤트입니다.
      *
      * Keep this as a data class. `FlowEvent.Value` is normally emitted as the
      * `FlowEvent<T>` interface type, where Kotlin/JVM value classes are boxed,
@@ -30,7 +30,7 @@ sealed interface FlowEvent<out T> {
     }
 
     /**
-     * Event containing an error.
+     * 오류를 담는 이벤트입니다.
      *
      * Keep this as a data class for the same compatibility and boxing reasons
      * as [Value]. When used as `FlowEvent<Nothing>`, a value-class variant would

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/Resumable.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/Resumable.kt
@@ -43,7 +43,7 @@ open class Resumable {
     private val continuation by continuationRef
 
     /**
-     * Suspends the current coroutine until [resume] is called externally.
+     * 외부에서 [resume]이 호출될 때까지 현재 코루틴을 일시 중단합니다.
      *
      * ## Behaviour / Contract
      * - Returns immediately without suspending if already in the READY state.

--- a/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/coroutines/KLoggingChannel.kt
+++ b/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/coroutines/KLoggingChannel.kt
@@ -208,7 +208,7 @@ open class KLoggingChannel(
     }
 
     /**
-     * 비동기 channel을 통해 전달되는 로그 이벤트입니다.
+     * 비동기 채널을 통해 전달되는 로그 이벤트입니다.
      *
      * ```kotlin
      * val event = LogEvent(Level.INFO, "server started", null)

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/cache2k/Cache2kSupport.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/cache2k/Cache2kSupport.kt
@@ -7,7 +7,7 @@ import org.cache2k.CacheManager
 import org.cache2k.config.Cache2kConfig
 
 /**
- * Default Cache2k [CacheManager]
+ * 기본 Cache2k [CacheManager]입니다.
  */
 val defaultCache2kManager: CacheManager by lazy { CacheManager.getInstance() }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/ehcache/EhcacheSupport.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/ehcache/EhcacheSupport.kt
@@ -13,7 +13,7 @@ import org.ehcache.config.units.EntryUnit
 import org.ehcache.config.units.MemoryUnit
 
 /**
- * Default Ehcache [CacheManager]
+ * 기본 Ehcache [CacheManager]입니다.
  */
 val DefaultEhCacheCacheManager: CacheManager by lazy {
     ehcacheManager {

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
@@ -42,10 +42,10 @@ fun <T: Any, R: Any> (suspend (T) -> R).withSuspendMemoizer(
  * ## Recursion Safety
  * Holding a global Mutex during evaluator execution causes deadlocks for recursive memoizers
  * (e.g., factorial, fibonacci) because Kotlin's Mutex is not reentrant.
- * The per-key Deferred pattern runs the evaluator outside any lock, so recursive calls are safe.
+ * per-key Deferred pattern은 evaluator를 lock 밖에서 실행하므로 재귀 호출이 안전합니다.
  *
  * ## Write-after-clear Safety
- * A generation counter ensures that results from in-flight evaluations started before [clear]
+ * generation counter는 [clear] 전에 시작된 in-flight evaluation 결과가
  * are not written back to the cache after it has been invalidated. The caller always receives
  * the computed value regardless of the generation check.
  *

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 /**
- * Creates a [CaffeineAsyncMemoizer] backed by this Caffeine [Cache].
+ * 이 Caffeine [Cache]를 backend로 사용하는 [CaffeineAsyncMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val cache = Caffeine.newBuilder().maximumSize(1000).build<String, Int>()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Creates an [InMemoryAsyncMemoizer] for this [CompletableFuture]-based evaluator.
+ * 이 [CompletableFuture] 기반 evaluator에 대한 [InMemoryAsyncMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val memo = ({ key: String -> CompletableFuture.completedFuture(key.length) }).asyncMemoizer()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizer.kt
@@ -7,7 +7,7 @@ import io.bluetape4k.logging.trace
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Creates an [InMemorySuspendMemoizer] for this suspend evaluator.
+ * 이 suspend evaluator에 대한 [InMemorySuspendMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val memo = (suspend { key: String -> key.length }).suspendMemoizer()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt
@@ -39,7 +39,7 @@ class NearJCacheManagementMXBean(
     /**
      * Determines if a [Cache] should operate in read-through mode.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return `true` when a [Cache] is in "read-through" mode.
      */
@@ -48,7 +48,7 @@ class NearJCacheManagementMXBean(
     /**
      * Determines if a [Cache] should operate in "write-through" mode.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return `true` when a [Cache] is in "write-through" mode.
      */
@@ -57,7 +57,7 @@ class NearJCacheManagementMXBean(
     /**
      * Whether storeByValue (true) or storeByReference (false).
      *
-     * The default value is `true`.
+     * 기본값은 `true`입니다.
      *
      * @return true if the cache is store by value
      */
@@ -66,7 +66,7 @@ class NearJCacheManagementMXBean(
     /**
      * Checks whether statistics collection is enabled in this cache.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return true if statistics collection is enabled
      */
@@ -75,7 +75,7 @@ class NearJCacheManagementMXBean(
     /**
      * Checks whether management is enabled on this cache.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return true if management is enabled
      */

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheStatisticsMXBean.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheStatisticsMXBean.kt
@@ -28,7 +28,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     private val putTime = atomic(0L)
 
     /**
-     * Clears the statistics counters to 0 for the associated Cache.
+     * 연결된 Cache의 statistics counter를 0으로 초기화합니다.
      */
     override fun clear() {
         removals.value = 0
@@ -47,7 +47,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The number of get requests that were satisfied by the cache.
+     * cache가 만족한 get request 수입니다.
      *
      *
      * [javax.cache.Cache.containsKey] is not a get request for
@@ -88,7 +88,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * A miss is a get request that is not satisfied.
+     * miss는 만족되지 않은 get request입니다.
      *
      *
      * In a simple cache a miss occurs when the cache does not satisfy the request.
@@ -119,7 +119,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     override fun getCacheMisses(): Long = misses.value
 
     /**
-     * Returns the percentage of cache accesses that did not find a requested entry
+     * 요청한 entry를 찾지 못한 cache access 비율을 반환합니다
      * in the cache.
      *
      *
@@ -136,7 +136,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of requests to the cache. This will be equal to the sum of
+     * cache에 대한 전체 request 수입니다. 이는 다음 합과 같습니다
      * the hits and misses.
      *
      *
@@ -156,10 +156,10 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of puts to the cache.
+     * cache에 대한 전체 put 수입니다.
      *
      *
-     * A put is counted even if it is immediately evicted.
+     * put 직후 evict되더라도 put으로 계산합니다.
      *
      *
      * Replaces, where a put occurs which overrides an existing mapping is counted
@@ -174,7 +174,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of removals from the cache. This does not include evictions,
+     * cache에서 제거된 전체 removal 수입니다. eviction은 포함하지 않습니다,
      * where the cache itself initiates the removal to make space.
      *
      * @return the number of removals
@@ -186,7 +186,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of evictions from the cache. An eviction is a removal
+     * cache에서 발생한 전체 eviction 수입니다. eviction은 removal입니다
      * initiated by the cache itself to free up space. An eviction is not treated as
      * a removal and does not appear in the removal counts.
      *
@@ -207,7 +207,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute gets.
+     * get 실행 평균 시간입니다.
      *
      *
      * In a read-through cache the time taken to load an entry on miss is not
@@ -222,7 +222,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute puts.
+     * put 실행 평균 시간입니다.
      *
      * @return the time in µs
      */
@@ -233,7 +233,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute removes.
+     * remove 실행 평균 시간입니다.
      *
      * @return the time in µs
      */

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
@@ -49,13 +49,13 @@ abstract class AbstractSuspendNearJCacheTest
     protected val frontCoCache2 by lazy { createFrontSuspendCache(Duration.ofMinutes(10)) }
 
     /**
-     * Creates a [SuspendNearJCache] for the given front and back caches.
+     * 주어진 front/back cache에 대한 [SuspendNearJCache]를 생성합니다.
      *
      * Override in subclasses that cannot register a listener (e.g. Hazelcast, which requires
      * [javax.cache.configuration.CacheEntryListenerConfiguration] to be Serializable for cluster
      * distribution) to call [SuspendNearJCache.withoutListener] instead.
      *
-     * The default implementation calls [SuspendNearJCache.invoke] which registers a
+     * 기본 구현은 [SuspendNearJCache.invoke]를 호출하여 등록합니다
      * [io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListener] on [backSuspendJCache] so that
      * mutations propagate from back → front.
      */

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/EncryptedStringConverters.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/EncryptedStringConverters.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference
  * from an external protected store, such as a secret manager, KMS envelope-encrypted file, or HSM-backed source,
  * before encrypted entity fields are read or written.
  *
- * The JSON keyset helpers expect cleartext Tink keyset JSON. Protect that JSON as secret key material and avoid
+ * JSON keyset helper는 cleartext Tink keyset JSON을 기대합니다. 이 JSON은 secret key material로 보호하고
  * embedding it in source code, logs, or plain configuration files.
  */
 object EncryptedStringConverterKeysets {
@@ -69,7 +69,7 @@ object EncryptedStringConverterKeysets {
 }
 
 /**
- * Base JPA converter that stores encrypted strings in a single database column.
+ * 암호화된 문자열을 단일 database column에 저장하는 base JPA converter입니다.
  *
  * Built-in subclasses fail fast unless [EncryptedStringConverterKeysets] has been configured with externally
  * persisted key material. This avoids writing ciphertext with process-local generated keys that cannot be decrypted

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsBase64StringConverter.kt
@@ -51,7 +51,7 @@ abstract class AbstractObjectAsBase64StringConverter(
 /**
  * Typed Base64 string converter that rejects deserialized values outside [targetType].
  *
- * Use this base class for persistent columns that may cross a trust boundary. The serializer is still
+ * trust boundary를 넘을 수 있는 persistent column에는 이 base class를 사용합니다. serializer는 계속
  * pluggable, so callers can combine the typed converter boundary with secure serializers such as
  * `KryoBinarySerializer.secure(...)` or `ForyBinarySerializer.secureFory(...)`.
  *

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsByteArrayConverter.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/converters/ObjectAsByteArrayConverter.kt
@@ -51,7 +51,7 @@ abstract class AbstractObjectAsByteArrayConverter(
 /**
  * Typed object converter that rejects deserialized values outside [targetType].
  *
- * Use this base class for persistent columns that may cross a trust boundary. The serializer is still
+ * trust boundary를 넘을 수 있는 persistent column에는 이 base class를 사용합니다. serializer는 계속
  * pluggable, so callers can combine the typed converter boundary with secure serializers such as
  * `KryoBinarySerializer.secure(...)` or `ForyBinarySerializer.secureFory(...)`.
  *

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt
@@ -7,7 +7,7 @@ import org.hibernate.Hibernate
 import java.io.Serializable
 
 /**
- * Base abstraction for JPA entities.
+ * JPA entity를 위한 base abstraction입니다.
  *
  * Equality uses the assigned identifier only when both entities are persisted.
  * Transient entities fall back to [equalProperties], so their default
@@ -17,20 +17,20 @@ abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(),
 
     companion object: KLogging() {
         /**
-         * Returns whether the persisted [target] has the same non-null identifier.
+         * 영속화된 [target]이 같은 non-null identifier를 가지는지 반환합니다.
          */
         private fun <TId> hasSameNonDefaultId(id: TId, target: JpaEntity<*>): Boolean =
             id == target.id
 
         /**
-         * Returns whether two transient entities share the same business signature.
+         * 두 transient entity가 같은 business signature를 공유하는지 반환합니다.
          */
         private fun <TId> hasSameBusinessSignature(self: AbstractJpaEntity<*>, target: JpaEntity<*>): Boolean =
             self.equalProperties(target)
     }
 
     /**
-     * Returns whether this entity already has an assigned identifier.
+     * 이 entity에 identifier가 이미 할당되어 있는지 반환합니다.
      */
     @get:Transient
     override val isPersisted: Boolean get() = id != null
@@ -53,7 +53,7 @@ abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(),
     }
 
     /**
-     * Returns the entity hash code.
+     * entity hash code를 반환합니다.
      *
      * Persisted entities use the identifier hash. Transient entities use the
      * Hibernate-resolved entity class hash so equal transient instances land in

--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/spring/StatelessSessionFactoryBean.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/spring/StatelessSessionFactoryBean.kt
@@ -18,7 +18,7 @@ import org.springframework.util.ReflectionUtils
 import java.sql.Connection
 
 /**
- * Provides a Hibernate [StatelessSession] proxy bound to the current Spring transaction.
+ * 현재 Spring transaction에 바인딩된 Hibernate [StatelessSession] proxy를 제공합니다.
  *
  * ## Contract
  * - [getObject] returns a proxy; the real session is resolved lazily for each method call.

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt
@@ -11,30 +11,28 @@ import java.util.logging.Logger
 import javax.sql.DataSource
 
 /**
- * Provides the current JDBC password for a physical connection attempt.
+ * 물리 connection 시도에 사용할 현재 JDBC password를 제공합니다.
  *
- * ## Contract
+ * ## 계약
  *
- * [RefreshingJdbcPasswordDataSource] calls [currentPassword] synchronously for
- * every no-arg [DataSource.getConnection] invocation. Implementations must be
- * thread-safe because connection pools may open multiple physical connections
- * concurrently. Expensive token generation, caching, and coalescing belong in
- * the provider implementation, not in the generic DataSource.
+ * [RefreshingJdbcPasswordDataSource]는 인자 없는 [DataSource.getConnection]을 호출할 때마다
+ * [currentPassword]를 동기적으로 호출합니다. connection pool이 여러 물리 connection을
+ * 동시에 열 수 있으므로 구현체는 thread-safe해야 합니다. 비용이 큰 token 생성, caching,
+ * coalescing은 generic DataSource가 아니라 provider 구현체가 담당해야 합니다.
  *
- * Implementations must not log or expose secrets. Exceptions thrown by the
- * provider are reported as secret-free [SQLException] failures by the
- * DataSource.
+ * 구현체는 secret을 log로 남기거나 노출하면 안 됩니다. provider에서 발생한 예외는
+ * secret을 포함하지 않는 [SQLException] 실패로 DataSource에 의해 보고됩니다.
  */
 fun interface JdbcPasswordProvider {
 
     /**
-     * Returns the current JDBC password or null when no password is available.
+     * 현재 JDBC password를 반환하거나 사용할 password가 없으면 null을 반환합니다.
      */
     fun currentPassword(): String?
 }
 
 /**
- * Configuration for [RefreshingJdbcPasswordDataSource].
+ * [RefreshingJdbcPasswordDataSource] 설정입니다.
  *
  * @property url JDBC URL used with [DriverManager.getConnection].
  * @property driverClassName optional driver class to load during construction.
@@ -68,7 +66,7 @@ data class RefreshingJdbcPasswordDataSourceConfig(
 }
 
 /**
- * A [DataSource] that obtains a fresh password for each physical connection.
+ * 각 물리 connection마다 새 password를 얻는 [DataSource]입니다.
  *
  * ## Behavior
  *

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/PreparedStatementExtensions.kt
@@ -109,7 +109,7 @@ private fun List<List<Any?>>.requireConsistentBatchParameterRows() {
 }
 
 /**
- * Executes a SQL update as prepared-statement batches.
+ * SQL update를 prepared-statement batch로 실행합니다.
  *
  * All parameter rows must have the same number of values. Inconsistent rows fail
  * before a statement is prepared, which prevents shorter rows from reusing
@@ -167,7 +167,7 @@ fun java.sql.Connection.executeBatch(
 }
 
 /**
- * Executes a SQL update as prepared-statement large batches.
+ * SQL update를 prepared-statement large batch로 실행합니다.
  *
  * All parameter rows must have the same number of values. Inconsistent rows fail
  * before a statement is prepared, which prevents shorter rows from reusing

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
@@ -4,9 +4,9 @@ import java.sql.Connection
 import java.sql.SQLException
 
 /**
- * Executes [block] inside a JDBC transaction.
+ * JDBC transaction 안에서 [block]을 실행합니다.
  *
- * The connection's `autoCommit`, isolation level, and read-only flag are restored
+ * connection의 `autoCommit`, isolation level, read-only flag는 복구됩니다
  * independently to their original values. Any [Throwable] from the block or
  * commit path triggers rollback and is rethrown unchanged. Rollback or restore
  * failures are attached as suppressed exceptions to the primary failure.
@@ -67,9 +67,9 @@ inline fun <T> Connection.withTransaction(
 }
 
 /**
- * Executes [block] inside a read-only JDBC transaction.
+ * read-only JDBC transaction 안에서 [block]을 실행합니다.
  *
- * The connection's original read-only flag is restored by [withTransaction], so
+ * connection의 원래 read-only flag는 [withTransaction]이 복구하므로
  * callers that provide an already read-only connection keep that state after the
  * transaction finishes.
  *

--- a/data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientProvider.kt
+++ b/data/mongodb/src/main/kotlin/io/bluetape4k/mongodb/MongoClientProvider.kt
@@ -36,9 +36,9 @@ object MongoClientProvider: KLogging() {
     private val settingsClientCache = ConcurrentHashMap<MongoClientSettings, MongoClient>()
 
     /**
-     * Returns a coroutine [MongoClient] for [connectionString].
+     * [connectionString]에 대한 coroutine [MongoClient]를 반환합니다.
      *
-     * The connection string is first converted to [MongoClientSettings], then the
+     * connection string을 먼저 [MongoClientSettings]로 변환한 뒤
      * settings-based cache is used. The returned client is provider-managed and
      * must be closed through [close] or [closeAll].
      *
@@ -56,9 +56,9 @@ object MongoClientProvider: KLogging() {
     }
 
     /**
-     * Returns a coroutine [MongoClient] for [connectionString] plus custom settings.
+     * [connectionString]과 custom settings에 대한 coroutine [MongoClient]를 반환합니다.
      *
-     * The final [MongoClientSettings] produced after applying [builder] is the cache
+     * [builder] 적용 후 생성된 최종 [MongoClientSettings]가 cache
      * key. Therefore the same URL can return different clients when timeout, TLS,
      * application name, credentials, or other effective settings differ.
      *
@@ -80,7 +80,7 @@ object MongoClientProvider: KLogging() {
     }
 
     /**
-     * Returns a coroutine [MongoClient] for [settings].
+     * [settings]에 대한 coroutine [MongoClient]를 반환합니다.
      *
      * [MongoClientSettings] is used directly as the cache key. The returned client is
      * provider-managed and must be closed through [close] or [closeAll].

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/config/R2dbcClientAutoConfiguration.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/config/R2dbcClientAutoConfiguration.kt
@@ -31,7 +31,7 @@ class R2dbcClientAutoConfiguration {
     companion object: KLogging()
 
     /**
-     * Creates the default [R2dbcClient] bean from Spring R2DBC infrastructure beans.
+     * Spring R2DBC infrastructure bean에서 기본 [R2dbcClient] bean을 생성합니다.
      */
     @Bean
     @ConditionalOnMissingBean(R2dbcClient::class)

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupport.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupport.kt
@@ -8,7 +8,7 @@ import org.springframework.r2dbc.core.DatabaseClient
 private val log by lazy { KotlinLogging.logger {} }
 
 /**
- * Binds named query parameters from a map.
+ * map에서 named query parameter를 bind합니다.
  *
  * Named parameters are referenced as `:name` in SQL and mapped by key.
  * Raw null values are rejected because they do not carry R2DBC type
@@ -48,7 +48,7 @@ fun DatabaseClient.GenericExecuteSpec.bindMap(parameters: Map<String, Any?>): Da
     }
 
 /**
- * Binds indexed query parameters.
+ * indexed query parameter를 bind합니다.
  *
  * Indexed parameters follow Spring R2DBC's zero-based binding contract. The first
  * positional parameter is index `0`, the second is index `1`, and so on.
@@ -126,7 +126,7 @@ fun DatabaseClient.execute(
 ): DatabaseClient.GenericExecuteSpec = sql(sqlString).bindMap(parameters)
 
 /**
- * Binds a nullable value to an indexed parameter.
+ * nullable 값을 indexed parameter에 bind합니다.
  *
  * The [index] follows Spring R2DBC's zero-based binding contract. The first
  * positional parameter is index `0`. Null values are bound as typed NULL values.

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/ParameterSupport.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/ParameterSupport.kt
@@ -4,7 +4,7 @@ import io.r2dbc.spi.Parameter
 import io.r2dbc.spi.Parameters
 
 /**
- * Creates an R2DBC [Parameter] that carries a typed NULL value.
+ * typed NULL 값을 담는 R2DBC [Parameter]를 생성합니다.
  *
  * Use this helper with map-based binding APIs when a nullable value needs to
  * preserve its database type information.
@@ -19,7 +19,7 @@ import io.r2dbc.spi.Parameters
 fun typedNullParameter(type: Class<*>): Parameter = Parameters.`in`(type)
 
 /**
- * Creates an R2DBC [Parameter] that carries a typed NULL value for [T].
+ * [T]의 typed NULL 값을 담는 R2DBC [Parameter]를 생성합니다.
  *
  * @param T Kotlin type to expose to the R2DBC driver.
  * @return typed NULL [Parameter].

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/SharedFlowAsEventBus.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/SharedFlowAsEventBus.kt
@@ -24,7 +24,7 @@ class SharedFlowAsEventBus {
     companion object: KLoggingChannel()
 
     /**
-     * An event bus implementation that uses a shared flow to broadcast events to multiple listeners.
+     * shared flow로 여러 listener에 event를 broadcast하는 event bus 구현입니다.
      */
     class EventBus<T> {
         // The shared flow that will be used to broadcast events to multiple listeners.

--- a/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/AbstractBlazePersistenceTest.kt
+++ b/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/AbstractBlazePersistenceTest.kt
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 /**
- * Base Spring Boot test configuration for the Blaze Persistence examples.
+ * Blaze Persistence example을 위한 base Spring Boot test configuration입니다.
  */
 @SpringBootTest(
     classes = [BlazePersistenceApplication::class],

--- a/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/BlazePersistenceApplication.kt
+++ b/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/BlazePersistenceApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 /**
- * Spring Boot test application for the Blaze Persistence JPA examples.
+ * Blaze Persistence JPA example용 Spring Boot test application입니다.
  */
 @SpringBootApplication
 @EnableJpaAuditing(modifyOnCreate = true)

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 /**
- * Spring Boot demo application for bluetape4k idgenerators.
+ * bluetape4k idgenerator용 Spring Boot demo application입니다.
  *
  * ## Behavior
  * - Registers `IdGenerator` implementations as Spring beans and injects them into the REST controller.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 /**
- * Example configuration that registers idgenerator implementations as Spring beans.
+ * idgenerator 구현체를 Spring bean으로 등록하는 example configuration입니다.
  *
  * ## Behavior
  * - UUID generators of the same type are distinguished by bean name.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.support.requirePositiveNumber
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * Configuration properties for the ID batch example.
+ * ID batch example 설정 property입니다.
  *
  * ## Behavior
  * - `defaultBatchSize` is used when the `size` query parameter is omitted.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * REST controller for the idgenerator Spring Boot demo.
+ * idgenerator Spring Boot demo용 REST controller입니다.
  *
  * ## Behavior
  * - The `/ids/{type}` family provides explicit endpoints that are easy to copy.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 /**
- * Converts input validation errors from the idgenerator REST demo into JSON responses.
+ * idgenerator REST demo의 input validation error를 JSON response로 변환합니다.
  *
  * ## Behavior
  * - Unsupported generator types and batch size errors return HTTP 400.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
@@ -43,7 +43,7 @@ data class GeneratorResponse(
 )
 
 /**
- * Example application health response.
+ * example application health response입니다.
  */
 data class HealthResponse(
     val status: String,

--- a/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
+++ b/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
@@ -23,7 +23,7 @@ import java.io.Serializable
 private const val REQUEST_ID_HEADER = "X-Request-Id"
 
 /**
- * Spring Boot observability example for Prometheus metrics and OTLP tracing configuration.
+ * Prometheus metric과 OTLP tracing configuration을 보여 주는 Spring Boot observability example입니다.
  *
  * ## Behavior
  * - Exposes application metrics through Spring Boot Actuator's Prometheus endpoint.

--- a/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt
+++ b/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt
@@ -241,12 +241,12 @@ data class BulkListenerHandle<Context>(
 }
 
 /**
- * Creates a [BulkListener] and [Flow] pair for bulk progress callbacks.
+ * bulk progress callback을 위한 [BulkListener]와 [Flow] pair를 생성합니다.
  *
  * Register the returned [BulkListener] with a [BulkIngester] to stream `beforeBulk`,
  * successful `afterBulk`, and failed `afterBulk` callbacks as [BulkProgressEvent] values.
  *
- * The callback path never suspends or blocks Elasticsearch client threads. Events are
+ * callback 경로는 Elasticsearch client thread를 suspend하거나 block하지 않습니다. event는
  * offered to a bounded [Channel] with [bufferCapacity] and [onBufferOverflow]. With the
  * default [BufferOverflow.SUSPEND] policy, `trySend` failures are logged and the event is
  * dropped when collectors are too slow or absent.

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -74,7 +74,7 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         /**
          * Sentinel value for [allowedTypePackages] that bypasses all package checks.
          *
-         * Use only in fully trusted, internal deployments where all Kafka producers are
+         * 모든 Kafka producer가 완전히 신뢰되는 internal deployment에서만 사용합니다
          * controlled. Assigning this constant re-enables the pre-1.8.0 allow-all behavior.
          *
          * ```kotlin

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -110,7 +110,7 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     fun receiveAutoAck(): Flow<ConsumerRecord<K, V>> = receiver.receiveAutoAck().concatMap { it }.asFlow()
 
     /**
-     * Returns a {@link Flux} of consumer record batches that may be used for exactly once
+     * exactly once 처리에 사용할 수 있는 consumer record batch의 {@link Flux}를 반환합니다
      * delivery semantics. A new transaction is started for each inner Flux and it is the
      * responsibility of the consuming application to commit or abort the transaction
      * using {@link TransactionManager#commit()} or {@link TransactionManager#abort()}

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -53,7 +53,7 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
 
     companion object: KLoggingChannel() {
         /**
-         * Create an instance of [SuspendKafkaProducerTemplate] with the provided configuration.
+         * 제공된 configuration으로 [SuspendKafkaProducerTemplate] instance를 생성합니다.
          *
          * @param senderOptions [SenderOptions] instance.
          * @param messageConverter [RecordMessageConverter] instance.

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
@@ -8,9 +8,9 @@ import org.apache.kafka.common.header.internals.RecordHeaders
 import org.junit.jupiter.api.Test
 
 /**
- * Security tests for [JacksonKafkaCodec] type allowlist enforcement.
+ * [JacksonKafkaCodec] type allowlist 강제를 검증하는 security test입니다.
  *
- * Verifies that:
+ * 다음을 검증합니다:
  * - Untrusted class names in the `VALUE_TYPE_KEY` header are rejected by default (empty allowedTypePackages)
  * - Explicitly allowed packages are deserialized correctly
  * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE] opt-in restores legacy allow-all behavior

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -151,7 +151,7 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         /**
          * Sentinel value for [allowedTypePackages] that bypasses all package checks.
          *
-         * Use only in fully trusted, internal deployments where all Kafka producers are
+         * 모든 Kafka producer가 완전히 신뢰되는 internal deployment에서만 사용합니다
          * controlled. Assigning this constant re-enables the pre-1.8.0 allow-all behavior.
          *
          * ```kotlin

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -110,7 +110,7 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     fun receiveAutoAck(): Flow<ConsumerRecord<K, V>> = receiver.receiveAutoAck().concatMap { it }.asFlow()
 
     /**
-     * Returns a {@link Flux} of consumer record batches that may be used for exactly once
+     * exactly once 처리에 사용할 수 있는 consumer record batch의 {@link Flux}를 반환합니다
      * delivery semantics. A new transaction is started for each inner Flux and it is the
      * responsibility of the consuming application to commit or abort the transaction
      * using {@link TransactionManager#commit()} or {@link TransactionManager#abort()}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -53,7 +53,7 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
 
     companion object: KLoggingChannel() {
         /**
-         * Create an instance of [SuspendKafkaProducerTemplate] with the provided configuration.
+         * 제공된 configuration으로 [SuspendKafkaProducerTemplate] instance를 생성합니다.
          *
          * @param senderOptions [SenderOptions] instance.
          * @param messageConverter [RecordMessageConverter] instance.

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
@@ -12,9 +12,9 @@ import org.apache.kafka.common.header.internals.RecordHeaders
 import org.junit.jupiter.api.Test
 
 /**
- * Security tests for [JacksonKafkaCodec] type allowlist enforcement.
+ * [JacksonKafkaCodec] type allowlist 강제를 검증하는 security test입니다.
  *
- * Verifies that:
+ * 다음을 검증합니다:
  * - Untrusted class names in the `VALUE_TYPE_KEY` header are rejected by default (empty allowedTypePackages)
  * - Explicitly allowed packages are deserialized correctly
  * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE] opt-in restores legacy allow-all behavior

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt
@@ -12,7 +12,7 @@ import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
 
 /**
- * A Lettuce [RedisCodec] that serializes values with a [BinarySerializer].
+ * [BinarySerializer]로 값을 직렬화하는 Lettuce [RedisCodec]입니다.
  *
  * ```kotlin
  * val codec = LettuceBinaryCodec<MyData>(BinarySerializers.LZ4Kryo)
@@ -23,7 +23,7 @@ import java.nio.ReadOnlyBufferException
  * // value == myData
  * ```
  *
- * The nullable target-taking [encodeValue] overload is the only supported source extension seam. Ordinary codec
+ * nullable target을 받는 [encodeValue] overload가 유일하게 지원되는 source extension 지점입니다. 일반 codec
  * methods remain final. Opening this class also makes compiler-generated JVM bridge methods bytecode-overrideable;
  * those bridges are not a supported extension API. Subclasses must override only the target overload and preserve
  * the configured [serializer] contract.
@@ -59,7 +59,7 @@ open class LettuceBinaryCodec<V: Any>(
     /**
      * Encodes [value] into the caller-owned [target].
      *
-     * A null target is a no-op. A read-only target fails before serializer dispatch and preserves its observable
+     * null target은 no-op입니다. 읽기 전용 target은 serializer dispatch 전에 실패하며 관찰 가능한 상태를 보존합니다
      * indices, marks, and reference count. The caller owns the target and its lifetime. A successful override must
      * commit the writer index only after the complete value has been written. A failed override may leave attempted
      * bytes or capacity changes behind, but it must not advance the writer index. Subclasses are responsible for

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
@@ -51,7 +51,7 @@ object LettuceBinaryCodecs {
     fun <V: Any> kryo(): LettuceBinaryCodec<V> = codec(BinarySerializers.Kryo)
 
     /**
-     * Creates a [LettuceBinaryCodec] with the raw Fory serializer.
+     * raw Fory serializer를 사용하는 [LettuceBinaryCodec]을 생성합니다.
      *
      * One-argument encode still creates a [ByteArray]. Caller-owned target encode uses the bounded stream path to
      * avoid the codec-level handoff array and commits the writer index only after success. Fory retains its internal
@@ -144,7 +144,7 @@ object LettuceBinaryCodecs {
     // -------------------------------------------------------------------------
 
     /**
-     * Creates a [LettuceBinaryCodec] with the raw FastFory serializer.
+     * raw FastFory serializer를 사용하는 [LettuceBinaryCodec]을 생성합니다.
      *
      * FastFory uses `CompatibleMode.SCHEMA_CONSISTENT`. One-argument encode still creates a [ByteArray].
      * Caller-owned target encode avoids only the codec-level handoff array; Fory's internal buffer remains, so this

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt
@@ -61,7 +61,7 @@ class LettuceJsonCodec<V: Any>(
     /**
      * Encodes [value] into the caller-owned [target].
      *
-     * A null target is a no-op. A read-only target fails before serializer dispatch and preserves its observable
+     * null target은 no-op입니다. 읽기 전용 target은 serializer dispatch 전에 실패하며 관찰 가능한 상태를 보존합니다
      * indices, marks, and reference count. Success commits the writer index only after the complete wire is written;
      * failure may leave attempted content or capacity changes but does not commit the writer index.
      */

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeasePerformanceTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeasePerformanceTest.kt
@@ -38,11 +38,11 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.ceil
 
 /**
- * Characterizes Redis-side multi-key lease cost outside the default test task.
+ * 기본 test task 밖에서 Redis-side multi-key lease 비용을 특성화합니다.
  *
- * Re-run `:bluetape4k-lettuce:multiKeyLeasePerformanceTest` after changing the Lua scripts or the default `maxKeys`.
- * Absolute latency is environment-dependent; the regression assertion compares normalized p95 values within one run.
- * This test deliberately owns a dedicated Redis server and explicit executors: a shared launcher would contaminate
+ * Lua script 또는 기본 `maxKeys`를 변경한 뒤 `:bluetape4k-lettuce:multiKeyLeasePerformanceTest`를 다시 실행합니다.
+ * 절대 latency는 환경 의존적이므로 regression assertion은 한 run 안의 normalized p95 값을 비교합니다.
+ * 이 test는 전용 Redis server와 explicit executor를 의도적으로 소유합니다. shared launcher는 오염시킬 수 있습니다
  * latency samples, while `MultithreadingTester` cannot preserve per-attempt timing, persistent connections, and the
  * independently scheduled PING probe that this characterization requires.
  */

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockPerformanceTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockPerformanceTest.kt
@@ -44,9 +44,9 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Characterizes coordination lock command, scheduler, latency, and retained-state bounds.
+ * coordination lock command, scheduler, latency, retained-state 한계를 특성화합니다.
  *
- * Absolute timings vary by host. This suite therefore asserts exact command budgets, hard caps, cleanup invariants,
+ * 절대 시간은 host마다 달라집니다. 따라서 이 suite는 정확한 command budget, hard cap, cleanup invariant,
  * and normalized within-run relationships. It is intentionally isolated from the default test task.
  */
 @Tag("coordination-lock-performance")

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroGenericRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroGenericRecordSerializer.kt
@@ -44,7 +44,7 @@ interface AvroGenericRecordSerializer {
     fun serialize(schema: Schema, graph: GenericRecord?): ByteArray?
 
     /**
-     * Serializes [graph] under [schema] into the caller-owned [target] from its current position.
+     * [schema] 아래의 [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating fallback that calls [serialize] first. A read-only target fails with
      * `ReadOnlyBufferException` before serializer code runs. A null result writes nothing and returns `0`; insufficient
@@ -78,7 +78,7 @@ interface AvroGenericRecordSerializer {
     fun deserialize(schema: Schema, avroBytes: ByteArray?): GenericData.Record?
 
     /**
-     * Deserializes trusted, caller-bounded bytes in `[source.position(), source.limit())` under [schema].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [schema] 아래에서 역직렬화합니다.
      *
      * This allocating fallback copies the remaining bytes to a new [ByteArray] before calling [deserialize]. Heap,
      * direct, sliced, and read-only sources are supported. Position, limit, mark, and byte order are preserved on every
@@ -130,9 +130,9 @@ interface AvroGenericRecordSerializer {
 }
 
 /**
- * Deserializes the remaining trusted, caller-bounded bytes in [source] under [schema].
+ * [source]에 남은 신뢰된 호출자 한정 바이트를 [schema] 아래에서 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, thread-confinement, and source-state preservation rules of
+ * 할당 기반 fallback, 호출자 소유권, 스레드 한정, source 상태 보존 규칙은
  * [AvroGenericRecordSerializer.deserializeFrom] apply.
  */
 fun AvroGenericRecordSerializer.deserialize(schema: Schema, source: ByteBuffer): GenericData.Record? =

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroReflectSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroReflectSerializer.kt
@@ -42,7 +42,7 @@ interface AvroReflectSerializer {
     fun <T> serialize(graph: T?): ByteArray?
 
     /**
-     * Serializes [graph] into the caller-owned [target] from its current position.
+     * [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating fallback that calls [serialize] first. A read-only target fails with
      * `ReadOnlyBufferException` before serializer code runs. A null [serialize] result writes nothing and returns `0`;
@@ -76,7 +76,7 @@ interface AvroReflectSerializer {
     fun <T> deserialize(avroBytes: ByteArray?, clazz: Class<T>): T?
 
     /**
-     * Deserializes trusted, caller-bounded bytes in `[source.position(), source.limit())` as [clazz].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [clazz]로 역직렬화합니다.
      *
      * This allocating fallback copies the remaining bytes to a new [ByteArray] before calling [deserialize]. Heap,
      * direct, sliced, and read-only sources are supported. Position, limit, mark, and byte order are preserved on every
@@ -146,15 +146,15 @@ inline fun <reified T: Any> AvroReflectSerializer.deserialize(avroBytes: ByteArr
 }
 
 /**
- * Deserializes the remaining bytes in [source] as [clazz] through [AvroReflectSerializer.deserializeFrom].
+ * [source]에 남은 바이트를 [AvroReflectSerializer.deserializeFrom]을 통해 [clazz]로 역직렬화합니다.
  */
 fun <T> AvroReflectSerializer.deserialize(source: ByteBuffer, clazz: Class<T>): T? =
     deserializeFrom(source, clazz)
 
 /**
- * Deserializes the remaining trusted, caller-bounded bytes in [source] as reified [T].
+ * [source]에 남은 신뢰된 호출자 한정 바이트를 reified [T]로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, thread-confinement, and source-state preservation rules of
+ * 할당 기반 fallback, 호출자 소유권, 스레드 한정, source 상태 보존 규칙은
  * [AvroReflectSerializer.deserializeFrom] apply.
  */
 inline fun <reified T: Any> AvroReflectSerializer.deserialize(source: ByteBuffer): T? =

--- a/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroSpecificRecordSerializer.kt
+++ b/io/avro/src/main/kotlin/io/bluetape4k/avro/AvroSpecificRecordSerializer.kt
@@ -40,7 +40,7 @@ interface AvroSpecificRecordSerializer {
     fun <T: SpecificRecord> serialize(graph: T?): ByteArray?
 
     /**
-     * Serializes [graph] into the caller-owned [target] from its current position.
+     * [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating fallback that calls [serialize] first. A read-only target fails with
      * `ReadOnlyBufferException` before serializer code runs. A null result writes nothing and returns `0`; insufficient
@@ -74,7 +74,7 @@ interface AvroSpecificRecordSerializer {
     fun <T: SpecificRecord> deserialize(avroBytes: ByteArray?, clazz: Class<T>): T?
 
     /**
-     * Deserializes trusted, caller-bounded bytes in `[source.position(), source.limit())` as [clazz].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [clazz]로 역직렬화합니다.
      *
      * This allocating fallback copies the remaining bytes to a new [ByteArray] before calling [deserialize]. Heap,
      * direct, sliced, and read-only sources are supported. Position, limit, mark, and byte order are preserved on every
@@ -142,7 +142,7 @@ interface AvroSpecificRecordSerializer {
     fun <T: SpecificRecord> serializeList(collection: List<T>?): ByteArray?
 
     /**
-     * Serializes [collection] into the caller-owned [target] from its current position.
+     * [collection]을 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This allocating fallback delegates to [serializeList]. Null or empty collections retain that method's policy; a
      * null result writes nothing and returns `0`. Read-only validation occurs before serializer code, and insufficient
@@ -175,7 +175,7 @@ interface AvroSpecificRecordSerializer {
     fun <T: SpecificRecord> deserializeList(avroBytes: ByteArray?, clazz: Class<T>): List<T>
 
     /**
-     * Deserializes trusted, caller-bounded bytes in `[source.position(), source.limit())` as a list of [clazz].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [clazz] 목록으로 역직렬화합니다.
      *
      * This allocating fallback copies the remaining bytes to a new [ByteArray] before calling [deserializeList]. Heap,
      * direct, sliced, and read-only sources are supported. Position, limit, mark, and byte order are preserved on every
@@ -205,15 +205,15 @@ inline fun <reified T: SpecificRecord> AvroSpecificRecordSerializer.deserialize(
 }
 
 /**
- * Deserializes the remaining bytes in [source] as [clazz] through [AvroSpecificRecordSerializer.deserializeFrom].
+ * [source]에 남은 바이트를 [AvroSpecificRecordSerializer.deserializeFrom]을 통해 [clazz]로 역직렬화합니다.
  */
 fun <T: SpecificRecord> AvroSpecificRecordSerializer.deserialize(source: ByteBuffer, clazz: Class<T>): T? =
     deserializeFrom(source, clazz)
 
 /**
- * Deserializes the remaining trusted, caller-bounded bytes in [source] as reified [T].
+ * [source]에 남은 신뢰된 호출자 한정 바이트를 reified [T]로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, thread-confinement, and source-state preservation rules of
+ * 할당 기반 fallback, 호출자 소유권, 스레드 한정, source 상태 보존 규칙은
  * [AvroSpecificRecordSerializer.deserializeFrom] apply.
  */
 inline fun <reified T: SpecificRecord> AvroSpecificRecordSerializer.deserialize(source: ByteBuffer): T? =
@@ -258,15 +258,15 @@ inline fun <reified T: SpecificRecord> AvroSpecificRecordSerializer.deserializeL
 }
 
 /**
- * Deserializes the remaining bytes in [source] as [clazz] through [AvroSpecificRecordSerializer.deserializeListFrom].
+ * [source]에 남은 바이트를 [AvroSpecificRecordSerializer.deserializeListFrom]을 통해 [clazz] 목록으로 역직렬화합니다.
  */
 fun <T: SpecificRecord> AvroSpecificRecordSerializer.deserializeList(source: ByteBuffer, clazz: Class<T>): List<T> =
     deserializeListFrom(source, clazz)
 
 /**
- * Deserializes the remaining trusted, caller-bounded bytes in [source] as a list of reified [T].
+ * [source]에 남은 신뢰된 호출자 한정 바이트를 reified [T] 목록으로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, thread-confinement, and source-state preservation rules of
+ * 할당 기반 fallback, 호출자 소유권, 스레드 한정, source 상태 보존 규칙은
  * [AvroSpecificRecordSerializer.deserializeListFrom] apply.
  */
 inline fun <reified T: SpecificRecord> AvroSpecificRecordSerializer.deserializeList(source: ByteBuffer): List<T> =

--- a/io/fastjson2/src/main/kotlin/io/bluetape4k/fastjson2/FastjsonSerializer.kt
+++ b/io/fastjson2/src/main/kotlin/io/bluetape4k/fastjson2/FastjsonSerializer.kt
@@ -81,7 +81,7 @@ class FastjsonSerializer: JsonSerializer {
     }
 
     /**
-     * Serializes through `JSONB.toBytes` and copies the result into [target].
+     * `JSONB.toBytes`로 직렬화한 뒤 결과를 [target]에 복사합니다.
      * This compatibility path commits the target position only on success and does not claim allocation reduction.
      */
     override fun serializeTo(graph: Any?, target: ByteBuffer): Int {

--- a/io/http/src/main/kotlin/io/bluetape4k/http/vertx/VertxHttpClientSupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/vertx/VertxHttpClientSupport.kt
@@ -15,7 +15,7 @@ private val defaultVertxHttpClientLock = ReentrantLock()
 private var defaultVertxHttpClientRef: HttpClient? = null
 
 /**
- * Default Vert.x [HttpClientOptions].
+ * 기본 Vert.x [HttpClientOptions]입니다.
  *
  * Security note: `trustAll = false` keeps TLS certificate verification enabled.
  * Use custom options with `trustAll = true` only for controlled test environments.
@@ -30,12 +30,12 @@ val defaultVertxHttpClientOptions: HttpClientOptions = httpClientOptionsOf(
 )
 
 /**
- * Managed default Vert.x [HttpClient].
+ * 관리되는 기본 Vert.x [HttpClient]입니다.
  *
  * ## Behaviour / Contract
  * - The client is created lazily from `bluetape4k-vertx`'s managed [defaultVertx].
  * - The client is reused across calls to this property.
- * - Call [closeDefaultVertxHttpClient] before closing the managed default Vert.x during shutdown.
+ * - shutdown 중 관리되는 기본 Vert.x를 닫기 전에 [closeDefaultVertxHttpClient]를 호출합니다.
  *
  * ```kotlin
  * val client = defaultVertxHttpClient
@@ -49,7 +49,7 @@ val defaultVertxHttpClient: HttpClient
     }
 
 /**
- * Closes and clears the managed default Vert.x [HttpClient], if it was created.
+ * 관리되는 기본 Vert.x [HttpClient]가 생성되어 있으면 닫고 지웁니다.
  */
 fun closeDefaultVertxHttpClient(): Future<Void> {
     val client = defaultVertxHttpClientLock.withLock {

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmark.kt
@@ -62,7 +62,7 @@ import okhttp3.Dispatcher as OkHttpDispatcher
  * - Ktor CIO + Coroutines
  * - Vert.x WebClient + Coroutines
  *
- * Ktor CIO 3.5 opens dedicated HTTP/1 connections when its pipeline path is
+ * Ktor CIO 3.5는 pipeline 경로가 사용될 때 전용 HTTP/1 connection을 엽니다
  * disabled. The benchmark therefore keeps a short equal-thread measurement
  * window for every client instead of limiting only the CIO row to one thread.
  */

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientLatencyBenchmark.kt
@@ -55,11 +55,11 @@ import okhttp3.Dispatcher as OkHttpDispatcher
  * 동기 클라이언트 이론 상한: threads × (1000 / 50ms) = 2,000 ops/s
  * 비동기는 스레드 블로킹 없이 더 높은 동시성 확보 가능.
  *
- * Vert.x 5 defaults to a 5-connection HTTP/1 pool. This benchmark configures
+ * Vert.x 5는 기본적으로 5개 connection의 HTTP/1 pool을 사용합니다. 이 benchmark는
  * the pool to match the other clients so the high-latency test compares client
- * behavior instead of the default connection cap.
+ * 기본 connection cap 대신 동작 자체를 측정하도록 설정합니다.
  *
- * Ktor CIO 3.5 opens dedicated HTTP/1 connections when its pipeline path is
+ * Ktor CIO 3.5는 pipeline 경로가 사용될 때 전용 HTTP/1 connection을 엽니다
  * disabled. The benchmark therefore keeps a short equal-thread measurement
  * window for every client instead of limiting only the CIO row to one thread.
  */

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializer.kt
@@ -19,7 +19,7 @@ import java.nio.ByteBuffer
  * val text = serializer.deserialize<String>(bytes)  // "Hello, World!"
  * ```
  *
- * The interface-default ByteBuffer methods are allocating compatibility fallbacks. See the
+ * interface default ByteBuffer 메서드는 할당 기반 호환성 fallback입니다. 자세한 내용은
  * [issue #1039 allocation evidence](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/docs/benchmarks/2026-07-18-bytebuffer-serializer-allocation.md)
  * before making backend-specific allocation claims.
  *
@@ -37,13 +37,13 @@ interface BinarySerializer {
     fun serialize(graph: Any?): ByteArray
 
     /**
-     * Serializes [graph] and writes the resulting bytes to the caller-owned [target].
+     * [graph]를 직렬화하고 결과 바이트를 호출자 소유 [target]에 씁니다.
      *
      * This interface default is an allocating fallback: it first obtains a [ByteArray] from [serialize], then writes
      * that array to [target]. Null input and zero-byte results retain [serialize]'s existing policy. On success, the
      * returned count is exactly the number of bytes written and is bounded by [Int.MAX_VALUE].
      *
-     * The target is borrowed synchronously and is not retained after the call. This method neither flushes nor closes
+     * target은 동기적으로 빌려 쓰며 호출 뒤 보관하지 않습니다. 이 메서드는 flush 또는 close를 수행하지 않습니다
      * it. Serializer and destination failures propagate unchanged; a failed destination may already contain partial
      * output.
      *
@@ -57,7 +57,7 @@ interface BinarySerializer {
     }
 
     /**
-     * Serializes [graph] into the caller-owned [target], starting at its current position.
+     * [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating compatibility fallback: it first calls [serialize] to create a [ByteArray], then
      * copies that array into [target]. A read-only target fails with `ReadOnlyBufferException` before [serialize] is
@@ -84,7 +84,7 @@ interface BinarySerializer {
     fun <T: Any> deserialize(bytes: ByteArray?): T?
 
     /**
-     * Deserializes the trusted, caller-bounded bytes in `[source.position(), source.limit())`.
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 역직렬화합니다.
      *
      * This default is an allocating compatibility fallback: it copies the remaining bytes to a new [ByteArray] and
      * delegates to [deserialize]. The source position, limit, mark, and byte order are preserved on success and failure;

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializerDecorator.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/BinarySerializerDecorator.kt
@@ -34,9 +34,9 @@ open class BinarySerializerDecorator(
     companion object: KLogging()
 
     /**
-     * Serializes through this decorator's virtual [serialize] contract before writing to caller-owned [target].
+     * 호출자 소유 [target]에 쓰기 전에 이 decorator의 virtual [serialize] 계약을 통해 직렬화합니다.
      *
-     * The allocating compatibility path is intentional: Kotlin interface delegation would otherwise bypass
+     * 할당 기반 호환성 경로는 의도된 것입니다. 그렇지 않으면 Kotlin interface delegation이
      * serializer transforms supplied by subclasses of this decorator.
      */
     @Throws(IOException::class)

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/CompressableBinarySerializer.kt
@@ -66,7 +66,7 @@ open class CompressableBinarySerializer(
     }
 
     /**
-     * Serializes and compresses [graph] before writing the compressed wire bytes into caller-owned [target].
+     * [graph]를 직렬화하고 압축한 뒤 압축된 wire byte를 호출자 소유 [target]에 씁니다.
      *
      * This allocating compatibility path intentionally preserves compression and restores nested control-flow
      * failures that standard-array serializer wrappers may hide.
@@ -80,7 +80,7 @@ open class CompressableBinarySerializer(
         }
 
     /**
-     * Serializes and compresses [graph] before copying the compressed wire bytes into caller-owned [target].
+     * [graph]를 직렬화하고 압축한 뒤 압축된 wire byte를 호출자 소유 [target]에 복사합니다.
      *
      * This allocating compatibility path is intentional: decorator semantics take precedence over bypassing compression.
      * Nested cancellation and fatal failures are restored from standard-array serializer wrappers.

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/ForyBinarySerializer.kt
@@ -117,7 +117,7 @@ class ForyBinarySerializer(
         }
 
         /**
-         * Returns a [ForyBinarySerializer] configured with `SCHEMA_CONSISTENT` and reference tracking disabled.
+         * `SCHEMA_CONSISTENT`와 비활성화된 reference tracking으로 설정된 [ForyBinarySerializer]를 반환합니다.
          *
          * Throughput depends on the payload and runtime profile. Use committed benchmark evidence for the exact
          * workload instead of assuming a fixed uplift over the default serializer.

--- a/io/io/src/main/kotlin/io/bluetape4k/io/serializer/SerializationTrustProfile.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/serializer/SerializationTrustProfile.kt
@@ -24,7 +24,7 @@ enum class SerializationTrustProfile(
     ALLOW_LISTED_TYPES("AllowListedTypes"),
 
     /**
-     * The caller supplies the target type statically; serialized data does not
+     * 호출자는 target 타입을 정적으로 제공합니다. 직렬화된 데이터는
      * choose the class to instantiate.
      */
     NO_DYNAMIC_TYPE_LOADING("NoDynamicTypeLoading"),

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
@@ -67,7 +67,7 @@ object Jackson: KLogging() {
     }
 
     /**
-     * Creates a [JsonMapper] that writes property-based type information and allows only trusted
+     * property 기반 타입 정보를 기록하고 신뢰된 타입만 허용하는 [JsonMapper]를 생성합니다
      * subtype packages.
      *
      * ## Security contract

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/JacksonSerializer.kt
@@ -118,8 +118,8 @@ open class JacksonSerializer(
     }
 
     /**
-     * Serializes into [target] through the configured mapper instead of the compatibility [serialize] method.
-     * The target position is committed only on success; read-only and overflow failures remain raw buffer exceptions.
+     * 호환성 [serialize] 메서드 대신 설정된 mapper를 통해 [target]으로 직렬화합니다.
+     * target 위치는 성공할 때만 커밋됩니다. 읽기 전용과 overflow 실패는 원래 buffer 예외로 유지합니다.
      */
     override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
         if (target.isReadOnly) throw ReadOnlyBufferException()
@@ -169,7 +169,7 @@ open class JacksonSerializer(
     }
 
     /**
-     * Deserializes the remaining [source] range through a duplicate-backed stream and preserves caller state.
+     * 남은 [source] 범위를 duplicate 기반 stream으로 역직렬화하고 호출자 상태를 보존합니다.
      */
     override fun <T: Any> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? =
         try {
@@ -228,7 +228,7 @@ open class JacksonSerializer(
 }
 
 /**
- * Deserializes the remaining [source] range with a Jackson type reference, preserving generic type arguments.
+ * 남은 [source] 범위를 Jackson type reference로 역직렬화하여 generic type argument를 보존합니다.
  *
  * This stays an extension so adding it does not introduce a final JVM method on the open [JacksonSerializer] class.
  */

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/crypto/TinkEncryptAlgorithm.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/crypto/TinkEncryptAlgorithm.kt
@@ -34,7 +34,7 @@ enum class TinkEncryptAlgorithm {
     DETERMINISTIC_AES256_SIV;
 
     /**
-     * Returns the singleton [TinkEncryptor] mapped to this algorithm.
+     * 이 알고리즘에 매핑된 singleton [TinkEncryptor]를 반환합니다.
      *
      * @return preconfigured singleton [TinkEncryptor].
      */

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/JacksonSerializer.kt
@@ -101,7 +101,7 @@ open class JacksonSerializer(
     }
 
     /**
-     * Serializes [graph] directly through this serializer's configured mapper while preserving caller ownership of
+     * 호출자 소유권을 보존하면서 이 serializer에 설정된 mapper로 [graph]를 직접 직렬화합니다
      * [target]. Encoder close drains buffered wire bytes without flushing or closing the caller stream.
      */
     @Throws(IOException::class)
@@ -121,8 +121,8 @@ open class JacksonSerializer(
     }
 
     /**
-     * Serializes into [target] through the configured mapper instead of the compatibility [serialize] method.
-     * The target position is committed only on success; read-only and overflow failures remain raw buffer exceptions.
+     * 호환성 [serialize] 메서드 대신 설정된 mapper를 통해 [target]으로 직렬화합니다.
+     * target 위치는 성공할 때만 커밋됩니다. 읽기 전용과 overflow 실패는 원래 buffer 예외로 유지합니다.
      */
     override fun serializeTo(graph: Any?, target: ByteBuffer): Int {
         if (target.isReadOnly) throw ReadOnlyBufferException()
@@ -172,7 +172,7 @@ open class JacksonSerializer(
     }
 
     /**
-     * Deserializes the remaining [source] range through a duplicate-backed stream and preserves caller state.
+     * 남은 [source] 범위를 duplicate 기반 stream으로 역직렬화하고 호출자 상태를 보존합니다.
      */
     override fun <T: Any> deserializeFrom(source: ByteBuffer, clazz: Class<T>): T? =
         try {
@@ -233,7 +233,7 @@ open class JacksonSerializer(
 }
 
 /**
- * Deserializes the remaining [source] range with a Jackson type reference, preserving generic type arguments.
+ * 남은 [source] 범위를 Jackson type reference로 역직렬화하여 generic type argument를 보존합니다.
  *
  * This stays an extension so adding it does not introduce a final JVM method on the open [JacksonSerializer] class.
  */

--- a/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/TinkEncryptAlgorithm.kt
+++ b/io/jackson3/src/main/kotlin/io/bluetape4k/jackson3/crypto/TinkEncryptAlgorithm.kt
@@ -34,7 +34,7 @@ enum class TinkEncryptAlgorithm {
     DETERMINISTIC_AES256_SIV;
 
     /**
-     * Returns the singleton [TinkEncryptor] mapped to this algorithm.
+     * 이 알고리즘에 매핑된 singleton [TinkEncryptor]를 반환합니다.
      *
      * @return preconfigured singleton [TinkEncryptor].
      */

--- a/io/json/src/main/kotlin/io/bluetape4k/json/JsonSerializer.kt
+++ b/io/json/src/main/kotlin/io/bluetape4k/json/JsonSerializer.kt
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer
  * // value?.get("id") == 1
  * ```
  *
- * The interface-default ByteBuffer methods are allocating compatibility fallbacks. Concrete backend verdicts are in
+ * interface default ByteBuffer 메서드는 할당 기반 호환성 fallback입니다. 구체 backend 판정은
  * the [issue #1039 allocation evidence](https://github.com/bluetape4k/bluetape4k-projects/blob/develop/docs/benchmarks/2026-07-18-bytebuffer-serializer-allocation.md).
  */
 interface JsonSerializer {
@@ -41,13 +41,13 @@ interface JsonSerializer {
     fun serialize(graph: Any?): ByteArray
 
     /**
-     * Serializes [graph] and writes the resulting bytes to the caller-owned [target].
+     * [graph]를 직렬화하고 결과 바이트를 호출자 소유 [target]에 씁니다.
      *
      * This interface default is an allocating fallback: it first obtains a [ByteArray] from [serialize], then writes
      * that array to [target]. Null input and zero-byte results retain [serialize]'s existing policy. On success, the
      * returned count is exactly the number of bytes written and is bounded by [Int.MAX_VALUE].
      *
-     * The target is borrowed synchronously and is not retained after the call. This method neither flushes nor closes
+     * target은 동기적으로 빌려 쓰며 호출 뒤 보관하지 않습니다. 이 메서드는 flush 또는 close를 수행하지 않습니다
      * it. Serializer and destination failures propagate unchanged; a failed destination may already contain partial
      * output.
      *
@@ -61,10 +61,10 @@ interface JsonSerializer {
     }
 
     /**
-     * Serializes [graph] into the caller-owned [target], beginning at its current position.
+     * [graph]를 호출자 소유 [target]의 현재 위치부터 직렬화합니다.
      *
      * This default is an allocating fallback: it obtains a [ByteArray] from [serialize] before copying it into [target].
-     * A read-only target fails with `ReadOnlyBufferException` before serializer code runs. Null input retains the
+     * 읽기 전용 target은 serializer 코드 실행 전 `ReadOnlyBufferException`으로 실패합니다. null 입력은
      * existing [serialize] policy, and a zero-byte result returns `0`. Insufficient remaining space fails with the raw
      * `BufferOverflowException`.
      *
@@ -94,7 +94,7 @@ interface JsonSerializer {
     fun <T: Any> deserialize(bytes: ByteArray?, clazz: Class<T>): T?
 
     /**
-     * Deserializes the trusted, caller-bounded bytes in `[source.position(), source.limit())` as [clazz].
+     * `[source.position(), source.limit())` 범위의 신뢰된 호출자 한정 바이트를 [clazz]로 역직렬화합니다.
      *
      * This default is an allocating fallback that copies the remaining bytes to a new [ByteArray] before delegating to
      * [deserialize]. It supports heap, direct, sliced, and read-only sources while preserving the source position,
@@ -154,18 +154,18 @@ inline fun <reified T: Any> JsonSerializer.deserialize(bytes: ByteArray?): T? =
     deserialize(bytes, T::class.java)
 
 /**
- * Deserializes the remaining bytes in [source] as [clazz] through [JsonSerializer.deserializeFrom].
+ * [source]에 남은 바이트를 [JsonSerializer.deserializeFrom]을 통해 [clazz]로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, trusted bounded-input, thread-confinement, and source-state preservation
+ * 할당 기반 fallback, 호출자 소유권, 신뢰된 bounded-input, 스레드 한정, source 상태 보존
  * rules of [JsonSerializer.deserializeFrom] apply.
  */
 fun <T: Any> JsonSerializer.deserialize(source: ByteBuffer, clazz: Class<T>): T? =
     deserializeFrom(source, clazz)
 
 /**
- * Deserializes the remaining bytes in [source] as reified [T] through [JsonSerializer.deserializeFrom].
+ * [source]에 남은 바이트를 [JsonSerializer.deserializeFrom]을 통해 reified [T]로 역직렬화합니다.
  *
- * The allocating fallback, caller ownership, trusted bounded-input, thread-confinement, and source-state preservation
+ * 할당 기반 fallback, 호출자 소유권, 신뢰된 bounded-input, 스레드 한정, source 상태 보존
  * rules of [JsonSerializer.deserializeFrom] apply.
  */
 inline fun <reified T: Any> JsonSerializer.deserialize(source: ByteBuffer): T? =

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/PipeTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/PipeTest.kt
@@ -166,7 +166,7 @@ class PipeTest: AbstractOkioTest() {
     }
 
     /**
-     * The writer is writing 12 bytes as fast as it can to a 3 byte buffer. The reader alternates
+     * writer는 12바이트를 3바이트 buffer에 가능한 한 빠르게 씁니다. reader는 번갈아
      * sleeping 1000 ms, then reading 3 bytes. That should make for an approximate timeline like
      * this:
      *
@@ -177,12 +177,12 @@ class PipeTest: AbstractOkioTest() {
      * 2000: reader reads 'def', sleeps until 3000
      * 2000: writer writes 'ghi', blocks
      * 3000: reader reads 'ghi', sleeps until 4000
-     * 3000: writer writes 'jkl', returns
-     * 4000: reader reads 'jkl', returns
+     * 3000: writer가 'jkl'을 쓰고 반환합니다
+     * 4000: reader가 'jkl'을 읽고 반환합니다
      * ```
      *
      *
-     * Because the writer is writing to a buffer, it finishes before the reader does.
+     * writer가 buffer에 쓰기 때문에 reader보다 먼저 완료됩니다.
      */
     @Test
     fun `sink blocks on slow reader`() {
@@ -311,7 +311,7 @@ class PipeTest: AbstractOkioTest() {
 
 
     /**
-     * The writer has 12 bytes to write. It alternates sleeping 1000 ms, then writing 3 bytes. The
+     * writer는 12바이트를 써야 합니다. 1000 ms sleep 후 3바이트 쓰기를 반복합니다.
      * reader is reading as fast as it can. That should make for an approximate timeline like this:
      *
      * ```
@@ -323,8 +323,8 @@ class PipeTest: AbstractOkioTest() {
      * 2000: reader reads 'def'
      * 3000: writer writes 'ghi', sleeps until 4000
      * 3000: reader reads 'ghi'
-     * 4000: writer writes 'jkl', returns
-     * 4000: reader reads 'jkl', returns
+     * 4000: writer가 'jkl'을 쓰고 반환합니다
+     * 4000: reader가 'jkl'을 읽고 반환합니다
      * ```
      */
     @Test
@@ -374,7 +374,7 @@ class PipeTest: AbstractOkioTest() {
     }
 
     /**
-     * The writer has 12 bytes to write. It alternates sleeping 1000 ms, then writing 3 bytes. The
+     * writer는 12바이트를 써야 합니다. 1000 ms sleep 후 3바이트 쓰기를 반복합니다.
      * reader is reading as fast as it can. That should make for an approximate timeline like this:
      *
      * ```
@@ -386,8 +386,8 @@ class PipeTest: AbstractOkioTest() {
      * 2000: reader reads 'def'
      * 3000: writer writes 'ghi', sleeps until 4000
      * 3000: reader reads 'ghi'
-     * 4000: writer writes 'jkl', returns
-     * 4000: reader reads 'jkl', returns
+     * 4000: writer가 'jkl'을 쓰고 반환합니다
+     * 4000: reader가 'jkl'을 읽고 반환합니다
      * ```
      */
     @Test

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/MessageSupport.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/MessageSupport.kt
@@ -28,13 +28,13 @@ fun <T: Message> packMessage(message: T): ByteArray {
 /**
  * Packs [message] as protobuf `Any` wire bytes into [target].
  *
- * The bytes are identical to [packMessage]. Writing begins at the target's current position, so callers may use a
+ * [packMessage]와 동일한 바이트입니다. 쓰기는 target의 현재 위치에서 시작하므로 호출자는
  * nonzero position and a bounded limit. On success, the target's byte order, limit, and capacity are preserved, and
  * its position advances by the returned byte count. The exact encoded size is preflighted against
  * [ByteBuffer.remaining]; a read-only target is rejected before packing or checking the encoded size. These preflight
  * failures leave the target state and content unchanged.
  *
- * A later write failure restores only the target position; already-written content is intentionally unspecified. After
+ * 나중의 쓰기 실패는 target 위치만 복구합니다. 이미 기록된 내용은 의도적으로 지정하지 않습니다. 이후
  * such a failure, callers must clear, reinitialize, or discard the target before reusing it. The target remains
  * caller-owned and must be thread-confined or otherwise synchronized by its caller.
  *
@@ -74,7 +74,7 @@ inline fun <reified T: Message> unpackMessage(bytes: ByteArray): T? {
  *
  * Parsing uses a short-lived duplicate, so the caller's source position, limit, mark, and byte order are preserved;
  * this also supports nonzero positions and bounded sources. No buffer view is retained after this function returns.
- * A mismatched `Any` type returns `null`; malformed wire bytes propagate their parse failure.
+ * 일치하지 않는 `Any` 타입은 `null`을 반환합니다. 잘못된 wire byte는 parse 실패를 그대로 전파합니다.
  */
 inline fun <reified T: Message> unpackMessage(source: ByteBuffer): T? {
     val any = ProtoAny.parseFrom(source.duplicate())

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/ProtobufSerializer.kt
@@ -64,7 +64,7 @@ class ProtobufSerializer(
         )
 
         /**
-         * Creates the trusted-internal mixed Protobuf + fallback serializer.
+         * trusted-internal 혼합 Protobuf + fallback serializer를 생성합니다.
          *
          * Use this profile only for internal stores whose historical bytes may contain fallback-encoded payloads.
          */

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/LettuceProtobufCodecs.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/LettuceProtobufCodecs.kt
@@ -110,13 +110,13 @@ object LettuceProtobufCodecs {
     }
 
     /**
-     * Creates a strict Protobuf codec optimized for a direct ByteBuf target.
+     * direct ByteBuf target에 최적화된 strict Protobuf codec을 생성합니다.
      *
-     * The target remains caller-owned. This removes the payload-sized handoff for uncompressed Protobuf values but
+     * target은 계속 호출자 소유입니다. 압축되지 않은 Protobuf 값에서 payload 크기 handoff를 제거하지만
      * does not promise zero-copy operation. The unchanged ByteBuffer API and all compressed or custom-prefix codecs
      * retain their compatibility path. On failure, failure-aftercare belongs to the caller because attempted bytes or
      * capacity growth may remain even though the writer index is not advanced.
-     * The default allowlist accepts Bluetape and Google Protobuf message packages. Callers that need another package
+     * 기본 allowlist는 Bluetape 및 Google Protobuf message package를 허용합니다. 다른 package가 필요한 호출자는
      * prefix must construct [ProtobufSerializer] and [LettuceBinaryCodec] directly; that custom-prefix path retains
      * the allocating compatibility implementation.
      *
@@ -184,43 +184,43 @@ object LettuceProtobufCodecs {
         LettuceBinaryCodec(CompressableBinarySerializer(strictSerializer, Compressors.Zstd))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec optimized for a direct ByteBuf target.
+     * direct ByteBuf target에 최적화된 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      *
      * Use this factory only for internal stores where every producer and stored payload is trusted. Do not use it at
      * a shared or untrusted boundary.
      *
-     * The target is caller-owned and has the same failure-aftercare contract as [protobuf]. The unchanged ByteBuffer
+     * target은 호출자 소유이며 [protobuf]와 동일한 failure-aftercare 계약을 가집니다. 변경되지 않은 ByteBuffer
      * API, compressed factories, and any caller-configured custom-prefix serializer retain the compatibility path.
      */
     fun <V: Any> trustedInternalProtobuf(): LettuceBinaryCodec<V> =
         DirectProtobufLettuceCodec.create(trustedInternalSerializer)
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Gzip compression.
+     * Gzip 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalGzipProtobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.GZip))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Deflate compression.
+     * Deflate 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalDeflateProtobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Deflate))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with LZ4 compression.
+     * LZ4 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalLz4Protobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.LZ4))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Snappy compression.
+     * Snappy 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalSnappyProtobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Snappy))
 
     /**
-     * Creates a trusted-internal mixed Protobuf + Kryo fallback codec with Zstd compression.
+     * Zstd 압축을 사용하는 trusted-internal 혼합 Protobuf + Kryo fallback codec을 생성합니다.
      */
     fun <V: Any> trustedInternalZstdProtobuf(): LettuceBinaryCodec<V> =
         LettuceBinaryCodec(CompressableBinarySerializer(trustedInternalSerializer, Compressors.Zstd))

--- a/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
+++ b/io/protobuf/src/main/kotlin/io/bluetape4k/protobuf/serializers/redis/RedissonProtobufCodec.kt
@@ -93,7 +93,7 @@ class RedissonProtobufCodec private constructor(
         val ALLOW_ALL_CLASSES_UNSAFE: Set<String> = setOf("*")
 
         /**
-         * Creates a trusted-internal mixed Protobuf + fallback codec.
+         * trusted-internal 혼합 Protobuf + fallback codec을 생성합니다.
          *
          * Use this profile only for internal Redis stores whose historical bytes may contain fallback-encoded payloads.
          */

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kStatusPages.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kStatusPages.kt
@@ -8,7 +8,7 @@ import io.ktor.server.response.respond
 import kotlinx.coroutines.CancellationException
 
 /**
- * Registers default JSON error responses for common application exceptions.
+ * 일반 application exception에 대한 기본 JSON error response를 등록합니다.
  *
  * ## Contract
  * - [IllegalArgumentException] is mapped to HTTP 400.
@@ -42,7 +42,7 @@ fun StatusPagesConfig.bluetape4kErrorResponses() {
 }
 
 /**
- * Responds with the standard bluetape4k JSON error payload.
+ * 표준 bluetape4k JSON error payload로 응답합니다.
  */
 suspend fun ApplicationCall.respondApiError(
     status: HttpStatusCode,

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorRequestParameters.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorRequestParameters.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.support.requireNotBlank
 import io.ktor.server.application.ApplicationCall
 
 /**
- * Returns a required path parameter or throws [IllegalArgumentException].
+ * 필수 path parameter를 반환하거나 [IllegalArgumentException]을 던집니다.
  */
 fun ApplicationCall.requiredPathParameter(name: String): String {
     name.requireNotBlank("name")
@@ -14,7 +14,7 @@ fun ApplicationCall.requiredPathParameter(name: String): String {
 }
 
 /**
- * Returns a required query parameter or throws [IllegalArgumentException].
+ * 필수 query parameter를 반환하거나 [IllegalArgumentException]을 던집니다.
  */
 fun ApplicationCall.requiredQueryParameter(name: String): String {
     name.requireNotBlank("name")

--- a/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceStatusPages.kt
+++ b/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceStatusPages.kt
@@ -8,7 +8,7 @@ import io.ktor.server.plugins.statuspages.StatusPagesConfig
 import java.util.concurrent.TimeoutException
 
 /**
- * Registers generic JSON error responses for Resilience4j route failures.
+ * Resilience4j route failure에 대한 generic JSON error response를 등록합니다.
  *
  * ## Contract
  * - Open circuit failures map to HTTP 503.

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTesting.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTesting.kt
@@ -39,7 +39,7 @@ fun ApplicationTestBuilder.installBluetape4kKtorCoreForTest(
 }
 
 /**
- * Creates a Ktor test client with bluetape4k JSON defaults.
+ * bluetape4k JSON 기본값을 사용하는 Ktor test client를 생성합니다.
  *
  * ## Contract
  * - Uses [Bluetape4kKtorJson.defaultJson] unless a custom [jsonFormat] is supplied.

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorResponseAssertions.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorResponseAssertions.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 /**
- * Verifies the HTTP status and returns the same response for chaining.
+ * HTTP status를 검증하고 chaining할 수 있도록 같은 response를 반환합니다.
  */
 infix fun HttpResponse.shouldHaveStatus(expected: HttpStatusCode): HttpResponse {
     status shouldBeEqualTo expected
@@ -53,7 +53,7 @@ suspend inline fun <reified T> HttpResponse.shouldHaveJsonBody(
 }
 
 /**
- * Verifies a standard bluetape4k [ApiErrorResponse].
+ * 표준 bluetape4k [ApiErrorResponse]를 검증합니다.
  */
 suspend fun HttpResponse.shouldHaveApiError(
     expected: ExpectedApiError,

--- a/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/basic/BasicUserRepository.kt
+++ b/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/basic/BasicUserRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
 
     /**
-     * Sample method annotated with {@link Query}. This method executes the CQL from the {@link Query} value.
+     * {@link Query}가 붙은 sample method입니다. 이 method는 {@link Query} 값의 CQL을 실행합니다.
      *
      * @param id
      * @return
@@ -16,7 +16,7 @@ interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
     suspend fun findUserByIdIn(id: Long): BasicUser?
 
     /**
-     * Derived query method. This query corresponds with {@code SELECT * FROM users WHERE uname = ?0}.
+     * derived query method입니다. 이 query는 {@code SELECT * FROM users WHERE uname = ?0}에 대응합니다.
      * {@link User#username} is not part of the primary so it requires a secondary index.
      *
      * @param username
@@ -25,7 +25,7 @@ interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
     suspend fun findByUsername(username: String): BasicUser?
 
     /**
-     * Derived query method using SASI (SSTable Attached Secondary Index) features through the `LIKE` keyword. This
+     * `LIKE` keyword를 통해 SASI(SSTable Attached Secondary Index) 기능을 사용하는 derived query method입니다. 이
      * query corresponds with `SELECT * FROM users WHERE lname LIKE '?0'`}`. `User.lastname` is not part of the
      * primary key so it requires a secondary index.
      *

--- a/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/kotlin/PersonRepository.kt
+++ b/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/kotlin/PersonRepository.kt
@@ -12,7 +12,7 @@ interface PersonRepository: CoroutineCrudRepository<Person, String> {
     fun findByFirstname(firstname: String): Flow<Person>
 
     /**
-     * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
+     * 결과가 필요한 query method입니다. 결과를 찾지 못하면 [org.springframework.dao.EmptyResultDataAccessException]을 던집니다.
      * NOTE: suspend 메소드일 때에는 발생하지 않습니다.
      */
     suspend fun findOneByFirstname(firstname: String): Person?

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
@@ -6,9 +6,9 @@ import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Base controller that exposes a virtual-thread-per-task executor.
+ * virtual-thread-per-task executor를 노출하는 base controller입니다.
  *
- * Use this base class only when a controller needs an explicit
+ * controller가 explicit
  * [ExecutorService] for virtual-thread task submission. Spring calls
  * [closeVirtualThreadExecutor] when the controller bean is destroyed, and the
  * shared executor is recreated on the next access if a later context needs it.

--- a/spring-boot/r2dbc/src/test/kotlin/io/bluetape4k/spring/r2dbc/coroutines/blog/DatabaseInitializer.kt
+++ b/spring-boot/r2dbc/src/test/kotlin/io/bluetape4k/spring/r2dbc/coroutines/blog/DatabaseInitializer.kt
@@ -18,7 +18,7 @@ class DatabaseInitializer(
     companion object: KLoggingChannel()
 
     /**
-     * Spring Boot Application이 준비되면 호출되는 Event Listener
+     * Spring Boot application이 준비되면 호출되는 event listener입니다.
      */
     @EventListener(value = [ApplicationReadyEvent::class])
     fun init() {

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
@@ -5,9 +5,9 @@ import java.io.Serializable
 private const val REDACTED_MARKER_VALUE = "values redacted"
 
 /**
- * Identifies a framework boundary covered by a context propagation proof.
+ * context propagation proof가 다루는 framework boundary를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -22,9 +22,9 @@ enum class ContextPropagationBoundary {
 }
 
 /**
- * Identifies the lifecycle scenario exercised by a context propagation proof.
+ * context propagation proof가 실행하는 lifecycle scenario를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -39,9 +39,9 @@ enum class ContextPropagationScenario {
 }
 
 /**
- * Identifies the terminal outcome observed after crossing a context boundary.
+ * context boundary를 지난 뒤 관찰된 terminal outcome을 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -55,9 +55,9 @@ enum class ContextPropagationTerminal {
 }
 
 /**
- * Identifies where cleanup was probed after a boundary completed.
+ * boundary 완료 후 cleanup을 probe한 위치를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -72,7 +72,7 @@ enum class ContextProbeLocation {
 /**
  * Supplies a stable test-owned alias for one request or probe.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -88,7 +88,7 @@ enum class ContextRequestAlias {
 /**
  * Identifies a stable observation point inside a propagation lifecycle.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -103,7 +103,7 @@ enum class ContextObservationPoint {
 /**
  * Defines the relation applied to an isolation sample.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenariosTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenariosTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 class HttpIdempotencyBoundaryScenariosTest {
 
     /**
-     * Uses a custom barrier-aligned harness because `SuspendedJobTester` does not expose each
+     * `SuspendedJobTester`가 각 항목을 노출하지 않으므로 custom barrier-aligned harness를 사용합니다
      * attempt's result together with the per-key waiter-registration barrier. The bounded workload
      * is five rounds, three keys per round, and at most 105 concurrent requests per round.
      */

--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/MockServerApplication.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/MockServerApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 /**
- * Bluetape4k Mock Server 애플리케이션.
+ * Bluetape4k Mock Server 애플리케이션입니다.
  *
  * httpbin, jsonplaceholder 등 다양한 HTTP 테스트용 mock 엔드포인트를 제공하는 Spring Boot 애플리케이션.
  * 포트 80(HTTP)/443(HTTPS)에서 실행되며, Testcontainers 환경에서 외부 HTTP 의존성을 대체할 수 있다.

--- a/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
+++ b/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
@@ -9,7 +9,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 
 /**
- * README HTTPS port documentation must match runtime and container metadata.
+ * README HTTPS port 문서는 runtime 및 container metadata와 일치해야 합니다.
  */
 class ReadmeHttpsPortContractTest {
 

--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/MockWebfluxServerApplication.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/MockWebfluxServerApplication.kt
@@ -6,8 +6,8 @@ import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 
 /**
- * Mock WebFlux 서버 애플리케이션.
- * Spring Boot 4 WebFlux + Kotlin Coroutines 기반 테스트용 HTTP 서버.
+ * Mock WebFlux 서버 애플리케이션입니다.
+ * Spring Boot 4 WebFlux + Kotlin Coroutines 기반 테스트용 HTTP 서버입니다.
  */
 @EnableCaching
 @SpringBootApplication

--- a/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
+++ b/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
@@ -8,7 +8,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 
 /**
- * README endpoint rows must describe implemented mock-webflux routes only.
+ * README endpoint row는 구현된 mock-webflux route만 설명해야 합니다.
  */
 class ReadmeRouteContractTest {
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
@@ -11,7 +11,7 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
 
 /**
- * Runs a single-node [etcd](https://etcd.io/) server with Testcontainers.
+ * Testcontainers로 single-node [etcd](https://etcd.io/) server를 실행합니다.
  *
  * ## Behavior / Contract
  * - Exposes the etcd client API on [CLIENT_PORT] and the peer API on [PEER_PORT].
@@ -50,7 +50,7 @@ class EtcdServer private constructor(
         val EXPORT_PORTS = intArrayOf(CLIENT_PORT, PEER_PORT)
 
         /**
-         * Creates an [EtcdServer] from a [DockerImageName].
+         * [DockerImageName]으로 [EtcdServer]를 생성합니다.
          *
          * @param imageName Docker image name.
          * @param useDefaultPort binds 2379/2380 to the same host ports when `true`.
@@ -66,7 +66,7 @@ class EtcdServer private constructor(
         }
 
         /**
-         * Creates an [EtcdServer] from an image name and tag.
+         * image name과 tag로 [EtcdServer]를 생성합니다.
          *
          * @param image Docker image name; blank values are rejected.
          * @param tag Docker image tag; blank values are rejected.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
@@ -16,7 +16,7 @@ import java.time.Duration
 import java.util.Base64
 
 /**
- * Runs a [Grafana](https://grafana.com/) server in Docker for integration tests.
+ * integration test를 위해 Docker에서 [Grafana](https://grafana.com/) server를 실행합니다.
  *
  * Follows the same `GenericServer + Launcher` pattern as [PrometheusServer].
  *
@@ -62,7 +62,7 @@ class GrafanaServer private constructor(
         const val ADMIN_PASSWORD = "admin"
 
         /**
-         * Creates a [GrafanaServer] from a pre-built [DockerImageName].
+         * 미리 구성된 [DockerImageName]으로 [GrafanaServer]를 생성합니다.
          *
          * @param imageName      Fully qualified Docker image name with tag.
          * @param useDefaultPort When `true`, binds port [PORT] to the same fixed host port.
@@ -76,7 +76,7 @@ class GrafanaServer private constructor(
         ): GrafanaServer = GrafanaServer(imageName, useDefaultPort, reuse)
 
         /**
-         * Creates a [GrafanaServer] by image name and tag.
+         * image name과 tag로 [GrafanaServer]를 생성합니다.
          *
          * @param image          Docker image name; blank value throws [IllegalArgumentException].
          * @param tag            Docker image tag; blank value throws [IllegalArgumentException].

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
@@ -13,7 +13,7 @@ import org.testcontainers.k3s.K3sContainer
 import org.testcontainers.utility.DockerImageName
 
 /**
- * Runs a [K3s](https://k3s.io/) lightweight Kubernetes cluster in Docker for integration tests.
+ * integration test를 위해 Docker에서 [K3s](https://k3s.io/) lightweight Kubernetes cluster를 실행합니다.
  *
  * Extends the native testcontainers [K3sContainer] and adds the bluetape4k
  * `GenericServer + Launcher` pattern.
@@ -53,7 +53,7 @@ class K3sServer private constructor(
         const val API_PORT = 6443
 
         /**
-         * Creates a [K3sServer] from a pre-built [DockerImageName].
+         * 미리 구성된 [DockerImageName]으로 [K3sServer]를 생성합니다.
          *
          * @param imageName      Fully qualified Docker image name with tag.
          * @param useDefaultPort When `true`, binds port [API_PORT] to the same fixed host port.
@@ -67,7 +67,7 @@ class K3sServer private constructor(
         ): K3sServer = K3sServer(imageName, useDefaultPort, reuse)
 
         /**
-         * Creates a [K3sServer] by image name and tag.
+         * image name과 tag로 [K3sServer]를 생성합니다.
          *
          * @param image          Docker image name; blank value throws [IllegalArgumentException].
          * @param tag            Docker image tag; blank value throws [IllegalArgumentException].
@@ -118,7 +118,7 @@ class K3sServer private constructor(
     }
 
     /**
-     * Returns a fabric8 [KubernetesClient] pre-configured for this K3s cluster.
+     * 이 K3s cluster에 맞게 미리 설정된 fabric8 [KubernetesClient]를 반환합니다.
      *
      * Must be called **after** [start]. Each call returns a **new** client instance
      * registered in [ShutdownQueue] — it will be closed on JVM shutdown automatically.

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
@@ -6,8 +6,8 @@ import io.bluetape4k.testcontainers.AbstractContainerTest
 import org.junit.jupiter.api.Test
 
 /**
- * Validation tests for [K3sServer] that do not require a running container.
- * These run in regular CI without a privileged Docker runner.
+ * 실행 중인 container가 필요 없는 [K3sServer] validation test입니다.
+ * privileged Docker runner 없이 일반 CI에서 실행됩니다.
  */
 class K3sServerValidationTest: AbstractContainerTest() {
 

--- a/utils/geo/src/main/kotlin/io/bluetape4k/geohash/queries/GeoHashBoundingBoxQuery.kt
+++ b/utils/geo/src/main/kotlin/io/bluetape4k/geohash/queries/GeoHashBoundingBoxQuery.kt
@@ -176,7 +176,7 @@ class GeoHashBoundingBoxQuery(
     }
 
     /**
-     * Checks if the provided hash completely(!) contains the provided bounding box
+     * 제공된 hash가 제공된 bounding box를 완전히(!) 포함하는지 확인합니다
      */
     private fun hashContainsBoundingBox(
         hash: GeoHash,

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geohash/tests/RandomGeoHashes.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geohash/tests/RandomGeoHashes.kt
@@ -25,16 +25,16 @@ object RandomGeoHashes: KLogging() {
     }
 
     /**
-     * Create a completely random [GeoHash] with a random number of bits.
+     * random bit 수를 가진 완전 random [GeoHash]를 생성합니다.
      *
-     * Precision will be between [5,64] bits.
+     * precision은 [5,64] bit 사이입니다.
      */
     fun create(): GeoHash {
         return geoHashWithBits(randomLatitude(), randomLongitude(), randomPrecision())
     }
 
     /**
-     * Create a completely random geohash with
+     * 완전 random geohash를 생성합니다
      * a precision that is a multiple of 5 and in [5,60] bits.
      */
     fun createWith5BitsPrecision(): GeoHash {

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geohash/utils/GeoHashSizeTableTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geohash/utils/GeoHashSizeTableTest.kt
@@ -43,7 +43,7 @@ class GeoHashSizeTableTest {
         fun generate(bits: Int): BoundingBox
 
         /**
-         * Get expected bits
+         * expected bit를 가져옵니다.
          */
         fun getExpectedBits(bits: Int): Int
     }

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/hashids/Hashids.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/hashids/Hashids.kt
@@ -236,7 +236,7 @@ class Hashids(
         (numbersHash + returnStr[index].code) % guards.length
 
     /**
-     * Encode hexadecimal formatted string
+     * hexadecimal formatted string을 encode합니다.
      *
      * @param hexStr hexadecimal formatted string to encode
      * @return encoded string as hash
@@ -256,7 +256,7 @@ class Hashids(
     }
 
     /**
-     * Decode hash to hexadecimal formatted string
+     * hash를 hexadecimal formatted string으로 decode합니다.
      *
      * @param hash encoded string
      * @return hexadecimal formatted string

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/snowflake/SnowflakeId.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/snowflake/SnowflakeId.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.support.publicLazy
 import java.io.Serializable
 
 /**
- * Snowflake id
+ * Snowflake id입니다.
  *
  * ```kotlin
  * val snowflake = DefaultSnowflake()

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/ulid/utils/TestConstants.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/ulid/utils/TestConstants.kt
@@ -56,6 +56,6 @@ val PatternBytes =
     ).map { it.toByte() }.toByteArray()
 
 /**
- * Get timestamp and random part of ULID string.
+ * ULID string에서 timestamp와 random part를 가져옵니다.
  */
 fun partsOf(ulid: String): Pair<String, String> = ulid.substring(0, 10) to ulid.substring(10)

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
@@ -38,7 +38,7 @@ class JwtReader(
         get() = header<String>("kid")
 
     /**
-     * JWT expiration time as epoch milliseconds.
+     * JWT 만료 시각을 epoch milliseconds로 표현한 값입니다.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 `null`을 반환합니다.
@@ -47,7 +47,7 @@ class JwtReader(
         get() = expiration?.time
 
     /**
-     * Expiration TTL (Time To Live) in milliseconds.
+     * 만료 TTL(Time To Live)을 milliseconds로 표현한 값입니다.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 [Long.MAX_VALUE]를 반환합니다.
@@ -65,7 +65,7 @@ class JwtReader(
         get() = expiresAtMillis?.let { (it - System.currentTimeMillis()).coerceAtLeast(0L) } ?: Long.MAX_VALUE
 
     /**
-     * Expiration TTL (Time To Live) in milliseconds.
+     * 만료 TTL(Time To Live)을 milliseconds로 표현한 값입니다.
      *
      * @see remainingTtlMillis
      */

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/GroupingSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/GroupingSupport.kt
@@ -81,7 +81,7 @@ inline fun <T: Any, K: Any> Iterable<T>.groupingCount(crossinline keySelector: (
 /**
  * Groups elements from the [Grouping] source by key and applies [operation] to the elements of each group sequentially,
  * passing the previously accumulated value and the current element as arguments, and stores the results in a new map.
- * An initial value of accumulator is the same [initialValue] for each group.
+ * accumulator의 initial value는 각 group마다 같은 [initialValue]입니다.
  *
  * ```kotlin
  * val data = sequenceOf("apple" to 3, "banana" to 5, "apple" to 7)
@@ -110,7 +110,7 @@ inline fun <T: Any, K: Any, R: Any> Sequence<T>.groupingFold(
 /**
  * Groups elements from the [Grouping] source by key and applies [operation] to the elements of each group sequentially,
  * passing the previously accumulated value and the current element as arguments, and stores the results in a new map.
- * An initial value of accumulator is the same [initialValue] for each group.
+ * accumulator의 initial value는 각 group마다 같은 [initialValue]입니다.
  *
  * ```kotlin
  * val data = listOf("apple" to 3, "banana" to 5, "apple" to 7)
@@ -138,7 +138,7 @@ inline fun <T: Any, K: Any, R: Any> Iterable<T>.groupingFold(
  * sequentially starting from the second element of the group,
  * passing the previously accumulated value and the current element as arguments,
  * and stores the results in a new map.
- * An initial value of accumulator is the first element of the group.
+ * accumulator의 initial value는 group의 첫 번째 element입니다.
  *
  * ```kotlin
  * val data = sequenceOf("apple" to 1, "banana" to 2, "apple" to 3)
@@ -170,7 +170,7 @@ inline fun <T: S, K: Any, S: Any> Sequence<T>.groupingReduce(
  * sequentially starting from the second element of the group,
  * passing the previously accumulated value and the current element as arguments,
  * and stores the results in a new map.
- * An initial value of accumulator is the first element of the group.
+ * accumulator의 initial value는 group의 첫 번째 element입니다.
  *
  * ```kotlin
  * val data = listOf("apple" to 1, "banana" to 2, "apple" to 3)

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/MathConsts.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/MathConsts.kt
@@ -47,14 +47,14 @@ object MathConsts {
 
     /**
      * ln(10) / 20 - Power Decibel (dB) 를 Neper (Np) 로 변환할 때의 factor
-     * Use this version when the Decibel represent a power gain
+     * Decibel이 power gain을 나타낼 때 이 version을 사용합니다
      * but the compared values are not powers (e.g. amplitude, current, voltage).
      */
     val powerDecibel: Double get() = ln(10.0) / 20.0
 
     /**
      * ln(10) / 10 - Neutral Decibel (dB)를 Neper (Np)로 변환할 때의 factor
-     * Use this version when the Decibel represent a power gain
+     * Decibel이 power gain을 나타낼 때 이 version을 사용합니다
      * but the compared values are not powers (e.g. amplitude, current, voltage).
      */
     val neutralDecibel: Double get() = ln(10.0) / 10.0
@@ -65,25 +65,25 @@ object MathConsts {
     val goldenRatio: Double = (1.0 + sqrt(5.0)) / 2.0
 
     /**
-     * The Catalan constant
+     * Catalan constant입니다.
      * `Sum(k=0 -> inf){ (-1)^k/(2*k + 1)2 }`
      */
     const val CATALAN: Double = 0.9159655941772190150546035149323841107741493742816721342664981196217630197762547694794
 
     /**
-     * The Euler-Mascheroni constant
+     * Euler-Mascheroni constant입니다.
      * `lim(n -> inf){ Sum(k=1 -> n) { 1/k - log(n) } }`
      */
     const val EULER_MASCHERONI = 0.5772156649015328606065120900824024310421593359399235988057672348849
 
     /**
-     * The Glaisher constant
+     * Glaisher constant입니다.
      * `e^(1/12 - Zeta(-1))`
      */
     const val GLAISHER = 1.2824271291006226368753425688697917277676889273250011920637400217404063088588264611297
 
     /**
-     * The Khinchin constant
+     * Khinchin constant입니다.
      * `prod(k=1 -> inf){1+1/(k*(k+2))^log(k,2)}`</remarks>`
      */
     const val KHINCHIN = 2.6854520010653064453097148354817956938203822939944629530511523455572188595371520028011

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/RandomSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/RandomSupport.kt
@@ -141,7 +141,7 @@ fun <T: Any> Sequence<T>.random(sampleSize: Int): List<T> = toList().random(samp
 fun <T: Any> Iterable<T>.random(sampleSize: Int): List<T> = toList().random(sampleSize)
 
 /**
- * Simulates a weighted TRUE/FALSE coin flip, with a percentage of probability towards TRUE
+ * TRUE 쪽 probability percentage를 가진 weighted TRUE/FALSE coin flip을 시뮬레이션합니다
  * In other words, this is a Probability Density Function (PDF) for discrete TRUE/FALSE values
  *
  * ```kotlin
@@ -169,7 +169,7 @@ class WeightedCoin(val trueProbability: Double) {
 }
 
 /**
- * Simulates a weighted TRUE/FALSE coin flip, with a percentage of probability towards TRUE
+ * TRUE 쪽 probability percentage를 가진 weighted TRUE/FALSE coin flip을 시뮬레이션합니다
  * In other words, this is a Probability Density Function (PDF) for discrete TRUE/FALSE values
  *
  * ```kotlin

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.states.core
 import java.io.Serializable
 
 /**
- * Identifies an inherited transition registered for a state family.
+ * state family에 등록된 inherited transition을 식별합니다.
  *
  * Exact state transitions still have precedence. Parent transitions are used
  * when the current state is an instance of [stateType] and no exact transition

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
@@ -99,7 +99,7 @@ class StateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
-     * Registers an inherited transition for every state matching [from].
+     * [from]과 일치하는 모든 state에 inherited transition을 등록합니다.
      *
      * Exact state transitions have precedence over inherited transitions.
      */
@@ -212,7 +212,7 @@ class SuspendStateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
-     * Registers an inherited transition for every state matching [from].
+     * [from]과 일치하는 모든 state에 inherited transition을 등록합니다.
      *
      * Exact state transitions have precedence over inherited transitions.
      */
@@ -317,7 +317,7 @@ fun <S: Any, E: Any> suspendStateMachine(
 inline fun <reified E: Any> on(): Class<E> = E::class.java
 
 /**
- * Returns a state class for inherited transition registration.
+ * inherited transition 등록에 사용할 state class를 반환합니다.
  *
  * ```kotlin
  * transition(state<OrderState.Payable>(), on<OrderEvent.Cancel>(), to = OrderState.Cancelled)


### PR DESCRIPTION
## Summary

Closes #1157

- PR 제목: kdoc(core): Koreanize core support KDoc

- Koreanizes scoped KDoc in core support and Apache utility surfaces.
- Preserves API identifiers, sample snippets, and Apache contract examples.
- Keeps README files, LLM-facing operating docs, and bilingual manual pairs out of scope.

Closes #1157.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Koreanizes scoped KDoc in core support and Apache utility surfaces.
- Preserves API identifiers, sample snippets, and Apache contract examples.
- Keeps README files, LLM-facing operating docs, and bilingual manual pairs out of scope.

Closes #1157.

### Validation
- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`
- `rg -n '^\\s*\\* (Provides|Checks|System default|Abbreviates|Appends|Centers|Remove|Counts|Find|Left pad|Right pad|Gets|Wraps|Unwraps|Case insensitive|Case insensitively|Strips|Compares)\\b' bluetape4k/core/src/main/kotlin/io/bluetape4k/{apache,support,DefaultFields.kt} -g '*.kt'` returned no scoped drift

### CI
- Local Gradle CI was skipped because this is a KDoc/comment-only localization change.
- Remote `submit-gradle` is expected to remain the CI gate for the stacked PR.

### DoD Status
- [x] Scope candidates identified and exclusions recorded.
- [x] Korean rewrite or KDoc update completed for the scoped surface.
- [x] Links, code snippets, identifiers, and examples remain valid.
- [x] Guardrail and targeted verification evidence are recorded in the PR.

## Validation

- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`
- `rg -n '^\\s*\\* (Provides|Checks|System default|Abbreviates|Appends|Centers|Remove|Counts|Find|Left pad|Right pad|Gets|Wraps|Unwraps|Case insensitive|Case insensitively|Strips|Compares)\\b' bluetape4k/core/src/main/kotlin/io/bluetape4k/{apache,support,DefaultFields.kt} -g '*.kt'` returned no scoped drift

- Local Gradle CI was skipped because this is a KDoc/comment-only localization change.
- Remote `submit-gradle` is expected to remain the CI gate for the stacked PR.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1157, milestone `1.12.0`, assignee `debop`
- PR: #1205, head `6a5691fcff466d91f0f97410bfb56884f41d74d2`, milestone `1.12.0`, assignee `debop`
- Base: `docs/issue-1156-process-governance-notes`, head branch `docs/issue-1157-core-kdoc`
- Labels: `documentation`, `tech-debt`
- State: `MERGED`, merge commit `9fffd36bcd005f9ab7af8f7c58612bc32222ec10`
- CI: - Keeps README files, LLM-facing operating docs, and bilingual manual pairs out of scope. / ## CI / - Local Gradle CI was skipped because this is a KDoc/comment-only localization change.

## DoD Status

- [x] Scope candidates identified and exclusions recorded.
- [x] Korean rewrite or KDoc update completed for the scoped surface.
- [x] Links, code snippets, identifiers, and examples remain valid.
- [x] Guardrail and targeted verification evidence are recorded in the PR.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1205 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9fffd36bcd005f9ab7af8f7c58612bc32222ec10`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
