### PR TITLE
Make Lettuce JCache destruction failures observable and retryable

### DIFF
--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCacheManager.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCacheManager.kt
@@ -31,6 +31,10 @@ import kotlin.concurrent.withLock
  * ## 동작/계약
  * - `createCache`는 [LettuceCacheConfig]를 받아 [LettuceJCache]를 생성합니다.
  * - 캐시 인스턴스는 내부 맵에 이름 기준으로 보관되며 중복 생성 시 [javax.cache.CacheException]이 발생합니다.
+ * - `destroyCache`는 Redis 데이터 삭제가 성공한 뒤에만 캐시를 닫고 registry에서
+ *   제거합니다. 삭제 실패는 [javax.cache.CacheException]으로 전파하며 재시도할 수
+ *   있도록 캐시를 유지합니다. 리소스 close 실패도 [javax.cache.CacheException]으로
+ *   전파하지만 데이터 삭제가 끝났으므로 registry에서는 제거합니다.
  * - 매니저가 닫히면 공개 API 대부분이 `IllegalStateException`을 발생시킵니다.
  */
 class LettuceCacheManager(
@@ -152,22 +156,48 @@ class LettuceCacheManager(
 
     override fun getCacheNames(): MutableIterable<String> = caches.keys.toMutableSet()
 
+    /**
+     * Redis 데이터를 삭제한 뒤 캐시 리소스를 닫고 registry에서 제거합니다.
+     *
+     * `clear()`가 실패하면 [CacheException]을 원인과 함께 전파하고 캐시를 registry에 남겨
+     * 호출자가 같은 인스턴스로 재시도할 수 있게 합니다. `close()`가 실패하면 데이터
+     * 삭제는 완료된 상태이므로 registry에서 제거한 뒤 [CacheException]을 전파합니다.
+     */
+    @Suppress("TooGenericExceptionCaught")
     override fun destroyCache(cacheName: String?) {
         checkNotClosed()
-        cacheName.requireNotBlank("cacheName")
-        log.debug { "Destroy LettuceCache. cacheName=$cacheName" }
-        caches.remove(cacheName)?.let { cache ->
-            log.info { "Destroy LettuceCache [$cacheName]" }
-            runCatching { cache.clear() }
-            runCatching { cache.close() }
+        val validCacheName = cacheName.requireNotBlank("cacheName")
+        log.debug { "Destroy LettuceCache. cacheName=$validCacheName" }
+        caches[validCacheName]?.let { cache ->
+            log.info { "Destroy LettuceCache [$validCacheName]" }
+            try {
+                cache.clear()
+            } catch (e: Exception) {
+                throw destructionException(validCacheName, "clear", e)
+            }
+
+            try {
+                cache.close()
+            } catch (e: Exception) {
+                caches.remove(validCacheName, cache)
+                throw destructionException(validCacheName, "close", e)
+            }
+            caches.remove(validCacheName, cache)
         }
     }
+
+    private fun destructionException(cacheName: String, operation: String, cause: Exception): CacheException =
+        if (cause is CacheException) {
+            cause
+        } else {
+            CacheException("LettuceCache [$cacheName] $operation 중 오류가 발생했습니다.", cause)
+        }
 
     /**
      * 캐시 이름을 기준으로 내부 맵에서 제거합니다. [LettuceJCache.close] 내부에서 호출됩니다.
      */
     fun closeCache(cache: LettuceJCache<*, *>) {
-        caches.remove(cache.name)
+        caches.remove(cache.name, cache)
     }
 
     override fun enableManagement(cacheName: String, enabled: Boolean) {

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceJCache.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceJCache.kt
@@ -9,6 +9,7 @@ import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import javax.cache.Cache
 import javax.cache.CacheManager
+import javax.cache.CacheException
 import javax.cache.configuration.CacheEntryListenerConfiguration
 import javax.cache.configuration.Configuration
 import javax.cache.event.CacheEntryCreatedListener
@@ -32,6 +33,8 @@ import javax.cache.processor.MutableEntry
  * - [ttlSeconds]가 지정되면 Redis 8+에서는 `HSETEX` 후 hash key `EXPIRE`를 함께 갱신하고, 미지원 서버에서는 `HSET/HMSET + EXPIRE`로 fallback 합니다.
  * - `close()`는 JSR-107 명세에 따라 리소스만 해제하며, Redis hash 데이터는 **삭제하지 않습니다**.
  *   데이터 삭제가 필요하면 `close()` 전에 `clear()`를 명시적으로 호출하세요.
+ * - 리소스 close 실패는 [CacheException]으로 호출자에게 전파하며, wrapper는 닫힌
+ *   상태로 유지됩니다.
  * - 직렬화는 [codec]의 serializer로 처리하며, 기본값은 LZ4+Fory 기반 직렬화입니다.
  */
 class LettuceJCache<K: Any, V: Any>(
@@ -339,12 +342,19 @@ class LettuceJCache<K: Any, V: Any>(
 
     override fun isClosed(): Boolean = closed.value
 
+    @Suppress("TooGenericExceptionCaught")
     override fun close() {
         if (!closed.compareAndSet(expect = false, update = true)) return
         // JCache 명세: close()는 리소스를 해제하는 것이지 데이터를 삭제하는 것이 아님.
         // 데이터 삭제가 필요하면 close() 전에 clear()를 명시적으로 호출할 것.
         cacheManager.closeCache(this)
-        runCatching { closeResource() }
+        try {
+            closeResource()
+        } catch (e: CacheException) {
+            throw e
+        } catch (e: Exception) {
+            throw CacheException("LettuceCache[$cacheName] 리소스 close 중 오류가 발생했습니다.", e)
+        }
     }
 
     private fun dispatchEvent(eventType: EventType, key: K, value: V?) {

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendCacheManager.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendCacheManager.kt
@@ -25,6 +25,10 @@ import java.util.concurrent.ConcurrentHashMap
  * - 매니저가 닫히면(`isClosed == true`) 대부분의 공개 API가 즉시 예외를 발생시킵니다.
  * - `getOrCreate`는 같은 이름에 대해 기존 캐시를 재사용하고, 없을 때만 Redis 연결을 생성합니다.
  * - [defaultTtlSeconds], [defaultCodec]는 `getOrCreate` 호출 시 개별 파라미터가 없을 때 적용됩니다.
+ * - `destroyCache`는 Redis 데이터 삭제와 리소스 close가 성공한 뒤 registry에서
+ *   제거합니다. 삭제 실패는 [javax.cache.CacheException]으로 전파하며 재시도할 수
+ *   있도록 캐시를 유지합니다.
+ *   close 실패는 registry에서 제거한 뒤 [javax.cache.CacheException]으로 전파합니다.
  *
  * ```kotlin
  * val manager = LettuceSuspendCacheManager(redisClient, defaultTtlSeconds = 60)
@@ -136,7 +140,11 @@ class LettuceSuspendCacheManager(
      * ## 동작/계약
      * - 매니저가 닫혀 있으면 `IllegalStateException`이 발생합니다.
      * - [cacheName] blank 입력은 `IllegalArgumentException`을 발생시킵니다.
-     * - 캐시가 존재할 때만 `clear()`를 수행하고 맵에서 제거합니다.
+     * - 캐시가 존재할 때만 `clear()`와 `close()`를 수행하고 registry에서 제거합니다.
+     * - clear 실패는 원인과 함께 [javax.cache.CacheException]으로 전파하며 캐시를
+     *   registry에 유지합니다.
+     * - close 실패는 registry에서 제거한 뒤 [javax.cache.CacheException]으로 전파합니다.
+     * - [CancellationException]은 cache lifecycle 오류로 변환하지 않고 그대로 재전파합니다.
      *
      * ```kotlin
      * manager.destroyCache("users")
@@ -144,16 +152,47 @@ class LettuceSuspendCacheManager(
      * // deleted == null
      * ```
      */
+    @Suppress("TooGenericExceptionCaught", "ThrowsCount")
     suspend fun destroyCache(cacheName: String) {
         checkNotClosed()
         cacheName.requireNotBlank("cacheName")
 
         caches[cacheName]?.let { cache ->
             log.info { "Destroy LettuceSuspendCache. name=$cacheName" }
-            cache.clear()
-            caches.remove(cacheName)
+            try {
+                cache.clear()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw destructionException(cacheName, "clear", e)
+            }
+
+            try {
+                cache.close()
+            } catch (e: CancellationException) {
+                caches.remove(cacheName, cache)
+                throw e
+            } catch (e: Exception) {
+                caches.remove(cacheName, cache)
+                throw destructionException(cacheName, "close", e)
+            }
+            caches.remove(cacheName, cache)
         }
     }
+
+    private fun destructionException(
+        cacheName: String,
+        operation: String,
+        cause: Exception,
+    ): javax.cache.CacheException =
+        if (cause is javax.cache.CacheException) {
+            cause
+        } else {
+            javax.cache.CacheException(
+                "LettuceSuspendCache [$cacheName] $operation 중 오류가 발생했습니다.",
+                cause,
+            )
+        }
 
     /**
      * 캐시 이름을 기준으로 매니저 등록 목록에서 제거합니다.
@@ -169,7 +208,7 @@ class LettuceSuspendCacheManager(
      * ```
      */
     fun closeCache(cache: LettuceSuspendJCache<*>) {
-        caches.remove(cache.name)
+        caches.remove(cache.name, cache)
     }
 
     /**

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheManagerTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheManagerTest.kt
@@ -2,15 +2,22 @@ package io.bluetape4k.cache.jcache
 
 import io.bluetape4k.cache.RedisServers.redisClient
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.redis.lettuce.map.LettuceMap
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import io.bluetape4k.assertions.assertFailsWith
 import javax.cache.CacheException
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -19,9 +26,12 @@ class LettuceJCacheManagerTest {
     companion object: KLogging()
 
     private lateinit var manager: LettuceCacheManager
+    private val registeredCache = mockk<LettuceJCache<Any, Any>>(relaxed = true)
+    private val cacheMap = mockk<LettuceMap<ByteArray>>(relaxed = true)
 
     @BeforeEach
     fun setup() {
+        clearMocks(registeredCache, cacheMap)
         manager = LettuceCacheManager(
             redisClient = redisClient,
             classLoader = javaClass.classLoader,
@@ -128,6 +138,74 @@ class LettuceJCacheManagerTest {
     }
 
     @Test
+    fun `destroyCache propagates clear failure and keeps cache registered`() {
+        val cacheName = "clear-failure-cache"
+        val cause = IllegalStateException("redis clear failed")
+        every { registeredCache.name } returns cacheName
+        every { registeredCache.clear() } throws cause
+        registerCache(cacheName, registeredCache)
+
+        val thrown = assertFailsWith<CacheException> {
+            manager.destroyCache(cacheName)
+        }
+
+        thrown.cause shouldBeEqualTo cause
+        manager.getCache<Any, Any>(cacheName) shouldBeEqualTo registeredCache
+        verify(exactly = 0) { registeredCache.close() }
+    }
+
+    @Test
+    fun `destroyCache propagates close failure after clear and removes cache`() {
+        val cacheName = "close-failure-cache"
+        val cause = IllegalStateException("resource close failed")
+        every { registeredCache.name } returns cacheName
+        every { registeredCache.clear() } returns Unit
+        every { registeredCache.close() } throws cause
+        registerCache(cacheName, registeredCache)
+
+        val thrown = assertFailsWith<CacheException> {
+            manager.destroyCache(cacheName)
+        }
+
+        thrown.cause shouldBeEqualTo cause
+        manager.getCache<Any, Any>(cacheName).shouldBeNull()
+        verify { registeredCache.clear() }
+        verify { registeredCache.close() }
+    }
+
+    @Test
+    fun `destroyCache deletes redis data before same-name recreation`() {
+        val cacheName = "recreate-after-destroy"
+        val config = lettuceCacheConfigOf<String, String>()
+        val cache = manager.createCache(cacheName, config)
+        cache.put("key", "value")
+
+        manager.destroyCache(cacheName)
+
+        val recreated = manager.createCache(cacheName, config)
+        recreated.get("key").shouldBeNull()
+    }
+
+    @Test
+    fun `cache close exposes resource failure`() {
+        val cause = IllegalStateException("connection close failed")
+        every { cacheMap.mapKey } returns "close-resource-failure"
+        val cache = LettuceJCache(
+            map = cacheMap,
+            cacheManager = manager,
+            configuration = lettuceCacheConfigOf<String, String>(),
+            closeResource = { throw cause },
+        )
+
+        val thrown = assertFailsWith<CacheException> {
+            cache.close()
+        }
+
+        thrown.cause shouldBeEqualTo cause
+        cache.isClosed.shouldBeTrue()
+    }
+
+    @Test
     fun `isClosed after close`() {
         manager.isClosed.shouldBeFalse()
         manager.close()
@@ -140,5 +218,14 @@ class LettuceJCacheManagerTest {
         assertFailsWith<IllegalStateException> {
             manager.createCache("after-close", lettuceCacheConfigOf<String, String>())
         }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun registerCache(cacheName: String, cache: LettuceJCache<Any, Any>) {
+        val field = LettuceCacheManager::class.java.getDeclaredField("caches").apply {
+            isAccessible = true
+        }
+        val caches = field.get(manager) as MutableMap<String, LettuceJCache<*, *>>
+        caches[cacheName] = cache
     }
 }

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendJCacheManagerTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceSuspendJCacheManagerTest.kt
@@ -4,13 +4,27 @@ import io.bluetape4k.cache.RedisServers.redisClient
 import io.bluetape4k.codec.encodeBase62
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.assertFailsWith
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
+import javax.cache.CacheException
 
 class LettuceSuspendJCacheManagerTest {
+
+    private val registeredCache = mockk<LettuceSuspendJCache<Any>>(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        clearMocks(registeredCache)
+    }
 
     @Test
     fun `closeCache removes registry entry but keeps redis data`() = runSuspendIO {
@@ -26,6 +40,71 @@ class LettuceSuspendJCacheManagerTest {
 
             val reopened = manager.getOrCreate<String>(cacheName)
             reopened.get("key") shouldBeEqualTo "value"
+        } finally {
+            runCatching { manager.destroyCache(cacheName) }
+            runCatching { manager.close() }
+        }
+    }
+
+    @Test
+    fun `destroyCache propagates clear failure and keeps cache registered`() = runSuspendIO {
+        val cacheName = "suspend-clear-failure-cache"
+        val cause = IllegalStateException("redis clear failed")
+        val manager = LettuceSuspendCacheManager(redisClient, defaultCodec = LettuceBinaryCodecs.lz4Fory())
+        every { registeredCache.name } returns cacheName
+        coEvery { registeredCache.clear() } throws cause
+        registerCache(manager, cacheName, registeredCache)
+
+        try {
+            val thrown = assertFailsWith<CacheException> {
+                manager.destroyCache(cacheName)
+            }
+
+            thrown.cause shouldBeEqualTo cause
+            manager.getCache<Any>(cacheName) shouldBeEqualTo registeredCache
+            coVerify(exactly = 0) { registeredCache.close() }
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun `destroyCache propagates close failure after clear and removes cache`() = runSuspendIO {
+        val cacheName = "suspend-close-failure-cache"
+        val cause = IllegalStateException("resource close failed")
+        val manager = LettuceSuspendCacheManager(redisClient, defaultCodec = LettuceBinaryCodecs.lz4Fory())
+        every { registeredCache.name } returns cacheName
+        coEvery { registeredCache.clear() } returns Unit
+        coEvery { registeredCache.close() } throws cause
+        registerCache(manager, cacheName, registeredCache)
+
+        try {
+            val thrown = assertFailsWith<CacheException> {
+                manager.destroyCache(cacheName)
+            }
+
+            thrown.cause shouldBeEqualTo cause
+            manager.getCache<Any>(cacheName).shouldBeNull()
+            coVerify { registeredCache.clear() }
+            coVerify { registeredCache.close() }
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun `destroyCache deletes redis data before same-name recreation`() = runSuspendIO {
+        val cacheName = "suspend-recreate-after-destroy-" + UUID.randomUUID().encodeBase62()
+        val manager = LettuceSuspendCacheManager(redisClient, defaultCodec = LettuceBinaryCodecs.lz4Fory())
+
+        try {
+            val cache = manager.getOrCreate<String>(cacheName)
+            cache.put("key", "value")
+
+            manager.destroyCache(cacheName)
+
+            manager.getCache<String>(cacheName).shouldBeNull()
+            manager.getOrCreate<String>(cacheName).get("key").shouldBeNull()
         } finally {
             runCatching { manager.destroyCache(cacheName) }
             runCatching { manager.close() }
@@ -102,5 +181,18 @@ class LettuceSuspendJCacheManagerTest {
             runCatching { manager.destroyCache(cacheName) }
             runCatching { manager.close() }
         }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun registerCache(
+        manager: LettuceSuspendCacheManager,
+        cacheName: String,
+        cache: LettuceSuspendJCache<Any>,
+    ) {
+        val field = LettuceSuspendCacheManager::class.java.getDeclaredField("caches").apply {
+            isAccessible = true
+        }
+        val caches = field.get(manager) as MutableMap<String, LettuceSuspendJCache<out Any>>
+        caches[cacheName] = cache
     }
 }

--- a/docs/lessons/2026-08-01-issue-1270-lettuce-jcache-destruction.md
+++ b/docs/lessons/2026-08-01-issue-1270-lettuce-jcache-destruction.md
@@ -1,0 +1,50 @@
+# #1270 Lettuce JCache destroy 실패 가시성과 재시도 상태
+
+## Context
+
+`LettuceCacheManager.destroyCache`는 기존에 registry에서 캐시를 먼저
+제거한 뒤 `clear()`와 `close()` 예외를 `runCatching`으로 삼켰습니다. 따라서
+Redis 데이터 삭제가 실패해도 호출자는 성공으로 오인하고, 같은 이름으로
+캐시를 다시 만들 때 stale 데이터가 남을 수 있었습니다. suspend manager도
+clear 뒤 wrapper를 닫지 않았고, blocking JCache wrapper의 resource close
+실패 역시 숨겨졌습니다.
+
+## Decision or Finding
+
+- sync/suspend `destroyCache`는 `clear()`를 먼저 완료한 뒤 `close()`를 수행하고,
+  두 단계의 실패를 `CacheException`으로 호출자에게 전파합니다.
+- clear 실패 시 registry 항목을 유지해 같은 인스턴스로 재시도할 수 있게 합니다.
+  close 실패 시 Redis 데이터 삭제는 완료된 상태이므로 해당 registry 항목은
+  제거하고 실패를 전파합니다.
+- `LettuceJCache.close()`는 wrapper를 closed 상태로 전환하고 manager registry에서
+  제거한 뒤 resource close 실패를 `CacheException`으로 보존합니다. 기존의
+  log-only/`runCatching` 처리는 사용하지 않습니다.
+- suspend 경로는 `CancellationException`을 lifecycle 오류로 변환하지 않고
+  그대로 재전파하며, 정상 종료 시에는 현재 wrapper와 일치하는 registry entry만
+  제거합니다.
+
+## Outcome
+
+호출자는 clear 또는 close의 terminal 상태와 원래 원인을 관찰할 수 있습니다.
+clear 실패 뒤에는 캐시가 registry에 남아 재시도할 수 있고, 성공적인 clear 뒤
+동일한 이름으로 캐시를 재생성해도 이전 Redis hash 데이터가 보이지 않습니다.
+blocking과 suspend 경로의 삭제 순서, registry 정책, 예외 가시성이 일치합니다.
+
+## Verification
+
+- RED: sync/suspend manager targeted suite에서 clear/close 예외 전파와 직접
+  resource close 가시성에 대한 5개 회귀 실패를 먼저 재현했습니다.
+- GREEN: `LettuceJCacheManagerTest`와 `LettuceSuspendJCacheManagerTest` 23개가
+  모두 통과했습니다.
+- `:bluetape4k-cache-lettuce:test` 전체 443개 통과, `BUILD SUCCESSFUL`.
+- `:bluetape4k-cache-lettuce:compileKotlin` 및 `compileTestKotlin` 통과.
+- `git diff --check` 통과.
+
+## Future Guidance
+
+JCache lifecycle을 변경할 때는 데이터 삭제, resource close, registry 제거를
+서로 다른 terminal 단계로 취급합니다. cleanup 실패를 로그로만 남기지 말고
+호출자가 원인과 재시도 가능 상태를 판단할 수 있는 예외 계약을 유지해야 합니다.
+blocking과 suspend 구현은 동일한 순서와 실패 정책을 함께 검증하고, concurrent
+재생성 가능성이 있는 registry 제거에는 이름뿐 아니라 현재 wrapper 일치 여부를
+확인합니다.


### PR DESCRIPTION
## Summary

Closes #1270

- PR 제목: Make Lettuce JCache destruction failures observable and retryable

Closes #1270

This stacked PR makes Lettuce JCache destruction observable and retryable when Redis clear or resource close fails. It is based on `fix/issue-1269-resilient-near-cache-failure` in the milestone 1.12.0 train.

## Background

`destroyCache` acknowledged cleanup after swallowing failures and removed the registry entry before clear. The suspend path did not close the wrapper, and direct resource-close failures were also hidden. These behaviors could leave stale Redis data or make a failed cleanup look successful.

## What This Solves

- Clear failures now surface as `CacheException` with the original cause while retaining the retryable cache registry entry.
- Close failures surface after the explicit policy removes the registry entry once data deletion has completed; same-name recreation starts empty.
- Blocking and suspend lifecycle paths preserve the same ordering, cancellation behavior, and value-matched registry removal.

## Work Done

- Updated sync/suspend `destroyCache` to clear before close and deregistration, translate ordinary failures, preserve `CancellationException`, and protect concurrent registry replacement.
- Updated `LettuceJCache.close()` to expose resource failures as `CacheException` while keeping the wrapper closed.
- Added field-scoped MockK regression tests with `clearMocks`, Redis recreation tests, and the durable lifecycle lesson.

## Validation

- `./gradlew :bluetape4k-cache-lettuce:test --tests 'io.bluetape4k.cache.jcache.LettuceJCacheManagerTest' --tests 'io.bluetape4k.cache.jcache.LettuceSuspendJCacheManagerTest' --no-daemon`: PASS (23 tests)
- `./gradlew :bluetape4k-cache-lettuce:test --no-daemon`: PASS (443 tests)
- `./gradlew :bluetape4k-cache-lettuce:compileKotlin :bluetape4k-cache-lettuce:compileTestKotlin --no-daemon`: PASS
- `./gradlew :bluetape4k-cache-lettuce:detekt --no-daemon`: PASS (existing findings only; ignoreFailures is repository policy)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: none
- Review evidence: local final diff review recorded in the workflow receipt; no unresolved implementation blocker.

## Metadata

- Issue: #1270, milestone `1.12.0`, assignee `debop`
- PR: #1288, head `80c9993f1a4248cd93fa3ea2f0b2a62ce3206ac3`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1270-lettuce-jcache-destroy`
- Labels: `bug`, `cache`
- State: `MERGED`, merge commit `e91b216bce13b76a3470da88e7e10e34dcc8a772`
- CI: - Close failures surface after the explicit policy removes the registry entry once data deletion has completed; same-name recreation starts empty. / - `./gradlew :bluetape4k-cache-lettuce:test --tests 'io.bluetape4k.cache.jcache.LettuceJCacheManagerTest' --tests 'io.bluetape4k.cache.jcache.LettuceSuspendJCacheManagerTest' --no-daemon`: PASS (23 tests) / - `./gradlew :bluetape4k-cache-lettuce:test --no-daemon`: PASS (443 tests)

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| issue-metadata - live issue and stacked base | Verified issue #1270 and PR #1287 metadata/head | PASS | Live `gh issue view 1270`, `gh pr view 1287` | none |
| regression-red - TDD regression lock | Captured five expected failures before the fix | PASS | Receipt sequence 9; targeted RED run | none |
| targeted-tests - sync/suspend lifecycle | Ran focused manager suite after final registry hardening | PASS | 23 passing, `BUILD SUCCESSFUL` | none |
| module-validation - module/build/static checks | Ran full module tests, Kotlin compile, detekt, and diff check | PASS | 443 passing; `BUILD SUCCESSFUL`; diff clean | Existing detekt findings are pre-existing and ignored by repository policy |
| final-review - scoped code/document review | Reviewed contract, failure policy, Kotlin patterns, and writer-style KDoc/lesson | PASS | P0/P1=0; receipt sequence 14 | none |
| pr-ci - exact-head CI | Waited for required checks on the published PR head | PASS | `submit-gradle` SUCCESS on `80c9993f1a4248cd93fa3ea2f0b2a62ce3206ac3` | none |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1288 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e91b216bce13b76a3470da88e7e10e34dcc8a772`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
