### PR TITLE
Fix utils math diagram relationship validation

### DIFF
--- a/docs/images/readme-diagrams/utils-math-diagram-01.svg
+++ b/docs/images/readme-diagrams/utils-math-diagram-01.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="2060" height="1280" viewBox="0 0 2060 1280" role="img" aria-label="Math module feature structure">
+<svg xmlns="http://www.w3.org/2000/svg" data-layout="feature-map" data-allow-grid="true" width="2060" height="1280" viewBox="0 0 2060 1280" role="img" aria-label="Math module feature structure">
 <defs><filter id="softShadow" x="-8%" y="-10%" width="116%" height="124%"><feDropShadow dx="0" dy="5" stdDeviation="5" flood-color="#0F172A" flood-opacity="0.10"/></filter>
 <marker id="arrow-apiStats" markerWidth="22" markerHeight="18" refX="20" refY="9" orient="auto" markerUnits="userSpaceOnUse" viewBox="0 0 22 18"><path d="M2 2 L20 9 L2 16 Z" fill="#2563EB"/></marker>
 <marker id="arrow-apiRandom" markerWidth="22" markerHeight="18" refX="20" refY="9" orient="auto" markerUnits="userSpaceOnUse" viewBox="0 0 22 18"><path d="M2 2 L20 9 L2 16 Z" fill="#16A34A"/></marker>
@@ -13,14 +13,14 @@
 <text class="title" x="78" y="88">Math Feature Structure</text>
 <text class="subtitle" x="82" y="120">A task-oriented map of bluetape4k-math: statistics, random sampling, numeric methods, algebra, geometry, and ML helpers over Apache Commons Math3.</text>
 <rect class="lane" x="70" y="455" width="1875" height="592" rx="8" fill="#DBEAFE" stroke="#93C5FD" fill-opacity="1"/><text class="laneTitle" x="98" y="442">reader-facing feature groups backed by concrete package/file families</text>
-<g id="edges"><path class="edge " d="M310 345 L310 510" stroke="#2563EB" marker-end="url(#arrow-apiStats)"/>
-<path class="edge " d="M760 345 L760 510" stroke="#16A34A" marker-end="url(#arrow-apiRandom)"/>
-<path class="edge " d="M1230 345 L1230 510" stroke="#0D9488" marker-end="url(#arrow-apiCalculus)"/>
-<path class="edge " d="M1705 345 L1705 510" stroke="#EA580C" marker-end="url(#arrow-apiSolving)"/>
-<path class="edge " d="M310 700 L310 820" stroke="#7C3AED" marker-end="url(#arrow-statsSpecial)"/>
-<path class="edge " d="M760 700 L760 820" stroke="#DB2777" marker-end="url(#arrow-randomAlgebra)"/>
-<path class="edge " d="M1230 700 L1230 820" stroke="#D97706" marker-end="url(#arrow-calculusGeometry)"/>
-<path class="edge " d="M1705 700 L1705 820" stroke="#64748B" marker-end="url(#arrow-solvingMl)"/></g>
+<g id="edges"><path class="edge route" data-from="api" data-to="stats" d="M310 345 L310 510" stroke="#2563EB" marker-end="url(#arrow-apiStats)"/>
+<path class="edge route" data-from="api" data-to="random" d="M760 345 L760 510" stroke="#16A34A" marker-end="url(#arrow-apiRandom)"/>
+<path class="edge route" data-from="api" data-to="calculus" d="M1230 345 L1230 510" stroke="#0D9488" marker-end="url(#arrow-apiCalculus)"/>
+<path class="edge route" data-from="api" data-to="solving" d="M1705 345 L1705 510" stroke="#EA580C" marker-end="url(#arrow-apiSolving)"/>
+<path class="edge route" data-from="stats" data-to="special" d="M310 700 L310 820" stroke="#7C3AED" marker-end="url(#arrow-statsSpecial)"/>
+<path class="edge route" data-from="random" data-to="algebra" d="M760 700 L760 820" stroke="#DB2777" marker-end="url(#arrow-randomAlgebra)"/>
+<path class="edge route" data-from="calculus" data-to="geometry" d="M1230 700 L1230 820" stroke="#D97706" marker-end="url(#arrow-calculusGeometry)"/>
+<path class="edge route" data-from="solving" data-to="ml" d="M1705 700 L1705 820" stroke="#64748B" marker-end="url(#arrow-solvingMl)"/></g>
 <g id="labels"><g class="edgeLabel" transform="translate(336 406)"><rect width="136" height="30" rx="8"/><text x="68" y="20" text-anchor="middle">descriptive data</text></g>
 <g class="edgeLabel" transform="translate(795 406)"><rect width="90" height="30" rx="8"/><text x="45" y="20" text-anchor="middle">sampling</text></g>
 <g class="edgeLabel" transform="translate(1262 406)"><rect width="136" height="30" rx="8"/><text x="68" y="20" text-anchor="middle">numeric methods</text></g>

--- a/scripts/generate-utils-math-diagram-01.mjs
+++ b/scripts/generate-utils-math-diagram-01.mjs
@@ -84,12 +84,12 @@ function icon(type, x, y, color) {
   if (type === "stats") return `${base}<path d="M${cx - 15} ${cy + 13} V${cy - 2} M${cx} ${cy + 13} V${cy - 14} M${cx + 15} ${cy + 13} V${cy - 7}" stroke="#fff" stroke-width="4" stroke-linecap="round"/>`;
   if (type === "random") return `${base}<rect x="${cx - 14}" y="${cy - 14}" width="28" height="28" rx="5" fill="none" stroke="#fff" stroke-width="3"/><circle cx="${cx - 7}" cy="${cy - 7}" r="2.6" fill="#fff"/><circle cx="${cx + 7}" cy="${cy}" r="2.6" fill="#fff"/><circle cx="${cx - 7}" cy="${cy + 7}" r="2.6" fill="#fff"/>`;
   if (type === "curve") return `${base}<path d="M${cx - 16} ${cy + 12} C${cx - 5} ${cy - 18}, ${cx + 4} ${cy + 18}, ${cx + 16} ${cy - 12}" fill="none" stroke="#fff" stroke-width="3.5" stroke-linecap="round"/>`;
-  if (type === "root") return `${base}<path d="M${cx - 16} ${cy + 7} L${cx - 5} ${cy + 7} L${cx + 1} ${cy - 12} L${cx + 8} ${cy + 12} L${cx + 17} ${cy + 12}" fill="none" stroke="#fff" stroke-width="3.3" stroke-linecap="round" stroke-linejoin="round"/>`;
+  if (type === "root") return `${base}<path d="M ${cx - 16} ${cy + 7} L ${cx - 9} ${cy + 7} Q ${cx - 5} ${cy + 7} ${cx - 3.8} ${cy + 3.19} L ${cx + 1} ${cy - 12} L ${cx + 6.88} ${cy + 8.16} Q ${cx + 8} ${cy + 12} ${cx + 12} ${cy + 12} L ${cx + 17} ${cy + 12}" fill="none" stroke="#fff" stroke-width="3.3" stroke-linecap="round" stroke-linejoin="round"/>`;
   if (type === "sigma") return `${base}<path d="M${cx + 13} ${cy - 15} H${cx - 13} L${cx + 2} ${cy} L${cx - 13} ${cy + 15} H${cx + 13}" fill="none" stroke="#fff" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>`;
   if (type === "matrix") return `${base}<path d="M${cx - 16} ${cy - 14} H${cx + 16} M${cx - 16} ${cy} H${cx + 16} M${cx - 16} ${cy + 14} H${cx + 16} M${cx - 6} ${cy - 16} V${cy + 16} M${cx + 7} ${cy - 16} V${cy + 16}" stroke="#fff" stroke-width="2.5"/>`;
   if (type === "geometry") return `${base}<path d="M${cx - 15} ${cy + 13} L${cx} ${cy - 15} L${cx + 15} ${cy + 13} Z" fill="none" stroke="#fff" stroke-width="3.4" stroke-linejoin="round"/><circle cx="${cx}" cy="${cy + 4}" r="4" fill="#fff"/>`;
   if (type === "cluster") return `${base}<circle cx="${cx - 10}" cy="${cy - 5}" r="6" fill="#fff"/><circle cx="${cx + 9}" cy="${cy - 10}" r="6" fill="#fff"/><circle cx="${cx + 3}" cy="${cy + 11}" r="6" fill="#fff"/><path d="M${cx - 5} ${cy - 7} L${cx + 4} ${cy - 9} M${cx - 6} ${cy} L${cx - 1} ${cy + 7} M${cx + 8} ${cy - 4} L${cx + 5} ${cy + 5}" stroke="#fff" stroke-width="2.6"/>`;
-  if (type === "foundation") return `${base}<path d="M${cx - 16} ${cy + 12} H${cx + 16} M${cx - 11} ${cy + 12} V${cy - 5} H${cx - 2} V${cy + 12} M${cx + 4} ${cy + 12} V${cy - 13} H${cx + 13} V${cy + 12}" fill="none" stroke="#fff" stroke-width="3" stroke-linejoin="round"/>`;
+  if (type === "foundation") return `${base}<path d="M ${cx - 16} ${cy + 12} L ${cx + 16} ${cy + 12} L ${cx - 4.2} ${cy + 12} Q ${cx - 11} ${cy + 12} ${cx - 11} ${cy + 5.2} L ${cx - 11} ${cy - 1} Q ${cx - 11} ${cy - 5} ${cx - 7} ${cy - 5} L ${cx - 6} ${cy - 5} Q ${cx - 2} ${cy - 5} ${cx - 2} ${cy - 1} L ${cx - 2} ${cy + 8} Q ${cx - 2} ${cy + 12} ${cx + 2} ${cy + 12} L ${cx} ${cy + 12} Q ${cx + 4} ${cy + 12} ${cx + 4} ${cy + 8} L ${cx + 4} ${cy - 9} Q ${cx + 4} ${cy - 13} ${cx + 8} ${cy - 13} L ${cx + 9} ${cy - 13} Q ${cx + 13} ${cy - 13} ${cx + 13} ${cy - 9} L ${cx + 13} ${cy + 12}" fill="none" stroke="#fff" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>`;
   return `${base}<path d="M${cx - 16} ${cy} H${cx + 16} M${cx} ${cy - 16} V${cy + 16}" stroke="#fff" stroke-width="3.5" stroke-linecap="round"/>`;
 }
 
@@ -156,15 +156,15 @@ function validate() {
 
 validate();
 
-const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" role="img" aria-label="Math module feature structure">
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" data-layout="feature-map" data-allow-grid="true" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" role="img" aria-label="Math module feature structure">
 <defs><filter id="softShadow" x="-8%" y="-10%" width="116%" height="124%"><feDropShadow dx="0" dy="5" stdDeviation="5" flood-color="#0F172A" flood-opacity="0.10"/></filter>
 ${edges.map((e) => marker(e.id, e.color)).join("\n")}
 <style>svg{font-family:"Architects Daughter","Comic Mono","Comic Sans MS",ui-sans-serif,system-ui,sans-serif}.canvas{fill:${colors.canvas}}.frame{fill:${colors.frame};stroke:${colors.line};stroke-width:1.5;filter:url(#softShadow)}.title{font-family:"Architects Daughter";font-size:44px;fill:${colors.ink}}.subtitle{font-family:"Comic Mono";font-size:16px;fill:${colors.muted}}.lane{fill:#F3F8FF;stroke:#94A3B8;stroke-width:1.8;stroke-dasharray:12 8}.laneTitle{font-family:"Comic Mono";font-size:13px;fill:${colors.muted}}.card{filter:url(#softShadow);stroke-width:2}.kicker{font-family:"Comic Mono";font-size:12.8px;fill:${colors.muted}}.cardTitle{font-family:"Architects Daughter";font-size:24px;fill:${colors.ink}}.detail{font-family:"Comic Mono";font-size:13.2px;fill:${colors.muted}}.edge{fill:none;stroke-width:3.2;stroke-linecap:round;stroke-linejoin:round}.dashed{stroke-dasharray:9 8}.edgeLabel rect{fill:#FFFFFF;stroke:${colors.line};stroke-width:1.25;opacity:.96}.edgeLabel text{font-family:"Comic Mono";font-size:12.2px;fill:${colors.muted}}</style></defs>
 <rect class="canvas" width="${W}" height="${H}"/><rect class="frame" x="34" y="30" width="${W - 68}" height="${H - 66}" rx="8"/>
 <text class="title" x="78" y="88">Math Feature Structure</text>
 <text class="subtitle" x="82" y="120">A task-oriented map of bluetape4k-math: statistics, random sampling, numeric methods, algebra, geometry, and ML helpers over Apache Commons Math3.</text>
-<rect class="lane" x="70" y="455" width="1875" height="592" rx="8"/><text class="laneTitle" x="98" y="442">reader-facing feature groups backed by concrete package/file families</text>
-<g id="edges">${edges.map((e) => `<path class="edge ${e.dashed ? "dashed" : ""}" d="${e.d}" stroke="${e.color}" marker-end="url(#arrow-${e.id})"/>`).join("\n")}</g>
+<rect class="lane" x="70" y="455" width="1875" height="592" rx="8" fill="#DBEAFE" stroke="#93C5FD" fill-opacity="1"/><text class="laneTitle" x="98" y="442">reader-facing feature groups backed by concrete package/file families</text>
+<g id="edges">${edges.map((e) => `<path class="edge route${e.dashed ? " dashed" : ""}" data-from="${e.from}" data-to="${e.to}" d="${e.d}" stroke="${e.color}" marker-end="url(#arrow-${e.id})"/>`).join("\n")}</g>
 <g id="labels">${edges.map((e) => label(e.label)).join("\n")}</g>
 ${Object.keys(cards).map(card).join("\n")}
 </svg>`;

--- a/scripts/validate-readme-diagram-assets_test.mjs
+++ b/scripts/validate-readme-diagram-assets_test.mjs
@@ -275,6 +275,35 @@ test("canonical Ktor OpenAPI route helpers have balanced content margins", (cont
   );
 });
 
+test("canonical utils math feature structure exposes routed content bounds", (context) => {
+  const root = mkdtempSync(join(tmpdir(), "readme-diagram-validator-"));
+  const diagramDir = join(root, "docs/images/readme-diagrams");
+  const diagramName = "utils-math-diagram-01.svg";
+  const report = join(root, "diagram-validation-report.json");
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+
+  mkdirSync(diagramDir, { recursive: true });
+  writeFileSync(
+    join(diagramDir, diagramName),
+    readFileSync(join(repositoryRoot, "docs/images/readme-diagrams", diagramName), "utf8"),
+    "utf8",
+  );
+
+  const result = spawnSync(process.execPath, [validator], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, DIAGRAM_VALIDATION_REPORT: report },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const validation = JSON.parse(readFileSync(report, "utf8"));
+  assert.equal(validation.total, 1);
+  assert.equal(validation.failed, 0);
+  assert.equal(validation.rows[0].cards, 10);
+  assert.equal(validation.rows[0].paths, 8);
+  assert.deepEqual(validation.rows[0].failures, []);
+});
+
 test("canonical bluetape4k core overview uses explicit color arrow markers", () => {
   const svg = readFileSync(
     join(repositoryRoot, "docs/images/readme-diagrams/bluetape4k-core-diagram-01.svg"),


### PR DESCRIPTION
## Summary

Closes #768

- PR 제목: Fix utils math diagram relationship validation

Expose the canonical utils-math feature-map relationships to the README diagram validator without changing the approved rendered image.

Refs #768

## Background

`utils-math-diagram-01.svg` failed the vertical content-margin check with `352/4` against an allowed difference of `42`. The generator emitted connection paths as plain `edge` elements without `route` or `data-from`/`data-to` metadata, so the validator excluded the large routed API card and measured only 9 cards with 0 paths.

## What This Solves

The generated SVG now declares its intentional feature-map grid and exposes all eight card relationships. The validator consequently measures 10 cards and 8 paths and no longer reports the target margin failure. Validator thresholds and visual coordinates remain unchanged.

## Work Done

- Added `data-layout="feature-map"` and the existing intentional-grid contract.
- Added `route`, `data-from`, and `data-to` metadata to all generated relationship paths.
- Reconciled pre-existing generator drift so the canonical PNG remains byte-identical.
- Added a canonical regression test that requires 10 cards, 8 paths, and zero failures.

## Validation

- Target validator: `total=1`, `failed=0`, `cards=10`, `paths=8`.
- Node validator tests: `15/15` passed.
- Full scan: `274/127` baseline to `274/126`, with only `utils-math-diagram-01.svg` changing status.
- XML parse, deterministic generator rerender, endpoint, connector, mixed-corner, text, and diff checks passed.
- PNG: `4120x2560`, SHA-256 `84f820dad2479b17a5cd78b9718179ab4740c3eb92f4e5be6ade76b1c0a13b34`, byte-identical to `develop`.
- Independent review: `P0=0`, `P1=0`, `APPROVE`.

## Review Notes

The generic geometry audit still recognizes two diagonal segments inside the unchanged decorative sigma icon. A connector-specific fallback proves all 8 actual routes are vertical with 0 diagonal connectors; the rendered PNG is unchanged.

## Metadata

- Issue: #768, milestone `1.12.0`, assignee `debop`
- PR: #1236, head `b2f6a3c648f78cbe3299a53135dde4fd07e43927`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-768-utils-math-margin`
- Labels: `bug`, `test`, `codex`, `codex-automation`
- State: `MERGED`, merge commit `2aaa2368bf8261aab6927f105935a450ea7d2a73`
- CI: - Reconciled pre-existing generator drift so the canonical PNG remains byte-identical. / The generic geometry audit still recognizes two diagonal segments inside the unchanged decorative sigma icon. A connector-specific fallback proves all 8 actual routes are vertical with 0 diagonal connectors; the rendered PNG is unchanged.

## DoD Status

- [x] Reproduced the original target failure and identified the generator metadata root cause.
- [x] Added RED/GREEN regression coverage.
- [x] Preserved the approved visual output byte-for-byte.
- [x] Completed targeted, suite, full-baseline, structural, and visual validation.
- [x] Completed independent code review with no P0/P1 findings.
- [x] Required GitHub checks pass on the exact head.
- [x] Live reviews, comments, and unresolved threads are clear on the exact head.
- [x] Fresh merge approval is received.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1236 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2aaa2368bf8261aab6927f105935a450ea7d2a73`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
