### PR TITLE
Add validated caller-owned Snappy buffer paths

### DIFF
--- a/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
+++ b/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
@@ -78,6 +78,28 @@ identity, cleanup-only identity, compression/decompression no-progress, overflow
 storage coverage만 뜻하며 allocation 개선은 아직 측정하지 않았으므로
 `eligible, not yet measured`로 유지한다.
 
+## Snappy slice에서 고정한 출력 상한과 validation 경계
+
+snappy-java 1.1.10.8은 direct `ByteBuffer` 쌍과 array offset API를 모두 제공하지만 두 API의
+안전성 계약은 같지 않다. array compression API는 target offset만 받고 caller
+`ByteBuffer.remaining()`을 출력 길이로 받지 않는다. backing array에 limit 뒤 여유 공간이
+있으면 caller가 공개하지 않은 범위까지 쓸 수 있으므로 heap→heap을 optimized로 분류하지
+않았다. direct→direct만 native 경로를 사용하고 heap/mixed 조합은 compatibility fallback을
+유지한다.
+
+direct compression도 `Snappy.maxCompressedLength(source.remaining())` 전체를 target이 수용할
+때만 native 경로를 선택한다. 다만 이 안전 상한보다 작다는 이유만으로 곧바로 overflow를
+던지면 실제 압축 결과가 target에 들어가던 기존 fallback 성공을 깨뜨린다. 따라서 상한이
+부족하면 allocating fallback으로 내려가고, 실제 결과가 target을 넘을 때만
+`BufferOverflowException`을 유지한다.
+
+direct decompression은 정확한 caller-visible source range를 먼저 검증한 뒤 복원 크기와 기존
+256 MiB 한도, target remaining을 순서대로 확인한다. invalid payload는
+`IllegalArgumentException`으로 거부하고 native decode를 호출하지 않는다. duplicate view에서
+native 연산을 실행해 원본 source/target limit을 보존하며, singleton 동시 호출 테스트로
+호출 간 mutable codec state가 없음을 고정한다. README의 `optimized`는 이 제한된 native
+dispatch capability만 뜻하며 allocation 개선은 아직 측정하지 않았다.
+
 ## 왜 broad backend slice를 중단했는가
 
 LZ4의 capacity-tail read는 source isolation 문제이고, zstd-jni의 throw-before-return은 예외

--- a/docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md
+++ b/docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md
@@ -52,6 +52,15 @@
 - 2026-07-21의 terminal blocked fallback command와 checksum은 과거 audit record다.
   현재 mutation authority, lifecycle 및 completion evidence는 위 fresh run에서만 가져온다.
 
+### 1.2 2026-07-31 Snappy 실행 상태
+
+- Deflate Task 5는 PR #1229로 반영되었고 현재 기준은
+  `origin/develop@53f9b86c562c8fb5ba2ddd539abc10ac2d406b1f`이다.
+- 현재 격리 worktree와 branch는 `.worktrees/issue-755-snappy-bytebuffer`,
+  `feat/issue-755-snappy-bytebuffer`다.
+- 현재 실행 범위는 Task 6 Snappy slice다. 이 PR의 exact-head CI/review와 별도 merge
+  승인 전에는 Task 7 Zstd branch 또는 구현을 시작하지 않는다.
+
 ## 2. Broad Backend Matrix 전달 topology
 
 | 순서 | 역할              | head branch                                     | base              | 독립 결과                                                         | 다음 단계 진입 조건               |
@@ -59,7 +68,7 @@
 |    1 | core/API/ABI      | `feat/issue-755-bytebuffer-compressor`          | `develop`         | JVM default API, fallback, 공통 contract, ABI fixture, 초기 docs  | PR merge와 local sync 완료        |
 |    2 | LZ4 backend       | `feat/issue-755-bytebuffer-lz4`                 | updated `develop` | heap/direct 전체 조합, bounded payload slice                      | PR merge와 local sync 완료        |
 |    3 | Deflate backend   | `feat/issue-755-bytebuffer-codecs`              | updated `develop` | JDK buffer loop와 deterministic cleanup                           | PR merge와 local sync 완료        |
-|    4 | Snappy backend    | `feat/issue-755-bytebuffer-snappy`              | updated `develop` | heap→heap/direct→direct native path와 validation-first            | PR merge와 local sync 완료        |
+|    4 | Snappy backend    | `feat/issue-755-snappy-bytebuffer`              | updated `develop` | bounded direct→direct native path와 validation-first              | PR merge와 local sync 완료        |
 |    5 | Zstd backend      | `feat/issue-755-bytebuffer-zstd`                | updated `develop` | declared-size native bound와 exact exception taxonomy             | PR merge와 local sync 완료        |
 |    6 | adoption/evidence | `perf/issue-755-bytebuffer-compressor-evidence` | updated `develop` | cross-codec concurrency, examples, two canonical runs, final docs | PR merge-ready 보고 후 fresh 승인 |
 
@@ -322,7 +331,7 @@ fun decompress(source: ByteBuffer, target: ByteBuffer): Int
 |-----------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
 | JVM default overload가 legacy implementor/caller를 깨뜨림 | fixture compile/linkage failure, `isDefault=false`               | frozen baseline jar와 Java/Kotlin source/classfile runtime fixture를 core RED로 먼저 고정      | core PR 중단, interface method를 revert하고 spec 재개방                  |
 | LZ4가 caller limit 뒤 capacity tail을 읽음                | truncated limit fixture가 성공하거나 consumed가 remaining 초과   | payload를 position 0, limit=capacity=remaining인 bounded slice로 전달                          | LZ4 override만 fallback으로 revert, LZ4 slice rerun                      |
-| Snappy invalid input이 native crash 경계로 진입           | validation seam 뒤 uncompress 호출 count 증가                    | heap/direct 모두 validation-first, exact range만 length/decode에 전달                          | Snappy override만 fallback으로 revert, forked targeted test rerun        |
+| Snappy invalid input이 native crash 경계로 진입           | validation seam 뒤 uncompress 호출 count 증가                    | direct optimized 경로는 validation-first, exact range만 length/decode에 전달                   | Snappy override만 fallback으로 revert, forked targeted test rerun        |
 | Zstd under-declared header가 declared size보다 많이 기록  | large target sentinel 변경, `dstSize` seam mismatch              | native destination을 `declaredOriginalSize`로 고정                                             | Zstd override만 fallback으로 revert, heap/direct corruption matrix rerun |
 | Zstd retry 의미가 오분류됨                                | decompression mismatch가 `BufferOverflowException`               | compression `errDstSizeTooSmall`만 overflow; decompression은 cause-less exact ISE              | exception taxonomy RED부터 재실행                                        |
 | Deflate loop가 무한 정지 또는 cleanup 누락                | zero-progress 반복, end count != 1                               | state table, progress snapshot, Deflate-local operation-primary cleanup helper, per-call codec | Deflate override revert, lifecycle seam tests부터 rerun                  |
@@ -1977,17 +1986,36 @@ gh pr create --repo bluetape4k/bluetape4k-projects \
 ## Task 6: Snappy slice — validation-first matched-storage native path를 전달한다
 
 **복잡도:** 높음 **Dependency:** Deflate PR merge + updated `develop` sync **Write
-scope:** `SnappyCompressor.kt`, Snappy test, README locale rows, lesson native-validation section **Pattern
-skill:** `bluetape-kotlin-patterns`, `test-driven-development`
+scope:** `SnappyCompressor.kt`, Snappy test, README locale rows, validator, Snappy design/plan
+correction, lesson native-validation section **Pattern skill:** `bluetape-kotlin-patterns`,
+`test-driven-development`
 
 **파일:**
 
 - 수정: `io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt`
 - 생성: `io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyCompressorByteBufferTest.kt`
 - 수정: `io/io/README.md`, `io/io/README.ko.md`
+- 수정: `scripts/check-compressor-buffer-docs.py`
+- 수정: `docs/superpowers/specs/2026-07-21-issue-755-bytebuffer-compressor-design.md`
+- 수정: `docs/superpowers/plans/2026-07-21-issue-755-bytebuffer-compressor-plan.md`
 - 수정: `docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md`
 
-- [ ] **Step 6.1: merge된 develop에서 Snappy worktree를 만든다**
+### 2026-07-31 실행 정정
+
+resolved snappy-java 1.1.10.8 source를 다시 확인한 결과 array compression API는 target
+offset만 받고 caller target length를 받지 않는다. 따라서 아래 초기 승인 예시의
+heap→heap native dispatch와 max-bound 부족 즉시 overflow는 구현하지 않는다. 실제 실행
+계약은 다음과 같다.
+
+- direct→direct만 native `ByteBuffer` 경로 후보이며 heap/mixed는 fallback이다.
+- compression은 max bound가 충분할 때만 native 경로를 사용하고, 부족하면 실제 압축 결과가
+  들어갈 수 있는 compatibility fallback으로 내려간다.
+- direct decompression은 exact range validation → 복원 크기/256 MiB → target bound →
+  native decode 순서를 유지한다.
+- invalid direct payload는 `IllegalArgumentException`이며 native decode를 호출하지 않는다.
+- Step 6.2, 6.4, 6.5는 이 정정에 맞춘 실행 결과와 검증 계약만 기록한다.
+
+- [x] **Step 6.1: merge된 develop에서 Snappy worktree를 만든다**
 
 ```bash
 set -euo pipefail
@@ -1995,73 +2023,19 @@ git -C /Users/debop/work/bluetape4k/bluetape4k-projects fetch origin develop
 git -C /Users/debop/work/bluetape4k/bluetape4k-projects switch develop
 git -C /Users/debop/work/bluetape4k/bluetape4k-projects pull --ff-only origin develop
 git -C /Users/debop/work/bluetape4k/bluetape4k-projects worktree add \
-  /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feat-issue-755-bytebuffer-snappy \
-  -b feat/issue-755-bytebuffer-snappy origin/develop
+  /Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/issue-755-snappy-bytebuffer \
+  -b feat/issue-755-snappy-bytebuffer origin/develop
 ```
 
 예상 결과: core/LZ4/Deflate merge commits가 ancestor이고 worktree clean.
 
-- [ ] **Step 6.2: dispatch와 native validation ordering RED를 작성한다**
+- [x] **Step 6.2: dispatch와 native validation ordering RED를 작성한다**
 
-```kotlin
-private class RecordingSnappyOperations(
-    private val calls: MutableList<String>,
-    private val valid: Boolean = true,
-    private val maxCompressedLength: Int = 64,
-    private val uncompressedLength: Int = 8,
-): SnappyBufferOperations {
-    override fun maxCompressedLength(sourceLength: Int): Int = maxCompressedLength.also { calls += "maxCompressedLength" }
-    override fun isValidHeap(source: ByteArray, sourceOffset: Int, sourceLength: Int): Boolean =
-        valid.also { calls += "validateHeap" }
-    override fun isValidDirect(source: ByteBuffer): Boolean = valid.also { calls += "validateDirect" }
-    override fun uncompressedLengthHeap(source: ByteArray, sourceOffset: Int, sourceLength: Int): Int =
-        uncompressedLength.also { calls += "lengthHeap" }
-    override fun uncompressedLengthDirect(source: ByteBuffer): Int =
-        uncompressedLength.also { calls += "lengthDirect" }
-    override fun compressHeap(source: ByteArray, sourceOffset: Int, sourceLength: Int, target: ByteArray, targetOffset: Int): Int =
-        error("compressHeap must not be called by these ordering tests")
-    override fun compressDirect(source: ByteBuffer, target: ByteBuffer): Int =
-        error("compressDirect must not be called by these ordering tests")
-    override fun uncompressHeap(source: ByteArray, sourceOffset: Int, sourceLength: Int, target: ByteArray, targetOffset: Int): Int =
-        error("uncompressHeap must not be called by these ordering tests")
-    override fun uncompressDirect(source: ByteBuffer, target: ByteBuffer): Int =
-        error("uncompressDirect must not be called by these ordering tests")
-}
+RED는 direct pair backend dispatch, caller state/wire 호환성, max bound보다 작은 target의
+fallback, invalid direct payload의 decode 차단, 256 MiB 경계, backend throwable identity,
+inspection view 격리, exact output bound, singleton concurrency를 포함한다.
 
-class SnappyCompressorByteBufferTest {
-    @Test
-    fun `invalid direct payload is rejected before length and native decode`() {
-        val calls = mutableListOf<String>()
-        val operations = RecordingSnappyOperations(calls, valid = false)
-        val compressor = SnappyCompressor.forTesting(operations)
-
-        val failure = assertFailsWith<SnappyException> {
-            compressor.decompress(ByteBuffer.allocateDirect(8), ByteBuffer.allocateDirect(32))
-        }
-
-        failure.errorCode shouldBeEqualTo SnappyErrorCode.PARSING_ERROR
-        calls shouldBeEqualTo listOf("validateDirect")
-    }
-
-    @Test
-    fun `heap compression checks max size before array native call`() {
-        val calls = mutableListOf<String>()
-        val operations = RecordingSnappyOperations(calls, maxCompressedLength = 64)
-        val compressor = SnappyCompressor.forTesting(operations)
-
-        assertFailsWith<BufferOverflowException> {
-            compressor.compress(ByteBuffer.wrap(ByteArray(8)), ByteBuffer.allocate(63))
-        }
-
-        calls shouldBeEqualTo listOf("maxCompressedLength")
-    }
-}
-```
-
-추가 RED: heap→heap/direct→direct native dispatch, heap→direct/direct→heap fallback, read-only heap source fallback, arrayOffset/slice, exact target size, validation→uncompressedLength→256MiB→target→decode call order, invalid+small target에서 SnappyException 우선, output duplicate limit isolation, failure identity, overflow/corrupt 후 retry, existing/new wire, sentinel, singleton concurrency를 포함한다. operation fake가
-`maxCompressedLength`로 `-1`, `0`, `sourceLength - 1`을 반환하면 heap/direct native compression은 호출되지 않고 stable `IllegalStateException`, position rollback과 sentinel 보존을 요구한다.
-
-- [ ] **Step 6.3: Snappy RED를 실행한다**
+- [x] **Step 6.3: Snappy RED를 실행한다**
 
 ```bash
 set -euo pipefail
@@ -2072,93 +2046,22 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test \
 
 예상 결과: `forTesting`과 native dispatch가 없어 compile/ordering assertion FAIL.
 
-- [ ] **Step 6.4: exact storage dispatch와 compression을 구현한다**
+- [x] **Step 6.4: bounded direct storage dispatch와 compression을 구현한다**
 
-```kotlin
-internal interface SnappyBufferOperations {
-    fun maxCompressedLength(sourceLength: Int): Int
-    fun compressHeap(source: ByteArray, sourceOffset: Int, sourceLength: Int, target: ByteArray, targetOffset: Int): Int
-    fun compressDirect(source: ByteBuffer, target: ByteBuffer): Int
-    fun isValidHeap(source: ByteArray, sourceOffset: Int, sourceLength: Int): Boolean
-    fun isValidDirect(source: ByteBuffer): Boolean
-    fun uncompressedLengthHeap(source: ByteArray, sourceOffset: Int, sourceLength: Int): Int
-    fun uncompressedLengthDirect(source: ByteBuffer): Int
-    fun uncompressHeap(source: ByteArray, sourceOffset: Int, sourceLength: Int, target: ByteArray, targetOffset: Int): Int
-    fun uncompressDirect(source: ByteBuffer, target: ByteBuffer): Int
-}
+public no-arg constructor와 기존 ByteArray methods는 유지하고 private primary constructor +
+`internal forTesting` factory로 direct-only `SnappyBufferOperations`를 주입한다. common
+preflight 안에서 positive max bound를 확인한다. bound가 충분하면 output duplicate limit을
+그 bound로 고정해 native compression을 실행하고, 부족하면 compatibility fallback을
+실행한다.
 
-override fun compress(source: ByteBuffer, target: ByteBuffer): Int = when {
-    source.hasArray() && target.hasArray() -> compressHeap(source, target)
-    source.isDirect && target.isDirect -> compressDirect(source, target)
-    else -> super.compress(source, target)
-}
+- [x] **Step 6.5: validation-first decompression을 구현한다**
 
-private fun compressHeap(source: ByteBuffer, target: ByteBuffer): Int =
-    writeToCallerBuffer(source, target) { sourcePosition, sourceRemaining, targetPosition, targetRemaining ->
-        val required = operations.maxCompressedLength(sourceRemaining)
-        check(required > 0 && required >= sourceRemaining) {
-            "Snappy maxCompressedLength is invalid: sourceLength=$sourceRemaining, required=$required"
-        }
-        if (targetRemaining < required) throw BufferOverflowException()
-        operations.compressHeap(
-            source.array(), source.arrayOffset() + sourcePosition, sourceRemaining,
-            target.array(), target.arrayOffset() + targetPosition,
-        )
-    }
+validation, uncompressed-length 확인, native decode에는 각각 fresh input duplicate를 전달한다.
+invalid payload는 `IllegalArgumentException`으로 거부하고, 복원 크기는 `0..256 MiB`와
+target remaining에 대해 검증한다. native output limit은 exact 복원 크기로 고정하며 반환량이
+그 크기와 같을 때만 원본 target position을 commit한다.
 
-private fun compressDirect(source: ByteBuffer, target: ByteBuffer): Int =
-    writeToCallerBuffer(source, target) { sourcePosition, sourceRemaining, targetPosition, targetRemaining ->
-        val required = operations.maxCompressedLength(sourceRemaining)
-        check(required > 0 && required >= sourceRemaining) {
-            "Snappy maxCompressedLength is invalid: sourceLength=$sourceRemaining, required=$required"
-        }
-        if (targetRemaining < required) throw BufferOverflowException()
-        val input = source.duplicate().position(sourcePosition).limit(sourcePosition + sourceRemaining)
-        val output = target.duplicate().position(targetPosition).limit(targetPosition + targetRemaining)
-        operations.compressDirect(input, output)
-    }
-```
-
-`source.hasArray()`가 false인 read-only heap은 compatibility fallback으로 내려간다. public no-arg constructor와 기존 ByteArray methods는 유지하고 private primary constructor + `internal forTesting`
-factory로 `SnappyBufferOperations`를 주입한다.
-
-- [ ] **Step 6.5: validation-first decompression을 구현한다**
-
-```kotlin
-private fun decompressHeap(source: ByteBuffer, target: ByteBuffer): Int =
-    writeToCallerBuffer(source, target) { sourcePosition, sourceRemaining, targetPosition, targetRemaining ->
-        val sourceOffset = source.arrayOffset() + sourcePosition
-        if (!operations.isValidHeap(source.array(), sourceOffset, sourceRemaining)) {
-            throw SnappyException(SnappyErrorCode.PARSING_ERROR, "Invalid Snappy compressed buffer")
-        }
-        val expected = operations.uncompressedLengthHeap(source.array(), sourceOffset, sourceRemaining)
-        require(expected in 0..MAX_DECOMPRESSED_SIZE) { "uncompressedSize exceeds 256 MiB: $expected" }
-        if (expected > targetRemaining) throw BufferOverflowException()
-        val written = operations.uncompressHeap(
-            source.array(), sourceOffset, sourceRemaining,
-            target.array(), target.arrayOffset() + targetPosition,
-        )
-        check(written == expected) { "Snappy decompressed size mismatch: expected=$expected, actual=$written" }
-        written
-    }
-
-private fun decompressDirect(source: ByteBuffer, target: ByteBuffer): Int =
-    writeToCallerBuffer(source, target) { sourcePosition, sourceRemaining, targetPosition, targetRemaining ->
-        val input = source.duplicate().position(sourcePosition).limit(sourcePosition + sourceRemaining)
-        if (!operations.isValidDirect(input.duplicate())) {
-            throw SnappyException(SnappyErrorCode.PARSING_ERROR, "Invalid Snappy compressed buffer")
-        }
-        val expected = operations.uncompressedLengthDirect(input.duplicate())
-        require(expected in 0..MAX_DECOMPRESSED_SIZE) { "uncompressedSize exceeds 256 MiB: $expected" }
-        if (expected > targetRemaining) throw BufferOverflowException()
-        val output = target.duplicate().position(targetPosition).limit(targetPosition + targetRemaining)
-        val written = operations.uncompressDirect(input, output)
-        check(written == expected) { "Snappy decompressed size mismatch: expected=$expected, actual=$written" }
-        written
-    }
-```
-
-- [ ] **Step 6.6: Snappy GREEN/full regression/Detekt를 실행한다**
+- [x] **Step 6.6: Snappy GREEN/full regression/Detekt를 실행한다**
 
 ```bash
 set -euo pipefail
@@ -2171,23 +2074,28 @@ repo-test-summary -- ./gradlew :bluetape4k-io:test --no-build-cache --rerun-task
 git diff --check
 ```
 
-예상 결과: invalid heap/direct payload는 native decode 미호출, max-size preflight와 mixed fallback, 원본 limit 보존, 전체 suite와 Detekt PASS.
+실행 결과: Snappy 전용 10건, 공통 target suite 48건, 전체 모듈 1,225건이 PASS했다.
+문서 검증기와 `git diff --check`도 PASS했다. root Detekt 진입점은 모두 `NO-SOURCE`이며
+`bluetape4k-io` 전용 Detekt task는 등록되어 있지 않다.
 
 - [ ] **Step 6.7: docs/lesson/Lore commit과 Snappy PR을 수렴한다**
 
-README Snappy 행은 heap→heap/direct→direct `optimized, evidence pending`, mixed/read-only heap
-`fallback, ineligible`로 변경한다. lesson은 validation-first가 JVM crash boundary인 이유를 기록한다. Lore intent는 `Keep invalid Snappy ranges outside the native decoder`. PR metadata: base `develop`, head `feat/issue-755-bytebuffer-snappy`, English title
-`Add validated caller-owned Snappy buffer paths`. Six-perspective review/CI 후 fresh merge approval에서 멈추며 Zstd branch를 미리 만들지 않는다.
+README Snappy 행은 direct→direct만 `optimized`, heap/mixed는 `compatibility fallback`,
+allocation은 `eligible for direct pair, not yet measured`로 변경한다. lesson은 validation-first
+native crash 경계와 array API가 caller limit을 강제하지 못하는 이유를 기록한다. Lore intent는
+`Keep invalid Snappy ranges outside the native decoder`. PR metadata: base `develop`, head
+`feat/issue-755-snappy-bytebuffer`, English title `Add validated caller-owned Snappy buffer paths`.
+Six-perspective review/CI 후 fresh merge approval에서 멈추며 Zstd branch를 미리 만들지 않는다.
 
 ```bash
 set -euo pipefail
-git push -u origin feat/issue-755-bytebuffer-snappy
+git push -u origin feat/issue-755-snappy-bytebuffer
 gh pr create --repo bluetape4k/bluetape4k-projects \
-  --base develop --head feat/issue-755-bytebuffer-snappy \
+  --base develop --head feat/issue-755-snappy-bytebuffer \
   --title 'Add validated caller-owned Snappy buffer paths' \
   --assignee debop --milestone '1.12.0' \
   --label enhancement --label performance --label infra/io \
-  --body $'Refs #755\n\n## Summary\n- add matched-storage Snappy caller-owned paths\n- validate exact source ranges before native length and decode calls\n- keep mixed and read-only heap inputs on the compatibility fallback\n\n## Verification\n- Snappy validation-order and storage-dispatch tests\n- full bluetape4k-io tests and Detekt\n- six-perspective review\n\n## DoD Status\n- [x] Snappy backend slice complete\n- [x] Allocation promotion remains pending final evidence'
+  --body $'Refs #755\n\n## Summary\n- add bounded direct-pair Snappy caller-owned paths\n- validate exact source ranges before native length and decode calls\n- keep heap, mixed, and undersized compression bounds on the compatibility fallback\n\n## Verification\n- Snappy validation-order and storage-dispatch tests\n- full bluetape4k-io tests and Detekt\n- six-perspective review\n\n## DoD Status\n- [x] Snappy backend slice complete\n- [x] Allocation promotion remains pending final evidence'
 ```
 
 **Step DoD:** Snappy PR이 invalid range를 native decode에 전달하지 않고 CG-16 PENDING이다.

--- a/docs/superpowers/specs/2026-07-21-issue-755-bytebuffer-compressor-design.md
+++ b/docs/superpowers/specs/2026-07-21-issue-755-bytebuffer-compressor-design.md
@@ -65,26 +65,28 @@ fun decompress(source: ByteBuffer, target: ByteBuffer): Int
 |--------------------------|----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | LZ4 1.11.0               | absolute-offset `compress(ByteBuffer, ...)`, `decompress(ByteBuffer, ...)` | heap/direct 및 slice 지원, position은 변경하지 않지만 fast decompression은 source 길이를 `capacity - offset`으로 계산함 |
 | Snappy 1.1.10.8          | `compress(ByteBuffer, ByteBuffer)`, `uncompress(ByteBuffer, ByteBuffer)`   | direct→direct만 지원하고 output limit을 변경함                                                                          |
-| Snappy 1.1.10.8          | offset 기반 `byte[]` API                                                   | array-backed heap→heap 지원                                                                                             |
+| Snappy 1.1.10.8          | offset 기반 `byte[]` API                                                   | target offset만 받고 출력 길이 상한을 받지 않아 caller `ByteBuffer.limit`을 강제할 수 없음                              |
 | zstd-jni 1.5.7-11        | direct-buffer 및 byte-array offset API                                     | direct→direct 또는 array-backed heap→heap만 직접 지원하고 native error는 반환 전에 `ZstdException`으로 변환됨           |
 | JDK 21 Deflater/Inflater | `setInput(ByteBuffer)`, `deflate(ByteBuffer)`, `inflate(ByteBuffer)`       | heap/direct buffer를 처리하지만 출력 크기를 사전 확정할 수 없음                                                         |
 | JDK/Apache framed codecs | stream API                                                                 | buffer-native API가 아니므로 이번 범위에서는 compatibility fallback                                                     |
 
-### 3.3 2026-07-30 구현 재개 근거
+### 3.3 2026-07-31 구현 재개 근거
 
 - core API와 allocating compatibility fallback은 PR #1067로 반영되었다.
 - LZ4 caller-owned 경로는 PR #1091로 반영되었고, merge commit
   `e2869bddee9c21bd6b9eee1f549c521b8e400f83` 이후 `develop`에서 검증되었다.
-- 이 branch 시작 시 `DeflateCompressor`, `SnappyCompressor`, `ZstdCompressor`는
-  two-argument `ByteBuffer` 메서드를 override하지 않아 interface fallback을 사용했다.
-  현재 Deflate slice는 승인된 JDK `ByteBuffer` override와 lifecycle 검증을 구현했고,
-  Snappy와 Zstd는 후속 slice까지 fallback을 유지한다.
+- Deflate caller-owned 경로는 PR #1229로 반영되었고, 이 branch는 갱신된 `develop`
+  `53f9b86c562c8fb5ba2ddd539abc10ac2d406b1f`에서 시작했다.
+- 이 slice는 Snappy direct/direct 조합에만 native `ByteBuffer` override를 추가한다.
+  heap/mixed 조합은 caller target limit을 안전하게 강제할 수 없어 interface fallback을
+  유지하며, Zstd는 후속 slice까지 fallback을 유지한다.
 - 현재 dependency resolution은 Snappy `1.1.10.8`, zstd-jni `1.5.7-11`이다.
   `javap`으로 Snappy의 direct `ByteBuffer` 및 heap offset API, zstd-jni의
   direct/heap offset API, JDK 21 `Deflater`/`Inflater`의 `ByteBuffer` API를
   다시 확인했다.
-- 위 근거는 3.2의 capability matrix와 backend별 설계를 변경하지 않는다. 따라서
-  대안 재선정 없이 기존 승인 설계를 이어서 구현한다.
+- source jar 재검토로 Snappy array compression API가 target offset 뒤의 writable length를
+  받지 않는다는 제약을 확인했다. 따라서 기존 heap→heap 최적화 계획은 철회하고,
+  direct/direct만 증명 가능한 native 경로로 좁힌다.
 
 ## 4. 검토한 대안
 
@@ -155,8 +157,8 @@ source와 target의 underlying byte range는 겹치지 않아야 한다. 동일 
 2. source와 target이 동일 객체이거나 탐지 가능한 array range가 겹치면
    `IllegalArgumentException`을 던진다.
 3. source remaining이 0이면 `0`을 반환한다.
-4. backend가 exact 결과 크기를 알거나 안전상 full bound가 필수이면
-   `initialTargetRemaining`을 검사한다.
+4. backend가 exact 결과 크기를 알면 `initialTargetRemaining`을 검사하고, 안전상 full
+   bound가 필요한 Snappy compression은 bound가 충분할 때만 native 경로를 선택한다.
 5. absolute/offset API 또는 backend가 caller 범위를 보존하는 데 필요한 bounded/duplicate view에서 codec을 실행한다.
 6. 성공한 기록량만 원본 target position에 commit한다.
 
@@ -166,7 +168,10 @@ read-only target은 alias, empty-source, codec 초기화, 압축 또는 복원�
 
 - 기본 fallback은 결과 `ByteArray` 크기를 확인한 뒤 기록하므로 작은 target을 raw
   `BufferOverflowException`으로 보고하고 byte를 기록하지 않는다.
-- exact 크기를 아는 decompression 경로와 full bound가 native 안전성에 필수인 Snappy compression은 codec 호출 전에 `BufferOverflowException`으로 실패한다.
+- exact 크기를 아는 decompression 경로는 codec 호출 전에 `BufferOverflowException`으로
+  실패한다. Snappy compression은 native 안전 상한이 부족하면 compatibility fallback으로
+  내려가며, 실제 압축 결과도 target에 들어가지 않을 때만 fallback이
+  `BufferOverflowException`을 보고한다.
 - destination length를 안전하게 받는 LZ4/Zstd compression은 4-byte header를 제외한
   `payloadCapacity = initialTargetRemaining - 4`를 codec에 전달한다. backend의 destination-too-small 결과만 raw `BufferOverflowException`으로 정규화한다. 현재 zstd-jni offset API는 native error를 code로 반환하지 않고 `ZstdException`으로 던지므로
   `errorCode == Zstd.errDstSizeTooSmall()`인 예외만 이 정규화 대상이다.
@@ -238,11 +243,16 @@ header-prefixed codec은 wrapper에 전체 기록량을 반환한다. LZ4와 Zst
 ### 7.2 Snappy
 
 - direct→direct는 Snappy ByteBuffer API를 duplicate view에서 사용한다.
-- writable array-backed heap→heap은 offset 기반 byte-array API를 사용한다.
-- mixed storage, read-only heap source, 또는 array를 노출하지 않는 heap source는 기본 fallback으로 내려간다.
-- compression target은 `Snappy.maxCompressedLength(source.remaining())` 이상이어야 한다.
+- heap 및 mixed storage는 기본 fallback으로 내려간다. byte-array compression API는 target
+  offset만 받고 target length를 받지 않으므로 caller limit 뒤를 덮어쓰지 않는다고 증명할
+  수 없다.
+- compression target이 `Snappy.maxCompressedLength(source.remaining())` 이상이면 native
+  경로를 사용한다. 그보다 작으면 실제 압축 결과가 들어갈 수 있는 기존 동작을 보존하기
+  위해 compatibility fallback을 사용한다.
 - decompression은 정확한 source range에서 `Snappy.uncompressedLength`로 exact size를 확인하고 기존 256 MiB 제한을 적용한다.
-- heap과 direct optimized decompression 모두 native crash 위험을 줄이기 위해 codec이 제공하는 range-aware compressed-buffer validation을 먼저 수행한다. invalid/truncated input은 `SnappyException`으로 보고하며 native decompression을 실행하지 않는다.
+- direct optimized decompression은 native crash 위험을 줄이기 위해 codec이 제공하는
+  range-aware compressed-buffer validation을 먼저 수행한다. invalid/truncated input은
+  `IllegalArgumentException`으로 보고하며 native decompression을 실행하지 않는다.
 - Snappy가 output duplicate의 limit을 바꾸더라도 원본 target limit은 보존한다.
 
 ### 7.3 Zstd
@@ -336,7 +346,7 @@ LZ4/Zstd header byte order, Snappy raw format, Deflate zlib framing은 변경하
 | 경로                              | 구현이 아는 크기                              | caller 계약                                                                                                           |
 |-----------------------------------|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | LZ4/Zstd compression              | native 호출 전 exact size는 모름              | 현재 target remaining을 사용하고 overflow 시 더 큰 target으로 전체 재시도                                             |
-| Snappy compression                | native 안전상 max bound 필요                  | bound보다 작으면 preflight overflow; caller는 더 큰 target으로 재시도                                                 |
+| Snappy compression                | native 안전상 max bound 필요                  | bound가 충분하면 native 경로, 부족하면 fallback; 실제 결과가 target을 넘을 때만 overflow                              |
 | Deflate compression/decompression | 완료 전 exact size 모름                       | bounded write 중 overflow; 더 큰 target으로 전체 재시도                                                               |
 | LZ4/Snappy/Zstd decompression     | 구현 내부에서 declared/exact size 확인        | target이 작으면 overflow지만 필요 크기는 외부에 노출하지 않음                                                         |
 | compatibility fallback            | 내부 결과 `ByteArray` 생성 후 exact size 확인 | target은 최종 write bound일 뿐 decompression resource bound가 아님; overflow에 exact size를 첨부하지 않고 전체 재시도 |
@@ -350,7 +360,7 @@ LZ4/Zstd header byte order, Snappy raw format, Deflate zlib framing은 변경하
 - optimized decompression에서 caller target remaining은 codec 실행 전 또는 실행 중 적용되는 추가 hard output bound다.
 - compatibility fallback의 target remaining은 전체 결과 `ByteArray`가 생성된 뒤 적용되는 최종 write bound일 뿐 decompression memory/resource bound가 아니다. 작은 target만으로 untrusted fallback input의 대규모 할당이나 `OutOfMemoryError`를 방지한다고 보장하지 않는다.
 - corrupt header, negative size, oversized declared size, truncated payload를 테스트한다.
-- Snappy heap/direct optimized path는 invalid native input validation 없이 raw decompression을 호출하지 않는다.
+- Snappy direct optimized path는 invalid native input validation 없이 raw decompression을 호출하지 않는다.
 - 동일 객체와 탐지 가능한 array-backed overlap은 즉시 거부한다.
 - no-progress loop, native error code 무시, cleanup 누락을 허용하지 않는다.
 - 공유 `Compressors` singleton 호출 사이에 mutable buffer/codec state를 보관하지 않는다.
@@ -369,7 +379,7 @@ LZ4/Zstd header byte order, Snappy raw format, Deflate zlib framing은 변경하
 | fallback | 기존 ByteArray decompression과 security limit → exact result target overflow                                               |
 
 LZ4/Zstd는 header 구조와 declared-size 오류만 target overflow보다 우선한다. header가 유효하지만 payload가 corrupt한 상태에서 target까지 작으면 decode 전에
-`BufferOverflowException`이 발생한다. Snappy는 compressed-range validation을 먼저 수행하므로 같은 복합 입력에서 `SnappyException`이 우선한다. Deflate는 output size를 사전 결정할 수 없으므로 corruption이 target exhaustion 전에 관찰되면 `ZipException`, target이 먼저 소진되면 `BufferOverflowException`이다. fallback은 기존 `ByteArray` decompression이 target 검사보다 먼저 실행되므로 기존 corrupt-input failure가 우선할 수 있다. 각 backend는 corrupt-payload+too-small-target compound fixture로 이 순서를 검증한다.
+`BufferOverflowException`이 발생한다. Snappy는 compressed-range validation을 먼저 수행하므로 같은 복합 입력에서 `IllegalArgumentException`이 우선한다. Deflate는 output size를 사전 결정할 수 없으므로 corruption이 target exhaustion 전에 관찰되면 `ZipException`, target이 먼저 소진되면 `BufferOverflowException`이다. fallback은 기존 `ByteArray` decompression이 target 검사보다 먼저 실행되므로 기존 corrupt-input failure가 우선할 수 있다. 각 backend는 corrupt-payload+too-small-target compound fixture로 이 순서를 검증한다.
 
 ### 10.2 runtime diagnosis
 
@@ -407,7 +417,7 @@ fallback codec도 correctness contract를 통과해야 하지만 allocation 감�
 
 - LZ4: heap/direct 모든 조합, header 경계, high-compression payload의
   `written=declaredOriginalSize`, consumed mismatch, trailing/truncated payload, caller limit 뒤 capacity tail이 valid payload를 포함해도 bounded source만으로 실패하는 regression
-- Snappy: heap→heap, direct→direct optimized; mixed 조합 fallback; heap/direct invalid input이 native call 전에 거부됨
+- Snappy: direct→direct optimized; heap/mixed 조합 fallback; direct invalid input이 native call 전에 거부됨; compression max bound가 부족한 direct pair는 fallback
 - Zstd: heap→heap, direct→direct optimized; mixed 조합 fallback; header 이후 native destination length가 `initialTargetRemaining - 4`임을 non-zero position, exact-limit/sentinel,
   `initialTargetRemaining == 4` 경계로 검증; heap/direct의 compression `errDstSizeTooSmall` `ZstdException`만 raw `BufferOverflowException`으로 정규화하고 그 밖의 `ZstdException` identity를 보존하며, decompression은 native destination을 `declaredOriginalSize`로 고정하고 그 경로의 `errDstSizeTooSmall` 및 successful result mismatch를 exact class/stable-message/no-cause `IllegalStateException`으로 검증; under-declared header+큰 target의 heap/direct regression, 과대·과소 header, truncated payload
 - Deflate: heap/direct 조합, incompressible payload, target exhaustion, corrupt input, dictionary/no-progress 상태, dictionary+zero-remaining target의 `BufferOverflowException`, exact-fit success, `end()` 1회, cleanup suppression
@@ -543,7 +553,7 @@ Kotlin/Java README 예제는 compile test에 포함하고 source position 불변
 | Zstd under-declared header                                    | native destination을 declared size로 고정하고 `errDstSizeTooSmall` 분류 | stable mismatch message를 가진 정확한 `IllegalStateException`, cause 없음                                                             |
 | Zstd invalid payload의 `errDstSizeTooSmall` 이외 native error | zstd-jni가 변환한 native exception                                      | 원래 `ZstdException` identity 보존                                                                                                    |
 | Zstd successful result와 declared size 불일치                 | exact result 검사                                                       | stable mismatch message를 가진 정확한 `IllegalStateException`, cause 없음                                                             |
-| Snappy invalid/truncated input                                | heap/direct range validation 선행                                       | `SnappyException`, native decompression 미실행                                                                                        |
+| Snappy invalid/truncated direct input                         | exact range validation 선행                                              | `IllegalArgumentException`, native decompression 미실행                                                                               |
 | Deflate invalid/truncated/dictionary input                    | loop 상태표와 cause 보존                                                | 충분한 target에서는 `ZipException`; dictionary와 zero-remaining target이 동시에 관찰되면 상태표 순서에 따라 `BufferOverflowException` |
 | backend가 duplicate limit 변경                                | 원본과 분리된 view에서 실행                                             | 원본 limit 보존                                                                                                                       |
 | backend failure 후 partial write                              | 원본 position rollback                                                  | bytes unspecified, 전체 재기록으로 retry                                                                                              |
@@ -561,7 +571,8 @@ Kotlin/Java README 예제는 compile test에 포함하고 source position 불변
 3. 모든 compressor가 공통 buffer correctness contract를 통과한다.
 4. LZ4와 Deflate는 지원되는 heap/direct 조합에서 payload-sized intermediate
    `ByteArray` 없이 동작한다.
-5. Snappy와 Zstd는 heap→heap 및 direct→direct에서 저할당 경로를 사용하고 나머지는 명시적 fallback을 사용한다.
+5. Snappy는 안전 상한을 충족한 direct→direct에서 native 경로를 사용하고 나머지는 명시적
+   fallback을 사용한다. Zstd storage 범위는 후속 slice에서 확정한다.
 6. source state, target success commit, failure rollback, read-only 및 overflow 계약이 direct test로 증명된다.
 7. 기존 wire와 신규 API의 양방향 복원이 증명된다.
 8. 기존 decompression 제한과 corrupt-input 방어가 신규 경로에도 적용된다.

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -243,11 +243,13 @@ Read-only target은 `ReadOnlyBufferException`으로 거부하고, 동일한 buff
 |--------------|------------------------|------------------------|------------------------|------------------------|
 | LZ4          | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Deflate      | optimized              | optimized              | optimized              | eligible, not yet measured |
-| Snappy       | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
+| Snappy       | compatibility fallback | optimized              | compatibility fallback | eligible for direct pair, not yet measured |
 | Zstd         | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Other codecs | compatibility fallback | compatibility fallback | compatibility fallback | ineligible             |
 
 `optimized`는 해당 storage 조합에서 codec의 backend `ByteBuffer` 경로를 사용한다는 뜻입니다. 처리량 개선을 주장하지 않으며 측정된 allocation 개선을 뜻하지도 않습니다.
+
+Snappy는 direct source/target 조합에서만 native `ByteBuffer` 경로를 사용합니다. 압축은 `target.remaining()`이 `Snappy.maxCompressedLength(source.remaining())` 이상일 때 이 경로를 사용하며, 그보다 작은 direct target은 압축 결과가 실제로 들어갈 때 성공할 수 있도록 compatibility fallback으로 처리합니다. direct 압축 해제는 native decode 전에 payload 전체와 정확한 복원 크기를 검증합니다. 현재 배열 API는 호출자 target의 임의 limit을 출력 상한으로 강제할 수 없으므로 heap 및 mixed-storage 조합은 compatibility fallback을 유지합니다.
 
 <!-- issue-755-storage-matrix:end -->
 

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -243,11 +243,13 @@ Existing one-argument `ByteBuffer` APIs may consume the source `position`; the n
 |--------------|------------------------|------------------------|------------------------|------------------------|
 | LZ4          | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Deflate      | optimized              | optimized              | optimized              | eligible, not yet measured |
-| Snappy       | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
+| Snappy       | compatibility fallback | optimized              | compatibility fallback | eligible for direct pair, not yet measured |
 | Zstd         | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
 | Other codecs | compatibility fallback | compatibility fallback | compatibility fallback | ineligible             |
 
 `optimized` means that the codec uses a backend `ByteBuffer` path for that storage pairing. It is not a throughput claim and does not assert measured allocation improvement.
+
+Snappy uses its native `ByteBuffer` path only for direct source/target pairs. Compression takes that path when `target.remaining()` is at least `Snappy.maxCompressedLength(source.remaining())`; a smaller direct target uses the compatibility fallback so a compressible result can still succeed when it fits. Direct decompression validates the complete payload and its exact decompressed size before native decoding. Heap and mixed-storage pairs remain compatibility fallbacks because the available array API cannot enforce an arbitrary caller target limit.
 
 <!-- issue-755-storage-matrix:end -->
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/SnappyCompressor.kt
@@ -2,12 +2,61 @@ package io.bluetape4k.io.compressor
 
 import org.xerial.snappy.Snappy
 import org.xerial.snappy.SnappyError
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+
+/**
+ * Snappy의 caller-owned 버퍼 연산을 격리한 내부 어댑터입니다.
+ *
+ * 운영 구현은 안전한 direct/direct 조합을 Snappy의 `ByteBuffer` API에 위임합니다.
+ * 테스트 구현은 backend 선택과 반환값·실패 경계를 검증합니다.
+ */
+internal interface SnappyBufferOperations {
+    fun maxCompressedLength(sourceLength: Int): Int
+
+    fun compress(source: ByteBuffer, target: ByteBuffer): Int
+
+    fun isValidCompressedBuffer(source: ByteBuffer): Boolean
+
+    fun uncompressedLength(source: ByteBuffer): Int
+
+    fun decompress(source: ByteBuffer, target: ByteBuffer): Int
+}
+
+private object DefaultSnappyBufferOperations: SnappyBufferOperations {
+    override fun maxCompressedLength(sourceLength: Int): Int =
+        Snappy.maxCompressedLength(sourceLength)
+
+    override fun compress(source: ByteBuffer, target: ByteBuffer): Int =
+        Snappy.compress(source, target)
+
+    override fun isValidCompressedBuffer(source: ByteBuffer): Boolean =
+        Snappy.isValidCompressedBuffer(source)
+
+    override fun uncompressedLength(source: ByteBuffer): Int =
+        Snappy.uncompressedLength(source)
+
+    override fun decompress(source: ByteBuffer, target: ByteBuffer): Int =
+        Snappy.uncompress(source, target)
+}
 
 /**
  * Snappy 알고리즘을 사용한 Compressor
  *
  * Apache Commons Compress의 FramedSnappyCompressorOutputStream보다 훨씬 빠릅니다 (약 2배).
  * 낮은 지연 시간이 중요한 경우에 권장됩니다.
+ *
+ * caller-owned [ByteBuffer] 압축 API는 direct/direct 조합에서 target 여유 공간이
+ * [Snappy.maxCompressedLength] 이상일 때 Snappy native `ByteBuffer` 연산을 사용합니다.
+ * 압축 결과는 들어가지만 안전 상한보다 작은 target과 heap/mixed storage는 기존
+ * allocating compatibility fallback을 유지합니다. 압축 해제는 복원 크기를 먼저
+ * 확인할 수 있으므로 충분한 direct/direct target에서 native 경로를 사용합니다.
+ * 이는 backend capability 설명이며 측정된 allocation 또는 처리량 개선을 주장하지
+ * 않습니다.
+ *
+ * 압축은 [Snappy.maxCompressedLength]만큼 target 여유 공간이 있는지 native 호출 전에
+ * 확인합니다. 압축 해제는 payload 전체를 검증하고 복원 크기와 256 MB 한도를 확인한
+ * 뒤 target에 기록합니다.
  *
  * 팩토리를 통한 사용을 권장합니다:
  * ```kotlin
@@ -22,10 +71,104 @@ import org.xerial.snappy.SnappyError
  * @throws SnappyError when the Snappy native library or codec reports a state error.
  * @throws org.xerial.snappy.SnappyException when the Snappy codec reports a codec failure.
  */
-class SnappyCompressor: AbstractCompressor() {
+class SnappyCompressor private constructor(
+    private val bufferOperations: SnappyBufferOperations,
+): AbstractCompressor() {
+
+    constructor(): this(DefaultSnappyBufferOperations)
 
     companion object {
         private const val MAX_DECOMPRESSED_SIZE = 256 * 1024 * 1024  // 256 MB
+
+        /**
+         * backend 선택과 실패 경계를 검증하기 위한 내부 테스트 팩토리입니다.
+         */
+        internal fun forTesting(bufferOperations: SnappyBufferOperations): SnappyCompressor =
+            SnappyCompressor(bufferOperations)
+    }
+
+    /**
+     * [source]의 남은 데이터를 Snappy raw 형식으로 압축해 [target]에 기록합니다.
+     * direct/direct 조합에서 안전 상한을 충족하면 native `ByteBuffer` 경로를 사용하고,
+     * 그보다 작은 target이나 다른 storage 조합은 compatibility fallback으로 처리합니다.
+     *
+     * @return [target]에 기록한 압축 데이터 길이
+     * @throws BufferOverflowException 실제 압축 결과를 target 여유 공간에 기록할 수 없는 경우
+     */
+    override fun compress(source: ByteBuffer, target: ByteBuffer): Int {
+        if (!supportsOptimizedStoragePair(source, target)) {
+            return super.compress(source, target)
+        }
+        return writeToCallerBufferViews(source, target) {
+                sourceView,
+                targetView,
+                sourcePosition,
+                sourceRemaining,
+                targetPosition,
+                targetRemaining,
+            ->
+            val maxCompressedLength = bufferOperations.maxCompressedLength(sourceRemaining)
+            check(maxCompressedLength > 0) {
+                "Snappy max compressed length must be positive: $maxCompressedLength"
+            }
+            if (maxCompressedLength > targetRemaining) {
+                return@writeToCallerBufferViews writeFallback(sourceView, targetView) { bytes ->
+                    compress(bytes)
+                }
+            }
+            val input = sourceView
+                .position(sourcePosition)
+                .limit(sourcePosition + sourceRemaining)
+            val output = targetView
+                .position(targetPosition)
+                .limit(targetPosition + maxCompressedLength)
+            val written = bufferOperations.compress(input, output)
+            check(written in 1..maxCompressedLength) {
+                "Snappy compressed size out of range: written=$written, max=$maxCompressedLength"
+            }
+            written
+        }
+    }
+
+    /**
+     * [source]의 Snappy raw payload를 검증하고 [target]에 복원합니다.
+     *
+     * @return [target]에 기록한 복원 데이터 길이
+     * @throws BufferOverflowException target 여유 공간이 복원 크기보다 작은 경우
+     * @throws IllegalArgumentException payload가 유효하지 않거나 복원 크기 한도를 벗어난 경우
+     */
+    override fun decompress(source: ByteBuffer, target: ByteBuffer): Int {
+        if (!supportsOptimizedStoragePair(source, target)) {
+            return super.decompress(source, target)
+        }
+        return writeToCallerBufferViews(source, target) {
+                sourceView,
+                targetView,
+                sourcePosition,
+                sourceRemaining,
+                targetPosition,
+                targetRemaining,
+            ->
+            val input = sourceView
+                .position(sourcePosition)
+                .limit(sourcePosition + sourceRemaining)
+            require(bufferOperations.isValidCompressedBuffer(input.duplicate())) {
+                "유효하지 않은 Snappy payload입니다."
+            }
+
+            val uncompressedSize = bufferOperations.uncompressedLength(input.duplicate())
+            validateUncompressedSize(uncompressedSize)
+            if (uncompressedSize > targetRemaining) throw BufferOverflowException()
+
+            val output = targetView
+                .position(targetPosition)
+                .limit(targetPosition + uncompressedSize)
+            val written = bufferOperations.decompress(input.duplicate(), output)
+            check(written == uncompressedSize) {
+                "Snappy decompressed size mismatch: written=$written, expected=$uncompressedSize"
+            }
+            written
+        }
     }
 
     /**
@@ -42,12 +185,19 @@ class SnappyCompressor: AbstractCompressor() {
      */
     override fun doDecompress(compressed: ByteArray): ByteArray {
         val uncompressedSize = Snappy.uncompressedLength(compressed)
+        validateUncompressedSize(uncompressedSize)
+        return Snappy.uncompress(compressed)
+    }
+
+    private fun supportsOptimizedStoragePair(source: ByteBuffer, target: ByteBuffer): Boolean =
+        source.isDirect && target.isDirect
+
+    private fun validateUncompressedSize(uncompressedSize: Int) {
         require(uncompressedSize >= 0) {
             "uncompressedSize가 음수입니다. 손상된 데이터일 수 있습니다. uncompressedSize=$uncompressedSize"
         }
         require(uncompressedSize <= MAX_DECOMPRESSED_SIZE) {
             "uncompressedSize가 허용 한도(256MB)를 초과합니다. 손상되거나 악의적인 데이터일 수 있습니다. uncompressedSize=$uncompressedSize"
         }
-        return Snappy.uncompress(compressed)
     }
 }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyCompressorByteBufferTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/SnappyCompressorByteBufferTest.kt
@@ -1,0 +1,268 @@
+package io.bluetape4k.io.compressor
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContentEqual
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import org.junit.jupiter.api.Test
+import org.xerial.snappy.Snappy
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ReadOnlyBufferException
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicInteger
+
+class SnappyCompressorByteBufferTest {
+    private val compressor = SnappyCompressor()
+
+    @Test
+    fun `safe direct storage pair dispatches to the Snappy buffer backend`() {
+        val operations = RecordingSnappyBufferOperations()
+        val compressor = SnappyCompressor.forTesting(operations)
+        val payload = byteArrayOf(1, 2, 3)
+
+        listOf(false, true).forEach { direct ->
+            val target = CompressorByteBufferTestSupport.writableTarget(16, direct)
+            val targetStart = target.position()
+
+            val written = compressor.compress(
+                if (direct) {
+                    CompressorByteBufferTestSupport.direct(payload)
+                } else {
+                    CompressorByteBufferTestSupport.heap(payload)
+                },
+                target,
+            )
+
+            written shouldBeEqualTo if (direct) 1 else compressor.compress(payload).size
+            target.position() shouldBeEqualTo targetStart + written
+        }
+
+        operations.compressInvocations.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `direct caller-owned APIs preserve wire compatibility and caller state`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val expectedWire = compressor.compress(payload)
+        val source = CompressorByteBufferTestSupport.direct(payload)
+        val sourceStart = source.position()
+        val sourceLimit = source.limit()
+        val compressed = CompressorByteBufferTestSupport.writableTarget(
+            Snappy.maxCompressedLength(payload.size),
+            direct = true,
+        )
+        val compressedStart = compressed.position()
+
+        val written = compressor.compress(source, compressed)
+
+        written shouldBeEqualTo expectedWire.size
+        source.position() shouldBeEqualTo sourceStart
+        source.limit() shouldBeEqualTo sourceLimit
+        CompressorByteBufferTestSupport.assertMark(source, sourceStart)
+        compressed.position() shouldBeEqualTo compressedStart + written
+        CompressorByteBufferTestSupport.bytes(compressed, compressedStart, written)
+            .shouldContentEqual(expectedWire)
+
+        val restoredSource = CompressorByteBufferTestSupport.direct(expectedWire)
+        val restored = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = true)
+        val restoredStart = restored.position()
+
+        compressor.decompress(restoredSource, restored) shouldBeEqualTo payload.size
+        restored.position() shouldBeEqualTo restoredStart + payload.size
+        CompressorByteBufferTestSupport.bytes(restored, restoredStart, payload.size)
+            .shouldContentEqual(payload)
+    }
+
+    @Test
+    fun `direct compression below the native safety bound keeps compatibility behavior`() {
+        val operations = RecordingSnappyBufferOperations(maxCompressedLength = 64)
+        val compressor = SnappyCompressor.forTesting(operations)
+        val payload = byteArrayOf(1, 2, 3)
+        val expectedWire = compressor.compress(payload)
+        val target = CompressorByteBufferTestSupport.writableTarget(expectedWire.size, direct = true)
+        val targetStart = target.position()
+
+        compressor.compress(CompressorByteBufferTestSupport.direct(payload), target)
+            .shouldBeEqualTo(expectedWire.size)
+
+        operations.compressInvocations.get() shouldBeEqualTo 0
+        CompressorByteBufferTestSupport.bytes(target, targetStart, expectedWire.size)
+            .shouldContentEqual(expectedWire)
+    }
+
+    @Test
+    fun `common preflight rejects read-only and empty calls before backend bounds`() {
+        val operations = RecordingSnappyBufferOperations()
+        val compressor = SnappyCompressor.forTesting(operations)
+
+        compressor.compress(
+            ByteBuffer.allocateDirect(0),
+            ByteBuffer.allocateDirect(1),
+        ) shouldBeEqualTo 0
+        assertFailsWith<ReadOnlyBufferException> {
+            compressor.compress(
+                CompressorByteBufferTestSupport.direct(byteArrayOf(1)),
+                ByteBuffer.allocateDirect(8).asReadOnlyBuffer(),
+            )
+        }
+
+        operations.maxCompressedLengthInvocations.get() shouldBeEqualTo 0
+        operations.compressInvocations.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `invalid direct payload is rejected before native decode`() {
+        val operations = RecordingSnappyBufferOperations(valid = false)
+        val compressor = SnappyCompressor.forTesting(operations)
+        val source = CompressorByteBufferTestSupport.direct(byteArrayOf(1, 2, 3))
+        val target = CompressorByteBufferTestSupport.writableTarget(32, direct = true)
+        val sourceStart = source.position()
+        val targetStart = target.position()
+
+        val failure = assertFailsWith<IllegalArgumentException> {
+            compressor.decompress(source, target)
+        }
+
+        failure.message shouldBeEqualTo "유효하지 않은 Snappy payload입니다."
+        operations.decompressInvocations.get() shouldBeEqualTo 0
+        source.position() shouldBeEqualTo sourceStart
+        target.position() shouldBeEqualTo targetStart
+    }
+
+    @Test
+    fun `real invalid direct payload wins over an empty target`() {
+        val source = CompressorByteBufferTestSupport.direct(byteArrayOf(1, 2, 3))
+        val target = ByteBuffer.allocateDirect(0)
+
+        assertFailsWith<IllegalArgumentException> {
+            compressor.decompress(source, target)
+        }
+    }
+
+    @Test
+    fun `declared direct payload size is bounded before native decode`() {
+        val operations = RecordingSnappyBufferOperations(uncompressedLength = 32)
+        val compressor = SnappyCompressor.forTesting(operations)
+        val source = CompressorByteBufferTestSupport.direct(byteArrayOf(1))
+        val target = CompressorByteBufferTestSupport.writableTarget(31, direct = true)
+        val targetStart = target.position()
+
+        assertFailsWith<BufferOverflowException> {
+            compressor.decompress(source, target)
+        }
+
+        operations.decompressInvocations.get() shouldBeEqualTo 0
+        target.position() shouldBeEqualTo targetStart
+    }
+
+    @Test
+    fun `direct decompression isolates inspection views and bounds native output exactly`() {
+        val operations = RecordingSnappyBufferOperations(
+            uncompressedLength = 2,
+            consumeInspectionViews = true,
+        )
+        val compressor = SnappyCompressor.forTesting(operations)
+        val source = CompressorByteBufferTestSupport.direct(byteArrayOf(1, 2, 3))
+        val target = CompressorByteBufferTestSupport.writableTarget(16, direct = true)
+
+        compressor.decompress(source, target) shouldBeEqualTo 2
+
+        operations.inspectedSourceRemaining shouldBeEqualTo listOf(3, 3, 3)
+        operations.decompressionTargetRemaining.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `backend failures preserve throwable identity and caller positions`() {
+        val expected = CancellationException("cancelled")
+        val operations = RecordingSnappyBufferOperations(compressFailure = expected)
+        val compressor = SnappyCompressor.forTesting(operations)
+        val source = CompressorByteBufferTestSupport.direct(byteArrayOf(1, 2, 3))
+        val target = CompressorByteBufferTestSupport.writableTarget(16, direct = true)
+        val sourceStart = source.position()
+        val targetStart = target.position()
+
+        val actual = assertFailsWith<Throwable> {
+            compressor.compress(source, target)
+        }
+
+        actual shouldBeSameInstanceAs expected
+        source.position() shouldBeEqualTo sourceStart
+        target.position() shouldBeEqualTo targetStart
+    }
+
+    @Test
+    fun `singleton native direct operations are safe under concurrency`() {
+        val payload = CompressorByteBufferTestSupport.payload
+
+        MultithreadingTester()
+            .workers(8)
+            .rounds(2)
+            .add {
+                val wire = CompressorByteBufferTestSupport.writableTarget(
+                    Snappy.maxCompressedLength(payload.size),
+                    direct = true,
+                )
+                val wireStart = wire.position()
+                val written = Compressors.Snappy.compress(
+                    CompressorByteBufferTestSupport.direct(payload),
+                    wire,
+                )
+                val restored = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = true)
+                Compressors.Snappy.decompress(
+                    wire.duplicate().position(wireStart).limit(wireStart + written),
+                    restored,
+                )
+                CompressorByteBufferTestSupport.bytes(restored, 5, payload.size)
+                    .shouldContentEqual(payload)
+            }
+            .run()
+    }
+
+    private class RecordingSnappyBufferOperations(
+        private val maxCompressedLength: Int = 4,
+        private val valid: Boolean = true,
+        private val uncompressedLength: Int = 1,
+        private val compressFailure: Throwable? = null,
+        private val consumeInspectionViews: Boolean = false,
+    ): SnappyBufferOperations {
+        val maxCompressedLengthInvocations = AtomicInteger()
+        val compressInvocations = AtomicInteger()
+        val decompressInvocations = AtomicInteger()
+        val decompressionTargetRemaining = AtomicInteger()
+        val inspectedSourceRemaining = mutableListOf<Int>()
+
+        override fun maxCompressedLength(sourceLength: Int): Int {
+            maxCompressedLengthInvocations.incrementAndGet()
+            return maxCompressedLength
+        }
+
+        override fun compress(source: ByteBuffer, target: ByteBuffer): Int {
+            compressInvocations.incrementAndGet()
+            compressFailure?.let { throw it }
+            target.put(0x2A)
+            return 1
+        }
+
+        override fun isValidCompressedBuffer(source: ByteBuffer): Boolean {
+            inspectedSourceRemaining += source.remaining()
+            if (consumeInspectionViews) source.position(source.limit())
+            return valid
+        }
+
+        override fun uncompressedLength(source: ByteBuffer): Int {
+            inspectedSourceRemaining += source.remaining()
+            if (consumeInspectionViews) source.position(source.limit())
+            return uncompressedLength
+        }
+
+        override fun decompress(source: ByteBuffer, target: ByteBuffer): Int {
+            decompressInvocations.incrementAndGet()
+            inspectedSourceRemaining += source.remaining()
+            decompressionTargetRemaining.set(target.remaining())
+            repeat(uncompressedLength) { target.put(0x2A) }
+            return uncompressedLength
+        }
+    }
+}

--- a/scripts/check-compressor-buffer-docs.py
+++ b/scripts/check-compressor-buffer-docs.py
@@ -97,8 +97,8 @@ def validate_readmes() -> None:
     expected_matrix = {
         "LZ4": ("optimized", "optimized", "optimized", "eligible, not yet measured"),
         "Deflate": ("optimized", "optimized", "optimized", "eligible, not yet measured"),
-        "Snappy": ("compatibility fallback", "compatibility fallback", "compatibility fallback",
-                   "none in the core slice"),
+        "Snappy": ("compatibility fallback", "optimized", "compatibility fallback",
+                   "eligible for direct pair, not yet measured"),
         "Zstd": ("compatibility fallback", "compatibility fallback", "compatibility fallback",
                  "none in the core slice"),
         "Other codecs": ("compatibility fallback", "compatibility fallback", "compatibility fallback", "ineligible"),
@@ -117,6 +117,19 @@ def validate_readmes() -> None:
         ("`optimized`는", "backend `ByteBuffer` 경로", "처리량 개선을 주장하지 않으며",
          "측정된 allocation 개선"),
         "Korean optimized capability boundary",
+    )
+    require_tokens(
+        sections["en"]["issue-755-storage-matrix"],
+        ("Snappy.maxCompressedLength(source.remaining())", "smaller direct target",
+         "compatibility fallback", "validates the complete payload",
+         "cannot enforce an arbitrary caller target limit"),
+        "English Snappy dispatch boundary",
+    )
+    require_tokens(
+        sections["ko"]["issue-755-storage-matrix"],
+        ("Snappy.maxCompressedLength(source.remaining())", "그보다 작은 direct target",
+         "compatibility fallback", "payload 전체", "임의 limit"),
+        "Korean Snappy dispatch boundary",
     )
 
     shared_contract = (


### PR DESCRIPTION
## Summary

Closes #755

- PR 제목: Add validated caller-owned Snappy buffer paths

- add a bounded direct/direct Snappy caller-owned `ByteBuffer` path
- validate the exact compressed range, decompressed size, 256 MiB limit, and target capacity before native decoding
- retain compatibility fallback for heap, mixed storage, and direct compression targets below the native maximum bound
- preserve caller state, raw Snappy wire compatibility, and backend throwable identity
- document capability without promoting unmeasured allocation or throughput claims

### 원문 선행 내용

Refs #755

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Verification

- Snappy dispatch, validation, bounds, retry, wire, failure, and concurrency tests: 10 passing
- targeted Snappy/common caller-owned contract tests: 48 passing
- full `bluetape4k-io` suite: 1,225 passing
- compressor README locale/docs validator: passing
- `git diff --check`: passing
- root `detekt`, `detektMain`, and `detektTest`: `NO-SOURCE`; no `bluetape4k-io` Detekt task is registered

### 기존 섹션: Review Convergence

| Lens | Initial | Final |
|---|---:|---:|
| Performance | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| Stability | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| Security | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| Operator/Ops | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| Developer/API | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |
| User/caller | P0=0 P1=0 P2=0 P3=0 | P0=0 P1=0 P2=0 P3=0 |

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #755, milestone `1.12.0`, assignee `debop`
- PR: #1231, head `176358a7b83d7cdbaf30184c25960e67f61b6e9f`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-755-snappy-bytebuffer`
- Labels: `enhancement`, `performance`, `infra/io`
- State: `MERGED`, merge commit `1c3de9063dcaed96bc8586636235b5e99bd00a46`
- CI: - validate the exact compressed range, decompressed size, 256 MiB limit, and target capacity before native decoding / - root `detekt`, `detektMain`, and `detektTest`: `NO-SOURCE`; no `bluetape4k-io` Detekt task is registered

## DoD Status

- [x] Snappy direct/direct backend slice complete
- [x] Existing raw Snappy wire remains interoperable
- [x] Invalid direct payloads are rejected before native decode
- [x] Heap, mixed, and undersized compression-bound paths retain compatibility fallback
- [x] Allocation promotion remains pending the final evidence slice
- [ ] Issue #755 remains open for Zstd and canonical allocation evidence

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1231 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1c3de9063dcaed96bc8586636235b5e99bd00a46`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
