### PR TITLE
Fix: run Detekt across Kotlin subprojects (#1265)

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -374,12 +374,22 @@ jobs:
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
 
+      - name: Verify Detekt source coverage
+        run: |
+          test -s build/reports/detekt/source-coverage.md
+          grep -Eq '^- Included modules: [1-9][0-9]*$' build/reports/detekt/source-coverage.md
+          grep -Eq '^- Kotlin source files: [1-9][0-9]* \(main: [0-9]+, test: [0-9]+\)$' build/reports/detekt/source-coverage.md
+          grep -q '^- Empty included modules: 0$' build/reports/detekt/source-coverage.md
+
       - name: Upload detekt report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: nightly-detekt-report
-          path: '**/build/reports/detekt/*.xml'
+          path: |
+            **/build/reports/detekt/*.xml
+            build/reports/detekt/source-coverage.md
+          if-no-files-found: error
           retention-days: 14
 
   # ── Core 모듈 테스트 ──────────────────────────────────────────────────────

--- a/README.ko.md
+++ b/README.ko.md
@@ -313,6 +313,13 @@ Jib으로 Mock Server Docker 이미지를 다시 빌드할 때는 Gradle configu
 ./gradlew detekt
 ```
 
+이 명령은 분석 대상 library subproject의 Kotlin 소스를 검사하며, 포함된
+프로젝트의 소스가 비어 있으면 실패합니다. 분석 모듈/파일 영수증은
+`build/reports/detekt/source-coverage.md`에, 병합된 Checkstyle 결과는
+`build/reports/detekt/merged.xml`에 생성됩니다. examples·demo·benchmark·workshop
+소스, 메타데이터 전용 프로젝트와 문서화된 `exposed-jdbc-tests` 예외는 영수증에
+명시적인 제외 항목으로 기록됩니다.
+
 ## 배포 방법
 
 버전 확인은 `gradle.properties` 파일에서 확인

--- a/README.md
+++ b/README.md
@@ -312,6 +312,13 @@ The legacy `x-obsoleted/` directory was removed. The table below documents the f
 ./gradlew detekt
 ```
 
+The command analyzes Kotlin sources in the intended library subprojects and
+fails if an included project has no source files. The source/module receipt is
+written to `build/reports/detekt/source-coverage.md`; the merged Checkstyle
+findings are written to `build/reports/detekt/merged.xml`. Examples, demos,
+benchmarks, workshop sources, metadata-only projects, and the documented
+`exposed-jdbc-tests` exception are listed as explicit exclusions in the receipt.
+
 ## Publishing
 
 Check `gradle.properties` for the current version:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,12 @@ import io.bluetape4k.gradle.configurePublishingSigning
 import io.bluetape4k.gradle.DisabledTestReportTask
 import io.bluetape4k.gradle.resolveCentralPublishingConfig
 import io.bluetape4k.gradle.resolvePublishingSigningConfig
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.report.ReportMergeTask
+import dev.detekt.gradle.Detekt
+import dev.detekt.gradle.report.ReportMergeTask
 import nmcp.NmcpAggregationExtension
 import nmcp.NmcpExtension
 import org.gradle.api.Project
+import org.gradle.api.file.FileTree
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.io.File
@@ -104,6 +105,27 @@ fun Project.isSampleOrBenchmarkProject(): Boolean {
             name.endsWith("-benchmark")
 }
 
+private val detektExplicitExclusionReasons = linkedMapOf(
+    "bluetape4k-bom" to "BOM metadata-only project has no Kotlin source.",
+    "bluetape4k-redis" to "Umbrella project delegates to Lettuce and Redisson and has no Kotlin source.",
+    "exposed-jdbc-tests" to "Documented Testcontainers-backed test exception; this project is not registered in this repository.",
+)
+
+fun Project.detektExclusionReason(): String? = when {
+    name in detektExplicitExclusionReasons -> detektExplicitExclusionReasons.getValue(name)
+    isSampleOrBenchmarkProject() -> "Examples, demos, benchmarks, and workshop sources are excluded from library analysis."
+    else -> null
+}
+
+fun Project.isDetektTargetProject(): Boolean = detektExclusionReason() == null
+
+fun Project.detektKotlinSourceFiles(): FileTree = fileTree(projectDir) {
+    include("src/main/kotlin/**/*.kt")
+    include("src/test/kotlin/**/*.kt")
+    exclude("**/build/**")
+    exclude("**/generated/**")
+}
+
 subprojects {
     if (!isSampleOrBenchmarkProject()) {
         apply(plugin = "com.gradleup.nmcp")
@@ -141,6 +163,11 @@ subprojects {
 
         // Kotlin 1.9.20 부터는 pluginId 를 지정해줘야 합니다.
         plugin("org.jetbrains.kotlin.jvm")
+
+        // Detekt — 실제 Kotlin 소스가 있는 library subproject만 분석 대상으로 등록한다.
+        if (isDetektTargetProject()) {
+            plugin("dev.detekt")
+        }
 
         // Atomicfu
         plugin("org.jetbrains.kotlinx.atomicfu")
@@ -302,14 +329,24 @@ subprojects {
             showFullStackTraces = true
         }
 
-        val reportMerge by registering(ReportMergeTask::class) {
-            val file = rootProject.layout.buildDirectory.asFile.get().resolve("reports/detekt/merged.xml")
-            output.set(file)
-        }
         withType<Detekt>().configureEach detekt@{
-            finalizedBy(reportMerge)
-            reportMerge.configure {
-                input.from(this@detekt.xmlReportFile)
+            exclude("**/build/**")
+            exclude("**/generated/**")
+            if (name == "detekt" && project.isDetektTargetProject()) {
+                setSource(project.detektKotlinSourceFiles())
+                reports {
+                    checkstyle.required.set(true)
+                    checkstyle.outputLocation.set(project.layout.buildDirectory.file("reports/detekt/detekt.xml"))
+                }
+                // This issue establishes trustworthy source coverage; rule cleanup is tracked separately.
+                ignoreFailures.set(true)
+                doFirst {
+                    val sourceFiles = source.files
+                    check(sourceFiles.isNotEmpty()) {
+                        "Detekt source scope is empty for $path; refusing a false-green analysis."
+                    }
+                    logger.lifecycle("Detekt source scope for $path: ${sourceFiles.size} Kotlin files")
+                }
             }
         }
 
@@ -994,6 +1031,110 @@ subprojects {
     tasks.matching { it.name.endsWith("ToNmcpRepository") }.configureEach {
         outputs.upToDateWhen { false }
     }
+}
+
+val detektTargetProjects = subprojects
+    .filter(Project::isDetektTargetProject)
+    .sortedBy(Project::getPath)
+
+val detektSourceCoverageReport = layout.buildDirectory.file("reports/detekt/source-coverage.md")
+val detektSourceFilesByProject = detektTargetProjects.associateWith { it.detektKotlinSourceFiles() }
+
+val detektSourceCoverage by tasks.registering {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Verifies and reports the Kotlin source scope analyzed by Detekt."
+
+    inputs.files(detektSourceFilesByProject.values)
+    outputs.file(detektSourceCoverageReport)
+
+    doLast {
+        val rows = detektSourceFilesByProject.map { (module, sourceFiles) ->
+            val files = sourceFiles.files
+            val mainRoot = module.projectDir.toPath().resolve("src/main/kotlin")
+            val testRoot = module.projectDir.toPath().resolve("src/test/kotlin")
+            val mainCount = files.count { it.toPath().startsWith(mainRoot) }
+            val testCount = files.count { it.toPath().startsWith(testRoot) }
+            module to Triple(mainCount, testCount, files.size)
+        }
+        val emptyModules = rows.filter { (_, counts) -> counts.third == 0 }
+        val totalMain = rows.sumOf { it.second.first }
+        val totalTest = rows.sumOf { it.second.second }
+        val totalFiles = rows.sumOf { it.second.third }
+        val exclusions = (
+            subprojects
+                .mapNotNull { module -> module.detektExclusionReason()?.let { module.path to it } } +
+                detektExplicitExclusionReasons
+                    .filterKeys { moduleName -> subprojects.none { it.name == moduleName } }
+                    .map { (moduleName, reason) -> ":$moduleName" to reason }
+            )
+            .sortedBy { it.first }
+
+        val report = detektSourceCoverageReport.get().asFile
+        report.parentFile.mkdirs()
+        report.writeText(buildString {
+            appendLine("# Detekt source coverage")
+            appendLine()
+            appendLine("- Included modules: ${rows.size}")
+            appendLine("- Kotlin source files: $totalFiles (main: $totalMain, test: $totalTest)")
+            appendLine("- Empty included modules: ${emptyModules.size}")
+            appendLine()
+            appendLine("## Included modules")
+            appendLine()
+            appendLine("| Project | Main Kotlin | Test Kotlin | Total |")
+            appendLine("| --- | ---: | ---: | ---: |")
+            rows.forEach { (module, counts) ->
+                appendLine("| `${module.path}` | ${counts.first} | ${counts.second} | ${counts.third} |")
+            }
+            appendLine()
+            appendLine("## Explicit exclusions")
+            appendLine()
+            if (exclusions.isEmpty()) {
+                appendLine("No explicit exclusions.")
+            } else {
+                exclusions.forEach { (modulePath, reason) ->
+                    appendLine("- `$modulePath` — $reason")
+                }
+            }
+        })
+
+        check(emptyModules.isEmpty()) {
+            "Detekt source coverage is empty for included modules: ${emptyModules.joinToString { it.first.path }}"
+        }
+        logger.lifecycle(
+            "Detekt source coverage: ${rows.size} modules, $totalFiles Kotlin files " +
+                "(main: $totalMain, test: $totalTest)",
+        )
+    }
+}
+
+val detektModuleTasks = detektTargetProjects.map { module ->
+    module.tasks.named<Detekt>("detekt")
+}
+
+val detektReportMerge by tasks.registering(ReportMergeTask::class) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Merges XML reports from all Detekt Kotlin subprojects."
+    output.set(layout.buildDirectory.file("reports/detekt/merged.xml"))
+    dependsOn(detektSourceCoverage)
+    detektModuleTasks.forEach { moduleTask ->
+        dependsOn(moduleTask)
+        input.from(moduleTask.flatMap { it.reports.checkstyle.outputLocation })
+    }
+}
+
+detektModuleTasks.forEach { moduleTask ->
+    moduleTask.configure {
+        mustRunAfter(detektSourceCoverage)
+    }
+}
+
+tasks.named<Detekt>("detekt") {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Analyzes all intended Kotlin library subprojects with Detekt."
+    dependsOn(detektSourceCoverage)
+    dependsOn(detektReportMerge)
+    // The root project is an orchestration boundary; analysis runs in module tasks.
+    onlyIf { false }
 }
 
 val publishableProjects = subprojects.filterNot { project ->

--- a/docs/lessons/2026-08-01-issue-1265-detekt-source-coverage.md
+++ b/docs/lessons/2026-08-01-issue-1265-detekt-source-coverage.md
@@ -1,0 +1,57 @@
+# 이슈 #1265 Kotlin 서브프로젝트 Detekt source coverage
+
+## 배경
+
+기존 `./gradlew detekt`는 root 프로젝트에 Kotlin source가 없어 `:detekt NO-SOURCE`로
+성공했다. 실제 library Kotlin source가 subproject에 있다는 사실을 task 결과가 검증하지
+못했으므로 Nightly static-analysis gate가 false-green 상태였다.
+
+## 결정
+
+- 실제 library 분석 대상 subproject에만 `dev.detekt` plugin과 `detekt` task를 등록한다.
+- examples·demo·benchmark·workshop source와 metadata-only/umbrella project는 명시적인
+  사유와 함께 제외한다. 문서화된 `exposed-jdbc-tests` 예외도 receipt에 기록한다.
+- root `detektSourceCoverage` task가 대상별 main/test Kotlin file 수를 계산하고, 대상
+  module의 source가 하나라도 비어 있으면 실패한다.
+- root `detekt`는 module task를 orchestration하고 `detektReportMerge`가 Checkstyle XML을
+  `build/reports/detekt/merged.xml`로 병합한다. 분석 범위 영수증은
+  `build/reports/detekt/source-coverage.md`에 저장한다.
+- 현재 저장소의 기존 Detekt rule finding 정리는 이 이슈의 source-coverage 범위를 넘는다.
+  finding은 module/merged report에 보존하고, source가 비어 있는 경우의 실패 보장은
+  별도의 guard로 유지한다.
+
+Detekt 2.0.0-alpha.5는 현재 repository Kotlin 2.4 toolchain과 호환되므로 legacy
+`io.gitlab.arturbosch.detekt` plugin 대신 `dev.detekt` plugin과 `checkstyle` report API를
+사용한다.
+
+## 검증
+
+실제 worktree에서 다음 명령을 실행했다.
+
+```bash
+./gradlew detekt --rerun-tasks --no-configuration-cache --console=plain
+```
+
+결과:
+
+- `BUILD SUCCESSFUL`
+- 분석 대상 75개 module
+- main 1,945개 + test 2,156개 = Kotlin source 4,101개
+- empty included module 0개
+- module Checkstyle XML 75개와 root merged XML 1개 생성
+- root task output은 module task를 집계하는 `SKIPPED` orchestration boundary이며, 실제
+  source scope 로그는 각 module task에서 출력된다.
+
+Nightly workflow는 source-coverage receipt를 검사하고 XML/receipt를
+`nightly-detekt-report` artifact로 보관한다.
+
+## 향후 방지책
+
+Detekt task를 추가하거나 분석 제외 범위를 바꿀 때는 `source-coverage.md`의 module 수,
+source file 수, `Empty included modules: 0`을 함께 확인한다. 새로운 rule cleanup은
+merged report의 finding을 기준으로 별도 issue에서 좁은 범위로 처리한다.
+
+## 참고
+
+- Detekt Gradle plugin: https://detekt.dev/docs/gettingstarted/gradle/
+- Detekt 2.0 migration: https://detekt.dev/docs/introduction/migration/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,7 +104,7 @@ lingua = "1.2.2"  # https://mvnrepository.com/artifact/com.github.pemistahl/ling
 kuromoji = "0.9.0"  # https://mvnrepository.com/artifact/com.atilika.kuromoji/kuromoji-ipadic
 
 # Plugin versions
-detekt = "1.23.8"  # https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-formatting
+detekt = "2.0.0-alpha.5"  # https://mvnrepository.com/artifact/dev.detekt/detekt-rules-ktlint-wrapper
 test-logger = "4.0.0"  # https://mvnrepository.com/artifact/com.adarshr/gradle-test-logger-plugin
 protobuf-plugin = "0.10.0"  # https://mvnrepository.com/artifact/com.google.protobuf/protobuf-gradle-plugin
 avro-plugin = "1.9.1"  # https://mvnrepository.com/artifact/com.github.davidmc24.gradle.plugin/gradle-avro-plugin
@@ -115,7 +115,7 @@ dependency-check = "12.2.2"  # https://mvnrepository.com/artifact/org.owasp/depe
 kotlinx-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlinx-atomicfu" }
 kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
 
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }
 graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvm-native" }
 protobuf-plugin = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
@@ -949,7 +949,7 @@ archunit = { module = "com.tngtech.archunit:archunit", version.ref = "archunit" 
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }
 
 # Detekt
-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+detekt-formatting = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }
 
 # Logback Appenders
 logback-slack-appender = { module = "com.github.maricn:logback-slack-appender", version.ref = "logback-slack-appender" }


### PR DESCRIPTION
## Summary

Closes #1265

- PR 제목: Fix: run Detekt across Kotlin subprojects (#1265)

Closes #1265.

The root `detekt` command now analyzes intended Kotlin library subprojects instead of returning a false-green `NO-SOURCE` result.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Upgrade Detekt to `2.0.0-alpha.5` and the `dev.detekt` plugin/report API for the repository Kotlin `2.4.0` toolchain.
- Register module Detekt tasks for the library source scope, with explicit example/demo/benchmark/workshop, metadata-only, umbrella, and documented `exposed-jdbc-tests` exclusions.
- Add a source coverage guard and deterministic receipt at `build/reports/detekt/source-coverage.md`.
- Merge module Checkstyle reports into `build/reports/detekt/merged.xml`.
- Verify and archive source/module coverage in Nightly CI.
- Document the behavior in both READMEs and a Korean lesson.

Existing Detekt findings remain available in the module and merged reports; rule cleanup is intentionally separate from this source-coverage issue. The empty-source guard remains blocking.

### 기존 섹션: Verification

- `./gradlew detekt --rerun-tasks --no-configuration-cache --console=plain` — `BUILD SUCCESSFUL`; 75 modules and 4,101 Kotlin files analyzed; empty included modules: 0.
- 75 module Checkstyle XML reports plus one merged XML report generated.
- `actionlint .github/workflows/nightly-tests.yml` — pass.
- `git diff --check` — pass.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1265, milestone `1.12.0`, assignee `debop`
- PR: #1282, head `52f6cbaee886354ad7fbfc690f3b708736eb1c9c`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1265-detekt-source-coverage`
- Labels: `build`, `ci`
- State: `MERGED`, merge commit `1c354807449560c51fa171f81c3336932815da71`
- CI: The root `detekt` command now analyzes intended Kotlin library subprojects instead of returning a false-green `NO-SOURCE` result. / - Upgrade Detekt to `2.0.0-alpha.5` and the `dev.detekt` plugin/report API for the repository Kotlin `2.4.0` toolchain. / - Register module Detekt tasks for the library source scope, with explicit example/demo/benchmark/workshop, metadata-only, umbrella, and documented `exposed-jdbc-tests` exclusions.

## DoD Status

- [x] Detekt tasks cover intended Kotlin subprojects.
- [x] Empty included source scope fails the build.
- [x] Exclusions are explicit and reviewable.
- [x] Source/module receipt and merged report are generated and archived by Nightly.
- [x] README and lesson documentation updated.
- [x] GitHub-hosted CI for this PR passed: 20 checks successful at head `52f6cbaee886354ad7fbfc690f3b708736eb1c9c`.
- [ ] Merge requires fresh exact-head approval.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1282 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1c354807449560c51fa171f81c3336932815da71`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
