### PR TITLE
fix(cache): propagate Hibernate eviction failures

### DIFF
--- a/cache/hibernate-cache-lettuce/README.ko.md
+++ b/cache/hibernate-cache-lettuce/README.ko.md
@@ -43,6 +43,7 @@ cache 폴더 재편으로 소스 위치는 `cache/hibernate-cache-lettuce/`가 �
 ## 최근 변경
 
 - `LettuceNearCacheStorageAccess.evictData()`를 region local-only clear에서 **local + Redis clearAll**로 변경
+- key 및 region eviction 중 Redis 오류를 성공으로 처리하지 않고 호출자에게 전파
 - 테스트에서 `session.get()`을 `session.find()`로 교체해 Hibernate deprecated API 제거
 - One-To-Many / Many-To-One / Many-To-Many 관계 엔티티 캐시 시나리오 테스트 추가
 
@@ -160,6 +161,10 @@ val products: MutableList<Product> = mutableListOf()
 | `evictData(key)`            | L1 + L2 해당 key 삭제                                         |
 | `evictData()` (region 전체) | L1 + L2 전체 제거 (`clearAll()`)                              |
 | 외부 Redis 변경 감지        | RESP3 CLIENT TRACKING push → L1 자동 무효화                   |
+
+### Eviction 실패 계약
+
+`evictData(key)`와 `evictData()`는 L1과 L2를 함께 무효화하는 write-through 연산이다. Redis에서 제거를 완료하지 못하면 backend 예외를 로깅한 뒤 Hibernate에 전파하며, eviction을 성공으로 보고하지 않는다. 로컬 front cache가 먼저 비워진 상태에서 Redis stale entry가 남을 수 있으므로 호출자는 해당 연산을 실패로 처리하고 복구 정책을 적용해야 한다.
 
 ## 지원 코덱
 

--- a/cache/hibernate-cache-lettuce/README.md
+++ b/cache/hibernate-cache-lettuce/README.md
@@ -45,6 +45,7 @@ No user import migration is required for the reorganization.
 ## Recent Changes
 
 - Changed `LettuceNearCacheStorageAccess.evictData()` from region local-only clear to **local + Redis clearAll**
+- Propagated Redis failures from keyed and region eviction instead of reporting normal success
 - Replaced `session.get()` with `session.find()` in tests to remove deprecated Hibernate API usage
 - Added cache scenario tests for One-To-Many, Many-To-One, and Many-To-Many relationships
 
@@ -163,6 +164,10 @@ val products: MutableList<Product> = mutableListOf()
 | `evictData(key)`                | Delete the key from both L1 and L2                                     |
 | `evictData()` (entire region)   | Remove all entries from L1 and L2 (`clearAll()`)                       |
 | External Redis change detection | RESP3 CLIENT TRACKING push → automatic L1 invalidation                 |
+
+### Eviction failure contract
+
+`evictData(key)` and `evictData()` are write-through invalidation operations. If Redis cannot complete the removal, the backend exception is logged and propagated to Hibernate instead of being reported as a successful eviction. The local front cache may already be cleared while a stale Redis entry remains, so callers must treat the operation as failed and apply their recovery policy.
 
 ## Supported Codecs
 

--- a/cache/hibernate-cache-lettuce/src/main/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCacheStorageAccess.kt
+++ b/cache/hibernate-cache-lettuce/src/main/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCacheStorageAccess.kt
@@ -27,6 +27,7 @@ import java.util.Base64
  *   L2 장애 시 예외를 로깅하고 무시한다 (Hibernate 트랜잭션에 영향 없음).
  * - [evictData]: region 전체 evict 시 local + Redis 모두 제거
  * - [evictData] with key: 특정 key만 L1+L2 제거
+ * - eviction 중 Redis 오류가 발생하면 예외를 호출자에게 전파하여 Hibernate가 성공으로 처리하지 않도록 한다.
  */
 class LettuceNearCacheStorageAccess(
     private val regionName: String,
@@ -212,21 +213,31 @@ class LettuceNearCacheStorageAccess(
     /**
      * 특정 키를 캐시(L1+L2)에서 제거한다.
      *
-     * Redis 장애 등 예외 발생 시 예외를 로깅하고 무시한다.
+     * Redis 제거가 완료되지 않으면 예외를 로깅한 뒤 호출자에게 전파한다.
+     * 로컬 캐시는 먼저 제거될 수 있으므로, 호출자는 eviction을 실패한 것으로 처리해야 한다.
      */
     override fun evictData(key: Any) {
-        runCatching { nearCache.remove(cacheKey(key)) }
-            .onFailure { e -> log.warn(e) { "캐시 evict 실패 (region=$regionName, key=$key) → 무시" } }
+        try {
+            nearCache.remove(cacheKey(key))
+        } catch (e: Exception) {
+            log.warn(e) { "캐시 evict 실패 (region=$regionName, key=$key) → 호출자에게 전파" }
+            throw e
+        }
     }
 
     /**
      * region 전체 evict: local + Redis 모두 제거한다.
      *
-     * Redis 장애 등 예외 발생 시 예외를 로깅하고 무시한다.
+     * Redis 전체 제거가 완료되지 않으면 예외를 로깅한 뒤 호출자에게 전파한다.
+     * 로컬 캐시는 먼저 제거될 수 있으므로, 호출자는 eviction을 실패한 것으로 처리해야 한다.
      */
     override fun evictData() {
-        runCatching { nearCache.clearAll() }
-            .onFailure { e -> log.warn(e) { "캐시 전체 evict 실패 (region=$regionName) → 무시" } }
+        try {
+            nearCache.clearAll()
+        } catch (e: Exception) {
+            log.warn(e) { "캐시 전체 evict 실패 (region=$regionName) → 호출자에게 전파" }
+            throw e
+        }
     }
 
     /**

--- a/cache/hibernate-cache-lettuce/src/test/kotlin/io/bluetape4k/hibernate/cache/lettuce/HibernateEvictionFailureTest.kt
+++ b/cache/hibernate-cache-lettuce/src/test/kotlin/io/bluetape4k/hibernate/cache/lettuce/HibernateEvictionFailureTest.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.hibernate.cache.lettuce
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.cache.nearcache.LettuceNearCache
+import io.bluetape4k.cache.nearcache.LettuceNearCacheConfig
+import io.mockk.clearMocks
+import io.mockk.mockk
+import io.lettuce.core.RedisClient
+import io.lettuce.core.codec.StringCodec
+import org.hibernate.engine.spi.SharedSessionContractImplementor
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Hibernate L2 eviction 실패 전파를 검증한다.
+ *
+ * Near Cache 연결을 먼저 닫아 Redis backend failure를 재현한다.
+ * eviction 호출은 정상 반환하지 않아야 하며, Redis에 남아 있는 stale entry도
+ * 성공적으로 제거된 것으로 취급하지 않아야 한다.
+ */
+class HibernateEvictionFailureTest {
+
+    private val session = mockk<SharedSessionContractImplementor>(relaxed = true)
+
+    private lateinit var redisClient: RedisClient
+    private lateinit var cache: LettuceNearCache<Any>
+    private lateinit var cacheName: String
+    private lateinit var storageAccess: LettuceNearCacheStorageAccess
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(session)
+        cacheName = "issue-1273-${UUID.randomUUID()}"
+        redisClient = RedisClient.create(RedisServers.redis.url)
+
+        @Suppress("UNCHECKED_CAST")
+        val stringCache = LettuceNearCache(
+            redisClient,
+            StringCodec.UTF8,
+            LettuceNearCacheConfig<String, String>(
+                cacheName = cacheName,
+                useRespProtocol3 = false,
+            )
+        ) as LettuceNearCache<Any>
+
+        cache = stringCache
+        storageAccess = LettuceNearCacheStorageAccess("region", cache)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        runCatching {
+            if (::redisClient.isInitialized) {
+                redisClient.connect(StringCodec.UTF8).use { connection ->
+                    val commands = connection.sync()
+                    val keys = commands.keys("$cacheName:*")
+                    if (keys.isNotEmpty()) commands.unlink(*keys.toTypedArray())
+                }
+            }
+        }
+        runCatching { if (::cache.isInitialized) cache.close() }
+        runCatching { if (::redisClient.isInitialized) redisClient.shutdown() }
+    }
+
+    @Test
+    fun `key eviction backend failure is propagated and stale Redis entry is not treated as evicted`() {
+        storageAccess.putIntoCache("key", "value", session)
+        redisKeys().shouldNotBeEmpty()
+
+        // Close the Near Cache connection while the Redis entry remains.
+        cache.close()
+
+        assertFailsWith<Exception> {
+            storageAccess.evictData("key")
+        }
+
+        redisKeys().shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `region eviction backend failure is propagated and stale Redis entries remain observable`() {
+        listOf("first", "second").forEach { key ->
+            storageAccess.putIntoCache(key, key, session)
+        }
+        redisKeys().size shouldBeGreaterThan 1
+
+        // Close the Near Cache connection while the Redis entries remain.
+        cache.close()
+
+        assertFailsWith<Exception> {
+            storageAccess.evictData()
+        }
+
+        redisKeys().size shouldBeGreaterThan 1
+    }
+
+    private fun redisKeys(): List<String> =
+        redisClient.connect(StringCodec.UTF8).use { connection ->
+            connection.sync().keys("$cacheName:*")
+        }
+}


### PR DESCRIPTION
## Summary

Closes #1273

- PR 제목: fix(cache): propagate Hibernate eviction failures

- Propagate keyed and region Redis eviction failures from `LettuceNearCacheStorageAccess` instead of reporting normal success to Hibernate.
- Add failing-backend regression coverage that proves stale Redis entries remain observable when eviction fails.
- Document the partial-clear failure contract in Korean-first KDoc and the English/Korean module READMEs.

### 원문 선행 내용

Fixes #1273

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

### 기존 섹션: Lesson gate

No new lesson file is required. Existing cache failure lessons already document caller-visible cleanup failures; this PR applies that rule at the Hibernate adapter boundary without introducing new failure, recovery, design, or operational guidance.

## Validation

- RED: the two new failing-backend tests failed before the production change because eviction returned normally.
- GREEN: targeted regression suite passed with 2 tests and zero failures/errors/skips.
- Full `:bluetape4k-hibernate-cache-lettuce:test --rerun-tasks`: 83 tests across 15 suites, zero failures/errors/skips.
- `:bluetape4k-hibernate-cache-lettuce:detekt`: passed for 25 Kotlin files.
- `git diff --check`: passed.
- Exact-head GitHub CI passed: Build, Test / Data, Coverage Report, CI Status, policy, security, catalog, and dependency submission checks; unrelated test lanes were skipped by path filters.
- Fresh review/thread inventory is empty and GitHub reports `CLEAN` / `MERGEABLE`.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1273, milestone `1.12.0`, assignee `debop`
- PR: #1290, head `2bbab4d39ffbf96bf4b0cb9a1df629cae16d7792`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1273-eviction-failure`
- Labels: `bug`, `cache`
- State: `MERGED`, merge commit `4d877bdc950b601cd53c4bde1ab39456c0d80bad`
- CI: - `:bluetape4k-hibernate-cache-lettuce:detekt`: passed for 25 Kotlin files. / - Exact-head GitHub CI passed: Build, Test / Data, Coverage Report, CI Status, policy, security, catalog, and dependency submission checks; unrelated test lanes were skipped by path filters. / No new lesson file is required. Existing cache failure lessons already document caller-visible cleanup failures; this PR applies that rule at the Hibernate adapter boundary without introducing new failure, recovery, design, or operational guidance.

## DoD Status

- [x] Keyed eviction failures propagate to Hibernate.
- [x] Region eviction failures propagate to Hibernate.
- [x] Failing-backend regression tests cover both paths.
- [x] Stale Redis entries are asserted as not successfully evicted.
- [x] KDoc and bilingual README failure contract are aligned.
- [x] Targeted and full module validation passed.
- [x] Exact-head GitHub CI passed with no unresolved review/thread findings.
- [ ] Merge: pending fresh exact-head approval.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1290 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `4d877bdc950b601cd53c4bde1ab39456c0d80bad`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
