### PR TITLE
kdoc(cache): Koreanize cache core and backend KDoc

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/cache2k/Cache2kSupport.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/cache2k/Cache2kSupport.kt
@@ -7,7 +7,7 @@ import org.cache2k.CacheManager
 import org.cache2k.config.Cache2kConfig
 
 /**
- * Default Cache2k [CacheManager]
+ * 기본 Cache2k [CacheManager]입니다.
  */
 val defaultCache2kManager: CacheManager by lazy { CacheManager.getInstance() }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/ehcache/EhcacheSupport.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/ehcache/EhcacheSupport.kt
@@ -13,7 +13,7 @@ import org.ehcache.config.units.EntryUnit
 import org.ehcache.config.units.MemoryUnit
 
 /**
- * Default Ehcache [CacheManager]
+ * 기본 Ehcache [CacheManager]입니다.
  */
 val DefaultEhCacheCacheManager: CacheManager by lazy {
     ehcacheManager {

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/cache2k/Cache2kSuspendMemoizer.kt
@@ -42,10 +42,10 @@ fun <T: Any, R: Any> (suspend (T) -> R).withSuspendMemoizer(
  * ## Recursion Safety
  * Holding a global Mutex during evaluator execution causes deadlocks for recursive memoizers
  * (e.g., factorial, fibonacci) because Kotlin's Mutex is not reentrant.
- * The per-key Deferred pattern runs the evaluator outside any lock, so recursive calls are safe.
+ * per-key Deferred pattern은 evaluator를 lock 밖에서 실행하므로 재귀 호출이 안전합니다.
  *
  * ## Write-after-clear Safety
- * A generation counter ensures that results from in-flight evaluations started before [clear]
+ * generation counter는 [clear] 전에 시작된 in-flight evaluation 결과가
  * are not written back to the cache after it has been invalidated. The caller always receives
  * the computed value regardless of the generation check.
  *

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineAsyncMemoizer.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 /**
- * Creates a [CaffeineAsyncMemoizer] backed by this Caffeine [Cache].
+ * 이 Caffeine [Cache]를 backend로 사용하는 [CaffeineAsyncMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val cache = Caffeine.newBuilder().maximumSize(1000).build<String, Int>()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemoryAsyncMemoizer.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Creates an [InMemoryAsyncMemoizer] for this [CompletableFuture]-based evaluator.
+ * 이 [CompletableFuture] 기반 evaluator에 대한 [InMemoryAsyncMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val memo = ({ key: String -> CompletableFuture.completedFuture(key.length) }).asyncMemoizer()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/inmemory/InMemorySuspendMemoizer.kt
@@ -7,7 +7,7 @@ import io.bluetape4k.logging.trace
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Creates an [InMemorySuspendMemoizer] for this suspend evaluator.
+ * 이 suspend evaluator에 대한 [InMemorySuspendMemoizer]를 생성합니다.
  *
  * ```kotlin
  * val memo = (suspend { key: String -> key.length }).suspendMemoizer()

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt
@@ -39,7 +39,7 @@ class NearJCacheManagementMXBean(
     /**
      * Determines if a [Cache] should operate in read-through mode.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return `true` when a [Cache] is in "read-through" mode.
      */
@@ -48,7 +48,7 @@ class NearJCacheManagementMXBean(
     /**
      * Determines if a [Cache] should operate in "write-through" mode.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return `true` when a [Cache] is in "write-through" mode.
      */
@@ -57,7 +57,7 @@ class NearJCacheManagementMXBean(
     /**
      * Whether storeByValue (true) or storeByReference (false).
      *
-     * The default value is `true`.
+     * 기본값은 `true`입니다.
      *
      * @return true if the cache is store by value
      */
@@ -66,7 +66,7 @@ class NearJCacheManagementMXBean(
     /**
      * Checks whether statistics collection is enabled in this cache.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return true if statistics collection is enabled
      */
@@ -75,7 +75,7 @@ class NearJCacheManagementMXBean(
     /**
      * Checks whether management is enabled on this cache.
      *
-     * The default value is `false`.
+     * 기본값은 `false`입니다.
      *
      * @return true if management is enabled
      */

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheStatisticsMXBean.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheStatisticsMXBean.kt
@@ -28,7 +28,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     private val putTime = atomic(0L)
 
     /**
-     * Clears the statistics counters to 0 for the associated Cache.
+     * 연결된 Cache의 statistics counter를 0으로 초기화합니다.
      */
     override fun clear() {
         removals.value = 0
@@ -47,7 +47,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The number of get requests that were satisfied by the cache.
+     * cache가 만족한 get request 수입니다.
      *
      *
      * [javax.cache.Cache.containsKey] is not a get request for
@@ -88,7 +88,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * A miss is a get request that is not satisfied.
+     * miss는 만족되지 않은 get request입니다.
      *
      *
      * In a simple cache a miss occurs when the cache does not satisfy the request.
@@ -119,7 +119,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     override fun getCacheMisses(): Long = misses.value
 
     /**
-     * Returns the percentage of cache accesses that did not find a requested entry
+     * 요청한 entry를 찾지 못한 cache access 비율을 반환합니다
      * in the cache.
      *
      *
@@ -136,7 +136,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of requests to the cache. This will be equal to the sum of
+     * cache에 대한 전체 request 수입니다. 이는 다음 합과 같습니다
      * the hits and misses.
      *
      *
@@ -156,10 +156,10 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of puts to the cache.
+     * cache에 대한 전체 put 수입니다.
      *
      *
-     * A put is counted even if it is immediately evicted.
+     * put 직후 evict되더라도 put으로 계산합니다.
      *
      *
      * Replaces, where a put occurs which overrides an existing mapping is counted
@@ -174,7 +174,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of removals from the cache. This does not include evictions,
+     * cache에서 제거된 전체 removal 수입니다. eviction은 포함하지 않습니다,
      * where the cache itself initiates the removal to make space.
      *
      * @return the number of removals
@@ -186,7 +186,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The total number of evictions from the cache. An eviction is a removal
+     * cache에서 발생한 전체 eviction 수입니다. eviction은 removal입니다
      * initiated by the cache itself to free up space. An eviction is not treated as
      * a removal and does not appear in the removal counts.
      *
@@ -207,7 +207,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute gets.
+     * get 실행 평균 시간입니다.
      *
      *
      * In a read-through cache the time taken to load an entry on miss is not
@@ -222,7 +222,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute puts.
+     * put 실행 평균 시간입니다.
      *
      * @return the time in µs
      */
@@ -233,7 +233,7 @@ open class NearJCacheStatisticsMXBean: CacheStatisticsMXBean {
     }
 
     /**
-     * The mean time to execute removes.
+     * remove 실행 평균 시간입니다.
      *
      * @return the time in µs
      */

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractSuspendNearJCacheTest.kt
@@ -49,13 +49,13 @@ abstract class AbstractSuspendNearJCacheTest
     protected val frontCoCache2 by lazy { createFrontSuspendCache(Duration.ofMinutes(10)) }
 
     /**
-     * Creates a [SuspendNearJCache] for the given front and back caches.
+     * 주어진 front/back cache에 대한 [SuspendNearJCache]를 생성합니다.
      *
      * Override in subclasses that cannot register a listener (e.g. Hazelcast, which requires
      * [javax.cache.configuration.CacheEntryListenerConfiguration] to be Serializable for cluster
      * distribution) to call [SuspendNearJCache.withoutListener] instead.
      *
-     * The default implementation calls [SuspendNearJCache.invoke] which registers a
+     * 기본 구현은 [SuspendNearJCache.invoke]를 호출하여 등록합니다
      * [io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListener] on [backSuspendJCache] so that
      * mutations propagate from back → front.
      */

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/SharedFlowAsEventBus.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/SharedFlowAsEventBus.kt
@@ -24,7 +24,7 @@ class SharedFlowAsEventBus {
     companion object: KLoggingChannel()
 
     /**
-     * An event bus implementation that uses a shared flow to broadcast events to multiple listeners.
+     * shared flow로 여러 listener에 event를 broadcast하는 event bus 구현입니다.
      */
     class EventBus<T> {
         // The shared flow that will be used to broadcast events to multiple listeners.

--- a/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/AbstractBlazePersistenceTest.kt
+++ b/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/AbstractBlazePersistenceTest.kt
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 /**
- * Base Spring Boot test configuration for the Blaze Persistence examples.
+ * Blaze Persistence example을 위한 base Spring Boot test configuration입니다.
  */
 @SpringBootTest(
     classes = [BlazePersistenceApplication::class],

--- a/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/BlazePersistenceApplication.kt
+++ b/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/BlazePersistenceApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 /**
- * Spring Boot test application for the Blaze Persistence JPA examples.
+ * Blaze Persistence JPA example용 Spring Boot test application입니다.
  */
 @SpringBootApplication
 @EnableJpaAuditing(modifyOnCreate = true)

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 /**
- * Spring Boot demo application for bluetape4k idgenerators.
+ * bluetape4k idgenerator용 Spring Boot demo application입니다.
  *
  * ## Behavior
  * - Registers `IdGenerator` implementations as Spring beans and injects them into the REST controller.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 /**
- * Example configuration that registers idgenerator implementations as Spring beans.
+ * idgenerator 구현체를 Spring bean으로 등록하는 example configuration입니다.
  *
  * ## Behavior
  * - UUID generators of the same type are distinguished by bean name.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.support.requirePositiveNumber
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * Configuration properties for the ID batch example.
+ * ID batch example 설정 property입니다.
  *
  * ## Behavior
  * - `defaultBatchSize` is used when the `size` query parameter is omitted.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * REST controller for the idgenerator Spring Boot demo.
+ * idgenerator Spring Boot demo용 REST controller입니다.
  *
  * ## Behavior
  * - The `/ids/{type}` family provides explicit endpoints that are easy to copy.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 /**
- * Converts input validation errors from the idgenerator REST demo into JSON responses.
+ * idgenerator REST demo의 input validation error를 JSON response로 변환합니다.
  *
  * ## Behavior
  * - Unsupported generator types and batch size errors return HTTP 400.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
@@ -43,7 +43,7 @@ data class GeneratorResponse(
 )
 
 /**
- * Example application health response.
+ * example application health response입니다.
  */
 data class HealthResponse(
     val status: String,

--- a/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
+++ b/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
@@ -23,7 +23,7 @@ import java.io.Serializable
 private const val REQUEST_ID_HEADER = "X-Request-Id"
 
 /**
- * Spring Boot observability example for Prometheus metrics and OTLP tracing configuration.
+ * Prometheus metric과 OTLP tracing configuration을 보여 주는 Spring Boot observability example입니다.
  *
  * ## Behavior
  * - Exposes application metrics through Spring Boot Actuator's Prometheus endpoint.

--- a/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt
+++ b/infra/elasticsearch/src/main/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutines.kt
@@ -241,12 +241,12 @@ data class BulkListenerHandle<Context>(
 }
 
 /**
- * Creates a [BulkListener] and [Flow] pair for bulk progress callbacks.
+ * bulk progress callback을 위한 [BulkListener]와 [Flow] pair를 생성합니다.
  *
  * Register the returned [BulkListener] with a [BulkIngester] to stream `beforeBulk`,
  * successful `afterBulk`, and failed `afterBulk` callbacks as [BulkProgressEvent] values.
  *
- * The callback path never suspends or blocks Elasticsearch client threads. Events are
+ * callback 경로는 Elasticsearch client thread를 suspend하거나 block하지 않습니다. event는
  * offered to a bounded [Channel] with [bufferCapacity] and [onBufferOverflow]. With the
  * default [BufferOverflow.SUSPEND] policy, `trySend` failures are logged and the event is
  * dropped when collectors are too slow or absent.

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -74,7 +74,7 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         /**
          * Sentinel value for [allowedTypePackages] that bypasses all package checks.
          *
-         * Use only in fully trusted, internal deployments where all Kafka producers are
+         * 모든 Kafka producer가 완전히 신뢰되는 internal deployment에서만 사용합니다
          * controlled. Assigning this constant re-enables the pre-1.8.0 allow-all behavior.
          *
          * ```kotlin

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -110,7 +110,7 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     fun receiveAutoAck(): Flow<ConsumerRecord<K, V>> = receiver.receiveAutoAck().concatMap { it }.asFlow()
 
     /**
-     * Returns a {@link Flux} of consumer record batches that may be used for exactly once
+     * exactly once 처리에 사용할 수 있는 consumer record batch의 {@link Flux}를 반환합니다
      * delivery semantics. A new transaction is started for each inner Flux and it is the
      * responsibility of the consuming application to commit or abort the transaction
      * using {@link TransactionManager#commit()} or {@link TransactionManager#abort()}

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -53,7 +53,7 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
 
     companion object: KLoggingChannel() {
         /**
-         * Create an instance of [SuspendKafkaProducerTemplate] with the provided configuration.
+         * 제공된 configuration으로 [SuspendKafkaProducerTemplate] instance를 생성합니다.
          *
          * @param senderOptions [SenderOptions] instance.
          * @param messageConverter [RecordMessageConverter] instance.

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
@@ -8,9 +8,9 @@ import org.apache.kafka.common.header.internals.RecordHeaders
 import org.junit.jupiter.api.Test
 
 /**
- * Security tests for [JacksonKafkaCodec] type allowlist enforcement.
+ * [JacksonKafkaCodec] type allowlist 강제를 검증하는 security test입니다.
  *
- * Verifies that:
+ * 다음을 검증합니다:
  * - Untrusted class names in the `VALUE_TYPE_KEY` header are rejected by default (empty allowedTypePackages)
  * - Explicitly allowed packages are deserialized correctly
  * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE] opt-in restores legacy allow-all behavior

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/codec/KafkaCodec.kt
@@ -151,7 +151,7 @@ abstract class AbstractKafkaCodec<T>: KafkaCodec<T> {
         /**
          * Sentinel value for [allowedTypePackages] that bypasses all package checks.
          *
-         * Use only in fully trusted, internal deployments where all Kafka producers are
+         * 모든 Kafka producer가 완전히 신뢰되는 internal deployment에서만 사용합니다
          * controlled. Assigning this constant re-enables the pre-1.8.0 allow-all behavior.
          *
          * ```kotlin

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaConsumerTemplate.kt
@@ -110,7 +110,7 @@ class SuspendKafkaConsumerTemplate<K, V> private constructor(
     fun receiveAutoAck(): Flow<ConsumerRecord<K, V>> = receiver.receiveAutoAck().concatMap { it }.asFlow()
 
     /**
-     * Returns a {@link Flux} of consumer record batches that may be used for exactly once
+     * exactly once 처리에 사용할 수 있는 consumer record batch의 {@link Flux}를 반환합니다
      * delivery semantics. A new transaction is started for each inner Flux and it is the
      * responsibility of the consuming application to commit or abort the transaction
      * using {@link TransactionManager#commit()} or {@link TransactionManager#abort()}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/spring/core/SuspendKafkaProducerTemplate.kt
@@ -53,7 +53,7 @@ class SuspendKafkaProducerTemplate<K, V> private constructor(
 
     companion object: KLoggingChannel() {
         /**
-         * Create an instance of [SuspendKafkaProducerTemplate] with the provided configuration.
+         * 제공된 configuration으로 [SuspendKafkaProducerTemplate] instance를 생성합니다.
          *
          * @param senderOptions [SenderOptions] instance.
          * @param messageConverter [RecordMessageConverter] instance.

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/codec/JacksonKafkaCodecSecurityTest.kt
@@ -12,9 +12,9 @@ import org.apache.kafka.common.header.internals.RecordHeaders
 import org.junit.jupiter.api.Test
 
 /**
- * Security tests for [JacksonKafkaCodec] type allowlist enforcement.
+ * [JacksonKafkaCodec] type allowlist 강제를 검증하는 security test입니다.
  *
- * Verifies that:
+ * 다음을 검증합니다:
  * - Untrusted class names in the `VALUE_TYPE_KEY` header are rejected by default (empty allowedTypePackages)
  * - Explicitly allowed packages are deserialized correctly
  * - [AbstractKafkaCodec.ALLOW_ALL_TYPES_UNSAFE] opt-in restores legacy allow-all behavior

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodec.kt
@@ -12,7 +12,7 @@ import java.nio.ByteBuffer
 import java.nio.ReadOnlyBufferException
 
 /**
- * A Lettuce [RedisCodec] that serializes values with a [BinarySerializer].
+ * [BinarySerializer]로 값을 직렬화하는 Lettuce [RedisCodec]입니다.
  *
  * ```kotlin
  * val codec = LettuceBinaryCodec<MyData>(BinarySerializers.LZ4Kryo)
@@ -23,7 +23,7 @@ import java.nio.ReadOnlyBufferException
  * // value == myData
  * ```
  *
- * The nullable target-taking [encodeValue] overload is the only supported source extension seam. Ordinary codec
+ * nullable target을 받는 [encodeValue] overload가 유일하게 지원되는 source extension 지점입니다. 일반 codec
  * methods remain final. Opening this class also makes compiler-generated JVM bridge methods bytecode-overrideable;
  * those bridges are not a supported extension API. Subclasses must override only the target overload and preserve
  * the configured [serializer] contract.
@@ -59,7 +59,7 @@ open class LettuceBinaryCodec<V: Any>(
     /**
      * Encodes [value] into the caller-owned [target].
      *
-     * A null target is a no-op. A read-only target fails before serializer dispatch and preserves its observable
+     * null target은 no-op입니다. 읽기 전용 target은 serializer dispatch 전에 실패하며 관찰 가능한 상태를 보존합니다
      * indices, marks, and reference count. The caller owns the target and its lifetime. A successful override must
      * commit the writer index only after the complete value has been written. A failed override may leave attempted
      * bytes or capacity changes behind, but it must not advance the writer index. Subclasses are responsible for

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceBinaryCodecs.kt
@@ -51,7 +51,7 @@ object LettuceBinaryCodecs {
     fun <V: Any> kryo(): LettuceBinaryCodec<V> = codec(BinarySerializers.Kryo)
 
     /**
-     * Creates a [LettuceBinaryCodec] with the raw Fory serializer.
+     * raw Fory serializer를 사용하는 [LettuceBinaryCodec]을 생성합니다.
      *
      * One-argument encode still creates a [ByteArray]. Caller-owned target encode uses the bounded stream path to
      * avoid the codec-level handoff array and commits the writer index only after success. Fory retains its internal
@@ -144,7 +144,7 @@ object LettuceBinaryCodecs {
     // -------------------------------------------------------------------------
 
     /**
-     * Creates a [LettuceBinaryCodec] with the raw FastFory serializer.
+     * raw FastFory serializer를 사용하는 [LettuceBinaryCodec]을 생성합니다.
      *
      * FastFory uses `CompatibleMode.SCHEMA_CONSISTENT`. One-argument encode still creates a [ByteArray].
      * Caller-owned target encode avoids only the codec-level handoff array; Fory's internal buffer remains, so this

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/codec/LettuceJsonCodec.kt
@@ -61,7 +61,7 @@ class LettuceJsonCodec<V: Any>(
     /**
      * Encodes [value] into the caller-owned [target].
      *
-     * A null target is a no-op. A read-only target fails before serializer dispatch and preserves its observable
+     * null target은 no-op입니다. 읽기 전용 target은 serializer dispatch 전에 실패하며 관찰 가능한 상태를 보존합니다
      * indices, marks, and reference count. Success commits the writer index only after the complete wire is written;
      * failure may leave attempted content or capacity changes but does not commit the writer index.
      */

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeasePerformanceTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lease/LettuceMultiKeyLeasePerformanceTest.kt
@@ -38,11 +38,11 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.ceil
 
 /**
- * Characterizes Redis-side multi-key lease cost outside the default test task.
+ * 기본 test task 밖에서 Redis-side multi-key lease 비용을 특성화합니다.
  *
- * Re-run `:bluetape4k-lettuce:multiKeyLeasePerformanceTest` after changing the Lua scripts or the default `maxKeys`.
- * Absolute latency is environment-dependent; the regression assertion compares normalized p95 values within one run.
- * This test deliberately owns a dedicated Redis server and explicit executors: a shared launcher would contaminate
+ * Lua script 또는 기본 `maxKeys`를 변경한 뒤 `:bluetape4k-lettuce:multiKeyLeasePerformanceTest`를 다시 실행합니다.
+ * 절대 latency는 환경 의존적이므로 regression assertion은 한 run 안의 normalized p95 값을 비교합니다.
+ * 이 test는 전용 Redis server와 explicit executor를 의도적으로 소유합니다. shared launcher는 오염시킬 수 있습니다
  * latency samples, while `MultithreadingTester` cannot preserve per-attempt timing, persistent connections, and the
  * independently scheduled PING probe that this characterization requires.
  */

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockPerformanceTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LockPerformanceTest.kt
@@ -44,9 +44,9 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Characterizes coordination lock command, scheduler, latency, and retained-state bounds.
+ * coordination lock command, scheduler, latency, retained-state 한계를 특성화합니다.
  *
- * Absolute timings vary by host. This suite therefore asserts exact command budgets, hard caps, cleanup invariants,
+ * 절대 시간은 host마다 달라집니다. 따라서 이 suite는 정확한 command budget, hard cap, cleanup invariant,
  * and normalized within-run relationships. It is intentionally isolated from the default test task.
  */
 @Tag("coordination-lock-performance")

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kStatusPages.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/Bluetape4kStatusPages.kt
@@ -8,7 +8,7 @@ import io.ktor.server.response.respond
 import kotlinx.coroutines.CancellationException
 
 /**
- * Registers default JSON error responses for common application exceptions.
+ * 일반 application exception에 대한 기본 JSON error response를 등록합니다.
  *
  * ## Contract
  * - [IllegalArgumentException] is mapped to HTTP 400.
@@ -42,7 +42,7 @@ fun StatusPagesConfig.bluetape4kErrorResponses() {
 }
 
 /**
- * Responds with the standard bluetape4k JSON error payload.
+ * 표준 bluetape4k JSON error payload로 응답합니다.
  */
 suspend fun ApplicationCall.respondApiError(
     status: HttpStatusCode,

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorRequestParameters.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/KtorRequestParameters.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.support.requireNotBlank
 import io.ktor.server.application.ApplicationCall
 
 /**
- * Returns a required path parameter or throws [IllegalArgumentException].
+ * 필수 path parameter를 반환하거나 [IllegalArgumentException]을 던집니다.
  */
 fun ApplicationCall.requiredPathParameter(name: String): String {
     name.requireNotBlank("name")
@@ -14,7 +14,7 @@ fun ApplicationCall.requiredPathParameter(name: String): String {
 }
 
 /**
- * Returns a required query parameter or throws [IllegalArgumentException].
+ * 필수 query parameter를 반환하거나 [IllegalArgumentException]을 던집니다.
  */
 fun ApplicationCall.requiredQueryParameter(name: String): String {
     name.requireNotBlank("name")

--- a/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceStatusPages.kt
+++ b/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceStatusPages.kt
@@ -8,7 +8,7 @@ import io.ktor.server.plugins.statuspages.StatusPagesConfig
 import java.util.concurrent.TimeoutException
 
 /**
- * Registers generic JSON error responses for Resilience4j route failures.
+ * Resilience4j route failure에 대한 generic JSON error response를 등록합니다.
  *
  * ## Contract
  * - Open circuit failures map to HTTP 503.

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTesting.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/Bluetape4kKtorTesting.kt
@@ -39,7 +39,7 @@ fun ApplicationTestBuilder.installBluetape4kKtorCoreForTest(
 }
 
 /**
- * Creates a Ktor test client with bluetape4k JSON defaults.
+ * bluetape4k JSON 기본값을 사용하는 Ktor test client를 생성합니다.
  *
  * ## Contract
  * - Uses [Bluetape4kKtorJson.defaultJson] unless a custom [jsonFormat] is supplied.

--- a/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorResponseAssertions.kt
+++ b/ktor/testing/src/main/kotlin/io/bluetape4k/ktor/testing/KtorResponseAssertions.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 /**
- * Verifies the HTTP status and returns the same response for chaining.
+ * HTTP status를 검증하고 chaining할 수 있도록 같은 response를 반환합니다.
  */
 infix fun HttpResponse.shouldHaveStatus(expected: HttpStatusCode): HttpResponse {
     status shouldBeEqualTo expected
@@ -53,7 +53,7 @@ suspend inline fun <reified T> HttpResponse.shouldHaveJsonBody(
 }
 
 /**
- * Verifies a standard bluetape4k [ApiErrorResponse].
+ * 표준 bluetape4k [ApiErrorResponse]를 검증합니다.
  */
 suspend fun HttpResponse.shouldHaveApiError(
     expected: ExpectedApiError,

--- a/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/basic/BasicUserRepository.kt
+++ b/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/basic/BasicUserRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
 
     /**
-     * Sample method annotated with {@link Query}. This method executes the CQL from the {@link Query} value.
+     * {@link Query}가 붙은 sample method입니다. 이 method는 {@link Query} 값의 CQL을 실행합니다.
      *
      * @param id
      * @return
@@ -16,7 +16,7 @@ interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
     suspend fun findUserByIdIn(id: Long): BasicUser?
 
     /**
-     * Derived query method. This query corresponds with {@code SELECT * FROM users WHERE uname = ?0}.
+     * derived query method입니다. 이 query는 {@code SELECT * FROM users WHERE uname = ?0}에 대응합니다.
      * {@link User#username} is not part of the primary so it requires a secondary index.
      *
      * @param username
@@ -25,7 +25,7 @@ interface BasicUserRepository: CoroutineCrudRepository<BasicUser, Long> {
     suspend fun findByUsername(username: String): BasicUser?
 
     /**
-     * Derived query method using SASI (SSTable Attached Secondary Index) features through the `LIKE` keyword. This
+     * `LIKE` keyword를 통해 SASI(SSTable Attached Secondary Index) 기능을 사용하는 derived query method입니다. 이
      * query corresponds with `SELECT * FROM users WHERE lname LIKE '?0'`}`. `User.lastname` is not part of the
      * primary key so it requires a secondary index.
      *

--- a/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/kotlin/PersonRepository.kt
+++ b/spring-boot/cassandra-demo/src/test/kotlin/io/bluetape4k/examples/cassandra/kotlin/PersonRepository.kt
@@ -12,7 +12,7 @@ interface PersonRepository: CoroutineCrudRepository<Person, String> {
     fun findByFirstname(firstname: String): Flow<Person>
 
     /**
-     * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
+     * 결과가 필요한 query method입니다. 결과를 찾지 못하면 [org.springframework.dao.EmptyResultDataAccessException]을 던집니다.
      * NOTE: suspend 메소드일 때에는 발생하지 않습니다.
      */
     suspend fun findOneByFirstname(firstname: String): Person?

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/virtualthread/AbstractVirtualThreadController.kt
@@ -6,9 +6,9 @@ import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Base controller that exposes a virtual-thread-per-task executor.
+ * virtual-thread-per-task executor를 노출하는 base controller입니다.
  *
- * Use this base class only when a controller needs an explicit
+ * controller가 explicit
  * [ExecutorService] for virtual-thread task submission. Spring calls
  * [closeVirtualThreadExecutor] when the controller bean is destroyed, and the
  * shared executor is recreated on the next access if a later context needs it.

--- a/spring-boot/r2dbc/src/test/kotlin/io/bluetape4k/spring/r2dbc/coroutines/blog/DatabaseInitializer.kt
+++ b/spring-boot/r2dbc/src/test/kotlin/io/bluetape4k/spring/r2dbc/coroutines/blog/DatabaseInitializer.kt
@@ -18,7 +18,7 @@ class DatabaseInitializer(
     companion object: KLoggingChannel()
 
     /**
-     * Spring Boot Application이 준비되면 호출되는 Event Listener
+     * Spring Boot application이 준비되면 호출되는 event listener입니다.
      */
     @EventListener(value = [ApplicationReadyEvent::class])
     fun init() {

--- a/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
+++ b/testing/junit5/src/main/kotlin/io/bluetape4k/junit5/observability/ContextPropagationConformance.kt
@@ -5,9 +5,9 @@ import java.io.Serializable
 private const val REDACTED_MARKER_VALUE = "values redacted"
 
 /**
- * Identifies a framework boundary covered by a context propagation proof.
+ * context propagation proof가 다루는 framework boundary를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -22,9 +22,9 @@ enum class ContextPropagationBoundary {
 }
 
 /**
- * Identifies the lifecycle scenario exercised by a context propagation proof.
+ * context propagation proof가 실행하는 lifecycle scenario를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -39,9 +39,9 @@ enum class ContextPropagationScenario {
 }
 
 /**
- * Identifies the terminal outcome observed after crossing a context boundary.
+ * context boundary를 지난 뒤 관찰된 terminal outcome을 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -55,9 +55,9 @@ enum class ContextPropagationTerminal {
 }
 
 /**
- * Identifies where cleanup was probed after a boundary completed.
+ * boundary 완료 후 cleanup을 probe한 위치를 식별합니다.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -72,7 +72,7 @@ enum class ContextProbeLocation {
 /**
  * Supplies a stable test-owned alias for one request or probe.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -88,7 +88,7 @@ enum class ContextRequestAlias {
 /**
  * Identifies a stable observation point inside a propagation lifecycle.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *
@@ -103,7 +103,7 @@ enum class ContextObservationPoint {
 /**
  * Defines the relation applied to an isolation sample.
  *
- * Future values are additive. Callers should include an `else` branch instead of treating an exhaustive `when` as
+ * future value는 additive입니다. 호출자는 exhaustive `when`으로 간주하지 말고 `else` branch를 포함해야 합니다
  * durable. Examples use only test-owned synthetic data; production request IDs, user data, and external trace IDs
  * must never be supplied.
  *

--- a/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenariosTest.kt
+++ b/testing/junit5/src/test/kotlin/io/bluetape4k/junit5/http/idempotency/HttpIdempotencyBoundaryScenariosTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 class HttpIdempotencyBoundaryScenariosTest {
 
     /**
-     * Uses a custom barrier-aligned harness because `SuspendedJobTester` does not expose each
+     * `SuspendedJobTester`가 각 항목을 노출하지 않으므로 custom barrier-aligned harness를 사용합니다
      * attempt's result together with the per-key waiter-registration barrier. The bounded workload
      * is five rounds, three keys per round, and at most 105 concurrent requests per round.
      */

--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/MockServerApplication.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/MockServerApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 /**
- * Bluetape4k Mock Server 애플리케이션.
+ * Bluetape4k Mock Server 애플리케이션입니다.
  *
  * httpbin, jsonplaceholder 등 다양한 HTTP 테스트용 mock 엔드포인트를 제공하는 Spring Boot 애플리케이션.
  * 포트 80(HTTP)/443(HTTPS)에서 실행되며, Testcontainers 환경에서 외부 HTTP 의존성을 대체할 수 있다.

--- a/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
+++ b/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
@@ -9,7 +9,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 
 /**
- * README HTTPS port documentation must match runtime and container metadata.
+ * README HTTPS port 문서는 runtime 및 container metadata와 일치해야 합니다.
  */
 class ReadmeHttpsPortContractTest {
 

--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/MockWebfluxServerApplication.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/MockWebfluxServerApplication.kt
@@ -6,8 +6,8 @@ import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 
 /**
- * Mock WebFlux 서버 애플리케이션.
- * Spring Boot 4 WebFlux + Kotlin Coroutines 기반 테스트용 HTTP 서버.
+ * Mock WebFlux 서버 애플리케이션입니다.
+ * Spring Boot 4 WebFlux + Kotlin Coroutines 기반 테스트용 HTTP 서버입니다.
  */
 @EnableCaching
 @SpringBootApplication

--- a/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
+++ b/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
@@ -8,7 +8,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 
 /**
- * README endpoint rows must describe implemented mock-webflux routes only.
+ * README endpoint row는 구현된 mock-webflux route만 설명해야 합니다.
  */
 class ReadmeRouteContractTest {
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
@@ -11,7 +11,7 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
 
 /**
- * Runs a single-node [etcd](https://etcd.io/) server with Testcontainers.
+ * Testcontainers로 single-node [etcd](https://etcd.io/) server를 실행합니다.
  *
  * ## Behavior / Contract
  * - Exposes the etcd client API on [CLIENT_PORT] and the peer API on [PEER_PORT].
@@ -50,7 +50,7 @@ class EtcdServer private constructor(
         val EXPORT_PORTS = intArrayOf(CLIENT_PORT, PEER_PORT)
 
         /**
-         * Creates an [EtcdServer] from a [DockerImageName].
+         * [DockerImageName]으로 [EtcdServer]를 생성합니다.
          *
          * @param imageName Docker image name.
          * @param useDefaultPort binds 2379/2380 to the same host ports when `true`.
@@ -66,7 +66,7 @@ class EtcdServer private constructor(
         }
 
         /**
-         * Creates an [EtcdServer] from an image name and tag.
+         * image name과 tag로 [EtcdServer]를 생성합니다.
          *
          * @param image Docker image name; blank values are rejected.
          * @param tag Docker image tag; blank values are rejected.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
@@ -16,7 +16,7 @@ import java.time.Duration
 import java.util.Base64
 
 /**
- * Runs a [Grafana](https://grafana.com/) server in Docker for integration tests.
+ * integration test를 위해 Docker에서 [Grafana](https://grafana.com/) server를 실행합니다.
  *
  * Follows the same `GenericServer + Launcher` pattern as [PrometheusServer].
  *
@@ -62,7 +62,7 @@ class GrafanaServer private constructor(
         const val ADMIN_PASSWORD = "admin"
 
         /**
-         * Creates a [GrafanaServer] from a pre-built [DockerImageName].
+         * 미리 구성된 [DockerImageName]으로 [GrafanaServer]를 생성합니다.
          *
          * @param imageName      Fully qualified Docker image name with tag.
          * @param useDefaultPort When `true`, binds port [PORT] to the same fixed host port.
@@ -76,7 +76,7 @@ class GrafanaServer private constructor(
         ): GrafanaServer = GrafanaServer(imageName, useDefaultPort, reuse)
 
         /**
-         * Creates a [GrafanaServer] by image name and tag.
+         * image name과 tag로 [GrafanaServer]를 생성합니다.
          *
          * @param image          Docker image name; blank value throws [IllegalArgumentException].
          * @param tag            Docker image tag; blank value throws [IllegalArgumentException].

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
@@ -13,7 +13,7 @@ import org.testcontainers.k3s.K3sContainer
 import org.testcontainers.utility.DockerImageName
 
 /**
- * Runs a [K3s](https://k3s.io/) lightweight Kubernetes cluster in Docker for integration tests.
+ * integration test를 위해 Docker에서 [K3s](https://k3s.io/) lightweight Kubernetes cluster를 실행합니다.
  *
  * Extends the native testcontainers [K3sContainer] and adds the bluetape4k
  * `GenericServer + Launcher` pattern.
@@ -53,7 +53,7 @@ class K3sServer private constructor(
         const val API_PORT = 6443
 
         /**
-         * Creates a [K3sServer] from a pre-built [DockerImageName].
+         * 미리 구성된 [DockerImageName]으로 [K3sServer]를 생성합니다.
          *
          * @param imageName      Fully qualified Docker image name with tag.
          * @param useDefaultPort When `true`, binds port [API_PORT] to the same fixed host port.
@@ -67,7 +67,7 @@ class K3sServer private constructor(
         ): K3sServer = K3sServer(imageName, useDefaultPort, reuse)
 
         /**
-         * Creates a [K3sServer] by image name and tag.
+         * image name과 tag로 [K3sServer]를 생성합니다.
          *
          * @param image          Docker image name; blank value throws [IllegalArgumentException].
          * @param tag            Docker image tag; blank value throws [IllegalArgumentException].
@@ -118,7 +118,7 @@ class K3sServer private constructor(
     }
 
     /**
-     * Returns a fabric8 [KubernetesClient] pre-configured for this K3s cluster.
+     * 이 K3s cluster에 맞게 미리 설정된 fabric8 [KubernetesClient]를 반환합니다.
      *
      * Must be called **after** [start]. Each call returns a **new** client instance
      * registered in [ShutdownQueue] — it will be closed on JVM shutdown automatically.

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
@@ -6,8 +6,8 @@ import io.bluetape4k.testcontainers.AbstractContainerTest
 import org.junit.jupiter.api.Test
 
 /**
- * Validation tests for [K3sServer] that do not require a running container.
- * These run in regular CI without a privileged Docker runner.
+ * 실행 중인 container가 필요 없는 [K3sServer] validation test입니다.
+ * privileged Docker runner 없이 일반 CI에서 실행됩니다.
  */
 class K3sServerValidationTest: AbstractContainerTest() {
 

--- a/utils/geo/src/main/kotlin/io/bluetape4k/geohash/queries/GeoHashBoundingBoxQuery.kt
+++ b/utils/geo/src/main/kotlin/io/bluetape4k/geohash/queries/GeoHashBoundingBoxQuery.kt
@@ -176,7 +176,7 @@ class GeoHashBoundingBoxQuery(
     }
 
     /**
-     * Checks if the provided hash completely(!) contains the provided bounding box
+     * 제공된 hash가 제공된 bounding box를 완전히(!) 포함하는지 확인합니다
      */
     private fun hashContainsBoundingBox(
         hash: GeoHash,

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geohash/tests/RandomGeoHashes.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geohash/tests/RandomGeoHashes.kt
@@ -25,16 +25,16 @@ object RandomGeoHashes: KLogging() {
     }
 
     /**
-     * Create a completely random [GeoHash] with a random number of bits.
+     * random bit 수를 가진 완전 random [GeoHash]를 생성합니다.
      *
-     * Precision will be between [5,64] bits.
+     * precision은 [5,64] bit 사이입니다.
      */
     fun create(): GeoHash {
         return geoHashWithBits(randomLatitude(), randomLongitude(), randomPrecision())
     }
 
     /**
-     * Create a completely random geohash with
+     * 완전 random geohash를 생성합니다
      * a precision that is a multiple of 5 and in [5,60] bits.
      */
     fun createWith5BitsPrecision(): GeoHash {

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geohash/utils/GeoHashSizeTableTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geohash/utils/GeoHashSizeTableTest.kt
@@ -43,7 +43,7 @@ class GeoHashSizeTableTest {
         fun generate(bits: Int): BoundingBox
 
         /**
-         * Get expected bits
+         * expected bit를 가져옵니다.
          */
         fun getExpectedBits(bits: Int): Int
     }

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/hashids/Hashids.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/hashids/Hashids.kt
@@ -236,7 +236,7 @@ class Hashids(
         (numbersHash + returnStr[index].code) % guards.length
 
     /**
-     * Encode hexadecimal formatted string
+     * hexadecimal formatted string을 encode합니다.
      *
      * @param hexStr hexadecimal formatted string to encode
      * @return encoded string as hash
@@ -256,7 +256,7 @@ class Hashids(
     }
 
     /**
-     * Decode hash to hexadecimal formatted string
+     * hash를 hexadecimal formatted string으로 decode합니다.
      *
      * @param hash encoded string
      * @return hexadecimal formatted string

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/snowflake/SnowflakeId.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/snowflake/SnowflakeId.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.support.publicLazy
 import java.io.Serializable
 
 /**
- * Snowflake id
+ * Snowflake id입니다.
  *
  * ```kotlin
  * val snowflake = DefaultSnowflake()

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/ulid/utils/TestConstants.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/ulid/utils/TestConstants.kt
@@ -56,6 +56,6 @@ val PatternBytes =
     ).map { it.toByte() }.toByteArray()
 
 /**
- * Get timestamp and random part of ULID string.
+ * ULID string에서 timestamp와 random part를 가져옵니다.
  */
 fun partsOf(ulid: String): Pair<String, String> = ulid.substring(0, 10) to ulid.substring(10)

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
@@ -38,7 +38,7 @@ class JwtReader(
         get() = header<String>("kid")
 
     /**
-     * JWT expiration time as epoch milliseconds.
+     * JWT 만료 시각을 epoch milliseconds로 표현한 값입니다.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 `null`을 반환합니다.
@@ -47,7 +47,7 @@ class JwtReader(
         get() = expiration?.time
 
     /**
-     * Expiration TTL (Time To Live) in milliseconds.
+     * 만료 TTL(Time To Live)을 milliseconds로 표현한 값입니다.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 [Long.MAX_VALUE]를 반환합니다.
@@ -65,7 +65,7 @@ class JwtReader(
         get() = expiresAtMillis?.let { (it - System.currentTimeMillis()).coerceAtLeast(0L) } ?: Long.MAX_VALUE
 
     /**
-     * Expiration TTL (Time To Live) in milliseconds.
+     * 만료 TTL(Time To Live)을 milliseconds로 표현한 값입니다.
      *
      * @see remainingTtlMillis
      */

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/GroupingSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/GroupingSupport.kt
@@ -81,7 +81,7 @@ inline fun <T: Any, K: Any> Iterable<T>.groupingCount(crossinline keySelector: (
 /**
  * Groups elements from the [Grouping] source by key and applies [operation] to the elements of each group sequentially,
  * passing the previously accumulated value and the current element as arguments, and stores the results in a new map.
- * An initial value of accumulator is the same [initialValue] for each group.
+ * accumulator의 initial value는 각 group마다 같은 [initialValue]입니다.
  *
  * ```kotlin
  * val data = sequenceOf("apple" to 3, "banana" to 5, "apple" to 7)
@@ -110,7 +110,7 @@ inline fun <T: Any, K: Any, R: Any> Sequence<T>.groupingFold(
 /**
  * Groups elements from the [Grouping] source by key and applies [operation] to the elements of each group sequentially,
  * passing the previously accumulated value and the current element as arguments, and stores the results in a new map.
- * An initial value of accumulator is the same [initialValue] for each group.
+ * accumulator의 initial value는 각 group마다 같은 [initialValue]입니다.
  *
  * ```kotlin
  * val data = listOf("apple" to 3, "banana" to 5, "apple" to 7)
@@ -138,7 +138,7 @@ inline fun <T: Any, K: Any, R: Any> Iterable<T>.groupingFold(
  * sequentially starting from the second element of the group,
  * passing the previously accumulated value and the current element as arguments,
  * and stores the results in a new map.
- * An initial value of accumulator is the first element of the group.
+ * accumulator의 initial value는 group의 첫 번째 element입니다.
  *
  * ```kotlin
  * val data = sequenceOf("apple" to 1, "banana" to 2, "apple" to 3)
@@ -170,7 +170,7 @@ inline fun <T: S, K: Any, S: Any> Sequence<T>.groupingReduce(
  * sequentially starting from the second element of the group,
  * passing the previously accumulated value and the current element as arguments,
  * and stores the results in a new map.
- * An initial value of accumulator is the first element of the group.
+ * accumulator의 initial value는 group의 첫 번째 element입니다.
  *
  * ```kotlin
  * val data = listOf("apple" to 1, "banana" to 2, "apple" to 3)

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/MathConsts.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/MathConsts.kt
@@ -47,14 +47,14 @@ object MathConsts {
 
     /**
      * ln(10) / 20 - Power Decibel (dB) 를 Neper (Np) 로 변환할 때의 factor
-     * Use this version when the Decibel represent a power gain
+     * Decibel이 power gain을 나타낼 때 이 version을 사용합니다
      * but the compared values are not powers (e.g. amplitude, current, voltage).
      */
     val powerDecibel: Double get() = ln(10.0) / 20.0
 
     /**
      * ln(10) / 10 - Neutral Decibel (dB)를 Neper (Np)로 변환할 때의 factor
-     * Use this version when the Decibel represent a power gain
+     * Decibel이 power gain을 나타낼 때 이 version을 사용합니다
      * but the compared values are not powers (e.g. amplitude, current, voltage).
      */
     val neutralDecibel: Double get() = ln(10.0) / 10.0
@@ -65,25 +65,25 @@ object MathConsts {
     val goldenRatio: Double = (1.0 + sqrt(5.0)) / 2.0
 
     /**
-     * The Catalan constant
+     * Catalan constant입니다.
      * `Sum(k=0 -> inf){ (-1)^k/(2*k + 1)2 }`
      */
     const val CATALAN: Double = 0.9159655941772190150546035149323841107741493742816721342664981196217630197762547694794
 
     /**
-     * The Euler-Mascheroni constant
+     * Euler-Mascheroni constant입니다.
      * `lim(n -> inf){ Sum(k=1 -> n) { 1/k - log(n) } }`
      */
     const val EULER_MASCHERONI = 0.5772156649015328606065120900824024310421593359399235988057672348849
 
     /**
-     * The Glaisher constant
+     * Glaisher constant입니다.
      * `e^(1/12 - Zeta(-1))`
      */
     const val GLAISHER = 1.2824271291006226368753425688697917277676889273250011920637400217404063088588264611297
 
     /**
-     * The Khinchin constant
+     * Khinchin constant입니다.
      * `prod(k=1 -> inf){1+1/(k*(k+2))^log(k,2)}`</remarks>`
      */
     const val KHINCHIN = 2.6854520010653064453097148354817956938203822939944629530511523455572188595371520028011

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/RandomSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/RandomSupport.kt
@@ -141,7 +141,7 @@ fun <T: Any> Sequence<T>.random(sampleSize: Int): List<T> = toList().random(samp
 fun <T: Any> Iterable<T>.random(sampleSize: Int): List<T> = toList().random(sampleSize)
 
 /**
- * Simulates a weighted TRUE/FALSE coin flip, with a percentage of probability towards TRUE
+ * TRUE 쪽 probability percentage를 가진 weighted TRUE/FALSE coin flip을 시뮬레이션합니다
  * In other words, this is a Probability Density Function (PDF) for discrete TRUE/FALSE values
  *
  * ```kotlin
@@ -169,7 +169,7 @@ class WeightedCoin(val trueProbability: Double) {
 }
 
 /**
- * Simulates a weighted TRUE/FALSE coin flip, with a percentage of probability towards TRUE
+ * TRUE 쪽 probability percentage를 가진 weighted TRUE/FALSE coin flip을 시뮬레이션합니다
  * In other words, this is a Probability Density Function (PDF) for discrete TRUE/FALSE values
  *
  * ```kotlin

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.states.core
 import java.io.Serializable
 
 /**
- * Identifies an inherited transition registered for a state family.
+ * state family에 등록된 inherited transition을 식별합니다.
  *
  * Exact state transitions still have precedence. Parent transitions are used
  * when the current state is an instance of [stateType] and no exact transition

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
@@ -99,7 +99,7 @@ class StateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
-     * Registers an inherited transition for every state matching [from].
+     * [from]과 일치하는 모든 state에 inherited transition을 등록합니다.
      *
      * Exact state transitions have precedence over inherited transitions.
      */
@@ -212,7 +212,7 @@ class SuspendStateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
-     * Registers an inherited transition for every state matching [from].
+     * [from]과 일치하는 모든 state에 inherited transition을 등록합니다.
      *
      * Exact state transitions have precedence over inherited transitions.
      */
@@ -317,7 +317,7 @@ fun <S: Any, E: Any> suspendStateMachine(
 inline fun <reified E: Any> on(): Class<E> = E::class.java
 
 /**
- * Returns a state class for inherited transition registration.
+ * inherited transition 등록에 사용할 state class를 반환합니다.
  *
  * ```kotlin
  * transition(state<OrderState.Payable>(), on<OrderEvent.Cancel>(), to = OrderState.Cancelled)


### PR DESCRIPTION
## Summary

Closes #1166

- PR 제목: kdoc(cache): Koreanize cache core and backend KDoc

- Koreanizes scoped cache KDoc for Cache2k/Ehcache defaults, near-cache management metrics, and memoizer helpers.
- Preserves cache backend names, metric semantics, and management API identifiers.

Closes #1166.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Koreanizes scoped cache KDoc for Cache2k/Ehcache defaults, near-cache management metrics, and memoizer helpers.
- Preserves cache backend names, metric semantics, and management API identifiers.

Closes #1166.

### Validation
- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`
- Targeted cache KDoc review

### CI
- Local Gradle CI was skipped because this is a KDoc/comment-only localization change.
- Remote `submit-gradle` is expected to remain the CI gate for the stacked PR.

### DoD Status
- [x] Scope candidates identified and exclusions recorded.
- [x] Korean rewrite or KDoc update completed for the scoped surface.
- [x] Links, code snippets, identifiers, and examples remain valid.
- [x] Guardrail and targeted verification evidence are recorded in the PR.

## Validation

- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`
- Targeted cache KDoc review

- Local Gradle CI was skipped because this is a KDoc/comment-only localization change.
- Remote `submit-gradle` is expected to remain the CI gate for the stacked PR.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1166, milestone `1.12.0`, assignee `debop`
- PR: #1214, head `5f511317a73b5a19c4431fa1a9072de94c2a6a6b`, milestone `1.12.0`, assignee `debop`
- Base: `docs/issue-1165-mongodb-cassandra-kdoc`, head branch `docs/issue-1166-cache-kdoc`
- Labels: `documentation`, `tech-debt`
- State: `MERGED`, merge commit `6c7dd11bd8f8e9b8f1c0d9543ae124dbe922d7e1`
- CI: ## CI / - Local Gradle CI was skipped because this is a KDoc/comment-only localization change. / - Remote `submit-gradle` is expected to remain the CI gate for the stacked PR.

## DoD Status

- [x] Scope candidates identified and exclusions recorded.
- [x] Korean rewrite or KDoc update completed for the scoped surface.
- [x] Links, code snippets, identifiers, and examples remain valid.
- [x] Guardrail and targeted verification evidence are recorded in the PR.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1214 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6c7dd11bd8f8e9b8f1c0d9543ae124dbe922d7e1`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
