### PR TITLE
Make resilient near-cache failures caller-visible

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCache.kt
@@ -11,6 +11,7 @@ import io.github.resilience4j.core.IntervalFunction
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import kotlinx.atomicfu.atomic
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.locks.ReentrantLock
@@ -28,6 +29,9 @@ import kotlin.concurrent.withLock
  * - **retry**: consumer thread에서 resilience4j [Retry]로 재시도 (지수 백오프 옵션)
  * - **get graceful degradation**: back cache GET 실패 시 front 값 반환 또는 null
  *
+ * write-behind mutation 메서드는 [CompletableFuture]를 반환한다. future가 정상 완료되면
+ * back cache 반영까지 끝난 것이고, 재시도 소진 또는 close drain timeout은 예외 완료된다.
+ *
  * ```kotlin
  * Application (blocking)
  *     |
@@ -44,7 +48,7 @@ import kotlin.concurrent.withLock
  * ```kotlin
  * val config = ResilientNearJCacheConfig<String, Int>(retryMaxAttempts = 3)
  * val nearCache = ResilientNearJCache(backJCache, config)
- * nearCache.put("hello", 5)
+ * nearCache.put("hello", 5).join()
  * val value = nearCache.get("hello")
  * // value == 5
  * nearCache.close()
@@ -60,7 +64,7 @@ class ResilientNearJCache<K: Any, V: Any>(
 
     companion object: KLogging()
 
-    private val closeDrainTimeoutMillis: Long = 5_000L
+    private val closeDrainTimeoutMillis: Long = config.closeDrainTimeout.toMillis().coerceAtLeast(1L)
 
     private val closed = atomic(false)
     val isClosed by closed
@@ -75,6 +79,7 @@ class ResilientNearJCache<K: Any, V: Any>(
     private val retry: Retry = buildRetry()
     private val queue = LinkedBlockingQueue<QueuedCommand<K, V>>(config.writeQueueCapacity)
     private val writeStateLock = ReentrantLock()
+    private val pendingCommands = ConcurrentHashMap.newKeySet<QueuedCommand<K, V>>()
     private val pendingMutationTokens = ConcurrentHashMap<K, MutationToken<V>>()
     private val pendingClearToken = atomic<ClearToken?>(null)
     private val stateVersion = atomic(0L)
@@ -111,7 +116,7 @@ class ResilientNearJCache<K: Any, V: Any>(
                         "Back cache write failed after ${config.retryMaxAttempts} retries, compensating command: ${cmd.command}"
                     }
                     writeStateLock.withLock {
-                        completeCommand(cmd, failed = true)
+                        completeCommand(cmd, failed = true, failure = e)
                     }
                 }
             } catch (e: InterruptedException) {
@@ -148,19 +153,28 @@ class ResilientNearJCache<K: Any, V: Any>(
         }
     }
 
-    private fun completeCommand(queued: QueuedCommand<K, V>, failed: Boolean) {
+    private fun completeCommand(queued: QueuedCommand<K, V>, failed: Boolean, failure: Throwable? = null) {
+        if (!queued.completed.compareAndSet(false, true)) return
         when (val command = queued.command) {
             is BackJCacheCommand.Put       -> completePut(queued, setOf(command.key), failed)
             is BackJCacheCommand.PutAll    -> completePut(queued, command.entries.keys, failed)
-            is BackJCacheCommand.Remove    -> completeRemove(queued, setOf(command.key))
-            is BackJCacheCommand.RemoveAll -> completeRemove(queued, command.keys)
+            is BackJCacheCommand.Remove    -> completeRemove(queued, setOf(command.key), failed)
+            is BackJCacheCommand.RemoveAll -> completeRemove(queued, command.keys, failed)
             is BackJCacheCommand.ClearBack -> queued.clearToken?.let { token ->
-                if (pendingClearToken.compareAndSet(token, null)) {
+                if (!failed && pendingClearToken.compareAndSet(token, null)) {
                     stateVersion.incrementAndGet()
                     clearPending.value = false
                 }
             }
         }
+        if (failed) {
+            queued.completion.completeExceptionally(
+                failure ?: IllegalStateException("Back cache write failed for ${queued.command}")
+            )
+        } else {
+            queued.completion.complete(Unit)
+        }
+        pendingCommands.remove(queued)
     }
 
     private fun completePut(queued: QueuedCommand<K, V>, keys: Set<K>, failed: Boolean) {
@@ -173,10 +187,10 @@ class ResilientNearJCache<K: Any, V: Any>(
         }
     }
 
-    private fun completeRemove(queued: QueuedCommand<K, V>, keys: Set<K>) {
+    private fun completeRemove(queued: QueuedCommand<K, V>, keys: Set<K>, failed: Boolean) {
         keys.forEach { key ->
             val token = queued.mutationTokens.getValue(key)
-            if (pendingMutationTokens.remove(key, token)) {
+            if (pendingMutationTokens.remove(key, token) && !failed) {
                 stateVersion.incrementAndGet()
                 tombstones.remove(key)
             }
@@ -250,10 +264,14 @@ class ResilientNearJCache<K: Any, V: Any>(
      * 키-값 쌍을 저장한다.
      * - front cache 즉시 반영
      * - back cache write는 queue로 큐잉 (write-behind)
+     *
+     * @return back cache 반영 완료 future. 재시도 소진 또는 close drain timeout이면
+     *   exceptionally completed 상태가 된다. 큐가 가득 차면 front cache를 변경하기 전에
+     *   [IllegalStateException]을 즉시 던진다.
      */
-    fun put(key: K, value: V) {
+    fun put(key: K, value: V): CompletableFuture<Unit> {
         key.requireNotNull("key")
-        enqueueWrite(BackJCacheCommand.Put(key, value), "Write queue full for Put key=$key") {
+        return enqueueWrite(BackJCacheCommand.Put(key, value), "Write queue full for Put key=$key") {
             tombstones.remove(key)
             frontCache.put(key, value)
         }
@@ -261,10 +279,16 @@ class ResilientNearJCache<K: Any, V: Any>(
 
     /**
      * 여러 키-값 쌍을 저장한다.
+     *
+     * @return 모든 항목의 back cache 반영 완료 future. 재시도 소진 또는 close drain timeout이면
+     *   exceptionally completed 상태가 된다.
      */
-    fun putAll(entries: Map<K, V>) {
+    fun putAll(entries: Map<K, V>): CompletableFuture<Unit> {
         val entriesSnapshot = entries.toMap()
-        enqueueWrite(BackJCacheCommand.PutAll(entriesSnapshot), "Write queue full for PutAll entries=${entries.size}") {
+        return enqueueWrite(
+            BackJCacheCommand.PutAll(entriesSnapshot),
+            "Write queue full for PutAll entries=${entries.size}"
+        ) {
             tombstones.removeAll(entriesSnapshot.keys)
             frontCache.putAll(entriesSnapshot)
         }
@@ -280,7 +304,10 @@ class ResilientNearJCache<K: Any, V: Any>(
             frontCache.get(key)?.let { return it }
             val pendingMutation = pendingMutationTokens[key]
             val pendingClear = pendingClearToken.value
-            if (pendingMutation?.value != null && (pendingClear == null || pendingMutation.sequence > pendingClear.sequence)) {
+            if (
+                pendingMutation?.value != null &&
+                (pendingClear == null || pendingMutation.sequence > pendingClear.sequence)
+            ) {
                 return pendingMutation.value
             }
 
@@ -365,10 +392,13 @@ class ResilientNearJCache<K: Any, V: Any>(
      * 키에 해당하는 캐시 항목을 제거한다.
      * - front cache 즉시 반영
      * - back cache delete는 queue로 큐잉 (write-behind)
+     *
+     * @return back cache 삭제 완료 future. 재시도 소진 또는 close drain timeout이면
+     *   exceptionally completed 상태가 되며, stale back read를 막는 tombstone은 유지된다.
      */
-    fun remove(key: K) {
+    fun remove(key: K): CompletableFuture<Unit> {
         key.requireNotNull("key")
-        enqueueWrite(BackJCacheCommand.Remove(key), "Write queue full for Remove key=$key") {
+        return enqueueWrite(BackJCacheCommand.Remove(key), "Write queue full for Remove key=$key") {
             frontCache.remove(key)
             tombstones.add(key)
         }
@@ -376,10 +406,15 @@ class ResilientNearJCache<K: Any, V: Any>(
 
     /**
      * 여러 키에 해당하는 캐시 항목을 제거한다.
+     *
+     * @return 모든 키의 back cache 삭제 완료 future. 실패 시 각 키의 tombstone은 유지된다.
      */
-    fun removeAll(keys: Set<K>) {
+    fun removeAll(keys: Set<K>): CompletableFuture<Unit> {
         val keysSnapshot = keys.toSet()
-        enqueueWrite(BackJCacheCommand.RemoveAll(keysSnapshot), "Write queue full for RemoveAll keys=${keys.size}") {
+        return enqueueWrite(
+            BackJCacheCommand.RemoveAll(keysSnapshot),
+            "Write queue full for RemoveAll keys=${keys.size}"
+        ) {
             frontCache.removeAll(keysSnapshot)
             tombstones.addAll(keysSnapshot)
         }
@@ -395,9 +430,12 @@ class ResilientNearJCache<K: Any, V: Any>(
 
     /**
      * 로컬 캐시와 back cache를 모두 비운다 (write-behind).
+     *
+     * @return back cache clear 완료 future. 실패 또는 close drain timeout이면 clear pending
+     *   상태와 stale read 차단을 유지한 채 exceptionally completed 상태가 된다.
      */
-    fun clearAll() {
-        enqueueWrite(BackJCacheCommand.ClearBack(), "Write queue full for ClearBack") {
+    fun clearAll(): CompletableFuture<Unit> {
+        return enqueueWrite(BackJCacheCommand.ClearBack(), "Write queue full for ClearBack") {
             clearPending.value = true
             clearLocal()
         }
@@ -425,6 +463,7 @@ class ResilientNearJCache<K: Any, V: Any>(
                     consumerThread.join(closeDrainTimeoutMillis)
                     if (consumerThread.isAlive) {
                         log.warn { "Timed out draining back cache write queue. remaining=${queue.size}" }
+                        failPendingCommands(IllegalStateException("Timed out draining back cache write queue"))
                     }
                 }
             }
@@ -437,9 +476,9 @@ class ResilientNearJCache<K: Any, V: Any>(
         command: BackJCacheCommand<K, V>,
         failureMessage: String,
         updateFrontState: () -> Unit,
-    ) {
+    ): CompletableFuture<Unit> {
         writeStateLock.withLock {
-            enqueueWriteLocked(command, failureMessage, updateFrontState)
+            return enqueueWriteLocked(command, failureMessage, updateFrontState)
         }
     }
 
@@ -447,14 +486,25 @@ class ResilientNearJCache<K: Any, V: Any>(
         command: BackJCacheCommand<K, V>,
         failureMessage: String,
         updateFrontState: () -> Unit,
-    ) {
+    ): CompletableFuture<Unit> {
         val queued = QueuedCommand(command, ++nextCommandSequence)
         check(!closed.value) { "ResilientNearCache is closed" }
-        check(queue.offer(queued)) { failureMessage }
+        pendingCommands.add(queued)
+        if (!queue.offer(queued)) {
+            pendingCommands.remove(queued)
+            check(false) { failureMessage }
+        }
         queued.mutationTokens.forEach(pendingMutationTokens::put)
         queued.clearToken?.let { pendingClearToken.value = it }
         stateVersion.incrementAndGet()
         updateFrontState()
+        return queued.completion
+    }
+
+    private fun failPendingCommands(failure: Throwable) {
+        pendingCommands.toList().forEach { queued ->
+            completeCommand(queued, failed = true, failure = failure)
+        }
     }
 
     private class MutationToken<V: Any>(
@@ -468,6 +518,9 @@ class ResilientNearJCache<K: Any, V: Any>(
         val command: BackJCacheCommand<K, V>,
         sequence: Long,
     ) {
+        val completion: CompletableFuture<Unit> = CompletableFuture()
+        val completed = atomic(false)
+
         val mutationTokens: Map<K, MutationToken<V>> = when (command) {
             is BackJCacheCommand.Put       -> mapOf(command.key to MutationToken(command.value, sequence))
             is BackJCacheCommand.PutAll    -> command.entries.mapValues { MutationToken(it.value, sequence) }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheConfig.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheConfig.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.nearcache.GetFailureStrategy
 
+import io.bluetape4k.support.requireGt
 import io.bluetape4k.support.requirePositiveNumber
 import java.time.Duration
 
@@ -25,6 +26,7 @@ import java.time.Duration
  * @param frontExpireAfterAccess 로컬 캐시 접근 후 만료 시간 (null이면 비활성)
  * @param recordStats 로컬 캐시 통계 기록 여부
  * @param writeQueueCapacity write-behind 큐(또는 채널) 최대 용량
+ * @param closeDrainTimeout close()가 수락된 write-behind 명령을 drain할 최대 대기 시간
  * @param retryMaxAttempts back cache 쓰기 실패 시 최대 재시도 횟수
  * @param retryWaitDuration 재시도 대기 시간
  * @param retryExponentialBackoff 지수 백오프 사용 여부
@@ -37,6 +39,7 @@ data class ResilientNearJCacheConfig<K: Any, V: Any>(
     val frontExpireAfterAccess: Duration? = null,
     val recordStats: Boolean = false,
     val writeQueueCapacity: Int = 1024,
+    val closeDrainTimeout: Duration = Duration.ofSeconds(5),
     val retryMaxAttempts: Int = 3,
     val retryWaitDuration: Duration = Duration.ofMillis(500),
     val retryExponentialBackoff: Boolean = true,
@@ -45,6 +48,7 @@ data class ResilientNearJCacheConfig<K: Any, V: Any>(
     init {
         maxLocalSize.requirePositiveNumber("maxLocalSize")
         writeQueueCapacity.requirePositiveNumber("writeQueueCapacity")
+        closeDrainTimeout.requireGt(Duration.ZERO, "closeDrainTimeout")
         retryMaxAttempts.requirePositiveNumber("retryMaxAttempts")
     }
 }
@@ -76,6 +80,7 @@ class ResilientNearJCacheConfigBuilder<K: Any, V: Any> {
     var frontExpireAfterAccess: Duration? = null
     var recordStats: Boolean = false
     var writeQueueCapacity: Int = 1024
+    var closeDrainTimeout: Duration = Duration.ofSeconds(5)
     var retryMaxAttempts: Int = 3
     var retryWaitDuration: Duration = Duration.ofMillis(500)
     var retryExponentialBackoff: Boolean = true
@@ -88,6 +93,7 @@ class ResilientNearJCacheConfigBuilder<K: Any, V: Any> {
         frontExpireAfterAccess = frontExpireAfterAccess,
         recordStats = recordStats,
         writeQueueCapacity = writeQueueCapacity.requirePositiveNumber("writeQueueCapacity"),
+        closeDrainTimeout = closeDrainTimeout,
         retryMaxAttempts = retryMaxAttempts.requirePositiveNumber("retryMaxAttempts"),
         retryWaitDuration = retryWaitDuration,
         retryExponentialBackoff = retryExponentialBackoff,

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCache.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -36,6 +37,9 @@ import java.util.concurrent.ConcurrentHashMap
  *   back cache 쓰기는 [Channel]에 큐잉하여 consumer coroutine이 순차 처리
  * - **retry**: consumer에서 resilience4j [Retry]로 재시도 (지수 백오프 옵션)
  * - **get graceful degradation**: back cache GET 실패 시 front 값 반환 또는 null
+ *
+ * write-behind mutation 메서드는 [CompletableFuture]를 반환한다. future가 정상 완료되면
+ * back cache 반영까지 끝난 것이고, 재시도 소진 또는 close drain timeout은 예외 완료된다.
  *
  * ```kotlin
  * Application (suspend)
@@ -53,7 +57,7 @@ import java.util.concurrent.ConcurrentHashMap
  * ```kotlin
  * val config = ResilientNearJCacheConfig<String, Int>(retryMaxAttempts = 3)
  * val nearCache = ResilientSuspendNearJCache(backSuspendCache, config)
- * nearCache.put("hello", 5)
+ * nearCache.put("hello", 5).join()
  * val value = nearCache.get("hello")
  * // value == 5
  * nearCache.close()
@@ -69,7 +73,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
 
     companion object: KLogging()
 
-    private val closeDrainTimeoutMillis: Long = 5_000L
+    private val closeDrainTimeoutMillis: Long = config.closeDrainTimeout.toMillis().coerceAtLeast(1L)
 
     private val closed = atomic(false)
     val isClosed by closed
@@ -84,6 +88,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val writeChannel = Channel<QueuedCommand<K, V>>(capacity = config.writeQueueCapacity)
     private val writeStateMutex = Mutex()
+    private val pendingCommands = ConcurrentHashMap.newKeySet<QueuedCommand<K, V>>()
     private val pendingMutationTokens = ConcurrentHashMap<K, MutationToken<V>>()
     private val pendingClearToken = atomic<ClearToken?>(null)
     private val stateVersion = atomic(0L)
@@ -132,7 +137,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
                         "Back cache write failed after ${config.retryMaxAttempts} retries, compensating command: ${cmd.command}"
                     }
                     writeStateMutex.withLock {
-                        completeCommand(cmd, failed = true)
+                        completeCommand(cmd, failed = true, failure = e)
                     }
                 }
             }
@@ -148,19 +153,28 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         }
     }
 
-    private fun completeCommand(queued: QueuedCommand<K, V>, failed: Boolean) {
+    private fun completeCommand(queued: QueuedCommand<K, V>, failed: Boolean, failure: Throwable? = null) {
+        if (!queued.completed.compareAndSet(false, true)) return
         when (val command = queued.command) {
             is BackJCacheCommand.Put       -> completePut(queued, setOf(command.key), failed)
             is BackJCacheCommand.PutAll    -> completePut(queued, command.entries.keys, failed)
-            is BackJCacheCommand.Remove    -> completeRemove(queued, setOf(command.key))
-            is BackJCacheCommand.RemoveAll -> completeRemove(queued, command.keys)
+            is BackJCacheCommand.Remove    -> completeRemove(queued, setOf(command.key), failed)
+            is BackJCacheCommand.RemoveAll -> completeRemove(queued, command.keys, failed)
             is BackJCacheCommand.ClearBack -> queued.clearToken?.let { token ->
-                if (pendingClearToken.compareAndSet(token, null)) {
+                if (!failed && pendingClearToken.compareAndSet(token, null)) {
                     stateVersion.incrementAndGet()
                     clearPending.value = false
                 }
             }
         }
+        if (failed) {
+            queued.completion.completeExceptionally(
+                failure ?: IllegalStateException("Back cache write failed for ${queued.command}")
+            )
+        } else {
+            queued.completion.complete(Unit)
+        }
+        pendingCommands.remove(queued)
     }
 
     private fun completePut(queued: QueuedCommand<K, V>, keys: Set<K>, failed: Boolean) {
@@ -173,10 +187,10 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         }
     }
 
-    private fun completeRemove(queued: QueuedCommand<K, V>, keys: Set<K>) {
+    private fun completeRemove(queued: QueuedCommand<K, V>, keys: Set<K>, failed: Boolean) {
         keys.forEach { key ->
             val token = queued.mutationTokens.getValue(key)
-            if (pendingMutationTokens.remove(key, token)) {
+            if (pendingMutationTokens.remove(key, token) && !failed) {
                 stateVersion.incrementAndGet()
                 tombstones.remove(key)
             }
@@ -251,10 +265,14 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      * 키-값 쌍을 저장한다.
      * - front cache 즉시 반영
      * - back cache write는 channel로 큐잉 (write-behind)
+     *
+     * @return back cache 반영 완료 future. 재시도 소진 또는 close drain timeout이면
+     *   exceptionally completed 상태가 된다. 채널이 가득 차면 front cache를 변경하기 전에
+     *   [IllegalStateException]을 즉시 던진다.
      */
-    suspend fun put(key: K, value: V) {
+    suspend fun put(key: K, value: V): CompletableFuture<Unit> {
         key.requireNotNull("key")
-        enqueueWrite(BackJCacheCommand.Put(key, value), "Write channel full for Put key=$key") {
+        return enqueueWrite(BackJCacheCommand.Put(key, value), "Write channel full for Put key=$key") {
             tombstones.remove(key)
             frontCache.put(key, value)
         }
@@ -262,10 +280,13 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
 
     /**
      * 여러 키-값 쌍을 저장한다.
+     *
+     * @return 모든 항목의 back cache 반영 완료 future. 재시도 소진 또는 close drain timeout이면
+     *   exceptionally completed 상태가 된다.
      */
-    suspend fun putAll(entries: Map<K, V>) {
+    suspend fun putAll(entries: Map<K, V>): CompletableFuture<Unit> {
         val entriesSnapshot = entries.toMap()
-        enqueueWrite(
+        return enqueueWrite(
             BackJCacheCommand.PutAll(entriesSnapshot),
             "Write channel full for PutAll entries=${entries.size}"
         ) {
@@ -284,7 +305,10 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
             frontCache.get(key)?.let { return it }
             val pendingMutation = pendingMutationTokens[key]
             val pendingClear = pendingClearToken.value
-            if (pendingMutation?.value != null && (pendingClear == null || pendingMutation.sequence > pendingClear.sequence)) {
+            if (
+                pendingMutation?.value != null &&
+                (pendingClear == null || pendingMutation.sequence > pendingClear.sequence)
+            ) {
                 return pendingMutation.value
             }
 
@@ -367,10 +391,13 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
      * 키에 해당하는 캐시 항목을 제거한다.
      * - front cache 즉시 반영
      * - back cache delete는 channel로 큐잉 (write-behind)
+     *
+     * @return back cache 삭제 완료 future. 재시도 소진 또는 close drain timeout이면
+     *   exceptionally completed 상태가 되며, stale back read를 막는 tombstone은 유지된다.
      */
-    suspend fun remove(key: K) {
+    suspend fun remove(key: K): CompletableFuture<Unit> {
         key.requireNotNull("key")
-        enqueueWrite(BackJCacheCommand.Remove(key), "Write channel full for Remove key=$key") {
+        return enqueueWrite(BackJCacheCommand.Remove(key), "Write channel full for Remove key=$key") {
             frontCache.remove(key)
             tombstones.add(key)
         }
@@ -378,10 +405,15 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
 
     /**
      * 여러 키에 해당하는 캐시 항목을 제거한다.
+     *
+     * @return 모든 키의 back cache 삭제 완료 future. 실패 시 각 키의 tombstone은 유지된다.
      */
-    suspend fun removeAll(keys: Set<K>) {
+    suspend fun removeAll(keys: Set<K>): CompletableFuture<Unit> {
         val keysSnapshot = keys.toSet()
-        enqueueWrite(BackJCacheCommand.RemoveAll(keysSnapshot), "Write channel full for RemoveAll keys=${keys.size}") {
+        return enqueueWrite(
+            BackJCacheCommand.RemoveAll(keysSnapshot),
+            "Write channel full for RemoveAll keys=${keys.size}"
+        ) {
             frontCache.removeAll(keysSnapshot)
             tombstones.addAll(keysSnapshot)
         }
@@ -397,9 +429,12 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
 
     /**
      * 로컬 캐시와 back cache를 모두 비운다 (write-behind).
+     *
+     * @return back cache clear 완료 future. 실패 또는 close drain timeout이면 clear pending
+     *   상태와 stale read 차단을 유지한 채 exceptionally completed 상태가 된다.
      */
-    suspend fun clearAll() {
-        enqueueWrite(BackJCacheCommand.ClearBack(), "Write channel full for ClearBack") {
+    suspend fun clearAll(): CompletableFuture<Unit> {
+        return enqueueWrite(BackJCacheCommand.ClearBack(), "Write channel full for ClearBack") {
             clearPending.value = true
             clearLocal()
         }
@@ -452,6 +487,7 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
                     } ?: false
                     if (!drained) {
                         log.warn { "Timed out draining back cache write channel." }
+                        failPendingCommands(IllegalStateException("Timed out draining back cache write channel"))
                     }
                 }
             }
@@ -465,9 +501,9 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         command: BackJCacheCommand<K, V>,
         failureMessage: String,
         updateFrontState: () -> Unit,
-    ) {
+    ): CompletableFuture<Unit> {
         writeStateMutex.withLock {
-            enqueueWriteLocked(command, failureMessage, updateFrontState)
+            return enqueueWriteLocked(command, failureMessage, updateFrontState)
         }
     }
 
@@ -475,14 +511,25 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         command: BackJCacheCommand<K, V>,
         failureMessage: String,
         updateFrontState: () -> Unit,
-    ) {
+    ): CompletableFuture<Unit> {
         val queued = QueuedCommand(command, ++nextCommandSequence)
         check(!closed.value) { "ResilientSuspendNearCache is closed" }
-        check(writeChannel.trySend(queued).isSuccess) { failureMessage }
+        pendingCommands.add(queued)
+        if (!writeChannel.trySend(queued).isSuccess) {
+            pendingCommands.remove(queued)
+            check(false) { failureMessage }
+        }
         queued.mutationTokens.forEach(pendingMutationTokens::put)
         queued.clearToken?.let { pendingClearToken.value = it }
         stateVersion.incrementAndGet()
         updateFrontState()
+        return queued.completion
+    }
+
+    private fun failPendingCommands(failure: Throwable) {
+        pendingCommands.toList().forEach { queued ->
+            completeCommand(queued, failed = true, failure = failure)
+        }
     }
 
     private class MutationToken<V: Any>(
@@ -496,6 +543,9 @@ class ResilientSuspendNearJCache<K: Any, V: Any>(
         val command: BackJCacheCommand<K, V>,
         sequence: Long,
     ) {
+        val completion: CompletableFuture<Unit> = CompletableFuture()
+        val completed = atomic(false)
+
         val mutationTokens: Map<K, MutationToken<V>> = when (command) {
             is BackJCacheCommand.Put       -> mapOf(command.key to MutationToken(command.value, sequence))
             is BackJCacheCommand.PutAll    -> command.entries.mapValues { MutationToken(it.value, sequence) }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientNearJCacheTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.CompletionException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -86,9 +87,10 @@ class ResilientNearJCacheTest {
 
     @Test
     fun `put - write-behind - 잠시 후 back cache에도 반영됨`() {
-        cache.put("wb-key", "wb-val")
+        val completion = cache.put("wb-key", "wb-val")
         // front cache 즉시 확인
         cache.get("wb-key") shouldBeEqualTo "wb-val"
+        completion.join()
         // back cache는 write-behind로 비동기 반영 → awaitility 폴링
         await atMost 5.seconds until { backCache.get("wb-key") != null }
         backCache.get("wb-key") shouldBeEqualTo "wb-val"
@@ -376,17 +378,47 @@ class ResilientNearJCacheTest {
     }
 
     @Test
-    fun `remove - retry exhaustion releases tombstone`() {
+    fun `remove - retry exhaustion keeps tombstone and blocks stale back reads`() {
+        val removeAttempts = AtomicInteger()
         val failingCache = resilientCacheWithFailingBackCache { backCache ->
             every { backCache.get("remove-key") } returns "back-value"
-            every { backCache.remove("remove-key") } throws IllegalStateException("remove failed")
+            every { backCache.remove("remove-key") } answers {
+                removeAttempts.incrementAndGet()
+                throw IllegalStateException("remove failed")
+            }
         }
 
         try {
             failingCache.get("remove-key") shouldBeEqualTo "back-value"
-            failingCache.remove("remove-key")
+            val completion = failingCache.remove("remove-key")
 
-            await atMost 5.seconds until { failingCache.get("remove-key") == "back-value" }
+            await atMost 5.seconds until { removeAttempts.get() == 1 }
+            assertFailsWith<CompletionException> { completion.join() }
+            failingCache.get("remove-key").shouldBeNull()
+        } finally {
+            failingCache.close()
+        }
+    }
+
+    @Test
+    fun `removeAll - retry exhaustion keeps tombstones and blocks stale back reads`() {
+        val removeAttempts = AtomicInteger()
+        val failingCache = resilientCacheWithFailingBackCache { backCache ->
+            every { backCache.get("remove-a") } returns "back-a"
+            every { backCache.get("remove-b") } returns "back-b"
+            every { backCache.remove(any()) } answers {
+                removeAttempts.incrementAndGet()
+                throw IllegalStateException("remove failed")
+            }
+        }
+
+        try {
+            val completion = failingCache.removeAll(setOf("remove-a", "remove-b"))
+
+            await atMost 5.seconds until { removeAttempts.get() == 1 }
+            assertFailsWith<CompletionException> { completion.join() }
+            failingCache.get("remove-a").shouldBeNull()
+            failingCache.get("remove-b").shouldBeNull()
         } finally {
             failingCache.close()
         }
@@ -597,19 +629,66 @@ class ResilientNearJCacheTest {
     }
 
     @Test
-    fun `clearAll - retry exhaustion restores back reads`() {
+    fun `clearAll - retry exhaustion keeps clear pending and blocks stale back reads`() {
+        val clearAttempts = AtomicInteger()
         val failingCache = resilientCacheWithFailingBackCache { backCache ->
             every { backCache.get("clear-key") } returns "back-value"
-            every { backCache.clear() } throws IllegalStateException("clear failed")
+            every { backCache.clear() } answers {
+                clearAttempts.incrementAndGet()
+                throw IllegalStateException("clear failed")
+            }
         }
 
         try {
             failingCache.get("clear-key") shouldBeEqualTo "back-value"
-            failingCache.clearAll()
+            val completion = failingCache.clearAll()
 
-            await atMost 5.seconds until { failingCache.get("clear-key") == "back-value" }
+            await atMost 5.seconds until { clearAttempts.get() == 1 }
+            assertFailsWith<CompletionException> { completion.join() }
+            failingCache.get("clear-key").shouldBeNull()
         } finally {
             failingCache.close()
+        }
+    }
+
+    @Test
+    fun `close - timeout completes pending write exceptionally`() {
+        val writeStarted = CountDownLatch(1)
+        val releaseWrite = CountDownLatch(1)
+        val writeFinished = CountDownLatch(1)
+        val blockingBackCache = mockk<Cache<String, String>>(relaxed = true)
+        every { blockingBackCache.put("blocked", "value") } answers {
+            writeStarted.countDown()
+            while (true) {
+                try {
+                    if (releaseWrite.await(10, TimeUnit.MILLISECONDS)) break
+                } catch (_: InterruptedException) {
+                    // close() interrupts the consumer; keep the backend operation pending
+                    // to exercise the timeout path.
+                }
+            }
+            writeFinished.countDown()
+        }
+        val timeoutCache = ResilientNearJCache(
+            backCache = blockingBackCache,
+            config = ResilientNearJCacheConfig(
+                closeDrainTimeout = Duration.ofMillis(50),
+                retryMaxAttempts = 1,
+                retryWaitDuration = Duration.ofMillis(10),
+            )
+        )
+
+        try {
+            val completion = timeoutCache.put("blocked", "value")
+            writeStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            timeoutCache.close()
+
+            assertFailsWith<CompletionException> { completion.join() }
+        } finally {
+            releaseWrite.countDown()
+            writeFinished.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            timeoutCache.close()
         }
     }
 

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/ResilientSuspendNearJCacheTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -85,8 +86,9 @@ class ResilientSuspendNearJCacheTest {
     @Test
     fun `put - write-behind - 잠시 후 back cache에도 반영됨`() =
         runSuspendIO {
-            cache.put("wb-key", "wb-val")
+            val completion = cache.put("wb-key", "wb-val")
             cache.get("wb-key") shouldBeEqualTo "wb-val"
+            completion.join()
 
             await atMost 5.seconds untilSuspending { backCache.get("wb-key") == "wb-val" }
             backCache.get("wb-key") shouldBeEqualTo "wb-val"
@@ -407,18 +409,49 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
-    fun `remove - retry exhaustion releases tombstone`() =
+    fun `remove - retry exhaustion keeps tombstone and blocks stale back reads`() =
         runSuspendIO {
+            val removeAttempts = AtomicInteger()
             val failingCache = resilientCacheWithFailingBackCache { backCache ->
                 coEvery { backCache.get("remove-key") } returns "back-value"
-                coEvery { backCache.remove("remove-key") } throws IllegalStateException("remove failed")
+                coEvery { backCache.remove("remove-key") } coAnswers {
+                    removeAttempts.incrementAndGet()
+                    throw IllegalStateException("remove failed")
+                }
             }
 
             try {
                 failingCache.get("remove-key") shouldBeEqualTo "back-value"
-                failingCache.remove("remove-key")
+                val completion = failingCache.remove("remove-key")
 
-                await atMost 5.seconds untilSuspending { failingCache.get("remove-key") == "back-value" }
+                await atMost 5.seconds untilSuspending { removeAttempts.get() == 1 }
+                assertFailsWith<CompletionException> { completion.join() }
+                failingCache.get("remove-key").shouldBeNull()
+            } finally {
+                failingCache.close()
+            }
+        }
+
+    @Test
+    fun `removeAll - retry exhaustion keeps tombstones and blocks stale back reads`() =
+        runSuspendIO {
+            val removeAttempts = AtomicInteger()
+            val failingCache = resilientCacheWithFailingBackCache { backCache ->
+                coEvery { backCache.get("remove-a") } returns "back-a"
+                coEvery { backCache.get("remove-b") } returns "back-b"
+                coEvery { backCache.removeAll(setOf("remove-a", "remove-b")) } coAnswers {
+                    removeAttempts.incrementAndGet()
+                    throw IllegalStateException("remove failed")
+                }
+            }
+
+            try {
+                val completion = failingCache.removeAll(setOf("remove-a", "remove-b"))
+
+                await atMost 5.seconds untilSuspending { removeAttempts.get() == 1 }
+                assertFailsWith<CompletionException> { completion.join() }
+                failingCache.get("remove-a").shouldBeNull()
+                failingCache.get("remove-b").shouldBeNull()
             } finally {
                 failingCache.close()
             }
@@ -664,20 +697,68 @@ class ResilientSuspendNearJCacheTest {
         }
 
     @Test
-    fun `clearAll - retry exhaustion restores back reads`() =
+    fun `clearAll - retry exhaustion keeps clear pending and blocks stale back reads`() =
         runSuspendIO {
+            val clearAttempts = AtomicInteger()
             val failingCache = resilientCacheWithFailingBackCache { backCache ->
                 coEvery { backCache.get("clear-key") } returns "back-value"
-                coEvery { backCache.clear() } throws IllegalStateException("clear failed")
+                coEvery { backCache.clear() } coAnswers {
+                    clearAttempts.incrementAndGet()
+                    throw IllegalStateException("clear failed")
+                }
             }
 
             try {
                 failingCache.get("clear-key") shouldBeEqualTo "back-value"
-                failingCache.clearAll()
+                val completion = failingCache.clearAll()
 
-                await atMost 5.seconds untilSuspending { failingCache.get("clear-key") == "back-value" }
+                await atMost 5.seconds untilSuspending { clearAttempts.get() == 1 }
+                assertFailsWith<CompletionException> { completion.join() }
+                failingCache.get("clear-key").shouldBeNull()
             } finally {
                 failingCache.close()
+            }
+        }
+
+    @Test
+    fun `close - timeout completes pending write exceptionally`() =
+        runSuspendIO {
+            val writeStarted = CountDownLatch(1)
+            val releaseWrite = CountDownLatch(1)
+            val writeFinished = CountDownLatch(1)
+            val blockingBackCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            coEvery { blockingBackCache.put("blocked", "value") } coAnswers {
+                writeStarted.countDown()
+                while (true) {
+                    try {
+                        if (releaseWrite.await(10, TimeUnit.MILLISECONDS)) break
+                    } catch (_: InterruptedException) {
+                        // close() cancels the consumer; keep the backend operation pending
+                        // to exercise the timeout path.
+                    }
+                }
+                writeFinished.countDown()
+            }
+            val timeoutCache = ResilientSuspendNearJCache(
+                backCache = blockingBackCache,
+                config = ResilientNearJCacheConfig(
+                    closeDrainTimeout = Duration.ofMillis(50),
+                    retryMaxAttempts = 1,
+                    retryWaitDuration = Duration.ofMillis(10),
+                )
+            )
+
+            try {
+                val completion = timeoutCache.put("blocked", "value")
+                writeStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+                timeoutCache.close()
+
+                assertFailsWith<CompletionException> { completion.join() }
+            } finally {
+                releaseWrite.countDown()
+                writeFinished.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                timeoutCache.close()
             }
         }
 

--- a/docs/lessons/2026-08-01-issue-1269-near-cache-mutation-failures.md
+++ b/docs/lessons/2026-08-01-issue-1269-near-cache-mutation-failures.md
@@ -1,0 +1,63 @@
+# #1269 Near Cache write-behind mutation 실패 전파
+
+## Context
+
+`ResilientNearJCache`와 `ResilientSuspendNearJCache`는 front cache를 먼저
+변경하고 back cache mutation을 queue 또는 channel에서 비동기로 처리합니다.
+기존 구현은 retry exhaustion이나 close drain timeout을 로그로만 남겼습니다.
+특히 remove 실패 뒤 tombstone을 해제하고 clear 실패 뒤 `clearPending`을 해제해,
+back cache의 stale value가 삭제 또는 clear 성공처럼 다시 보일 수 있었습니다.
+
+## Decision or Finding
+
+- write-behind mutation 메서드(`put`, `putAll`, `remove`, `removeAll`, `clearAll`)는
+  back cache 반영 완료를 나타내는 `CompletableFuture<Unit>`을 반환합니다. 정상 완료는
+  back cache 반영 완료이며, retry exhaustion과 close drain timeout은 future를
+  exceptionally complete합니다.
+- queue 또는 channel이 가득 차면 front cache를 변경하기 전에 기존처럼
+  `IllegalStateException`을 동기적으로 던집니다. 수락되지 않은 명령에는 completion
+  future를 만들지 않습니다.
+- remove 명령이 실패하면 tombstone을 유지하고, clear 명령이 실패하면
+  `clearPending`과 clear token을 유지합니다. 따라서 caller가 실패를 확인하고
+  재시도하기 전까지 stale back read가 성공처럼 노출되지 않습니다.
+- close timeout 시 아직 완료되지 않은 명령을 idempotent하게 실패 완료합니다.
+  consumer가 이후 늦게 반환해도 이미 실패한 completion과 보호 상태를 덮어쓰지
+  않습니다.
+- blocking 구현과 suspend 구현은 동일한 completion, retry, tombstone/clear guard,
+  close timeout 정책을 사용합니다. drain timeout은
+  `ResilientNearJCacheConfig.closeDrainTimeout`으로 조정할 수 있습니다.
+
+## Outcome
+
+호출자는 mutation의 terminal 상태를 future로 관찰할 수 있고, 실패한 삭제 또는
+clear가 stale back state를 성공처럼 되살리지 않습니다. 수락된 명령은 close 시
+설정된 시간만큼 drain을 시도하고, 시간 안에 끝나지 않으면 caller-visible failure로
+남습니다. 성공 명령은 기존 write-behind 순서와 front cache 즉시 반영 동작을
+유지합니다.
+
+## Verification
+
+- RED: blocking/suspend remove, removeAll, clear retry exhaustion에서 back value가
+  다시 읽히는 6개 회귀 실패를 재현했습니다.
+- GREEN: blocking/suspend near-cache targeted test에서 completion success/failure,
+  tombstone/clear guard, queue/channel backpressure, close timeout을 검증했습니다.
+  73개 테스트가 6.6초에 통과했습니다.
+- `:bluetape4k-cache-core:compileKotlin` 통과.
+- `:bluetape4k-cache-core:test --rerun-tasks` 507개 통과, 48.9초,
+  `BUILD SUCCESSFUL`.
+- `git diff --check` 통과.
+- `:bluetape4k-cache-core:detekt`는 기존 cache-core의 ReturnCount, TooManyFunctions,
+  TooGenericExceptionCaught, MagicNumber finding으로 실패했습니다. 새 동작과 무관한
+  기존 finding이며, 새로 추가한 긴 표현식은 정리했습니다.
+- `:bluetape4k-cache-core:dokkaGenerate`는 기존 `README.md`의
+  `Package / Import Stability` package-name 오류로 실패했습니다. 변경 KDoc 자체의
+  unresolved link 경고(`CacheEntryListenerException`, `Cache`)도 남아 있습니다.
+
+## Future Guidance
+
+write-behind API를 변경할 때는 front 반영 성공과 back 반영 완료를 같은 상태로
+취급하지 말고, caller가 terminal failure를 관찰할 수 있는 계약을 먼저 정의합니다.
+retry가 끝난 뒤에는 실패 증거(tombstone 또는 clear guard)를 보존해야 하며,
+close timeout은 pending 명령을 예외 완료해 무기한 대기를 방지해야 합니다.
+blocking과 suspend 경로는 동일한 상태 전이와 테스트 시나리오를 공유하고,
+queue overflow는 front mutation보다 먼저 검증합니다.


### PR DESCRIPTION
## Summary

Closes #1269

- PR 제목: Make resilient near-cache failures caller-visible

Make deferred near-cache mutation outcomes observable to callers while preserving sync/suspend parity and stale-read protection.

- Return a CompletableFuture<Unit> from write-behind put, putAll, remove, removeAll, and clearAll operations.
- Complete the future exceptionally on retry exhaustion or close drain timeout.
- Preserve remove tombstones and clear-pending evidence after failure.
- Add configurable closeDrainTimeout and document retry, durability, and backpressure semantics.
- Add blocking/suspend regression coverage and a Korean lesson.

Closes #1269

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Stack

This PR is stacked on fix/issue-1268-jpa-entity-equality and must merge after the base PR.

### 기존 섹션: Verification

- Targeted near-cache tests: 73 passed in 6.6s.
- Full :bluetape4k-cache-core:test --rerun-tasks: 507 passed in 48.9s.
- :bluetape4k-cache-core:compileKotlin: passed.
- git diff --check: passed.
- Detekt reports existing cache-core findings.
- Dokka is blocked by the existing README.md package-name error.
- Remote CI run 30702957911: all 18 jobs passed, including Build, 9 Test jobs, Coverage Report, CI Status, and policy/security/catalog checks.
- Exact head 6d259b40698ebd26bb140b63b7c3db9adb239e74 matches the successful CI run; PR is mergeable and CLEAN.
- gh pr checks --required reports no required checks configured for this branch.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1269, milestone `1.12.0`, assignee `debop`
- PR: #1287, head `6d259b40698ebd26bb140b63b7c3db9adb239e74`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1269-resilient-near-cache-failure`
- Labels: `bug`, `cache`
- State: `MERGED`, merge commit `a60305cfb59f0eb352348f6cf9220d28f8c5b79d`
- CI: - Detekt reports existing cache-core findings. / - Remote CI run 30702957911: all 18 jobs passed, including Build, 9 Test jobs, Coverage Report, CI Status, and policy/security/catalog checks. / - Exact head 6d259b40698ebd26bb140b63b7c3db9adb239e74 matches the successful CI run; PR is mergeable and CLEAN.

## DoD Status

- [x] Caller-visible completion and failure contract implemented.
- [x] Failure evidence and stale-read guards preserved.
- [x] Blocking and suspending implementations covered.
- [x] Retry exhaustion, close timeout, pending operations, and backpressure tested.
- [x] Durability/retry/backpressure semantics documented.
- [x] Remote CI run 30702957911 completed successfully at the exact head.
- [x] No review comments are currently present.
- [ ] Fresh merge approval is pending; merge is not requested in this step.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1287 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a60305cfb59f0eb352348f6cf9220d28f8c5b79d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
