### PR TITLE
feat(coroutines): add idle timeout fallback Flow operators (#1297)

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/timeout.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/timeout.kt
@@ -1,0 +1,102 @@
+package io.bluetape4k.coroutines.flow.extensions
+
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.channels.onSuccess
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.onTimeout
+import kotlinx.coroutines.selects.whileSelect
+import kotlinx.coroutines.supervisorScope
+import java.util.concurrent.TimeoutException
+import kotlin.time.Duration
+
+/** Flow가 지정된 idle 시간 안에 원소를 방출하지 않았을 때 사용하는 예외입니다. */
+class FlowTimeoutException(
+    val timeout: Duration,
+): TimeoutException("Flow did not emit within $timeout")
+
+/**
+ * collection 시작 후 [timeout] 동안 새 원소가 없으면 [FlowTimeoutException]을
+ * 방출하는 idle-timeout 연산자입니다.
+ *
+ * ## 동작/계약
+ * - timer는 collection 시작과 동시에 시작하고, 각 원소를 downstream으로
+ *   방출한 뒤 다시 시작합니다.
+ * - 정상 완료가 pending timeout보다 먼저 관찰되면 원소를 그대로 완료합니다.
+ * - timeout 시 upstream을 먼저 취소하고 cleanup이 끝난 뒤 예외를 방출합니다.
+ * - caller의 `CancellationException`은 timeout 예외로 변환하지 않습니다.
+ *
+ * ```kotlin
+ * val result = source.timeout(500.milliseconds).toList()
+ * ```
+ *
+ * @param timeout 허용할 최대 idle 시간입니다.
+ */
+fun <T> Flow<T>.timeout(timeout: Duration): Flow<T> =
+    timeoutInternal(timeout, fallback = null)
+
+/**
+ * collection 시작 후 idle timeout이 발생하면 upstream cleanup 뒤 [fallback]을
+ * 정확히 한 번 수집하는 연산자입니다.
+ *
+ * upstream 정상 완료와 upstream/fallback 실패는 원래 의미 그대로 전달되며,
+ * caller 취소는 항상 cancellation으로 유지됩니다.
+ *
+ * ```kotlin
+ * val result = source.timeoutOrFallback(500.milliseconds, cached).toList()
+ * ```
+ *
+ * @param timeout 허용할 최대 idle 시간입니다.
+ * @param fallback timeout 이후 한 번 수집할 cold fallback Flow입니다.
+ */
+fun <T> Flow<T>.timeoutOrFallback(timeout: Duration, fallback: Flow<T>): Flow<T> =
+    timeoutInternal(timeout, fallback)
+
+private fun <T> Flow<T>.timeoutInternal(timeout: Duration, fallback: Flow<T>?): Flow<T> = flow {
+    require(timeout.isPositive()) { "timeout must be positive" }
+
+    supervisorScope {
+        val input = Channel<T>(Channel.BUFFERED)
+        val upstream = launch {
+            try {
+                this@timeoutInternal.collect { input.send(it) }
+                input.close()
+            } catch (cause: Throwable) {
+                input.close(cause)
+            }
+        }
+
+        var timedOut = false
+        try {
+            whileSelect {
+                input.onReceiveCatching { result ->
+                    result
+                        .onSuccess { emit(it) }
+                        .onFailure { cause -> cause?.let { throw it } }
+                        .isSuccess
+                }
+                onTimeout(timeout) {
+                    timedOut = true
+                    upstream.cancelAndJoin()
+                    input.cancel()
+                    false
+                }
+            }
+        } finally {
+            if (!timedOut) upstream.cancelAndJoin()
+            input.cancel()
+        }
+
+        if (timedOut) {
+            if (fallback == null) {
+                throw FlowTimeoutException(timeout)
+            }
+            emitAll(fallback)
+        }
+    }
+}

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/TimeoutTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/TimeoutTest.kt
@@ -1,0 +1,95 @@
+package io.bluetape4k.coroutines.flow.extensions
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+
+class TimeoutTest: AbstractFlowTest() {
+
+    @Test
+    fun `idle timeout starts at collection and resets after each item`() = runTest {
+        val error = assertFailsWith<FlowTimeoutException> {
+            flow {
+                emit(1)
+                delay(40.milliseconds)
+                emit(2)
+                delay(60.milliseconds)
+                emit(3)
+            }.timeout(50.milliseconds).toList()
+        }
+
+        error.timeout shouldBeEqualTo 50.milliseconds
+    }
+
+    @Test
+    fun `timeout fallback is collected once after upstream cleanup`() = runTest {
+        var cleaned = false
+        var fallbackSubscriptions = 0
+        val result = flow {
+            try {
+                emit(1)
+                awaitCancellation()
+            } finally {
+                cleaned = true
+            }
+        }.timeoutOrFallback(
+            50.milliseconds,
+            flow {
+                fallbackSubscriptions++
+                emit(9)
+                emit(10)
+            },
+        ).toList()
+
+        cleaned shouldBeEqualTo true
+        fallbackSubscriptions shouldBeEqualTo 1
+        result shouldBeEqualTo listOf(1, 9, 10)
+    }
+
+    @Test
+    fun `normal completion wins over pending timeout`() = runTest {
+        flowOf(1, 2).timeout(1.hours).toList() shouldBeEqualTo listOf(1, 2)
+    }
+
+    @Test
+    fun `upstream failure remains unchanged`() = runTest {
+        assertFailsWith<IllegalStateException> {
+            flow<Int> { throw IllegalStateException("upstream") }
+                .timeout(1.hours)
+                .collect()
+        }
+    }
+
+    @Test
+    fun `caller cancellation is not converted to timeout`() = runTest {
+        val job = launch { flow<Int> { awaitCancellation() }.timeout(1.hours).collect() }
+        job.cancelAndJoin()
+        job.isCancelled shouldBeEqualTo true
+    }
+
+    @Test
+    fun `invalid timeout is rejected`() = runTest {
+        assertFailsWith<IllegalArgumentException> { flowOf(1).timeout(Duration.ZERO).toList() }
+    }
+
+    @Test
+    fun `fallback failure remains unchanged`() = runTest {
+        assertFailsWith<IllegalStateException> {
+            flow<Int> { awaitCancellation() }
+                .timeoutOrFallback(50.milliseconds, flow { throw IllegalStateException("fallback") })
+                .toList()
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-08-03-flow-operator-parity-plan.md
+++ b/docs/superpowers/plans/2026-08-03-flow-operator-parity-plan.md
@@ -4,7 +4,12 @@
 
 **목표:** `bluetape4k-coroutines`에 count-or-time batching/windowing, idle timeout fallback, bounded eager ordered mapping을 추가하고 Rx/Reactor/표준 Flow 대응표와 검증 근거를 제공한다.
 
-**아키텍처:** Timer 기반 연산자는 `produceIn`/`select`를 이용한 내부 count-or-time collector 하나와 channel lifecycle로 구현한다. Timeout은 upstream producer를 먼저 취소한 뒤 fallback을 한 번만 수집한다. `concatMapEager`의 제한된 overload는 `Semaphore`와 내부 항목별 `Channel`을 사용하며 기존 무제한 overload와 원본 순서 방출 계약을 유지한다.
+**아키텍처:** Count-or-time 연산자는 `produceIn`/`select`를 이용한 내부
+collector 하나와 channel lifecycle로 구현한다. 유휴 timeout은 명시적 upstream
+`Job`과 `Channel`을 `select`로 감시하고, timeout 시 `cancelAndJoin`을 완료한 뒤
+fallback을 한 번만 수집한다. `concatMapEager`의 제한된 overload는 `Semaphore`와
+내부 항목별 `Channel`을 사용하며 기존 무제한 overload와 원본 순서 방출 계약을
+유지한다.
 
 **기술 스택:** Kotlin 2.3, kotlinx.coroutines Flow/Channel/Select, `kotlinx-coroutines-test`, JUnit 5, bluetape assertion, kotlinx-benchmark, Gradle
 
@@ -347,9 +352,10 @@ fun `fallback failure remains unchanged`() = runTest {
 공개 `FlowTimeoutException : java.util.concurrent.TimeoutException`
 (`import java.util.concurrent.TimeoutException`)과 공개 함수 두 개를 구현한다.
 내부 반복은 `onReceiveCatching`과 함께 `onTimeout(timeout)`을 등록한다. Timeout
-발생 시 flag를 표시하고 input channel을 취소한 다음 select 밖에서 예외를
-던지거나 fallback을 수집한다. `CancellationException`은 다시 던지고
-upstream/fallback 원인은 보존한다.
+발생 시 flag를 표시하고 명시적 upstream `Job`을 취소한 뒤 `cancelAndJoin`으로
+종료를 기다린다. 이어서 input channel을 닫고 select 밖에서 예외를 던지거나
+fallback을 수집한다. `CancellationException`은 다시 던지고 upstream/fallback
+원인은 보존한다.
 
 ```kotlin
 class FlowTimeoutException(val timeout: Duration) : TimeoutException(


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat(coroutines): add idle timeout fallback Flow operators (#1297)

Part of #1297

This slice adds idle-timeout and timeout-fallback operators with explicit upstream cleanup ordering.

## Background

The selected parity contract needs timeout reset semantics without converting caller cancellation or fallback failures into a different error.

## What This Solves

- Adds `timeout` and `timeoutOrFallback` with deterministic completion/timeout ordering.
- Ensures upstream `cancelAndJoin` completes before timeout failure or fallback collection.

## Work Done

- Added `FlowTimeoutException`, public Korean-first KDoc, and explicit Job/Channel coordination.
- Added seven tests for idle reset, cleanup, completion, cancellation, invalid timeout, and fallback failure.

## Validation

- `TimeoutTest`: PASS, 7 tests, zero failures/errors
- RED/GREEN targeted Gradle run: PASS after implementation

## Review Notes

- P0/P1: 0
- P2/P3: no new findings
- Review evidence: `TimeoutTest.kt` and final review artifact in the top PR

## Metadata

- Issue: #1297, milestone `1.12.0`, assignee debop
- PR: #1304, head `9bedfee1832149d226155b330cf103585a5ce770`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1297-flow-operators-task3`
- Labels: `enhancement`, `coroutines`
- State: `MERGED`, merge commit `1e6a549e9d1f0aa73bd21401072d3f0f1e118585`
- CI: This slice adds idle-timeout and timeout-fallback operators with explicit upstream cleanup ordering. / - Added `FlowTimeoutException`, public Korean-first KDoc, and explicit Job/Channel coordination. / - RED/GREEN targeted Gradle run: PASS after implementation
## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1304 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `1e6a549e9d1f0aa73bd21401072d3f0f1e118585`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
