### PR TITLE
Exclude decorative icon paths from route validation

### DIFF
--- a/docs/lessons/2026-07-31-readme-diagram-icon-line-validation.md
+++ b/docs/lessons/2026-07-31-readme-diagram-icon-line-validation.md
@@ -1,0 +1,59 @@
+# README 다이어그램의 장식 path와 route 분류
+
+## 배경
+
+Issue #768의 전체 README 다이어그램 검증은 `274`개 asset 중 `132`개에서
+실패했다. Okio 다이어그램 4개는 모두 `content outside frame=-34/...`를
+보고했지만, 렌더링된 장식 아이콘은 frame 내부에 있었다.
+
+## 원인
+
+`scripts/validate-readme-diagram-assets.mjs`는 SVG `path`의 `class` 문자열에서
+`route`, `flow`, `line` 같은 단어를 찾는다. 기존 정규식은 단어 경계를
+사용하므로 `icon-line-green`의 하이픈 앞뒤를 경계로 해석하고, 장식 path를
+route로 분류했다.
+
+해당 path는 `transform="translate(...)"`가 적용된 아이콘 그룹 안에서
+`M -10 -8 H 10` 같은 로컬 좌표를 사용한다. validator는 route 좌표에 상위
+transform을 적용하지 않으므로, 잘못 분류된 음수 좌표가 frame 밖의 content로
+계산됐다.
+
+## 판단
+
+이번 수정은 route 좌표계 전체를 다시 구현하지 않는다. SVG `class`는
+공백으로 구분된 token이라는 계약에 따라 `icon-line`과 `icon-line-*` token만
+route 후보에서 제외한다. 기존 `route`, `flow-*`, `line` 분류와 connector
+검사는 그대로 유지한다.
+
+회귀 fixture에는 실제 `flow-green` route와 transform 내부의
+`icon-line-green`을 함께 둔다. 검증 결과는 카드 2개와 route 1개여야 한다.
+따라서 장식 path만 제외하면서 실제 연결선 검사가 유지되는지도 한 테스트에서
+증명한다.
+
+## 결과
+
+`icon-line*`을 사용하는 SVG 8개만 결과가 달라졌다. Okio 01/02는 실패가
+사라졌고, Okio 03/04와 일부 Ktor asset에서는 잘못된 outside-frame 실패가
+사라진 뒤 기존 세로 여백 또는 source metadata 실패가 드러났다. 전체 실패
+asset 수는 `132`에서 `130`으로 줄었다.
+
+분류기 수정이 새로 드러난 asset 결함까지 해결한 것으로 간주하지 않는다.
+이번 변경은 false positive 제거에 한정하고, 남은 margin과 metadata 실패는
+Issue #768의 후속 slice에서 별도로 다룬다.
+
+## 검증
+
+- `node --test scripts/validate-readme-diagram-assets_test.mjs`
+- `DIAGRAM_VALIDATION_TARGETS='io-okio-diagram-01.svg,io-okio-diagram-02.svg,io-okio-diagram-03.svg,io-okio-diagram-04.svg' node scripts/validate-readme-diagram-assets.mjs`
+- `DIAGRAM_VALIDATION_REPORT=/tmp/issue-768-icon-lines-fixed.json node scripts/validate-readme-diagram-assets.mjs`
+- `node --check scripts/validate-readme-diagram-assets.mjs`
+- `node --check scripts/validate-readme-diagram-assets_test.mjs`
+- `git diff --check`
+
+## 향후 지침
+
+route parser 변경 전후를 비교할 때 전체 실패 수만 보지 않는다. 영향받은
+각 asset의 `paths`와 `failures`를 함께 비교하고, 잘못된 경계 실패가 사라진
+뒤 새로 드러난 검증 결과는 별도 결함으로 분리한다. transform이 필요한
+실제 route가 확인되기 전에는 장식 path 한 사례를 이유로 범용 transform
+해석기를 추가하지 않는다.

--- a/scripts/validate-readme-diagram-assets.mjs
+++ b/scripts/validate-readme-diagram-assets.mjs
@@ -461,6 +461,9 @@ function extractRoutes(svg) {
         .map((match) => {
             const attrs = `${match[1]} ${match[3]}`;
             const className = attrs.match(/\bclass="([^"]+)"/)?.[1] || "";
+            const decorativeIconLine = className.split(/\s+/)
+                .some((token) => token === "icon-line" || token.startsWith("icon-line-"));
+            if (decorativeIconLine) return null;
             if (!/\b(?:route|flow|inherit|dependency|line|Line|connector|dashed|implLine|inheritLine)\b/.test(className)) return null;
             const points = parsePath(match[2]);
             if (points.length < 2) return null;

--- a/scripts/validate-readme-diagram-assets_test.mjs
+++ b/scripts/validate-readme-diagram-assets_test.mjs
@@ -42,6 +42,44 @@ test("validator skips card-like groups without shape geometry", (context) => {
   assert.equal(validation.rows[0].cards, 0);
 });
 
+test("validator excludes decorative icon lines from diagram routes", (context) => {
+  const root = mkdtempSync(join(tmpdir(), "readme-diagram-validator-"));
+  const diagramDir = join(root, "docs/images/readme-diagrams");
+  const report = join(root, "diagram-validation-report.json");
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+
+  mkdirSync(diagramDir, { recursive: true });
+  writeFileSync(join(diagramDir, "decorative-icon-line.svg"), `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <title>Decorative icon line</title>
+  <rect x="24" y="24" width="752" height="552" class="frame" />
+  <rect x="72" y="170" width="300" height="350" class="source-panel" />
+  <rect x="428" y="170" width="300" height="350" class="sink-panel" />
+  <g id="source"><rect class="card" x="100" y="300" width="100" height="80" /></g>
+  <g id="target"><rect class="card" x="600" y="300" width="100" height="80" /></g>
+  <path class="flow-green" data-from="source" data-to="target" d="M 200 340 H 600" />
+  <g transform="translate(340 200)" aria-hidden="true">
+    <path d="M -10 -8 H 10" class="icon-line-green" />
+    <path d="M -8 8 H 8" class="icon-line" />
+  </g>
+</svg>
+`, "utf8");
+
+  const result = spawnSync(process.execPath, [validator], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, DIAGRAM_VALIDATION_REPORT: report },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const validation = JSON.parse(readFileSync(report, "utf8"));
+  assert.equal(validation.total, 1);
+  assert.equal(validation.failed, 0);
+  assert.equal(validation.rows[0].cards, 2);
+  assert.equal(validation.rows[0].paths, 1);
+  assert.deepEqual(validation.rows[0].failures, []);
+});
+
 test("validator preserves relationship endpoint checks across Q and q bends", (context) => {
   const root = mkdtempSync(join(tmpdir(), "readme-diagram-validator-"));
   const diagramDir = join(root, "docs/images/readme-diagrams");


### PR DESCRIPTION
## Summary

Closes #768

- PR 제목: Exclude decorative icon paths from route validation

- exclude `icon-line` and `icon-line-*` class tokens from README diagram route extraction
- retain real route classification and endpoint validation with a mixed real-route/decorative-path regression fixture
- document why classifier changes must compare per-asset rows instead of only the aggregate failure count

### 원문 선행 내용

Refs #768

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Root Cause

The route classifier used word boundaries around `line`, so hyphenated decorative classes such as `icon-line-green` were treated as routes. Those icon paths use negative local coordinates inside translated groups, but route extraction does not apply the parent transform. The local coordinates therefore produced false `content outside frame` findings.

### 기존 섹션: Verification

- regression test without the production filter: 1 expected failure
- `node --test scripts/validate-readme-diagram-assets_test.mjs`: 11 passing
- Node syntax checks for the validator and test: passing
- Okio scoped report: 4 assets, 0 `content outside frame` findings, 0 extracted decorative paths
- full validator comparison: 274 assets, failed assets reduced from 132 to 130
- before/after row changes limited to the 8 SVGs that use `icon-line*`
- `git diff --check`: passing
- SVG/PNG changes: 0
- `codex review --uncommitted`: no actionable findings

### 기존 섹션: Known Follow-ups

The corrected classifier exposes existing vertical-margin findings in Okio diagrams 03/04 and `ktor-openapi-routes-01.svg`; other affected Ktor assets still have source-metadata findings. These remain tracked by #768 and are intentionally outside this parser-only slice.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #768, milestone `1.12.0`, assignee `debop`
- PR: #1232, head `2f3b20893d3794216bbbbdef43a884e2544216ae`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-768-validator-icon-lines`
- Labels: `bug`, `test`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `a52da43796a4a464eb82b4544ede9fc32f48839b`
- CI: - [x] Decorative icon paths no longer participate in route geometry

## DoD Status

- [x] Decorative icon paths no longer participate in route geometry
- [x] A real `flow-green` route remains classified and endpoint-validated in the regression fixture
- [x] All affected outside-frame false positives are removed
- [x] Full-scan failed-asset count decreases without hiding newly exposed findings
- [x] Reusable validator guidance is recorded in a Korean technical lesson
- [ ] Issue #768 remains open for the remaining 130 failing assets

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1232 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a52da43796a4a464eb82b4544ede9fc32f48839b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
