### PR TITLE
fix(ktor): inherit observability correlation policy in tracing

### DIFF
--- a/docs/lessons/2026-08-03-issue-1277-ktor-correlation-policy.md
+++ b/docs/lessons/2026-08-03-issue-1277-ktor-correlation-policy.md
@@ -1,0 +1,41 @@
+# 교훈: 이슈 #1277 Ktor correlation 정책 상속과 trace override
+
+## 배경
+
+통합 Ktor observability installer는 top-level `CorrelationIdSettings`를
+CallId와 CallLogging에 전달했지만, tracing 설정에는 별도의 기본 정책을
+생성했습니다. tracing이 `call.callId`를 먼저 읽기 때문에 trace 전용 header와
+`maxLength`를 명시해도 애플리케이션 correlation ID가 span attribute를 덮어쓸 수
+있었습니다.
+
+## 결정
+
+- `KtorOpenTelemetryTracingConfig.correlationId == null`을 통합 installer의
+  top-level 정책을 상속한다는 의미로 사용합니다.
+- combined installer는 상속 정책을 tracing helper에 전달합니다.
+- 명시적인 trace 정책은 해당 request header만 읽어 top-level CallId 정책과
+  독립적으로 정제합니다.
+- standalone tracing에서 정책을 생략하면 기존처럼 CallId 값을 우선하고, 없으면
+  기본 request header를 확인합니다.
+
+## 결과
+
+CallId, CallLogging, 응답 전파, tracing이 기본 correlation 정책을 공유하면서도,
+trace 전용 header와 길이 제한을 지정한 사용자는 명시한 override를 유지합니다.
+KDoc과 EN/KO README에 상속 및 override 규칙을 함께 기록했습니다.
+
+## 향후 방지책
+
+관측성 plugin을 조합할 때는 정책의 상속·override 여부를 nullable 설정 또는
+동등한 명시적 상태로 표현하고, `call.callId` fallback이 명시 override를
+덮어쓰지 않는지 확인합니다. custom header와 non-default `maxLength`를 사용하는
+combined installer regression test를 유지합니다.
+
+## 검증
+
+- RED: explicit trace override 테스트가 top-level `applicat`를 반환해 trace 전용
+  기대값과 불일치함을 확인했습니다.
+- GREEN: inherited/explicit correlation 정책 회귀 테스트 2개 통과.
+- `repo-test-summary -- ./gradlew :bluetape4k-ktor-observability:cleanTest :bluetape4k-ktor-observability:test --rerun-tasks --no-build-cache --no-configuration-cache`: 22 passing.
+- `./gradlew :bluetape4k-ktor-observability:detekt --no-build-cache --no-configuration-cache`: `BUILD SUCCESSFUL`; 기존 파일의 경고성 규칙 위반만 보고됨.
+- `git diff --check`: 통과.

--- a/ktor/observability/README.ko.md
+++ b/ktor/observability/README.ko.md
@@ -16,6 +16,10 @@ bluetape4k 애플리케이션에서 관측성 기본값을 명시적으로 설�
 - 애플리케이션이 `MeterRegistry`를 제공할 때만 Micrometer `MicrometerMetrics`를 설치합니다.
 - `prometheusScrapeRoute()`는 애플리케이션이 소유한 `PrometheusMeterRegistry`로 scrape route를 엽니다.
 - 선택적 OpenTelemetry 서버 tracing은 애플리케이션이 소유한 `OpenTelemetry` 인스턴스를 사용합니다.
+- 통합 installer는 기본적으로 `Bluetape4kKtorObservabilityConfig.correlationId`를 CallId,
+  CallLogging, tracing이 함께 사용합니다.
+- tracing에 별도 header 또는 length 정책이 필요할 때만
+  `KtorOpenTelemetryTracingConfig.correlationId`를 명시적인 override로 지정합니다.
 
 ## 의존성
 
@@ -79,6 +83,11 @@ fun Application.module(openTelemetry: OpenTelemetry) {
 `captureSanitizedCorrelationId`는 정제된 `correlation.id` trace attribute만
 기록합니다. raw request header는 기록하지 않습니다. traced request에는 bounded
 `correlation.present` attribute가 항상 기록됩니다.
+
+통합 installer는 CallId, CallLogging, 응답 전파, tracing에 하나의 correlation
+정책을 적용합니다. `correlationId`를 지정하지 않은 tracing 설정은 top-level 정책의
+request header와 `maxLength`를 상속합니다. 애플리케이션 correlation ID와 분리된 trace
+전용 정책이 필요하면 `KtorOpenTelemetryTracingConfig.correlationId`를 지정합니다.
 
 ## 의존성 정책
 

--- a/ktor/observability/README.md
+++ b/ktor/observability/README.md
@@ -16,6 +16,8 @@ Explicit Ktor observability defaults for bluetape4k applications.
 - `MicrometerMetrics` is installed only when the application supplies a `MeterRegistry`.
 - `prometheusScrapeRoute()` exposes an optional scrape route backed by an application-owned `PrometheusMeterRegistry`.
 - Optional OpenTelemetry server tracing uses the application-owned `OpenTelemetry` instance.
+- The combined installer shares `Bluetape4kKtorObservabilityConfig.correlationId` with CallId, CallLogging, and tracing by default.
+- Set `KtorOpenTelemetryTracingConfig.correlationId` only when tracing needs an explicit header or length policy override.
 
 ## Dependency
 
@@ -80,6 +82,12 @@ fun Application.module(openTelemetry: OpenTelemetry) {
 `captureSanitizedCorrelationId` records only the sanitized `correlation.id`
 trace attribute. Raw request headers are not recorded. Traced requests always
 record the bounded `correlation.present` attribute.
+
+The combined installer applies one correlation policy to CallId, CallLogging,
+response propagation, and tracing. A tracing configuration without
+`correlationId` inherits the top-level policy, including its request header and
+`maxLength`. Set `KtorOpenTelemetryTracingConfig.correlationId` to keep a
+deliberate trace-specific policy separate from the application correlation ID.
 
 ## Dependency Policy
 

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservability.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservability.kt
@@ -7,13 +7,19 @@ import io.ktor.server.plugins.callid.CallId
 import io.ktor.server.plugins.calllogging.CallLogging
 
 /**
- * Installs the bluetape4k Ktor observability baseline.
+ * bluetape4k Ktor 관측성 기본 구성을 설치합니다.
  *
- * ## Contract
- * - Plugin installation is explicit and application-owned.
- * - Correlation IDs are sanitized before MDC or response propagation.
- * - Micrometer metrics are installed only when a [Bluetape4kKtorObservabilityConfig.meterRegistry] is provided.
- * - OpenTelemetry tracing is installed only when a [Bluetape4kKtorObservabilityConfig.tracing] config is provided.
+ * ## 계약
+ * - plugin 설치는 명시적이며 애플리케이션이 소유합니다.
+ * - correlation ID는 MDC 또는 응답으로 전파하기 전에 정제합니다.
+ * - [Bluetape4kKtorObservabilityConfig.correlationId]를 CallId, CallLogging,
+ *   tracing이 기본으로 공유합니다.
+ * - [KtorOpenTelemetryTracingConfig.correlationId]를 지정하면 tracing만 사용하는
+ *   명시적 override로 동작합니다.
+ * - Micrometer metrics는 [Bluetape4kKtorObservabilityConfig.meterRegistry]가 제공된
+ *   경우에만 설치합니다.
+ * - OpenTelemetry tracing은 [Bluetape4kKtorObservabilityConfig.tracing]이 제공된
+ *   경우에만 설치합니다.
  *
  * ```kotlin
  * fun Application.module(registry: MeterRegistry) {
@@ -26,7 +32,12 @@ import io.ktor.server.plugins.calllogging.CallLogging
 fun Application.installBluetape4kKtorObservability(
     config: Bluetape4kKtorObservabilityConfig = Bluetape4kKtorObservabilityConfig(),
 ) {
-    config.tracing?.let(::installBluetape4kKtorOpenTelemetryTracing)
+    config.tracing?.let { tracing ->
+        installBluetape4kKtorOpenTelemetryTracing(
+            config = tracing,
+            inheritedCorrelationId = config.correlationId,
+        )
+    }
 
     if (config.installCorrelationId) {
         install(CallId) {

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityConfig.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityConfig.kt
@@ -4,13 +4,16 @@ import io.ktor.server.metrics.micrometer.MicrometerMetricsConfig
 import io.micrometer.core.instrument.MeterRegistry
 
 /**
- * Explicit opt-in configuration for [installBluetape4kKtorObservability].
+ * [installBluetape4kKtorObservability]를 위한 명시적 opt-in 설정입니다.
  *
- * ## Contract
- * - CallId and CallLogging are enabled by default.
- * - Micrometer is enabled only when [meterRegistry] is supplied.
- * - OpenTelemetry tracing is installed only when [tracing] is supplied.
- * - Prometheus export is provided by route helpers, not by this installer.
+ * ## 계약
+ * - CallId와 CallLogging은 기본으로 활성화합니다.
+ * - [correlationId]는 CallId, CallLogging, tracing의 공통 기본 정책입니다.
+ * - [tracing]이 있고 그 설정의 [KtorOpenTelemetryTracingConfig.correlationId]가
+ *   `null`이면 [correlationId]를 상속합니다.
+ * - tracing 설정에 correlation ID 정책을 지정하면 tracing 전용 override로 사용합니다.
+ * - [meterRegistry]가 제공된 경우에만 Micrometer를 활성화합니다.
+ * - Prometheus export는 이 installer가 아니라 route helper가 제공합니다.
  */
 class Bluetape4kKtorObservabilityConfig(
     val correlationId: CorrelationIdSettings = CorrelationIdSettings(),

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingConfig.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingConfig.kt
@@ -3,15 +3,18 @@ package io.bluetape4k.ktor.observability
 import io.opentelemetry.api.OpenTelemetry
 
 /**
- * Explicit opt-in configuration for Ktor OpenTelemetry server tracing.
+ * Ktor OpenTelemetry 서버 tracing을 명시적으로 활성화하는 설정입니다.
  *
- * ## Contract
- * - The application owns the [openTelemetry] instance, SDK, exporters, and backend.
- * - This module does not register or mutate a global OpenTelemetry SDK.
- * - Sanitized correlation IDs are captured only when [captureSanitizedCorrelationId] is enabled.
+ * ## 계약
+ * - 애플리케이션이 [openTelemetry] 인스턴스, SDK, exporter, backend를 소유합니다.
+ * - 이 모듈은 전역 OpenTelemetry SDK를 등록하거나 변경하지 않습니다.
+ * - [correlationId]가 `null`이면 통합 observability installer의 정책을 상속하고,
+ *   standalone tracing 설치에서는 기본 [CorrelationIdSettings]를 사용합니다.
+ * - 명시한 [correlationId]는 통합 installer의 정책보다 우선하는 trace 전용 override입니다.
+ * - 정제된 correlation ID는 [captureSanitizedCorrelationId]가 활성화된 경우에만 수집합니다.
  */
 class KtorOpenTelemetryTracingConfig(
     val openTelemetry: OpenTelemetry,
-    val correlationId: CorrelationIdSettings = CorrelationIdSettings(),
+    val correlationId: CorrelationIdSettings? = null,
     val captureSanitizedCorrelationId: Boolean = false,
 )

--- a/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingSupport.kt
+++ b/ktor/observability/src/main/kotlin/io/bluetape4k/ktor/observability/KtorOpenTelemetryTracingSupport.kt
@@ -7,25 +7,32 @@ import io.ktor.server.request.ApplicationRequest
 import io.opentelemetry.instrumentation.ktor.v3_0.KtorServerTelemetry
 
 /**
- * Installs opt-in OpenTelemetry server tracing for Ktor.
+ * Ktor에 opt-in OpenTelemetry server tracing을 설치합니다.
  *
- * ## Contract
- * - Delegates HTTP server span creation to OpenTelemetry's Ktor 3 instrumentation.
- * - Uses the caller-provided [KtorOpenTelemetryTracingConfig.openTelemetry] instance.
- * - Records `correlation.present` by default before the span ends.
- * - Records `correlation.id` only after CallId sanitization/generation and explicit opt-in.
+ * ## 계약
+ * - HTTP server span 생성은 OpenTelemetry Ktor 3 instrumentation에 위임합니다.
+ * - 호출자가 제공한 [KtorOpenTelemetryTracingConfig.openTelemetry] 인스턴스를 사용합니다.
+ * - [KtorOpenTelemetryTracingConfig.correlationId]가 지정되지 않으면
+ *   [inheritedCorrelationId]를 사용하고, standalone 설치에서는 기본 정책을 사용합니다.
+ * - trace 전용 정책을 명시한 경우 해당 request header만 사용해 상위 CallId 정책과 분리합니다.
+ * - span 종료 전에 `correlation.present`를 기록하고, 명시적으로 활성화한 경우에만
+ *   정제된 `correlation.id`를 기록합니다.
  */
 fun Application.installBluetape4kKtorOpenTelemetryTracing(
     config: KtorOpenTelemetryTracingConfig,
+    inheritedCorrelationId: CorrelationIdSettings? = null,
 ) {
+    val correlationId = config.correlationId ?: inheritedCorrelationId ?: CorrelationIdSettings()
+    val useCallIdFallback = config.correlationId == null
+
     install(KtorServerTelemetry) {
         setOpenTelemetry(config.openTelemetry)
         attributesExtractor {
             onEnd {
-                val correlationId = request.sanitizedCorrelationId(config.correlationId)
-                attributes.put(CORRELATION_PRESENT_ATTRIBUTE, correlationId != null)
-                if (config.captureSanitizedCorrelationId && correlationId != null) {
-                    attributes.put(CORRELATION_ID_ATTRIBUTE, correlationId)
+                val sanitizedCorrelationId = request.sanitizedCorrelationId(correlationId, useCallIdFallback)
+                attributes.put(CORRELATION_PRESENT_ATTRIBUTE, sanitizedCorrelationId != null)
+                if (config.captureSanitizedCorrelationId && sanitizedCorrelationId != null) {
+                    attributes.put(CORRELATION_ID_ATTRIBUTE, sanitizedCorrelationId)
                 }
             }
         }
@@ -37,8 +44,13 @@ private const val CORRELATION_ID_ATTRIBUTE: String = "correlation.id"
 
 private fun ApplicationRequest.sanitizedCorrelationId(
     settings: CorrelationIdSettings,
+    useCallIdFallback: Boolean,
 ): String? =
     KtorCorrelationId.sanitize(
-        rawValue = call.callId ?: headers[settings.requestHeaderName],
+        rawValue = if (useCallIdFallback) {
+            call.callId ?: headers[settings.requestHeaderName]
+        } else {
+            headers[settings.requestHeaderName]
+        },
         maxLength = settings.maxLength
     )

--- a/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
+++ b/ktor/observability/src/test/kotlin/io/bluetape4k/ktor/observability/Bluetape4kKtorObservabilityTest.kt
@@ -148,6 +148,92 @@ class Bluetape4kKtorObservabilityTest {
     }
 
     @Test
+    fun `observability installer shares custom correlation policy with tracing`() = testTracing { tracing ->
+        val correlationId = CorrelationIdSettings(
+            requestHeaderName = "X-Correlation-ID",
+            responseHeaderName = "X-Correlation-ID",
+            maxLength = 8,
+        )
+
+        testApplication {
+            application {
+                installBluetape4kKtorObservability(
+                    Bluetape4kKtorObservabilityConfig(
+                        correlationId = correlationId,
+                        tracing = KtorOpenTelemetryTracingConfig(
+                            openTelemetry = tracing.openTelemetry,
+                            captureSanitizedCorrelationId = true,
+                        ),
+                    )
+                )
+                routing {
+                    get("/ping") {
+                        call.respondText("pong")
+                    }
+                }
+            }
+
+            val response = client.get("/ping") {
+                header(correlationId.requestHeaderName, "client-correlation-id")
+            }
+
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            response.headers[correlationId.responseHeaderName] shouldBeEqualTo "client-c"
+            tracing.flush()
+
+            val span = tracing.spanExporter.finishedSpanItems.single()
+            span.attributes[CORRELATION_PRESENT_KEY].shouldBeTrue()
+            span.attributes[CORRELATION_ID_KEY] shouldBeEqualTo "client-c"
+        }
+    }
+
+    @Test
+    fun `observability installer preserves explicit tracing correlation override`() = testTracing { tracing ->
+        val correlationId = CorrelationIdSettings(
+            requestHeaderName = "X-Correlation-ID",
+            responseHeaderName = "X-Correlation-ID",
+            maxLength = 8,
+        )
+        val tracingCorrelationId = CorrelationIdSettings(
+            requestHeaderName = "X-Trace-ID",
+            maxLength = 12,
+        )
+
+        testApplication {
+            application {
+                installBluetape4kKtorObservability(
+                    Bluetape4kKtorObservabilityConfig(
+                        correlationId = correlationId,
+                        tracing = KtorOpenTelemetryTracingConfig(
+                            openTelemetry = tracing.openTelemetry,
+                            correlationId = tracingCorrelationId,
+                            captureSanitizedCorrelationId = true,
+                        ),
+                    )
+                )
+                routing {
+                    get("/ping") {
+                        call.respondText("pong")
+                    }
+                }
+            }
+
+            val response = client.get("/ping") {
+                header(correlationId.requestHeaderName, "application-correlation-id")
+                header(tracingCorrelationId.requestHeaderName, "trace-correlation-id")
+            }
+
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            response.headers[correlationId.responseHeaderName] shouldBeEqualTo "applicat"
+            tracing.flush()
+
+            val span = tracing.spanExporter.finishedSpanItems.single()
+            span.attributes[CORRELATION_PRESENT_KEY].shouldBeTrue()
+            span.attributes[CORRELATION_ID_KEY] shouldBeEqualTo "trace-correl"
+        }
+    }
+
+    @Test
     fun `observability installer does not create spans when tracing is disabled`() = testTracing { tracing ->
         testApplication {
             application {


### PR DESCRIPTION
## Summary

Closes #1277

- PR 제목: fix(ktor): inherit observability correlation policy in tracing

The combined Ktor observability installer now resolves one effective correlation policy for CallId, CallLogging, response propagation, and OpenTelemetry tracing by default. Explicit tracing configuration remains an isolated trace-specific override.

### 원문 선행 내용

Fixes #1277

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Pass the top-level `CorrelationIdSettings` into tracing when the combined installer is used.
- Use nullable tracing policy configuration as the inheritance signal.
- Keep explicit tracing overrides on their configured request header and `maxLength`, without falling back to the application-generated CallId.
- Preserve standalone tracing defaults and application-owned OpenTelemetry lifecycle.
- Add regression coverage for inherited custom header/length policy and explicit trace override behavior.
- Document inheritance and override rules in KDoc, English/Korean READMEs, and the Korean lesson note.

### 기존 섹션: Verification

- TDD RED: the explicit override test reproduced the root cause by observing the top-level application value in the span.
- TDD GREEN: inherited and explicit override regression tests pass.
- `repo-test-summary -- ./gradlew :bluetape4k-ktor-observability:cleanTest :bluetape4k-ktor-observability:test --rerun-tasks --no-build-cache --no-configuration-cache` — `BUILD SUCCESSFUL`, 22 passing.
- `./gradlew :bluetape4k-ktor-observability:cleanDetekt :bluetape4k-ktor-observability:detekt --rerun-tasks --no-build-cache --no-configuration-cache` — `BUILD SUCCESSFUL`; existing warning-only findings remain unchanged.
- `git diff --check` and EN/KO README heading/fence parity checks pass.
- Bluetape workflow receipt run `20260802T153606Z-67b25d4c` completed and verified with 18 events.

### 기존 섹션: Scope and Risk

This is a narrow Ktor observability fix. No production OpenTelemetry backend or external client lifecycle is changed. Remote CI remains the next validation layer; no CI result is claimed locally.

Final status: PENDING remote CI and fresh exact-head merge review/approval.

## Validation

- N/A: 역사적 PR이며 본문 정규화 과정에서는 원래 CI·테스트를 재실행하지 않았습니다.

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1277, milestone `1.12.0`, assignee `debop`
- PR: #1298, head `726adaa9fc3e7a90aa1935f92bcdee878bfb1151`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1277-ktor-correlation-policy`
- Labels: `bug`, `infra/io`
- State: `MERGED`, merge commit `3441bbd761175801a400361512c4f3e2332c72c5`
- CI: The combined Ktor observability installer now resolves one effective correlation policy for CallId, CallLogging, response propagation, and OpenTelemetry tracing by default. Explicit tracing configuration remains an isolated trace-specific override. / - Pass the top-level `CorrelationIdSettings` into tracing when the combined installer is used. / - Use nullable tracing policy configuration as the inheritance signal.

## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1298 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `3441bbd761175801a400361512c4f3e2332c72c5`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
