### PR TITLE
Fix Hibernate entity equality across types and persistence

### DIFF
--- a/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt
+++ b/data/hibernate/src/main/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntity.kt
@@ -9,9 +9,10 @@ import java.io.Serializable
 /**
  * JPA entity를 위한 base abstraction입니다.
  *
- * Equality uses the assigned identifier only when both entities are persisted.
- * Transient entities fall back to [equalProperties], so their default
- * [hashCode] must stay stable for hash-based collections before persistence.
+ * Equality는 Hibernate proxy를 해제한 effective entity type이 같은 경우에만
+ * persisted identifier 또는 transient business signature를 사용합니다.
+ * [hashCode]는 type 기반으로만 계산하여 transient entity가 영속화된 뒤에도
+ * `HashSet`과 `HashMap`에서 같은 위치를 유지합니다.
  */
 abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(), JpaEntity<ID> {
 
@@ -21,6 +22,12 @@ abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(),
          */
         private fun <TId> hasSameNonDefaultId(id: TId, target: JpaEntity<*>): Boolean =
             id == target.id
+
+        /**
+         * Hibernate proxy를 해제한 두 entity의 effective type이 같은지 반환합니다.
+         */
+        private fun hasSameEntityType(self: AbstractJpaEntity<*>, target: JpaEntity<*>): Boolean =
+            Hibernate.getClass(self) == Hibernate.getClass(target)
 
         /**
          * 두 transient entity가 같은 business signature를 공유하는지 반환합니다.
@@ -46,6 +53,7 @@ abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(),
     override fun equals(other: Any?): Boolean {
         val target = other?.let { Hibernate.unproxy(it) } as? JpaEntity<*> ?: return false
         return when {
+            !hasSameEntityType(this, target) -> false
             isPersisted != target.isPersisted -> false
             isPersisted && target.isPersisted -> hasSameNonDefaultId(id, target)
             else                              -> hasSameBusinessSignature<ID>(this, target)
@@ -55,12 +63,13 @@ abstract class AbstractJpaEntity<ID: Serializable>: AbstractPersistenceObject(),
     /**
      * entity hash code를 반환합니다.
      *
-     * Persisted entities use the identifier hash. Transient entities use the
-     * Hibernate-resolved entity class hash so equal transient instances land in
-     * the same hash bucket even before an identifier is assigned.
+     * Persisted 여부와 관계없이 Hibernate가 해석한 effective entity type만
+     * 사용합니다. 따라서 identifier가 할당되어도 hash-based collection에서
+     * entity의 위치가 바뀌지 않습니다. 서로 다른 type은 같은 hash를 가질 수
+     * 있지만 equals가 false이므로 hash contract를 위반하지 않습니다.
      */
     override fun hashCode(): Int {
-        return id?.hashCode() ?: Hibernate.getClass(this).hashCode()
+        return Hibernate.getClass(this).hashCode()
     }
 
     /**

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntityUnitTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/model/AbstractJpaEntityUnitTest.kt
@@ -6,9 +6,26 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.hibernate.Hibernate
+import org.hibernate.proxy.HibernateProxy
+import org.hibernate.proxy.LazyInitializer
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class AbstractJpaEntityUnitTest {
+
+    private val proxy = mockk<HibernateProxy>()
+    private val initializer = mockk<LazyInitializer>()
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(proxy, initializer)
+        every { proxy.asHibernateProxy() } returns proxy
+        every { proxy.hibernateLazyInitializer } returns initializer
+    }
 
     // 테스트용 구체 엔티티
     class TestEntity(
@@ -17,6 +34,14 @@ class AbstractJpaEntityUnitTest {
     ) : AbstractJpaEntity<Long>() {
         override fun equalProperties(other: Any): Boolean =
             other is TestEntity && name == other.name
+    }
+
+    class OtherEntity(
+        val name: String,
+        override var id: Long? = null,
+    ) : AbstractJpaEntity<Long>() {
+        override fun equalProperties(other: Any): Boolean =
+            other is OtherEntity && name == other.name
     }
 
     @Test
@@ -74,6 +99,31 @@ class AbstractJpaEntityUnitTest {
     }
 
     @Test
+    fun `다른 entity type은 같은 id여도 equals false`() {
+        val testEntity = TestEntity("alice", id = 1L)
+        val otherEntity = OtherEntity("alice", id = 1L)
+
+        testEntity.equals(otherEntity).shouldBeFalse()
+    }
+
+    @Test
+    fun `같은 entity type의 Hibernate proxy는 실제 entity와 equals true`() {
+        val entity = TestEntity("alice", id = 1L)
+        every { initializer.implementation } returns entity
+
+        entity.equals(proxy).shouldBeTrue()
+    }
+
+    @Test
+    fun `다른 entity type을 감싼 Hibernate proxy는 같은 id여도 equals false`() {
+        val entity = TestEntity("alice", id = 1L)
+        val otherEntity = OtherEntity("alice", id = 1L)
+        every { initializer.implementation } returns otherEntity
+
+        entity.equals(proxy).shouldBeFalse()
+    }
+
+    @Test
     fun `persisted와 transient 엔티티는 false`() {
         val persisted = TestEntity("alice", id = 1L)
         val transient = TestEntity("alice")
@@ -83,7 +133,7 @@ class AbstractJpaEntityUnitTest {
     @Test
     fun `null과 비교하면 false`() {
         val entity = TestEntity("test")
-        entity.equals(null).shouldBeFalse()
+        (entity == null).shouldBeFalse()
     }
 
     @Test
@@ -113,9 +163,24 @@ class AbstractJpaEntityUnitTest {
     }
 
     @Test
-    fun `hashCode는 persisted 엔티티에서 id hashCode를 반환한다`() {
+    fun `hashCode는 persisted 엔티티에서도 effective type hashCode를 반환한다`() {
         val entity = TestEntity("test", id = 42L)
-        entity.hashCode() shouldBeEqualTo 42L.hashCode()
+        entity.hashCode() shouldBeEqualTo Hibernate.getClass(entity).hashCode()
+    }
+
+    @Test
+    fun `transient에서 persisted로 전환해도 hash collection 조회가 유지된다`() {
+        val entity = TestEntity("alice")
+        val hashBefore = entity.hashCode()
+        val assignedId = hashBefore.toLong() + 1L
+        val entities = hashSetOf(entity)
+        val values = hashMapOf(entity to "value")
+
+        entity.id = assignedId
+
+        entity.hashCode() shouldBeEqualTo hashBefore
+        entities.contains(entity).shouldBeTrue()
+        values[entity] shouldBeEqualTo "value"
     }
 
     @Test

--- a/docs/lessons/2026-08-01-issue-1268-jpa-entity-equality.md
+++ b/docs/lessons/2026-08-01-issue-1268-jpa-entity-equality.md
@@ -1,0 +1,46 @@
+# #1268 Hibernate 엔티티 equality와 hash 안정성
+
+## Context
+
+`AbstractJpaEntity`는 persisted entity를 identifier만으로 비교하고 transient
+entity는 business signature로 비교했습니다. 이 경로는 서로 다른 entity type이
+같은 identifier를 가질 때 동일하다고 판정했으며, identifier가 할당되면 hash code가
+type hash에서 identifier hash로 바뀌어 `HashSet`과 `HashMap` 조회가 끊겼습니다.
+
+## Decision or Finding
+
+- equality는 `Hibernate.unproxy` 이후 effective entity type이 같은 경우에만
+  persisted identifier 또는 transient business signature를 비교합니다.
+- hash code는 persisted 여부와 무관하게 `Hibernate.getClass(this)`의 hash만
+  사용합니다. 서로 다른 type의 hash 충돌은 허용되며 type equality가 이를
+  구분합니다.
+- proxy fixture는 테스트 필드로 재사용하고 `@BeforeEach`에서 `clearMocks`한 뒤
+  각 테스트가 implementation만 설정하도록 했습니다.
+
+## Outcome
+
+서로 다른 entity type과 proxy가 같은 identifier를 공유해도 equality가 false가
+되며, 같은 type의 proxy는 실제 entity와 계속 equality를 유지합니다. transient
+entity를 hash collection에 넣은 뒤 identifier를 할당해도 기존 key 위치와 조회가
+유지됩니다.
+
+## Verification
+
+- RED: `AbstractJpaEntityUnitTest`에서 다른 type proxy equality와
+  transient-to-persisted hash collection 조회의 2개 실패를 재현했습니다.
+- GREEN: 대상 테스트 19개 통과, `BUILD SUCCESSFUL`.
+- GREEN: `:bluetape4k-hibernate:test` 502개 통과, 13.6초, `BUILD SUCCESSFUL`.
+- `git diff --check` 통과.
+- `:bluetape4k-hibernate:detekt` task는 `BUILD SUCCESSFUL`이며 변경 파일 finding은
+  없습니다. 기존 Hibernate 모듈의 generic exception, function-count,
+  Serializable 경고는 남아 있습니다.
+- `:bluetape4k-hibernate:dokkaGenerate`는 `BUILD SUCCESSFUL`입니다. 기존
+  `README.ko.md` 링크 unresolved warning이 남아 있습니다.
+
+## Future Guidance
+
+JPA entity equality를 변경할 때는 identifier 비교만 확인하지 말고 Hibernate
+proxy의 effective type, persisted 전환 전후 hash collection 동작, 서로 다른
+subclass의 동일 identifier를 함께 검증합니다. Hash code에 mutable identifier를
+포함하면 collection key가 소실될 수 있으므로 type 기반의 안정적인 hash 정책을
+유지해야 합니다.


### PR DESCRIPTION
## Summary

Closes #1268

- PR 제목: Fix Hibernate entity equality across types and persistence

- require Hibernate-unproxied effective entity types to match before persisted identifier equality
- keep entity hash codes stable across transient-to-persisted transitions
- cover same-type and cross-type proxies plus HashSet/HashMap transitions

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Stack

- Stacked on #1285 (`fix/issue-1267-subject-terminal-fanout`)
- Closes #1268

### 기존 섹션: Verification

- `:bluetape4k-hibernate:test --tests "io.bluetape4k.hibernate.model.AbstractJpaEntityUnitTest"` — 19 tests passed
- `:bluetape4k-hibernate:test` — 502 tests passed
- `:bluetape4k-hibernate:detekt` — task passed; pre-existing findings remain outside changed files
- `:bluetape4k-hibernate:dokkaGenerate` — task passed; pre-existing README.ko.md link warning remains
- `git diff --check` — passed

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1268, milestone `1.12.0`, assignee `debop`
- PR: #1286, head `8ccff11b51faf97858730825c112566865b2c0d3`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1268-jpa-entity-equality`
- Labels: `bug`
- State: `MERGED`, merge commit `9b054ec7ca54f55fb0a2b89e8cf41d680a2885c0`
- CI: - `:bluetape4k-hibernate:detekt` — task passed; pre-existing findings remain outside changed files / - [ ] Remote CI and exact-head review

## DoD Status

- [x] Type-aware proxy equality
- [x] Stable hash-based collection membership
- [x] Regression tests and Korean lesson
- [ ] Remote CI and exact-head review
- [ ] Merge after separate approval gate

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1286 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9b054ec7ca54f55fb0a2b89e8cf41d680a2885c0`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
