### PR TITLE
Fix: fail closed on unsupported Hibernate cache identifiers

### DIFF
--- a/cache/hibernate-cache-lettuce/README.ko.md
+++ b/cache/hibernate-cache-lettuce/README.ko.md
@@ -40,10 +40,17 @@ cache 폴더 재편으로 소스 위치는 `cache/hibernate-cache-lettuce/`가 �
 - **Hibernate key encoding**: Hibernate key는 Region prefix 적용 전에 versioned collision-resistant digest로 정규화
 - **AccessType**: `NONSTRICT_READ_WRITE` 권장 (분산 캐시에서 soft-lock 불필요)
 
+### Cache Key 요구 사항
+
+캐시 key에 사용하는 모든 Hibernate 식별자(entity ID, natural ID, composite key 구성 요소)는 지원되는 scalar/array 값이거나 전체 object graph가 `java.io.Serializable`이어야 합니다. Canonicalization은 fail-closed로 동작하므로, 지원되지 않는 값과 직렬화할 수 없는 nested member를 포함한 `Serializable` 값은 조회 시 cache miss, 저장 시 무시, keyed eviction 시 예외 전파로 처리됩니다. `toString()`이나 `hashCode()`를 fallback으로 사용하지 않습니다.
+
+text fallback을 사용하던 이전 버전이 만든 기존 entry는 이 변경 후 다시 주소화할 수 없습니다. 해당 legacy entry를 제거해야 한다면 rollout 중 영향받는 region을 한 번 evict하세요. 직렬화 가능한 key는 기존 `hck2` digest 표현을 유지하므로 전체 cache migration은 필요하지 않습니다.
+
 ## 최근 변경
 
 - `LettuceNearCacheStorageAccess.evictData()`를 region local-only clear에서 **local + Redis clearAll**로 변경
 - key 및 region eviction 중 Redis 오류를 성공으로 처리하지 않고 호출자에게 전파
+- correctness-critical text/hashCode cache-key fallback 제거: 지원되지 않는 식별자 graph는 fail-closed 처리
 - 테스트에서 `session.get()`을 `session.find()`로 교체해 Hibernate deprecated API 제거
 - One-To-Many / Many-To-One / Many-To-Many 관계 엔티티 캐시 시나리오 테스트 추가
 

--- a/cache/hibernate-cache-lettuce/README.md
+++ b/cache/hibernate-cache-lettuce/README.md
@@ -42,10 +42,17 @@ No user import migration is required for the reorganization.
   Encoding**: Hibernate keys are normalized to a versioned collision-resistant digest before the region prefix is applied
 - **AccessType**: `NONSTRICT_READ_WRITE` is recommended (soft-locking is unnecessary in a distributed cache)
 
+### Cache Key Requirements
+
+Every Hibernate identifier used in a cache key (entity IDs, natural IDs, and composite-key components) must be a supported scalar/array value or implement `java.io.Serializable` across its complete object graph. Canonicalization is fail-closed: unsupported values and `Serializable` values with a non-serializable nested member produce a cache miss for reads, ignore writes, and propagate keyed-eviction failures. No `toString()` or `hashCode()` fallback is used.
+
+Existing entries created by versions that used the text fallback are not addressable after this change. Evict affected regions once during rollout if those legacy entries must be removed; supported serializable keys keep the existing `hck2` digest representation, so a blanket cache migration is not required.
+
 ## Recent Changes
 
 - Changed `LettuceNearCacheStorageAccess.evictData()` from region local-only clear to **local + Redis clearAll**
 - Propagated Redis failures from keyed and region eviction instead of reporting normal success
+- Removed correctness-critical text/hashCode cache-key fallback; unsupported identifier graphs now fail closed
 - Replaced `session.get()` with `session.find()` in tests to remove deprecated Hibernate API usage
 - Added cache scenario tests for One-To-Many, Many-To-One, and Many-To-Many relationships
 

--- a/cache/hibernate-cache-lettuce/src/main/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCacheStorageAccess.kt
+++ b/cache/hibernate-cache-lettuce/src/main/kotlin/io/bluetape4k/hibernate/cache/lettuce/LettuceNearCacheStorageAccess.kt
@@ -9,6 +9,7 @@ import org.hibernate.cache.internal.NaturalIdCacheKey
 import org.hibernate.cache.spi.support.DomainDataStorageAccess
 import org.hibernate.engine.spi.SharedSessionContractImplementor
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.io.ObjectOutputStream
 import java.io.Serializable
 import java.security.MessageDigest
@@ -27,6 +28,7 @@ import java.util.Base64
  *   L2 장애 시 예외를 로깅하고 무시한다 (Hibernate 트랜잭션에 영향 없음).
  * - [evictData]: region 전체 evict 시 local + Redis 모두 제거
  * - [evictData] with key: 특정 key만 L1+L2 제거
+ * - cache key canonicalization을 수행할 수 없는 식별자는 text/hashCode fallback 없이 fail-closed 처리한다.
  * - eviction 중 Redis 오류가 발생하면 예외를 호출자에게 전파하여 Hibernate가 성공으로 처리하지 않도록 한다.
  */
 class LettuceNearCacheStorageAccess(
@@ -113,7 +115,7 @@ class LettuceNearCacheStorageAccess(
             is LongArray    -> writePrimitiveArray("long[]", value.toList()) { writeLong(it) }
             is ShortArray   -> writePrimitiveArray("short[]", value.toList()) { writeShort(it.toInt()) }
             is Serializable -> writeSerializableValue(value)
-            else            -> writeTextFallback(value)
+            else            -> throw UnsupportedCacheKeyException(value)
         }
     }
 
@@ -143,10 +145,13 @@ class LettuceNearCacheStorageAccess(
     }
 
     private fun ObjectOutputStream.writeSerializableValue(value: Serializable) {
-        val serialized = serializeValue(value)
-        if (serialized == null) {
-            writeTextFallback(value)
-            return
+        val serialized = try {
+            ByteArrayOutputStream().use { bytes ->
+                ObjectOutputStream(bytes).use { out -> out.writeObject(value) }
+                bytes.toByteArray()
+            }
+        } catch (e: IOException) {
+            throw UnsupportedCacheKeyException(value, e)
         }
 
         writeUTF("serializable")
@@ -155,26 +160,19 @@ class LettuceNearCacheStorageAccess(
         write(serialized)
     }
 
-    private fun serializeValue(value: Serializable): ByteArray? =
-        runCatching {
-            ByteArrayOutputStream().use { bytes ->
-                ObjectOutputStream(bytes).use { out -> out.writeObject(value) }
-                bytes.toByteArray()
-            }
-        }.getOrNull()
-
-    private fun ObjectOutputStream.writeTextFallback(value: Serializable) {
-        writeUTF("text")
-        writeUTF(value.javaClass.name)
-        writeInt(value.hashCode())
-        writeUTF(value.toString())
-    }
-
-    private fun ObjectOutputStream.writeTextFallback(value: Any) {
-        writeUTF("text")
-        writeUTF(value.javaClass.name)
-        writeUTF(value.toString())
-    }
+    /**
+     * 식별자 전체 object graph를 canonical bytes로 만들 수 없을 때 사용한다.
+     *
+     * text/hashCode 기반 fallback은 서로 다른 식별자를 같은 cache key로 만들 수 있으므로
+     * 허용하지 않는다. 호출 계층의 `runCatching`이 읽기 miss/쓰기 무시로 안전하게 폴백한다.
+     */
+    private class UnsupportedCacheKeyException(
+        value: Any,
+        cause: Throwable? = null,
+    ): IllegalArgumentException(
+        "Hibernate cache key value cannot be canonically serialized: ${value.javaClass.name}",
+        cause,
+    )
 
     /**
      * 캐시에서 값을 조회한다. Caffeine(L1) miss 시 Redis(L2)를 조회한다.

--- a/cache/hibernate-cache-lettuce/src/test/kotlin/io/bluetape4k/hibernate/cache/lettuce/HibernateAdvancedKeyCacheTest.kt
+++ b/cache/hibernate-cache-lettuce/src/test/kotlin/io/bluetape4k/hibernate/cache/lettuce/HibernateAdvancedKeyCacheTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.hibernate.cache.lettuce
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.cache.nearcache.LettuceNearCache
@@ -155,6 +156,38 @@ class HibernateAdvancedKeyCacheTest: AbstractHibernateNearCacheTest() {
     }
 
     @Test
+    fun `nested graph serialization failure는 cache key를 fail-closed 처리한다`() {
+        withStorageAccess("broken-serializable-id-${System.nanoTime()}") { cacheName, storageAccess, session ->
+            val firstKey = BrokenSerializableIdentifier("first")
+            val secondKey = BrokenSerializableIdentifier("second")
+
+            storageAccess.putIntoCache(firstKey, "first-value", session)
+            storageAccess.putIntoCache(secondKey, "second-value", session)
+
+            storageAccess.getFromCache(firstKey, session).shouldBeNull()
+            storageAccess.getFromCache(secondKey, session).shouldBeNull()
+            storageAccess.contains(firstKey) shouldBeEqualTo false
+            redisKeys("$cacheName:*").size shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `동일 textual representation의 비직렬화 식별자는 cache key를 fail-closed 처리한다`() {
+        withStorageAccess("non-serializable-id-${System.nanoTime()}") { cacheName, storageAccess, session ->
+            val firstKey = NonSerializableIdentifier("first")
+            val secondKey = NonSerializableIdentifier("second")
+
+            storageAccess.putIntoCache(firstKey, "first-value", session)
+            storageAccess.putIntoCache(secondKey, "second-value", session)
+
+            storageAccess.getFromCache(firstKey, session).shouldBeNull()
+            storageAccess.getFromCache(secondKey, session).shouldBeNull()
+            storageAccess.contains(firstKey) shouldBeEqualTo false
+            redisKeys("$cacheName:*").size shouldBeEqualTo 0
+        }
+    }
+
+    @Test
     fun `update timestamps cache도 digest 문자열 key를 사용한다`() {
         sessionFactory.openSession().use { session ->
             session.beginTransaction()
@@ -226,5 +259,25 @@ class HibernateAdvancedKeyCacheTest: AbstractHibernateNearCacheTest() {
         companion object {
             private const val serialVersionUID: Long = 1L
         }
+    }
+
+    private class BrokenSerializableIdentifier(
+        private val value: String,
+    ): Serializable {
+        private val nestedState: Any = Any()
+
+        override fun hashCode(): Int = 0
+
+        override fun toString(): String = "same-text"
+
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    private class NonSerializableIdentifier(
+        private val value: String,
+    ) {
+        override fun toString(): String = "same-text"
     }
 }


### PR DESCRIPTION
## Summary

Closes #1274

- PR 제목: Fix: fail closed on unsupported Hibernate cache identifiers

Closes #1274

Hibernate cache-key canonicalization no longer falls back to `toString()` or `hashCode()` when an identifier cannot be serialized. Unsupported identifier graphs now fail closed, preventing distinct values from sharing a Redis key.

## Background

Milestone `1.12.0` issue #1274 identified a correctness and security gap in the versioned Hibernate cache-key digest. A `Serializable` identifier with a non-serializable nested member, or two non-serializable identifiers with the same textual representation, could reach a correctness-critical text fallback and collide.

## What This Solves

- Prevents cache poisoning and cross-identifier collisions caused by text/hashCode fallback bytes.
- Makes unsupported cache-key values safe: reads miss, writes are ignored, and keyed eviction reports the canonicalization failure.

## Work Done

- Removed both text fallback branches from `LettuceNearCacheStorageAccess` and convert Java serialization failures into an explicit unsupported-key exception.
- Added RED/GREEN Testcontainers-backed regressions for broken Serializable graphs and distinct non-Serializable identifiers with identical text.
- Documented complete-object-graph `Serializable` requirements and legacy fallback-entry migration impact in both README locales.

## Validation

- `./gradlew :bluetape4k-hibernate-cache-lettuce:test --tests 'io.bluetape4k.hibernate.cache.lettuce.HibernateAdvancedKeyCacheTest' --no-build-cache`: PASS (8 tests)
- `./gradlew :bluetape4k-hibernate-cache-lettuce:test --no-build-cache`: PASS (85 tests)
- `./gradlew :bluetape4k-hibernate-cache-lettuce:detekt --no-build-cache`: PASS (task completed; pre-existing findings remain outside this fix)
- `git diff --check` plus README asset/link/config-key parity checks: PASS

## Review Notes

- P0/P1: 0 blockers. Local review scripts reported 0 findings; live GitHub reviewDecision is empty with no review requests, reviews, or comments, and the PR is `MERGEABLE`/`CLEAN` after required checks.
- P2/P3: Existing Detekt findings in unrelated model/config code and pre-existing eviction catch/complexity findings are deferred; none were introduced by this fix.
- Review evidence: final local diff at commit `c8f736459d12ec62de108312f4ddb83268e166bf`; live PR #1291 review/thread and mergeability query.

## Metadata

- Issue: #1274, milestone `1.12.0`, assignee `debop`
- PR: #1291, head `c8f736459d12ec62de108312f4ddb83268e166bf`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1274-cache-key-serialization`
- Labels: `bug`, `security`, `cache`
- State: `MERGED`, merge commit `4ba8e9765616b3b8bf70c9a446697420c4154ba1`
- CI: - Removed both text fallback branches from `LettuceNearCacheStorageAccess` and convert Java serialization failures into an explicit unsupported-key exception. / - `./gradlew :bluetape4k-hibernate-cache-lettuce:test --tests 'io.bluetape4k.hibernate.cache.lettuce.HibernateAdvancedKeyCacheTest' --no-build-cache`: PASS (8 tests) / - `./gradlew :bluetape4k-hibernate-cache-lettuce:test --no-build-cache`: PASS (85 tests)

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 - Classification | Classified as Type C bug fix | PASS | Issue #1274 and approved Type-C plan | none |
| CG-02 - Acceptance | Confirmed fail-closed and migration requirements | PASS | Live issue body and milestone metadata | none |
| CG-03 - Isolation | Created isolated `fix/issue-1274-cache-key-serialization` worktree | PASS | `git worktree list`; root `develop` remains clean | none |
| CG-04 - Context | Queried GNO, then verified sparse results with live `gh` issue/repository state | PASS | GNO no-result evidence plus issue #1274 metadata | none |
| CG-05 - Scope/reuse | Reused existing canonical digest format and dependencies | PASS | Four-path diff; no new dependency | none |
| CG-06 - RED | Added and ran two failing collision regressions before the fix | PASS | RED run: 2 new failures returned `second-value` | none |
| CG-07 - Surgical fix | Removed text/hashCode fallback and narrowed serialization failure handling | PASS | Commit `c8f736459d12ec62de108312f4ddb83268e166bf` | none |
| CG-08 - GREEN/blast radius | Ran targeted and full module validation | PASS | 8 targeted and 85 module tests passed | none |
| CG-09 - Lesson | Reusable identifier requirement is captured in both module READMEs; no cross-repo lesson file is needed | N/A | README contract and migration guidance are committed in this fix | none |
| CG-10 - Final proof | Converged scoped diff and exact local head | PASS | `git diff --check`; exact head `c8f736459d12ec62de108312f4ddb83268e166bf` | none |
| CG-11 - Delivery authority | Verified approved repo/base/head PR scope | PASS | `bluetape4k-projects`, `develop`, `fix/issue-1274-cache-key-serialization` | none |
| CG-12 - Publish | Published the exact head without force | PASS | Remote branch resolves to `c8f736459d12ec62de108312f4ddb83268e166bf` | none |
| CG-13 - PR body | Create and live-verify this PR body | PASS | PR #1291 body ends with `## DoD Status` and mirrors issue metadata | none |
| CG-14 - CI/review | Verify exact-head CI and current review threads | PASS | 11 applicable checks pass; 8 non-applicable matrix jobs skipped by changed-module detection; no review requests/threads; `MERGEABLE`/`CLEAN` | none |
| CG-15 - Merge-ready | PASS | Render final merge-ready DoD | PR #1291, head `c8f736459d12ec62de108312f4ddb83268e166bf`, pre-approval counts 14/17, N/A 1, Blocked 0 | none |
| CG-16 - Merge approval | PASS | Fresh approval received for the exact PR/head | User approval received after CG-15 for PR #1291 head `c8f736459d12ec62de108312f4ddb83268e166bf` |
| CG-17 - Merge | PASS | Verified live merged state and merge commit | Merge commit `4ba8e9765616b3b8bf70c9a446697420c4154ba1`; merge-commit strategy | none |
| CG-18 - Sync/cleanup | PASS | Fast-forwarded local `develop` and removed only the clean merged feature worktree | `HEAD == origin/develop == 4ba8e9765616b3b8bf70c9a446697420c4154ba1`; ahead/behind `0/0`; local branch retained; remote feature ref gone | none |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1291 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `4ba8e9765616b3b8bf70c9a446697420c4154ba1`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
