### PR TITLE
Fix: renew Redis keychain rotation lock through commit

### DIFF
--- a/docs/lessons/2026-08-02-issue-1275-redis-lock-lease.md
+++ b/docs/lessons/2026-08-02-issue-1275-redis-lock-lease.md
@@ -1,0 +1,38 @@
+# 이슈 #1275 Redis key-chain rotation lock lease
+
+이슈 #1275는 `RedisKeyChainRepository`가 rotation lock에 30초 고정 lease를
+사용하고, lock 해제 과정의 오류를 `runCatching`으로 삼키던 문제를 다룬다. Redis
+저장과 오래된 KeyChain 정리가 lease보다 오래 걸리면 lock이 먼저 만료되어 두 노드가
+동시에 rotation을 commit할 수 있고, 소유권 상실이나 해제 실패가 관찰되지 않았다.
+
+## 결정
+
+rotation lock은 lease 시간을 지정하지 않는 Redisson `tryLock(waitTime, unit)`
+overload를 사용한다. 이 방식은 Redisson watchdog가 commit이 끝날 때까지 lock
+소유권을 갱신하도록 한다. 해제 직전에 현재 스레드의 소유권을 확인하고, 소유권 상실이나
+unlock 실패를 호출자에게 전달한다. rotation 본문이 먼저 실패했다면 unlock 오류는
+suppressed exception으로 붙여 원래 오류를 primary failure로 보존한다.
+
+## 교훈
+
+- 분산 lock의 고정 lease는 여러 Redis 명령으로 구성된 commit 구간의 상한으로 사용할 수
+  없다. client watchdog 또는 fencing 같은 명시적인 소유권 전략이 필요하다.
+- lock 해제 실패를 무시하면 commit 결과와 lock 상태가 달라져 장애 원인을 추적할 수 없다.
+  release 오류는 관찰 가능해야 하며, primary failure를 덮어쓰면 안 된다.
+- concurrent two-node 회전 테스트와 짧은 lease를 시뮬레이션한 watchdog 테스트를 함께 두면
+  실제 Redis 수렴과 lease 만료 회귀를 긴 wall-clock 대기 없이 검증할 수 있다.
+
+## 검증
+
+- RED: 기존 고정 lease 호출은 watchdog-overload를 검증하는 테스트에서
+  `Failed to acquire Redis keychain rotation lock.`으로 실패했다.
+- GREEN targeted: `./gradlew :bluetape4k-jwt:test --tests
+  "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest" --no-build-cache`가
+  15 tests로 통과했다.
+- module: `./gradlew :bluetape4k-jwt:test --no-build-cache`가 155 tests, 10 pending으로
+  통과했다.
+- build: `./gradlew :bluetape4k-jwt:build --no-build-cache`가 통과했다.
+- static analysis: `./gradlew :bluetape4k-jwt:detekt --no-build-cache
+  --no-configuration-cache`가 통과했고 변경한 `RedisKeyChainRepository.kt`에는
+  새 detekt finding이 없었다. 기존 JWT 파일의 finding은 별도 이슈로 남아 있다.
+- hygiene: `git diff --check`가 통과했다.

--- a/utils/jwt/README.ko.md
+++ b/utils/jwt/README.ko.md
@@ -207,6 +207,8 @@ val jwtProvider = JwtProviderFactory.default(keyChainRepository = repository)
 jwtProvider.rotate()
 ```
 
+`RedisKeyChainRepository`는 Redisson watchdog 기반 분산 lock으로 회전을 보호합니다. 고정 lease 시간을 지정하지 않고 lock을 획득하므로 새 키를 저장하고 오래된 키를 정리하는 commit이 끝날 때까지 소유권을 갱신합니다. 소유권을 잃거나 lock 해제에 실패하면 오류를 숨기지 않고 호출자에게 전달하며, 회전 작업 자체가 먼저 실패한 경우에는 해제 오류를 suppressed exception으로 보존합니다. 모든 노드는 동일한 Redis namespace와 살아 있는 Redisson client를 사용해야 합니다.
+
 ### In-Memory KeyChain 저장소
 
 ```kotlin

--- a/utils/jwt/README.md
+++ b/utils/jwt/README.md
@@ -189,6 +189,8 @@ val jwtProvider = JwtProviderFactory.default(keyChainRepository = repository)
 jwtProvider.rotate()
 ```
 
+`RedisKeyChainRepository` protects rotation with Redisson's watchdog-backed lock. The lock is acquired without a fixed lease time, so ownership is renewed while the new key is committed and older keys are trimmed. If ownership is lost or unlocking fails, the failure is propagated; when rotation already failed, the unlock failure is retained as a suppressed exception. Use the same Redis namespace and a live Redisson client on every node.
+
 ### In-Memory KeyChain Repository
 
 ```kotlin

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/redis/RedisKeyChainRepository.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/redis/RedisKeyChainRepository.kt
@@ -21,6 +21,9 @@ import java.util.concurrent.TimeUnit
 /**
  * JWT 토큰 발급에 사용된 [KeyChain]을 Redis에 저장하여, 분산환경에서 [KeyChain]을 공유하고, rotate 시에 전파되도록 합니다.
  * 또한 rotate로 인해 key chain이 변경된 경우에도 토큰 파싱이 가능하도록 저장합니다.
+ * 회전은 lease 시간을 고정하지 않는 Redisson watchdog 기반 lock으로 보호하므로, 여러 Redis 명령으로
+ * 구성된 저장 및 오래된 KeyChain 정리 작업이 끝날 때까지 현재 스레드의 소유권을 갱신합니다.
+ * lock 소유권을 잃거나 해제에 실패하면 오류를 숨기지 않고 호출자에게 전달합니다.
  *
  * ```kotlin
  * val redisson: RedissonClient = // ...
@@ -109,19 +112,8 @@ class RedisKeyChainRepository private constructor(
         return changed
     }
 
-    private inline fun withRotationLock(action: () -> Boolean): Boolean {
-        check(rotationLock.tryLock(5, 30, TimeUnit.SECONDS)) {
-            "Failed to acquire Redis keychain rotation lock."
-        }
-        return try {
-            action()
-        } finally {
-            runCatching {
-                if (rotationLock.isHeldByCurrentThread) {
-                    rotationLock.unlock()
-                }
-            }
-        }
+    private fun withRotationLock(action: () -> Boolean): Boolean {
+        return withRedisRotationLock(rotationLock, action)
     }
 
     override fun deleteAll() {
@@ -129,4 +121,42 @@ class RedisKeyChainRepository private constructor(
         cachedCurrent = null
         keyChainStore.clear()
     }
+}
+
+private const val ROTATION_LOCK_WAIT_SECONDS = 5L
+
+/**
+ * Redis rotation 작업을 Redisson watchdog 기반 lock 소유권 안에서 실행합니다.
+ *
+ * lease 시간을 고정하지 않으므로 Redisson watchdog가 commit이 끝날 때까지 lock을 갱신합니다.
+ * 소유권을 잃었거나 해제에 실패하면 오류를 숨기지 않으며, 작업 오류가 이미 발생한 경우에는
+ * 해제 오류를 suppressed exception으로 보존해 원래 오류를 주 오류로 유지합니다.
+ */
+internal fun <T> withRedisRotationLock(lock: RLock, action: () -> T): T {
+    check(lock.tryLock(ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS)) {
+        "Failed to acquire Redis keychain rotation lock."
+    }
+
+    var actionResult: Result<T>? = null
+    var releaseFailure: Throwable? = null
+    try {
+        actionResult = runCatching(action)
+    } finally {
+        releaseFailure = runCatching {
+            check(lock.isHeldByCurrentThread) {
+                "Redis keychain rotation lock ownership was lost before commit."
+            }
+            lock.unlock()
+        }.exceptionOrNull()
+    }
+
+    val result = checkNotNull(actionResult)
+    val primaryFailure = result.exceptionOrNull()
+    if (primaryFailure != null) {
+        releaseFailure?.let(primaryFailure::addSuppressed)
+        throw primaryFailure
+    }
+
+    releaseFailure?.let { throw it }
+    return result.getOrThrow()
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
@@ -1,16 +1,32 @@
 package io.bluetape4k.jwt.keychain.redis
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.jwt.keychain.AbstractKeyChainRepositoryTest
 import io.bluetape4k.jwt.keychain.KeyChain
+import io.bluetape4k.jwt.keychain.KeyChainDto
 import io.bluetape4k.jwt.keychain.repository.KeyChainRepository
 import io.bluetape4k.jwt.keychain.repository.redis.RedisKeyChainRepository
+import io.bluetape4k.jwt.keychain.repository.redis.withRedisRotationLock
 import io.bluetape4k.testcontainers.storage.RedisServer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Test
+import org.redisson.Redisson
+import org.redisson.api.RDeque
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
 import java.time.Duration
 import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
 
@@ -20,6 +36,86 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
 
     override val repository: KeyChainRepository by lazy {
         RedisKeyChainRepository(redisson)
+    }
+
+    @Test
+    fun `rotation uses watchdog-backed lock acquisition`() {
+        val queue = mockk<RDeque<KeyChainDto>>(relaxed = true)
+        val lock = mockk<RLock>(relaxed = true)
+        val redisson = mockk<RedissonClient>(relaxed = true)
+        every { redisson.getDeque<KeyChainDto>(any<String>()) } returns queue
+        every { redisson.getLock(any<String>()) } returns lock
+        every { lock.tryLock(5, TimeUnit.SECONDS) } returns true
+        every { lock.isHeldByCurrentThread } returns true
+
+        RedisKeyChainRepository(redisson).forcedRotate(KeyChain()).shouldBeTrue()
+
+        verify(exactly = 1) { lock.tryLock(5, TimeUnit.SECONDS) }
+    }
+
+    @Test
+    fun `rotation reports ownership loss before commit`() {
+        val lock = mockk<RLock>()
+        every { lock.tryLock(5, TimeUnit.SECONDS) } returns true
+        every { lock.isHeldByCurrentThread } returns false
+
+        val failure = assertFailsWith<IllegalStateException> {
+            withRedisRotationLock(lock) { Unit }
+        }
+
+        failure.message shouldContain "ownership was lost"
+    }
+
+    @Test
+    fun `rotation keeps primary failure when unlock fails`() {
+        val lock = mockk<RLock>()
+        val primaryFailure = IllegalStateException("commit failed")
+        val unlockFailure = IllegalStateException("unlock failed")
+        every { lock.tryLock(5, TimeUnit.SECONDS) } returns true
+        every { lock.isHeldByCurrentThread } returns true
+        every { lock.unlock() } throws unlockFailure
+
+        val failure = assertFailsWith<IllegalStateException> {
+            withRedisRotationLock(lock) { throw primaryFailure }
+        }
+
+        assertSame(primaryFailure, failure)
+        assertSame(unlockFailure, failure.suppressed.single())
+    }
+
+    @Test
+    fun `watchdog keeps rotation lock until a long commit completes`() {
+        val firstClient = createWatchdogClient()
+        val secondClient = createWatchdogClient()
+        val lockName = "test:jwt:keychain:watchdog:${UUID.randomUUID()}"
+        val ownerLock = LeaseCappingLock(firstClient.getLock(lockName), 250)
+        val contenderLock = secondClient.getLock(lockName)
+        val started = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val result = executor.submit<Boolean> {
+                withRedisRotationLock(ownerLock) {
+                    started.countDown()
+                    Thread.sleep(1_200)
+                    true
+                }
+            }
+
+            started.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            Thread.sleep(600)
+            contenderLock.tryLock(100, TimeUnit.MILLISECONDS).shouldBeFalse()
+            result.get(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            contenderLock.tryLock(1, TimeUnit.SECONDS).shouldBeTrue()
+        } finally {
+            if (contenderLock.isHeldByCurrentThread) {
+                contenderLock.unlock()
+            }
+            executor.shutdownNow()
+            firstClient.shutdown()
+            secondClient.shutdown()
+        }
     }
 
     @Test
@@ -55,5 +151,66 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         } finally {
             seedRepository.deleteAll()
         }
+    }
+
+    @Test
+    fun `expired cached keychain rotates concurrently with single Redis winner`() {
+        val queueName = "test:jwt:keychain:${UUID.randomUUID()}"
+        val seedRepository = RedisKeyChainRepository(redisson, queueName = queueName)
+        val firstNode = RedisKeyChainRepository(redisson, queueName = queueName)
+        val secondNode = RedisKeyChainRepository(redisson, queueName = queueName)
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val expiredKeyChain = KeyChain(expiredTtl = Duration.ofMillis(1))
+            seedRepository.forcedRotate(expiredKeyChain).shouldBeTrue()
+            Thread.sleep(10)
+
+            firstNode.current() shouldBeEqualTo expiredKeyChain
+            secondNode.current() shouldBeEqualTo expiredKeyChain
+
+            val firstCandidate = KeyChain()
+            val secondCandidate = KeyChain()
+            val start = CountDownLatch(1)
+            val firstFuture = executor.submit<Boolean> {
+                start.await()
+                firstNode.rotate(firstCandidate)
+            }
+            val secondFuture = executor.submit<Boolean> {
+                start.await()
+                secondNode.rotate(secondCandidate)
+            }
+
+            start.countDown()
+            val firstRotated = firstFuture.get(10, TimeUnit.SECONDS)
+            val secondRotated = secondFuture.get(10, TimeUnit.SECONDS)
+            listOf(firstRotated, secondRotated).count { it }.shouldBeEqualTo(1)
+
+            val winner = if (firstRotated) firstCandidate else secondCandidate
+            val loser = if (firstRotated) secondCandidate else firstCandidate
+            firstNode.current() shouldBeEqualTo winner
+            secondNode.current() shouldBeEqualTo winner
+            seedRepository.findOrNull(winner.id) shouldBeEqualTo winner
+            assertNull(seedRepository.findOrNull(loser.id))
+        } finally {
+            executor.shutdownNow()
+            seedRepository.deleteAll()
+        }
+    }
+
+    private fun createWatchdogClient(): RedissonClient =
+        Redisson.create(
+            RedisServer.Launcher.RedissonLib.getRedissonConfig().apply {
+                setLockWatchdogTimeout(900)
+            },
+        )
+
+    private class LeaseCappingLock(
+        private val delegate: RLock,
+        private val cappedLeaseMillis: Long,
+    ): RLock by delegate {
+
+        override fun tryLock(waitTime: Long, leaseTime: Long, unit: TimeUnit): Boolean =
+            delegate.tryLock(waitTime, cappedLeaseMillis, TimeUnit.MILLISECONDS)
     }
 }


### PR DESCRIPTION
## Summary

Closes #1275

- PR 제목: Fix: renew Redis keychain rotation lock through commit

- replace the fixed 30-second Redis rotation lease with Redisson watchdog-backed ownership
- surface lock ownership and unlock failures while preserving the primary rotation failure
- add concurrent and short-lease regression coverage, bilingual README guidance, and a durable lesson

Closes #1275
Parent epic: #1271

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### Summary

- replace the fixed 30-second Redis rotation lease with Redisson watchdog-backed ownership
- surface lock ownership and unlock failures while preserving the primary rotation failure
- add concurrent and short-lease regression coverage, bilingual README guidance, and a durable lesson

Closes #1275
Parent epic: #1271

### Validation

- `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest" --no-build-cache` — 15 passing
- `./gradlew :bluetape4k-jwt:test --no-build-cache` — 155 passing, 10 pending
- `./gradlew :bluetape4k-jwt:build --no-build-cache`
- `./gradlew :bluetape4k-jwt:detekt --no-build-cache --no-configuration-cache` — task succeeds; pre-existing findings remain in untouched JWT files
- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`

### DoD Status

- [x] Lock ownership is renewable until the multi-command rotation commit completes
- [x] Concurrent two-node rotation has a single committed winner and converged state
- [x] Ownership loss and unlock failure are observable without masking a primary failure
- [x] Bilingual operational documentation and a reusable lesson are included
- [ ] Merge — fresh exact-head approval required

## Validation

- `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest" --no-build-cache` — 15 passing
- `./gradlew :bluetape4k-jwt:test --no-build-cache` — 155 passing, 10 pending
- `./gradlew :bluetape4k-jwt:build --no-build-cache`
- `./gradlew :bluetape4k-jwt:detekt --no-build-cache --no-configuration-cache` — task succeeds; pre-existing findings remain in untouched JWT files
- `python3 scripts/docs-localization-inventory.py --check`
- `git diff --check`

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1275, milestone `1.12.0`, assignee `debop`
- PR: #1293, head `028ec42d0ec50879f7d839d9aed6dff211c59bff`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1275-redis-lock-lease`
- Labels: `bug`, `security`
- State: `MERGED`, merge commit `f4ecca848d22fa6faf6ebc6a2b65e8363d2de77c`
- CI: - `./gradlew :bluetape4k-jwt:test --tests "io.bluetape4k.jwt.keychain.redis.RedisKeyChainRepositoryTest" --no-build-cache` — 15 passing / - `./gradlew :bluetape4k-jwt:test --no-build-cache` — 155 passing, 10 pending / - `./gradlew :bluetape4k-jwt:build --no-build-cache`

## DoD Status

- [x] Lock ownership is renewable until the multi-command rotation commit completes
- [x] Concurrent two-node rotation has a single committed winner and converged state
- [x] Ownership loss and unlock failure are observable without masking a primary failure
- [x] Bilingual operational documentation and a reusable lesson are included
- [ ] Merge — fresh exact-head approval required

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1293 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f4ecca848d22fa6faf6ebc6a2b65e8363d2de77c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
