### PR TITLE
Harden Zstd ByteBuffer native-result and boundary conformance

### DIFF
--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZstdCompressor.kt
@@ -151,7 +151,9 @@ private object DefaultZstdBufferOperations: ZstdBufferOperations {
  *
  * 압축 데이터의 header에 선언된 원본 크기와 zstd-jni가 실제로 복원한 크기는 정확히
  * 일치해야 합니다. `ByteArray`와 `ByteBuffer` API는 저장소 유형과 관계없이 이 계약을
- * 동일하게 적용하며, 불일치하면 [IllegalStateException]을 던집니다.
+ * 동일하게 적용하며, 불일치하면 [IllegalStateException]을 던집니다. 비어 있지 않은
+ * `ByteBuffer` 압축에서 native codec이 반환하는 기록량은 양수여야 하며, `0`은 유효한
+ * 성공 결과로 취급하지 않습니다.
  *
  * 참고: [zstd-jni](https://github.com/luben/zstd-jni)
  *
@@ -259,7 +261,7 @@ class ZstdCompressor private constructor(
                 if (failure.errorCode == Zstd.errDstSizeTooSmall()) throw BufferOverflowException()
                 throw failure
             }
-            check(payloadWritten in 0L..payloadCapacity.toLong()) {
+            check(payloadWritten in 1L..payloadCapacity.toLong()) {
                 "Zstd compression returned invalid size=$payloadWritten, payloadCapacity=$payloadCapacity"
             }
             Math.addExact(MAGIC_NUMBER_SIZE, Math.toIntExact(payloadWritten))

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZstdCompressorByteBufferTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZstdCompressorByteBufferTest.kt
@@ -97,10 +97,10 @@ class ZstdCompressorByteBufferTest {
 
     @Test
     fun `compression passes exact payload capacity after the four-byte header`() {
-        val operations = RecordingZstdBufferOperations(compressResult = 0)
+        val operations = RecordingZstdBufferOperations(compressResult = 1)
         val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
 
-        (0 until Int.SIZE_BYTES).forEach { capacity ->
+        (0..Int.SIZE_BYTES).forEach { capacity ->
             assertFailsWith<BufferOverflowException> {
                 testCompressor.compress(
                     CompressorByteBufferTestSupport.direct(byteArrayOf(1)),
@@ -115,11 +115,80 @@ class ZstdCompressorByteBufferTest {
             Int.SIZE_BYTES + payloadCapacity,
             direct = true,
         )
-        testCompressor.compress(source, target) shouldBeEqualTo Int.SIZE_BYTES
+        testCompressor.compress(source, target) shouldBeEqualTo Int.SIZE_BYTES + 1
 
         operations.compressionTargetLength shouldBeEqualTo payloadCapacity
         operations.compressionSourceOffset shouldBeEqualTo source.position()
-        operations.compressionTargetOffset shouldBeEqualTo target.position()
+        operations.compressionTargetOffset shouldBeEqualTo target.position() - 1
+    }
+
+    @Test
+    fun `native zero compression result is rejected for heap and direct paths`() {
+        val payload = byteArrayOf(1, 2, 3)
+
+        listOf(false, true).forEach { direct ->
+            val operations = RecordingZstdBufferOperations(compressResult = 0)
+            val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+            val source = if (direct) {
+                CompressorByteBufferTestSupport.direct(payload)
+            } else {
+                CompressorByteBufferTestSupport.heap(payload)
+            }
+            val target = CompressorByteBufferTestSupport.writableTarget(
+                Int.SIZE_BYTES + Zstd.compressBound(payload.size.toLong()).toInt(),
+                direct = direct,
+            )
+            val sourcePosition = source.position()
+            val targetPosition = target.position()
+            val payloadCapacity = target.remaining() - Int.SIZE_BYTES
+
+            assertFailsWith<IllegalStateException> {
+                testCompressor.compress(source, target)
+            }.message shouldBeEqualTo
+                    "Zstd compression returned invalid size=0, payloadCapacity=$payloadCapacity"
+
+            source.position() shouldBeEqualTo sourcePosition
+            target.position() shouldBeEqualTo targetPosition
+            operations.compressInvocations.get() shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `compression rejects the exact four-byte header-only target boundary`() {
+        val operations = RecordingZstdBufferOperations()
+        val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+        val source = CompressorByteBufferTestSupport.direct(byteArrayOf(1))
+        val target = CompressorByteBufferTestSupport.writableTarget(Int.SIZE_BYTES, direct = true)
+        val sourcePosition = source.position()
+        val targetPosition = target.position()
+
+        assertFailsWith<BufferOverflowException> {
+            testCompressor.compress(source, target)
+        }
+
+        source.position() shouldBeEqualTo sourcePosition
+        target.position() shouldBeEqualTo targetPosition
+        operations.compressInvocations.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `direct read-only source uses the optimized native path`() {
+        val operations = RecordingZstdBufferOperations(compressResult = 1)
+        val testCompressor = ZstdCompressor.forTesting(ZstdCompressor.DEFAULT_LEVEL, operations)
+        val source = CompressorByteBufferTestSupport.direct(byteArrayOf(1, 2, 3))
+            .asReadOnlyBuffer()
+        val target = CompressorByteBufferTestSupport.writableTarget(
+            Int.SIZE_BYTES + Zstd.compressBound(source.remaining().toLong()).toInt(),
+            direct = true,
+        )
+        val sourcePosition = source.position()
+        val targetPosition = target.position()
+
+        testCompressor.compress(source, target) shouldBeEqualTo Int.SIZE_BYTES + 1
+
+        source.position() shouldBeEqualTo sourcePosition
+        target.position() shouldBeEqualTo targetPosition + Int.SIZE_BYTES + 1
+        operations.compressInvocations.get() shouldBeEqualTo 1
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1264

- PR 제목: Harden Zstd ByteBuffer native-result and boundary conformance

The optimized Zstd `ByteBuffer` compression paths accepted a native result of `0` for a non-empty source. That value can produce a header-only wire value without a payload, so it is not a valid successful compression result.

This change:

- requires a positive native payload length (`1..payloadCapacity`) for heap and direct optimized paths;
- documents the non-empty `ByteBuffer` result contract in Korean-first KDoc;
- covers the exact four-byte header-only target boundary without invoking native compression;
- covers direct read-only sources and preserves source/target positions on rejection;
- retains and verifies the real zstd-jni malformed-wire matrix across heap, direct, sliced, and read-only sources alongside native-call mocks.

### 원문 선행 내용

Fixes #1264

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

Fixes #1264

### Summary

The optimized Zstd `ByteBuffer` compression paths accepted a native result of `0` for a non-empty source. That value can produce a header-only wire value without a payload, so it is not a valid successful compression result.

This change:

- requires a positive native payload length (`1..payloadCapacity`) for heap and direct optimized paths;
- documents the non-empty `ByteBuffer` result contract in Korean-first KDoc;
- covers the exact four-byte header-only target boundary without invoking native compression;
- covers direct read-only sources and preserves source/target positions on rejection;
- retains and verifies the real zstd-jni malformed-wire matrix across heap, direct, sliced, and read-only sources alongside native-call mocks.

### Validation

- RED: the new zero-result regression test failed before the production guard (`Expected IllegalStateException but no exception was thrown`).
- GREEN: `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.compressor.ZstdCompressorByteBufferTest' --rerun-tasks` — 19/19 passed.
- `./gradlew :bluetape4k-io:test --rerun-tasks` — 1260 tests, 0 failures, 0 errors, 0 skipped.
- `./gradlew :bluetape4k-io:compileKotlin :bluetape4k-io:compileTestKotlin --rerun-tasks` — passed.
- `git diff --check` — passed.
- `./gradlew :bluetape4k-io:detekt --rerun-tasks` — N/A: the module task is not registered; Detekt registration is tracked separately by #1265.

### DoD Status

| Item | Status | Evidence |
| --- | --- | --- |
| Type-C bugfix scope | PASS | Only Zstd ByteBuffer production/Kotlin test paths changed |
| Native result `0` contract | PASS | Positive-length guard and heap/direct regression coverage |
| Four-byte boundary | PASS | Exact header-only capacity rejected before native invocation |
| Read-only direct source | PASS | Optimized dispatch and position preservation covered |
| Actual malformed zstd-jni wire cases | PASS | Existing storage/read-only matrix retained and full IO suite passed |
| Targeted and module tests | PASS | 19/19 targeted; 1260/0/0/0 module result |
| Static analysis | N/A | Module Detekt task unavailable; #1265 owns registration |
| Inline review | PASS | No actionable defects found |
| CI | PASS | Exact head `8ba6817e5b4d5439b67dedab44995da82a1db85a` has 11 successful checks, 8 path-skipped checks, and 0 failures |
| Merge | PENDING | Separate exact-head approval gate |

Required checks: 4/6 gates passed; N/A: 1 (module Detekt task unavailable); Blocked: 0; merge remains pending at the separate exact-head approval gate.

## Validation

- RED: the new zero-result regression test failed before the production guard (`Expected IllegalStateException but no exception was thrown`).
- GREEN: `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.compressor.ZstdCompressorByteBufferTest' --rerun-tasks` — 19/19 passed.
- `./gradlew :bluetape4k-io:test --rerun-tasks` — 1260 tests, 0 failures, 0 errors, 0 skipped.
- `./gradlew :bluetape4k-io:compileKotlin :bluetape4k-io:compileTestKotlin --rerun-tasks` — passed.
- `git diff --check` — passed.
- `./gradlew :bluetape4k-io:detekt --rerun-tasks` — N/A: the module task is not registered; Detekt registration is tracked separately by #1265.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1264, milestone `1.12.0`, assignee `debop`
- PR: #1281, head `8ba6817e5b4d5439b67dedab44995da82a1db85a`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1264-zstd-boundary-conformance`
- Labels: `test`, `infra/io`
- State: `MERGED`, merge commit `aa3d311e4383a307e824f7f57551deb3d00921a4`
- CI: - requires a positive native payload length (`1..payloadCapacity`) for heap and direct optimized paths; / - GREEN: `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.compressor.ZstdCompressorByteBufferTest' --rerun-tasks` — 19/19 passed. / - `./gradlew :bluetape4k-io:test --rerun-tasks` — 1260 tests, 0 failures, 0 errors, 0 skipped.

## DoD Status

| Item | Status | Evidence |
| --- | --- | --- |
| Type-C bugfix scope | PASS | Only Zstd ByteBuffer production/Kotlin test paths changed |
| Native result `0` contract | PASS | Positive-length guard and heap/direct regression coverage |
| Four-byte boundary | PASS | Exact header-only capacity rejected before native invocation |
| Read-only direct source | PASS | Optimized dispatch and position preservation covered |
| Actual malformed zstd-jni wire cases | PASS | Existing storage/read-only matrix retained and full IO suite passed |
| Targeted and module tests | PASS | 19/19 targeted; 1260/0/0/0 module result |
| Static analysis | N/A | Module Detekt task unavailable; #1265 owns registration |
| Inline review | PASS | No actionable defects found |
| CI | PASS | Exact head `8ba6817e5b4d5439b67dedab44995da82a1db85a` has 11 successful checks, 8 path-skipped checks, and 0 failures |
| Merge | PENDING | Separate exact-head approval gate |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1281 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `aa3d311e4383a307e824f7f57551deb3d00921a4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
