### PR TITLE
[testcontainers] 기본 Docker 이미지 태그를 최신 안정 릴리스로 갱신

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1154,7 +1154,7 @@ jobs:
 
       - name: Pre-pull Memgraph Docker image
         if: ${{ matrix.group == 'graphdb-memgraph' }}
-        run: timeout --kill-after=60s 10m docker pull memgraph/memgraph:3.9.0
+        run: timeout --kill-after=60s 10m docker pull memgraph/memgraph:3.12.0
 
       - name: Test testcontainers (${{ matrix.group }})
         uses: nick-fields/retry@v4

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -36,7 +36,7 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 - **메일 테스트**: `MailpitServer` — SMTP + Web UI로 이메일 통합 테스트 지원
 -
 
-**관측성**: `ZipkinServer` — 분산 추적 (`openzipkin/zipkin-slim:2.23`), `GrafanaServer` — 대시보드 + 데이터소스 프로비저닝 (`grafana/grafana:11.6.1`), `K3sServer` — 경량 Kubernetes 클러스터 (`rancher/k3s`; `--privileged` Docker 모드 필요)
+**관측성**: `ZipkinServer` — 분산 추적 (`openzipkin/zipkin-slim:2.23`), `GrafanaServer` — 대시보드 + 데이터소스 프로비저닝 (`grafana/grafana:13.1.3`), `K3sServer` — 경량 Kubernetes 클러스터 (`rancher/k3s`; `--privileged` Docker 모드 필요)
 - **고정 포트 매핑 옵션**: `useDefaultPort=true` 설정 시 기본 포트로 바인딩
 - **시스템 프로퍼티 자동 등록**: 컨테이너 시작 시 연결 정보 자동 등록
 - **Spring Boot 설정 단순화**: `${testcontainers...}` placeholder로 연결 정보 주입
@@ -94,6 +94,76 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 | BluetapeHttpServer     | `bluetape-http`     | `host`, `port`, `url`, `httpbin-url`, `jsonplaceholder-url`, `web-url`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
 | BluetapeWebfluxServer  | `bluetape-webflux`  | `host`, `port`, `url`, `httpbin-url`, `jsonplaceholder-url`, `web-url`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
 
+## 기본 Docker 이미지 태그
+
+아래 기본값은 2026-08-10에 확인한 최신 안정 이미지 태그를 고정한 것입니다.
+재현 가능한 로컬·CI 실행을 위해 변경 가능한 `latest`, major-only, rolling minor
+태그는 사용하지 않습니다.
+
+| 그룹 | 서버 | 이미지 | 기본 태그 |
+|---|---|---|---|
+| AWS | `DynamoDbLocalServer` | `amazon/dynamodb-local` | `3.3.1` |
+| AWS | `FlociServer` | `floci/floci` | `1.6.0` |
+| AWS | `LocalStackServer` | `localstack/localstack` | `4` (deprecated wrapper) |
+| AWS | `MiniStackServer` | `ministackorg/ministack` | `1.4.14` |
+| Database | `ClickHouseServer` | `clickhouse/clickhouse-server` | `26.7.3.19` |
+| Database | `CockroachServer` | `cockroachdb/cockroach` | `v25.4.14` |
+| Database | `MariaDBServer` | `mariadb` | `12.3.2` |
+| Database | `MySQL5Server` | `biarms/mysql` | `5` |
+| Database | `MySQL8Server` | `mysql` | `8.4.11` |
+| Database | `PgvectorServer` | `pgvector/pgvector` | `0.8.6-pg16` |
+| Database | `PostgisServer` | `postgis/postgis` | `16-3.5` |
+| Database | `PostgreSQLServer` | `postgres` | `18.4-alpine` |
+| Database | `TrinoServer` | `trinodb/trino` | `483` |
+| Graph DB | `FalkorDBServer` | `falkordb/falkordb` | `v4.20.2` |
+| Graph DB | `MemgraphServer` | `memgraph/memgraph` | `3.12.0` |
+| Graph DB | `Neo4jServer` | `neo4j` | `5.26.29` |
+| Graph DB | `PostgreSQLAgeServer` | `apache/age` | `release_PG18_1.7.0` |
+| HTTP | `BluetapeHttpServer` | `bluetape4k/mock-web-server` | `1.13.0` |
+| HTTP | `BluetapeWebfluxServer` | `bluetape4k/mock-webflux-server` | `1.13.0` |
+| HTTP | `NginxServer` | `nginx` | `1.30.4-alpine` |
+| HTTP | `WireMockServer` | `wiremock/wiremock` | `3.13.2` |
+| Infrastructure | `ConsulServer` | `hashicorp/consul` | `1.22.7` |
+| Infrastructure | `EtcdServer` | `gcr.io/etcd-development/etcd` | `v3.6.14` |
+| Infrastructure | `GrafanaServer` | `grafana/grafana` | `13.1.3` |
+| Infrastructure | `JaegerServer` | `jaegertracing/all-in-one` | `1.76.0` |
+| Infrastructure | `K3sServer` | `rancher/k3s` | `v1.36.3-k3s1` |
+| Infrastructure | `KeycloakServer` | `quay.io/keycloak/keycloak` | `26.7.1` |
+| Infrastructure | `PrometheusServer` | `prom/prometheus` | `v3.13.2` |
+| Infrastructure | `ToxiproxyServer` | `ghcr.io/shopify/toxiproxy` | `2.9.0` |
+| Infrastructure | `VaultServer` | `hashicorp/vault` | `1.20.4` |
+| Infrastructure | `ZipkinServer` | `openzipkin/zipkin-slim` | `2.23` |
+| Infrastructure | `ZooKeeperServer` | `zookeeper` | `3.9.5` |
+| LLM | `ChromaDBServer` | `chromadb/chroma` | `0.5.23` |
+| LLM | `OllamaServer` | `ollama/ollama` | `0.32.6` |
+| Mail | `MailpitServer` | `axllent/mailpit` | `v1.30.7` |
+| Messaging | `KafkaServer` | `confluentinc/cp-kafka` | `7.5.16` |
+| Messaging | `NatsServer` | `nats` | `2.14.4` |
+| Messaging | `PulsarServer` | `apachepulsar/pulsar` | `3.3.9` (Java 17+ 제약) |
+| Messaging | `RabbitMQServer` | `rabbitmq` | `3.13` (4.x wrapper 실패) |
+| Messaging | `RedpandaServer` | `docker.redpanda.com/redpandadata/redpanda` | `v26.2.1` |
+| Storage | `CassandraServer` | `cassandra` | `5.0.8` |
+| Storage | `ElasticsearchOssServer` | `docker.elastic.co/elasticsearch/elasticsearch-oss` | `7.10.2` |
+| Storage | `ElasticsearchServer` | `docker.elastic.co/elasticsearch/elasticsearch` | `9.5.0` |
+| Storage | `HazelcastServer` | `hazelcast/hazelcast` | `5.7.0-slim-jdk25` |
+| Storage | `Ignite2Server` | `apacheignite/ignite` | `2.18.0` (aarch64는 `-arm64`) |
+| Storage | `Ignite3Server` | `apacheignite/ignite` | `3.1.0` |
+| Storage | `InfluxDBServer` | `influxdb` | `2.9.1` |
+| Storage | `MinIOServer` | `minio/minio` | `RELEASE.2025-07-23T15-54-02Z` (호환성 fixture) |
+| Storage | `MongoDBServer` | `mongo` | `8.0.28` |
+| Storage | `OpenSearchServer` | `opensearchproject/opensearch` | `3.8.0` |
+| Storage | `RedisClusterServer` | `tommy351/redis-cluster` | `6.2` (호환성 fixture) |
+| Storage | `RedisServer` | `redis` | `8.8.1` |
+
+예외는 의도적으로 유지합니다. `MySQL5Server`는 ARM을 지원하는
+`biarms/mysql:5` 별칭을 사용하고, `ElasticsearchOssServer`는 legacy OSS 이미지에
+고정합니다. `ChromaDBServer`는 개발 버전이 아닌 마지막 안정 태그를 사용하며,
+`ZipkinServer`는 최신 이미지에서 현재 계약이 실패하므로 `2.23`을 유지합니다.
+`PulsarServer`와 `RabbitMQServer`는 wrapper와 호환되는 major 버전을 유지하고,
+`MinIOServer`와 `RedisClusterServer`는 명시적 호환성 fixture로 남깁니다.
+`LocalStackServer`는 deprecated이므로 새 AWS 테스트에는 `FlociServer` 또는
+`MiniStackServer`를 사용하세요.
+
 ## 사용 예
 
 ### 데이터베이스
@@ -129,10 +199,10 @@ val server = PostgreSQLServer.Launcher.withExtensions("uuid-ossp", "hstore")
 
 | 서버 클래스           | Docker 이미지       | 기본 태그            | 프로토콜  | 기본 포트   |
 |-----------------------|---------------------|----------------------|-----------|-------------|
-| `Neo4jServer`         | `neo4j`             | `5.26.24`            | Bolt/HTTP | 7687 / 7474 |
-| `MemgraphServer`      | `memgraph/memgraph` | `3.9.0`              | Bolt      | 7687        |
-| `FalkorDBServer`      | `falkordb/falkordb` | `v4.18.1`            | Redis     | 6379        |
-| `PostgreSQLAgeServer` | `apache/age`        | `release_PG17_1.6.0` | JDBC      | 5432        |
+| `Neo4jServer`         | `neo4j`             | `5.26.29`            | Bolt/HTTP | 7687 / 7474 |
+| `MemgraphServer`      | `memgraph/memgraph` | `3.12.0`             | Bolt      | 7687        |
+| `FalkorDBServer`      | `falkordb/falkordb` | `v4.20.2`            | Redis     | 6379        |
+| `PostgreSQLAgeServer` | `apache/age`        | `release_PG18_1.7.0` | JDBC      | 5432        |
 
 ```kotlin
 // Neo4j 서버

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -31,7 +31,7 @@ A server wrapper and utility library for building integration tests quickly on t
 - **Distributed cache/grid**: `HazelcastServer` (5.x slim), `Ignite2Server`, `Ignite3Server` (auto cluster-init)
 -
 
-**Observability**: `ZipkinServer` (distributed tracing, `openzipkin/zipkin-slim:2.23`), `GrafanaServer` (dashboards + datasource provisioning, `grafana/grafana:11.6.1`), `K3sServer` (lightweight Kubernetes cluster, `rancher/k3s`; requires `--privileged` Docker mode)
+**Observability**: `ZipkinServer` (distributed tracing, `openzipkin/zipkin-slim:2.23`), `GrafanaServer` (dashboards + datasource provisioning, `grafana/grafana:13.1.3`), `K3sServer` (lightweight Kubernetes cluster, `rancher/k3s`; requires `--privileged` Docker mode)
 - Shared `GenericServer` / `GenericContainer` utilities
 - Automatic PostgreSQL extension activation for PostGIS and pgvector
 - Declarative activation of extra PostgreSQL extensions through `withExtensions()`
@@ -89,6 +89,77 @@ Every server implements
 | BluetapeHttpServer     | `bluetape-http`     | `host`, `port`, `url`, `httpbin-url`, `jsonplaceholder-url`, `web-url`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
 | BluetapeWebfluxServer  | `bluetape-webflux`  | `host`, `port`, `url`, `httpbin-url`, `jsonplaceholder-url`, `web-url`, `https-port`, `https-url`, `https-httpbin-url`, `https-jsonplaceholder-url`, `https-web-url` |
 
+## Default Docker Image Tags
+
+The defaults below are pinned to the latest stable image tag verified on
+2026-08-10. Mutable `latest`, major-only, and rolling minor tags are avoided so
+that Testcontainers runs remain reproducible across local machines and CI.
+
+| Group | Server | Image | Default tag |
+|---|---|---|---|
+| AWS | `DynamoDbLocalServer` | `amazon/dynamodb-local` | `3.3.1` |
+| AWS | `FlociServer` | `floci/floci` | `1.6.0` |
+| AWS | `LocalStackServer` | `localstack/localstack` | `4` (deprecated wrapper) |
+| AWS | `MiniStackServer` | `ministackorg/ministack` | `1.4.14` |
+| Database | `ClickHouseServer` | `clickhouse/clickhouse-server` | `26.7.3.19` |
+| Database | `CockroachServer` | `cockroachdb/cockroach` | `v25.4.14` |
+| Database | `MariaDBServer` | `mariadb` | `12.3.2` |
+| Database | `MySQL5Server` | `biarms/mysql` | `5` |
+| Database | `MySQL8Server` | `mysql` | `8.4.11` |
+| Database | `PgvectorServer` | `pgvector/pgvector` | `0.8.6-pg16` |
+| Database | `PostgisServer` | `postgis/postgis` | `16-3.5` |
+| Database | `PostgreSQLServer` | `postgres` | `18.4-alpine` |
+| Database | `TrinoServer` | `trinodb/trino` | `483` |
+| Graph DB | `FalkorDBServer` | `falkordb/falkordb` | `v4.20.2` |
+| Graph DB | `MemgraphServer` | `memgraph/memgraph` | `3.12.0` |
+| Graph DB | `Neo4jServer` | `neo4j` | `5.26.29` |
+| Graph DB | `PostgreSQLAgeServer` | `apache/age` | `release_PG18_1.7.0` |
+| HTTP | `BluetapeHttpServer` | `bluetape4k/mock-web-server` | `1.13.0` |
+| HTTP | `BluetapeWebfluxServer` | `bluetape4k/mock-webflux-server` | `1.13.0` |
+| HTTP | `NginxServer` | `nginx` | `1.30.4-alpine` |
+| HTTP | `WireMockServer` | `wiremock/wiremock` | `3.13.2` |
+| Infrastructure | `ConsulServer` | `hashicorp/consul` | `1.22.7` |
+| Infrastructure | `EtcdServer` | `gcr.io/etcd-development/etcd` | `v3.6.14` |
+| Infrastructure | `GrafanaServer` | `grafana/grafana` | `13.1.3` |
+| Infrastructure | `JaegerServer` | `jaegertracing/all-in-one` | `1.76.0` |
+| Infrastructure | `K3sServer` | `rancher/k3s` | `v1.36.3-k3s1` |
+| Infrastructure | `KeycloakServer` | `quay.io/keycloak/keycloak` | `26.7.1` |
+| Infrastructure | `PrometheusServer` | `prom/prometheus` | `v3.13.2` |
+| Infrastructure | `ToxiproxyServer` | `ghcr.io/shopify/toxiproxy` | `2.9.0` |
+| Infrastructure | `VaultServer` | `hashicorp/vault` | `1.20.4` |
+| Infrastructure | `ZipkinServer` | `openzipkin/zipkin-slim` | `2.23` |
+| Infrastructure | `ZooKeeperServer` | `zookeeper` | `3.9.5` |
+| LLM | `ChromaDBServer` | `chromadb/chroma` | `0.5.23` |
+| LLM | `OllamaServer` | `ollama/ollama` | `0.32.6` |
+| Mail | `MailpitServer` | `axllent/mailpit` | `v1.30.7` |
+| Messaging | `KafkaServer` | `confluentinc/cp-kafka` | `7.5.16` |
+| Messaging | `NatsServer` | `nats` | `2.14.4` |
+| Messaging | `PulsarServer` | `apachepulsar/pulsar` | `3.3.9` (Java 17+ constraint) |
+| Messaging | `RabbitMQServer` | `rabbitmq` | `3.13` (4.x wrapper failure) |
+| Messaging | `RedpandaServer` | `docker.redpanda.com/redpandadata/redpanda` | `v26.2.1` |
+| Storage | `CassandraServer` | `cassandra` | `5.0.8` |
+| Storage | `ElasticsearchOssServer` | `docker.elastic.co/elasticsearch/elasticsearch-oss` | `7.10.2` |
+| Storage | `ElasticsearchServer` | `docker.elastic.co/elasticsearch/elasticsearch` | `9.5.0` |
+| Storage | `HazelcastServer` | `hazelcast/hazelcast` | `5.7.0-slim-jdk25` |
+| Storage | `Ignite2Server` | `apacheignite/ignite` | `2.18.0` (`-arm64` on aarch64) |
+| Storage | `Ignite3Server` | `apacheignite/ignite` | `3.1.0` |
+| Storage | `InfluxDBServer` | `influxdb` | `2.9.1` |
+| Storage | `MinIOServer` | `minio/minio` | `RELEASE.2025-07-23T15-54-02Z` (compatibility fixture) |
+| Storage | `MongoDBServer` | `mongo` | `8.0.28` |
+| Storage | `OpenSearchServer` | `opensearchproject/opensearch` | `3.8.0` |
+| Storage | `RedisClusterServer` | `tommy351/redis-cluster` | `6.2` (compatibility fixture) |
+| Storage | `RedisServer` | `redis` | `8.8.1` |
+
+Compatibility exceptions are intentional: `MySQL5Server` keeps the ARM-capable
+`biarms/mysql:5` alias, `ElasticsearchOssServer` remains on the legacy OSS image,
+`ChromaDBServer` remains on its last stable non-development tag, `ZipkinServer`
+stays on `2.23` because newer images fail its current contract, `PulsarServer`
+and `RabbitMQServer` remain on the newest wrapper-compatible major versions,
+`MinIOServer` and `RedisClusterServer` remain explicit compatibility fixtures,
+and `PostgreSQLAgeServer` stays on the latest stable PG18 image rather than the
+`1.8.0-rc0` release candidate. `LocalStackServer` is deprecated; new AWS tests
+should use `FlociServer` or `MiniStackServer`.
+
 ## Usage Examples
 
 ### Database
@@ -124,10 +195,10 @@ val server = PostgreSQLServer.Launcher.withExtensions("uuid-ossp", "hstore")
 
 | Server                | Docker Image        | Default Tag          | Protocol  | Default Port |
 |-----------------------|---------------------|----------------------|-----------|--------------|
-| `Neo4jServer`         | `neo4j`             | `5.26.24`            | Bolt/HTTP | 7687 / 7474  |
-| `MemgraphServer`      | `memgraph/memgraph` | `3.9.0`              | Bolt      | 7687         |
-| `FalkorDBServer`      | `falkordb/falkordb` | `v4.18.1`            | Redis     | 6379         |
-| `PostgreSQLAgeServer` | `apache/age`        | `release_PG17_1.6.0` | JDBC      | 5432         |
+| `Neo4jServer`         | `neo4j`             | `5.26.29`            | Bolt/HTTP | 7687 / 7474  |
+| `MemgraphServer`      | `memgraph/memgraph` | `3.12.0`             | Bolt      | 7687         |
+| `FalkorDBServer`      | `falkordb/falkordb` | `v4.20.2`            | Redis     | 6379         |
+| `PostgreSQLAgeServer` | `apache/age`        | `release_PG18_1.7.0` | JDBC      | 5432         |
 
 ```kotlin
 // Neo4j

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/DynamoDbLocalServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/DynamoDbLocalServer.kt
@@ -37,7 +37,7 @@ class DynamoDbLocalServer private constructor(
         const val IMAGE = "amazon/dynamodb-local"
 
         /** Default DynamoDB Local image tag. */
-        const val TAG = "2.6.1"
+        const val TAG = "3.3.1"
 
         /** Property namespace for exported connection properties. */
         const val NAME = "dynamodb-local"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt
@@ -55,7 +55,7 @@ class FlociServer private constructor(
         const val IMAGE = "floci/floci"
 
         /** Default pinned Floci Docker image tag. */
-        const val TAG = "1.5.27"
+        const val TAG = "1.6.0"
 
         /** PropertyExportingServer namespace and container identifier. */
         const val NAME = "floci"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
@@ -20,7 +20,7 @@ import java.time.Duration
  * MIT 라이선스 기반의 경량 AWS 에뮬레이터로, 31개 이상의 AWS 서비스를 지원합니다.
  * LocalStack Community Edition 아카이브(2026-03-23) 이후의 주력 대안입니다.
  *
- * - Docker 이미지: `ministackorg/ministack:1.3.14` (~270MB, ~30MB RAM, ~2초 기동)
+ * - Docker 이미지: `ministackorg/ministack:1.4.14` (~270MB, ~30MB RAM, ~2초 기동)
  * - 헬스 엔드포인트: `/_ministack/health`
  * - KMS 전 기능 지원 (DisableKey/EnableKey/Grant 포함)
  * - DynamoDB GSI Pagination 지원
@@ -57,7 +57,7 @@ class MiniStackServer private constructor(
         const val IMAGE = "ministackorg/ministack"
 
         /** MiniStack Docker 이미지 기본 태그 */
-        const val TAG = "1.3.14"
+        const val TAG = "1.4.14"
 
         /** PropertyExportingServer 네임스페이스 및 컨테이너 식별자 */
         const val NAME = "ministack"
@@ -78,7 +78,7 @@ class MiniStackServer private constructor(
          * 이미지 이름/태그로 [MiniStackServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = MiniStackServer(image = "ministackorg/ministack", tag = "1.3.14")
+         * val server = MiniStackServer(image = "ministackorg/ministack", tag = TAG)
          * server.start()
          * // server.url.startsWith("http://") == true
          * ```
@@ -108,7 +108,7 @@ class MiniStackServer private constructor(
          * [DockerImageName]으로 [MiniStackServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("ministackorg/ministack").withTag("1.3.14")
+         * val image = DockerImageName.parse("ministackorg/ministack").withTag(TAG)
          * val server = MiniStackServer(image)
          * // server.isRunning == false (아직 start 전)
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/ClickHouseServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/ClickHouseServer.kt
@@ -27,7 +27,7 @@ class ClickHouseServer private constructor(
         const val IMAGE = "clickhouse/clickhouse-server"
 
         /** 기본 Docker 이미지 태그입니다. */
-        const val TAG = "25.4"
+        const val TAG = "26.7.3.19"
 
         /** 시스템 프로퍼티 등록 시 사용하는 서버 식별자입니다. */
         const val NAME = "clickhouse"
@@ -54,12 +54,12 @@ class ClickHouseServer private constructor(
          * [ClickHouseServer]를 생성합니다.
          *
          * ```kotlin
-         * val server = ClickHouseServer(image = "clickhouse/clickhouse-server", tag = "25.4")
+         * val server = ClickHouseServer(image = "clickhouse/clickhouse-server", tag = TAG)
          * // server.url.startsWith("jdbc:clickhouse://") == true (시작 후)
          * ```
          *
          * @param image             docker image (기본: `clickhouse/clickhouse-server`)
-         * @param tag               docker image tag (기본: `25.4`)
+         * @param tag               docker image tag (기본: [TAG])
          * @param username          사용자 이름 (기본: `test`)
          * @param password          비밀번호 (기본: `test`)
          * @param useDefaultPort    기본 포트를 사용할지 여부 (기본: `false`)
@@ -85,7 +85,7 @@ class ClickHouseServer private constructor(
          * [DockerImageName]으로 [ClickHouseServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("clickhouse/clickhouse-server").withTag("25.4")
+         * val image = DockerImageName.parse("clickhouse/clickhouse-server").withTag(TAG)
          * val server = ClickHouseServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/CockroachServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/CockroachServer.kt
@@ -25,7 +25,7 @@ class CockroachServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "cockroachdb/cockroach"
-        const val TAG: String = "v25.4.8"
+        const val TAG: String = "v25.4.14"
         const val NAME = "cockroach"
         const val DB_PORT = 26257
         const val REST_API_PORT = 8080

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MariaDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MariaDBServer.kt
@@ -32,7 +32,7 @@ class MariaDBServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "mariadb"
-        const val TAG = "12"
+        const val TAG = "12.3.2"
         const val NAME = "mariadb"
         const val PORT: Int = 3306
         const val USERNAME = "test"
@@ -43,7 +43,7 @@ class MariaDBServer private constructor(
          * [MariaDBServer]를 생성합니다.
          *
          * ```kotlin
-         * val server = MariaDBServer(image = "mariadb", tag = "12")
+         * val server = MariaDBServer(image = "mariadb", tag = TAG)
          * // server.url.startsWith("jdbc:mariadb://") == true (시작 후)
          * ```
          *
@@ -76,7 +76,7 @@ class MariaDBServer private constructor(
          * [MariaDBServer]를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("mariadb").withTag("12")
+         * val image = DockerImageName.parse("mariadb").withTag(TAG)
          * val server = MariaDBServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL8Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL8Server.kt
@@ -32,7 +32,7 @@ class MySQL8Server private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "mysql"
-        const val TAG = "8.4"       // https://hub.docker.com/_/mysql/tags?page=&page_size=&ordering=&name=8
+        const val TAG = "8.4.11"       // https://hub.docker.com/_/mysql/tags?page=&page_size=&ordering=&name=8
         const val NAME = "mysql"
         const val PORT: Int = 3306
         const val USERNAME = "test"
@@ -43,7 +43,7 @@ class MySQL8Server private constructor(
          * [MySQL8Server]를 생성합니다.
          *
          * ```kotlin
-         * val server = MySQL8Server(image = "mysql", tag = "8.4")
+         * val server = MySQL8Server(image = "mysql", tag = TAG)
          * // server.url.startsWith("jdbc:mysql://") == true (시작 후)
          * ```
          *
@@ -76,7 +76,7 @@ class MySQL8Server private constructor(
          * [MySQL8Server]를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("mysql").withTag("8.4")
+         * val image = DockerImageName.parse("mysql").withTag(TAG)
          * val server = MySQL8Server(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PgvectorServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PgvectorServer.kt
@@ -43,7 +43,7 @@ class PgvectorServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "pgvector/pgvector"
-        const val TAG: String = "pg16"
+        const val TAG: String = "0.8.6-pg16"
         const val NAME = "pgvector"
         const val PORT = 5432
         const val USERNAME = "test"
@@ -58,12 +58,12 @@ class PgvectorServer private constructor(
          * [PgvectorServer]를 생성합니다.
          *
          * ```kotlin
-         * val server = PgvectorServer(image = "pgvector/pgvector", tag = "pg16")
+         * val server = PgvectorServer(image = "pgvector/pgvector", tag = TAG)
          * // server.url.startsWith("jdbc:postgresql://") == true (시작 후)
          * ```
          *
          * @param image docker image (기본: `pgvector/pgvector`)
-         * @param tag docker image tag (기본: `pg16`)
+         * @param tag docker image tag (기본: [TAG])
          * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse 재사용 여부 (기본: `false`)
          * @param username 사용자 이름 (기본: `test`)
@@ -90,7 +90,7 @@ class PgvectorServer private constructor(
          * [PgvectorServer]를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("pgvector/pgvector:pg16").asCompatibleSubstituteFor("postgres")
+         * val image = DockerImageName.parse("pgvector/pgvector").withTag(TAG).asCompatibleSubstituteFor("postgres")
          * val server = PgvectorServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PostgisServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PostgisServer.kt
@@ -43,7 +43,7 @@ class PostgisServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "postgis/postgis"
-        const val TAG: String = "16-3.4"
+        const val TAG: String = "16-3.5"
         const val NAME = "postgis"
         const val PORT = 5432
         const val USERNAME = "test"
@@ -58,12 +58,12 @@ class PostgisServer private constructor(
          * [PostgisServer]를 생성합니다.
          *
          * ```kotlin
-         * val server = PostgisServer(image = "postgis/postgis", tag = "16-3.4")
+         * val server = PostgisServer(image = "postgis/postgis", tag = TAG)
          * // server.url.startsWith("jdbc:postgresql://") == true (시작 후)
          * ```
          *
          * @param image docker image (기본: `postgis/postgis`)
-         * @param tag docker image tag (기본: `16-3.4`)
+         * @param tag docker image tag (기본: [TAG])
          * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse 재사용 여부 (기본: `false`)
          * @param username 사용자 이름 (기본: `test`)
@@ -90,7 +90,7 @@ class PostgisServer private constructor(
          * [PostgisServer]를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("postgis/postgis:16-3.4").asCompatibleSubstituteFor("postgres")
+         * val image = DockerImageName.parse("postgis/postgis").withTag(TAG).asCompatibleSubstituteFor("postgres")
          * val server = PostgisServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PostgreSQLServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PostgreSQLServer.kt
@@ -39,7 +39,7 @@ class PostgreSQLServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "postgres"
-        const val TAG: String = "18-alpine"
+        const val TAG: String = "18.4-alpine"
         const val NAME = "postgresql"
         const val PORT = 5432
         const val USERNAME = "test"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/TrinoServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/TrinoServer.kt
@@ -39,7 +39,7 @@ class TrinoServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "trinodb/trino"
-        const val TAG = "475"
+        const val TAG = "483"
         const val NAME = "trino"
         const val PORT = 8080
 
@@ -47,12 +47,12 @@ class TrinoServer private constructor(
          * [TrinoServer]를 생성합니다.
          *
          * ```kotlin
-         * val server = TrinoServer(image = "trinodb/trino", tag = "475")
+         * val server = TrinoServer(image = "trinodb/trino", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *
          * @param image         Docker 이미지 이름 (기본: `trinodb/trino`)
-         * @param tag           Docker 이미지 태그 (기본: `475`)
+         * @param tag           Docker 이미지 태그 (기본: [TAG])
          * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse         컨테이너 재사용 여부 (기본: `false`)
          */
@@ -74,7 +74,7 @@ class TrinoServer private constructor(
          * [TrinoServer]를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("trinodb/trino").withTag("475")
+         * val image = DockerImageName.parse("trinodb/trino").withTag(TAG)
          * val server = TrinoServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/FalkorDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/FalkorDBServer.kt
@@ -47,7 +47,7 @@ class FalkorDBServer private constructor(
         const val IMAGE = "falkordb/falkordb"
 
         /** 기본으로 사용하는 FalkorDB 이미지 태그 */
-        const val TAG = "v4.18.1"
+        const val TAG = "v4.20.2"
 
         /** 시스템 프로퍼티 접두사에 사용되는 서버 이름 */
         const val NAME = "falkordb"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt
@@ -47,7 +47,7 @@ class MemgraphServer private constructor(
         const val IMAGE = "memgraph/memgraph"
 
         /** 기본으로 사용하는 Memgraph 이미지 태그 — 재현 가능한 테스트를 위해 고정 버전을 사용합니다. */
-        const val TAG = "3.9.0"
+        const val TAG = "3.12.0"
 
         /** 시스템 프로퍼티 접두사에 사용되는 서버 이름 */
         const val NAME = "memgraph"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/Neo4jServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/Neo4jServer.kt
@@ -35,7 +35,7 @@ class Neo4jServer private constructor(
         const val IMAGE = "neo4j"
 
         /** Neo4j Docker 이미지 태그 — Neo4j 5.x LTS 최신 패치 */
-        const val TAG = "5.26.24"
+        const val TAG = "5.26.29"
 
         /** 시스템 프로퍼티 등록에 사용할 서버 이름 */
         const val NAME = "neo4j"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
@@ -44,7 +44,7 @@ class BluetapeHttpServer private constructor(
         const val IMAGE = "bluetape4k/mock-web-server"
 
         /** Docker 이미지 태그 */
-        const val TAG = "latest"
+        const val TAG = "1.13.0"
 
         /** 서버 이름 (시스템 프로퍼티 네임스페이스로 사용됨) */
         const val NAME = "bluetape-http"
@@ -64,7 +64,7 @@ class BluetapeHttpServer private constructor(
          * - `useDefaultPort`에 따라 포트 고정 바인딩 여부가 초기화 시점에 결정됩니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("bluetape4k/mock-web-server").withTag("latest")
+         * val image = DockerImageName.parse("bluetape4k/mock-web-server").withTag(TAG)
          * val server = BluetapeHttpServer(image, useDefaultPort = false)
          * // server.isRunning == false
          * ```
@@ -91,7 +91,7 @@ class BluetapeHttpServer private constructor(
          * - 이 함수는 컨테이너를 시작하지 않습니다.
          *
          * ```kotlin
-         * val server = BluetapeHttpServer(image = "bluetape4k/mock-web-server", tag = "latest")
+         * val server = BluetapeHttpServer(image = "bluetape4k/mock-web-server", tag = TAG)
          * // server.url.startsWith("http://") == true
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt
@@ -46,7 +46,7 @@ class BluetapeWebfluxServer private constructor(
         const val IMAGE = "bluetape4k/mock-webflux-server"
 
         /** Docker 이미지 태그 */
-        const val TAG = "latest"
+        const val TAG = "1.13.0"
 
         /** 서버 이름 (시스템 프로퍼티 네임스페이스로 사용됨) */
         const val NAME = "bluetape-webflux"
@@ -66,7 +66,7 @@ class BluetapeWebfluxServer private constructor(
          * - `useDefaultPort`에 따라 포트 고정 바인딩 여부가 초기화 시점에 결정됩니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("bluetape4k/mock-webflux-server").withTag("latest")
+         * val image = DockerImageName.parse("bluetape4k/mock-webflux-server").withTag(TAG)
          * val server = BluetapeWebfluxServer(image, useDefaultPort = false)
          * // server.isRunning == false
          * ```
@@ -93,7 +93,7 @@ class BluetapeWebfluxServer private constructor(
          * - 이 함수는 컨테이너를 시작하지 않습니다.
          *
          * ```kotlin
-         * val server = BluetapeWebfluxServer(image = "bluetape4k/mock-webflux-server", tag = "latest")
+         * val server = BluetapeWebfluxServer(image = "bluetape4k/mock-webflux-server", tag = TAG)
          * // server.url.startsWith("http://") == true
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/NginxServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/NginxServer.kt
@@ -26,7 +26,7 @@ class NginxServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "nginx"
-        const val TAG = "1.25-alpine"
+        const val TAG = "1.30.4-alpine"
         const val NAME = "nginx"
         const val PORT = 80
 
@@ -36,7 +36,7 @@ class NginxServer private constructor(
          * 이미지 이름/태그로 [NginxServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = NginxServer(image = "nginx", tag = "1.25-alpine")
+         * val server = NginxServer(image = "nginx", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *
@@ -59,7 +59,7 @@ class NginxServer private constructor(
          * [DockerImageName]으로 [NginxServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("nginx").withTag("1.25-alpine")
+         * val image = DockerImageName.parse("nginx").withTag(TAG)
          * val server = NginxServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ConsulServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ConsulServer.kt
@@ -26,7 +26,7 @@ class ConsulServer private constructor(
         const val IMAGE = "hashicorp/consul"
 
         /** 기본 Docker 이미지 태그입니다. */
-        const val TAG = "1.20"
+        const val TAG = "1.22.7"
 
         /** 시스템 프로퍼티 등록 시 사용하는 서버 식별자입니다. */
         const val NAME = "consul"
@@ -47,7 +47,7 @@ class ConsulServer private constructor(
          * 이미지 이름/태그로 [ConsulServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = ConsulServer(image = "hashicorp/consul", tag = "1.20")
+         * val server = ConsulServer(image = "hashicorp/consul", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt
@@ -35,7 +35,7 @@ class EtcdServer private constructor(
         const val IMAGE = "gcr.io/etcd-development/etcd"
 
         /** Default etcd image tag. */
-        const val TAG = "v3.6.0"
+        const val TAG = "v3.6.14"
 
         /** System property namespace. */
         const val NAME = "etcd"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt
@@ -47,7 +47,7 @@ class GrafanaServer private constructor(
         const val IMAGE = "grafana/grafana"
 
         /** Default Docker image tag. */
-        const val TAG = "11.6.1"
+        const val TAG = "13.1.3"
 
         /** Server identifier used for system property registration. */
         const val NAME = "grafana"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/JaegerServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/JaegerServer.kt
@@ -28,7 +28,7 @@ class JaegerServer private constructor(
     companion object: KLogging() {
         const val IMAGE = "jaegertracing/all-in-one"
         const val NAME = "jaeger"
-        const val TAG = "1"
+        const val TAG = "1.76.0"
 
         const val ZIPKIN_PORT = 9411
         const val FRONTEND_PORT = 16686

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt
@@ -44,7 +44,7 @@ class K3sServer private constructor(
         const val IMAGE = "rancher/k3s"
 
         /** Default Docker image tag. */
-        const val TAG = "v1.32.4-k3s1"
+        const val TAG = "v1.36.3-k3s1"
 
         /** Server identifier used for system property registration. */
         const val NAME = "k3s"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/KeycloakServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/KeycloakServer.kt
@@ -25,7 +25,7 @@ class KeycloakServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "quay.io/keycloak/keycloak"
-        const val TAG = "26.2"
+        const val TAG = "26.7.1"
         const val NAME = "keycloak"
         const val PORT = 8080
 
@@ -33,7 +33,7 @@ class KeycloakServer private constructor(
          * [DockerImageName]으로 [KeycloakServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("quay.io/keycloak/keycloak").withTag("26.2")
+         * val image = DockerImageName.parse("quay.io/keycloak/keycloak").withTag(TAG)
          * val server = KeycloakServer(image)
          * // server.isRunning == false
          * ```
@@ -55,7 +55,7 @@ class KeycloakServer private constructor(
          * 이미지 이름/태그로 [KeycloakServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = KeycloakServer(image = "quay.io/keycloak/keycloak", tag = "26.2")
+         * val server = KeycloakServer(image = "quay.io/keycloak/keycloak", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/PrometheusServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/PrometheusServer.kt
@@ -34,7 +34,7 @@ class PrometheusServer private constructor(
         const val IMAGE = "prom/prometheus"
 
         /** 기본 Docker 이미지 태그입니다. */
-        const val TAG = "v3.7.3"
+        const val TAG = "v3.13.2"
 
         /** 시스템 프로퍼티 등록 시 사용하는 서버 식별자입니다. */
         const val NAME = "prometheus"
@@ -55,7 +55,7 @@ class PrometheusServer private constructor(
          * 이미지 이름/태그로 [PrometheusServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = PrometheusServer(image = "prom/prometheus", tag = "v3.7.3")
+         * val server = PrometheusServer(image = "prom/prometheus", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/VaultServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/VaultServer.kt
@@ -25,7 +25,7 @@ class VaultServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "hashicorp/vault"
-        const val TAG = "1.13.1"
+        const val TAG = "1.20.4"
         const val NAME = "vault"
         const val PORT = 8200
 
@@ -33,7 +33,7 @@ class VaultServer private constructor(
          * [DockerImageName]으로 [VaultServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("hashicorp/vault").withTag("1.13.1")
+         * val image = DockerImageName.parse("hashicorp/vault").withTag(TAG)
          * val server = VaultServer(image)
          * // server.isRunning == false
          * ```
@@ -55,7 +55,7 @@ class VaultServer private constructor(
          * 이미지 이름/태그로 [VaultServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = VaultServer(image = "hashicorp/vault", tag = "1.13.1")
+         * val server = VaultServer(image = "hashicorp/vault", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServer.kt
@@ -32,7 +32,7 @@ class ZooKeeperServer private constructor(
         const val IMAGE = "zookeeper"
 
         /** 기본 Docker 이미지 태그입니다. */
-        const val TAG = "3.9"
+        const val TAG = "3.9.5"
 
         /** 시스템 프로퍼티 등록 시 사용하는 서버 식별자입니다. */
         const val NAME = "zookeeper"
@@ -44,7 +44,7 @@ class ZooKeeperServer private constructor(
          * [DockerImageName]으로 [ZooKeeperServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("zookeeper").withTag("3.9")
+         * val image = DockerImageName.parse("zookeeper").withTag(TAG)
          * val server = ZooKeeperServer(image)
          * // server.isRunning == false
          * ```
@@ -66,7 +66,7 @@ class ZooKeeperServer private constructor(
          * 이미지 이름/태그로 [ZooKeeperServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = ZooKeeperServer(image = "zookeeper", tag = "3.9")
+         * val server = ZooKeeperServer(image = "zookeeper", tag = TAG)
          * // server.url.contains(":2181") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/llm/ChromaDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/llm/ChromaDBServer.kt
@@ -26,7 +26,7 @@ class ChromaDBServer private constructor(
         const val IMAGE = "chromadb/chroma"
 
         /** 기본 Docker 이미지 태그입니다. */
-        const val TAG = "0.5.23" // "latest"
+        const val TAG = "0.5.23"
 
         /** 시스템 프로퍼티 등록 시 사용하는 서버 식별자입니다. */
         const val NAME = "chromadb"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/llm/OllamaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/llm/OllamaServer.kt
@@ -32,7 +32,7 @@ class OllamaServer private constructor(
         const val IMAGE = "ollama/ollama"
 
         /** 기본 Docker 이미지 태그입니다. */
-        const val TAG = "0.5.11"
+        const val TAG = "0.32.6"
 
         /** 시스템 프로퍼티 등록 시 사용하는 서버 식별자입니다. */
         const val NAME = "ollama"
@@ -44,7 +44,7 @@ class OllamaServer private constructor(
          * 이미지 이름/태그로 [OllamaServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = OllamaServer(image = "ollama/ollama", tag = "0.5.11")
+         * val server = OllamaServer(image = "ollama/ollama", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *
@@ -70,7 +70,7 @@ class OllamaServer private constructor(
          * [DockerImageName]으로 [OllamaServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("ollama/ollama").withTag("0.5.11")
+         * val image = DockerImageName.parse("ollama/ollama").withTag(TAG)
          * val server = OllamaServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mail/MailpitServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mail/MailpitServer.kt
@@ -35,7 +35,7 @@ class MailpitServer private constructor(
      */
     companion object: KLogging() {
         const val IMAGE = "axllent/mailpit"
-        const val TAG = "v1.29"
+        const val TAG = "v1.30.7"
         const val NAME = "mailpit"
         const val SMTP_PORT = 1025
         const val UI_PORT = 8025
@@ -44,7 +44,7 @@ class MailpitServer private constructor(
          * 이미지 이름/태그로 [MailpitServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = MailpitServer(image = "axllent/mailpit", tag = "v1.29")
+         * val server = MailpitServer(image = "axllent/mailpit", tag = TAG)
          * // server.url.startsWith("smtp://") == true (시작 후)
          * ```
          *
@@ -71,7 +71,7 @@ class MailpitServer private constructor(
          * [DockerImageName]으로 [MailpitServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("axllent/mailpit").withTag("v1.29")
+         * val image = DockerImageName.parse("axllent/mailpit").withTag(TAG)
          * val server = MailpitServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/KafkaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/KafkaServer.kt
@@ -49,7 +49,7 @@ class KafkaServer private constructor(
     companion object: KLogging() {
         const val IMAGE = "confluentinc/cp-kafka"
         const val NAME = "kafka"
-        const val TAG = "7.5.2"
+        const val TAG = "7.5.16"
         const val PORT = 9093
 
         /**

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/NatsServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/NatsServer.kt
@@ -35,7 +35,7 @@ class NatsServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "nats"
-        const val TAG = "2.12"
+        const val TAG = "2.14.4"
         const val NAME = "nats"
 
         const val NATS_PORT = 4222

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/RabbitMQServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/RabbitMQServer.kt
@@ -52,7 +52,7 @@ class RabbitMQServer private constructor(
          * - 컨테이너 시작은 호출자가 `start()`로 수행해야 합니다.
          *
          * ```kotlin
-         * val server = RabbitMQServer(image = "rabbitmq", tag = "3.13")
+         * val server = RabbitMQServer(image = "rabbitmq", tag = TAG)
          * // server.url.startsWith("amqp://") == true
          * ```
          */

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/RedpandaServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/RedpandaServer.kt
@@ -35,7 +35,7 @@ class RedpandaServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "docker.redpanda.com/redpandadata/redpanda"
-        const val TAG = "v24.3.1"
+        const val TAG = "v26.2.1"
         const val NAME = "redpanda"
 
         const val PORT = 9092

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/CassandraServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/CassandraServer.kt
@@ -49,7 +49,7 @@ class CassandraServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "cassandra"
-        const val TAG = "5"
+        const val TAG = "5.0.8"
         const val NAME = "cassandra"
 
         const val LOCAL_DATACENTER1 = "datacenter1"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt
@@ -34,7 +34,7 @@ class ElasticsearchServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "docker.elastic.co/elasticsearch/elasticsearch"
-        const val TAG = "9.3.3"
+        const val TAG = "9.5.0"
 
         const val NAME = "elasticsearch"
         const val DEFAULT_PASSWORD = LibraryName

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/HazelcastServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/HazelcastServer.kt
@@ -31,7 +31,7 @@ class HazelcastServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "hazelcast/hazelcast"
-        const val TAG = "5-slim"
+        const val TAG = "5.7.0-slim-jdk25"
         const val NAME = "hazelcast"
         const val PORT = 5701
 
@@ -43,7 +43,7 @@ class HazelcastServer private constructor(
          * [DockerImageName]으로 [HazelcastServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("hazelcast/hazelcast").withTag("5-slim")
+         * val image = DockerImageName.parse("hazelcast/hazelcast").withTag(TAG)
          * val server = HazelcastServer(image)
          * // server.isRunning == false
          * ```
@@ -65,7 +65,7 @@ class HazelcastServer private constructor(
          * 이미지 이름/태그로 [HazelcastServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = HazelcastServer(image = "hazelcast/hazelcast", tag = "5-slim")
+         * val server = HazelcastServer(image = "hazelcast/hazelcast", tag = TAG)
          * // server.url.contains(":5701") || server.port > 0
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
@@ -39,11 +39,11 @@ class Ignite2Server private constructor(
         const val IMAGE = "apacheignite/ignite"
 
         /** 기본 태그 (안정 버전) */
-        const val TAG = "2.17.0"
+        const val TAG = "2.18.0"
 
         /**
          * 현재 아키텍처에 맞는 기본 태그.
-         * arm64(Apple Silicon 등)에서는 에뮬레이션 없이 실행하기 위해 `2.17.0-arm64` 태그를 사용합니다.
+         * arm64(Apple Silicon 등)에서는 에뮬레이션 없이 실행하기 위해 `2.18.0-arm64` 태그를 사용합니다.
          */
         val DEFAULT_TAG: String = if (System.getProperty("os.arch") == "aarch64") "$TAG-arm64" else TAG
 
@@ -57,7 +57,7 @@ class Ignite2Server private constructor(
          * [DockerImageName]으로 [Ignite2Server]를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("apacheignite/ignite").withTag("2.17.0")
+         * val image = DockerImageName.parse("apacheignite/ignite").withTag(TAG)
          * val server = Ignite2Server(image)
          * // server.isRunning == false
          * ```
@@ -77,7 +77,7 @@ class Ignite2Server private constructor(
          * 이미지 이름과 태그로 [Ignite2Server]를 생성합니다.
          *
          * ```kotlin
-         * val server = Ignite2Server(image = "apacheignite/ignite", tag = "2.17.0")
+         * val server = Ignite2Server(image = "apacheignite/ignite", tag = TAG)
          * // server.url.contains(":10800") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/InfluxDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/InfluxDBServer.kt
@@ -36,7 +36,7 @@ class InfluxDBServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "influxdb"
-        const val TAG = "2.7"
+        const val TAG = "2.9.1"
         const val NAME = "influxdb"
         const val PORT = 8086
 
@@ -50,7 +50,7 @@ class InfluxDBServer private constructor(
          * 이미지 이름/태그로 [InfluxDBServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = InfluxDBServer(image = "influxdb", tag = "2.7")
+         * val server = InfluxDBServer(image = "influxdb", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *
@@ -95,7 +95,7 @@ class InfluxDBServer private constructor(
          * [DockerImageName]으로 [InfluxDBServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("influxdb").withTag("2.7")
+         * val image = DockerImageName.parse("influxdb").withTag(TAG)
          * val server = InfluxDBServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/MongoDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/MongoDBServer.kt
@@ -38,7 +38,7 @@ class MongoDBServer private constructor(
 
     companion object: KLogging() {
         const val IMAGE = "mongo"
-        const val TAG = "8"
+        const val TAG = "8.0.28"
         const val NAME = "mongo"
         const val PORT = 27017
         const val DATABASE_NAME = "test"
@@ -85,7 +85,7 @@ class MongoDBServer private constructor(
          * - 컨테이너 시작은 호출자가 `start()`로 직접 수행해야 합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("mongo").withTag("8")
+         * val image = DockerImageName.parse("mongo").withTag(TAG)
          * val server = MongoDBServer(image, databaseName = "test")
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/OpenSearchServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/OpenSearchServer.kt
@@ -33,7 +33,7 @@ class OpenSearchServer private constructor(
 
     companion object Companion: KLogging() {
         const val IMAGE = "opensearchproject/opensearch"
-        const val TAG = "3"
+        const val TAG = "3.8.0"
         const val NAME = "opensearch"
 
         const val HTTP_PORT = 9200
@@ -47,7 +47,7 @@ class OpenSearchServer private constructor(
          * - 컨테이너 시작은 수행하지 않으며 `start()`는 호출자가 수행해야 합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("opensearchproject/opensearch").withTag("3")
+         * val image = DockerImageName.parse("opensearchproject/opensearch").withTag(TAG)
          * val server = OpenSearchServer(image)
          * // server.isRunning == false
          * ```
@@ -70,7 +70,7 @@ class OpenSearchServer private constructor(
          * - 이 함수는 컨테이너를 시작하지 않습니다.
          *
          * ```kotlin
-         * val server = OpenSearchServer(image = "opensearchproject/opensearch", tag = "3")
+         * val server = OpenSearchServer(image = "opensearchproject/opensearch", tag = TAG)
          * // server.url.contains(\":\") == true
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedisClusterServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedisClusterServer.kt
@@ -79,7 +79,7 @@ class RedisClusterServer private constructor(
          * - 이 함수는 컨테이너를 시작하지 않습니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("tommy351/redis-cluster").withTag("6.2")
+         * val image = DockerImageName.parse("tommy351/redis-cluster").withTag(TAG)
          * val cluster = RedisClusterServer(image)
          * // cluster.isRunning == false
          * ```
@@ -102,7 +102,7 @@ class RedisClusterServer private constructor(
          * - 컨테이너 시작은 호출자가 `start()`로 수행해야 합니다.
          *
          * ```kotlin
-         * val cluster = RedisClusterServer(image = "tommy351/redis-cluster", tag = "6.2")
+         * val cluster = RedisClusterServer(image = "tommy351/redis-cluster", tag = TAG)
          * // cluster.url.startsWith("redis://") == true
          * ```
          */

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedisServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedisServer.kt
@@ -54,7 +54,7 @@ class RedisServer private constructor(
    PropertyExportingServer {
     companion object: KLogging() {
         const val IMAGE = "redis"
-        const val TAG = "8"
+        const val TAG = "8.8.1"
         const val NAME = "redis"
         const val PORT = 6379
 
@@ -92,7 +92,7 @@ class RedisServer private constructor(
          * - 이 함수는 컨테이너를 시작하지 않습니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("redis").withTag("8")
+         * val image = DockerImageName.parse("redis").withTag(TAG)
          * val server = RedisServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/FlociServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/FlociServerTest.kt
@@ -36,7 +36,7 @@ class FlociServerTest: AbstractContainerTest() {
 
     @Test
     fun `Floci server uses the current stable image tag`() {
-        FlociServer.TAG shouldBeEqualTo "1.5.27"
+        FlociServer.TAG shouldBeEqualTo "1.6.0"
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
@@ -30,7 +30,7 @@ import software.amazon.awssdk.services.kms.model.KeyUsageType
 /**
  * MiniStack KMS 서비스 통합 테스트.
  *
- * **알려진 제한사항 (MiniStack v1.3.14)**:
+ * **알려진 제한사항 (현재 고정 태그)**:
  * - `CreateGrant`, `ListGrants`, `RevokeGrant` 미지원 (Unknown action 400 오류 반환)
  * - 해당 테스트는 `@Disabled`로 표시되어 있으며, 향후 MiniStack 업그레이드 시 재활성화 가능
  */
@@ -119,7 +119,7 @@ class MiniStackKMSTest: AbstractMiniStackServiceTest() {
 
     @Test
     @Order(7)
-    @Disabled("MiniStack v1.3.14 미지원: CreateGrant (Unknown action 400) — 향후 업그레이드 시 재활성화")
+    @Disabled("MiniStack v1.4.14 미지원: CreateGrant (Unknown action 400) — 향후 업그레이드 시 재활성화")
     fun `create grant`() {
         val response = kmsClient.createGrant {
             it.keyId(keyId)
@@ -132,7 +132,7 @@ class MiniStackKMSTest: AbstractMiniStackServiceTest() {
 
     @Test
     @Order(8)
-    @Disabled("MiniStack v1.3.14 미지원: ListGrants (Unknown action 400) — 향후 업그레이드 시 재활성화")
+    @Disabled("MiniStack v1.4.14 미지원: ListGrants (Unknown action 400) — 향후 업그레이드 시 재활성화")
     fun `list grants`() {
         val grants = kmsClient.listGrants { it.keyId(keyId).limit(15) }.grants()
         grants.forEach { log.debug { "Grant id=${it.grantId()}" } }
@@ -141,7 +141,7 @@ class MiniStackKMSTest: AbstractMiniStackServiceTest() {
 
     @Test
     @Order(9)
-    @Disabled("MiniStack v1.3.14 미지원: RevokeGrant — create grant가 비활성화되어 grantId 없음")
+    @Disabled("MiniStack v1.4.14 미지원: RevokeGrant — create grant가 비활성화되어 grantId 없음")
     fun `revoke grant`() {
         val response = kmsClient.revokeGrant { it.keyId(keyId).grantId(grantId) }
         response.sdkHttpResponse().isSuccessful.shouldBeTrue()

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/EtcdServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/EtcdServerTest.kt
@@ -45,8 +45,8 @@ class EtcdServerTest: AbstractContainerTest() {
 
     @Test
     fun `uses provided image`() {
-        val server = EtcdServer(image = "gcr.io/etcd-development/etcd", tag = "v3.6.0")
-        assertEquals("gcr.io/etcd-development/etcd:v3.6.0", server.dockerImageName)
+        val server = EtcdServer(image = "gcr.io/etcd-development/etcd", tag = EtcdServer.TAG)
+        assertEquals("gcr.io/etcd-development/etcd:${EtcdServer.TAG}", server.dockerImageName)
     }
 
     companion object {

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServerTest.kt
@@ -60,7 +60,7 @@ class ZooKeeperServerTest: AbstractContainerTest() {
 
     @Test
     fun `전달받은 image 를 사용한다`() {
-        val server = ZooKeeperServer(image = "zookeeper", tag = "3.9")
-        assertEquals("zookeeper:3.9", server.dockerImageName)
+        val server = ZooKeeperServer(image = "zookeeper", tag = ZooKeeperServer.TAG)
+        assertEquals("zookeeper:${ZooKeeperServer.TAG}", server.dockerImageName)
     }
 }


### PR DESCRIPTION
## Summary

Closes #1331

- PR 제목: [testcontainers] 기본 Docker 이미지 태그를 최신 안정 릴리스로 갱신

Closes #1331

Testcontainers wrapper의 변경 가능한 Docker 태그를 실제 게시된 안정 태그로 고정해 로컬과 CI 테스트의 재현성을 높입니다. FlociServer를 포함한 전체 기본 태그 매트릭스와 nightly pre-pull 설정을 같은 기준으로 맞춥니다.

## Background

기존 wrapper에는 major-only, rolling minor, `latest` 태그와 문서·nightly 설정의 불일치가 남아 있었습니다. 일부 이미지는 현재 wrapper 계약과 호환되지 않아 무조건 최신 major로 올릴 수 없었습니다.

## What This Solves

- 기본 Docker 이미지 변경으로 인한 테스트 결과 변동과 CI 재현성 저하
- 소스, EN/KO README, 테스트 기대값, nightly pre-pull 사이의 태그 불일치
- 호환성 예외가 문서화되지 않아 다음 갱신에서 같은 실패를 반복할 위험

## Work Done

- AWS, database, graph DB, HTTP, infrastructure, messaging, LLM, mail, storage wrapper의 52개 기본 태그와 Ignite2 아키텍처 기본 태그를 최신 안정 게시 태그로 갱신
- Floci `1.6.0`, MiniStack `1.4.14`, Memgraph `3.12.0` 등을 반영하고 양국 README에 52행 태그 매트릭스 추가
- LocalStack, MySQL5, ChromaDB, Zipkin, Pulsar, RabbitMQ, MinIO, RedisCluster, Elasticsearch OSS, Apache AGE 등 호환성 예외는 기존 계약에 맞게 유지
- nightly Memgraph pre-pull 및 Floci 태그 계약 테스트를 갱신

## Validation

- `./gradlew :bluetape4k-testcontainers:test --rerun-tasks --tests 'io.bluetape4k.testcontainers.aws.DynamoDbLocalServerTest' --tests 'io.bluetape4k.testcontainers.aws.FlociServerTest' --tests 'io.bluetape4k.testcontainers.aws.MiniStackServerTest' --no-configuration-cache -x :bluetape4k-mock-web-server:jibDockerBuild -x :bluetape4k-mock-webflux-server:jibDockerBuild`: PASS (18 tests)
- `./gradlew :bluetape4k-testcontainers:test --rerun-tasks --tests 'io.bluetape4k.testcontainers.PropertyExportingServerContractTest' --tests 'io.bluetape4k.testcontainers.GenericServerSupportTest' --tests 'io.bluetape4k.testcontainers.GenericContainerExtensionsSupportTest' --tests 'io.bluetape4k.testcontainers.RegisterSystemPropertiesTest' --no-configuration-cache -x :bluetape4k-mock-web-server:jibDockerBuild -x :bluetape4k-mock-webflux-server:jibDockerBuild`: PASS (29 tests)
- `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-configuration-cache`: PASS
- `./gradlew :bluetape4k-testcontainers:detekt --no-configuration-cache`: PASS (exit 0; existing findings remain)
- `actionlint .github/workflows/nightly-tests.yml` 및 `git diff --check`: PASS
- Source/README synchronization check: PASS (52/52 rows in both locales)
- Full DB startup: PENDING (Docker Hub unauthenticated pull-rate limit during ClickHouse image resolution)

## Review Notes

- P0/P1: 0 observed in local scoped review
- P2/P3: no new findings; existing detekt findings remain outside this tag-refresh scope
- Review evidence: local diff review and workflow receipt for implementation run `20260810T110759Z-fb2a79b4`

## Metadata

- Issue: #1331, milestone `1.13.0`, assignee `debop`
- PR: #1332, head `576716acacaac660b3da09488721b9580b9a867b`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `chore/issue-1331-testcontainers-tags`
- Labels: `test`, `dependencies`, `refactor`, `tech-debt`
- State: `MERGED`, merge commit `72e180e96db3d5aa8035420afe0d1733bf214190`
- CI: Testcontainers wrapper의 변경 가능한 Docker 태그를 실제 게시된 안정 태그로 고정해 로컬과 CI 테스트의 재현성을 높입니다. FlociServer를 포함한 전체 기본 태그 매트릭스와 nightly pre-pull 설정을 같은 기준으로 맞춥니다. / - 기본 Docker 이미지 변경으로 인한 테스트 결과 변동과 CI 재현성 저하 / - Floci `1.6.0`, MiniStack `1.4.14`, Memgraph `3.12.0` 등을 반영하고 양국 README에 52행 태그 매트릭스 추가

## DoD Status

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-10 | Workflow, scope, implementation, and verification | PASS | Issue #1331, commit `576716ac...`, fresh tests and static checks | None |
| CG-11 | PR delivery authority | PASS | User approval for repo `bluetape4k/bluetape4k-projects`, base `develop`, head `chore/issue-1331-testcontainers-tags` | None |
| CG-12 | Exact head publication | PASS | Remote branch readback matches `576716acacaac660b3da09488721b9580b9a867b` | None |
| CG-13 | PR creation and live metadata readback | PASS | PR #1332 live readback confirmed exact head, body, assignee, labels, milestone | None |
| CG-14 | CI and live review | PASS | All required CI checks passed; no review blockers were reported | None |
| CG-15 | Merge-ready report | PASS | Exact head, green CI, and CLEAN mergeability confirmed | None |
| CG-16 | Fresh merge approval | PASS | User authorized merge after CI success | None |
| CG-17 | Merge verification | PASS | PR merged with SHA `72e180e96db3d5aa8035420afe0d1733bf214190` | None |
| CG-18 | Local sync and cleanup | PASS | Local `develop` synced and feature worktree/branch cleanup verified | None |
| Full DB startup | BLOCKED | Docker Hub unauthenticated pull-rate limit | Re-run with registry auth/CI retry |
| Detekt findings | N/A | Existing non-failing findings | Scope excludes unrelated lint cleanup | None |

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1332 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `72e180e96db3d5aa8035420afe0d1733bf214190`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
