### PR TITLE
Fix subject terminal fanout after caller cancellation

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/ResumableCollector.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/ResumableCollector.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.FlowCollector
  * - `drain`은 값 1건 소비 후 producer를 다시 깨우는 핸드셰이크 루프를 수행합니다.
  * - 완료 시 error가 있으면 예외를 던지고, 없으면 정상 종료합니다.
  * - 단일 슬롯(`value`) 구조라 동시 다중 producer에는 적합하지 않습니다.
+ * - drain 종료 시 producer 대기자를 깨우고 종료 callback을 한 번만 호출합니다.
  *
  * ```kotlin
  * val rc = ResumableCollector<Int>()
@@ -97,6 +98,22 @@ class ResumableCollector<T>: Resumable() {
         }
     }
 
+    /**
+     * consumer 준비를 기다리지 않고 terminal 상태를 기록합니다.
+     *
+     * ## 동작/계약
+     * - 호출자 취소 또는 개별 collector 취소로 [error]/[complete]의 handshake가 중단된 경우 사용합니다.
+     * - [error]를 저장하고 `done`을 설정한 뒤 drain을 재개해 collector가 종료 상태를 관찰하도록 합니다.
+     * - suspend하지 않으므로 terminal fanout의 남은 collector를 계속 처리할 수 있습니다.
+     *
+     * @param error 종료 시 전파할 예외이며 `null`이면 정상 완료입니다.
+     */
+    internal fun terminate(error: Throwable?) {
+        this.error = error
+        this.done.value = true
+        resume()
+    }
+
     private suspend inline fun whenConsumerReady(action: () -> Unit) {
         consumerReady.await()
         action()
@@ -141,30 +158,29 @@ class ResumableCollector<T>: Resumable() {
      */
     suspend fun drain(collector: FlowCollector<T>, onComplete: ((ResumableCollector<T>) -> Unit)? = null) =
         coroutineScope {
-            while (true) {
-                coroutineContext.ensureActive()
-                readyConsumer()
-                awaitSignal()
+            try {
+                while (true) {
+                    coroutineContext.ensureActive()
+                    readyConsumer()
+                    awaitSignal()
 
-                if (hasValue.value) {
-                    val v = value
-                    value = uninitialized()
-                    hasValue.value = false
+                    if (hasValue.value) {
+                        val v = value
+                        value = uninitialized()
+                        hasValue.value = false
 
-                    try {
                         coroutineContext.ensureActive()
                         collector.emit(v)
-                    } catch (ex: Throwable) {
-                        onComplete?.invoke(this@ResumableCollector)
-                        readyConsumer()             // unblock waiters
-                        throw ex
+                    }
+
+                    if (done.value) {
+                        error?.let { throw it }
+                        break
                     }
                 }
-
-                if (done.value) {
-                    error?.let { throw it }
-                    break
-                }
+            } finally {
+                onComplete?.invoke(this@ResumableCollector)
+                readyConsumer()
             }
         }
 }

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/MulticastSubject.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/MulticastSubject.kt
@@ -4,13 +4,13 @@ import io.bluetape4k.coroutines.flow.exceptions.FlowOperationException
 import io.bluetape4k.coroutines.flow.extensions.Resumable
 import io.bluetape4k.coroutines.flow.extensions.ResumableCollector
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.logging.debug
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -118,6 +118,7 @@ class MulticastSubject<T> private constructor(
      * - 최초 terminal 신호만 적용하며 이미 종료된 이후 재호출하면 추가 동작 없이 반환합니다.
      * - `terminated`에 예외를 저장한 뒤 collector 배열을 종료 상태로 교체합니다.
      * - 교체 시점의 collector 각각에 `error(ex)`를 호출합니다.
+     * - 호출자 취소가 fanout 중 발생해도 모든 collector에 오류를 전달한 뒤 원래 취소를 다시 전파합니다.
      * - 종료 이후 신규 collect는 등록에 실패하고 저장된 예외가 재전파될 수 있습니다.
      *
      * @param ex 종료 원인 예외입니다.
@@ -129,15 +130,8 @@ class MulticastSubject<T> private constructor(
         }
 
         terminated = ex
-        collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
-            .forEach { collector ->
-                try {
-                    collector.error(ex)
-                } catch (e: CancellationException) {
-                    currentCoroutineContext().ensureActive() // 부모 취소 시 rethrow
-                    log.debug { "$collector 는 개별 취소됨." } // 이 collector만 취소된 경우
-                }
-            }
+        val colls = collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
+        notifyTerminalCollectors(colls, { error(ex) }, ex)
     }
 
     /**
@@ -148,6 +142,7 @@ class MulticastSubject<T> private constructor(
      * - 최초 terminal 신호만 적용하며 이미 종료된 이후 재호출하면 추가 동작 없이 반환합니다.
      * - 내부 종료 원인을 `DONE`으로 기록하고 collector 배열을 종료 상태로 교체합니다.
      * - 교체 시점의 collector 각각에 `complete()`를 호출합니다.
+     * - 호출자 취소가 fanout 중 발생해도 모든 collector를 깨운 뒤 원래 취소를 다시 전파합니다.
      */
     @Suppress("UNCHECKED_CAST")
     override suspend fun complete() = signalMutex.withLock {
@@ -156,15 +151,46 @@ class MulticastSubject<T> private constructor(
         }
 
         terminated = DONE
-        collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
-            .forEach { collector ->
-                try {
-                    collector.complete()
-                } catch (e: CancellationException) {
-                    currentCoroutineContext().ensureActive() // 부모 취소 시 rethrow
-                    log.debug { "$collector 는 개별 취소됨." } // 이 collector만 취소된 경우
+        val colls = collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
+        notifyTerminalCollectors(colls, { complete() }, null)
+    }
+
+    /**
+     * terminal 신호를 스냅샷 전체에 전달하고 호출자 취소는 fanout 이후 다시 전파합니다.
+     *
+     * ## 동작/계약
+     * - 호출자가 취소된 뒤에는 consumer 준비를 다시 기다리지 않고 terminal 상태와 wake-up을 기록합니다.
+     * - 개별 collector 취소는 해당 collector만 깨운 뒤 다음 collector로 진행합니다.
+     * - 호출자 취소가 있었다면 최초 `CancellationException`을 fanout 완료 후 다시 던집니다.
+     */
+    private suspend fun notifyTerminalCollectors(
+        collectors: Array<ResumableCollector<T>>,
+        signal: suspend ResumableCollector<T>.() -> Unit,
+        terminalError: Throwable?,
+    ) {
+        var callerCancellation: CancellationException? = null
+
+        collectors.forEach { collector ->
+            if (callerCancellation != null) {
+                collector.terminate(terminalError)
+                return@forEach
+            }
+
+            try {
+                currentCoroutineContext().ensureActive()
+                collector.signal()
+            } catch (e: CancellationException) {
+                if (currentCoroutineContext().isActive) {
+                    collector.terminate(terminalError)
+                } else {
+                    callerCancellation = e
+                    collector.terminate(terminalError)
                 }
             }
+        }
+
+        callerCancellation?.let { throw it }
+        currentCoroutineContext().ensureActive()
     }
 
     /**

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/PublishSubject.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/PublishSubject.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.AbstractFlow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -134,6 +135,7 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
      * ## 동작/계약
      * - 진행 중인 값 전파와 다른 종료 신호가 끝날 때까지 Subject 단위로 대기합니다.
      * - 최초 1회 호출에서만 `error`를 저장하고 collector 배열을 종료 상태로 교체합니다.
+     * - 호출자 취소가 fanout 중 발생해도 스냅샷의 모든 collector에 오류를 전달한 뒤 원래 취소를 다시 전파합니다.
      * - 이미 종료된 이후 재호출하면 추가 동작 없이 반환합니다.
      * - 이후 신규 collect는 저장된 오류를 다시 전파할 수 있습니다.
      *
@@ -152,13 +154,7 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
 
         this.error = ex
         val colls = collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
-        colls.forEach { collector ->
-            try {
-                collector.error(ex)
-            } catch (e: CancellationException) {
-                currentCoroutineContext().ensureActive()
-            }
-        }
+        notifyTerminalCollectors(colls, { error(ex) }, ex)
     }
 
     /**
@@ -167,18 +163,51 @@ class PublishSubject<T>: AbstractFlow<T>(), SubjectApi<T> {
      * ## 동작/계약
      * - 진행 중인 값 전파와 다른 종료 신호가 끝날 때까지 Subject 단위로 대기합니다.
      * - collector 배열을 종료 상태로 교체한 뒤 각 collector에 `complete()`를 호출합니다.
+     * - 호출자 취소가 fanout 중 발생해도 스냅샷의 모든 collector를 깨운 뒤 원래 취소를 다시 전파합니다.
      * - 완료 이후 신규 collect는 즉시 반환될 수 있으며 과거 값은 재생되지 않습니다.
      * - 종료 전 등록된 collector가 없으면 상태 전환만 수행하고 반환합니다.
      */
     override suspend fun complete() = signalMutex.withLock {
         val colls = collectors.getAndSet(TERMINATED as Array<ResumableCollector<T>>)
-        colls.forEach { collector ->
+        notifyTerminalCollectors(colls, { complete() }, null)
+    }
+
+    /**
+     * terminal 신호를 스냅샷 전체에 전달하고 호출자 취소는 fanout 이후 다시 전파합니다.
+     *
+     * ## 동작/계약
+     * - 호출자가 취소된 뒤에는 consumer 준비를 다시 기다리지 않고 terminal 상태와 wake-up을 기록합니다.
+     * - 개별 collector 취소는 해당 collector만 깨운 뒤 다음 collector로 진행합니다.
+     * - 호출자 취소가 있었다면 최초 `CancellationException`을 fanout 완료 후 다시 던집니다.
+     */
+    private suspend fun notifyTerminalCollectors(
+        collectors: Array<ResumableCollector<T>>,
+        signal: suspend ResumableCollector<T>.() -> Unit,
+        terminalError: Throwable?,
+    ) {
+        var callerCancellation: CancellationException? = null
+
+        collectors.forEach { collector ->
+            if (callerCancellation != null) {
+                collector.terminate(terminalError)
+                return@forEach
+            }
+
             try {
-                collector.complete()
-            } catch (e: CancellationException) {
                 currentCoroutineContext().ensureActive()
+                collector.signal()
+            } catch (e: CancellationException) {
+                if (currentCoroutineContext().isActive) {
+                    collector.terminate(terminalError)
+                } else {
+                    callerCancellation = e
+                    collector.terminate(terminalError)
+                }
             }
         }
+
+        callerCancellation?.let { throw it }
+        currentCoroutineContext().ensureActive()
     }
 
     private fun add(inner: ResumableCollector<T>): Boolean {

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/SubjectCancellationTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/SubjectCancellationTest.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.coroutines.flow.extensions.subject
 
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.junit5.coroutines.withSingleThread
@@ -9,6 +11,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -348,5 +351,299 @@ class SubjectCancellationTest {
 
         releaseCollector.complete(Unit)
         job.cancelAndJoin()
+    }
+
+    @Test
+    fun `PublishSubject terminal fanout continues after caller cancellation`() = runTest {
+        val subject = PublishSubject<Int>()
+        val firstCollectorEntered = CompletableDeferred<Unit>()
+        val releaseFirstCollector = CompletableDeferred<Unit>()
+        val secondCollectorCompleted = CompletableDeferred<Unit>()
+
+        val firstCollector = launch {
+            subject.collect {
+                firstCollectorEntered.complete(Unit)
+                releaseFirstCollector.await()
+            }
+        }
+        val secondCollector = launch {
+            subject.collect { }
+            secondCollectorCompleted.complete(Unit)
+        }
+
+        subject.awaitCollectors(2)
+        subject.emit(1)
+        firstCollectorEntered.await()
+
+        val releaseJob = launch {
+            delay(20.milliseconds)
+            releaseFirstCollector.complete(Unit)
+        }
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(10.milliseconds) {
+                subject.complete()
+            }
+        }
+        releaseJob.join()
+
+        withTimeout(1.seconds) {
+            secondCollectorCompleted.await()
+        }
+
+        firstCollector.cancelAndJoin()
+        secondCollector.cancelAndJoin()
+        subject.collectorCount shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `PublishSubject error fanout continues after caller cancellation`() = runTest {
+        val subject = PublishSubject<Int>()
+        val failure = IllegalStateException("boom")
+        val firstCollectorEntered = CompletableDeferred<Unit>()
+        val releaseFirstCollector = CompletableDeferred<Unit>()
+        val secondCollectorError = CompletableDeferred<Throwable>()
+
+        val firstCollector = launch {
+            try {
+                subject.collect {
+                    firstCollectorEntered.complete(Unit)
+                    releaseFirstCollector.await()
+                }
+            } catch (_: IllegalStateException) {
+            }
+        }
+        val secondCollector = launch {
+            try {
+                subject.collect { }
+            } catch (ex: IllegalStateException) {
+                secondCollectorError.complete(ex)
+            }
+        }
+
+        subject.awaitCollectors(2)
+        subject.emit(1)
+        firstCollectorEntered.await()
+
+        val releaseJob = launch {
+            delay(20.milliseconds)
+            releaseFirstCollector.complete(Unit)
+        }
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(10.milliseconds) {
+                subject.emitError(failure)
+            }
+        }
+        releaseJob.join()
+
+        val actual = withTimeout(1.seconds) {
+            secondCollectorError.await()
+        }
+        (actual.cause ?: actual) shouldBeSameInstanceAs failure
+
+        firstCollector.cancelAndJoin()
+        secondCollector.cancelAndJoin()
+        subject.collectorCount shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `PublishSubject complete continues after first collector cancellation`() = runTest {
+        val subject = PublishSubject<Int>()
+        val secondCollectorCompleted = CompletableDeferred<Unit>()
+
+        val firstCollector = launch {
+            subject.collect { }
+        }
+        val secondCollector = launch {
+            subject.collect { }
+            secondCollectorCompleted.complete(Unit)
+        }
+
+        subject.awaitCollectors(2)
+        firstCollector.cancelAndJoin()
+        subject.complete()
+
+        withTimeout(1.seconds) {
+            secondCollectorCompleted.await()
+        }
+
+        secondCollector.cancelAndJoin()
+        subject.collectorCount shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `PublishSubject error fanout continues after first collector cancellation`() = runTest {
+        val subject = PublishSubject<Int>()
+        val failure = IllegalStateException("boom")
+        val secondCollectorError = CompletableDeferred<Throwable>()
+
+        val firstCollector = launch {
+            subject.collect { }
+        }
+        val secondCollector = launch {
+            try {
+                subject.collect { }
+            } catch (ex: IllegalStateException) {
+                secondCollectorError.complete(ex)
+            }
+        }
+
+        subject.awaitCollectors(2)
+        firstCollector.cancelAndJoin()
+        subject.emitError(failure)
+
+        val actual = withTimeout(1.seconds) {
+            secondCollectorError.await()
+        }
+        (actual.cause ?: actual) shouldBeSameInstanceAs failure
+
+        secondCollector.cancelAndJoin()
+        subject.collectorCount shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `MulticastSubject terminal fanout continues after caller cancellation`() = runTest {
+        val subject = MulticastSubject<Int>(2)
+        val firstCollectorEntered = CompletableDeferred<Unit>()
+        val releaseFirstCollector = CompletableDeferred<Unit>()
+        val secondCollectorCompleted = CompletableDeferred<Unit>()
+
+        val firstCollector = launch {
+            subject.collect {
+                firstCollectorEntered.complete(Unit)
+                releaseFirstCollector.await()
+            }
+        }
+        val secondCollector = launch {
+            subject.collect { }
+            secondCollectorCompleted.complete(Unit)
+        }
+
+        subject.awaitCollectors(2)
+        subject.emit(1)
+        firstCollectorEntered.await()
+
+        val releaseJob = launch {
+            delay(20.milliseconds)
+            releaseFirstCollector.complete(Unit)
+        }
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(10.milliseconds) {
+                subject.complete()
+            }
+        }
+        releaseJob.join()
+
+        withTimeout(1.seconds) {
+            secondCollectorCompleted.await()
+        }
+
+        firstCollector.cancelAndJoin()
+        secondCollector.cancelAndJoin()
+        subject.collectorCount shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `MulticastSubject error fanout continues after caller cancellation`() = runTest {
+        val subject = MulticastSubject<Int>(2)
+        val failure = IllegalStateException("boom")
+        val firstCollectorEntered = CompletableDeferred<Unit>()
+        val releaseFirstCollector = CompletableDeferred<Unit>()
+        val secondCollectorError = CompletableDeferred<Throwable>()
+
+        val firstCollector = launch {
+            try {
+                subject.collect {
+                    firstCollectorEntered.complete(Unit)
+                    releaseFirstCollector.await()
+                }
+            } catch (_: IllegalStateException) {
+            }
+        }
+        val secondCollector = launch {
+            try {
+                subject.collect { }
+            } catch (ex: IllegalStateException) {
+                secondCollectorError.complete(ex)
+            }
+        }
+
+        subject.awaitCollectors(2)
+        subject.emit(1)
+        firstCollectorEntered.await()
+
+        val releaseJob = launch {
+            delay(20.milliseconds)
+            releaseFirstCollector.complete(Unit)
+        }
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(10.milliseconds) {
+                subject.emitError(failure)
+            }
+        }
+        releaseJob.join()
+
+        val actual = withTimeout(1.seconds) {
+            secondCollectorError.await()
+        }
+        (actual.cause ?: actual) shouldBeSameInstanceAs failure
+
+        firstCollector.cancelAndJoin()
+        secondCollector.cancelAndJoin()
+        subject.collectorCount shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `MulticastSubject complete continues after first collector cancellation`() = runTest {
+        val subject = MulticastSubject<Int>(2)
+        val secondCollectorCompleted = CompletableDeferred<Unit>()
+
+        val firstCollector = launch {
+            subject.collect { }
+        }
+        val secondCollector = launch {
+            subject.collect { }
+            secondCollectorCompleted.complete(Unit)
+        }
+
+        subject.awaitCollectors(2)
+        firstCollector.cancelAndJoin()
+        subject.complete()
+
+        withTimeout(1.seconds) {
+            secondCollectorCompleted.await()
+        }
+
+        secondCollector.cancelAndJoin()
+        subject.collectorCount shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `MulticastSubject error fanout continues after first collector cancellation`() = runTest {
+        val subject = MulticastSubject<Int>(2)
+        val failure = IllegalStateException("boom")
+        val secondCollectorError = CompletableDeferred<Throwable>()
+
+        val firstCollector = launch {
+            subject.collect { }
+        }
+        val secondCollector = launch {
+            try {
+                subject.collect { }
+            } catch (ex: IllegalStateException) {
+                secondCollectorError.complete(ex)
+            }
+        }
+
+        subject.awaitCollectors(2)
+        firstCollector.cancelAndJoin()
+        subject.emitError(failure)
+
+        val actual = withTimeout(1.seconds) {
+            secondCollectorError.await()
+        }
+        (actual.cause ?: actual) shouldBeSameInstanceAs failure
+
+        secondCollector.cancelAndJoin()
+        subject.collectorCount shouldBeEqualTo 0
     }
 }

--- a/docs/lessons/2026-08-01-issue-1267-subject-terminal-fanout.md
+++ b/docs/lessons/2026-08-01-issue-1267-subject-terminal-fanout.md
@@ -1,0 +1,51 @@
+# 이슈 #1267 Subject terminal fanout 취소 경계
+
+## Context
+
+`PublishSubject`와 `MulticastSubject`는 terminal 상태를 먼저 기록한 뒤 현재
+collector 배열을 순서대로 순회한다. 첫 collector가 값 소비 중이면
+`ResumableCollector.complete()`/`error()`가 consumer 준비 신호를 기다리는데,
+이때 caller가 취소되면 기존 순회가 즉시 중단되어 뒤의 collector가 종료 신호를
+받지 못하고 Subject에 남을 수 있었다.
+
+## Decision or Finding
+
+- terminal fanout은 호출 시점의 collector snapshot을 끝까지 처리한다.
+- caller 또는 개별 collector 취소로 handshake가 중단된 collector에는
+  `ResumableCollector.terminate()`로 terminal 상태와 wake-up을 non-suspending 방식으로
+  기록한다.
+- caller 취소가 감지되면 남은 snapshot collector도 같은 terminal 상태로 정리한 뒤
+  최초 `CancellationException`을 다시 던진다.
+- 예외 terminal은 coroutine stack-trace recovery로 wrapper가 생길 수 있으므로
+  regression test는 wrapper의 cause가 원래 예외 객체인지 검증한다.
+
+## Outcome
+
+첫 collector가 값 소비를 멈춘 상태에서 caller timeout을 발생시켜도 두 번째
+collector가 정상 완료 또는 동일한 terminal error를 받는다. 종료 후 두
+Subject의 `collectorCount`는 0이며, 기존 single-collector timeout 및
+개별 collector 취소 계약은 유지된다.
+
+## Verification
+
+- RED: 수정 전 `SubjectCancellationTest` 16개 중 새 terminal fanout 4개가 두 번째
+  collector 대기에서 virtual-time timeout으로 실패했다.
+- GREEN targeted: `./gradlew :bluetape4k-coroutines:test --tests
+  'io.bluetape4k.coroutines.flow.extensions.subject.SubjectCancellationTest'
+  --rerun-tasks --no-configuration-cache --console=plain` 결과
+  `SUCCESS: Executed 20 tests in 2.5s`, `BUILD SUCCESSFUL`.
+- GREEN full: `./gradlew :bluetape4k-coroutines:test --rerun-tasks
+  --no-configuration-cache --console=plain` 결과 `SUCCESS: Executed 590 tests in
+  15.3s`, `BUILD SUCCESSFUL`.
+- affected detekt와 Dokka 생성이 `BUILD SUCCESSFUL`로 완료되었고,
+  `git diff --check`도 통과했다. Detekt/Dokka의 기존 StructuredConcurrency
+  링크 경고는 남아 있지만 이번 변경 파일에는 새 경고가 없다.
+
+## Future Guidance
+
+`ResumableCollector`의 producer-consumer handshake를 바꿀 때는 caller timeout이
+첫 terminal signal에서 발생하는 fanout, 개별 collector 취소, 종료 후
+`collectorCount == 0`을 함께 검증한다. 취소된 caller의 cleanup을
+`NonCancellable` 대기만으로 처리하면 영구적으로 busy한 collector에서 terminal
+호출이 반환하지 않을 수 있으므로, bounded non-suspending terminal state와
+wake-up 경로를 우선 검토한다.


### PR DESCRIPTION
## Summary

Closes #1267

- PR 제목: Fix subject terminal fanout after caller cancellation

- preserve terminal state and wake-up when a subject caller or individual collector is cancelled during handshake
- continue terminal fanout across the full collector snapshot, then rethrow the original caller cancellation
- add PublishSubject and MulticastSubject regressions plus a Korean technical lesson

Closes #1267

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary
- preserve terminal state and wake-up when a subject caller or individual collector is cancelled during handshake
- continue terminal fanout across the full collector snapshot, then rethrow the original caller cancellation
- add PublishSubject and MulticastSubject regressions plus a Korean technical lesson

Closes #1267

### Testing
- `SubjectCancellationTest`: 20 tests
- `:bluetape4k-coroutines:test`: 590 tests
- `:bluetape4k-coroutines:detekt`: BUILD SUCCESSFUL (pre-existing findings remain outside this change)
- `:bluetape4k-coroutines:dokkaGenerate`: BUILD SUCCESSFUL (pre-existing StructuredConcurrency link warnings remain)
- `git diff --check`

### DoD Status
- [x] caller cancellation does not strand later snapshot collectors
- [x] individual collector cancellation wakes the producer and removes the collector
- [x] terminal error identity is preserved through coroutine stack-trace recovery
- [x] collectorCount reaches zero after terminal fanout
- [ ] remote CI and exact-head review pending

## Validation

- `SubjectCancellationTest`: 20 tests
- `:bluetape4k-coroutines:test`: 590 tests
- `:bluetape4k-coroutines:detekt`: BUILD SUCCESSFUL (pre-existing findings remain outside this change)
- `:bluetape4k-coroutines:dokkaGenerate`: BUILD SUCCESSFUL (pre-existing StructuredConcurrency link warnings remain)
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1267, milestone `1.12.0`, assignee `debop`
- PR: #1285, head `8fe854ce91bb960a20549d2a61a48dd85cf6642f`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1267-subject-terminal-fanout`
- Labels: 없음
- State: `MERGED`, merge commit `e77d462c5253b3e9d02c7d42f35667e090724edb`
- CI: - `:bluetape4k-coroutines:detekt`: BUILD SUCCESSFUL (pre-existing findings remain outside this change) / - [ ] remote CI and exact-head review pending

## DoD Status

- [x] caller cancellation does not strand later snapshot collectors
- [x] individual collector cancellation wakes the producer and removes the collector
- [x] terminal error identity is preserved through coroutine stack-trace recovery
- [x] collectorCount reaches zero after terminal fanout
- [ ] remote CI and exact-head review pending

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1285 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e77d462c5253b3e9d02c7d42f35667e090724edb`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
