### PR TITLE
feat(coroutines): bound eager Flow mapping concurrency (#1297)

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/concatMapEager.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/concatMapEager.kt
@@ -4,11 +4,13 @@ import io.bluetape4k.logging.KotlinLogging
 import io.bluetape4k.logging.trace
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
 import org.slf4j.Logger
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.experimental.ExperimentalTypeInference
@@ -33,6 +35,37 @@ private val log: Logger by lazy { KotlinLogging.logger { } }
  */
 fun <T: Any, R: Any> Flow<T>.concatMapEager(transform: suspend (T) -> Flow<R>): Flow<R> =
     concatMapEagerInternal(transform)
+
+/**
+ * inner Flow를 eager하게 수집하되 동시 inner 수와 inner별 출력 queue 용량을 제한합니다.
+ *
+ * ## 동작/계약
+ * - 최대 [maxConcurrency]개의 inner만 동시에 수집합니다.
+ * - 각 inner는 [bufferCapacity] 용량의 `Channel`을 사용하며, queue가 가득 차면
+ *   inner producer가 suspend됩니다. `0`은 rendezvous queue입니다.
+ * - downstream 방출은 source 순서를 유지합니다. 앞선 inner가 느려도 뒤 inner의
+ *   값은 자신의 bounded queue까지만 누적됩니다.
+ * - transform/inner 실패는 원래 예외로 전달되고, 모든 child와 permit는
+ *   structured cancellation과 `finally`에서 정리됩니다.
+ *
+ * ```kotlin
+ * val out = source.concatMapEager(maxConcurrency = 4, bufferCapacity = 8) { load(it) }
+ *     .toList()
+ * ```
+ *
+ * @param maxConcurrency 동시에 수집할 inner Flow의 최대 개수입니다.
+ * @param bufferCapacity inner별 출력 queue의 최대 용량입니다.
+ * @param transform source 값을 inner Flow로 변환하는 함수입니다.
+ */
+fun <T: Any, R: Any> Flow<T>.concatMapEager(
+    maxConcurrency: Int,
+    bufferCapacity: Int = maxConcurrency,
+    transform: suspend (T) -> Flow<R>,
+): Flow<R> {
+    require(maxConcurrency > 0) { "maxConcurrency must be positive" }
+    require(bufferCapacity >= 0) { "bufferCapacity must be non-negative" }
+    return concatMapEagerBoundedInternal(maxConcurrency, bufferCapacity, transform)
+}
 
 @OptIn(ExperimentalTypeInference::class)
 internal fun <T: Any, R: Any> Flow<T>.concatMapEagerInternal(
@@ -99,6 +132,80 @@ internal fun <T: Any, R: Any> Flow<T>.concatMapEagerInternal(
     }
 }
 
+private fun <T: Any, R: Any> Flow<T>.concatMapEagerBoundedInternal(
+    maxConcurrency: Int,
+    bufferCapacity: Int,
+    transform: suspend (T) -> Flow<R>,
+): Flow<R> = channelFlow {
+    coroutineScope {
+        val resumeOutput = Resumable()
+        val innerQueues = ConcurrentLinkedQueue<BoundedConcatMapEagerInnerQueue<R>>()
+        val state = ConcatMapEagerState()
+        val permits = Semaphore(maxConcurrency)
+
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                collect { item ->
+                    permits.acquire()
+                    var releasePermit = true
+                    try {
+                        val inner = transform(item)
+                        val queue = BoundedConcatMapEagerInnerQueue<R>(bufferCapacity)
+                        innerQueues.offer(queue)
+                        resumeOutput.resume()
+
+                        launch {
+                            var failure: Throwable? = null
+                            try {
+                                inner.collect { value ->
+                                    queue.channel.send(value)
+                                    resumeOutput.resume()
+                                }
+                            } catch (cause: Throwable) {
+                                failure = cause
+                                throw cause
+                            } finally {
+                                queue.channel.close(failure)
+                                permits.release()
+                                resumeOutput.resume()
+                            }
+                        }
+                        releasePermit = false
+                    } finally {
+                        if (releasePermit) permits.release()
+                    }
+                }
+            } finally {
+                state.innerDone.value = true
+                resumeOutput.resume()
+            }
+        }
+
+        var current: BoundedConcatMapEagerInnerQueue<R>? = null
+        while (true) {
+            coroutineContext.ensureActive()
+            if (current == null) {
+                val done = state.innerDone.value
+                current = innerQueues.poll()
+                if (done && current == null) break
+            }
+
+            val queue = current
+            if (queue != null) {
+                val result = queue.channel.receiveCatching()
+                if (result.isSuccess) {
+                    send(result.getOrThrow())
+                    continue
+                }
+                current = null
+                result.exceptionOrNull()?.let { throw it }
+                continue
+            }
+            resumeOutput.await()
+        }
+    }
+}
+
 private class ConcatMapEagerInnerQueue<R: Any> {
     val queue = ConcurrentLinkedQueue<R>()
     val done = atomic(false)
@@ -106,4 +213,8 @@ private class ConcatMapEagerInnerQueue<R: Any> {
 
 private class ConcatMapEagerState {
     val innerDone = atomic(false)
+}
+
+private class BoundedConcatMapEagerInnerQueue<R: Any>(capacity: Int) {
+    val channel = Channel<R>(capacity)
 }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ConcatMapEagerBoundedTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ConcatMapEagerBoundedTest.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.coroutines.flow.extensions
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+
+class ConcatMapEagerBoundedTest: AbstractFlowTest() {
+
+    @Test
+    fun `bounded eager mapping preserves order and limits active inners`() = runTest {
+        val active = AtomicInteger(0)
+        val peak = AtomicInteger(0)
+        val result = flowRangeOf(1, 8)
+            .concatMapEager(maxConcurrency = 2, bufferCapacity = 1) { value ->
+                flow {
+                    active.incrementAndGet()
+                    peak.updateAndGet { maxOf(it, active.get()) }
+                    try {
+                        emit(value * 10)
+                        delay(10.milliseconds)
+                        emit(value * 10 + 1)
+                    } finally {
+                        active.decrementAndGet()
+                    }
+                }
+            }.toList()
+
+        result shouldBeEqualTo (1..8).flatMap { listOf(it * 10, it * 10 + 1) }
+        peak.get() shouldBeLessOrEqualTo 2
+        active.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `bounded eager cancellation stops all inners`() = runTest {
+        val cancelled = AtomicInteger(0)
+        flowRangeOf(1, 20)
+            .concatMapEager(maxConcurrency = 2, bufferCapacity = 1) {
+                flow {
+                    try {
+                        emit(it)
+                        awaitCancellation()
+                    } finally {
+                        cancelled.incrementAndGet()
+                    }
+                }
+            }.take(1).toList()
+
+        cancelled.get() shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `bounded arguments fail before collection`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            flowOf(1).concatMapEager(maxConcurrency = 0) { flowOf(it) }.toList()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            flowOf(1).concatMapEager(maxConcurrency = 1, bufferCapacity = -1) { flowOf(it) }.toList()
+        }
+    }
+
+    @Test
+    fun `transform failure remains unchanged`() = runTest {
+        assertFailsWith<IllegalStateException> {
+            flowOf(1).concatMapEager<Int, Int>(maxConcurrency = 2) {
+                throw IllegalStateException("transform")
+            }.toList()
+        }
+    }
+
+    @Test
+    fun `inner failure remains unchanged`() = runTest {
+        assertFailsWith<IllegalStateException> {
+            flowOf(1).concatMapEager(maxConcurrency = 2) {
+                flow { throw IllegalStateException("inner") }
+            }.toList()
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-08-03-flow-operator-parity-plan.md
+++ b/docs/superpowers/plans/2026-08-03-flow-operator-parity-plan.md
@@ -466,9 +466,10 @@ fun <T : Any, R : Any> Flow<T>.concatMapEager(
 ```
 
 내부 queue는 `Semaphore(maxConcurrency)`와 `Channel<R>(bufferCapacity)`을
-사용한다. 기존 overload는 `Channel.UNLIMITED`/`Int.MAX_VALUE`에 위임한다.
-내부 `finally`는 channel을 닫고 permit을 해제하며 완료를 표시한 뒤 drain을
-재개한다. Child 실패를 catch한 뒤 무시해서는 안 된다.
+사용한다. 기존 동작을 바꾸지 않도록 기존 overload는
+`ConcurrentLinkedQueue` 호환 경로를 유지하며 새 overload만 제한된 channel
+경로를 사용한다. 내부 `finally`는 channel을 닫고 permit을 해제하며 완료를
+표시한 뒤 drain을 재개한다. Child 실패를 catch한 뒤 무시해서는 안 된다.
 
 - [ ] **Step 4: GREEN run과 기존 회귀 테스트를 확인한다**
 


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: feat(coroutines): bound eager Flow mapping concurrency (#1297)

Part of #1297

This slice adds an additive bounded `concatMapEager` overload while preserving the legacy compatibility path.

## Background

Eager mapping needs an explicit active-inner and per-inner queue bound without changing established source-order behavior.

## What This Solves

- Bounds active inner collectors with a `Semaphore`.
- Bounds each inner output queue with `Channel(bufferCapacity)` while preserving source-order drain and structured cancellation.

## Work Done

- Added `maxConcurrency`/`bufferCapacity` validation and bounded overload.
- Added five lifecycle tests plus regression coverage for the existing overload.

## Validation

- Bounded and existing `ConcatMapEagerTest`: PASS, 9 tests, zero failures/errors
- Cancellation, transform failure, inner failure, order, and peak-concurrency tests: PASS

## Review Notes

- P0/P1: 0
- P2/P3: no new findings
- Review evidence: `ConcatMapEagerBoundedTest.kt` and final review artifact in the top PR

## Metadata

- Issue: #1297, milestone `1.12.0`, assignee debop
- PR: #1305, head `e16de5a0e386d36adc15e31adeaa51eefd211d4f`, milestone `1.12.0`, assignee `debop`
- Base: `develop`, head branch `feat/issue-1297-flow-operators-task4`
- Labels: `enhancement`, `coroutines`
- State: `MERGED`, merge commit `9a0db93e9a4575200833ec53457d9f1a6bee4a82`
- CI: Eager mapping needs an explicit active-inner and per-inner queue bound without changing established source-order behavior. / - Bounds each inner output queue with `Channel(bufferCapacity)` while preserving source-order drain and structured cancellation. / - Added `maxConcurrency`/`bufferCapacity` validation and bounded overload.
## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1305 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9a0db93e9a4575200833ec53457d9f1a6bee4a82`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
