### PR TITLE
feat(coroutines): add count-time Flow buffers and windows (#1297)

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/bufferTimeout.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/bufferTimeout.kt
@@ -1,0 +1,102 @@
+package io.bluetape4k.coroutines.flow.extensions
+
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.channels.onSuccess
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.produceIn
+import kotlinx.coroutines.selects.onTimeout
+import kotlinx.coroutines.selects.whileSelect
+import kotlinx.coroutines.supervisorScope
+import kotlin.time.Duration
+
+private const val DEFAULT_BUFFER_TIMEOUT_CAPACITY = 16
+
+/**
+ * 최대 원소 수 또는 timeout 중 먼저 도달한 경계로 원소를 batch로 묶습니다.
+ *
+ * ## 동작/계약
+ * - `maxSize`와 [timeout]은 양수여야 합니다.
+ * - timer는 구독 시점이 아니라 첫 원소가 현재 batch에 들어온 시점에 시작합니다.
+ * - count 또는 timeout 경계에 도달하면 비어 있지 않은 새 리스트를 방출합니다.
+ * - 정상 완료 시 마지막 부분 batch를 방출하고, upstream 실패 시 진행 중인
+ *   부분 batch를 버린 뒤 원래 예외를 전달합니다.
+ * - 수신 clause를 timeout clause보다 먼저 등록하므로 같은 virtual time에 값과
+ *   timeout이 동시에 준비되면 값이 우선합니다.
+ * - downstream 취소는 upstream producer와 timer를 함께 취소하며
+ *   `CancellationException`을 일반 오류로 바꾸지 않습니다.
+ *
+ * ```kotlin
+ * val batches = source.bufferTimeout(maxSize = 100, timeout = 1.seconds).toList()
+ * // count/time 경계로 닫힌 비어 있지 않은 List<Int> batch
+ * ```
+ *
+ * @param maxSize 한 batch에 허용하는 최대 원소 수입니다.
+ * @param timeout 첫 원소부터 batch를 유지할 최대 시간입니다.
+ */
+fun <T> Flow<T>.bufferTimeout(maxSize: Int, timeout: Duration): Flow<List<T>> =
+    countOrTimeout(maxSize, timeout)
+
+/**
+ * 최대 원소 수 또는 timeout 중 먼저 도달한 경계로 원소를 window snapshot으로 묶습니다.
+ *
+ * 각 방출 window는 이미 완료된 리스트를 감싼 repeatable cold [Flow]입니다.
+ * 따라서 같은 window를 여러 번 수집해도 동일한 snapshot을 재생하며, live
+ * single-consumer window로 동작하지 않습니다. 그 밖의 완료·실패·취소 계약은
+ * [bufferTimeout]과 같습니다.
+ *
+ * ```kotlin
+ * val windows = source.windowTimeout(maxSize = 100, timeout = 1.seconds).toList()
+ * val first = windows.first().toList()
+ * ```
+ *
+ * @param maxSize 한 window에 허용하는 최대 원소 수입니다.
+ * @param timeout 첫 원소부터 window를 유지할 최대 시간입니다.
+ */
+fun <T> Flow<T>.windowTimeout(maxSize: Int, timeout: Duration): Flow<Flow<T>> =
+    countOrTimeout(maxSize, timeout).map { it.asFlow() }
+
+private fun <T> Flow<T>.countOrTimeout(maxSize: Int, timeout: Duration): Flow<List<T>> = flow {
+    require(maxSize > 0) { "maxSize must be positive" }
+    require(timeout.isPositive()) { "timeout must be positive" }
+
+    supervisorScope {
+        val input = this@countOrTimeout.produceIn(this)
+        try {
+            var current = ArrayList<T>(minOf(maxSize, DEFAULT_BUFFER_TIMEOUT_CAPACITY))
+
+            whileSelect {
+                input.onReceiveCatching { result ->
+                    result
+                        .onSuccess { value ->
+                            current += value
+                            if (current.size == maxSize) {
+                                emit(current)
+                                current = ArrayList(minOf(maxSize, DEFAULT_BUFFER_TIMEOUT_CAPACITY))
+                            }
+                        }
+                        .onFailure { cause ->
+                            cause?.let { throw it }
+                            if (current.isNotEmpty()) {
+                                emit(current)
+                                current = ArrayList(minOf(maxSize, DEFAULT_BUFFER_TIMEOUT_CAPACITY))
+                            }
+                        }
+                        .isSuccess
+                }
+                if (current.isNotEmpty()) {
+                    onTimeout(timeout) {
+                        emit(current)
+                        current = ArrayList(minOf(maxSize, DEFAULT_BUFFER_TIMEOUT_CAPACITY))
+                        true
+                    }
+                }
+            }
+            if (current.isNotEmpty()) emit(current)
+        } finally {
+            input.cancel()
+        }
+    }
+}

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/BufferTimeoutTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/BufferTimeoutTest.kt
@@ -1,0 +1,99 @@
+package io.bluetape4k.coroutines.flow.extensions
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class BufferTimeoutTest: AbstractFlowTest() {
+
+    @Test
+    fun `count boundary closes buffer before timeout`() = runTest {
+        flowOf(1, 2, 3, 4, 5)
+            .bufferTimeout(maxSize = 2, timeout = 1.hours)
+            .toList() shouldBeEqualTo listOf(listOf(1, 2), listOf(3, 4), listOf(5))
+    }
+
+    @Test
+    fun `virtual time closes a partial buffer`() = runTest {
+        val values = flow {
+            emit(1)
+            delay(100.milliseconds)
+            emit(2)
+        }.bufferTimeout(maxSize = 10, timeout = 50.milliseconds).toList()
+
+        values shouldBeEqualTo listOf(listOf(1), listOf(2))
+    }
+
+    @Test
+    fun `completion emits one non empty partial buffer`() = runTest {
+        flowOf(1, 2, 3)
+            .bufferTimeout(maxSize = 10, timeout = 1.hours)
+            .toList() shouldBeEqualTo listOf(listOf(1, 2, 3))
+    }
+
+    @Test
+    fun `upstream failure drops in flight partial buffer`() = runTest {
+        val emitted = mutableListOf<List<Int>>()
+        val source = flow<Int> {
+            emit(1)
+            throw IllegalStateException("boom")
+        }
+
+        assertFailsWith<IllegalStateException> {
+            source.bufferTimeout(10, 1.hours).collect { emitted += it }
+        }
+        emitted shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `window timeout exposes repeatable cold windows`() = runTest {
+        val windows = flowOf(1, 2, 3).windowTimeout(2, 1.hours).toList()
+
+        windows.map { it.toList() } shouldBeEqualTo listOf(listOf(1, 2), listOf(3))
+        windows.first().toList() shouldBeEqualTo listOf(1, 2)
+    }
+
+    @Test
+    fun `invalid size and duration fail before collection`() = runTest {
+        assertFailsWith<IllegalArgumentException> { flowOf(1).bufferTimeout(0, 1.seconds).toList() }
+        assertFailsWith<IllegalArgumentException> { flowOf(1).bufferTimeout(1, Duration.ZERO).toList() }
+    }
+
+    @Test
+    fun `receive wins a same instant count timeout tie`() = runTest {
+        val values = flow {
+            emit(1)
+            delay(50.milliseconds)
+            emit(2)
+        }.bufferTimeout(2, 50.milliseconds).toList()
+
+        values shouldBeEqualTo listOf(listOf(1, 2))
+    }
+
+    @Test
+    fun `take cancellation closes the upstream producer`() = runTest {
+        var cancelled = false
+        flow {
+            try {
+                emit(1)
+                awaitCancellation()
+            } finally {
+                cancelled = true
+            }
+        }.bufferTimeout(10, 1.hours).take(1).collect()
+
+        cancelled shouldBeEqualTo true
+    }
+}


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat(coroutines): add count-time Flow buffers and windows (#1297)

Part of #1297

This slice adds deterministic count-or-time `bufferTimeout` and repeatable cold `windowTimeout` operators.

## Background

The approved parity scope requires non-empty count/time snapshots with explicit completion, failure, tie, and cancellation behavior.

## What This Solves

- Adds count and timeout boundaries using virtual-time-friendly Flow coordination.
- Preserves partial-on-completion, drop-on-upstream-failure, and receive-before-timeout tie semantics.

## Work Done

- Added Korean-first KDoc and implementation in `bufferTimeout.kt`.
- Added eight deterministic tests covering boundaries, repeatability, errors, invalid arguments, ties, and `take` cancellation.

## Validation

- `BufferTimeoutTest`: PASS, 8 tests, zero failures/errors
- RED/GREEN targeted Gradle run: PASS after implementation

## Review Notes

- P0/P1: 0
- P2/P3: no new findings
- Review evidence: `BufferTimeoutTest.kt` and final review artifact in the top PR

## Metadata

- Issue: #1297, milestone `1.12.0`, assignee debop
- PR: #1303, head `0db530a1b3d6a61009cfac9225b3e3e5a55a566c`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1297-flow-operators-task2`
- Labels: `enhancement`, `coroutines`
- State: `MERGED`, merge commit `f5ee53a9f293afd0a40923e87c2707f7e6baa355`
- CI: The approved parity scope requires non-empty count/time snapshots with explicit completion, failure, tie, and cancellation behavior. / - RED/GREEN targeted Gradle run: PASS after implementation / - CI: pending GitHub checks on this exact head
## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1303 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f5ee53a9f293afd0a40923e87c2707f7e6baa355`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
