### PR TITLE
docs(coroutines): bound selected Flow parity inventory (#1297)

### DIFF
--- a/bluetape4k/coroutines/README.ko.md
+++ b/bluetape4k/coroutines/README.ko.md
@@ -140,6 +140,43 @@ suspend fun flowExample() {
 - `amb`, `race`, `withLatestFrom`
 - `groupBy`, `publish`, `replay`
 
+#### Rx/Reactor 스타일 대응 (선택한 계약)
+
+표준 Flow 연산자가 이미 제공하는 기능은 중복 wrapper를 만들지 않고,
+호출자에게 필요한 경계·취소 계약만 추가합니다.
+
+```kotlin
+import io.bluetape4k.coroutines.flow.extensions.bufferTimeout
+import io.bluetape4k.coroutines.flow.extensions.concatMapEager
+import io.bluetape4k.coroutines.flow.extensions.timeoutOrFallback
+import io.bluetape4k.coroutines.flow.extensions.windowTimeout
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+suspend fun parityExample(source: kotlinx.coroutines.flow.Flow<Int>) {
+    val batches = source.bufferTimeout(maxSize = 100, timeout = 1.seconds).toList()
+    val windows = source.windowTimeout(maxSize = 100, timeout = 1.seconds).toList()
+    val cached = flowOf(0)
+    val recovered = source.timeoutOrFallback(500.milliseconds, fallback = cached).toList()
+    val ordered = source.concatMapEager(maxConcurrency = 4, bufferCapacity = 8) { value ->
+        flowOf(value * 2)
+    }.toList()
+    check(batches.isNotEmpty() || windows.isNotEmpty() || recovered.isNotEmpty() || ordered.isNotEmpty())
+}
+```
+
+정상 완료 시 비어 있지 않은 마지막 batch/window를 한 번 방출하며, upstream
+실패 시 진행 중인 부분 값은 버립니다. `windowTimeout`은 반복 수집 가능한
+cold snapshot을 방출하고, `timeoutOrFallback`은 upstream cleanup 완료 후에만
+fallback을 한 번 수집합니다. `CancellationException`은 계속 취소로
+전달되며, bounded `concatMapEager`는 source 순서를 유지하면서
+`bufferCapacity`에서 inner producer를 suspend합니다. `switchMap`, `buffer`,
+`conflate`, `combine`, `zip`, `retryWhen`은 표준 Flow 연산자를 사용합니다.
+delay-error와 명시적 overflow 정책은 [후속 이슈 #1300](https://github.com/bluetape4k/bluetape4k-projects/issues/1300)에서
+다룹니다.
+
 ### Subject
 
 Subject 구현체는 producer와 collector를 연결하는 hot `Flow` 브릿지입니다.

--- a/bluetape4k/coroutines/README.md
+++ b/bluetape4k/coroutines/README.md
@@ -140,6 +140,42 @@ Useful entry points:
 - `amb`, `race`, `withLatestFrom`
 - `groupBy`, `publish`, `replay`
 
+#### Rx/Reactor-style parity (selected contracts)
+
+The selected parity operators add only contracts that are not already covered
+by standard Flow operators:
+
+```kotlin
+import io.bluetape4k.coroutines.flow.extensions.bufferTimeout
+import io.bluetape4k.coroutines.flow.extensions.concatMapEager
+import io.bluetape4k.coroutines.flow.extensions.timeoutOrFallback
+import io.bluetape4k.coroutines.flow.extensions.windowTimeout
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+suspend fun parityExample(source: kotlinx.coroutines.flow.Flow<Int>) {
+    val batches = source.bufferTimeout(maxSize = 100, timeout = 1.seconds).toList()
+    val windows = source.windowTimeout(maxSize = 100, timeout = 1.seconds).toList()
+    val cached = flowOf(0)
+    val recovered = source.timeoutOrFallback(500.milliseconds, fallback = cached).toList()
+    val ordered = source.concatMapEager(maxConcurrency = 4, bufferCapacity = 8) { value ->
+        flowOf(value * 2)
+    }.toList()
+    check(batches.isNotEmpty() || windows.isNotEmpty() || recovered.isNotEmpty() || ordered.isNotEmpty())
+}
+```
+
+Completion emits one non-empty partial batch/window; upstream failure drops the
+in-flight partial value. `windowTimeout` exposes repeatable cold snapshots, and
+`timeoutOrFallback` subscribes to its fallback only after upstream cleanup.
+`CancellationException` remains cancellation, and bounded `concatMapEager`
+preserves source order while suspending inner producers at `bufferCapacity`.
+For `switchMap`, `buffer`, `conflate`, `combine`, `zip`, and `retryWhen`, use
+the standard Flow operators. Delay-error and explicit overflow families are
+tracked in [follow-up issue #1300](https://github.com/bluetape4k/bluetape4k-projects/issues/1300).
+
 ### Subjects
 
 Subject implementations are hot `Flow` bridges for producer/collector coordination.

--- a/docs/flow-operator-inventory.md
+++ b/docs/flow-operator-inventory.md
@@ -1,0 +1,42 @@
+# Flow Operator Parity Inventory
+
+Issue #1297의 범위는 RxJava 3/Reactor `Flux` 용어 중 Kotlin Flow에서
+호출자 가치가 높고 취소·메모리 계약을 명확히 검증할 수 있는 최소 집합으로
+한정한다. 표준 `kotlinx.coroutines` 연산자가 이미 같은 계약을 제공하는
+가족은 별도 wrapper를 만들지 않는다.
+
+| Current API | Selected/proposed API | RxJava/Reactor analogue | Standard Flow mapping or non-goal |
+|---|---|---|---|
+| `chunked`, `windowed` | `bufferTimeout`, `windowTimeout` | `Observable.buffer(timespan, count)`, `Flux.bufferTimeout` | 신규 count-or-time 계약 |
+| 없음 | `timeout`, `timeoutOrFallback` | `Observable.timeout`, `Flux.timeout` | 신규 idle-timeout 계약 |
+| unbounded `concatMapEager` | bounded overload | ordered eager concat family | 명시적 concurrency/inner queue 계약 |
+| 없음 | `switchMap` vocabulary decision | `switchMap`, `switchOnNext` | `flatMapLatest`; 이 이슈에서는 wrapper를 추가하지 않음 |
+| `merge`, `concat` | delay-error follow-up | `mergeDelayError`, `concatDelayError` | [#1300](https://github.com/bluetape4k/bluetape4k-projects/issues/1300) 후속 |
+| `onBackpressureDrop` | overflow mapping | Reactor/Rx overflow families | `buffer`/`conflate`; 명시적 overflow 정책은 #1300 |
+| `withLatestFrom` | existing API | `withLatestFrom` | 기존 single-secondary 계약 |
+| 없음 | — | `combine`, `zip`, `retryWhen` | 표준 Flow non-goal |
+
+## Selected contracts
+
+- `bufferTimeout`와 `windowTimeout`은 `maxSize` 개수 또는 첫 원소부터의
+  `timeout` 중 먼저 도달한 경계로 닫힌다. timer는 subscription 시점이
+  아니라 첫 원소가 들어온 시점에 시작하며 빈 batch/window는 방출하지 않는다.
+- 정상 완료 시 비어 있지 않은 마지막 부분 batch/window를 한 번 방출한다.
+  upstream 실패 시 진행 중인 부분 값은 버리고 원래 예외를 전달한다.
+- `windowTimeout`이 방출하는 각 `Flow`는 완료 snapshot을 감싼 repeatable
+  cold `Flow`다. live single-consumer Reactor window로 취급하면 안 된다.
+- `timeout`은 collection 시작 후 idle 기간을 감시하고 각 원소 뒤에 timer를
+  재설정한다. `timeoutOrFallback`은 upstream 취소와 cleanup이 끝난 뒤
+  fallback을 정확히 한 번 수집한다.
+- `concatMapEager(maxConcurrency, bufferCapacity, transform)`은 source 순서를
+  유지하면서 inner 동시성과 inner별 queue 용량을 제한한다. 기존
+  `concatMapEager(transform)` 시그니처와 ordering은 유지한다.
+- 모든 신규 연산자는 `CancellationException`을 data-plane 오류로 바꾸지
+  않으며, dispatcher를 바꾸거나 detached child를 만들지 않는다.
+
+## Deliberate non-goals
+
+`switchMap`, `buffer`, `conflate`, `combine`, `zip`, `retryWhen`은 표준 Flow
+연산자를 사용한다. delay-error 조합, explicit overflow/error 정책,
+event-boundary window 계열은 호출자 근거와 별도 메모리·취소 계약을 먼저
+확정해야 하므로 #1300에서 다룬다.


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: docs(coroutines): bound selected Flow parity inventory (#1297)

Part of #1297

This stacked slice turns the approved contract into a caller-facing inventory and bilingual module guidance.

## Background

The implementation needs an explicit boundary between selected operators, standard Flow mappings, and deferred policy families.

## What This Solves

- Documents selected/proposed APIs and their RxJava/Reactor analogues without claiming Reactive Streams demand semantics.
- Keeps English and Korean README examples aligned and links the delay-error/overflow follow-up.

## Work Done

- Added `docs/flow-operator-inventory.md`.
- Updated `bluetape4k/coroutines/README.md` and `README.ko.md` with the selected scope and non-goals.

## Validation

- `git diff --check`: PASS
- Inventory terminology and README parity scan: PASS

## Review Notes

- P0/P1: 0
- P2/P3: deferred families remain in #1300
- Review evidence: inventory matrix and bilingual README diff

## Metadata

- Issue: #1297, milestone `1.12.0`, assignee debop
- PR: #1302, head `fdbd316cf82acd4567e6bb068e26c21163317446`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1297-flow-operators-task1`
- Labels: `enhancement`, `coroutines`
- State: `MERGED`, merge commit `8b9bdbbdb0c8c2d9de69d4e0c61ad6294a599c11`
- CI: This stacked slice turns the approved contract into a caller-facing inventory and bilingual module guidance. / The implementation needs an explicit boundary between selected operators, standard Flow mappings, and deferred policy families. / - CI: pending GitHub checks on this exact head
## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1302 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `8b9bdbbdb0c8c2d9de69d4e0c61ad6294a599c11`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
