### PR TITLE
Add bounded caller-owned Zstd buffer paths

### DIFF
--- a/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
+++ b/docs/lessons/2026-07-21-issue-755-bytebuffer-compressor.md
@@ -100,6 +100,27 @@ native 연산을 실행해 원본 source/target limit을 보존하며, singleton
 호출 간 mutable codec state가 없음을 고정한다. README의 `optimized`는 이 제한된 native
 dispatch capability만 뜻하며 allocation 개선은 아직 측정하지 않았다.
 
+## Zstd slice에서 고정한 declared-size 출력 경계
+
+zstd-jni 1.5.7-11의 heap/direct offset API는 오류 코드를 반환한 뒤 호출자가 검사하는 흐름만
+제공하지 않는다. 내부 context가 native 오류를 `ZstdException`으로 바꿔 반환 전에 던질 수
+있으므로, 운영 경로는 반환값에 `Zstd.isError`를 다시 적용하지 않고 예외의 `errorCode`를
+연산별로 해석한다. 압축 중 `errDstSizeTooSmall`만 raw `BufferOverflowException`으로 바꾸며,
+압축 해제 중 같은 코드는 wire header가 실제 payload보다 작은 의미이므로 원인 없는
+`IllegalStateException`으로 분류한다. 그 밖의 `ZstdException`은 identity를 그대로 보존한다.
+
+압축은 writable heap끼리와 direct끼리 조합에서 `compressBound + 4` 안전 상한을 만족할 때
+caller target의 header 뒤 잔여량을 native destination 길이로 그대로 전달한다. zstd-jni는 실제
+결과가 들어갈 만큼의 공간이 있어도 이 안전 상한보다 작은 destination을 거부할 수 있으므로,
+그보다 작은 matched-storage target은 기존 성공 가능성을 보존하는 compatibility fallback으로
+처리한다. 압축 해제는 target에 더 많은 공간이 있어도 native
+destination 길이를 반드시 header의 declared size로 제한한다. 성공 반환값은 declared size와
+정확히 같아야 하며 `Long` 상태에서 검증한 뒤에만 `Int`로 축소한다. 이로써 음수,
+`Long.MAX_VALUE`, 32-bit 범위를 넘는 합성 반환값도 caller position을 commit하기 전에 거부한다.
+mixed-storage와 read-only heap source는 compatibility fallback을 유지한다. README의
+`optimized`는 이 offset API dispatch만 뜻하고 allocation 개선은 마지막 evidence slice 전까지
+주장하지 않는다.
+
 ## 왜 broad backend slice를 중단했는가
 
 LZ4의 capacity-tail read는 source isolation 문제이고, zstd-jni의 throw-before-return은 예외

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -244,12 +244,14 @@ Read-only target은 `ReadOnlyBufferException`으로 거부하고, 동일한 buff
 | LZ4          | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Deflate      | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Snappy       | compatibility fallback | optimized              | compatibility fallback | eligible for direct pair, not yet measured |
-| Zstd         | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
+| Zstd         | optimized              | optimized              | compatibility fallback | eligible, not yet measured |
 | Other codecs | compatibility fallback | compatibility fallback | compatibility fallback | ineligible             |
 
 `optimized`는 해당 storage 조합에서 codec의 backend `ByteBuffer` 경로를 사용한다는 뜻입니다. 처리량 개선을 주장하지 않으며 측정된 allocation 개선을 뜻하지도 않습니다.
 
 Snappy는 direct source/target 조합에서만 native `ByteBuffer` 경로를 사용합니다. 압축은 `target.remaining()`이 `Snappy.maxCompressedLength(source.remaining())` 이상일 때 이 경로를 사용하며, 그보다 작은 direct target은 압축 결과가 실제로 들어갈 때 성공할 수 있도록 compatibility fallback으로 처리합니다. direct 압축 해제는 native decode 전에 payload 전체와 정확한 복원 크기를 검증합니다. 현재 배열 API는 호출자 target의 임의 limit을 출력 상한으로 강제할 수 없으므로 heap 및 mixed-storage 조합은 compatibility fallback을 유지합니다.
+
+Zstd는 writable heap끼리 또는 direct끼리 조합하고 압축 target에 `Zstd.compressBound(source.remaining()) + 4`바이트 이상 남았을 때 native offset API를 사용합니다. 이 안전 상한보다 작은 target은 실제 압축 결과가 들어가면 성공할 수 있도록 compatibility fallback으로 처리합니다. native 경로는 big-endian 원본 크기 header 다음의 `target.remaining() - 4`바이트만 codec에 노출합니다. 압축 해제는 native destination을 header에 선언된 원본 크기로 제한하고, 반환된 `Long`을 축소하기 전에 정확히 검증합니다. mixed-storage 조합과 read-only heap source는 compatibility fallback을 유지합니다. `optimized`는 dispatch만 뜻하며 allocation 근거는 아직 측정 전입니다.
 
 <!-- issue-755-storage-matrix:end -->
 

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -244,12 +244,14 @@ Existing one-argument `ByteBuffer` APIs may consume the source `position`; the n
 | LZ4          | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Deflate      | optimized              | optimized              | optimized              | eligible, not yet measured |
 | Snappy       | compatibility fallback | optimized              | compatibility fallback | eligible for direct pair, not yet measured |
-| Zstd         | compatibility fallback | compatibility fallback | compatibility fallback | none in the core slice |
+| Zstd         | optimized              | optimized              | compatibility fallback | eligible, not yet measured |
 | Other codecs | compatibility fallback | compatibility fallback | compatibility fallback | ineligible             |
 
 `optimized` means that the codec uses a backend `ByteBuffer` path for that storage pairing. It is not a throughput claim and does not assert measured allocation improvement.
 
 Snappy uses its native `ByteBuffer` path only for direct source/target pairs. Compression takes that path when `target.remaining()` is at least `Snappy.maxCompressedLength(source.remaining())`; a smaller direct target uses the compatibility fallback so a compressible result can still succeed when it fits. Direct decompression validates the complete payload and its exact decompressed size before native decoding. Heap and mixed-storage pairs remain compatibility fallbacks because the available array API cannot enforce an arbitrary caller target limit.
+
+Zstd uses its native offset APIs for matched writable heap and direct source/target pairs when compression has at least `Zstd.compressBound(source.remaining()) + 4` bytes available. A smaller target uses the compatibility fallback so an actual compressed result that fits can still succeed. The native path exposes exactly `target.remaining() - 4` bytes to the codec after the big-endian original-size header. Decompression bounds the native destination to the declared original size, validates the exact returned `Long` before narrowing, and keeps mixed-storage or read-only heap sources on the compatibility fallback. `optimized` describes dispatch only; allocation evidence remains pending.
 
 <!-- issue-755-storage-matrix:end -->
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt
@@ -7,6 +7,129 @@ import io.bluetape4k.logging.trace
 import io.bluetape4k.support.toByteArray
 import io.bluetape4k.support.toInt
 import org.apache.commons.compress.compressors.zstandard.ZstdUtils
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+
+/**
+ * Zstd의 배열 및 direct buffer offset API를 격리한 내부 연산 계약입니다.
+ *
+ * offset은 각 저장소의 시작점을 기준으로 한 절대 위치이며, [targetLength]는 codec이 기록할 수
+ * 있는 최대 길이입니다. 테스트에서는 이 경계를 사용해 JNI 호출 전 검증과 반환값 처리를 확인합니다.
+ */
+internal interface ZstdBufferOperations {
+    /** direct source를 direct target에 압축하고 기록량을 반환합니다. */
+    fun compressDirect(
+        target: ByteBuffer,
+        targetOffset: Int,
+        targetLength: Int,
+        source: ByteBuffer,
+        sourceOffset: Int,
+        sourceLength: Int,
+        level: Int,
+    ): Long
+
+    /** direct source를 direct target에 복원하고 기록량을 반환합니다. */
+    fun decompressDirect(
+        target: ByteBuffer,
+        targetOffset: Int,
+        targetLength: Int,
+        source: ByteBuffer,
+        sourceOffset: Int,
+        sourceLength: Int,
+    ): Long
+
+    /** 배열 source를 배열 target에 압축하고 기록량을 반환합니다. */
+    fun compressHeap(
+        target: ByteArray,
+        targetOffset: Int,
+        targetLength: Int,
+        source: ByteArray,
+        sourceOffset: Int,
+        sourceLength: Int,
+        level: Int,
+    ): Long
+
+    /** 배열 source를 배열 target에 복원하고 기록량을 반환합니다. */
+    fun decompressHeap(
+        target: ByteArray,
+        targetOffset: Int,
+        targetLength: Int,
+        source: ByteArray,
+        sourceOffset: Int,
+        sourceLength: Int,
+    ): Long
+}
+
+/** zstd-jni 정적 offset API에 직접 위임하는 운영 어댑터입니다. */
+private object DefaultZstdBufferOperations: ZstdBufferOperations {
+    override fun compressDirect(
+        target: ByteBuffer,
+        targetOffset: Int,
+        targetLength: Int,
+        source: ByteBuffer,
+        sourceOffset: Int,
+        sourceLength: Int,
+        level: Int,
+    ): Long = Zstd.compressDirectByteBuffer(
+        target,
+        targetOffset,
+        targetLength,
+        source,
+        sourceOffset,
+        sourceLength,
+        level,
+    )
+
+    override fun decompressDirect(
+        target: ByteBuffer,
+        targetOffset: Int,
+        targetLength: Int,
+        source: ByteBuffer,
+        sourceOffset: Int,
+        sourceLength: Int,
+    ): Long = Zstd.decompressDirectByteBuffer(
+        target,
+        targetOffset,
+        targetLength,
+        source,
+        sourceOffset,
+        sourceLength,
+    )
+
+    override fun compressHeap(
+        target: ByteArray,
+        targetOffset: Int,
+        targetLength: Int,
+        source: ByteArray,
+        sourceOffset: Int,
+        sourceLength: Int,
+        level: Int,
+    ): Long = Zstd.compressByteArray(
+        target,
+        targetOffset,
+        targetLength,
+        source,
+        sourceOffset,
+        sourceLength,
+        level,
+    )
+
+    override fun decompressHeap(
+        target: ByteArray,
+        targetOffset: Int,
+        targetLength: Int,
+        source: ByteArray,
+        sourceOffset: Int,
+        sourceLength: Int,
+    ): Long = Zstd.decompressByteArray(
+        target,
+        targetOffset,
+        targetLength,
+        source,
+        sourceOffset,
+        sourceLength,
+    )
+}
 
 /**
  * zstd-jni 라이브러리를 사용하여 Zstd 알고리즘을 활용한 압축기
@@ -29,14 +152,19 @@ import org.apache.commons.compress.compressors.zstandard.ZstdUtils
  * 참고: [zstd-jni](https://github.com/luben/zstd-jni)
  *
  * @property level 압축 레벨
- * @throws IllegalArgumentException when the stored source-size header is negative or exceeds the 256 MB limit.
- * @throws IllegalStateException when the Zstd compression API returns an error code.
- * @throws ZstdException when zstd-jni codec processing fails.
+ * @throws IllegalArgumentException 저장된 원본 크기가 음수이거나 256 MiB 한도를 초과할 때
+ * @throws IllegalStateException 압축 해제 결과가 저장된 원본 크기와 일치하지 않을 때
+ * @throws BufferOverflowException 호출자가 제공한 target 공간이 부족할 때
+ * @throws ZstdException zstd-jni codec 처리에 실패할 때
  */
-class ZstdCompressor private constructor(val level: Int): AbstractCompressor() {
+class ZstdCompressor private constructor(
+    val level: Int,
+    private val bufferOperations: ZstdBufferOperations,
+): AbstractCompressor() {
 
     companion object: KLogging() {
         private const val MAGIC_NUMBER_SIZE = Int.SIZE_BYTES
+        private const val MAX_DECOMPRESSED_SIZE = 256 * 1024 * 1024
         const val DEFAULT_LEVEL: Int = 3
 
         /**
@@ -46,9 +174,150 @@ class ZstdCompressor private constructor(val level: Int): AbstractCompressor() {
         operator fun invoke(level: Int = DEFAULT_LEVEL): ZstdCompressor {
             val cLevel = level.coerceIn(Zstd.minCompressionLevel(), Zstd.maxCompressionLevel())
             ZstdUtils.setCacheZstdAvailablity(true)
-            return ZstdCompressor(cLevel)
+            return ZstdCompressor(cLevel, DefaultZstdBufferOperations)
         }
+
+        internal fun forTesting(level: Int, bufferOperations: ZstdBufferOperations): ZstdCompressor =
+            ZstdCompressor(level, bufferOperations)
     }
+
+    /**
+     * 호출자가 제공한 [target]에 [source]의 압축 결과를 기록합니다.
+     *
+     * heap끼리 또는 direct끼리 조합하고 target이 `compressBound + 4` 안전 상한을 수용하면
+     * zstd-jni offset API를 사용합니다. 그 밖의 조합은 호환성 경로로 처리합니다. 성공할 때만
+     * target position을 기록량만큼 이동합니다.
+     */
+    override fun compress(source: ByteBuffer, target: ByteBuffer): Int =
+        when {
+            source.hasArray() && target.hasArray() && hasNativeCompressionCapacity(source, target) ->
+                compressOptimized(source, target, direct = false)
+            source.isDirect && target.isDirect && hasNativeCompressionCapacity(source, target) ->
+                compressOptimized(source, target, direct = true)
+            else -> super.compress(source, target)
+        }
+
+    private fun hasNativeCompressionCapacity(source: ByteBuffer, target: ByteBuffer): Boolean {
+        if (target.remaining() < MAGIC_NUMBER_SIZE) return false
+        val payloadCapacity = target.remaining() - MAGIC_NUMBER_SIZE
+        return payloadCapacity.toLong() >= Zstd.compressBound(source.remaining().toLong())
+    }
+
+    /**
+     * [source]의 압축 데이터를 호출자가 제공한 [target]에 복원합니다.
+     *
+     * heap끼리 또는 direct끼리 조합하면 zstd-jni offset API를 사용합니다. 그 밖의 조합은
+     * 호환성 경로로 처리합니다. native 출력 길이는 wire header에 선언된 크기로 제한합니다.
+     */
+    override fun decompress(source: ByteBuffer, target: ByteBuffer): Int =
+        when {
+            source.hasArray() && target.hasArray() -> decompressOptimized(source, target, direct = false)
+            source.isDirect && target.isDirect -> decompressOptimized(source, target, direct = true)
+            else -> super.decompress(source, target)
+        }
+
+    private fun compressOptimized(source: ByteBuffer, target: ByteBuffer, direct: Boolean): Int =
+        writeToCallerBufferViews(source, target) {
+                sourceView,
+                targetView,
+                sourcePosition,
+                sourceRemaining,
+                targetPosition,
+                targetRemaining,
+            ->
+            if (targetRemaining < MAGIC_NUMBER_SIZE) throw BufferOverflowException()
+
+            putIntBigEndian(targetView, targetPosition, sourceRemaining)
+            val payloadCapacity = targetRemaining - MAGIC_NUMBER_SIZE
+            val payloadWritten = try {
+                if (direct) {
+                    bufferOperations.compressDirect(
+                        targetView,
+                        targetPosition + MAGIC_NUMBER_SIZE,
+                        payloadCapacity,
+                        sourceView,
+                        sourcePosition,
+                        sourceRemaining,
+                        level,
+                    )
+                } else {
+                    bufferOperations.compressHeap(
+                        targetView.array(),
+                        targetView.arrayOffset() + targetPosition + MAGIC_NUMBER_SIZE,
+                        payloadCapacity,
+                        sourceView.array(),
+                        sourceView.arrayOffset() + sourcePosition,
+                        sourceRemaining,
+                        level,
+                    )
+                }
+            } catch (failure: ZstdException) {
+                if (failure.errorCode == Zstd.errDstSizeTooSmall()) throw BufferOverflowException()
+                throw failure
+            }
+            check(payloadWritten in 0L..payloadCapacity.toLong()) {
+                "Zstd compression returned invalid size=$payloadWritten, payloadCapacity=$payloadCapacity"
+            }
+            Math.addExact(MAGIC_NUMBER_SIZE, Math.toIntExact(payloadWritten))
+        }
+
+    private fun decompressOptimized(source: ByteBuffer, target: ByteBuffer, direct: Boolean): Int =
+        writeToCallerBufferViews(source, target) {
+                sourceView,
+                targetView,
+                sourcePosition,
+                sourceRemaining,
+                targetPosition,
+                targetRemaining,
+            ->
+            if (sourceRemaining < MAGIC_NUMBER_SIZE) {
+                throw IndexOutOfBoundsException("Zstd header requires 4 bytes")
+            }
+
+            val declaredSize = getIntBigEndian(sourceView, sourcePosition)
+            require(declaredSize >= 0) { "sourceSize must not be negative: $declaredSize" }
+            require(declaredSize <= MAX_DECOMPRESSED_SIZE) {
+                "sourceSize exceeds 256 MiB: $declaredSize"
+            }
+            if (declaredSize > targetRemaining) throw BufferOverflowException()
+
+            val payloadOffset = sourcePosition + MAGIC_NUMBER_SIZE
+            val payloadLength = sourceRemaining - MAGIC_NUMBER_SIZE
+            val actual = try {
+                if (direct) {
+                    bufferOperations.decompressDirect(
+                        targetView,
+                        targetPosition,
+                        declaredSize,
+                        sourceView,
+                        payloadOffset,
+                        payloadLength,
+                    )
+                } else {
+                    bufferOperations.decompressHeap(
+                        targetView.array(),
+                        targetView.arrayOffset() + targetPosition,
+                        declaredSize,
+                        sourceView.array(),
+                        sourceView.arrayOffset() + payloadOffset,
+                        payloadLength,
+                    )
+                }
+            } catch (failure: ZstdException) {
+                if (failure.errorCode == Zstd.errDstSizeTooSmall()) {
+                    throw IllegalStateException(
+                        "Zstd decompressed payload exceeds declared size=$declaredSize"
+                    )
+                }
+                throw failure
+            }
+            if (actual != declaredSize.toLong()) {
+                throw IllegalStateException(
+                    "Zstd decompressed size mismatch: expected=$declaredSize, actual=$actual"
+                )
+            }
+            Math.toIntExact(actual)
+        }
 
     /**
      * I/O 압축에서 `doCompress` 함수를 제공합니다.

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZstdCompressorByteBufferTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZstdCompressorByteBufferTest.kt
@@ -1,0 +1,458 @@
+package io.bluetape4k.io.compressor
+
+import com.github.luben.zstd.Zstd
+import com.github.luben.zstd.ZstdException
+import io.bluetape4k.assertions.assertFails
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContentEqual
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import org.junit.jupiter.api.Test
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicInteger
+
+class ZstdCompressorByteBufferTest {
+    private val compressor = ZstdCompressor()
+
+    @Test
+    fun `matched heap and direct storage use native paths and preserve wire compatibility`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val expectedWire = compressor.compress(payload)
+        val targetCapacity = Int.SIZE_BYTES + Zstd.compressBound(payload.size.toLong()).toInt()
+
+        listOf(false, true).forEach { direct ->
+            val source = if (direct) {
+                CompressorByteBufferTestSupport.directSlice(payload)
+            } else {
+                CompressorByteBufferTestSupport.heapSlice(payload)
+            }
+            val sourceStart = source.position()
+            val target = CompressorByteBufferTestSupport.slicedTarget(targetCapacity, direct)
+            val targetStart = target.position()
+
+            val written = compressor.compress(source, target)
+
+            written shouldBeEqualTo expectedWire.size
+            source.position() shouldBeEqualTo sourceStart
+            target.position() shouldBeEqualTo targetStart + written
+            CompressorByteBufferTestSupport.bytes(target, targetStart, written)
+                .shouldContentEqual(expectedWire)
+
+            val wire = if (direct) {
+                CompressorByteBufferTestSupport.directSlice(expectedWire)
+            } else {
+                CompressorByteBufferTestSupport.heapSlice(expectedWire)
+            }
+            val restored = CompressorByteBufferTestSupport.slicedTarget(payload.size, direct)
+            val restoredStart = restored.position()
+
+            compressor.decompress(wire, restored) shouldBeEqualTo payload.size
+            CompressorByteBufferTestSupport.bytes(restored, restoredStart, payload.size)
+                .shouldContentEqual(payload)
+        }
+    }
+
+    @Test
+    fun `mixed storage and read-only heap source use compatibility fallback`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val expectedWire = compressor.compress(payload)
+        val operations = RecordingZstdBufferOperations()
+        val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+        val sources = listOf(
+            CompressorByteBufferTestSupport.heap(payload) to true,
+            CompressorByteBufferTestSupport.direct(payload) to false,
+            CompressorByteBufferTestSupport.heap(payload).asReadOnlyBuffer() to false,
+        )
+
+        sources.forEach { (source, directTarget) ->
+            val target = CompressorByteBufferTestSupport.writableTarget(expectedWire.size, direct = directTarget)
+            val targetStart = target.position()
+
+            testCompressor.compress(source, target) shouldBeEqualTo expectedWire.size
+            CompressorByteBufferTestSupport.bytes(target, targetStart, expectedWire.size)
+                .shouldContentEqual(expectedWire)
+        }
+
+        val compressedSources = listOf(
+            CompressorByteBufferTestSupport.heap(expectedWire) to true,
+            CompressorByteBufferTestSupport.direct(expectedWire) to false,
+            CompressorByteBufferTestSupport.heap(expectedWire).asReadOnlyBuffer() to false,
+        )
+        compressedSources.forEach { (source, directTarget) ->
+            val target = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = directTarget)
+            val targetStart = target.position()
+
+            testCompressor.decompress(source, target) shouldBeEqualTo payload.size
+            CompressorByteBufferTestSupport.bytes(target, targetStart, payload.size)
+                .shouldContentEqual(payload)
+        }
+
+        operations.compressInvocations.get() shouldBeEqualTo 0
+        operations.decompressInvocations.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `compression passes exact payload capacity after the four-byte header`() {
+        val operations = RecordingZstdBufferOperations(compressResult = 0)
+        val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+
+        (0 until Int.SIZE_BYTES).forEach { capacity ->
+            assertFailsWith<BufferOverflowException> {
+                testCompressor.compress(
+                    CompressorByteBufferTestSupport.direct(byteArrayOf(1)),
+                    CompressorByteBufferTestSupport.writableTarget(capacity, direct = true),
+                )
+            }
+        }
+
+        val source = CompressorByteBufferTestSupport.direct(byteArrayOf(1, 2, 3))
+        val payloadCapacity = Zstd.compressBound(source.remaining().toLong()).toInt()
+        val target = CompressorByteBufferTestSupport.writableTarget(
+            Int.SIZE_BYTES + payloadCapacity,
+            direct = true,
+        )
+        testCompressor.compress(source, target) shouldBeEqualTo Int.SIZE_BYTES
+
+        operations.compressionTargetLength shouldBeEqualTo payloadCapacity
+        operations.compressionSourceOffset shouldBeEqualTo source.position()
+        operations.compressionTargetOffset shouldBeEqualTo target.position()
+    }
+
+    @Test
+    fun `heap compression includes backing-array offsets`() {
+        val operations = RecordingZstdBufferOperations(compressResult = 1)
+        val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+        val source = CompressorByteBufferTestSupport.heapSlice(byteArrayOf(1, 2, 3))
+        val payloadCapacity = Zstd.compressBound(source.remaining().toLong()).toInt()
+        val target = CompressorByteBufferTestSupport.slicedTarget(
+            Int.SIZE_BYTES + payloadCapacity,
+            direct = false,
+        )
+        val expectedSourceOffset = source.arrayOffset() + source.position()
+        val expectedTargetOffset = target.arrayOffset() + target.position() + Int.SIZE_BYTES
+
+        testCompressor.compress(source, target) shouldBeEqualTo 5
+
+        operations.compressionSourceOffset shouldBeEqualTo expectedSourceOffset
+        operations.compressionTargetOffset shouldBeEqualTo expectedTargetOffset
+        operations.compressionTargetLength shouldBeEqualTo payloadCapacity
+    }
+
+    @Test
+    fun `compression maps only destination-too-small and rejects invalid long counts`() {
+        val destinationFailure = ZstdException(Zstd.errDstSizeTooSmall(), "small")
+        val otherFailure = ZstdException(Zstd.errCorruptionDetected(), "corrupt")
+        val nativeTargetCapacity = Int.SIZE_BYTES + Zstd.compressBound(1).toInt()
+
+        val overflow = RecordingZstdBufferOperations(compressFailure = destinationFailure)
+        assertFailsWith<BufferOverflowException> {
+            ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, overflow).compress(
+                CompressorByteBufferTestSupport.direct(byteArrayOf(1)),
+                CompressorByteBufferTestSupport.writableTarget(nativeTargetCapacity, direct = true),
+            )
+        }
+
+        val identity = RecordingZstdBufferOperations(compressFailure = otherFailure)
+        val thrown = assertFails {
+            ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, identity).compress(
+                CompressorByteBufferTestSupport.direct(byteArrayOf(1)),
+                CompressorByteBufferTestSupport.writableTarget(nativeTargetCapacity, direct = true),
+            )
+        }
+        thrown shouldBeSameInstanceAs otherFailure
+
+        listOf(-1L, Long.MAX_VALUE, (1L shl 32) + 1L).forEach { invalid ->
+            val target = CompressorByteBufferTestSupport.writableTarget(nativeTargetCapacity, direct = true)
+            val targetStart = target.position()
+            assertFailsWith<IllegalStateException> {
+                ZstdCompressor.forTesting(
+                    ZstdCompressor.DEFAULT_LEVEL,
+                    RecordingZstdBufferOperations(compressResult = invalid),
+                ).compress(CompressorByteBufferTestSupport.direct(byteArrayOf(1)), target)
+            }
+            target.position() shouldBeEqualTo targetStart
+        }
+    }
+
+    @Test
+    fun `decompression validates header and target before native decode`() {
+        val operations = RecordingZstdBufferOperations()
+        val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+
+        assertFailsWith<IndexOutOfBoundsException> {
+            testCompressor.decompress(
+                CompressorByteBufferTestSupport.direct(byteArrayOf(1, 2, 3)),
+                ByteBuffer.allocateDirect(32),
+            )
+        }.message shouldBeEqualTo "Zstd header requires 4 bytes"
+        assertFailsWith<IllegalArgumentException> {
+            testCompressor.decompress(directWire(-1, ByteArray(1)), ByteBuffer.allocateDirect(32))
+        }.message shouldBeEqualTo "sourceSize must not be negative: -1"
+        assertFailsWith<IllegalArgumentException> {
+            testCompressor.decompress(
+                directWire(256 * 1024 * 1024 + 1, ByteArray(1)),
+                ByteBuffer.allocateDirect(32),
+            )
+        }.message shouldBeEqualTo "sourceSize exceeds 256 MiB: 268435457"
+        assertFailsWith<BufferOverflowException> {
+            testCompressor.decompress(validHeaderWire(33), ByteBuffer.allocateDirect(32))
+        }
+
+        operations.decompressInvocations.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `under-declared direct header never expands beyond declared destination`() {
+        val operations = RecordingZstdBufferOperations().apply {
+            decompressFailure = ZstdException(Zstd.errDstSizeTooSmall(), "Destination too small")
+        }
+        val compressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+        val source = directWire(declaredSize = 8, payload = ByteArray(64))
+        val target = ByteBuffer.allocateDirect(1024)
+
+        val failure = assertFailsWith<IllegalStateException> {
+            compressor.decompress(source, target)
+        }
+
+        failure.message shouldBeEqualTo "Zstd decompressed payload exceeds declared size=8"
+        failure.cause.shouldBeNull()
+        operations.decompressionTargetLength shouldBeEqualTo 8
+        target.position() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `non-destination ZstdException keeps identity`() {
+        val expected = ZstdException(Zstd.errCorruptionDetected(), "corrupt")
+        val compressor = ZstdCompressor.forTesting(
+            ZstdCompressor.DEFAULT_LEVEL,
+            RecordingZstdBufferOperations().apply { decompressFailure = expected },
+        )
+
+        val thrown = assertFails {
+            compressor.decompress(validHeaderWire(32), ByteBuffer.allocateDirect(32))
+        }
+
+        thrown shouldBeSameInstanceAs expected
+    }
+
+    @Test
+    fun `under-declared heap header uses the declared destination bound`() {
+        val operations = RecordingZstdBufferOperations().apply {
+            decompressFailure = ZstdException(Zstd.errDstSizeTooSmall(), "Destination too small")
+        }
+        val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+        val wire = ByteBuffer.allocate(68).apply {
+            putInt(8)
+            put(ByteArray(64))
+            flip()
+        }
+        val target = ByteBuffer.allocate(1024)
+
+        val failure = assertFailsWith<IllegalStateException> {
+            testCompressor.decompress(wire, target)
+        }
+
+        failure.message shouldBeEqualTo "Zstd decompressed payload exceeds declared size=8"
+        failure.cause.shouldBeNull()
+        operations.decompressionTargetLength shouldBeEqualTo 8
+        target.position() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `successful decode must exactly match the declared size before narrowing`() {
+        listOf(-1L, 7L, 9L, Long.MAX_VALUE, (1L shl 32) + 8L).forEach { actual ->
+            val target = ByteBuffer.allocateDirect(32)
+            val failure = assertFailsWith<IllegalStateException> {
+                ZstdCompressor.forTesting(
+                    ZstdCompressor.DEFAULT_LEVEL,
+                    RecordingZstdBufferOperations(decompressResult = actual),
+                ).decompress(validHeaderWire(8), target)
+            }
+
+            failure.message shouldBeEqualTo
+                    "Zstd decompressed size mismatch: expected=8, actual=$actual"
+            failure.cause.shouldBeNull()
+            target.position() shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `target byte order does not change the wire header`() {
+        val payload = byteArrayOf(1, 2, 3, 4)
+        val target = CompressorByteBufferTestSupport.writableTarget(
+            Int.SIZE_BYTES + Zstd.compressBound(payload.size.toLong()).toInt(),
+            direct = true,
+        ).order(ByteOrder.LITTLE_ENDIAN)
+        val start = target.position()
+
+        compressor.compress(CompressorByteBufferTestSupport.direct(payload), target)
+
+        getIntBigEndian(target, start) shouldBeEqualTo payload.size
+        target.order() shouldBeEqualTo ByteOrder.LITTLE_ENDIAN
+    }
+
+    @Test
+    fun `truncated and corrupt native payloads fail without committing target position`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val validWire = compressor.compress(payload)
+        val invalidWires = listOf(
+            validWire.copyOf(validWire.size - 1),
+            byteArrayOf(0, 0, 0, 32, 1, 2, 3, 4),
+        )
+
+        invalidWires.forEach { wire ->
+            val target = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = true)
+            val targetStart = target.position()
+
+            assertFails {
+                compressor.decompress(CompressorByteBufferTestSupport.direct(wire), target)
+            }
+            target.position() shouldBeEqualTo targetStart
+        }
+    }
+
+    @Test
+    fun `overflow keeps caller position and allows retry with a valid wire`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val wire = compressor.compress(payload)
+        val target = CompressorByteBufferTestSupport.writableTarget(payload.size - 1, direct = true)
+        val targetStart = target.position()
+
+        assertFailsWith<BufferOverflowException> {
+            compressor.decompress(CompressorByteBufferTestSupport.direct(wire), target)
+        }
+        target.position() shouldBeEqualTo targetStart
+
+        target.limit(target.capacity())
+        compressor.decompress(CompressorByteBufferTestSupport.direct(wire), target)
+            .shouldBeEqualTo(payload.size)
+        CompressorByteBufferTestSupport.bytes(target, targetStart, payload.size)
+            .shouldContentEqual(payload)
+    }
+
+    @Test
+    fun `singleton matched-storage operations are safe under concurrency`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val wireCapacity = Int.SIZE_BYTES + Zstd.compressBound(payload.size.toLong()).toInt()
+
+        MultithreadingTester()
+            .workers(8)
+            .rounds(2)
+            .add {
+                val wire = CompressorByteBufferTestSupport.writableTarget(wireCapacity, direct = true)
+                val wireStart = wire.position()
+                val written = Compressors.Zstd.compress(
+                    CompressorByteBufferTestSupport.direct(payload),
+                    wire,
+                )
+                val restored = CompressorByteBufferTestSupport.writableTarget(payload.size, direct = true)
+                val restoredStart = restored.position()
+                Compressors.Zstd.decompress(
+                    wire.duplicate().position(wireStart).limit(wireStart + written),
+                    restored,
+                )
+                CompressorByteBufferTestSupport.bytes(restored, restoredStart, payload.size)
+                    .shouldContentEqual(payload)
+            }
+            .run()
+    }
+
+    private fun directWire(declaredSize: Int, payload: ByteArray): ByteBuffer =
+        ByteBuffer.allocateDirect(Int.SIZE_BYTES + payload.size).apply {
+            putInt(declaredSize)
+            put(payload)
+            flip()
+        }
+
+    private fun validHeaderWire(declaredSize: Int): ByteBuffer =
+        directWire(
+            declaredSize,
+            byteArrayOf(0x28.toByte(), 0xB5.toByte(), 0x2F.toByte(), 0xFD.toByte()),
+        )
+
+    private class RecordingZstdBufferOperations(
+        private val compressResult: Long = 1,
+        private val decompressResult: Long? = null,
+        private val compressFailure: ZstdException? = null,
+    ): ZstdBufferOperations {
+        var decompressFailure: ZstdException? = null
+        var decompressionTargetLength: Int? = null
+        var compressionTargetLength: Int? = null
+        var compressionSourceOffset: Int? = null
+        var compressionTargetOffset: Int? = null
+        val compressInvocations = AtomicInteger()
+        val decompressInvocations = AtomicInteger()
+
+        override fun compressDirect(
+            target: ByteBuffer,
+            targetOffset: Int,
+            targetLength: Int,
+            source: ByteBuffer,
+            sourceOffset: Int,
+            sourceLength: Int,
+            level: Int,
+        ): Long {
+            compressInvocations.incrementAndGet()
+            compressionTargetLength = targetLength
+            compressionSourceOffset = sourceOffset
+            compressionTargetOffset = targetOffset
+            compressFailure?.let { throw it }
+            if (compressResult > 0 && compressResult <= targetLength) {
+                target.put(targetOffset, 0x2A)
+            }
+            return compressResult
+        }
+
+        override fun decompressDirect(
+            target: ByteBuffer,
+            targetOffset: Int,
+            targetLength: Int,
+            source: ByteBuffer,
+            sourceOffset: Int,
+            sourceLength: Int,
+        ): Long {
+            decompressInvocations.incrementAndGet()
+            decompressionTargetLength = targetLength
+            decompressFailure?.let { throw it }
+            return decompressResult ?: targetLength.toLong()
+        }
+
+        override fun compressHeap(
+            target: ByteArray,
+            targetOffset: Int,
+            targetLength: Int,
+            source: ByteArray,
+            sourceOffset: Int,
+            sourceLength: Int,
+            level: Int,
+        ): Long {
+            compressInvocations.incrementAndGet()
+            compressionTargetLength = targetLength
+            compressionSourceOffset = sourceOffset
+            compressionTargetOffset = targetOffset
+            compressFailure?.let { throw it }
+            if (compressResult > 0 && compressResult <= targetLength) {
+                target[targetOffset] = 0x2A
+            }
+            return compressResult
+        }
+
+        override fun decompressHeap(
+            target: ByteArray,
+            targetOffset: Int,
+            targetLength: Int,
+            source: ByteArray,
+            sourceOffset: Int,
+            sourceLength: Int,
+        ): Long {
+            decompressInvocations.incrementAndGet()
+            decompressionTargetLength = targetLength
+            decompressFailure?.let { throw it }
+            return decompressResult ?: targetLength.toLong()
+        }
+    }
+}

--- a/scripts/check-compressor-buffer-docs.py
+++ b/scripts/check-compressor-buffer-docs.py
@@ -99,8 +99,8 @@ def validate_readmes() -> None:
         "Deflate": ("optimized", "optimized", "optimized", "eligible, not yet measured"),
         "Snappy": ("compatibility fallback", "optimized", "compatibility fallback",
                    "eligible for direct pair, not yet measured"),
-        "Zstd": ("compatibility fallback", "compatibility fallback", "compatibility fallback",
-                 "none in the core slice"),
+        "Zstd": ("optimized", "optimized", "compatibility fallback",
+                 "eligible, not yet measured"),
         "Other codecs": ("compatibility fallback", "compatibility fallback", "compatibility fallback", "ineligible"),
     }
     if en_matrix != expected_matrix:
@@ -130,6 +130,18 @@ def validate_readmes() -> None:
         ("Snappy.maxCompressedLength(source.remaining())", "그보다 작은 direct target",
          "compatibility fallback", "payload 전체", "임의 limit"),
         "Korean Snappy dispatch boundary",
+    )
+    require_tokens(
+        sections["en"]["issue-755-storage-matrix"],
+        ("Zstd.compressBound(source.remaining()) + 4", "smaller target",
+         "declared original size", "returned `Long`", "allocation evidence remains pending"),
+        "English Zstd dispatch boundary",
+    )
+    require_tokens(
+        sections["ko"]["issue-755-storage-matrix"],
+        ("Zstd.compressBound(source.remaining()) + 4", "안전 상한보다 작은 target",
+         "header에 선언된 원본 크기", "반환된 `Long`", "allocation 근거는 아직 측정 전"),
+        "Korean Zstd dispatch boundary",
     )
 
     shared_contract = (


### PR DESCRIPTION
## Summary

Closes #755

- PR 제목: Add bounded caller-owned Zstd buffer paths

- add matched writable heap and direct Zstd caller-owned buffer paths
- bind native decompression output to the four-byte wire-declared size
- preserve compatibility fallback success when compression capacity is below `compressBound + 4`
- synchronize Korean KDoc, English/Korean capability docs, lessons, and the docs contract checker

### 원문 선행 내용

Refs #755

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Compatibility and safety

- preserves the existing `[4-byte big-endian original size][compressed payload]` wire format
- preserves caller source state and commits target position only on success
- maps compression destination exhaustion to `BufferOverflowException`
- maps decompression destination exhaustion inside the declared bound to a cause-less `IllegalStateException`
- preserves all other `ZstdException` identities
- keeps decompressed output bounded to 256 MiB

### 기존 섹션: Verification

- RED: the new test initially failed at `compileTestKotlin` because the operation seam and testing factory did not exist
- `:bluetape4k-io:test` with Zstd and common caller-owned contract tests: 50 passing
- full `:bluetape4k-io:test`: 1,239 passing
- `python3 scripts/check-compressor-buffer-docs.py`: PASS
- `git diff --check`: PASS
- Kotlin unsafe-construct diff scan: PASS
- dependency/module/workflow scope scan: PASS
- root Detekt tasks: successful but `NO-SOURCE`; `:bluetape4k-io` exposes no Detekt task

### 기존 섹션: Six-perspective review

| Lens | P0 | P1 | Result |
|---|---:|---:|---|
| Performance | 0 | 0 | Native dispatch is conditional on the codec safety bound; no allocation claim is promoted. |
| Stability | 0 | 0 | JNI contexts are per call; failure rollback, retry, and singleton concurrency are covered. |
| Security | 0 | 0 | Declared output is validated before native decode and remains capped at 256 MiB. |
| Operator/Ops | 0 | 0 | Stable exception taxonomy supports diagnosis; no runtime configuration or lifecycle changed. |
| Developer/API | 0 | 0 | Existing public signatures and wire format are unchanged; internal seam mirrors resolved zstd-jni APIs. |
| User/Caller | 0 | 0 | README locales and KDoc describe optimized, fallback, sizing, and evidence boundaries. |

### 기존 섹션: Scope and follow-up

- no dependency, module registration, workflow, release, or changelog change
- final allocation/adoption evidence remains a later stacked slice under #755
- #767 remains in backlog and is outside this PR

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #755, milestone `1.12.0`, assignee `debop`
- PR: #1259, head `9f63a36dc9ac08e9f262a504a51efc34caa9d20b`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-755-bytebuffer-zstd`
- Labels: `enhancement`, `performance`, `infra/io`
- State: `MERGED`, merge commit `6fa6374d00d9cf1ac7058b43ae04c67148ed00bb`
- CI: - preserve compatibility fallback success when compression capacity is below `compressBound + 4` / - root Detekt tasks: successful but `NO-SOURCE`; `:bluetape4k-io` exposes no Detekt task / - [x] GitHub CI passes on the exact PR head

## DoD Status

- [x] Zstd matched-storage backend paths implemented
- [x] Declared-size native destination bound and exception taxonomy verified
- [x] Existing wire and caller-owned buffer contracts preserved
- [x] Korean KDoc and English/Korean README parity verified
- [x] Targeted and full module tests pass
- [x] Six-perspective review converged with P0=0 and P1=0
- [x] GitHub CI passes on the exact PR head
- [x] Fresh exact-head merge approval obtained
- [ ] Final allocation/adoption evidence completed in the later #755 slice

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1259 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `6fa6374d00d9cf1ac7058b43ae04c67148ed00bb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
