### PR TITLE
kdoc(testcontainers): Koreanize AWS and infra container KDoc

### DIFF
--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/SharedFlowAsEventBus.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/SharedFlowAsEventBus.kt
@@ -24,7 +24,7 @@ class SharedFlowAsEventBus {
     companion object: KLoggingChannel()
 
     /**
-     * An event bus implementation that uses a shared flow to broadcast events to multiple listeners.
+     * shared flow로 여러 listener에 event를 broadcast하는 event bus 구현입니다.
      */
     class EventBus<T> {
         // The shared flow that will be used to broadcast events to multiple listeners.

--- a/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/AbstractBlazePersistenceTest.kt
+++ b/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/AbstractBlazePersistenceTest.kt
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 /**
- * Base Spring Boot test configuration for the Blaze Persistence examples.
+ * Blaze Persistence example을 위한 base Spring Boot test configuration입니다.
  */
 @SpringBootTest(
     classes = [BlazePersistenceApplication::class],

--- a/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/BlazePersistenceApplication.kt
+++ b/examples/jpa-blazepersistence-demo/src/test/kotlin/io/bluetape4k/examples/jpa/blazepersistence/BlazePersistenceApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 /**
- * Spring Boot test application for the Blaze Persistence JPA examples.
+ * Blaze Persistence JPA example용 Spring Boot test application입니다.
  */
 @SpringBootApplication
 @EnableJpaAuditing(modifyOnCreate = true)

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/IdGeneratorDemoApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 /**
- * Spring Boot demo application for bluetape4k idgenerators.
+ * bluetape4k idgenerator용 Spring Boot demo application입니다.
  *
  * ## Behavior
  * - Registers `IdGenerator` implementations as Spring beans and injects them into the REST controller.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorConfiguration.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 /**
- * Example configuration that registers idgenerator implementations as Spring beans.
+ * idgenerator 구현체를 Spring bean으로 등록하는 example configuration입니다.
  *
  * ## Behavior
  * - UUID generators of the same type are distinguished by bean name.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/config/IdGeneratorProperties.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.support.requirePositiveNumber
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * Configuration properties for the ID batch example.
+ * ID batch example 설정 property입니다.
  *
  * ## Behavior
  * - `defaultBatchSize` is used when the `size` query parameter is omitted.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * REST controller for the idgenerator Spring Boot demo.
+ * idgenerator Spring Boot demo용 REST controller입니다.
  *
  * ## Behavior
  * - The `/ids/{type}` family provides explicit endpoints that are easy to copy.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorExceptionHandler.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 /**
- * Converts input validation errors from the idgenerator REST demo into JSON responses.
+ * idgenerator REST demo의 input validation error를 JSON response로 변환합니다.
  *
  * ## Behavior
  * - Unsupported generator types and batch size errors return HTTP 400.

--- a/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
+++ b/examples/spring-boot/idgenerator-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/idgenerator/controller/IdGeneratorResponses.kt
@@ -43,7 +43,7 @@ data class GeneratorResponse(
 )
 
 /**
- * Example application health response.
+ * example application health response입니다.
  */
 data class HealthResponse(
     val status: String,

--- a/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
+++ b/examples/spring-boot/observability-spring-boot-demo/src/main/kotlin/io/bluetape4k/examples/spring/observability/ObservabilitySpringBootDemoApplication.kt
@@ -23,7 +23,7 @@ import java.io.Serializable
 private const val REQUEST_ID_HEADER = "X-Request-Id"
 
 /**
- * Spring Boot observability example for Prometheus metrics and OTLP tracing configuration.
+ * Prometheus metric과 OTLP tracing configuration을 보여 주는 Spring Boot observability example입니다.
  *
  * ## Behavior
  * - Exposes application metrics through Spring Boot Actuator's Prometheus endpoint.

--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/MockServerApplication.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/MockServerApplication.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 /**
- * Bluetape4k Mock Server 애플리케이션.
+ * Bluetape4k Mock Server 애플리케이션입니다.
  *
  * httpbin, jsonplaceholder 등 다양한 HTTP 테스트용 mock 엔드포인트를 제공하는 Spring Boot 애플리케이션.
  * 포트 80(HTTP)/443(HTTPS)에서 실행되며, Testcontainers 환경에서 외부 HTTP 의존성을 대체할 수 있다.

--- a/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
+++ b/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/ReadmeHttpsPortContractTest.kt
@@ -9,7 +9,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 
 /**
- * README HTTPS port documentation must match runtime and container metadata.
+ * README HTTPS port 문서는 runtime 및 container metadata와 일치해야 합니다.
  */
 class ReadmeHttpsPortContractTest {
 

--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/MockWebfluxServerApplication.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/MockWebfluxServerApplication.kt
@@ -6,8 +6,8 @@ import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 
 /**
- * Mock WebFlux 서버 애플리케이션.
- * Spring Boot 4 WebFlux + Kotlin Coroutines 기반 테스트용 HTTP 서버.
+ * Mock WebFlux 서버 애플리케이션입니다.
+ * Spring Boot 4 WebFlux + Kotlin Coroutines 기반 테스트용 HTTP 서버입니다.
  */
 @EnableCaching
 @SpringBootApplication

--- a/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
+++ b/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/ReadmeRouteContractTest.kt
@@ -8,7 +8,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 
 /**
- * README endpoint rows must describe implemented mock-webflux routes only.
+ * README endpoint row는 구현된 mock-webflux route만 설명해야 합니다.
  */
 class ReadmeRouteContractTest {
 

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
@@ -11,7 +11,7 @@ import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
 
 /**
- * Runs a single-node [etcd](https://etcd.io/) server with Testcontainers.
+ * Testcontainers로 single-node [etcd](https://etcd.io/) server를 실행합니다.
  *
  * ## Behavior / Contract
  * - Exposes the etcd client API on [CLIENT_PORT] and the peer API on [PEER_PORT].
@@ -50,7 +50,7 @@ class EtcdServer private constructor(
         val EXPORT_PORTS = intArrayOf(CLIENT_PORT, PEER_PORT)
 
         /**
-         * Creates an [EtcdServer] from a [DockerImageName].
+         * [DockerImageName]으로 [EtcdServer]를 생성합니다.
          *
          * @param imageName Docker image name.
          * @param useDefaultPort binds 2379/2380 to the same host ports when `true`.
@@ -66,7 +66,7 @@ class EtcdServer private constructor(
         }
 
         /**
-         * Creates an [EtcdServer] from an image name and tag.
+         * image name과 tag로 [EtcdServer]를 생성합니다.
          *
          * @param image Docker image name; blank values are rejected.
          * @param tag Docker image tag; blank values are rejected.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
@@ -16,7 +16,7 @@ import java.time.Duration
 import java.util.Base64
 
 /**
- * Runs a [Grafana](https://grafana.com/) server in Docker for integration tests.
+ * integration test를 위해 Docker에서 [Grafana](https://grafana.com/) server를 실행합니다.
  *
  * Follows the same `GenericServer + Launcher` pattern as [PrometheusServer].
  *
@@ -62,7 +62,7 @@ class GrafanaServer private constructor(
         const val ADMIN_PASSWORD = "admin"
 
         /**
-         * Creates a [GrafanaServer] from a pre-built [DockerImageName].
+         * 미리 구성된 [DockerImageName]으로 [GrafanaServer]를 생성합니다.
          *
          * @param imageName      Fully qualified Docker image name with tag.
          * @param useDefaultPort When `true`, binds port [PORT] to the same fixed host port.
@@ -76,7 +76,7 @@ class GrafanaServer private constructor(
         ): GrafanaServer = GrafanaServer(imageName, useDefaultPort, reuse)
 
         /**
-         * Creates a [GrafanaServer] by image name and tag.
+         * image name과 tag로 [GrafanaServer]를 생성합니다.
          *
          * @param image          Docker image name; blank value throws [IllegalArgumentException].
          * @param tag            Docker image tag; blank value throws [IllegalArgumentException].

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
@@ -13,7 +13,7 @@ import org.testcontainers.k3s.K3sContainer
 import org.testcontainers.utility.DockerImageName
 
 /**
- * Runs a [K3s](https://k3s.io/) lightweight Kubernetes cluster in Docker for integration tests.
+ * integration test를 위해 Docker에서 [K3s](https://k3s.io/) lightweight Kubernetes cluster를 실행합니다.
  *
  * Extends the native testcontainers [K3sContainer] and adds the bluetape4k
  * `GenericServer + Launcher` pattern.
@@ -53,7 +53,7 @@ class K3sServer private constructor(
         const val API_PORT = 6443
 
         /**
-         * Creates a [K3sServer] from a pre-built [DockerImageName].
+         * 미리 구성된 [DockerImageName]으로 [K3sServer]를 생성합니다.
          *
          * @param imageName      Fully qualified Docker image name with tag.
          * @param useDefaultPort When `true`, binds port [API_PORT] to the same fixed host port.
@@ -67,7 +67,7 @@ class K3sServer private constructor(
         ): K3sServer = K3sServer(imageName, useDefaultPort, reuse)
 
         /**
-         * Creates a [K3sServer] by image name and tag.
+         * image name과 tag로 [K3sServer]를 생성합니다.
          *
          * @param image          Docker image name; blank value throws [IllegalArgumentException].
          * @param tag            Docker image tag; blank value throws [IllegalArgumentException].
@@ -118,7 +118,7 @@ class K3sServer private constructor(
     }
 
     /**
-     * Returns a fabric8 [KubernetesClient] pre-configured for this K3s cluster.
+     * 이 K3s cluster에 맞게 미리 설정된 fabric8 [KubernetesClient]를 반환합니다.
      *
      * Must be called **after** [start]. Each call returns a **new** client instance
      * registered in [ShutdownQueue] — it will be closed on JVM shutdown automatically.

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerValidationTest.kt
@@ -6,8 +6,8 @@ import io.bluetape4k.testcontainers.AbstractContainerTest
 import org.junit.jupiter.api.Test
 
 /**
- * Validation tests for [K3sServer] that do not require a running container.
- * These run in regular CI without a privileged Docker runner.
+ * 실행 중인 container가 필요 없는 [K3sServer] validation test입니다.
+ * privileged Docker runner 없이 일반 CI에서 실행됩니다.
  */
 class K3sServerValidationTest: AbstractContainerTest() {
 

--- a/utils/geo/src/main/kotlin/io/bluetape4k/geohash/queries/GeoHashBoundingBoxQuery.kt
+++ b/utils/geo/src/main/kotlin/io/bluetape4k/geohash/queries/GeoHashBoundingBoxQuery.kt
@@ -176,7 +176,7 @@ class GeoHashBoundingBoxQuery(
     }
 
     /**
-     * Checks if the provided hash completely(!) contains the provided bounding box
+     * 제공된 hash가 제공된 bounding box를 완전히(!) 포함하는지 확인합니다
      */
     private fun hashContainsBoundingBox(
         hash: GeoHash,

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geohash/tests/RandomGeoHashes.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geohash/tests/RandomGeoHashes.kt
@@ -25,16 +25,16 @@ object RandomGeoHashes: KLogging() {
     }
 
     /**
-     * Create a completely random [GeoHash] with a random number of bits.
+     * random bit 수를 가진 완전 random [GeoHash]를 생성합니다.
      *
-     * Precision will be between [5,64] bits.
+     * precision은 [5,64] bit 사이입니다.
      */
     fun create(): GeoHash {
         return geoHashWithBits(randomLatitude(), randomLongitude(), randomPrecision())
     }
 
     /**
-     * Create a completely random geohash with
+     * 완전 random geohash를 생성합니다
      * a precision that is a multiple of 5 and in [5,60] bits.
      */
     fun createWith5BitsPrecision(): GeoHash {

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geohash/utils/GeoHashSizeTableTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geohash/utils/GeoHashSizeTableTest.kt
@@ -43,7 +43,7 @@ class GeoHashSizeTableTest {
         fun generate(bits: Int): BoundingBox
 
         /**
-         * Get expected bits
+         * expected bit를 가져옵니다.
          */
         fun getExpectedBits(bits: Int): Int
     }

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/hashids/Hashids.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/hashids/Hashids.kt
@@ -236,7 +236,7 @@ class Hashids(
         (numbersHash + returnStr[index].code) % guards.length
 
     /**
-     * Encode hexadecimal formatted string
+     * hexadecimal formatted string을 encode합니다.
      *
      * @param hexStr hexadecimal formatted string to encode
      * @return encoded string as hash
@@ -256,7 +256,7 @@ class Hashids(
     }
 
     /**
-     * Decode hash to hexadecimal formatted string
+     * hash를 hexadecimal formatted string으로 decode합니다.
      *
      * @param hash encoded string
      * @return hexadecimal formatted string

--- a/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/snowflake/SnowflakeId.kt
+++ b/utils/idgenerators/src/main/kotlin/io/bluetape4k/idgenerators/snowflake/SnowflakeId.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.support.publicLazy
 import java.io.Serializable
 
 /**
- * Snowflake id
+ * Snowflake id입니다.
  *
  * ```kotlin
  * val snowflake = DefaultSnowflake()

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/ulid/utils/TestConstants.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/ulid/utils/TestConstants.kt
@@ -56,6 +56,6 @@ val PatternBytes =
     ).map { it.toByte() }.toByteArray()
 
 /**
- * Get timestamp and random part of ULID string.
+ * ULID string에서 timestamp와 random part를 가져옵니다.
  */
 fun partsOf(ulid: String): Pair<String, String> = ulid.substring(0, 10) to ulid.substring(10)

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/reader/JwtReader.kt
@@ -38,7 +38,7 @@ class JwtReader(
         get() = header<String>("kid")
 
     /**
-     * JWT expiration time as epoch milliseconds.
+     * JWT 만료 시각을 epoch milliseconds로 표현한 값입니다.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 `null`을 반환합니다.
@@ -47,7 +47,7 @@ class JwtReader(
         get() = expiration?.time
 
     /**
-     * Expiration TTL (Time To Live) in milliseconds.
+     * 만료 TTL(Time To Live)을 milliseconds로 표현한 값입니다.
      *
      * ## 동작/계약
      * - `exp` 클레임이 없으면 [Long.MAX_VALUE]를 반환합니다.
@@ -65,7 +65,7 @@ class JwtReader(
         get() = expiresAtMillis?.let { (it - System.currentTimeMillis()).coerceAtLeast(0L) } ?: Long.MAX_VALUE
 
     /**
-     * Expiration TTL (Time To Live) in milliseconds.
+     * 만료 TTL(Time To Live)을 milliseconds로 표현한 값입니다.
      *
      * @see remainingTtlMillis
      */

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/GroupingSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/GroupingSupport.kt
@@ -81,7 +81,7 @@ inline fun <T: Any, K: Any> Iterable<T>.groupingCount(crossinline keySelector: (
 /**
  * Groups elements from the [Grouping] source by key and applies [operation] to the elements of each group sequentially,
  * passing the previously accumulated value and the current element as arguments, and stores the results in a new map.
- * An initial value of accumulator is the same [initialValue] for each group.
+ * accumulator의 initial value는 각 group마다 같은 [initialValue]입니다.
  *
  * ```kotlin
  * val data = sequenceOf("apple" to 3, "banana" to 5, "apple" to 7)
@@ -110,7 +110,7 @@ inline fun <T: Any, K: Any, R: Any> Sequence<T>.groupingFold(
 /**
  * Groups elements from the [Grouping] source by key and applies [operation] to the elements of each group sequentially,
  * passing the previously accumulated value and the current element as arguments, and stores the results in a new map.
- * An initial value of accumulator is the same [initialValue] for each group.
+ * accumulator의 initial value는 각 group마다 같은 [initialValue]입니다.
  *
  * ```kotlin
  * val data = listOf("apple" to 3, "banana" to 5, "apple" to 7)
@@ -138,7 +138,7 @@ inline fun <T: Any, K: Any, R: Any> Iterable<T>.groupingFold(
  * sequentially starting from the second element of the group,
  * passing the previously accumulated value and the current element as arguments,
  * and stores the results in a new map.
- * An initial value of accumulator is the first element of the group.
+ * accumulator의 initial value는 group의 첫 번째 element입니다.
  *
  * ```kotlin
  * val data = sequenceOf("apple" to 1, "banana" to 2, "apple" to 3)
@@ -170,7 +170,7 @@ inline fun <T: S, K: Any, S: Any> Sequence<T>.groupingReduce(
  * sequentially starting from the second element of the group,
  * passing the previously accumulated value and the current element as arguments,
  * and stores the results in a new map.
- * An initial value of accumulator is the first element of the group.
+ * accumulator의 initial value는 group의 첫 번째 element입니다.
  *
  * ```kotlin
  * val data = listOf("apple" to 1, "banana" to 2, "apple" to 3)

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/MathConsts.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/MathConsts.kt
@@ -47,14 +47,14 @@ object MathConsts {
 
     /**
      * ln(10) / 20 - Power Decibel (dB) 를 Neper (Np) 로 변환할 때의 factor
-     * Use this version when the Decibel represent a power gain
+     * Decibel이 power gain을 나타낼 때 이 version을 사용합니다
      * but the compared values are not powers (e.g. amplitude, current, voltage).
      */
     val powerDecibel: Double get() = ln(10.0) / 20.0
 
     /**
      * ln(10) / 10 - Neutral Decibel (dB)를 Neper (Np)로 변환할 때의 factor
-     * Use this version when the Decibel represent a power gain
+     * Decibel이 power gain을 나타낼 때 이 version을 사용합니다
      * but the compared values are not powers (e.g. amplitude, current, voltage).
      */
     val neutralDecibel: Double get() = ln(10.0) / 10.0
@@ -65,25 +65,25 @@ object MathConsts {
     val goldenRatio: Double = (1.0 + sqrt(5.0)) / 2.0
 
     /**
-     * The Catalan constant
+     * Catalan constant입니다.
      * `Sum(k=0 -> inf){ (-1)^k/(2*k + 1)2 }`
      */
     const val CATALAN: Double = 0.9159655941772190150546035149323841107741493742816721342664981196217630197762547694794
 
     /**
-     * The Euler-Mascheroni constant
+     * Euler-Mascheroni constant입니다.
      * `lim(n -> inf){ Sum(k=1 -> n) { 1/k - log(n) } }`
      */
     const val EULER_MASCHERONI = 0.5772156649015328606065120900824024310421593359399235988057672348849
 
     /**
-     * The Glaisher constant
+     * Glaisher constant입니다.
      * `e^(1/12 - Zeta(-1))`
      */
     const val GLAISHER = 1.2824271291006226368753425688697917277676889273250011920637400217404063088588264611297
 
     /**
-     * The Khinchin constant
+     * Khinchin constant입니다.
      * `prod(k=1 -> inf){1+1/(k*(k+2))^log(k,2)}`</remarks>`
      */
     const val KHINCHIN = 2.6854520010653064453097148354817956938203822939944629530511523455572188595371520028011

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/RandomSupport.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/RandomSupport.kt
@@ -141,7 +141,7 @@ fun <T: Any> Sequence<T>.random(sampleSize: Int): List<T> = toList().random(samp
 fun <T: Any> Iterable<T>.random(sampleSize: Int): List<T> = toList().random(sampleSize)
 
 /**
- * Simulates a weighted TRUE/FALSE coin flip, with a percentage of probability towards TRUE
+ * TRUE 쪽 probability percentage를 가진 weighted TRUE/FALSE coin flip을 시뮬레이션합니다
  * In other words, this is a Probability Density Function (PDF) for discrete TRUE/FALSE values
  *
  * ```kotlin
@@ -169,7 +169,7 @@ class WeightedCoin(val trueProbability: Double) {
 }
 
 /**
- * Simulates a weighted TRUE/FALSE coin flip, with a percentage of probability towards TRUE
+ * TRUE 쪽 probability percentage를 가진 weighted TRUE/FALSE coin flip을 시뮬레이션합니다
  * In other words, this is a Probability Density Function (PDF) for discrete TRUE/FALSE values
  *
  * ```kotlin

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/ParentTransitionKey.kt
@@ -3,7 +3,7 @@ package io.bluetape4k.states.core
 import java.io.Serializable
 
 /**
- * Identifies an inherited transition registered for a state family.
+ * state family에 등록된 inherited transition을 식별합니다.
  *
  * Exact state transitions still have precedence. Parent transitions are used
  * when the current state is an instance of [stateType] and no exact transition

--- a/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
+++ b/utils/states/src/main/kotlin/io/bluetape4k/states/core/StateMachineDsl.kt
@@ -99,7 +99,7 @@ class StateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
-     * Registers an inherited transition for every state matching [from].
+     * [from]과 일치하는 모든 state에 inherited transition을 등록합니다.
      *
      * Exact state transitions have precedence over inherited transitions.
      */
@@ -212,7 +212,7 @@ class SuspendStateMachineBuilder<S: Any, E: Any> {
     }
 
     /**
-     * Registers an inherited transition for every state matching [from].
+     * [from]과 일치하는 모든 state에 inherited transition을 등록합니다.
      *
      * Exact state transitions have precedence over inherited transitions.
      */
@@ -317,7 +317,7 @@ fun <S: Any, E: Any> suspendStateMachine(
 inline fun <reified E: Any> on(): Class<E> = E::class.java
 
 /**
- * Returns a state class for inherited transition registration.
+ * inherited transition 등록에 사용할 state class를 반환합니다.
  *
  * ```kotlin
  * transition(state<OrderState.Payable>(), on<OrderEvent.Cancel>(), to = OrderState.Cancelled)


### PR DESCRIPTION
## Summary

Closes #1173

- PR 제목: kdoc(testcontainers): Koreanize AWS and infra container KDoc

- Koreanizes scoped Testcontainers infra fixture KDoc for K3s, Grafana, and etcd servers.
- Preserves image names, Docker/Testcontainers terms, lifecycle behavior, and client identifiers.

Closes #1173.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- Koreanizes scoped Testcontainers infra fixture KDoc for K3s, Grafana, and etcd servers.
- Preserves image names, Docker/Testcontainers terms, lifecycle behavior, and client identifiers.

Closes #1173.

### Validation
- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`
- Targeted Testcontainers KDoc review

### CI
- Local Gradle CI was skipped because this is a KDoc/comment-only localization change.
- Remote `submit-gradle` is expected to remain the CI gate for the stacked PR.

### DoD Status
- [x] Scope candidates identified and exclusions recorded.
- [x] Korean rewrite or KDoc update completed for the scoped surface.
- [x] Links, code snippets, identifiers, and examples remain valid.
- [x] Guardrail and targeted verification evidence are recorded in the PR.

## Validation

- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`
- Targeted Testcontainers KDoc review

- Local Gradle CI was skipped because this is a KDoc/comment-only localization change.
- Remote `submit-gradle` is expected to remain the CI gate for the stacked PR.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1173, milestone `1.12.0`, assignee `debop`
- PR: #1221, head `261ad815709992073cc5d2ffc6fd29f5558c3f8a`, milestone `1.12.0`, assignee `debop`
- Base: `docs/issue-1172-testing-kdoc`, head branch `docs/issue-1173-testcontainers-kdoc`
- Labels: `documentation`, `tech-debt`
- State: `MERGED`, merge commit `5b04885a0a25f0664b9003eca8db045a32b4cad4`
- CI: ## CI / - Local Gradle CI was skipped because this is a KDoc/comment-only localization change. / - Remote `submit-gradle` is expected to remain the CI gate for the stacked PR.

## DoD Status

- [x] Scope candidates identified and exclusions recorded.
- [x] Korean rewrite or KDoc update completed for the scoped surface.
- [x] Links, code snippets, identifiers, and examples remain valid.
- [x] Guardrail and targeted verification evidence are recorded in the PR.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1221 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `5b04885a0a25f0664b9003eca8db045a32b4cad4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
