### PR TITLE
Make JWT keychain refresh timers explicitly closeable

### DIFF
--- a/docs/lessons/2026-08-02-issue-1276-jwt-closeable.md
+++ b/docs/lessons/2026-08-02-issue-1276-jwt-closeable.md
@@ -1,0 +1,24 @@
+# JWT 백그라운드 타이머의 명시적 수명주기
+
+## Context
+
+JWT `KeyChainRepository`와 `DefaultJwtProvider`가 인스턴스마다 daemon `Timer`를 생성하지만, 호출자가 이를 종료할 공통 계약이 없었다. 반복적인 tenant/provider 재생성이나 테스트 fixture 폐기 뒤에도 timer task가 소유 객체를 붙잡을 수 있는 상태였으며, 이 문제를 #1276에서 추적했다.
+
+## Root cause
+
+`AbstractKeyChainRepository`와 `DefaultJwtProvider`가 `init`에서 `kotlin.concurrent.timer`를 시작하고도 `KeyChainRepository`와 `JwtProvider`에 `close()` 계약을 제공하지 않았다. 따라서 timer의 `cancel()`을 호출할 안정적인 public lifecycle 경계가 없었다.
+
+## Decision
+
+- 두 public contract는 `AutoCloseable`을 상속하고, 백그라운드 작업이 없는 구현체를 위해 idempotent no-op 기본 `close()`를 제공한다.
+- `AbstractKeyChainRepository.close()`는 repository가 소유한 refresh timer만 취소한다. timer callback과 close 사이의 경합은 lifecycle lock으로 직렬화한다.
+- `DefaultJwtProvider.close()`는 provider가 소유한 rotation timer만 취소한다. 주입받은 repository는 borrowed resource이므로 닫지 않으며, 호출자가 provider와 repository를 각각 닫는다.
+- cache provider는 delegate를 borrowed resource로 취급한다. delegate의 timer 수명은 원래 delegate 호출자가 관리한다. 외부 Redisson client도 repository가 닫지 않는다.
+
+## Verification
+
+`JwtLifecycleTest`는 짧은 refresh/rotation 주기로 callback이 실제 실행된 뒤 `close()`를 호출하고, 이후 callback count가 증가하지 않는지 검증한다. repository timer가 idempotent하게 종료되고 provider를 닫아도 borrowed repository timer가 살아 있는지도 확인한다. 전체 `:bluetape4k-jwt:test`는 157 passing, 10 pending으로 완료됐다.
+
+## Guidance for future changes
+
+새 JWT repository/provider가 timer, executor, scheduler 같은 백그라운드 자원을 소유하면 public lifecycle 계약과 deterministic cancellation 테스트를 같은 변경에 포함한다. 주입받은 자원의 소유권은 자동으로 전이된다고 가정하지 말고 KDoc과 README에 borrow/own 경계를 명시한다.

--- a/utils/jwt/README.ko.md
+++ b/utils/jwt/README.ko.md
@@ -146,6 +146,28 @@ val jwt2 = jwtProvider.composer().claim("user", "user2").compose()
 val reader1 = jwtProvider.parse(jwt1)  // OK (저장소에 이전 KeyChain이 있는 경우)
 ```
 
+### 수명주기와 자원 소유권
+
+`JwtProvider`와 `KeyChainRepository`는 `AutoCloseable`을 구현합니다. 기본 Provider는 자신의 KeyChain 회전 타이머를 소유하지만, 주입받은 저장소는 빌려서 사용하므로 Provider가 닫지 않습니다. 애플리케이션이나 테스트에서 함께 생성한 경우 두 객체를 명시적으로 닫으세요.
+
+```kotlin
+import io.bluetape4k.jwt.keychain.repository.inmemory.InMemoryKeyChainRepository
+import io.bluetape4k.jwt.provider.JwtProviderFactory
+
+val repository = InMemoryKeyChainRepository()
+val jwtProvider = JwtProviderFactory.default(keyChainRepository = repository)
+
+try {
+    val jwt = jwtProvider.compose { subject = "alice" }
+    jwtProvider.parse(jwt)
+} finally {
+    jwtProvider.close() // Provider의 회전 타이머를 취소합니다.
+    repository.close()  // 저장소의 refresh 타이머를 취소합니다.
+}
+```
+
+Cache Provider는 delegate를 빌려 사용하므로 회전 타이머를 소유한 원래 delegate를 별도로 닫아야 합니다. 백그라운드 작업이 없는 구현체는 기본 no-op `close()` 구현을 그대로 사용할 수 있습니다.
+
 ### 압축 사용
 
 큰 클레임 데이터가 있는 경우 jjwt 내장 압축 알고리즘을 사용할 수 있습니다.
@@ -219,6 +241,8 @@ import io.bluetape4k.jwt.provider.JwtProviderFactory
 val repository = InMemoryKeyChainRepository()
 val jwtProvider = JwtProviderFactory.default(keyChainRepository = repository)
 ```
+
+이 조합을 더 이상 사용하지 않을 때는 `jwtProvider.close()`와 `repository.close()`를 호출하세요. 저장소를 닫아도 외부에서 소유한 Redisson client는 종료하지 않습니다.
 
 ### 커스텀 KeyChain 저장소 구현
 

--- a/utils/jwt/README.md
+++ b/utils/jwt/README.md
@@ -137,6 +137,28 @@ val jwt2 = jwtProvider.composer().claim("user", "user2").compose()
 val reader1 = jwtProvider.parse(jwt1)
 ```
 
+### Lifecycle and resource ownership
+
+`JwtProvider` and `KeyChainRepository` implement `AutoCloseable`. The default provider owns its key rotation timer, while an injected repository is borrowed and is not closed by the provider. Close both explicitly when they share an application or test scope:
+
+```kotlin
+import io.bluetape4k.jwt.keychain.repository.inmemory.InMemoryKeyChainRepository
+import io.bluetape4k.jwt.provider.JwtProviderFactory
+
+val repository = InMemoryKeyChainRepository()
+val jwtProvider = JwtProviderFactory.default(keyChainRepository = repository)
+
+try {
+    val jwt = jwtProvider.compose { subject = "alice" }
+    jwtProvider.parse(jwt)
+} finally {
+    jwtProvider.close() // cancels the provider's rotation timer
+    repository.close()  // cancels the repository's refresh timer
+}
+```
+
+Cache providers borrow their delegate; close the original delegate separately when it owns a rotation timer. Implementations without background work may keep the default no-op `close()` implementation.
+
 ### Compression
 
 Use built-in jjwt compression for large claim payloads.
@@ -201,6 +223,8 @@ val repository = InMemoryKeyChainRepository()
 val jwtProvider = JwtProviderFactory.default(keyChainRepository = repository)
 ```
 
+Call `jwtProvider.close()` and `repository.close()` when this pair is no longer used. The repository close operation does not shut down an externally owned Redisson client.
+
 ### Custom KeyChain Repository
 
 ```kotlin
@@ -249,6 +273,21 @@ val jwtProvider = JwtProviderFactory.default(
 |---------------------|--------------------------------------|
 | `JwtCodecs.Deflate` | Deflate compression (`Jwts.ZIP.DEF`) |
 | `JwtCodecs.Gzip`    | GZIP compression (`Jwts.ZIP.GZIP`)   |
+
+## KeyChain Structure
+
+```kotlin
+class KeyChain(
+    val algorithm: SignatureAlgorithm,  // signing algorithm (jjwt 0.13.x SignatureAlgorithm)
+    val keyPair: KeyPair,               // RSA key pair
+    val id: String,                     // unique KeyChain ID (kid)
+    val createdAt: Long,                // creation time (epoch millis)
+    val expiredTtl: Long,               // expiration TTL (millis)
+) {
+    val isExpired: Boolean              // whether the key is expired
+    val expiredAt: Long                 // expiration time (epoch millis)
+}
+```
 
 ## Security Best Practices
 

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/AbstractKeyChainRepository.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/AbstractKeyChainRepository.kt
@@ -4,15 +4,17 @@ import io.bluetape4k.jwt.keychain.KeyChain
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
-import java.util.*
+import io.bluetape4k.support.requirePositiveNumber
+import java.util.Timer
 import kotlin.concurrent.timer
 
 /**
  * [KeyChainRepository]의 공통 로직을 구현하는 추상 기반 클래스입니다.
  *
  * ## 동작/계약
- * - 생성 시 1분(60초) 간격으로 현재 키체인을 자동 갱신하는 타이머가 시작됩니다.
+ * - 생성 시 기본 1분(60초) 간격으로 현재 키체인을 자동 갱신하는 타이머가 시작됩니다.
  * - [current]는 캐시된 키체인을 우선 반환하며, 없으면 [doLoadCurrent]를 호출합니다.
+ * - 저장소가 소유한 타이머는 [close]로 취소하며, [close]는 여러 번 호출해도 안전합니다.
  *
  * ```kotlin
  * class MyRepository : AbstractKeyChainRepository() {
@@ -26,7 +28,9 @@ import kotlin.concurrent.timer
  * }
  * ```
  */
-abstract class AbstractKeyChainRepository: KeyChainRepository {
+abstract class AbstractKeyChainRepository(
+    private val refreshIntervalMillis: Long = DEFAULT_REFRESH_TIME_MILLIS,
+): KeyChainRepository {
 
     companion object: KLogging() {
         /**
@@ -36,10 +40,14 @@ abstract class AbstractKeyChainRepository: KeyChainRepository {
     }
 
     protected var cachedCurrent: KeyChain? = null
+    private val lifecycleLock = Any()
+    @Volatile
+    private var closed = false
     private var timer: Timer? = null
 
     init {
-        timer = timer(this::class.java.name, true, DEFAULT_REFRESH_TIME_MILLIS, DEFAULT_REFRESH_TIME_MILLIS) {
+        refreshIntervalMillis.requirePositiveNumber("refreshIntervalMillis")
+        timer = timer(this::class.java.name, true, refreshIntervalMillis, refreshIntervalMillis) {
             refreshCurrent()
         }
     }
@@ -55,10 +63,29 @@ abstract class AbstractKeyChainRepository: KeyChainRepository {
     }
 
     protected fun refreshCurrent() {
-        runCatching {
-            cachedCurrent = doLoadCurrent()
-        }.onFailure {
-            log.warn(it) { "Fail to refresh current keyChain" }
+        synchronized(lifecycleLock) {
+            if (closed) return
+
+            runCatching {
+                cachedCurrent = doLoadCurrent()
+            }.onFailure {
+                log.warn(it) { "Fail to refresh current keyChain" }
+            }
+        }
+    }
+
+    /**
+     * 이 저장소가 소유한 refresh timer를 취소합니다.
+     *
+     * 주입받은 저장소나 클라이언트는 이 클래스가 소유하지 않으므로 닫지 않습니다.
+     */
+    override fun close() {
+        synchronized(lifecycleLock) {
+            if (closed) return
+
+            closed = true
+            timer?.cancel()
+            timer = null
         }
     }
 

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/KeyChainRepository.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/KeyChainRepository.kt
@@ -10,6 +10,8 @@ import io.bluetape4k.logging.KLogging
  * - [current]는 현재 서명에 사용할 키체인을 반환합니다.
  * - [findOrNull]은 이전 키로 서명된 JWT 검증 시 `kid` 조회에 사용됩니다.
  * - [rotate]는 구현체 정책에 따라 조건부 회전을 수행하고, [forcedRotate]는 강제 교체를 수행합니다.
+ * - 인스턴스가 백그라운드 작업을 소유하는 경우 [close]로 작업을 취소합니다.
+ * - 저장소는 주입받은 외부 자원을 소유하지 않으며, [close]는 저장소가 소유한 자원만 해제합니다.
  *
  * ```kotlin
  * val current = repository.current()
@@ -18,7 +20,7 @@ import io.bluetape4k.logging.KLogging
  * // rotated == true || rotated == false
  * ```
  */
-interface KeyChainRepository {
+interface KeyChainRepository: AutoCloseable {
 
     companion object: KLogging() {
         /** 기본 보관 개수입니다. */
@@ -107,4 +109,12 @@ interface KeyChainRepository {
      * ```
      */
     fun deleteAll()
+
+    /**
+     * 저장소가 소유한 백그라운드 작업을 종료합니다.
+     *
+     * 타이머가 없는 구현체는 기본 구현을 그대로 사용하면 됩니다. 구현체는 여러 번 호출해도
+     * 안전하게 동작하도록 만들어야 합니다.
+     */
+    override fun close() = Unit
 }

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProvider.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProvider.kt
@@ -8,8 +8,9 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
 import io.bluetape4k.logging.info
+import io.bluetape4k.support.requirePositiveNumber
 import io.jsonwebtoken.security.SignatureAlgorithm
-import java.util.*
+import java.util.Timer
 import kotlin.concurrent.timer
 import kotlin.concurrent.withLock
 
@@ -20,15 +21,20 @@ import kotlin.concurrent.withLock
  * - 생성 시 즉시 최초 키체인 로테이션을 수행합니다.
  * - 60초 간격으로 키체인 만료를 검사하고 필요 시 로테이션합니다.
  * - [repository]를 통해 키체인을 영속화합니다.
+ * - 회전 타이머는 이 공급자가 소유하므로 [close]로 취소합니다.
+ * - [repository]는 빌려서 사용하며 [close]에서 닫지 않습니다. 저장소 수명주기는 호출자가 관리합니다.
  *
  * @property signatureAlgorithm RSA 기반 서명 알고리즘
  */
 class DefaultJwtProvider private constructor(
     override val signatureAlgorithm: SignatureAlgorithm,
     private val repository: KeyChainRepository,
+    private val rotationIntervalMillis: Long = DEFAULT_ROTATION_TIME_MILLIS,
 ): AbstractJwtProvider() {
 
     companion object: KLogging() {
+        private const val DEFAULT_ROTATION_TIME_MILLIS = 60_000L
+
         /**
          * [DefaultJwtProvider] 인스턴스를 생성합니다.
          *
@@ -51,15 +57,46 @@ class DefaultJwtProvider private constructor(
             log.info { "Create DefaultJwtProvider" }
             return DefaultJwtProvider(signatureAlgorithm, keyChainRepository)
         }
+
+        /** 테스트에서 짧은 주기의 rotation timer를 검증하기 위한 내부 생성 경로입니다. */
+        internal fun forTesting(
+            signatureAlgorithm: SignatureAlgorithm = DefaultSignatureAlgorithm,
+            keyChainRepository: KeyChainRepository = DefaultKeyChainRepository,
+            rotationIntervalMillis: Long,
+        ): DefaultJwtProvider {
+            return DefaultJwtProvider(signatureAlgorithm, keyChainRepository, rotationIntervalMillis)
+        }
     }
 
     private var currentKeyChain: KeyChain? = null
+    private val lifecycleLock = Any()
+    @Volatile
+    private var closed = false
     private var timer: Timer? = null
 
     init {
+        rotationIntervalMillis.requirePositiveNumber("rotationIntervalMillis")
         rotate()
-        timer = timer(this.javaClass.name, true, 60_000, 60_000) {
-            rotate()
+        timer = timer(this.javaClass.name, true, rotationIntervalMillis, rotationIntervalMillis) {
+            synchronized(lifecycleLock) {
+                if (!closed) rotate()
+            }
+        }
+    }
+
+    /**
+     * 이 공급자가 소유한 key-chain rotation timer를 취소합니다.
+     *
+     * [repository]는 빌린 자원이므로 닫지 않습니다. 공급자와 저장소를 함께 생성한 호출자도
+     * 각각 [close]를 호출해 두 자원의 수명을 명시해야 합니다.
+     */
+    override fun close() {
+        synchronized(lifecycleLock) {
+            if (closed) return
+
+            closed = true
+            timer?.cancel()
+            timer = null
         }
     }
 

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/JwtProvider.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/JwtProvider.kt
@@ -15,6 +15,8 @@ import io.jsonwebtoken.security.SignatureAlgorithm
  * - [parse]는 파싱 실패 시 [JwtException]을 던집니다.
  * - [tryParse]는 실패를 `null`로 반환합니다.
  * - [composer]/[compose]는 현재 키체인(또는 지정 키체인)으로 서명 JWT를 생성합니다.
+ * - 구현체가 소유한 백그라운드 작업은 [close]로 취소하며, 주입받은 repository/delegate는
+ *   구현체 정책에 따라 빌려 사용할 수 있습니다.
  *
  * ```kotlin
  * val jwt = provider.compose { claim("claim1", "value") }
@@ -22,7 +24,7 @@ import io.jsonwebtoken.security.SignatureAlgorithm
  * // reader.claim<String>("claim1") == "value"
  * ```
  */
-interface JwtProvider {
+interface JwtProvider: AutoCloseable {
 
     companion object: KLogging()
 
@@ -149,4 +151,12 @@ interface JwtProvider {
         val jws = this.currentJwtParser().parseSignedClaims(jwtString)
         JwtReader(jws)
     }.getOrNull()
+
+    /**
+     * 이 공급자가 소유한 백그라운드 작업을 종료합니다.
+     *
+     * 백그라운드 작업이 없는 구현체는 기본 구현을 그대로 사용하면 됩니다. 주입받은
+     * repository나 delegate의 소유권은 구현체 문서를 따르며, 기본 공급자는 이를 닫지 않습니다.
+     */
+    override fun close() = Unit
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/AbstractKeyChainRepositoryTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/AbstractKeyChainRepositoryTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.jwt.keychain.repository.KeyChainRepository
 import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
@@ -21,6 +22,11 @@ abstract class AbstractKeyChainRepositoryTest {
     fun beforeEach() {
         // deleteAll 은 테스트 시에만 사용하세요
         repository.deleteAll()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        repository.close()
     }
 
     @Test

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/AbstractJwtProviderTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/AbstractJwtProviderTest.kt
@@ -21,6 +21,7 @@ import io.bluetape4k.logging.trace
 import io.jsonwebtoken.JwtException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
@@ -48,6 +49,12 @@ abstract class AbstractJwtProviderTest: AbstractJwtTest() {
     fun beforeEach() {
         repository.deleteAll()
         provider.rotate()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        provider.close()
+        repository.close()
     }
 
     @Test

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProviderTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProviderTest.kt
@@ -1,8 +1,17 @@
 package io.bluetape4k.jwt.provider
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.jwt.keychain.KeyChain
+import io.bluetape4k.jwt.keychain.repository.AbstractKeyChainRepository
 import io.bluetape4k.jwt.keychain.repository.KeyChainRepository
 import io.bluetape4k.jwt.keychain.repository.inmemory.InMemoryKeyChainRepository
 import io.bluetape4k.logging.KLogging
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertTrue
 
 class DefaultJwtProviderTest: AbstractJwtProviderTest() {
 
@@ -12,5 +21,95 @@ class DefaultJwtProviderTest: AbstractJwtProviderTest() {
 
     override val provider: JwtProvider =
         JwtProviderFactory.default(keyChainRepository = repository)
+
+    @Test
+    fun `key chain repository exposes close and stops its timer`() {
+        val lifecycleRepository = LifecycleKeyChainRepository(refreshIntervalMillis = 25)
+        val timerName = lifecycleRepository.javaClass.name
+
+        try {
+            await.atMost(Duration.ofSeconds(2)).until { lifecycleRepository.refreshCount.get() > 0 }
+            await.atMost(Duration.ofSeconds(2)).until { hasLiveThread(timerName) }
+
+            assertTrue(lifecycleRepository is AutoCloseable)
+            (lifecycleRepository as AutoCloseable).close()
+
+            val refreshCountAfterClose = lifecycleRepository.refreshCount.get()
+            Thread.sleep(100)
+            lifecycleRepository.refreshCount.get().shouldBeEqualTo(refreshCountAfterClose)
+            await.atMost(Duration.ofSeconds(2)).until { !hasLiveThread(timerName) }
+        } finally {
+            lifecycleRepository.close()
+        }
+    }
+
+    @Test
+    fun `default jwt provider exposes close and stops its timer without closing borrowed repository`() {
+        val lifecycleRepository = LifecycleKeyChainRepository(refreshIntervalMillis = 25)
+        val lifecycleProvider: JwtProvider = DefaultJwtProvider.forTesting(
+            keyChainRepository = lifecycleRepository,
+            rotationIntervalMillis = 25,
+        )
+        val repositoryTimerName = lifecycleRepository.javaClass.name
+
+        try {
+            await.atMost(Duration.ofSeconds(2)).until { lifecycleRepository.rotateCount.get() > 1 }
+            await.atMost(Duration.ofSeconds(2)).until { hasLiveThread(repositoryTimerName) }
+
+            assertTrue(lifecycleProvider is AutoCloseable)
+            (lifecycleProvider as AutoCloseable).close()
+
+            val rotationCountAfterClose = lifecycleRepository.rotateCount.get()
+            Thread.sleep(100)
+            lifecycleRepository.rotateCount.get().shouldBeEqualTo(rotationCountAfterClose)
+            hasLiveThread(repositoryTimerName).shouldBeEqualTo(true)
+
+            (lifecycleRepository as AutoCloseable).close()
+            await.atMost(Duration.ofSeconds(2)).until { !hasLiveThread(repositoryTimerName) }
+        } finally {
+            lifecycleProvider.close()
+            lifecycleRepository.close()
+        }
+    }
+
+    private fun hasLiveThread(name: String): Boolean =
+        Thread.getAllStackTraces().keys.any { it.isAlive && it.name == name }
+
+    private class LifecycleKeyChainRepository(
+        refreshIntervalMillis: Long,
+    ): AbstractKeyChainRepository(refreshIntervalMillis) {
+
+        private val keyChains = ConcurrentLinkedDeque<KeyChain>()
+        val refreshCount = AtomicInteger()
+        val rotateCount = AtomicInteger()
+
+        override val capacity: Int = KeyChainRepository.DEFAULT_CAPACITY
+
+        override fun doLoadCurrent(): KeyChain? {
+            refreshCount.incrementAndGet()
+            return keyChains.firstOrNull()
+        }
+
+        override fun doInsert(keyChain: KeyChain) {
+            keyChains.addFirst(keyChain)
+        }
+
+        override fun findOrNull(kid: String): KeyChain? = keyChains.find { it.id == kid }
+
+        override fun rotate(keyChain: KeyChain): Boolean {
+            rotateCount.incrementAndGet()
+            return changeCurrent(keyChain)
+        }
+
+        override fun forcedRotate(keyChain: KeyChain): Boolean {
+            rotateCount.incrementAndGet()
+            return changeCurrent(keyChain)
+        }
+
+        override fun deleteAll() {
+            keyChains.clear()
+            cachedCurrent = null
+        }
+    }
 
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/JCacheJwtProviderTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/JCacheJwtProviderTest.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.jwt.provider.JwtProvider
 import io.bluetape4k.jwt.provider.JwtProviderFactory
 import io.bluetape4k.jwt.reader.JwtReaderDto
 import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.AfterEach
 
 class JCacheJwtProviderTest: AbstractJwtProviderTest() {
 
@@ -23,4 +24,9 @@ class JCacheJwtProviderTest: AbstractJwtProviderTest() {
     private val delegate = JwtProviderFactory.default(keyChainRepository = repository)
 
     override val provider: JwtProvider = JwtProviderFactory.jcached(delegate, jcache)
+
+    @AfterEach
+    fun closeDelegate() {
+        delegate.close()
+    }
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedissonJwtProviderTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedissonJwtProviderTest.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.jwt.provider.JwtProviderFactory
 import io.bluetape4k.jwt.reader.JwtReaderDto
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.testcontainers.storage.RedisServer
+import org.junit.jupiter.api.AfterEach
 import org.redisson.codec.LZ4Codec
 
 class RedissonJwtProviderTest: AbstractJwtProviderTest() {
@@ -33,6 +34,11 @@ class RedissonJwtProviderTest: AbstractJwtProviderTest() {
 
     override val provider: JwtProvider by lazy {
         JwtProviderFactory.redissonCached(delegate, readerCache)
+    }
+
+    @AfterEach
+    fun closeDelegate() {
+        delegate.close()
     }
 
 }


### PR DESCRIPTION
## Summary

Closes #1276

- PR 제목: Make JWT keychain refresh timers explicitly closeable

Closes #1276

Make JWT keychain refresh and signing-key rotation timers explicitly closeable so applications and tests can deterministically stop background work.

## Background

Issue #1276 tracks the 1.12.0 lifecycle gap in the JWT keychain providers. Repository refresh and provider rotation each created a daemon `Timer` without an ownership contract or cancellation API.

## What This Solves

- Gives `KeyChainRepository` and `JwtProvider` an explicit, idempotent `AutoCloseable` lifecycle.
- Cancels owned timers deterministically while preserving borrowed-resource ownership for injected repositories and external cache/Redis clients.
- Locks the lifecycle behavior with short-interval refresh/rotation tests and documents application/test shutdown expectations.

## Work Done

- Added closeable contracts and lifecycle KDoc to `KeyChainRepository` and `JwtProvider`, with compatibility-preserving default no-op implementations.
- Added timer ownership, positive interval validation, synchronized cancellation, and idempotent `close()` implementations to the abstract repository and default provider.
- Added lifecycle regression coverage for repository refresh shutdown, provider rotation shutdown, borrowed repository behavior, wrapper-provider cleanup, and existing repository/provider tests.
- Documented ownership and `try/finally` shutdown patterns in both JWT README variants and captured the reusable lesson in `docs/lessons/2026-08-02-issue-1276-jwt-closeable.md`.

## Validation

- `./gradlew :bluetape4k-jwt:test --tests 'io.bluetape4k.jwt.provider.DefaultJwtProviderTest' --no-build-cache`: PASS (30 tests)
- `./gradlew :bluetape4k-jwt:test --no-build-cache`: PASS (157 tests, 10 pending, 0 failures)
- `./gradlew :bluetape4k-jwt:detekt --no-build-cache`: PASS (pre-existing findings remain outside this change)
- README parity/link validation and `git diff --check`: PASS

## Review Notes

- P0/P1: 0 known findings.
- P2/P3: none deferred; no unrelated wrapper implementation changes were added.
- Review evidence: local scoped diff review plus live PR review/thread query after CI; zero formal reviews, comments, or unresolved threads.

## Metadata

- Issue: #1276, milestone `1.12.0`, assignee `debop`
- PR: #1294, head `afcbf15fba51c17331fe0497b4ee02ea052c2424`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1276-jwt-closeable`
- Labels: `bug`
- State: `MERGED`, merge commit `ef0cbb729f11b58c84c10fc6e9d1c242e63320c4`
- CI: Make JWT keychain refresh and signing-key rotation timers explicitly closeable so applications and tests can deterministically stop background work. / - Gives `KeyChainRepository` and `JwtProvider` an explicit, idempotent `AutoCloseable` lifecycle. / - `./gradlew :bluetape4k-jwt:test --tests 'io.bluetape4k.jwt.provider.DefaultJwtProviderTest' --no-build-cache`: PASS (30 tests)

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01/C-02 - Root cause and scope | Reproduced the unmanaged daemon timers and froze the narrow JWT lifecycle scope | PASS | Issue #1276 acceptance criteria, root-cause receipt, and scoped diff | none |
| C-03 - RED regression | Ran lifecycle tests before the closeable contract existed | PASS | Recorded failing lifecycle assertions in workflow receipt | none |
| C-04 - GREEN regression | Added closeable ownership and verified lifecycle tests | PASS | Targeted `DefaultJwtProviderTest`: 30 passing | none |
| C-05 - Module verification | Ran the final JWT module test suite | PASS | `:bluetape4k-jwt:test`: 157 passing, 10 pending, 0 failures | none |
| C-06 - Documentation and lesson | Added reusable lesson plus English/Korean README lifecycle guidance | PASS | `docs/lessons/2026-08-02-issue-1276-jwt-closeable.md`, README parity/link check | Re-index lesson after merge because the GNO docs collection excludes `.worktrees` |
| C-07 - Diff convergence | Committed and pushed the exact scoped branch | PASS | `git diff --check`; head `afcbf15fba51c17331fe0497b4ee02ea052c2424` | none |
| CG-14 - PR CI and live review | Waited for CI and reread reviews/threads at the exact head | PASS | CI run 30749678582 all reported checks passed; `gh pr checks --required` reports no branch-specific required checks; zero formal reviews/comments/threads; `mergeStateStatus=CLEAN` | none |
| CG-16 - Fresh merge approval | Applied the explicit approval issued after the exact-head merge-ready report | PASS | User approval for PR #1294 head `afcbf15fba51c17331fe0497b4ee02ea052c2424` | none |
| CG-17 - Merge verification | Squash-merged the approved exact head without auto-merge | PASS | PR state `MERGED`, merge SHA `ef0cbb729f11b58c84c10fc6e9d1c242e63320c4` | none |
| CG-18 - Sync and cleanup | Fast-forwarded `develop`, reindexed the lesson, and removed proven merged local artifacts | PASS | Local/upstream `develop` both `ef0cbb729f11b58c84c10fc6e9d1c242e63320c4`; GNO search resolves the lesson; feature worktree/ref and remote branch absent | none |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1294 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ef0cbb729f11b58c84c10fc6e9d1c242e63320c4`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
