### PR TITLE
test(jwt): cover Redis-backed shutdown ownership through ToxiProxy

### DIFF
--- a/docs/lessons/2026-08-02-issue-1295-redis-jwt-shutdown.md
+++ b/docs/lessons/2026-08-02-issue-1295-redis-jwt-shutdown.md
@@ -1,0 +1,51 @@
+# Issue #1295 Redis-backed JWT shutdown 통합 검증 lesson
+
+## Context
+
+Issue #1276에서 JWT key-chain/provider의 timer를 명시적으로 닫을 수 있게 한
+뒤에도 Redis/Redisson 실제 경로와 proxy 장애 복구는 검증되지 않았다. Issue
+#1295는 이 공백을 milestone `1.12.0`에서 닫기 위한 test-only 통합 작업이다.
+
+## Decision
+
+- `gradle/libs.versions.toml`의 기존 `testcontainers-toxiproxy` alias를
+  `utils/jwt`의 `testImplementation`으로만 연결했다.
+- `RedisServer`와 `ToxiproxyServer`를 `Network.newNetwork()`에 함께 배치하고,
+  `0.0.0.0:8666 -> redis:6379` proxy endpoint를 host-mapped Redisson address로
+  사용했다.
+- Redisson config의 timeout/connectTimeout을 500ms, retryAttempts를 0으로
+  낮춰 proxy disable 중의 failure가 bounded하도록 했다. 이는 실제 장애를
+  빠르게 재현하기 위한 test-only 설정이며 production defaults를 바꾸지 않는다.
+- `RedissonJwtProvider`는 delegate와 cache를 빌려 쓰고, `DefaultJwtProvider`가
+  rotation timer를 소유한다. `RedisKeyChainRepository`는 refresh timer만
+  소유하며 주입받은 client를 닫지 않는다. wrapper close, delegate close,
+  repository close, application owner의 client shutdown 순서를 테스트와 README
+  두 locale에 동일하게 기록했다.
+
+## Verification evidence
+
+- RED: direct ToxiProxy dependency를 제거한 상태에서 새 test source set의
+  `compileTestKotlin`이 실패했다. 이는 `bluetape4k-testcontainers`의
+  `compileOnly` 의존성이 JWT 테스트에 transitive하게 노출되지 않는다는
+  classpath 경계를 확인했다.
+- GREEN: `./gradlew :bluetape4k-jwt:test --tests
+  io.bluetape4k.jwt.provider.cache.RedisJwtShutdownIntegrationTest
+  --rerun-tasks --no-build-cache`가 Docker에서 1 passing으로 완료했다.
+- 테스트는 정상 Redis JWT parsing, forced rotation, ToxiProxy disable 중
+  bounded false 결과, enable 후 recovery, 반복 close, delegate close 후
+  expired key-chain 재회전 억제, client의 명시적 terminal shutdown을 검증한다.
+
+## Reusable guard
+
+실제 Redis를 사용하는 borrowed-client fixture에서는 component close가 외부
+client close를 의미하지 않는다. integration test는 proxy/container/client를
+각각 소유하고, Testcontainers 실행은 모듈·worktree 간에 순차적으로 수행해야
+한다. Docker가 없는 hosted CI에서는 이 통합 행을 성공으로 추정하지 말고
+`PENDING`으로 보고한다.
+
+## Follow-up
+
+Fresh targeted/module tests, detekt, docs parity, diff-check, and runtime
+dependency-scope checks pass locally; the ToxiProxy dependency appears only on
+`testCompileClasspath`, not `runtimeClasspath`. Exact PR head/CI/review evidence
+is added at PR delivery. Production ownership/API 변경은 이 lesson의 범위가 아니다.

--- a/docs/superpowers/plans/2026-08-02-redis-jwt-shutdown-integration-plan.md
+++ b/docs/superpowers/plans/2026-08-02-redis-jwt-shutdown-integration-plan.md
@@ -1,0 +1,244 @@
+# Redis-backed JWT shutdown integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 실제 Redis/Redisson과 ToxiProxy를 통과하는 JWT provider shutdown, route recovery, borrowed-client ownership을 순차 integration test로 고정한다.
+
+**Architecture:** JWT 모듈 테스트 classpath에 version catalog의 `testcontainers-toxiproxy` alias만 test scope로 연결한다. 새 테스트는 shared `Network` 안에서 Redis와 ToxiProxy를 명시적으로 시작하고, host-mapped proxy endpoint를 짧은 timeout의 Redisson client에 주입한다. production API와 ownership은 바꾸지 않으며 README 두 locale에 실제 close 순서를 기록한다.
+
+**Tech Stack:** Kotlin 2.3, JUnit 5, Kotest-style bluetape assertions, Testcontainers Redis/ToxiProxy, Redisson 4.6.x, Gradle version catalog.
+
+---
+
+## 변경 파일 구조
+
+- Modify: `utils/jwt/build.gradle.kts` — ToxiProxy client를 test scope에만 추가한다.
+- Create: `utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedisJwtShutdownIntegrationTest.kt` — Redis/ToxiProxy/Redisson/JWT lifecycle 및 interruption/recovery를 한 sequential integration test로 검증한다.
+- Modify: `utils/jwt/README.md` — Redis-backed provider의 borrowed client ownership과 close 순서를 영어로 보강한다.
+- Modify: `utils/jwt/README.ko.md` — 같은 내용을 한국어로 보강한다.
+- Create: `docs/lessons/2026-08-02-issue-1295-redis-jwt-shutdown.md` — 재사용 가능한 Testcontainers/ownership 학습을 증거와 함께 기록한다.
+- Existing: `docs/superpowers/specs/2026-08-02-redis-jwt-shutdown-integration-design.md` — 승인된 설계. 계획 commit 전에 수정하지 않는다.
+
+Production Kotlin files, central catalog version definitions, and the shared `testing/testcontainers` API are intentionally unchanged unless a failing integration test proves a separate production defect.
+
+## Task 1: test dependency와 RED 테스트 뼈대 추가
+
+**Files:**
+- Modify: `utils/jwt/build.gradle.kts`
+- Create: `utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedisJwtShutdownIntegrationTest.kt`
+
+- [ ] **Step 1: test dependency만 추가한다.**
+
+`dependencies` 안의 Testcontainers test entries 뒤에 다음 한 줄만 추가한다.
+
+```kotlin
+testImplementation(libs.testcontainers.toxiproxy)
+```
+
+catalog alias는 이미 `gradle/libs.versions.toml`에 있으므로 version literal이나 새 repository를 추가하지 않는다.
+
+- [ ] **Step 2: integration test의 첫 RED assertion을 작성한다.**
+
+테스트는 `@TestInstance(PER_CLASS)`와 `@Execution(SAME_THREAD)`를 사용하고, 각 테스트에서 새 `Network`, `RedisServer`, `ToxiproxyServer`를 직접 소유한다. 첫 테스트는 proxy를 통한 `PONG`과 JWT parsing을 요구한다.
+
+```kotlin
+@Test
+fun `proxied Redis supports JWT parsing and close ownership`() {
+    Network.newNetwork().use { network ->
+        RedisServer().withNetwork(network).withNetworkAliases("redis").use { redis ->
+            ToxiproxyServer().withNetwork(network).use { toxiproxy ->
+                redis.start()
+                toxiproxy.start()
+                val proxyClient = ToxiproxyClient(toxiproxy.host, toxiproxy.controlPort)
+                val proxy = proxyClient.createProxy("jwt-redis", "0.0.0.0:8666", "redis:${RedisServer.PORT}")
+                val address = "redis://${toxiproxy.host}:${toxiproxy.getMappedPort(8666)}"
+                val redisson = Redisson.create(
+                    RedisServer.Launcher.RedissonLib.getRedissonConfig(address).apply {
+                        useSingleServer().apply {
+                            timeout = 500
+                            connectTimeout = 500
+                            retryAttempts = 0
+                        }
+                    },
+                )
+                val repository = RedisKeyChainRepository(redisson, queueName = "test:jwt:shutdown")
+                val delegate = DefaultJwtProvider.forTesting(
+                    keyChainRepository = repository,
+                    rotationIntervalMillis = 50,
+                )
+                val provider = RedissonJwtProvider(delegate, redisson)
+                try {
+                    val jwt = provider.compose { subject = "shutdown" }
+                    provider.tryParse(jwt)?.subject shouldBeEqualTo "shutdown"
+                    provider.close()
+                    provider.close()
+                    repository.close()
+                    repository.close()
+                    redisson.isShutdown.shouldBeFalse()
+                } finally {
+                    runCatching { proxy.delete() }
+                    runCatching { provider.close() }
+                    runCatching { repository.close() }
+                    runCatching { redisson.shutdown() }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: RED를 확인한다.**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-jwt:test --tests io.bluetape4k.jwt.provider.cache.RedisJwtShutdownIntegrationTest --no-build-cache
+```
+
+Expected: dependency/classpath 또는 아직 구현되지 않은 lifecycle assertion으로 실패한다. Docker 미가동으로 실패하면 Docker 상태를 먼저 진단하고, 테스트 코드 오류가 아닌 환경 blocker는 별도로 기록한다.
+
+## Task 2: 실제 proxy interruption/recovery와 timer 정지 assertion을 완성한다
+
+**Files:**
+- Modify: `utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedisJwtShutdownIntegrationTest.kt`
+
+- [ ] **Step 1: 정상 경로와 cache parsing을 명시한다.**
+
+```kotlin
+val firstJwt = provider.compose { subject = "shutdown" }
+provider.tryParse(firstJwt)?.subject shouldBeEqualTo "shutdown"
+provider.forcedRotate().shouldBeTrue()
+val rotatedJwt = provider.compose { subject = "rotated" }
+provider.tryParse(rotatedJwt)?.subject shouldBeEqualTo "rotated"
+```
+
+- [ ] **Step 2: disable 중 bounded failure, enable 후 recovery를 작성한다.**
+
+```kotlin
+proxy.disable()
+val interruptedAt = System.nanoTime()
+provider.forcedRotate().shouldBeFalse()
+val interruptedMillis = Duration.ofNanos(System.nanoTime() - interruptedAt).toMillis()
+assertTrue(interruptedMillis < 5_000, "proxy interruption must remain bounded: ${interruptedMillis}ms")
+proxy.enable()
+provider.forcedRotate().shouldBeTrue()
+provider.tryParse(provider.compose { subject = "recovered" })?.subject shouldBeEqualTo "recovered"
+```
+
+`shouldBeLessThan`가 현재 assertions surface에 없으면 표준 `assertTrue`로 대체하고, 그 이유를 evidence에 기록한다. route가 복구된 뒤 같은 Redisson client가 정상 동작해야 한다.
+
+- [ ] **Step 3: provider-owned timer가 close 후 Redis를 다시 회전시키지 않는지 고정한다.**
+
+provider를 두 번 닫은 뒤 repository로 `KeyChain(expiredTtl = Duration.ofMillis(1))`을 강제로 저장한다. `rotationIntervalMillis * 4` 이상 기다리고도 repository의 current key id가 그대로인지 확인한다. 이 assertion은 thread-name enumeration 없이 provider timer 취소를 입증한다.
+
+- [ ] **Step 4: 외부 client ownership과 terminal shutdown을 확인한다.**
+
+provider/repository 반복 close 직후 `redisson.isShuttingDown`과 `redisson.isShutdown`이 false인지 확인하고, finally에서 application owner로 `redisson.shutdown()`을 호출한 뒤 `isShutdown == true`를 확인한다. proxy, container, network 정리는 각각 외부 owner가 수행한다.
+
+- [ ] **Step 5: targeted RED→GREEN을 실행한다.**
+
+동일한 Gradle 명령을 다시 실행하여 테스트가 PASS하는지 확인한다. 실패하면 raw output에서 Docker readiness, Redisson timeout, ToxiProxy routing, ownership ordering을 분리해 수정하고 처음부터 targeted test를 재실행한다.
+
+## Task 3: 문서와 lesson을 실제 코드에 맞춰 작성한다
+
+**Files:**
+- Modify: `utils/jwt/README.md`
+- Modify: `utils/jwt/README.ko.md`
+- Create: `docs/lessons/2026-08-02-issue-1295-redis-jwt-shutdown.md`
+
+- [ ] **Step 1: README 두 locale에 Redis close 순서를 추가한다.**
+
+```kotlin
+val repository = RedisKeyChainRepository(redissonClient)
+val delegate = DefaultJwtProvider(keyChainRepository = repository)
+val provider = RedissonJwtProvider(delegate, redissonClient)
+try {
+    provider.tryParse(jwt)
+} finally {
+    provider.close()    // delegate/provider-owned rotation work
+    repository.close()  // repository-owned refresh work
+    redissonClient.shutdown() // application-owned client
+}
+```
+
+영문 README는 public API identifier를 유지하고, 한국어 README는 동일한 순서/ownership을 번역한다. code fence와 heading 수를 임의로 바꾸지 않는다.
+
+- [ ] **Step 2: lesson을 작성한다.**
+
+lesson에는 issue/PR 연결, local Docker prerequisite, shared network proxy 설정, `retryAttempts = 0`의 bounded-failure 이유, provider/repository/client ownership order, 실제 명령과 결과, hosted CI에서 Docker가 unavailable할 때 보고해야 할 보류 상태를 짧게 기록한다. filler 문장은 금지한다.
+
+- [ ] **Step 3: docs parity와 diff-check를 실행한다.**
+
+```bash
+git diff --check
+```
+
+README 두 파일의 heading/fenced-code 수, lifecycle marker, local link를 기존 repo 방식으로 비교하고, 기술 앵커/버전/명령/링크가 변하지 않았는지 확인한다.
+
+## Task 4: proportional verification과 pre-PR review
+
+**Files:** all changed paths
+
+- [ ] **Step 1: sequential targeted Testcontainers test를 재실행한다.**
+
+```bash
+./gradlew :bluetape4k-jwt:test --tests io.bluetape4k.jwt.provider.cache.RedisJwtShutdownIntegrationTest --no-build-cache
+```
+
+이 명령은 Docker-backed test이므로 다른 Testcontainers module/worktree와 동시에 실행하지 않는다.
+
+- [ ] **Step 2: JWT module tests와 detekt를 실행한다.**
+
+```bash
+./gradlew :bluetape4k-jwt:test --no-build-cache
+./gradlew :bluetape4k-jwt:detekt --no-build-cache
+```
+
+- [ ] **Step 3: dependency scope와 변경 범위를 확인한다.**
+
+```bash
+./gradlew :bluetape4k-jwt:dependencies --configuration testCompileClasspath --no-build-cache
+git diff --check
+git status --short
+git diff --stat origin/develop...HEAD
+```
+
+`testcontainers-toxiproxy`가 test classpath에만 있고 production runtime/API 변경이 없는지 확인한다. untracked/generated output은 PR에 포함하지 않는다.
+
+- [ ] **Step 4: issue acceptance와 exact diff를 대조한다.**
+
+각 acceptance criterion을 test/docs/dependency evidence에 매핑하고, production ownership 변경이 없다는 것을 diff로 확인한다. P0/P1 finding은 없어야 하며, Docker unavailable 같은 환경 gap은 PR DoD의 `PENDING` 행으로 남긴다.
+
+## Task 5: lesson commit, PR, live CI, merge-ready report
+
+- [ ] **Step 1: lesson과 구현을 Lore commit protocol로 commit한다.**
+
+commit message는 intent line을 먼저 쓰고 `Constraint`, `Rejected`, `Confidence`, `Scope-risk`, `Directive`, `Tested`, `Not-tested` trailers를 포함한다. spec/plan commit과 implementation commit을 구분한다.
+
+- [ ] **Step 2: issue metadata와 PR body를 live 검증한다.**
+
+PR title/body는 영어로 작성하고 issue #1295, milestone `1.12.0`, assignee `debop`, label `test`를 유지한다. body 마지막은 반드시 `## DoD Status`이며, exact head SHA, targeted/module/detekt/diff evidence, Docker CI N/A 사유, unchecked CG-16/17/18을 표시한다.
+
+- [ ] **Step 3: CI와 review를 exact head에서 확인한다.**
+
+`gh pr view`, `gh pr checks`, review/thread 상태, mergeability, branch head를 재조회한다. stale head, unresolved review, missing required check는 merge-ready가 아니다.
+
+- [ ] **Step 4: merge gate에서 멈춘다.**
+
+CG-16은 fresh explicit user approval이 있어야 하므로 merge-ready DoD를 보고하고 멈춘다. 승인 전에는 merge, branch deletion, worktree cleanup을 수행하지 않는다.
+
+## Risk prediction
+
+| Risk | Signal | Mitigation | Rerun point |
+| --- | --- | --- | --- |
+| Docker/ToxiProxy readiness flake | proxy creation 또는 Redisson warmup timeout | shared Network, explicit start order, short retry, finally cleanup | Task 2 Step 5 |
+| disable failure가 너무 오래 걸림 | targeted test가 5초 threshold 초과 | `timeout = 500`, `retryAttempts = 0`, one command at a time | Task 2 Step 2 |
+| borrowed client가 provider close로 종료됨 | close 직후 `isShutdown` true | provider/repository close와 client shutdown assertion 분리 | Task 2 Step 4 |
+| timer가 close 후 Redis를 변경함 | expired key id가 interval 뒤 변경 | provider close를 먼저 수행하고 Redis current id를 재검증 | Task 2 Step 3 |
+| docs/production scope drift | changed path에 catalog/runtime API가 나타남 | exact diff/stat와 dependency configuration 확인 | Task 4 Step 3 |
+
+## Rollback / rerun
+
+- 실패한 테스트와 새 dependency를 feature branch에서 되돌리고, 공용 `testing/testcontainers` API를 확장하지 않는다.
+- production contract 결함이 발견되면 이 계획의 범위를 확장하지 않고, 새 issue/설계 승인으로 분리한다.
+- Docker가 없는 환경이면 code compile/static checks만 수행하고 integration acceptance는 `PENDING`으로 남긴다.

--- a/docs/superpowers/plans/2026-08-02-redis-jwt-shutdown-integration-plan.md
+++ b/docs/superpowers/plans/2026-08-02-redis-jwt-shutdown-integration-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** 실제 Redis/Redisson과 ToxiProxy를 통과하는 JWT provider shutdown, route recovery, borrowed-client ownership을 순차 integration test로 고정한다.
 
-**Architecture:** JWT 모듈 테스트 classpath에 version catalog의 `testcontainers-toxiproxy` alias만 test scope로 연결한다. 새 테스트는 shared `Network` 안에서 Redis와 ToxiProxy를 명시적으로 시작하고, host-mapped proxy endpoint를 짧은 timeout의 Redisson client에 주입한다. production API와 ownership은 바꾸지 않으며 README 두 locale에 실제 close 순서를 기록한다.
+**Architecture:** JWT 모듈 테스트 classpath에 version catalog의 `testcontainers-toxiproxy` alias만 test scope로 연결한다. 새 테스트는 shared `Network` 안에서 Redis와 ToxiProxy를 명시적으로 시작하고, host-mapped proxy endpoint를 짧은 timeout의 Redisson client에 주입한다. `RedissonJwtProvider`는 delegate를 빌려 쓰고 `DefaultJwtProvider`가 rotation timer를 소유하므로, wrapper/delegate/repository/client의 실제 close 순서를 README 두 locale에 기록한다.
 
 **Tech Stack:** Kotlin 2.3, JUnit 5, Kotest-style bluetape assertions, Testcontainers Redis/ToxiProxy, Redisson 4.6.x, Gradle version catalog.
 
@@ -17,7 +17,7 @@
 - Modify: `utils/jwt/README.md` — Redis-backed provider의 borrowed client ownership과 close 순서를 영어로 보강한다.
 - Modify: `utils/jwt/README.ko.md` — 같은 내용을 한국어로 보강한다.
 - Create: `docs/lessons/2026-08-02-issue-1295-redis-jwt-shutdown.md` — 재사용 가능한 Testcontainers/ownership 학습을 증거와 함께 기록한다.
-- Existing: `docs/superpowers/specs/2026-08-02-redis-jwt-shutdown-integration-design.md` — 승인된 설계. 계획 commit 전에 수정하지 않는다.
+- Existing: `docs/superpowers/specs/2026-08-02-redis-jwt-shutdown-integration-design.md` — 구현 중 확인된 delegate ownership을 반영한 설계.
 
 Production Kotlin files, central catalog version definitions, and the shared `testing/testcontainers` API are intentionally unchanged unless a failing integration test proves a separate production defect.
 
@@ -39,18 +39,18 @@ catalog alias는 이미 `gradle/libs.versions.toml`에 있으므로 version lite
 
 - [ ] **Step 2: integration test의 첫 RED assertion을 작성한다.**
 
-테스트는 `@TestInstance(PER_CLASS)`와 `@Execution(SAME_THREAD)`를 사용하고, 각 테스트에서 새 `Network`, `RedisServer`, `ToxiproxyServer`를 직접 소유한다. 첫 테스트는 proxy를 통한 `PONG`과 JWT parsing을 요구한다.
+테스트는 `@Execution(SAME_THREAD)`를 사용하고, 각 테스트에서 새 `Network`, `RedisServer`, `ToxiproxyServer`를 직접 소유한다. 첫 테스트는 proxy를 통한 JWT parsing을 요구한다.
 
 ```kotlin
 @Test
 fun `proxied Redis supports JWT parsing and close ownership`() {
     Network.newNetwork().use { network ->
         RedisServer().withNetwork(network).withNetworkAliases("redis").use { redis ->
-            ToxiproxyServer().withNetwork(network).use { toxiproxy ->
+            ToxiproxyServer().apply { withNetwork(network) }.use { toxiproxy ->
                 redis.start()
                 toxiproxy.start()
                 val proxyClient = ToxiproxyClient(toxiproxy.host, toxiproxy.controlPort)
-                val proxy = proxyClient.createProxy("jwt-redis", "0.0.0.0:8666", "redis:${RedisServer.PORT}")
+                val proxy = proxyClient.createProxy("jwt-redis-${UUID.randomUUID()}", "0.0.0.0:8666", "redis:${RedisServer.PORT}")
                 val address = "redis://${toxiproxy.host}:${toxiproxy.getMappedPort(8666)}"
                 val redisson = Redisson.create(
                     RedisServer.Launcher.RedissonLib.getRedissonConfig(address).apply {
@@ -72,12 +72,15 @@ fun `proxied Redis supports JWT parsing and close ownership`() {
                     provider.tryParse(jwt)?.subject shouldBeEqualTo "shutdown"
                     provider.close()
                     provider.close()
+                    delegate.close()
+                    delegate.close()
                     repository.close()
                     repository.close()
                     redisson.isShutdown.shouldBeFalse()
                 } finally {
                     runCatching { proxy.delete() }
                     runCatching { provider.close() }
+                    runCatching { delegate.close() }
                     runCatching { repository.close() }
                     runCatching { redisson.shutdown() }
                 }
@@ -127,13 +130,13 @@ provider.tryParse(provider.compose { subject = "recovered" })?.subject shouldBeE
 
 `shouldBeLessThan`가 현재 assertions surface에 없으면 표준 `assertTrue`로 대체하고, 그 이유를 evidence에 기록한다. route가 복구된 뒤 같은 Redisson client가 정상 동작해야 한다.
 
-- [ ] **Step 3: provider-owned timer가 close 후 Redis를 다시 회전시키지 않는지 고정한다.**
+- [ ] **Step 3: delegate-owned timer가 close 후 Redis를 다시 회전시키지 않는지 고정한다.**
 
-provider를 두 번 닫은 뒤 repository로 `KeyChain(expiredTtl = Duration.ofMillis(1))`을 강제로 저장한다. `rotationIntervalMillis * 4` 이상 기다리고도 repository의 current key id가 그대로인지 확인한다. 이 assertion은 thread-name enumeration 없이 provider timer 취소를 입증한다.
+wrapper provider와 delegate를 각각 두 번 닫은 뒤 repository로 `KeyChain(expiredTtl = Duration.ofMillis(1))`을 강제로 저장한다. `rotationIntervalMillis * 5` 이상 기다리고도 repository의 current key id가 그대로인지 확인한다. 이 assertion은 thread-name enumeration 없이 delegate timer 취소를 입증한다.
 
 - [ ] **Step 4: 외부 client ownership과 terminal shutdown을 확인한다.**
 
-provider/repository 반복 close 직후 `redisson.isShuttingDown`과 `redisson.isShutdown`이 false인지 확인하고, finally에서 application owner로 `redisson.shutdown()`을 호출한 뒤 `isShutdown == true`를 확인한다. proxy, container, network 정리는 각각 외부 owner가 수행한다.
+provider/delegate/repository 반복 close 직후 `redisson.isShuttingDown`과 `redisson.isShutdown`이 false인지 확인하고, finally에서 application owner로 `redisson.shutdown()`을 호출한 뒤 `isShutdown == true`를 확인한다. proxy, container, network 정리는 각각 외부 owner가 수행한다.
 
 - [ ] **Step 5: targeted RED→GREEN을 실행한다.**
 
@@ -155,7 +158,8 @@ val provider = RedissonJwtProvider(delegate, redissonClient)
 try {
     provider.tryParse(jwt)
 } finally {
-    provider.close()    // delegate/provider-owned rotation work
+    provider.close()    // idempotent wrapper close; borrowed resources stay open
+    delegate.close()    // delegate-owned rotation work
     repository.close()  // repository-owned refresh work
     redissonClient.shutdown() // application-owned client
 }
@@ -234,7 +238,7 @@ CG-16은 fresh explicit user approval이 있어야 하므로 merge-ready DoD를 
 | Docker/ToxiProxy readiness flake | proxy creation 또는 Redisson warmup timeout | shared Network, explicit start order, short retry, finally cleanup | Task 2 Step 5 |
 | disable failure가 너무 오래 걸림 | targeted test가 5초 threshold 초과 | `timeout = 500`, `retryAttempts = 0`, one command at a time | Task 2 Step 2 |
 | borrowed client가 provider close로 종료됨 | close 직후 `isShutdown` true | provider/repository close와 client shutdown assertion 분리 | Task 2 Step 4 |
-| timer가 close 후 Redis를 변경함 | expired key id가 interval 뒤 변경 | provider close를 먼저 수행하고 Redis current id를 재검증 | Task 2 Step 3 |
+| timer가 close 후 Redis를 변경함 | expired key id가 interval 뒤 변경 | delegate close를 먼저 수행하고 Redis current id를 재검증 | Task 2 Step 3 |
 | docs/production scope drift | changed path에 catalog/runtime API가 나타남 | exact diff/stat와 dependency configuration 확인 | Task 4 Step 3 |
 
 ## Rollback / rerun

--- a/docs/superpowers/specs/2026-08-02-redis-jwt-shutdown-integration-design.md
+++ b/docs/superpowers/specs/2026-08-02-redis-jwt-shutdown-integration-design.md
@@ -1,0 +1,101 @@
+# Redis-backed JWT shutdown integration 설계
+
+## 목표
+
+Issue #1295의 목적은 실제 Redis와 Redisson을 통과하는 JWT key-chain 및
+cache provider의 종료 경로를 검증하는 것이다. 검증은 애플리케이션이
+주입한 `RedissonClient`의 소유권을 JWT provider/repository가 가져가지 않는
+계약과, 각 객체가 소유한 timer만 취소하는 계약을 동시에 고정한다.
+
+## 현재 근거
+
+- `RedisKeyChainRepository`는 `AbstractKeyChainRepository`의 refresh timer와
+  Redis deque/rotation lock을 사용하지만 주입된 `RedissonClient`를 직접 닫지
+  않는다.
+- `DefaultJwtProvider`는 `forTesting` 내부 생성 경로로 짧은 rotation interval을
+  사용할 수 있고, 주입된 repository를 빌려 쓰며 자체 timer만 닫는다.
+- `RedissonJwtProvider`는 delegate를 위임하고 Redis map cache를 빌려 쓰므로
+  client 종료 책임을 갖지 않는다.
+- `RedisServer`와 `ToxiproxyServer`는 이미 Testcontainers와 shared Network
+  패턴을 제공한다. `testcontainers-toxiproxy` catalog alias는 존재하지만
+  `bluetape4k-testcontainers`의 `compileOnly` dependency는 JWT 테스트에
+  transitive하게 노출되지 않는다.
+
+## 대안 비교
+
+### A. JWT 테스트에 ToxiProxy client를 직접 연결한다 (채택)
+
+`utils/jwt/build.gradle.kts`의 test scope에 `libs.testcontainers.toxiproxy`를
+추가하고, 새 테스트가 `Network.newNetwork()` 안에서 Redis와 ToxiProxy를
+직접 시작한다. proxy를 Redisson address로 사용하여 정상 요청, route
+disable 중의 bounded failure, enable 후 recovery를 순서대로 검증한다.
+
+장점은 acceptance criteria를 가장 작은 변경으로 충족하고 공용 테스트
+인프라 API를 변경하지 않는다는 점이다. 단점은 Docker가 필요한 테스트가
+하나 추가된다는 점이며, 이 테스트는 다른 Testcontainers 모듈과 병렬 실행하지
+않는다.
+
+### B. 공용 `ToxiproxyServer`에 Redis proxy factory를 추가한다 (제외)
+
+테스트 인프라 모듈에 proxy 생성/정리 helper를 추가하면 호출부는 짧아지지만,
+공용 API와 문서/테스트를 함께 변경하고 JWT의 단일 integration 요구를
+테스트 인프라 설계로 확장하게 된다. 현재 helper의 동작이 이미 충분하므로
+YAGNI에 맞지 않는다.
+
+### C. Redis만 사용하는 shutdown 통합 테스트를 추가한다 (제외)
+
+실제 Redisson ownership과 close 순서는 확인할 수 있지만 route interruption과
+recovery를 재현하지 못해 issue의 핵심 수용 기준을 충족하지 못한다.
+
+## 선택한 구성과 수명주기
+
+1. `Network.newNetwork()`를 만들고 `RedisServer`를 `redis` alias로, 이어서
+   `ToxiproxyServer`를 같은 network에 시작한다.
+2. `ToxiproxyClient`로 `0.0.0.0:8666 -> redis:6379` proxy를 만들고, host의
+   mapped proxy port를 짧은 timeout/retry Redisson config의 address로 사용한다.
+3. 실제 `RedisKeyChainRepository`와 짧은 interval의
+   `DefaultJwtProvider.forTesting`을 만들고, 그 delegate와 Redis map cache를
+   `RedissonJwtProvider`에 주입한다.
+4. JWT 생성/파싱과 forced rotation으로 key rotation 및 cache parsing을
+   확인한다. `proxy.disable()` 중 provider의 forced rotation이 정해진 짧은
+   시간 안에 false로 끝나는지 확인하고, `proxy.enable()` 후 같은 경로가
+   성공하는지 확인한다.
+5. provider를 두 번 닫고 repository를 두 번 닫는다. 두 close가
+   `RedissonClient`를 종료하지 않는지 확인한 뒤 application ownership으로
+   client를 닫고 `isShutdown` terminal state를 확인한다.
+6. provider를 닫은 뒤 만료된 key-chain을 Redis에 직접 넣고 refresh interval
+   이상 기다려도 timer가 새 회전을 만들지 않는지 deque의 key id로 확인한다.
+   이는 process-wide thread-name 검사 없이 provider-owned background work의
+   종료를 입증한다.
+
+## 오류와 경계
+
+- ToxiProxy disable 중의 Redis 명령은 Redisson config의 짧은 timeout과
+  `retryAttempts = 0`으로 bounded failure가 된다.
+- proxy가 복구되면 새 요청은 반드시 같은 client를 통해 성공해야 한다.
+- provider/repository close는 borrowed client나 Redis container를 닫지 않는다.
+  container와 client는 테스트의 외부 owner가 명시된 순서로 정리한다.
+- proxy/client/container 정리는 `finally`에서 각각 best-effort로 수행하며,
+  테스트 본문의 primary assertion failure를 덮지 않는다.
+- Redis cluster/failover, production API 변경, process-wide thread enumeration은
+  이 설계의 범위가 아니다.
+
+## 수용 기준 대응
+
+| 기준 | 검증 방법 |
+| --- | --- |
+| 실제 Redis + Redisson + JWT | shared Network의 RedisServer와 proxy 주소를 쓰는 integration test |
+| proxy interruption/recovery | `disable` 중 bounded rotation failure, `enable` 후 성공 |
+| ownership 분리 | provider/repository close 뒤 client가 살아 있고, 명시적 client shutdown 후만 `isShutdown` |
+| idempotent close 및 timer 종료 | 반복 close와 만료 key-chain 재회전 억제 확인 |
+| 문서화 | README 두 locale에 Redis-backed ownership/close 순서 추가 |
+| 품질 | targeted integration test, JWT detekt, diff-check 및 proportional module test |
+
+## Definition of Done
+
+- test-only dependency만 추가되고 production ownership/API는 변경하지 않는다.
+- 테스트가 Docker가 있는 로컬 환경에서 통과하고, hosted CI에서 Docker 결과가
+  없으면 PR에 그 사실을 명시한다.
+- README/KDoc 설명은 실제 코드의 close 순서와 일치한다.
+- 변경 파일의 `git diff --check`, targeted test, detekt, module test 결과와
+  exact PR head를 DoD에 남긴다.

--- a/docs/superpowers/specs/2026-08-02-redis-jwt-shutdown-integration-design.md
+++ b/docs/superpowers/specs/2026-08-02-redis-jwt-shutdown-integration-design.md
@@ -15,7 +15,8 @@ cache provider의 종료 경로를 검증하는 것이다. 검증은 애플리�
 - `DefaultJwtProvider`는 `forTesting` 내부 생성 경로로 짧은 rotation interval을
   사용할 수 있고, 주입된 repository를 빌려 쓰며 자체 timer만 닫는다.
 - `RedissonJwtProvider`는 delegate를 위임하고 Redis map cache를 빌려 쓰므로
-  client 종료 책임을 갖지 않는다.
+  delegate timer나 client 종료 책임을 갖지 않는다. 실제 rotation timer는
+  `DefaultJwtProvider`가 소유하므로 호출자가 delegate를 별도로 닫아야 한다.
 - `RedisServer`와 `ToxiproxyServer`는 이미 Testcontainers와 shared Network
   패턴을 제공한다. `testcontainers-toxiproxy` catalog alias는 존재하지만
   `bluetape4k-testcontainers`의 `compileOnly` dependency는 JWT 테스트에
@@ -60,12 +61,13 @@ recovery를 재현하지 못해 issue의 핵심 수용 기준을 충족하지 �
    확인한다. `proxy.disable()` 중 provider의 forced rotation이 정해진 짧은
    시간 안에 false로 끝나는지 확인하고, `proxy.enable()` 후 같은 경로가
    성공하는지 확인한다.
-5. provider를 두 번 닫고 repository를 두 번 닫는다. 두 close가
-   `RedissonClient`를 종료하지 않는지 확인한 뒤 application ownership으로
-   client를 닫고 `isShutdown` terminal state를 확인한다.
-6. provider를 닫은 뒤 만료된 key-chain을 Redis에 직접 넣고 refresh interval
+5. wrapper provider를 두 번 닫고, delegate를 두 번 닫고, repository를 두 번
+   닫는다. wrapper/repository/delegate close가 `RedissonClient`를 종료하지
+   않는지 확인한 뒤 application ownership으로 client를 닫고 `isShutdown`
+   terminal state를 확인한다.
+6. delegate를 닫은 뒤 만료된 key-chain을 Redis에 직접 넣고 refresh interval
    이상 기다려도 timer가 새 회전을 만들지 않는지 deque의 key id로 확인한다.
-   이는 process-wide thread-name 검사 없이 provider-owned background work의
+   이는 process-wide thread-name 검사 없이 delegate-owned background work의
    종료를 입증한다.
 
 ## 오류와 경계
@@ -73,7 +75,8 @@ recovery를 재현하지 못해 issue의 핵심 수용 기준을 충족하지 �
 - ToxiProxy disable 중의 Redis 명령은 Redisson config의 짧은 timeout과
   `retryAttempts = 0`으로 bounded failure가 된다.
 - proxy가 복구되면 새 요청은 반드시 같은 client를 통해 성공해야 한다.
-- provider/repository close는 borrowed client나 Redis container를 닫지 않는다.
+- provider/repository close는 borrowed delegate, client나 Redis container를
+  닫지 않는다. delegate의 rotation timer는 delegate close가 소유하며,
   container와 client는 테스트의 외부 owner가 명시된 순서로 정리한다.
 - proxy/client/container 정리는 `finally`에서 각각 best-effort로 수행하며,
   테스트 본문의 primary assertion failure를 덮지 않는다.
@@ -86,8 +89,8 @@ recovery를 재현하지 못해 issue의 핵심 수용 기준을 충족하지 �
 | --- | --- |
 | 실제 Redis + Redisson + JWT | shared Network의 RedisServer와 proxy 주소를 쓰는 integration test |
 | proxy interruption/recovery | `disable` 중 bounded rotation failure, `enable` 후 성공 |
-| ownership 분리 | provider/repository close 뒤 client가 살아 있고, 명시적 client shutdown 후만 `isShutdown` |
-| idempotent close 및 timer 종료 | 반복 close와 만료 key-chain 재회전 억제 확인 |
+| ownership 분리 | provider/delegate/repository close 뒤 client가 살아 있고, 명시적 client shutdown 후만 `isShutdown` |
+| idempotent close 및 timer 종료 | 반복 close와 delegate close 후 만료 key-chain 재회전 억제 확인 |
 | 문서화 | README 두 locale에 Redis-backed ownership/close 순서 추가 |
 | 품질 | targeted integration test, JWT detekt, diff-check 및 proportional module test |
 

--- a/utils/jwt/README.ko.md
+++ b/utils/jwt/README.ko.md
@@ -168,6 +168,31 @@ try {
 
 Cache Provider는 delegate를 빌려 사용하므로 회전 타이머를 소유한 원래 delegate를 별도로 닫아야 합니다. 백그라운드 작업이 없는 구현체는 기본 no-op `close()` 구현을 그대로 사용할 수 있습니다.
 
+Redis 기반 Provider를 사용할 때 `RedissonClient`와 delegate의 소유자는
+애플리케이션입니다. `RedissonJwtProvider`는 delegate와 cache를 빌려 쓰므로
+wrapper, delegate의 회전 작업, Repository의 refresh 작업, 애플리케이션이
+소유한 client 순서로 각각 닫으세요.
+
+```kotlin
+val repository = RedisKeyChainRepository(redissonClient)
+val delegate = DefaultJwtProvider(keyChainRepository = repository)
+val provider = RedissonJwtProvider(delegate, redissonClient)
+
+try {
+    provider.tryParse(jwt)
+} finally {
+    provider.close()          // idempotent이며 빌린 자원을 닫지 않습니다.
+    delegate.close()          // delegate의 회전 타이머를 닫습니다.
+    repository.close()        // Repository의 refresh 타이머를 닫습니다.
+    redissonClient.shutdown() // 애플리케이션이 소유한 Redisson client를 닫습니다.
+}
+```
+
+JWT 모듈의 Redis shutdown 통합 테스트는 하나의 Testcontainers network에서
+Redis와 ToxiProxy를 함께 실행합니다. Proxy를 비활성화했다가 다시 활성화하여
+bounded failure와 recovery를 검증하고, 주입받은 delegate/client의 소유권과
+종료 순서를 명시적으로 유지합니다.
+
 ### 압축 사용
 
 큰 클레임 데이터가 있는 경우 jjwt 내장 압축 알고리즘을 사용할 수 있습니다.

--- a/utils/jwt/README.md
+++ b/utils/jwt/README.md
@@ -159,6 +159,31 @@ try {
 
 Cache providers borrow their delegate; close the original delegate separately when it owns a rotation timer. Implementations without background work may keep the default no-op `close()` implementation.
 
+For a Redis-backed provider, both the `RedissonClient` and the delegate remain
+application-owned. `RedissonJwtProvider` borrows the delegate and cache, so close
+the wrapper, then the delegate's rotation work, then the repository refresh work,
+and finally the client:
+
+```kotlin
+val repository = RedisKeyChainRepository(redissonClient)
+val delegate = DefaultJwtProvider(keyChainRepository = repository)
+val provider = RedissonJwtProvider(delegate, redissonClient)
+
+try {
+    provider.tryParse(jwt)
+} finally {
+    provider.close()          // idempotent; does not close borrowed resources
+    delegate.close()          // closes the delegate rotation timer
+    repository.close()        // closes the repository refresh timer
+    redissonClient.shutdown() // closes the application-owned client
+}
+```
+
+The JWT module's Redis shutdown integration test uses Redis and ToxiProxy on a
+shared Testcontainers network. It disables and re-enables the proxy to verify a
+bounded failure and recovery while keeping the borrowed delegate/client ownership
+order explicit.
+
 ### Compression
 
 Use built-in jjwt compression for large claim payloads.

--- a/utils/jwt/build.gradle.kts
+++ b/utils/jwt/build.gradle.kts
@@ -47,5 +47,6 @@ dependencies {
 
     testImplementation(project(":bluetape4k-testcontainers"))
     testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.toxiproxy)
     testImplementation(libs.testcontainers.mongodb)
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedisJwtShutdownIntegrationTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedisJwtShutdownIntegrationTest.kt
@@ -1,0 +1,139 @@
+package io.bluetape4k.jwt.provider.cache
+
+import eu.rekawek.toxiproxy.Proxy
+import eu.rekawek.toxiproxy.ToxiproxyClient
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.jwt.keychain.KeyChain
+import io.bluetape4k.jwt.keychain.repository.redis.RedisKeyChainRepository
+import io.bluetape4k.jwt.provider.DefaultJwtProvider
+import io.bluetape4k.testcontainers.infra.ToxiproxyServer
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.testcontainers.containers.Network
+import java.time.Duration
+import java.util.UUID
+import kotlin.test.assertTrue
+
+@Execution(ExecutionMode.SAME_THREAD)
+class RedisJwtShutdownIntegrationTest {
+
+    @Test
+    fun `proxied Redis preserves close ownership`() {
+        Network.newNetwork().use { network ->
+            RedisServer().withNetwork(network).withNetworkAliases("redis").use { redis ->
+                ToxiproxyServer().apply { withNetwork(network) }.use { toxiproxy ->
+                    redis.start()
+                    toxiproxy.start()
+                    val proxy = createRedisProxy(toxiproxy)
+                    val redisson = createRedisson(toxiproxy)
+                    val repository = createRepository(redisson)
+                    val delegate = DefaultJwtProvider.forTesting(
+                        keyChainRepository = repository,
+                        rotationIntervalMillis = ROTATION_INTERVAL_MILLIS,
+                    )
+                    val provider = RedissonJwtProvider(delegate, redisson)
+
+                    try {
+                        verifyRedisLifecycle(proxy, delegate, provider, repository, redisson)
+                    } finally {
+                        closeResources(provider, delegate, repository, redisson, proxy)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun createRedisProxy(toxiproxy: ToxiproxyServer): Proxy =
+        ToxiproxyClient(toxiproxy.host, toxiproxy.controlPort).createProxy(
+            "jwt-redis-${UUID.randomUUID()}",
+            "0.0.0.0:8666",
+            "redis:${RedisServer.PORT}",
+        )
+
+    private fun createRedisson(toxiproxy: ToxiproxyServer): RedissonClient {
+        val address = "redis://${toxiproxy.host}:${toxiproxy.getMappedPort(8666)}"
+        return Redisson.create(
+            RedisServer.Launcher.RedissonLib.getRedissonConfig(address).apply {
+                useSingleServer().apply {
+                    timeout = 500
+                    connectTimeout = 500
+                    retryAttempts = 0
+                }
+            },
+        )
+    }
+
+    private fun createRepository(redisson: RedissonClient): RedisKeyChainRepository =
+        RedisKeyChainRepository(
+            redisson,
+            queueName = "test:jwt:shutdown:${UUID.randomUUID()}",
+        )
+
+    private fun verifyRedisLifecycle(
+        proxy: Proxy,
+        delegate: DefaultJwtProvider,
+        provider: RedissonJwtProvider,
+        repository: RedisKeyChainRepository,
+        redisson: RedissonClient,
+    ) {
+        val firstJwt = provider.compose { subject = "shutdown" }
+        provider.tryParse(firstJwt)?.subject shouldBeEqualTo "shutdown"
+
+        provider.forcedRotate().shouldBeTrue()
+        val rotatedJwt = provider.compose { subject = "rotated" }
+        provider.tryParse(rotatedJwt)?.subject shouldBeEqualTo "rotated"
+
+        proxy.disable()
+        val interruptedAt = System.nanoTime()
+        provider.forcedRotate().shouldBeFalse()
+        val interruptedMillis = Duration.ofNanos(System.nanoTime() - interruptedAt).toMillis()
+        assertTrue(
+            interruptedMillis < 5_000,
+            "proxy interruption must remain bounded: ${interruptedMillis}ms",
+        )
+
+        proxy.enable()
+        provider.forcedRotate().shouldBeTrue()
+        val recoveredJwt = provider.compose { subject = "recovered" }
+        provider.tryParse(recoveredJwt)?.subject shouldBeEqualTo "recovered"
+
+        provider.close()
+        provider.close()
+        delegate.close()
+        delegate.close()
+        val expiredKeyChain = KeyChain(expiredTtl = Duration.ofMillis(1))
+        repository.forcedRotate(expiredKeyChain).shouldBeTrue()
+        Thread.sleep(ROTATION_INTERVAL_MILLIS * 5)
+        repository.current().id shouldBeEqualTo expiredKeyChain.id
+
+        repository.close()
+        repository.close()
+        redisson.isShuttingDown.shouldBeFalse()
+        redisson.isShutdown.shouldBeFalse()
+    }
+
+    private fun closeResources(
+        provider: RedissonJwtProvider,
+        delegate: DefaultJwtProvider,
+        repository: RedisKeyChainRepository,
+        redisson: RedissonClient,
+        proxy: Proxy,
+    ) {
+        runCatching { provider.close() }
+        runCatching { delegate.close() }
+        runCatching { repository.close() }
+        runCatching { redisson.shutdown() }
+        runCatching { proxy.delete() }
+        redisson.isShutdown.shouldBeTrue()
+    }
+
+    private companion object {
+        const val ROTATION_INTERVAL_MILLIS = 50L
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1295

- PR 제목: test(jwt): cover Redis-backed shutdown ownership through ToxiProxy

Closes #1295

Add a production-shaped Redis/Redisson/ToxiProxy integration test for JWT shutdown ownership and proxy recovery without changing production ownership semantics.

## Background

Milestone `1.12.0` issue #1295 follows #1276, which made JWT provider and key-chain repository timers explicitly closeable. The real Redis path still needed proof that borrowed delegates and clients remain application-owned during teardown.

## What This Solves

- Exercises JWT parsing, forced rotation, cache parsing, and bounded ToxiProxy interruption/recovery through a real Redis container.
- Proves wrapper, delegate, repository, and externally owned Redisson client shutdown ordering, repeated close safety, and delegate timer quiescence.

## Work Done

- Added `testcontainers-toxiproxy` only to the JWT test classpath and added a sequential shared-network integration test.
- Documented borrowed delegate/client ownership and close ordering in both README locales, and captured the reusable lifecycle lesson and design/plan evidence.

## Validation

- `./gradlew :bluetape4k-jwt:test --tests io.bluetape4k.jwt.provider.cache.RedisJwtShutdownIntegrationTest --rerun-tasks --no-build-cache`: PASS (Docker, 1 passing)
- `./gradlew :bluetape4k-jwt:test --rerun-tasks --no-build-cache`: PASS (JWT module)
- `./gradlew :bluetape4k-jwt:detekt --no-build-cache`: PASS (`EXIT_CODE=0`)
- `git diff --cached --check`: PASS
- Dependency scope inspection: PASS (ToxiProxy on `testCompileClasspath`, absent from `runtimeClasspath`)

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: inline six-lens review; performance, stability, security, operator, developer/API, and user/caller lenses clear.

## Metadata

- Issue: #1295, milestone `1.12.0`, assignee `debop`
- PR: #1296, head `7d3c18351053ddc389c1096a92627fda0ee94909`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1295-redis-jwt-shutdown`
- Labels: `test`
- State: `MERGED`, merge commit `cab5693881dd062cc996c9d9ccad776c42e2ba20`
- CI: Milestone `1.12.0` issue #1295 follows #1276, which made JWT provider and key-chain repository timers explicitly closeable. The real Redis path still needed proof that borrowed delegates and clients remain application-owned during teardown. / - Exercises JWT parsing, forced rotation, cache parsing, and bounded ToxiProxy interruption/recovery through a real Redis container. / - `./gradlew :bluetape4k-jwt:test --tests io.bluetape4k.jwt.provider.cache.RedisJwtShutdownIntegrationTest --rerun-tasks --no-build-cache`: PASS (Docker, 1 passing)

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01..CG-10 - Pre-PR proof | Read authority, isolate worktree, implement, review, and verify | PASS | Feature branch commit `7d3c18351053ddc389c1096a92627fda0ee94909`; local receipt checks | none |
| Issue acceptance - Redis/ToxiProxy lifecycle | Run real Redis + Redisson + JWT provider through a shared proxy | PASS | Fresh targeted test: 1 passing, `EXIT_CODE=0` | none |
| Ownership - wrapper/delegate/repository/client | Close in documented order and assert client terminal state | PASS | Integration assertions and README EN/KO lifecycle examples | none |
| Quality - module/detekt/docs/dependency scope | Run module test, detekt, parity, diff, and scope checks | PASS | Fresh command outputs and receipt checks | none |
| CG-13 - PR metadata/body | Create and live-verify issue-linked PR | PASS | [PR #1296](https://github.com/bluetape4k/bluetape4k-projects/pull/1296), exact head and final heading verified | none |
| CG-14 - Exact-head CI/review | Wait for CI and reread reviews/threads | PASS | [CI run 30753032390](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/30753032390) all required checks pass; reviews/threads empty | none |
| CG-15 - Merge-ready report | Reconcile exact PR/head and required checks | PASS | PR #1296 head `7d3c18351053ddc389c1096a92627fda0ee94909`, `MERGEABLE`, `CLEAN`, exact-head checks pass | none |
| CG-16..CG-18 - Merge approval/merge/sync | Fresh approval, merge, local sync, cleanup | PENDING | Separate user merge gate | await explicit approval |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1296 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `cab5693881dd062cc996c9d9ccad776c42e2ba20`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
