### PR TITLE
Unify Zstd malformed-wire behavior across ByteBuffer storage

### DIFF
--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt
@@ -149,6 +149,10 @@ private object DefaultZstdBufferOperations: ZstdBufferOperations {
  * val compressor = ZstdCompressor(level = 10)
  * ```
  *
+ * 압축 데이터의 header에 선언된 원본 크기와 zstd-jni가 실제로 복원한 크기는 정확히
+ * 일치해야 합니다. `ByteArray`와 `ByteBuffer` API는 저장소 유형과 관계없이 이 계약을
+ * 동일하게 적용하며, 불일치하면 [IllegalStateException]을 던집니다.
+ *
  * 참고: [zstd-jni](https://github.com/luben/zstd-jni)
  *
  * @property level 압축 레벨
@@ -305,19 +309,24 @@ class ZstdCompressor private constructor(
                 }
             } catch (failure: ZstdException) {
                 if (failure.errorCode == Zstd.errDstSizeTooSmall()) {
-                    throw IllegalStateException(
-                        "Zstd decompressed payload exceeds declared size=$declaredSize"
-                    )
+                    throw decompressedPayloadExceedsDeclaredSize(declaredSize)
                 }
                 throw failure
             }
-            if (actual != declaredSize.toLong()) {
-                throw IllegalStateException(
-                    "Zstd decompressed size mismatch: expected=$declaredSize, actual=$actual"
-                )
-            }
-            Math.toIntExact(actual)
+            requireExactDecompressedSize(declaredSize, actual)
         }
+
+    private fun decompressedPayloadExceedsDeclaredSize(declaredSize: Int): IllegalStateException =
+        IllegalStateException("Zstd decompressed payload exceeds declared size=$declaredSize")
+
+    private fun requireExactDecompressedSize(declaredSize: Int, actualSize: Long): Int {
+        if (actualSize != declaredSize.toLong()) {
+            throw IllegalStateException(
+                "Zstd decompressed size mismatch: expected=$declaredSize, actual=$actualSize"
+            )
+        }
+        return Math.toIntExact(actualSize)
+    }
 
     /**
      * I/O 압축에서 `doCompress` 함수를 제공합니다.
@@ -356,14 +365,22 @@ class ZstdCompressor private constructor(
 
         log.trace { "sourceSize = $sourceSize" }
 
-        Zstd.decompressByteArray(
-            output,
-            0,
-            output.size,
-            compressed,
-            MAGIC_NUMBER_SIZE,
-            compressed.size - MAGIC_NUMBER_SIZE
-        )
+        val actualSize = try {
+            Zstd.decompressByteArray(
+                output,
+                0,
+                output.size,
+                compressed,
+                MAGIC_NUMBER_SIZE,
+                compressed.size - MAGIC_NUMBER_SIZE
+            )
+        } catch (failure: ZstdException) {
+            if (failure.errorCode == Zstd.errDstSizeTooSmall()) {
+                throw decompressedPayloadExceedsDeclaredSize(sourceSize)
+            }
+            throw failure
+        }
+        requireExactDecompressedSize(sourceSize, actualSize)
 
         return output
     }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZstdCompressorByteBufferTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZstdCompressorByteBufferTest.kt
@@ -263,6 +263,64 @@ class ZstdCompressorByteBufferTest {
     }
 
     @Test
+    fun `over-declared wire is rejected consistently across source and target storage`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val declaredSize = payload.size + 3
+        val wire = wireWithDeclaredSize(payload, declaredSize)
+
+        CompressorByteBufferTestSupport.sources(wire).forEach { (_, source) ->
+            CompressorByteBufferTestSupport.targets(declaredSize).forEach { (_, target) ->
+                val sourcePosition = source.position()
+                val sourceLimit = source.limit()
+                val targetPosition = target.position()
+                val targetLimit = target.limit()
+
+                val failure = assertFailsWith<IllegalStateException> {
+                    compressor.decompress(source, target)
+                }
+
+                failure.message shouldBeEqualTo
+                        "Zstd decompressed size mismatch: expected=$declaredSize, actual=${payload.size}"
+                source.position() shouldBeEqualTo sourcePosition
+                source.limit() shouldBeEqualTo sourceLimit
+                target.position() shouldBeEqualTo targetPosition
+                target.limit() shouldBeEqualTo targetLimit
+                CompressorByteBufferTestSupport.assertMark(source, sourcePosition)
+                CompressorByteBufferTestSupport.assertMark(target, targetPosition)
+            }
+        }
+    }
+
+    @Test
+    fun `under-declared wire is rejected consistently across source and target storage`() {
+        val payload = CompressorByteBufferTestSupport.payload
+        val declaredSize = payload.size - 1
+        val wire = wireWithDeclaredSize(payload, declaredSize)
+
+        CompressorByteBufferTestSupport.sources(wire).forEach { (_, source) ->
+            CompressorByteBufferTestSupport.targets(payload.size).forEach { (_, target) ->
+                val sourcePosition = source.position()
+                val sourceLimit = source.limit()
+                val targetPosition = target.position()
+                val targetLimit = target.limit()
+
+                val failure = assertFailsWith<IllegalStateException> {
+                    compressor.decompress(source, target)
+                }
+
+                failure.message shouldBeEqualTo
+                        "Zstd decompressed payload exceeds declared size=$declaredSize"
+                source.position() shouldBeEqualTo sourcePosition
+                source.limit() shouldBeEqualTo sourceLimit
+                target.position() shouldBeEqualTo targetPosition
+                target.limit() shouldBeEqualTo targetLimit
+                CompressorByteBufferTestSupport.assertMark(source, sourcePosition)
+                CompressorByteBufferTestSupport.assertMark(target, targetPosition)
+            }
+        }
+    }
+
+    @Test
     fun `successful decode must exactly match the declared size before narrowing`() {
         listOf(-1L, 7L, 9L, Long.MAX_VALUE, (1L shl 32) + 8L).forEach { actual ->
             val target = ByteBuffer.allocateDirect(32)
@@ -373,6 +431,11 @@ class ZstdCompressorByteBufferTest {
             declaredSize,
             byteArrayOf(0x28.toByte(), 0xB5.toByte(), 0x2F.toByte(), 0xFD.toByte()),
         )
+
+    private fun wireWithDeclaredSize(payload: ByteArray, declaredSize: Int): ByteArray =
+        compressor.compress(payload).also { wire ->
+            ByteBuffer.wrap(wire).putInt(declaredSize)
+        }
 
     private class RecordingZstdBufferOperations(
         private val compressResult: Long = 1,


### PR DESCRIPTION
## Summary

Closes #1263

- PR 제목: Unify Zstd malformed-wire behavior across ByteBuffer storage

- enforce one malformed-wire contract across optimized and compatibility Zstd decompression paths
- validate the zstd-jni decompressed byte count against the wire header before returning output
- preserve caller-owned source and target buffer state for every rejected storage combination

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Root cause

The optimized `ByteBuffer` paths validated the native decompressed byte count, but the compatibility fallback discarded the value returned by `Zstd.decompressByteArray`. As a result, over-declared payloads could succeed with zero padding and under-declared payloads could expose a raw `ZstdException`, depending on buffer storage.

### 기존 섹션: Verification

- `ZstdCompressorByteBufferTest`: 16/16 passed
- malformed-wire matrix: 24 over-declared + 24 under-declared source/target combinations passed
- `:bluetape4k-io:test`: 1,257 tests, 0 failures, 0 errors
- Kotlin main/test compilation passed
- compressor buffer ABI passed at `8773bb41ec6973ba44e3f55185aab5a4eeb8762c`
- `git diff --check` passed

Fixes #1263

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1263, milestone `1.12.0`, assignee `debop`
- PR: #1280, head `8773bb41ec6973ba44e3f55185aab5a4eeb8762c`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1263-zstd-malformed-wire`
- Labels: `bug`, `infra/io`
- State: `MERGED`, merge commit `1ab21841a5132adafe3d25b858a54d3d30c87ae4`
- CI: - [x] GitHub CI completed on the exact PR head

## DoD Status

- [x] Reproduced storage-dependent malformed-wire behavior
- [x] Added failing regression coverage before implementation
- [x] Unified optimized and fallback exception semantics
- [x] Preserved source/target position, limit, and mark on failure
- [x] Verified targeted tests, full module tests, compilation, and ABI
- [x] GitHub CI completed on the exact PR head
- [ ] Final review and merge approval completed

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1280 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1ab21841a5132adafe3d25b858a54d3d30c87ae4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
