### PR TITLE
fix: separate web-framework benchmark metrics and harden lifecycle cleanup

### DIFF
--- a/benchmark/web-framework-benchmark/README.ko.md
+++ b/benchmark/web-framework-benchmark/README.ko.md
@@ -8,8 +8,6 @@
 
 ![Web framework latency](../../docs/images/readme-charts/benchmark-web-framework-latency-chart-01.png)
 
-![Web framework startup](../../docs/images/readme-charts/benchmark-web-framework-startup-chart-01.png)
-
 ## 무엇을 측정하나
 
 Benchmark 소스는
@@ -28,7 +26,10 @@ Generator registry에는 UUIDv4, UUIDv7, ULID, KSUID, Snowflake, Flake가 함께
 
 ## 최근 로컬 결과
 
-실행일: 2026-06-19. Runtime: GraalVM JDK 21.0.11. 각 benchmark는 Gradle configuration에서 다르게 지정하지 않는 한 fork 1회, warmup 2회, measurement 3회로 실행합니다.
+Throughput과 latency snapshot은 2026-06-19 GraalVM JDK 21.0.11에서,
+startup과 memory lifecycle snapshot은 2026-08-03 GraalVM JDK 21.0.12에서
+실행했습니다. 각 benchmark는 Gradle configuration에서 다르게 지정하지 않는 한
+fork 1회, measurement 3회로 실행합니다.
 
 ### Throughput
 
@@ -60,18 +61,40 @@ Mode: JMH average time, `us/op`, 낮을수록 좋습니다.
 | Batch IDs   | 274.638 us/op |  167.923 us/op |
 | Bad request | 255.166 us/op |  164.028 us/op |
 
-### Startup
+### Ready-to-serve startup
 
 ```bash
 ./gradlew :web-framework-benchmark:startupBenchmark
 ```
 
-Mode: JMH average time, `ms/op`, 낮을수록 좋습니다.
+Mode: JMH average time, `ms/op`, 낮을수록 좋습니다. Server construction이
+connector/application readiness에 도달할 때까지를 측정하며,
+`@TearDown(Level.Invocation)`이 invocation 뒤에 server를 닫습니다. 따라서
+shutdown은 이 metric에 포함되지 않습니다.
 
-| Framework      |           Score |    Error |
-|----------------|----------------:|---------:|
-| Ktor CIO       |     0.683 ms/op |   ±0.770 |
-| Spring WebFlux | 2,091.794 ms/op | ±146.877 |
+| Framework      | Benchmark                   | Score | Error |
+|----------------|-----------------------------|------:|------:|
+| Ktor CIO       | `ktorReadyStartup`          | 0.675 ms/op | ±0.316 |
+| Spring WebFlux | `springWebFluxReadyStartup` | 77.821 ms/op | ±146.638 |
+
+### JVM used-heap snapshot
+
+```bash
+./gradlew :web-framework-benchmark:memoryBenchmark
+```
+
+Memory benchmark는 각 server가 ready가 된 직후, invocation teardown 전에
+`jvm.used_heap`를 기록합니다. `Runtime.totalMemory() - freeMemory()`를
+사용하므로 process RSS가 아니라 JVM used heap입니다. JMH JSON에는 raw event
+sample이 남고, 같은 디렉터리의 `memory-metrics.json`은 명시적인 `bytes` 단위,
+sample 수, `after_ready_before_shutdown` sampling point를 기록합니다.
+정규화된 byte 표가 memory 결과의 source of truth이며, memory benchmark의
+primary `ms/op` 값은 sampling harness invocation 시간일 뿐 memory 값이 아닙니다.
+
+| Framework      | Benchmark                    | Average bytes | Samples |
+|----------------|------------------------------|--------------:|--------:|
+| Ktor CIO       | `ktorReadyUsedHeap`          |    39,887,232 |       3 |
+| Spring WebFlux | `springWebFluxReadyUsedHeap` |    53,612,200 |       3 |
 
 이 숫자는 로컬 비교 snapshot이며, release 보증값이 아닙니다. Throughput과 latency는 1초 measurement window로 짧게 측정했으므로, 제품 수준의 성능 주장을 하려면 더 긴 JMH 실행으로 다시 측정해야 합니다.
 
@@ -81,7 +104,9 @@ Mode: JMH average time, `ms/op`, 낮을수록 좋습니다.
 ./gradlew :web-framework-benchmark:throughputBenchmark
 ./gradlew :web-framework-benchmark:latencyBenchmark
 ./gradlew :web-framework-benchmark:startupBenchmark
+./gradlew :web-framework-benchmark:memoryBenchmark
 ```
 
 원본 JMH JSON report는
 `benchmark/web-framework-benchmark/build/reports/benchmarks/` 아래에 생성됩니다.
+Memory 실행은 JMH `benchmark.json`과 함께 `memory-metrics.json`도 생성합니다.

--- a/benchmark/web-framework-benchmark/README.md
+++ b/benchmark/web-framework-benchmark/README.md
@@ -6,8 +6,6 @@ This module compares equivalent embedded HTTP workloads implemented with Ktor CI
 
 ![Web framework latency](../../docs/images/readme-charts/benchmark-web-framework-latency-chart-01.png)
 
-![Web framework startup](../../docs/images/readme-charts/benchmark-web-framework-startup-chart-01.png)
-
 ## What It Measures
 
 The benchmark source is
@@ -26,7 +24,9 @@ The generator registry also wires UUIDv4, UUIDv7, ULID, KSUID, Snowflake, and Fl
 
 ## Latest Local Results
 
-Run date: 2026-06-19. Runtime: GraalVM JDK 21.0.11. Each benchmark uses one fork, two warmup iterations, and three measured iterations unless the Gradle configuration says otherwise.
+Throughput and latency snapshot: 2026-06-19 on GraalVM JDK 21.0.11. Startup and
+memory lifecycle snapshot: 2026-08-03 on GraalVM JDK 21.0.12. Each benchmark uses
+one fork and three measured iterations unless the Gradle configuration says otherwise.
 
 ### Throughput
 
@@ -62,7 +62,7 @@ Mode: JMH average time, `us/op`, lower is better.
 | Batch IDs   | 274.638 us/op |  167.923 us/op |
 | Bad request | 255.166 us/op |  164.028 us/op |
 
-### Startup
+### Ready-to-serve startup
 
 Command:
 
@@ -70,12 +70,35 @@ Command:
 ./gradlew :web-framework-benchmark:startupBenchmark
 ```
 
-Mode: JMH average time, `ms/op`, lower is better.
+Mode: JMH average time, `ms/op`, lower is better. The benchmark measures server
+construction through connector/application readiness. `@TearDown(Level.Invocation)`
+closes each server after the invocation, so shutdown is excluded from this metric.
 
-| Framework      |           Score |    Error |
-|----------------|----------------:|---------:|
-| Ktor CIO       |     0.683 ms/op |   ±0.770 |
-| Spring WebFlux | 2,091.794 ms/op | ±146.877 |
+| Framework      | Benchmark                   | Score | Error |
+|----------------|-----------------------------|------:|------:|
+| Ktor CIO       | `ktorReadyStartup`          | 0.675 ms/op | ±0.316 |
+| Spring WebFlux | `springWebFluxReadyStartup` | 77.821 ms/op | ±146.638 |
+
+### JVM used-heap snapshot
+
+Command:
+
+```bash
+./gradlew :web-framework-benchmark:memoryBenchmark
+```
+
+The memory benchmark records `jvm.used_heap` after each server is ready and
+before invocation teardown. It uses `Runtime.totalMemory() - freeMemory()`, so
+the value is JVM used heap rather than process RSS. The generated JMH JSON keeps
+the raw event samples; `memory-metrics.json` normalizes them with the explicit
+`bytes` unit, sample count, and `after_ready_before_shutdown` sampling point.
+The normalized byte table is authoritative; the memory benchmark's primary
+`ms/op` result is only the JMH invocation timing for the sampling harness.
+
+| Framework      | Benchmark                      | Average bytes | Samples |
+|----------------|--------------------------------|--------------:|--------:|
+| Ktor CIO       | `ktorReadyUsedHeap`            |    39,887,232 |       3 |
+| Spring WebFlux | `springWebFluxReadyUsedHeap`   |    53,612,200 |       3 |
 
 These numbers are local comparison snapshots, not release guarantees. The throughput and latency runs use short one-second measurement windows, so use longer JMH runs before making a product-level performance claim.
 
@@ -85,7 +108,9 @@ These numbers are local comparison snapshots, not release guarantees. The throug
 ./gradlew :web-framework-benchmark:throughputBenchmark
 ./gradlew :web-framework-benchmark:latencyBenchmark
 ./gradlew :web-framework-benchmark:startupBenchmark
+./gradlew :web-framework-benchmark:memoryBenchmark
 ```
 
 The raw JMH JSON reports are written under
-`benchmark/web-framework-benchmark/build/reports/benchmarks/`.
+`benchmark/web-framework-benchmark/build/reports/benchmarks/`. The memory run
+also writes `memory-metrics.json` beside its JMH `benchmark.json` report.

--- a/benchmark/web-framework-benchmark/build.gradle.kts
+++ b/benchmark/web-framework-benchmark/build.gradle.kts
@@ -72,8 +72,43 @@ benchmark {
             outputTimeUnit = "ms"
             reportFormat = "json"
         }
+        register("memory") {
+            include("io.bluetape4k.benchmark.webframework.WebFrameworkMemoryBenchmark")
+            warmups = 1
+            iterations = 3
+            iterationTime = 1
+            iterationTimeUnit = "s"
+            mode = "avgt"
+            outputTimeUnit = "ms"
+            reportFormat = "json"
+        }
     }
 }
+
+val normalizeMemoryBenchmarkReport = tasks.register("normalizeMemoryBenchmarkReport") {
+    doLast {
+        val reportRoot = layout.buildDirectory.dir("reports/benchmarks/memory").get().asFile
+        val report = reportRoot
+            .walkTopDown()
+            .filter { it.isFile && it.name == "benchmark.json" }
+            .maxByOrNull { it.lastModified() }
+            ?: error("No memory benchmark JSON found under $reportRoot")
+        val normalized = report.resolveSibling("memory-metrics.json")
+
+        val exitCode = ProcessBuilder(
+            "python3",
+            rootProject.file("benchmark/web-framework-benchmark/scripts/normalize-memory-report.py").absolutePath,
+            report.absolutePath,
+            normalized.absolutePath,
+        ).inheritIO().start().waitFor()
+        check(exitCode == 0) { "memory report normalization failed with exit code $exitCode" }
+        logger.lifecycle("Normalized JVM heap report: ${normalized.relativeTo(rootProject.projectDir)}")
+    }
+}
+
+tasks
+    .matching { it.name == "memoryBenchmark" || it.name == "benchmarkMemoryBenchmark" }
+    .configureEach { finalizedBy(normalizeMemoryBenchmarkReport) }
 
 dependencies {
     add("benchmarkImplementation", project(":bluetape4k-idgenerators"))

--- a/benchmark/web-framework-benchmark/scripts/normalize-memory-report.py
+++ b/benchmark/web-framework-benchmark/scripts/normalize-memory-report.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Normalize the JMH heap event counter into an explicit byte metric."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from statistics import fmean
+from typing import Any
+
+
+METRIC_NAME = "jvmUsedHeapBytes"
+NORMALIZED_METRIC = "jvm.used_heap"
+SAMPLING_POINT = "after_ready_before_shutdown"
+
+
+def _as_number(value: Any) -> int | float:
+    if isinstance(value, (int, float)) and float(value).is_integer():
+        return int(value)
+    return value
+
+
+def _samples(raw_data: list[Any]) -> list[int | float]:
+    result: list[int | float] = []
+    for iteration in raw_data:
+        values = iteration if isinstance(iteration, list) else [iteration]
+        result.extend(_as_number(value) for value in values)
+    return result
+
+
+def normalize(input_path: Path) -> dict[str, Any]:
+    payload = json.loads(input_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("JMH report must contain a top-level array")
+
+    results: list[dict[str, Any]] = []
+    for entry in payload:
+        secondary = entry.get("secondaryMetrics", {})
+        metric = secondary.get(METRIC_NAME)
+        if not metric:
+            continue
+
+        samples = _samples(metric.get("rawData", []))
+        if not samples:
+            raise ValueError(f"{entry.get('benchmark', '<unknown>')} has no heap samples")
+
+        results.append(
+            {
+                "benchmark": entry["benchmark"],
+                "jmhVersion": entry.get("jmhVersion"),
+                "jdkVersion": entry.get("jdkVersion"),
+                "sampleCount": len(samples),
+                "averageBytes": _as_number(fmean(samples)),
+                "samples": samples,
+            }
+        )
+
+    if not results:
+        raise ValueError(f"no {METRIC_NAME} secondary metric found in {input_path}")
+
+    return {
+        "schemaVersion": 1,
+        "metric": NORMALIZED_METRIC,
+        "unit": "bytes",
+        "samplingPoint": SAMPLING_POINT,
+        "sourceArtifact": input_path.name,
+        "sourceMetric": METRIC_NAME,
+        "results": results,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="JMH JSON report from memoryBenchmark")
+    parser.add_argument("output", type=Path, help="normalized JSON output path")
+    args = parser.parse_args()
+
+    normalized = normalize(args.input)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(normalized, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/web-framework-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/webframework/WebFrameworkBenchmark.kt
+++ b/benchmark/web-framework-benchmark/src/benchmark/kotlin/io/bluetape4k/benchmark/webframework/WebFrameworkBenchmark.kt
@@ -16,6 +16,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
+import org.openjdk.jmh.annotations.AuxCounters
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
@@ -82,9 +83,12 @@ open class WebFrameworkRequestBenchmark: WebFrameworkBenchmarkSupport()
 open class WebFrameworkLatencyBenchmark: WebFrameworkBenchmarkSupport()
 
 /**
- * Startup and resident-memory snapshot benchmark for the same benchmark apps.
+ * Ready-to-serve startup benchmark for the same benchmark apps.
+ *
+ * The invocation measures server construction through connector/application
+ * readiness. Invocation teardown closes the server outside the timed method.
  */
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(1)
@@ -92,21 +96,101 @@ open class WebFrameworkLatencyBenchmark: WebFrameworkBenchmarkSupport()
 @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 open class WebFrameworkStartupBenchmark {
 
+    private var activeServer: AutoCloseable? = null
+
     @Benchmark
-    fun ktorStartup(blackhole: Blackhole) {
-        KtorBenchmarkServer().use { server ->
-            blackhole.consume(server.baseUrl)
-            blackhole.consume(usedMemoryBytes())
-        }
+    fun ktorReadyStartup(blackhole: Blackhole) {
+        val server = KtorBenchmarkServer()
+        activeServer = server
+        blackhole.consume(server.baseUrl)
     }
 
     @Benchmark
-    fun springWebFluxStartup(blackhole: Blackhole) {
-        SpringWebFluxBenchmarkServer().use { server ->
-            blackhole.consume(server.baseUrl)
-            blackhole.consume(usedMemoryBytes())
+    fun springWebFluxReadyStartup(blackhole: Blackhole) {
+        val server = SpringWebFluxBenchmarkServer()
+        activeServer = server
+        blackhole.consume(server.baseUrl)
+    }
+
+    @TearDown(Level.Invocation)
+    fun tearDownInvocation() {
+        activeServer?.let { server ->
+            activeServer = null
+            server.close()
         }
     }
+}
+
+/**
+ * JVM used-heap snapshot benchmark taken after each server is ready.
+ *
+ * The [WebFrameworkMemoryCounters.jvmUsedHeapBytes] event counter is copied
+ * into the normalized raw report as bytes. It is a JVM heap measurement, not
+ * process RSS; the benchmark documentation keeps that distinction explicit.
+ * One invocation per iteration records the sample so the event counter keeps
+ * one value per measurement iteration; later invocations are no-ops.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+open class WebFrameworkMemoryBenchmark {
+
+    private var activeServer: AutoCloseable? = null
+    private var sampledThisIteration = false
+
+    @Setup(Level.Iteration)
+    fun resetMemorySample() {
+        sampledThisIteration = false
+    }
+
+    @Benchmark
+    fun ktorReadyUsedHeap(counters: WebFrameworkMemoryCounters, blackhole: Blackhole) {
+        if (sampledThisIteration) {
+            blackhole.consume(0)
+            return
+        }
+        sampledThisIteration = true
+        val server = KtorBenchmarkServer()
+        activeServer = server
+        blackhole.consume(server.baseUrl)
+        counters.recordJvmUsedHeapBytes(jvmUsedHeapBytes())
+    }
+
+    @Benchmark
+    fun springWebFluxReadyUsedHeap(counters: WebFrameworkMemoryCounters, blackhole: Blackhole) {
+        if (sampledThisIteration) {
+            blackhole.consume(0)
+            return
+        }
+        sampledThisIteration = true
+        val server = SpringWebFluxBenchmarkServer()
+        activeServer = server
+        blackhole.consume(server.baseUrl)
+        counters.recordJvmUsedHeapBytes(jvmUsedHeapBytes())
+    }
+
+    @TearDown(Level.Invocation)
+    fun tearDownInvocation() {
+        activeServer?.let { server ->
+            activeServer = null
+            server.close()
+        }
+    }
+}
+
+@AuxCounters(AuxCounters.Type.EVENTS)
+@State(Scope.Thread)
+class WebFrameworkMemoryCounters {
+    private var usedHeapBytes: Long = 0
+
+    fun recordJvmUsedHeapBytes(value: Long) {
+        usedHeapBytes = value
+    }
+
+    fun jvmUsedHeapBytes(): Long = usedHeapBytes
 }
 
 @State(Scope.Benchmark)
@@ -189,15 +273,15 @@ private class BenchmarkServers(
 ): AutoCloseable {
 
     override fun close() {
-        runCatching { ktor.close() }
-        runCatching { spring.close() }
+        BenchmarkServerLifecycle.closeAll(ktor, spring)
     }
 
     companion object {
         fun start(): BenchmarkServers =
-            BenchmarkServers(
-                ktor = KtorBenchmarkServer(),
-                spring = SpringWebFluxBenchmarkServer(),
+            BenchmarkServerLifecycle.start(
+                firstFactory = ::KtorBenchmarkServer,
+                secondFactory = ::SpringWebFluxBenchmarkServer,
+                combine = ::BenchmarkServers,
             )
     }
 }
@@ -413,7 +497,7 @@ private data class BenchmarkHttpResponse(
     }
 }
 
-private fun usedMemoryBytes(): Long {
+private fun jvmUsedHeapBytes(): Long {
     val runtime = Runtime.getRuntime()
     return runtime.totalMemory() - runtime.freeMemory()
 }

--- a/benchmark/web-framework-benchmark/src/main/kotlin/io/bluetape4k/benchmark/webframework/BenchmarkServerLifecycle.kt
+++ b/benchmark/web-framework-benchmark/src/main/kotlin/io/bluetape4k/benchmark/webframework/BenchmarkServerLifecycle.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.benchmark.webframework
+
+/**
+ * Keeps benchmark server startup and cleanup failures observable to JMH.
+ *
+ * The first resource is always closed when the second factory or the combiner
+ * fails. Cleanup continues after a failure; the startup failure remains the
+ * primary exception and cleanup failures are attached as suppressed exceptions.
+ */
+internal object BenchmarkServerLifecycle {
+
+    fun <F: AutoCloseable, S: AutoCloseable, R> start(
+        firstFactory: () -> F,
+        secondFactory: () -> S,
+        combine: (F, S) -> R,
+    ): R {
+        val first = firstFactory()
+        var second: S? = null
+
+        return try {
+            second = secondFactory()
+            combine(first, second)
+        } catch (startupFailure: Throwable) {
+            second?.let { closeAndSuppress(it, startupFailure) }
+            closeAndSuppress(first, startupFailure)
+            throw startupFailure
+        }
+    }
+
+    fun closeAll(first: AutoCloseable, second: AutoCloseable) {
+        var primaryFailure: Throwable? = null
+
+        try {
+            first.close()
+        } catch (failure: Throwable) {
+            primaryFailure = failure
+        }
+
+        try {
+            second.close()
+        } catch (failure: Throwable) {
+            if (primaryFailure == null) {
+                primaryFailure = failure
+            } else if (primaryFailure !== failure) {
+                primaryFailure?.addSuppressed(failure)
+            }
+        }
+
+        primaryFailure?.let { throw it }
+    }
+
+    private fun closeAndSuppress(resource: AutoCloseable, primaryFailure: Throwable) {
+        try {
+            resource.close()
+        } catch (cleanupFailure: Throwable) {
+            if (cleanupFailure !== primaryFailure) {
+                primaryFailure.addSuppressed(cleanupFailure)
+            }
+        }
+    }
+}

--- a/benchmark/web-framework-benchmark/src/test/kotlin/io/bluetape4k/benchmark/webframework/WebFrameworkBenchmarkLifecycleTest.kt
+++ b/benchmark/web-framework-benchmark/src/test/kotlin/io/bluetape4k/benchmark/webframework/WebFrameworkBenchmarkLifecycleTest.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.benchmark.webframework
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class WebFrameworkBenchmarkLifecycleTest {
+
+    @Test
+    fun `partial startup closes the first resource and preserves cleanup failure`() {
+        val first = FakeCloseable(closeFailure = IllegalStateException("first close"))
+        val startupFailure = IllegalArgumentException("second startup")
+
+        val thrown = runCatching {
+            BenchmarkServerLifecycle.start(
+                firstFactory = { first },
+                secondFactory = { throw startupFailure },
+                combine = { _, _ -> Unit },
+            )
+        }.exceptionOrNull()
+
+        assertSame(startupFailure, thrown)
+        assertEquals(1, startupFailure.suppressed.size)
+        assertSame(first.closeFailure, startupFailure.suppressed.single())
+        assertEquals(1, first.closeCalls)
+    }
+
+    @Test
+    fun `dual close attempts both resources and reports the first failure with the second suppressed`() {
+        val firstFailure = IllegalStateException("first close")
+        val secondFailure = IllegalArgumentException("second close")
+        val first = FakeCloseable(closeFailure = firstFailure)
+        val second = FakeCloseable(closeFailure = secondFailure)
+
+        val thrown = runCatching {
+            BenchmarkServerLifecycle.closeAll(first, second)
+        }.exceptionOrNull()
+
+        assertSame(firstFailure, thrown)
+        assertEquals(1, first.closeCalls)
+        assertEquals(1, second.closeCalls)
+        assertEquals(1, firstFailure.suppressed.size)
+        assertSame(secondFailure, firstFailure.suppressed.single())
+    }
+
+    private class FakeCloseable(
+        val closeFailure: Throwable? = null,
+    ): AutoCloseable {
+        var closeCalls: Int = 0
+
+        override fun close() {
+            closeCalls++
+            closeFailure?.let { throw it }
+        }
+    }
+}

--- a/docs/lessons/2026-08-03-issue-1279-web-framework-benchmark-lifecycle.md
+++ b/docs/lessons/2026-08-03-issue-1279-web-framework-benchmark-lifecycle.md
@@ -1,0 +1,44 @@
+# Issue #1279 Web-framework benchmark lifecycle lesson
+
+## 배경
+
+기존 `WebFrameworkStartupBenchmark`는 startup과 JVM heap snapshot을 한
+invocation 안에서 실행하고 `Blackhole`에 memory 값을 소비했다. 따라서 raw JMH
+결과에는 startup `ms/op`만 남았고, shutdown 시간과 memory sampling 시점도
+구분되지 않았다. `BenchmarkServers.close()`의 `runCatching`은 두 server의
+종료 실패를 숨겼으며, Spring factory가 실패하면 이미 생성된 Ktor server를
+정리하지 못했다.
+
+## 적용한 규칙
+
+- ready-to-serve startup은 `ktorReadyStartup`과 `springWebFluxReadyStartup`으로
+  분리하고 `@TearDown(Level.Invocation)`에서 종료해 shutdown을 timed path에서
+  제외한다.
+- memory는 별도 `WebFrameworkMemoryBenchmark`에서
+  `jvm.used_heap`으로 기록한다. 이 값은 process RSS가 아니라
+  `Runtime.totalMemory() - freeMemory()`이며, sampling point는
+  `after_ready_before_shutdown`이다.
+- JMH `AuxCounters`의 이벤트 raw sample은 `normalize-memory-report.py`가
+  `bytes`, sample 수, sampling point를 가진 `memory-metrics.json`으로 변환한다.
+  JMH의 보조 metric `#` score를 byte 단위 결과로 직접 해석하지 않는다.
+- 두 resource를 닫을 때는 첫 실패를 primary로 유지하고 두 번째 실패를
+  suppressed로 추가한다. 부분 startup에서는 이미 생성된 첫 resource를 같은
+  규칙으로 정리한다.
+- fake factory lifecycle 테스트는 부분 startup과 dual-close failure를 실제
+  Ktor/Spring process 없이 고정한다.
+
+## 검증
+
+- `./gradlew :web-framework-benchmark:test --tests 'io.bluetape4k.benchmark.webframework.WebFrameworkBenchmarkLifecycleTest'`
+- `./gradlew :web-framework-benchmark:compileBenchmarkKotlin`
+- `./gradlew :web-framework-benchmark:startupBenchmark --no-configuration-cache`
+- `./gradlew :web-framework-benchmark:memoryBenchmark --no-configuration-cache`
+- generated `memory-metrics.json`의 `unit=bytes`,
+  `samplingPoint=after_ready_before_shutdown`, `sampleCount=3`
+
+## 남은 한계
+
+이 benchmark는 외부 production Redisson/real deployment가 아니라 local embedded
+Ktor와 Spring WebFlux를 비교한다. memory metric도 process RSS가 아니므로 RSS 기반
+운영 결론에는 사용할 수 없다. Throughput/latency와 마찬가지로 짧은 local run은
+release 성능 보증값이 아니다.


### PR DESCRIPTION
## Summary

Closes #1279

- PR 제목: fix: separate web-framework benchmark metrics and harden lifecycle cleanup

Closes #1279

This PR makes the web-framework benchmark evidence unambiguous and keeps server lifecycle failures observable instead of silently discarding them.

## Background

The previous startup benchmark mixed startup latency with a JVM heap snapshot and consumed the memory value through `Blackhole`, leaving no named memory metric in the raw report. It also included shutdown in the timed path and hid partial-startup or close failures.

## What This Solves

- Ready-to-serve startup latency and JVM used-heap snapshots are separate named metrics.
- Memory artifacts state bytes, sample count, and `after_ready_before_shutdown`; JVM heap is not presented as process RSS.
- Partial startup closes resources already created, and both server closes are attempted while primary and suppressed failures remain visible to JMH.

## Work Done

- Added `WebFrameworkMemoryBenchmark`, JMH auxiliary heap counters, and a normalizer that writes `memory-metrics.json` beside the raw JMH report.
- Moved startup cleanup to `@TearDown(Level.Invocation)` so shutdown is outside the startup timing.
- Added injectable `BenchmarkServerLifecycle` helpers and fake-resource tests for partial startup and dual-close failure.
- Updated `README.md`, `README.ko.md`, and `docs/lessons/2026-08-03-issue-1279-web-framework-benchmark-lifecycle.md`.

## Validation

- `./gradlew :web-framework-benchmark:test --tests 'io.bluetape4k.benchmark.webframework.WebFrameworkBenchmarkLifecycleTest'`: PASS (2 lifecycle tests)
- `./gradlew :web-framework-benchmark:check --no-configuration-cache --console=plain`: PASS (`BUILD SUCCESSFUL`)
- `./gradlew :web-framework-benchmark:compileBenchmarkKotlin`: PASS
- `./gradlew :web-framework-benchmark:startupBenchmark --no-configuration-cache`: PASS (Ktor 0.675 ms/op; Spring WebFlux 77.821 ms/op)
- `./gradlew :web-framework-benchmark:memoryBenchmark --no-configuration-cache`: PASS (normalized JVM heap artifact with 3 samples per benchmark)
- `git diff --cached --check`: PASS
- Detekt: N/A (no module detekt task; module check passed)

## Review Notes

- P0/P1: none known from local review.
- P2/P3: process RSS and external production deployment remain outside this benchmark's scope.
- Review evidence: lifecycle RED test before helper implementation, then GREEN targeted test and full module check.

## Metadata

- Issue: #1279, milestone `1.12.0`, assignee `debop`
- PR: #1299, head `e2e3195b01df288c78f149bff1c3216cee88b64c`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1279-web-framework-benchmark`
- Labels: `test`, `performance`
- State: `MERGED`, merge commit `f47da3e0da0e98da86d3361be5743ea74679f09c`
- CI: - `./gradlew :web-framework-benchmark:test --tests 'io.bluetape4k.benchmark.webframework.WebFrameworkBenchmarkLifecycleTest'`: PASS (2 lifecycle tests) / - `./gradlew :web-framework-benchmark:check --no-configuration-cache --console=plain`: PASS (`BUILD SUCCESSFUL`) / - `./gradlew :web-framework-benchmark:compileBenchmarkKotlin`: PASS

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| targeted-test | Run fake lifecycle tests | PASS | 2 JUnit tests passed | none |
| module-test | Run module check | PASS | `BUILD SUCCESSFUL` | none |
| benchmark-task | Run startup and memory benchmarks | PASS | startup scores and normalized `memory-metrics.json` | none |
| detekt | Attempt module detekt task | N/A | Task is not configured for this module | none |
| docs-parity | Compare English/Korean README lifecycle sections | PASS | Commands, units, sampling point, and shutdown semantics aligned | none |
| diff | Check staged diff | PASS | `git diff --cached --check` | none |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1299 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f47da3e0da0e98da86d3361be5743ea74679f09c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
