### PR TITLE
Add bounded caller-owned Deflate buffer paths

### DIFF
--- a/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
+++ b/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
@@ -56,6 +56,28 @@ overflow retry, pre-created failure identity를 포함한다. compression codec�
 dispatch와 storage coverage만 뜻하며, allocation 개선은 아직 측정하지 않았으므로
 `eligible, not yet measured`로 유지한다.
 
+## Deflate slice에서 고정한 lifecycle과 상태 우선순위
+
+Deflate caller-owned 경로는 매 호출마다 JDK `Deflater` 또는 `Inflater`를 새로 만들고
+`ByteBuffer` API에 직접 위임한다. codec을 singleton에 공유하지 않으므로 mutable native state는
+호출 사이에 남지 않는다. heap/direct/read-only/slice source와 heap/direct/slice target의 모든
+조합은 기존 allocating API와 같은 zlib wire를 교환한다.
+
+압축과 복원 loop는 codec의 `finished`, 입력·출력 byte count, target 잔여량을 매 반복마다
+검사한다. target이 소진되면 raw `BufferOverflowException`을 먼저 던진다. 그다음 복원 상태를
+사전 요구, 입력 중단, no-progress 순으로 분류해 각각 안정된 `ZipException`으로 보고한다.
+`DataFormatException`은 원인을 보존한 `ZipException("Invalid Deflate payload")`로 변환한다.
+이 순서 덕분에 zero-capacity target과 손상 상태가 겹쳐도 caller가 먼저 해결해야 할 용량
+실패가 결정적으로 유지된다.
+
+codec 정리는 성공과 실패 모두에서 정확히 한 번 실행한다. 연산과 정리가 함께 실패하면 연산
+throwable identity를 primary로 유지하고 정리 실패만 suppressed로 추가한다. 연산이 성공했을
+때는 정리 실패 자체를 전파한다. 테스트는 per-call codec 생성·정리 횟수, operation-primary
+identity, cleanup-only identity, compression/decompression no-progress, overflow 후 같은 target
+재시도, singleton 동시 호출을 고정한다. README의 `optimized`는 JDK `ByteBuffer` 직접 dispatch와
+storage coverage만 뜻하며 allocation 개선은 아직 측정하지 않았으므로
+`eligible, not yet measured`로 유지한다.
+
 ## 왜 broad backend slice를 중단했는가
 
 LZ4의 capacity-tail read는 source isolation 문제이고, zstd-jni의 throw-before-return은 예외

--- a/docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md
+++ b/docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md
@@ -23,15 +23,34 @@
   `enhancement`, `performance`, `infra/io`, assignee `debop`.
 - 현재 coordination/core branch:
   `feat/issue-755-bytebuffer-compressor`, base `origin/develop`.
-- machine-readable workflow run:
+- 2026-07-21 historical machine-readable workflow run:
   `20260721T115110Z-8e06d9a0`, manifest SHA-256
   `3e9a92a4ea0bef991d0613c8fad9b4fa90b27c520e16d1588005105aebd27638`, initial receipt checksum `9e1435c164dd203997fe9d41a49d8d95cb68d60de6f5074e76471e051262456e`. WF-04A fallback terminal 상태는 `blocked`, sequence `5`, checksum
-  `b0458931bc1b8a3f2b173f04116b010c938d804f737aae081daeed292ef3cda1`이다. 이 checksum은 final documented checklist closeout까지 immutable evidence로 보존한다.
+  `b0458931bc1b8a3f2b173f04116b010c938d804f737aae081daeed292ef3cda1`이다. 이 checksum은
+  과거 실행의 immutable audit evidence이며 현재 mutation, readiness 또는 completion
+  authority가 아니다.
 - 이번 계획 승인 전 stop condition: implementation, push, PR creation을 시작하지 않는다.
 - 계획 승인 후 stop condition: 각 PR은 exact-head CI/review 수렴 후 fresh merge 승인을 별도로 받고, 승인 전에는 다음 slice branch를 만들지 않는다.
 - merge approval은 누적되지 않는다. core 승인으로 LZ4 또는 이후 PR merge를 대신할 수 없다.
 - stable tag, publish, release, workflow dispatch는 범위 밖이다.
 - diagram/chart는 N/A다. 숫자 authority는 raw JSON/CSV와 표이며 새 visual asset을 만들지 않는다.
+
+### 1.1 2026-07-30 실행 재개 상태
+
+- 현재 기준은 `origin/develop@fa07277c8c123c1093299e10cf09504f13d177a1`이다.
+- core/API/ABI Task 1–3은 PR #1067, LZ4 Task 4는 PR #1091로 반영되었다.
+- 이번 실행의 machine-readable workflow run은
+  `20260730T121803Z-0b53afa0`이며, verified receipt checksum은
+  `dcb772cdb463c2c7eaa26f6eb6736c983016bb94644052c438a59d6aa48c8777`이다.
+- 현재 격리 worktree와 branch는 각각
+  `.worktrees/issue-755-bytebuffer-codecs`,
+  `feat/issue-755-bytebuffer-codecs`이다. 사용자가 승인한 현재 head 이름은
+  Task 5의 `feat/issue-755-bytebuffer-deflate` 이름을 대체하지만, Task 5의 파일 범위,
+  TDD 순서, 문서 범위와 검증 계약은 변경하지 않는다.
+- 현재 실행 범위는 Task 5 Deflate slice다. 이 PR의 exact-head CI/review와 별도 merge
+  승인 전에는 Task 6 Snappy branch 또는 구현을 시작하지 않는다.
+- 2026-07-21의 terminal blocked fallback command와 checksum은 과거 audit record다.
+  현재 mutation authority, lifecycle 및 completion evidence는 위 fresh run에서만 가져온다.
 
 ## 2. Broad Backend Matrix 전달 topology
 
@@ -39,7 +58,7 @@
 |-----:|-------------------|-------------------------------------------------|-------------------|-------------------------------------------------------------------|-----------------------------------|
 |    1 | core/API/ABI      | `feat/issue-755-bytebuffer-compressor`          | `develop`         | JVM default API, fallback, 공통 contract, ABI fixture, 초기 docs  | PR merge와 local sync 완료        |
 |    2 | LZ4 backend       | `feat/issue-755-bytebuffer-lz4`                 | updated `develop` | heap/direct 전체 조합, bounded payload slice                      | PR merge와 local sync 완료        |
-|    3 | Deflate backend   | `feat/issue-755-bytebuffer-deflate`             | updated `develop` | JDK buffer loop와 deterministic cleanup                           | PR merge와 local sync 완료        |
+|    3 | Deflate backend   | `feat/issue-755-bytebuffer-codecs`              | updated `develop` | JDK buffer loop와 deterministic cleanup                           | PR merge와 local sync 완료        |
 |    4 | Snappy backend    | `feat/issue-755-bytebuffer-snappy`              | updated `develop` | heap→heap/direct→direct native path와 validation-first            | PR merge와 local sync 완료        |
 |    5 | Zstd backend      | `feat/issue-755-bytebuffer-zstd`                | updated `develop` | declared-size native bound와 exact exception taxonomy             | PR merge와 local sync 완료        |
 |    6 | adoption/evidence | `perf/issue-755-bytebuffer-compressor-evidence` | updated `develop` | cross-codec concurrency, examples, two canonical runs, final docs | PR merge-ready 보고 후 fresh 승인 |
@@ -71,10 +90,14 @@ gh pr view "$pr_number" --repo "$repo" \
 
 candidate_key="${branch//\//-}"
 candidate_stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-readiness_run_file=/Users/debop/work/bluetape4k/.bluetape/runs/20260721T115110Z-8e06d9a0/run.json
-test "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$readiness_run_file")" = blocked
+flow=/Users/debop/.codex/skills/bluetape-workflow/scripts/bluetape-flow.py
+state_root=/Users/debop/work/bluetape4k/.bluetape
+readiness_run_id=20260730T121803Z-0b53afa0
+readiness_run_file="$state_root/runs/$readiness_run_id/run.json"
+python3 "$flow" --state-root "$state_root" verify --run-id "$readiness_run_id"
+test "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$readiness_run_file")" = running
 readiness_receipt_checksum="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["last_checksum"])' "$readiness_run_file")"
-test "$readiness_receipt_checksum" = b0458931bc1b8a3f2b173f04116b010c938d804f737aae081daeed292ef3cda1
+test "${#readiness_receipt_checksum}" -eq 64
 candidate_file="/Users/debop/work/bluetape4k/.bluetape/inputs/issue755/merge-candidates/${candidate_key}-${expected_head}-${candidate_stamp}.json"
 test ! -e "$candidate_file"
 ```
@@ -174,7 +197,9 @@ pr_number="$(jq -er '.pr_number' <<<"$candidate_json")"
 expected_head="$(jq -er '.head_sha' <<<"$candidate_json")"
 branch="$(jq -er '.head_branch' <<<"$candidate_json")"
 candidate_receipt_checksum="$(jq -er '.readiness_receipt_checksum' <<<"$candidate_json")"
-current_receipt_checksum="$(python3 -c 'import json; print(json.load(open("/Users/debop/work/bluetape4k/.bluetape/runs/20260721T115110Z-8e06d9a0/run.json"))["last_checksum"])')"
+current_run_file=/Users/debop/work/bluetape4k/.bluetape/runs/20260730T121803Z-0b53afa0/run.json
+test "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$current_run_file")" = running
+current_receipt_checksum="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["last_checksum"])' "$current_run_file")"
 test "$candidate_receipt_checksum" = "$current_receipt_checksum"
 test "$(git branch --show-current)" = "$branch"
 test "$(git rev-parse HEAD)" = "$expected_head"
@@ -1693,31 +1718,34 @@ Six-perspective review, CI, live threads가 P0=0/P1=0일 때 exact PR/head를 �
 ## Task 5: Deflate slice — bounded JDK loop와 deterministic cleanup을 전달한다
 
 **복잡도:** 높음 **Dependency:** LZ4 PR merge + updated `develop` sync **Write
-scope:** `DeflateCompressor.kt`, Deflate test, README locale rows, lesson lifecycle section **Pattern
-skill:** `bluetape-kotlin-patterns`, `test-driven-development`
+scope:** `DeflateCompressor.kt`, Deflate test, README locale rows, docs checker의 Deflate expected
+row, lesson lifecycle section **Pattern skill:** `bluetape-kotlin-patterns`,
+`test-driven-development`
 
 **파일:**
 
 - 수정: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt`
 - 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/DeflateCompressorByteBufferTest.kt`
 - 수정: `io/io/README.md`, `io/io/README.ko.md`
+- 수정: `scripts/check-compressor-buffer-docs.py`
 - 수정: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
 
-- [ ] **Step 5.1: merge된 develop에서 Deflate worktree를 만든다**
+- [x] **Step 5.1: merge된 develop에서 현재 Deflate worktree를 검증한다**
 
 ```bash
 set -euo pipefail
-git -C /Users/debop/work/bluetape4k/bluetape4k-projects fetch origin develop
-git -C /Users/debop/work/bluetape4k/bluetape4k-projects switch develop
-git -C /Users/debop/work/bluetape4k/bluetape4k-projects pull --ff-only origin develop
-git -C /Users/debop/work/bluetape4k/bluetape4k-projects worktree add \
-  /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feat-issue-755-bytebuffer-deflate \
-  -b feat/issue-755-bytebuffer-deflate origin/develop
+worktree=/Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/issue-755-bytebuffer-codecs
+test "$(git -C "$worktree" branch --show-current)" = feat/issue-755-bytebuffer-codecs
+test "$(git -C "$worktree" rev-parse HEAD)" = fa07277c8c123c1093299e10cf09504f13d177a1
+git -C "$worktree" merge-base --is-ancestor \
+  e2869bddee9c21bd6b9eee1f549c521b8e400f83 HEAD
+test -z "$(git -C "$worktree" status --short)"
 ```
 
-예상 결과: core와 LZ4 merge commit이 ancestor이며 worktree clean.
+예상 결과: core와 LZ4 merge commit이 ancestor이고, 승인된 branch/기준 commit의
+worktree가 clean이다.
 
-- [ ] **Step 5.2: Deflate state table와 cleanup RED를 작성한다**
+- [x] **Step 5.2: Deflate state table와 cleanup RED를 작성한다**
 
 ```kotlin
 class DeflateCompressorByteBufferTest {
@@ -1773,7 +1801,7 @@ exactly once on success/failure, cleanup-only failure, fatal/cancellation preced
 `IllegalStateException`, decompression zero-progress는 `ZipException`으로 구분한다. decompression 복합 실패는 deterministic inflater seam으로 corruption-first와 target-exhaustion-first를 각각 만들고, 처음 확정된 상태의 `ZipException` 또는
 `BufferOverflowException` identity와 같은 target 재시도를 검증한다.
 
-- [ ] **Step 5.3: Deflate RED를 실행한다**
+- [x] **Step 5.3: Deflate RED를 실행한다**
 
 ```bash
 set -euo pipefail
@@ -1784,7 +1812,7 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
 
 예상 결과: test seam/optimized override가 없어 compile 또는 dispatch assertion FAIL.
 
-- [ ] **Step 5.4: per-call factories, operation-primary cleanup helper와 compression loop를 구현한다**
+- [x] **Step 5.4: per-call factories, operation-primary cleanup helper와 compression loop를 구현한다**
 
 ```kotlin
 internal inline fun <R, T> useDeflateCodec(
@@ -1814,9 +1842,16 @@ internal inline fun <R, T> useDeflateCodec(
 }
 
 override fun compress(source: ByteBuffer, target: ByteBuffer): Int =
-    writeToCallerBuffer(source, target) { sourcePosition, sourceRemaining, targetPosition, targetRemaining ->
-        val input = source.duplicate().position(sourcePosition).limit(sourcePosition + sourceRemaining)
-        val output = target.duplicate().position(targetPosition).limit(targetPosition + targetRemaining)
+    writeToCallerBufferViews(source, target) {
+            sourceView,
+            targetView,
+            sourcePosition,
+            sourceRemaining,
+            targetPosition,
+            targetRemaining,
+        ->
+        val input = sourceView.position(sourcePosition).limit(sourcePosition + sourceRemaining)
+        val output = targetView.position(targetPosition).limit(targetPosition + targetRemaining)
         useDeflateCodec(deflaterFactory(), endDeflater) { deflater ->
             deflater.setInput(input)
             deflater.finish()
@@ -1837,13 +1872,20 @@ override fun compress(source: ByteBuffer, target: ByteBuffer): Int =
     }
 ```
 
-- [ ] **Step 5.5: decompression state table를 exact 순서로 구현한다**
+- [x] **Step 5.5: decompression state table를 exact 순서로 구현한다**
 
 ```kotlin
 override fun decompress(source: ByteBuffer, target: ByteBuffer): Int =
-    writeToCallerBuffer(source, target) { sourcePosition, sourceRemaining, targetPosition, targetRemaining ->
-        val input = source.duplicate().position(sourcePosition).limit(sourcePosition + sourceRemaining)
-        val output = target.duplicate().position(targetPosition).limit(targetPosition + targetRemaining)
+    writeToCallerBufferViews(source, target) {
+            sourceView,
+            targetView,
+            sourcePosition,
+            sourceRemaining,
+            targetPosition,
+            targetRemaining,
+        ->
+        val input = sourceView.position(sourcePosition).limit(sourcePosition + sourceRemaining)
+        val output = targetView.position(targetPosition).limit(targetPosition + targetRemaining)
         useDeflateCodec(inflaterFactory(), endInflater) { inflater ->
             inflater.setInput(input)
             while (!inflater.finished()) {
@@ -1879,7 +1921,7 @@ factory만 노출한다. production factory는 매 호출 새 `Deflater`/`Inflat
 
 각 조합은 operation identity와 suppressed relation을 test seam으로 고정한다. 같은 throwable이 operation과 cleanup 양쪽에서 던져지면 자기 자신을 suppress하지 않고, 이미 같은 identity가 suppressed면 중복 추가하지 않는다.
 
-- [ ] **Step 5.6: Deflate GREEN/full regression/Detekt를 실행한다**
+- [x] **Step 5.6: Deflate GREEN/full regression/정적 검증을 실행한다**
 
 ```bash
 set -euo pipefail
@@ -1889,26 +1931,43 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
   --no-build-cache --rerun-tasks
 repo-test-summary -- ./gradlew :bluetape4k-io:test --no-build-cache --rerun-tasks
 ./gradlew detekt detektMain detektTest --no-build-cache --rerun-tasks
+repo-test-summary -- ./gradlew :bluetape4k-io:compileKotlin --no-build-cache --rerun-tasks
+python3 scripts/check-compressor-buffer-docs.py
 git diff --check
 ```
 
 예상 결과: state table, exact-fit, dictionary/zero-target precedence, no-progress, end-once와 suppressed identity가 PASS하고 전체 module regression이 없다.
 
+2026-07-30 fresh evidence: Deflate 전용 12개와 공통 contract를 포함한 모듈 전체
+1,215개 테스트가 통과했고 `:bluetape4k-io:compileKotlin`, 문서 checker,
+`git diff --check`가 통과했다. 저장소 root의 `detekt`, `detektMain`, `detektTest`는
+`NO-SOURCE`였고 `:bluetape4k-io`에는 Detekt task가 등록되어 있지 않아 Kotlin
+compile과 전체 모듈 test를 현재 정적·동적 검증 근거로 사용한다.
+
 - [ ] **Step 5.7: docs/lesson/Lore commit과 Deflate PR을 수렴한다**
 
-README Deflate 행은 heap/direct/mixed `optimized, evidence pending`으로 변경한다. lesson은 state order와 cleanup precedence를 기록한다. Lore intent는
-`Keep Deflate buffer loops bounded and disposable per call`로 하고 full tests/Detekt를 trailers에 기록한다. PR metadata: base `develop`, head `feat/issue-755-bytebuffer-deflate`, English title
+README Deflate 행은 heap/direct/mixed capability cell을 `optimized`로 변경하고,
+`Allocation claim` cell만 `eligible, not yet measured`로 변경한다. 영문/한국어
+matrix의 cell 의미와 순서를 exact parity로 유지한다.
+`DeflateCompressor`와 신규 internal seam/helper KDoc은 `$bluetape-writer` 기준의 한국어
+기술 문체로 source/target 상태, per-call resource 수명, failure/cleanup precedence와
+fallback 경계를 설명한다. 영문/한국어 README는 capability와 allocation claim을 같은
+의미로 유지하고, lesson은 state order와 cleanup precedence를 기록한다. Lore intent는
+`Keep Deflate buffer loops bounded and disposable per call`로 하고 1,215개 module test,
+compile, docs validator, diff check와 Detekt `NO-SOURCE`/module task 미등록 사실을 trailers에
+정확히 기록한다. PR metadata: base `develop`, head
+`feat/issue-755-bytebuffer-codecs`, English title
 `Add bounded caller-owned Deflate buffer paths`. Six-perspective review/CI 후 fresh merge approval에서 멈추며 Snappy branch를 미리 만들지 않는다.
 
 ```bash
 set -euo pipefail
-git push -u origin feat/issue-755-bytebuffer-deflate
+git push -u origin feat/issue-755-bytebuffer-codecs
 gh pr create --repo bluetape4k/bluetape4k-projects \
-  --base develop --head feat/issue-755-bytebuffer-deflate \
+  --base develop --head feat/issue-755-bytebuffer-codecs \
   --title 'Add bounded caller-owned Deflate buffer paths' \
   --assignee debop --milestone '1.12.0' \
   --label enhancement --label performance --label infra/io \
-  --body $'Refs #755\n\n## Summary\n- add bounded JDK Deflater and Inflater ByteBuffer loops\n- fail closed on no-progress states\n- end every per-call codec with deterministic failure precedence\n\n## Verification\n- Deflate state-table and cleanup tests\n- full bluetape4k-io tests and Detekt\n- six-perspective review\n\n## DoD Status\n- [x] Deflate backend slice complete\n- [x] Allocation promotion remains pending final evidence'
+  --body $'Refs #755\n\n## Summary\n- add bounded JDK Deflater and Inflater ByteBuffer loops\n- fail closed on no-progress states\n- end every per-call codec with deterministic failure precedence\n\n## Verification\n- Deflate state-table and cleanup tests (12 passing)\n- full bluetape4k-io tests (1,215 passing)\n- compileKotlin, docs validator, and diff check\n- Detekt root tasks are NO-SOURCE; no bluetape4k-io Detekt task is registered\n- six-perspective review\n\n## DoD Status\n- [x] Deflate backend slice complete\n- [x] Allocation promotion remains pending final evidence'
 ```
 
 **Step DoD:** Deflate PR이 무한 loop와 cleanup leak 없이 독립 merge-ready이고 CG-16 PENDING이다.
@@ -3495,6 +3554,24 @@ DoD:** issue #755 final PR이 merged, local develop synced, Task 0의 terminal b
 | caller/user   |  0 |  0 |  0 |  0 | PASS      |
 
 main integration은 Deflate operation-primary cleanup, LZ4/Snappy/Zstd native bounds, ABI RED order, thread-local JMH reset, actual payload scaling, immutable candidate 승인 binding, coordinator lifecycle, fail-fast shell gates와 atomic no-replace evidence publication을 반영했다. 최종 재검토 뒤 남은 P0–P3는 없다.
+
+2026-07-30에는 현재 Task 5와 fresh workflow authority를 기준으로 계획을 다시
+검토했다.
+
+| 관점          | 최초 판정 | 수정·재검토 결과 |
+|---------------|-----------|------------------|
+| performance   | CLEAN     | CLEAN            |
+| stability     | timeout 후 회수 | 좁은 재검토 CLEAN |
+| security      | timeout 후 회수 | 좁은 재검토 CLEAN |
+| operator      | P1 1건    | fresh run readiness authority로 수정 후 VERIFIED |
+| developer/API | CLEAN     | CLEAN            |
+| caller/user   | P2 2건    | capability/claim 분리와 한국어 retry 문구 수정 후 VERIFIED |
+
+main integration은 실제 helper 이름 `writeToCallerBufferViews`, 승인된 현재 branch,
+Task 5 PR command, 한국어 KDoc 및 docs validator 누락을 P1로 추가 확인해 수정했다.
+현재 Task 5 계획의 최신 결과는 P0=0, P1=0이며 남은 P2/P3는 없다. Task 6 이후의
+과거 snippet은 각 slice 시작 전 현재 source/API에 다시 정합해야 하며, 이번 Task 5의
+실행 authority로 사용하지 않는다.
 
 ## 15. 구현 승인 handoff
 

--- a/docs/superpowers/specs/2026-07-21-issue-755-bytebuffer-compressor-design.md
+++ b/docs/superpowers/specs/2026-07-21-issue-755-bytebuffer-compressor-design.md
@@ -1,11 +1,11 @@
 # Issue #755 caller-owned ByteBuffer compressor 설계
 
-- 상태: 대안 1 선택 승인, 최종 명세 검토 완료, 구현 전 승인 대기
+- 상태: 대안 1 구현 승인, core API와 LZ4 반영 완료, Deflate 이후 순차 구현 중
 - 대상 issue: `#755 Add caller-owned ByteBuffer compressor APIs for lower GC pressure`
 - 대상 milestone: `1.12.0`
 - 대상 모듈: `:bluetape4k-io`
-- 기준 branch/commit: `origin/develop@a065a8e88cf246975660c68df2dd78dfb5b6dc4d`
-- feature branch: `feat/issue-755-bytebuffer-compressor`
+- 현재 기준 branch/commit: `origin/develop@fa07277c8c123c1093299e10cf09504f13d177a1`
+- 현재 feature branch: `feat/issue-755-bytebuffer-codecs`
 
 ## 1. 문제와 목표
 
@@ -54,7 +54,8 @@ fun decompress(source: ByteBuffer, target: ByteBuffer): Int
 - `ByteBufferInputStream`은 caller source의 duplicate view를 stream input으로 사용할 수 있다.
 - `ByteBufferOutputStream.fixed`는 caller target의 현재 limit을 hard bound로 사용하고 초과 기록을 `BufferOverflowException`으로 보고한다.
 - `BinarySerializer.serializeTo`는 이미 caller-owned target에 대해 다음 관례를 사용한다. 성공 시 position만 전진하고, 실패 시 position을 복원하며, 실패 전 덮어쓴 byte는 복구하지 않는다.
-- 변경 전 `./gradlew :bluetape4k-io:test`는 1,109 tests PASS이다.
+- 2026-07-30 기준 `repo-test-summary -- ./gradlew :bluetape4k-io:test
+  --no-configuration-cache`는 1,203 tests PASS이다.
 
 ### 3.2 dependency API 근거
 
@@ -68,6 +69,22 @@ fun decompress(source: ByteBuffer, target: ByteBuffer): Int
 | zstd-jni 1.5.7-11        | direct-buffer 및 byte-array offset API                                     | direct→direct 또는 array-backed heap→heap만 직접 지원하고 native error는 반환 전에 `ZstdException`으로 변환됨           |
 | JDK 21 Deflater/Inflater | `setInput(ByteBuffer)`, `deflate(ByteBuffer)`, `inflate(ByteBuffer)`       | heap/direct buffer를 처리하지만 출력 크기를 사전 확정할 수 없음                                                         |
 | JDK/Apache framed codecs | stream API                                                                 | buffer-native API가 아니므로 이번 범위에서는 compatibility fallback                                                     |
+
+### 3.3 2026-07-30 구현 재개 근거
+
+- core API와 allocating compatibility fallback은 PR #1067로 반영되었다.
+- LZ4 caller-owned 경로는 PR #1091로 반영되었고, merge commit
+  `e2869bddee9c21bd6b9eee1f549c521b8e400f83` 이후 `develop`에서 검증되었다.
+- 이 branch 시작 시 `DeflateCompressor`, `SnappyCompressor`, `ZstdCompressor`는
+  two-argument `ByteBuffer` 메서드를 override하지 않아 interface fallback을 사용했다.
+  현재 Deflate slice는 승인된 JDK `ByteBuffer` override와 lifecycle 검증을 구현했고,
+  Snappy와 Zstd는 후속 slice까지 fallback을 유지한다.
+- 현재 dependency resolution은 Snappy `1.1.10.8`, zstd-jni `1.5.7-11`이다.
+  `javap`으로 Snappy의 direct `ByteBuffer` 및 heap offset API, zstd-jni의
+  direct/heap offset API, JDK 21 `Deflater`/`Inflater`의 `ByteBuffer` API를
+  다시 확인했다.
+- 위 근거는 3.2의 capability matrix와 backend별 설계를 변경하지 않는다. 따라서
+  대안 재선정 없이 기존 승인 설계를 이어서 구현한다.
 
 ## 4. 검토한 대안
 
@@ -579,3 +596,12 @@ Kotlin/Java README 예제는 compile test에 포함하고 source position 불변
 | caller/user ergonomics |  0 |  0 |  0 |  0 | PASS      |
 
 검토 과정에서 발견된 header payload capacity, compound failure precedence, 외부 구현체 concurrency 및 default-method compatibility 경계, fallback decompression resource bound, Zstd exception taxonomy, ABI 기준물, mutable benchmark state와 evidence schema 문제는 본문에 반영한 뒤 해당 관점에서 재검토했다. 계획 단계의 dependency source·실행 검증에서 추가로 확인한 LZ4 capacity-tail read와 zstd-jni throw-before-return 동작도 본문에 반영했다. 구현 계획과 구현 review에서도 이 명세를 기준으로 P0=0, P1=0을 다시 확인한다.
+
+2026-07-30 구현 재개 시 여섯 관점의 독립 재검토 lane을 두 차례 실행했지만,
+Codex App의 90초 제출 한도 안에 근거를 반환하지 않아 모두 회수했다. main session은
+현재 issue, PR #1091 반영 범위, resolved dependency와 JVM API, compressor source,
+영문/한국어 README 및 문서 validator를 다시 대조했다. 최신성 관점의 P2 한 건으로
+상태, 기준 commit/branch, 기준 테스트 수와 LZ4 완료 근거가 표류한 것을 확인해 3.3과
+문서 머리말을 수정했다. 성능, 안정성/오류계약, 보안, 운영,
+developer/public API, caller/user ergonomics의 설계 내용에는 P0/P1 또는 material
+change가 없으며, 2026-07-21 독립 수렴 결과는 계속 유효하다.

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -242,10 +242,12 @@ Read-only target은 `ReadOnlyBufferException`으로 거부하고, 동일한 buff
 | Codec        | heap -> heap           | direct -> direct       | mixed storage          | Allocation claim       |
 |--------------|------------------------|------------------------|------------------------|------------------------|
 | LZ4          | optimized              | optimized              | optimized              | eligible, not yet measured |
-| Deflate      | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
+| Deflate      | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Snappy       | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Zstd         | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Other codecs | compatibility fallback | compatibility fallback | compatibility fallback | ineligible             |
+
+`optimized`는 해당 storage 조합에서 codec의 backend `ByteBuffer` 경로를 사용한다는 뜻입니다. 처리량 개선을 주장하지 않으며 측정된 allocation 개선을 뜻하지도 않습니다.
 
 <!-- issue-755-storage-matrix:end -->
 
@@ -283,7 +285,7 @@ compressed = compressed.slice();
 <!-- issue-755-java-example:end -->
 
 <!-- issue-755-sizing-retry:start -->
-target에 남은 공간이 부족하면 raw `BufferOverflowException`이 발생하며 예외에는 required size가 포함되지 않습니다. source 상태와 target `position`은 보존되므로 호출자는 애플리케이션 상한 안에서 더 큰 target을 준비해 전체 작업을 재시도할 수 있습니다. 성공 전 target byte는 재사용하지 마세요.
+target에 남은 공간이 부족하면 raw `BufferOverflowException`이 발생하며 예외에는 required size가 포함되지 않습니다. source 상태와 target `position`은 보존되므로 호출자는 애플리케이션 상한 안에서 더 큰 target을 준비해 전체 작업을 재시도할 수 있습니다. 실패한 시도에서 target에 기록된 byte는 재사용하지 마세요.
 <!-- issue-755-sizing-retry:end -->
 
 <!-- issue-755-resource-bound:start -->
@@ -291,7 +293,7 @@ target에 남은 공간이 부족하면 raw `BufferOverflowException`이 발생�
 <!-- issue-755-resource-bound:end -->
 
 <!-- issue-755-telemetry:start -->
-이 API는 runtime dispatch telemetry, logging, feature flag를 제공하지 않습니다. 필요한 경우 payload 내용을 남기지 말고 codec, storage 조합, 입력/출력 size, overflow 횟수 같은 privacy-safe diagnostics를 호출자 측에서 기록하세요. native override에 결함이 발견되면 patch에서는 public default와 wire contract를 유지하고 해당 override만 compatibility fallback으로 되돌립니다. patch 적용 전에는 기존 allocating API 또는 문서에 표시된 fallback storage 조합으로 우회하세요.
+이 API는 runtime dispatch telemetry, logging, feature flag를 제공하지 않습니다. 필요한 경우 payload 내용을 남기지 말고 codec, storage 조합, 입력/출력 size, overflow 횟수 같은 privacy-safe diagnostics를 호출자 측에서 기록하세요. optimized override에 결함이 발견되면 patch에서는 public default와 wire contract를 유지하고 해당 override만 compatibility fallback으로 되돌립니다. patch 적용 전에는 기존 allocating API 또는 문서에 표시된 fallback storage 조합으로 우회하세요.
 <!-- issue-755-telemetry:end -->
 
 **StreamingCompressor (대용량 스트리밍 처리):**

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -242,10 +242,12 @@ Existing one-argument `ByteBuffer` APIs may consume the source `position`; the n
 | Codec        | heap -> heap           | direct -> direct       | mixed storage          | Allocation claim       |
 |--------------|------------------------|------------------------|------------------------|------------------------|
 | LZ4          | optimized              | optimized              | optimized              | eligible, not yet measured |
-| Deflate      | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
+| Deflate      | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Snappy       | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Zstd         | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Other codecs | compatibility fallback | compatibility fallback | compatibility fallback | ineligible             |
+
+`optimized` means that the codec uses a backend `ByteBuffer` path for that storage pairing. It is not a throughput claim and does not assert measured allocation improvement.
 
 <!-- issue-755-storage-matrix:end -->
 
@@ -291,7 +293,7 @@ The current compatibility fallback may stage both input and transformed output i
 <!-- issue-755-resource-bound:end -->
 
 <!-- issue-755-telemetry:start -->
-This API provides no runtime dispatch telemetry, logging, or feature flag. If needed, record privacy-safe caller diagnostics such as codec, storage pairing, input/output size, and overflow count without payload contents. If a native override proves defective, a patch keeps the public defaults and wire contract and reverts only that override to the compatibility fallback. Until the patch is available, use an existing allocating API or a documented fallback storage pairing.
+This API provides no runtime dispatch telemetry, logging, or feature flag. If needed, record privacy-safe caller diagnostics such as codec, storage pairing, input/output size, and overflow count without payload contents. If an optimized override proves defective, a patch keeps the public defaults and wire contract and reverts only that override to the compatibility fallback. Until the patch is available, use an existing allocating API or a documented fallback storage pairing.
 <!-- issue-755-telemetry:end -->
 
 **StreamingCompressor (for large-scale streaming):**

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/DeflateCompressor.kt
@@ -2,12 +2,34 @@ package io.bluetape4k.io.compressor
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.util.zip.DataFormatException
+import java.util.zip.Deflater
 import java.util.zip.DeflaterOutputStream
+import java.util.zip.Inflater
 import java.util.zip.InflaterInputStream
 import java.util.zip.ZipException
 
 /**
- * JDK Deflate 알고리즘을 이용한 압축기
+ * JDK Deflate 알고리즘을 이용한 압축기입니다.
+ *
+ * `ByteArray` API는 기존 zlib wire 형식을 유지합니다. caller-owned [ByteBuffer] API는
+ * 호출할 때마다 새 [Deflater] 또는 [Inflater]를 생성하고 JDK의 `ByteBuffer` 연산에
+ * 직접 위임하므로 heap/direct 조합에서 중간 `ByteArray` 복사를 만들지 않습니다.
+ *
+ * ## Caller-owned 버퍼 계약
+ *
+ * - source의 `position`, `limit`, byte order, mark는 성공과 실패 모두 보존합니다.
+ * - target의 `position`은 성공한 byte 수만큼만 전진합니다.
+ * - 실패하면 target의 `position`을 호출 전 값으로 되돌립니다. 이미 기록된 byte의
+ *   내용은 보장하지 않으므로 실패한 target 구간을 재사용하거나 읽지 않아야 합니다.
+ * - target 용량이 부족하면 [BufferOverflowException]을 던집니다.
+ * - 손상되거나 중단된 Deflate payload는 [ZipException]으로 보고합니다.
+ *
+ * codec은 연산별로 소유하며 성공과 실패 모두에서 정확히 한 번 정리합니다. 연산과
+ * 정리가 함께 실패하면 연산 예외를 그대로 유지하고 정리 예외를 suppressed로
+ * 추가합니다.
  *
  * 팩토리를 통한 사용을 권장합니다:
  * ```kotlin
@@ -19,13 +41,159 @@ import java.util.zip.ZipException
  *
  * @see [DeflaterOutputStream]
  * @see [InflaterInputStream]
- * @throws java.io.IOException when Deflate stream processing fails.
- * @throws ZipException when the payload is corrupt or not valid Deflate data.
+ * @throws java.io.IOException Deflate stream 처리에 실패한 경우
+ * @throws BufferOverflowException caller-owned target 용량이 부족한 경우
+ * @throws ZipException caller-owned `ByteBuffer` 복원에서 payload가 손상되었거나 완전하지 않은 경우
  */
-class DeflateCompressor: AbstractCompressor() {
+class DeflateCompressor private constructor(
+    private val deflaterFactory: () -> Deflater,
+    private val inflaterFactory: () -> Inflater,
+    private val endDeflater: (Deflater) -> Unit,
+    private val endInflater: (Inflater) -> Unit,
+): AbstractCompressor() {
+
+    constructor(): this(
+        deflaterFactory = ::Deflater,
+        inflaterFactory = ::Inflater,
+        endDeflater = Deflater::end,
+        endInflater = Inflater::end,
+    )
+
+    companion object {
+        /**
+         * codec 상태와 정리 실패를 결정적으로 검증하기 위한 내부 테스트 팩토리입니다.
+         *
+         * 운영 호출은 public no-arg 생성자를 사용해야 합니다.
+         */
+        internal fun forTesting(
+            deflaterFactory: () -> Deflater,
+            inflaterFactory: () -> Inflater,
+            endDeflater: (Deflater) -> Unit,
+            endInflater: (Inflater) -> Unit,
+        ): DeflateCompressor =
+            DeflateCompressor(
+                deflaterFactory = deflaterFactory,
+                inflaterFactory = inflaterFactory,
+                endDeflater = endDeflater,
+                endInflater = endInflater,
+            )
+    }
 
     /**
-     * I/O 압축에서 `doCompress` 함수를 제공합니다.
+     * [source]의 남은 데이터를 Deflate zlib 형식으로 압축해 [target]에 기록합니다.
+     *
+     * JDK [Deflater]의 `ByteBuffer` 경로를 사용하며 caller가 소유한 버퍼 상태는 클래스
+     * 계약에 따라 보존하거나 commit합니다.
+     *
+     * @return [target]에 기록한 압축 데이터 길이
+     * @throws BufferOverflowException target 용량이 압축 결과보다 작은 경우
+     * @throws IllegalStateException codec이 완료되지 않은 채 진행을 멈춘 경우
+     */
+    override fun compress(source: ByteBuffer, target: ByteBuffer): Int =
+        writeToCallerBufferViews(source, target) {
+                sourceView,
+                targetView,
+                sourcePosition,
+                sourceRemaining,
+                targetPosition,
+                targetRemaining,
+            ->
+            val input = sourceView
+                .position(sourcePosition)
+                .limit(sourcePosition + sourceRemaining)
+            val output = targetView
+                .position(targetPosition)
+                .limit(targetPosition + targetRemaining)
+
+            useDeflateCodec(deflaterFactory(), endDeflater) { deflater ->
+                deflater.setInput(input)
+                deflater.finish()
+
+                while (!deflater.finished()) {
+                    val inputBefore = deflater.bytesRead
+                    val outputBefore = deflater.bytesWritten
+                    val produced = deflater.deflate(output)
+
+                    if (deflater.finished()) break
+                    if (!output.hasRemaining()) throw BufferOverflowException()
+                    if (
+                        produced > 0 ||
+                        deflater.bytesRead != inputBefore ||
+                        deflater.bytesWritten != outputBefore
+                    ) {
+                        continue
+                    }
+                    if (deflater.needsInput()) {
+                        throw IllegalStateException("Deflater needs input before finishing")
+                    }
+                    throw IllegalStateException("Deflater made no progress")
+                }
+                output.position() - targetPosition
+            }
+        }
+
+    /**
+     * [source]의 Deflate zlib payload를 복원해 [target]에 기록합니다.
+     *
+     * 손상, 중단, 사전 요구 상태를 서로 구분하는 안정된 [ZipException]으로 변환합니다.
+     * target이 먼저 소진되면 payload 상태보다 [BufferOverflowException]을 우선합니다.
+     *
+     * @return [target]에 기록한 복원 데이터 길이
+     * @throws BufferOverflowException target 용량이 복원 데이터보다 작은 경우
+     * @throws ZipException payload가 손상, 중단되었거나 사전을 요구하는 경우
+     */
+    override fun decompress(source: ByteBuffer, target: ByteBuffer): Int =
+        writeToCallerBufferViews(source, target) {
+                sourceView,
+                targetView,
+                sourcePosition,
+                sourceRemaining,
+                targetPosition,
+                targetRemaining,
+            ->
+            val input = sourceView
+                .position(sourcePosition)
+                .limit(sourcePosition + sourceRemaining)
+            val output = targetView
+                .position(targetPosition)
+                .limit(targetPosition + targetRemaining)
+
+            useDeflateCodec(inflaterFactory(), endInflater) { inflater ->
+                inflater.setInput(input)
+
+                while (!inflater.finished()) {
+                    val inputBefore = inflater.bytesRead
+                    val outputBefore = inflater.bytesWritten
+                    val produced = try {
+                        inflater.inflate(output)
+                    } catch (failure: DataFormatException) {
+                        throw ZipException("Invalid Deflate payload").apply {
+                            initCause(failure)
+                        }
+                    }
+
+                    if (inflater.finished()) break
+                    if (!output.hasRemaining()) throw BufferOverflowException()
+                    if (inflater.needsDictionary()) {
+                        throw ZipException("Deflate preset dictionary is required")
+                    }
+                    if (inflater.needsInput()) {
+                        throw ZipException("Truncated Deflate payload")
+                    }
+                    if (
+                        produced == 0 &&
+                        inflater.bytesRead == inputBefore &&
+                        inflater.bytesWritten == outputBefore
+                    ) {
+                        throw ZipException("Inflater made no progress")
+                    }
+                }
+                output.position() - targetPosition
+            }
+        }
+
+    /**
+     * [plain]을 기존 allocating Deflate zlib wire 형식으로 압축합니다.
      */
     override fun doCompress(plain: ByteArray): ByteArray {
         val output = ByteArrayOutputStream(plain.size)
@@ -37,12 +205,47 @@ class DeflateCompressor: AbstractCompressor() {
     }
 
     /**
-     * I/O 압축에서 `doDecompress` 함수를 제공합니다.
+     * 기존 allocating API가 받은 Deflate zlib payload를 복원합니다.
      */
     override fun doDecompress(compressed: ByteArray): ByteArray {
         return ByteArrayInputStream(compressed).use { input ->
             InflaterInputStream(input).use { inflate ->
                 inflate.readBytes()
+            }
+        }
+    }
+}
+
+/**
+ * Deflate codec의 단일 연산과 정리 순서를 보존합니다.
+ *
+ * 연산 실패가 있으면 같은 throwable identity를 primary로 유지하고 정리 실패를
+ * suppressed로 추가합니다. 연산이 성공한 경우에만 정리 실패 자체를 전파합니다.
+ */
+internal inline fun <R, T> useDeflateCodec(
+    resource: R,
+    cleanup: (R) -> Unit,
+    block: (R) -> T,
+): T {
+    var operationFailure: Throwable? = null
+    try {
+        return block(resource)
+    } catch (failure: Throwable) {
+        operationFailure = failure
+        throw failure
+    } finally {
+        try {
+            cleanup(resource)
+        } catch (cleanupFailure: Throwable) {
+            val operation = operationFailure
+            if (operation == null) {
+                throw cleanupFailure
+            }
+            if (
+                operation !== cleanupFailure &&
+                operation.suppressed.none { suppressed -> suppressed === cleanupFailure }
+            ) {
+                operation.addSuppressed(cleanupFailure)
             }
         }
     }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/DeflateCompressorByteBufferTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/DeflateCompressorByteBufferTest.kt
@@ -1,0 +1,430 @@
+package io.bluetape4k.io.compressor
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContentEqual
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import org.junit.jupiter.api.Test
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.zip.DataFormatException
+import java.util.zip.Deflater
+import java.util.zip.Inflater
+import java.util.zip.ZipException
+
+class DeflateCompressorByteBufferTest {
+    private val compressor = DeflateCompressor()
+
+    @Test
+    fun `caller-owned compression and decompression support all storage combinations`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val wire = compressor.compress(payload)
+
+        verifyStorageMatrix(payload, wire) { source, target ->
+            compressor.compress(source, target)
+        }
+        verifyStorageMatrix(wire, payload) { source, target ->
+            compressor.decompress(source, target)
+        }
+    }
+
+    @Test
+    fun `caller-owned APIs create a fresh JDK codec for each operation`() {
+        val deflaterCreations = AtomicInteger()
+        val inflaterCreations = AtomicInteger()
+        val deflaterEnds = AtomicInteger()
+        val inflaterEnds = AtomicInteger()
+        val compressor = DeflateCompressor.forTesting(
+            deflaterFactory = {
+                deflaterCreations.incrementAndGet()
+                Deflater()
+            },
+            inflaterFactory = {
+                inflaterCreations.incrementAndGet()
+                Inflater()
+            },
+            endDeflater = {
+                deflaterEnds.incrementAndGet()
+                it.end()
+            },
+            endInflater = {
+                inflaterEnds.incrementAndGet()
+                it.end()
+            },
+        )
+        val payload = CompressorByteBufferTestSupport.payload
+        val firstTarget = CompressorByteBufferTestSupport.writableTarget(payload.size * 2, direct = true)
+        val secondTarget = CompressorByteBufferTestSupport.writableTarget(payload.size * 2, direct = false)
+
+        val firstSize = compressor.compress(CompressorByteBufferTestSupport.direct(payload), firstTarget)
+        compressor.compress(CompressorByteBufferTestSupport.heap(payload), secondTarget)
+
+        val firstWire = CompressorByteBufferTestSupport.bytes(firstTarget, 5, firstSize)
+        val restored = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = true)
+        compressor.decompress(CompressorByteBufferTestSupport.direct(firstWire), restored)
+
+        deflaterCreations.get() shouldBeEqualTo 2
+        inflaterCreations.get() shouldBeEqualTo 1
+        deflaterEnds.get() shouldBeEqualTo 2
+        inflaterEnds.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `caller-owned compression rolls back an exhausted target and permits retry`() {
+        val largePayload = ByteArray(16 * 1024) { index ->
+            ((index * 31) xor (index ushr 3)).toByte()
+        }
+        val largeWire = compressor.compress(largePayload)
+        val target = CompressorByteBufferTestSupport.writableTarget(largeWire.size - 1, direct = true)
+        val targetStart = target.position()
+
+        assertFailsWith<BufferOverflowException> {
+            compressor.compress(CompressorByteBufferTestSupport.direct(largePayload), target)
+        }
+        target.position() shouldBeEqualTo targetStart
+
+        val retryPayload = ByteArray(512)
+        val retryWire = compressor.compress(retryPayload)
+        compressor.compress(CompressorByteBufferTestSupport.heap(retryPayload), target)
+            .shouldBeEqualTo(retryWire.size)
+        CompressorByteBufferTestSupport.bytes(target, targetStart, retryWire.size)
+            .shouldContentEqual(retryWire)
+    }
+
+    @Test
+    fun `data format failures observed before target exhaustion keep their cause`() {
+        val payload = "retry after corruption".encodeToByteArray()
+        val wire = compressor.compress(payload)
+        val cause = DataFormatException("corrupt")
+        val cleanupInvocations = AtomicInteger()
+        val compressor = DeflateCompressor.forTesting(
+            deflaterFactory = ::Deflater,
+            inflaterFactory = { ThrowingInflater(cause) },
+            endDeflater = Deflater::end,
+            endInflater = {
+                cleanupInvocations.incrementAndGet()
+                it.end()
+            },
+        )
+        val target = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = true)
+        val targetStart = target.position()
+        target.limit(targetStart)
+
+        val failure = assertFailsWith<ZipException> {
+            compressor.decompress(
+                CompressorByteBufferTestSupport.direct(byteArrayOf(1)),
+                target,
+            )
+        }
+
+        failure.message shouldBeEqualTo "Invalid Deflate payload"
+        failure.cause shouldBeSameInstanceAs cause
+        cleanupInvocations.get() shouldBeEqualTo 1
+        target.position() shouldBeEqualTo targetStart
+        target.limit() shouldBeEqualTo targetStart
+
+        target.limit(targetStart + payload.size)
+        this.compressor.decompress(CompressorByteBufferTestSupport.heap(wire), target)
+            .shouldBeEqualTo(payload.size)
+        CompressorByteBufferTestSupport.bytes(target, targetStart, payload.size)
+            .shouldContentEqual(payload)
+    }
+
+    @Test
+    fun `truncated payload and preset dictionary states fail with stable ZipExceptions`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val wire = compressor.compress(payload)
+        val truncated = wire.copyOf(wire.size - 1)
+
+        val truncatedFailure = assertFailsWith<ZipException> {
+            compressor.decompress(
+                CompressorByteBufferTestSupport.heap(truncated),
+                CompressorByteBufferTestSupport.writableTarget(payload.size + 1, direct = true),
+            )
+        }
+        truncatedFailure.message shouldBeEqualTo "Truncated Deflate payload"
+
+        val dictionaryFailure = assertFailsWith<ZipException> {
+            compressorWithInflater(DictionaryInflater()).decompress(
+                CompressorByteBufferTestSupport.heap(byteArrayOf(1)),
+                CompressorByteBufferTestSupport.writableTarget(32, direct = false),
+            )
+        }
+        dictionaryFailure.message shouldBeEqualTo "Deflate preset dictionary is required"
+    }
+
+    @Test
+    fun `target exhaustion wins before dictionary and no-progress states`() {
+        val retryPayload = byteArrayOf(1, 2, 3)
+        val retryWire = compressor.compress(retryPayload)
+
+        listOf(DictionaryInflater(), NoProgressInflater()).forEach { inflater ->
+            val target = CompressorByteBufferTestSupport.writableTarget(retryPayload.size, direct = true)
+            val targetStart = target.position()
+            target.limit(targetStart)
+
+            assertFailsWith<BufferOverflowException> {
+                compressorWithInflater(inflater).decompress(
+                    CompressorByteBufferTestSupport.heap(byteArrayOf(1)),
+                    target,
+                )
+            }
+
+            target.position() shouldBeEqualTo targetStart
+            target.limit() shouldBeEqualTo targetStart
+
+            target.limit(targetStart + retryPayload.size)
+            compressor.decompress(CompressorByteBufferTestSupport.heap(retryWire), target)
+                .shouldBeEqualTo(retryPayload.size)
+            CompressorByteBufferTestSupport.bytes(target, targetStart, retryPayload.size)
+                .shouldContentEqual(retryPayload)
+        }
+    }
+
+    @Test
+    fun `codec no-progress states fail closed without looping`() {
+        val needsInputFailure = assertFailsWith<IllegalStateException> {
+            compressorWithDeflater(NeedsInputDeflater()).compress(
+                CompressorByteBufferTestSupport.heap(byteArrayOf(1)),
+                CompressorByteBufferTestSupport.writableTarget(32, direct = true),
+            )
+        }
+        needsInputFailure.message shouldBeEqualTo "Deflater needs input before finishing"
+
+        val compressionFailure = assertFailsWith<IllegalStateException> {
+            compressorWithDeflater(NoProgressDeflater()).compress(
+                CompressorByteBufferTestSupport.heap(byteArrayOf(1)),
+                CompressorByteBufferTestSupport.writableTarget(32, direct = true),
+            )
+        }
+        compressionFailure.message shouldBeEqualTo "Deflater made no progress"
+
+        val decompressionFailure = assertFailsWith<ZipException> {
+            compressorWithInflater(NoProgressInflater()).decompress(
+                CompressorByteBufferTestSupport.heap(byteArrayOf(1)),
+                CompressorByteBufferTestSupport.writableTarget(32, direct = true),
+            )
+        }
+        decompressionFailure.message shouldBeEqualTo "Inflater made no progress"
+    }
+
+    @Test
+    fun `operation failure keeps identity and suppresses cleanup failure`() {
+        val operationFailure = CancellationException("operation")
+        val cleanupFailure = AssertionError("cleanup")
+        val cleanupInvocations = AtomicInteger()
+        val compressor = DeflateCompressor.forTesting(
+            deflaterFactory = { ThrowingDeflater(operationFailure) },
+            inflaterFactory = ::Inflater,
+            endDeflater = {
+                cleanupInvocations.incrementAndGet()
+                it.end()
+                throw cleanupFailure
+            },
+            endInflater = Inflater::end,
+        )
+
+        val failure = assertFailsWith<Throwable> {
+            compressor.compress(
+                CompressorByteBufferTestSupport.heap(byteArrayOf(1)),
+                CompressorByteBufferTestSupport.writableTarget(32, direct = true),
+            )
+        }
+
+        failure shouldBeSameInstanceAs operationFailure
+        failure.suppressed.shouldHaveSize(1)
+        failure.suppressed.single() shouldBeSameInstanceAs cleanupFailure
+        cleanupInvocations.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `cleanup helper preserves fatal cancellation overflow and runtime operation failures`() {
+        val operationFailures = listOf(
+            IllegalStateException("runtime"),
+            BufferOverflowException(),
+            AssertionError("fatal"),
+            CancellationException("cancelled"),
+        )
+
+        operationFailures.forEachIndexed { index, operationFailure ->
+            val cleanupFailure = IllegalArgumentException("cleanup-$index")
+            val failure = assertFailsWith<Throwable> {
+                useDeflateCodec(Unit, cleanup = { throw cleanupFailure }) {
+                    throw operationFailure
+                }
+            }
+
+            failure shouldBeSameInstanceAs operationFailure
+            failure.suppressed.shouldHaveSize(1)
+            failure.suppressed.single() shouldBeSameInstanceAs cleanupFailure
+        }
+    }
+
+    @Test
+    fun `cleanup helper neither self-suppresses nor duplicates the same cleanup failure`() {
+        val sharedFailure = IllegalStateException("shared")
+        val selfSuppressed = assertFailsWith<Throwable> {
+            useDeflateCodec(Unit, cleanup = { throw sharedFailure }) {
+                throw sharedFailure
+            }
+        }
+        selfSuppressed shouldBeSameInstanceAs sharedFailure
+        selfSuppressed.suppressed.shouldHaveSize(0)
+
+        val operationFailure = IllegalStateException("operation")
+        val cleanupFailure = IllegalArgumentException("cleanup")
+        operationFailure.addSuppressed(cleanupFailure)
+        val duplicateSuppressed = assertFailsWith<Throwable> {
+            useDeflateCodec(Unit, cleanup = { throw cleanupFailure }) {
+                throw operationFailure
+            }
+        }
+        duplicateSuppressed shouldBeSameInstanceAs operationFailure
+        duplicateSuppressed.suppressed.shouldHaveSize(1)
+        duplicateSuppressed.suppressed.single() shouldBeSameInstanceAs cleanupFailure
+    }
+
+    @Test
+    fun `cleanup-only failure keeps identity and target rollback`() {
+        val cleanupFailure = AssertionError("cleanup")
+        val cleanupInvocations = AtomicInteger()
+        val target = CompressorByteBufferTestSupport.writableTarget(64, direct = true)
+        val targetStart = target.position()
+        val compressor = DeflateCompressor.forTesting(
+            deflaterFactory = ::Deflater,
+            inflaterFactory = ::Inflater,
+            endDeflater = {
+                cleanupInvocations.incrementAndGet()
+                it.end()
+                throw cleanupFailure
+            },
+            endInflater = Inflater::end,
+        )
+
+        val failure = assertFailsWith<Throwable> {
+            compressor.compress(CompressorByteBufferTestSupport.heap(byteArrayOf(1)), target)
+        }
+
+        failure shouldBeSameInstanceAs cleanupFailure
+        target.position() shouldBeEqualTo targetStart
+        cleanupInvocations.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `singleton caller-owned operations are safe under concurrency`() {
+        val payload = CompressorByteBufferTestSupport.payload
+
+        MultithreadingTester()
+            .workers(8)
+            .rounds(2)
+            .add {
+                val wire = CompressorByteBufferTestSupport.writableTarget(payload.size * 2, direct = true)
+                val wireStart = wire.position()
+                val written = Compressors.Deflate.compress(
+                    CompressorByteBufferTestSupport.direct(payload),
+                    wire,
+                )
+                val restored = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = false)
+                Compressors.Deflate.decompress(
+                    wire.duplicate().position(wireStart).limit(wireStart + written),
+                    restored,
+                )
+                CompressorByteBufferTestSupport.bytes(restored, 5, payload.size)
+                    .shouldContentEqual(payload)
+            }
+            .run()
+    }
+
+    private fun verifyStorageMatrix(
+        input: ByteArray,
+        expected: ByteArray,
+        operation: (ByteBuffer, ByteBuffer) -> Int,
+    ) {
+        CompressorByteBufferTestSupport.sources(input).forEach { (_, source) ->
+            CompressorByteBufferTestSupport.targets(expected.size).forEach { (_, target) ->
+                val sourceStart = source.position()
+                val sourceLimit = source.limit()
+                val sourceOrder = source.order()
+                val targetStart = target.position()
+                val targetLimit = target.limit()
+                val targetOrder = target.order()
+                val before = CompressorByteBufferTestSupport.allBytes(target)
+
+                operation(source, target) shouldBeEqualTo expected.size
+
+                source.position() shouldBeEqualTo sourceStart
+                source.limit() shouldBeEqualTo sourceLimit
+                source.order() shouldBeEqualTo sourceOrder
+                CompressorByteBufferTestSupport.assertMark(source, sourceStart)
+                target.position() shouldBeEqualTo targetStart + expected.size
+                target.limit() shouldBeEqualTo targetLimit
+                target.order() shouldBeEqualTo targetOrder
+                CompressorByteBufferTestSupport.assertMark(target, targetStart)
+                CompressorByteBufferTestSupport.bytes(target, targetStart, expected.size)
+                    .shouldContentEqual(expected)
+                CompressorByteBufferTestSupport.allBytes(target).copyOfRange(0, targetStart)
+                    .shouldContentEqual(before.copyOfRange(0, targetStart))
+                CompressorByteBufferTestSupport.allBytes(target).copyOfRange(targetLimit, target.capacity())
+                    .shouldContentEqual(before.copyOfRange(targetLimit, target.capacity()))
+            }
+        }
+    }
+
+    private fun compressorWithDeflater(deflater: Deflater): DeflateCompressor =
+        DeflateCompressor.forTesting(
+            deflaterFactory = { deflater },
+            inflaterFactory = ::Inflater,
+            endDeflater = Deflater::end,
+            endInflater = Inflater::end,
+        )
+
+    private fun compressorWithInflater(inflater: Inflater): DeflateCompressor =
+        DeflateCompressor.forTesting(
+            deflaterFactory = ::Deflater,
+            inflaterFactory = { inflater },
+            endDeflater = Deflater::end,
+            endInflater = Inflater::end,
+        )
+
+    private class ThrowingDeflater(
+        private val failure: Throwable,
+    ): Deflater() {
+        override fun deflate(output: ByteBuffer): Int = throw failure
+    }
+
+    private class NoProgressDeflater: Deflater() {
+        override fun deflate(output: ByteBuffer): Int = 0
+        override fun finished(): Boolean = false
+        override fun needsInput(): Boolean = false
+    }
+
+    private class NeedsInputDeflater: Deflater() {
+        override fun deflate(output: ByteBuffer): Int = 0
+        override fun finished(): Boolean = false
+        override fun needsInput(): Boolean = true
+    }
+
+    private class ThrowingInflater(
+        private val failure: DataFormatException,
+    ): Inflater() {
+        override fun inflate(output: ByteBuffer): Int = throw failure
+    }
+
+    private class DictionaryInflater: Inflater() {
+        override fun inflate(output: ByteBuffer): Int = 0
+        override fun finished(): Boolean = false
+        override fun needsDictionary(): Boolean = true
+        override fun needsInput(): Boolean = false
+    }
+
+    private class NoProgressInflater: Inflater() {
+        override fun inflate(output: ByteBuffer): Int = 0
+        override fun finished(): Boolean = false
+        override fun needsDictionary(): Boolean = false
+        override fun needsInput(): Boolean = false
+    }
+}

--- a/scripts/check-compressor-buffer-docs.py
+++ b/scripts/check-compressor-buffer-docs.py
@@ -96,8 +96,7 @@ def validate_readmes() -> None:
             fail(f"README {language} example locale parity drift")
     expected_matrix = {
         "LZ4": ("optimized", "optimized", "optimized", "eligible, not yet measured"),
-        "Deflate": ("compatibility fallback", "compatibility fallback", "compatibility fallback",
-                    "none in the core slice"),
+        "Deflate": ("optimized", "optimized", "optimized", "eligible, not yet measured"),
         "Snappy": ("compatibility fallback", "compatibility fallback", "compatibility fallback",
                    "none in the core slice"),
         "Zstd": ("compatibility fallback", "compatibility fallback", "compatibility fallback",
@@ -106,6 +105,19 @@ def validate_readmes() -> None:
     }
     if en_matrix != expected_matrix:
         fail(f"storage matrix drift: expected={expected_matrix} actual={en_matrix}")
+
+    require_tokens(
+        sections["en"]["issue-755-storage-matrix"],
+        ("`optimized` means", "backend `ByteBuffer` path", "not a throughput claim",
+         "measured allocation improvement"),
+        "English optimized capability boundary",
+    )
+    require_tokens(
+        sections["ko"]["issue-755-storage-matrix"],
+        ("`optimized`는", "backend `ByteBuffer` 경로", "처리량 개선을 주장하지 않으며",
+         "측정된 allocation 개선"),
+        "Korean optimized capability boundary",
+    )
 
     shared_contract = (
         "position",
@@ -158,7 +170,8 @@ def validate_readmes() -> None:
                 fail(f"{locale} examples: forbidden allocating or unbounded pattern: {forbidden}")
         require_tokens(
             sections[locale]["issue-755-telemetry"],
-            ("runtime dispatch telemetry", "privacy-safe", "override", "allocating API", "fallback storage"),
+            ("runtime dispatch telemetry", "privacy-safe", "optimized override",
+             "allocating API", "fallback storage"),
             f"{locale} telemetry",
         )
 


### PR DESCRIPTION
## Summary

Closes #755

- PR 제목: Add bounded caller-owned Deflate buffer paths

- add bounded JDK `Deflater` and `Inflater` caller-owned `ByteBuffer` paths
- preserve source state and commit target position only on success
- fail closed on overflow, corrupt/truncated/dictionary, and no-progress states
- dispose each per-call codec with operation-primary cleanup precedence
- document Deflate storage capability without promoting allocation claims

### 원문 선행 내용

Refs #755

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- Deflate state-table, lifecycle, retry, and concurrency tests: 12 passing
- full `bluetape4k-io` suite: 1,215 passing
- `:bluetape4k-io:compileKotlin`: passing
- compressor README locale/docs validator: passing
- `git diff --check`: passing
- root `detekt`, `detektMain`, and `detektTest`: `NO-SOURCE`; no `bluetape4k-io` Detekt task is registered

### 기존 섹션: Review Convergence

| Lens | Initial | Final |
|---|---:|---:|
| Performance | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| Stability | P0=0 P1=2 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| Security | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| Operator/Ops | P0=0 P1=0 P2=1 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| Developer/API | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| User/caller | P0=0 P1=0 P2=2 P3=1 | P0=0 P1=0 P2=0 P3=0 |

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #755, milestone `1.12.0`, assignee `debop`
- PR: #1229, head `cf7f100cec7bdab5a9e638058936de1a63fd5009`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-755-bytebuffer-codecs`
- Labels: `enhancement`, `performance`, `infra/io`
- State: `MERGED`, merge commit `2c5e445e081ea043ac8779c7d46c219fdced0794`
- CI: - root `detekt`, `detektMain`, and `detektTest`: `NO-SOURCE`; no `bluetape4k-io` Detekt task is registered

## DoD Status

- [x] Deflate backend slice complete
- [x] Existing zlib wire remains interoperable
- [x] Heap/direct/mixed caller-owned paths are covered
- [x] Allocation promotion remains pending the final evidence slice
- [ ] Issue #755 remains open for Snappy, Zstd, and canonical allocation evidence

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1229 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2c5e445e081ea043ac8779c7d46c219fdced0794`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
