### PR TITLE
fix(lettuce): restore interruption status during blocking close

### DIFF
--- a/docs/lessons/2026-08-02-issue-1278-blocking-close-interruption.md
+++ b/docs/lessons/2026-08-02-issue-1278-blocking-close-interruption.md
@@ -1,0 +1,41 @@
+# #1278 Blocking loaded-map close interruption 복원
+
+## Context
+
+`LettuceSuspendedLoadedMap.close()`는 `Closeable` 호환을 위해 `runBlocking`으로
+write-behind drain을 기다립니다. 호출 스레드가 대기 중 interrupt되면
+`runBlocking`이 `InterruptedException`을 던지는데, 기존 broad `catch (Exception)`이
+이를 일반 drain 실패로 처리하면서 thread interrupt flag를 소비했습니다.
+
+## Decision or Finding
+
+- blocking close의 `InterruptedException`을 timeout 또는 일반 drain 실패와 분리해
+  처리하고, 로그를 남기기 전에 `Thread.currentThread().interrupt()`로 상태를
+  복원합니다.
+- interruption이 발생해도 기존 `finally` 경로에서 owned job과 Redis connection을
+  계속 정리합니다.
+- `suspendClose()`의 caller cancellation 전파와 내부 timeout 동작은 변경하지
+  않습니다.
+
+## Outcome
+
+외부 shutdown 또는 executor coordination이 전달한 interruption 신호가
+`close()`를 통과해도 호출 스레드에 보존됩니다. interruption, timeout, 일반 drain
+실패를 로그에서 구분할 수 있고, interruption 중에도 소유 리소스 정리는 유지됩니다.
+
+## Verification
+
+- RED: 새 blocking-close 회귀 테스트가 수정 전 interrupt flag 소실(`false`)로
+  실패했습니다.
+- GREEN: 회귀 테스트와 MockK failure-path 테스트 7개가 통과했습니다.
+- `:bluetape4k-lettuce:test` 전체 870개가 통과했습니다.
+- `:bluetape4k-lettuce:detekt` task와 `git diff --check`가 통과했습니다. detekt
+  출력의 기존 finding은 변경 파일 외부에 남아 있습니다.
+
+## Future Guidance
+
+`runBlocking`을 사용하는 blocking bridge에서 `InterruptedException`을
+`Exception`으로만 처리하지 않습니다. interruption은 호출자 제어 신호이므로
+별도 catch에서 상태를 복원하고, non-suspending cleanup은 모든 실패 경로의
+`finally`에서 수행합니다. timeout과 interruption의 로그·예외 semantics를 함께
+검증하고, suspend 경로의 cancellation 계약을 별도 회귀 테스트로 보존합니다.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
@@ -373,11 +373,11 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
     }
 
     /**
-     * Releases resources held by this map.
+     * 이 맵이 보유한 리소스를 해제한다.
      *
-     * **In coroutine contexts**: prefer [suspendClose] to avoid blocking the thread.
-     * This method uses [runBlocking] internally and will block the calling thread
-     * while waiting for the write-behind job to finish flushing.
+     * **코루틴 컨텍스트에서는** 호출 스레드를 차단하지 않도록 [suspendClose]를 사용한다.
+     * 이 메서드는 내부적으로 [runBlocking]을 사용하여 write-behind 작업의 drain을 기다린다.
+     * drain 대기 중 호출 스레드가 interrupt되면 interrupt 상태를 복원한 뒤 소유 리소스를 정리한다.
      */
     override fun close() {
         // 1. 채널을 먼저 닫아 새 write 차단 (producer가 IllegalStateException을 던짐)
@@ -392,6 +392,9 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
                     }
                 }
             }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            log.warn(e) { "Write-behind job drain interrupted during close(); interrupt status restored" }
         } catch (e: Exception) {
             log.warn(e) { "Write-behind job drain timed out or failed during close()" }
         } finally {

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapMockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapMockTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.redis.lettuce.map
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlin.test.assertFailsWith
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -14,12 +15,16 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 
 /**
  * MockK-based unit tests for [LettuceSuspendedLoadedMap] failure paths.
@@ -185,5 +190,40 @@ class LettuceSuspendedLoadedMapMockTest {
         assertFailsWith<CancellationException> {
             map.get("key1")
         }
+    }
+
+    @Test
+    fun `close - interrupted blocking caller restores status and closes owned resources`() {
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>(relaxed = true)
+        val connection = mockk<StatefulRedisConnection<String, String>>(relaxed = true)
+        every { connection.async() } returns asyncCommands
+
+        val client = mockk<RedisClient>(relaxed = true)
+        every { client.connect<String, String>(any()) } returns connection
+
+        val map = LettuceSuspendedLoadedMap(
+            client = client,
+            writer = object: SuspendedMapWriter<String, String> {
+                override suspend fun write(map: Map<String, String>) = Unit
+                override suspend fun delete(keys: Collection<String>) = Unit
+            },
+            config = LettuceCacheConfig.WRITE_BEHIND.copy(keyPrefix = "mock-close-interrupt"),
+        )
+        val interruptedStatusRestored = AtomicBoolean(false)
+        val completed = CountDownLatch(1)
+
+        thread(start = true, isDaemon = true, name = "loaded-map-close-interrupt-test") {
+            try {
+                Thread.currentThread().interrupt()
+                map.close()
+                interruptedStatusRestored.set(Thread.currentThread().isInterrupted)
+            } finally {
+                completed.countDown()
+            }
+        }
+
+        completed.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        interruptedStatusRestored.get().shouldBeTrue()
+        verify(exactly = 1) { connection.close() }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1278

- PR 제목: fix(lettuce): restore interruption status during blocking close

Fixes #1278

Preserve the caller thread's interruption signal when the blocking loaded-map
close bridge is interrupted, while retaining the existing resource cleanup
path.

## Background

This is a post-release follow-up scheduled for milestone `1.12.0`. The blocking
`LettuceSuspendedLoadedMap.close()` path waits for write-behind drain through
`runBlocking`; its broad exception handler previously consumed
`InterruptedException` without restoring the interrupt flag.

## What This Solves

- Prevents shutdown or executor coordination from silently losing a caller's
  thread interruption.
- Keeps owned job and Redis connection cleanup active after interruption.
- Preserves the existing `suspendClose()` cancellation and timeout contract.

## Work Done

- Handles `InterruptedException` separately in `close()`, restores
  `Thread.currentThread().interrupt()`, and emits interruption-specific
  diagnostics before the existing `finally` cleanup.
- Adds a deterministic MockK regression test covering restored interrupt status
  and connection cleanup for an interrupted blocking caller.
- Records the reusable blocking-coroutine-bridge interruption rule in
  `docs/lessons/2026-08-02-issue-1278-blocking-close-interruption.md`.

## Validation

- `repo-test-summary -- ./gradlew :bluetape4k-lettuce:test --tests io.bluetape4k.redis.lettuce.map.LettuceSuspendedLoadedMapMockTest.close\ -\ interrupted\ blocking\ caller\ restores\ status\ and\ closes\ owned\ resources --no-configuration-cache`: PASS after RED (1 test).
- `repo-test-summary -- ./gradlew :bluetape4k-lettuce:test --tests io.bluetape4k.redis.lettuce.map.LettuceSuspendedLoadedMapMockTest --no-configuration-cache`: PASS (7 tests).
- `repo-test-summary -- ./gradlew :bluetape4k-lettuce:test --no-configuration-cache`: PASS (870 tests).
- `./gradlew :bluetape4k-lettuce:detekt --no-configuration-cache --console=plain`: PASS; existing findings remain outside changed files.
- `git diff --check`: PASS.
- Remote CI run [`30709166286`](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/30709166286): PASS on exact head `a851fce0e77b4c5e81bcb5279483085a4260d129`; Build, Infra (Redis), Coverage Report, CI Status, policy, security, wrapper, catalog, and changed-module checks all passed.
- Remote test groups for Core, Data, IO, IO HTTP, Kafka Infra, Key Utils, Ktor, and Telemetry Infra were SKIPPED by the changed-module filter; they are outside this `infra/lettuce` scope.

## Review Notes

- P0/P1: 0.
- P2/P3: No new findings; existing detekt findings are outside the changed files.
- Review evidence: inline final diff review covering the changed close path,
  callers, regression test, cleanup semantics, and lesson (delegated review was
  not used under the approved inline execution constraint); live PR has no
  unresolved comments or review threads, and `develop` requires zero approving
  reviews.

## Metadata

- Issue: #1278, milestone `1.12.0`, assignee `debop`
- PR: #1289, head `a851fce0e77b4c5e81bcb5279483085a4260d129`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1278-thread-interruption`
- Labels: `bug`, `infra/io`, `coroutines`
- State: `MERGED`, merge commit `fb52cad5540450bb648df5a69660697f489d0636`
- CI: `Thread.currentThread().interrupt()`, and emits interruption-specific / - `repo-test-summary -- ./gradlew :bluetape4k-lettuce:test --tests io.bluetape4k.redis.lettuce.map.LettuceSuspendedLoadedMapMockTest.close\ -\ interrupted\ blocking\ caller\ restores\ status\ and\ closes\ owned\ resources --no-configuration-cache`: PASS after RED (1 test). / - `repo-test-summary -- ./gradlew :bluetape4k-lettuce:test --tests io.bluetape4k.redis.lettuce.map.LettuceSuspendedLoadedMapMockTest --no-configuration-cache`: PASS (7 tests).

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - Prove defect and root cause | Reproduced lost interrupt status and traced broad catch | PASS | RED XML failure at the new assertion; `LettuceSuspendedLoadedMap.close()` call-site review | none |
| C-02 - Confirm scope and issue gate | Verified live issue metadata and narrow single-module scope | PASS | `gh issue view 1278`; issue milestone/labels/assignee | none |
| C-03 - Lock regression RED | Added blocking-close interruption regression before fix | PASS | Targeted test failed with expected `false` interrupt status | none |
| C-04 - Apply surgical fix | Added separate interruption catch and restoration | PASS | Commit `8d6988c051cd8d1c1aa51bafb1f7f3da07e12b20` | none |
| C-05 - Prove GREEN and blast radius | Ran targeted, class, module, detekt, and diff checks | PASS | Local validation commands above | none |
| C-06 - Capture reusable learning | Added and committed durable lesson | PASS | `a851fce0e`; `docs/lessons/2026-08-02-issue-1278-blocking-close-interruption.md` | none |
| C-07 - Complete authorized PR delivery | Publish exact head, verify PR metadata, CI, and live review | PASS | [PR #1289](https://github.com/bluetape4k/bluetape4k-projects/pull/1289); live head matches `a851fce0e77b4c5e81bcb5279483085a4260d129`; CI run `30709166286` PASS; no unresolved comments/reviews | none |
| C-08 - Report merge readiness | Reconcile exact head and all Type C/common-gate evidence | PASS | PR is OPEN, `MERGEABLE`, `CLEAN`; exact head and metadata re-read after green CI | Reported merge-ready; stop at CG-16 |
| C-09 - Close after fresh merge approval | Merge, verify, sync, and clean up | PENDING | Requires fresh approval for the exact PR/head | Do not merge before CG-16 |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1289 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `fb52cad5540450bb648df5a69660697f489d0636`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
