### PR TITLE
[cache] NearJCache write-through 실패를 관찰 가능하게 한다

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -4,14 +4,37 @@ import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.cache.jcache.JCacheEntryEventListener
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.error
 import io.bluetape4k.logging.info
 import io.bluetape4k.logging.trace
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.asyncRunWithTimeout
 import java.time.Duration
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import javax.cache.Cache
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration
 import kotlin.concurrent.withLock
+
+/**
+ * Back Cache write-through 작업의 operation별 완료 결과입니다.
+ *
+ * [completion]은 관찰 전용 [CompletionStage]이며, 동일 [NearJCache] 인스턴스의
+ * 다른 mutation 결과와 섞이지 않도록 [operationId]로 상관관계를 유지합니다.
+ */
+data class BackCacheWriteCompletion(
+    val operationId: Long,
+    val operation: String,
+    val completion: CompletionStage<Unit>,
+)
 
 /**
  * 분산 환경에서 로컬 캐시(Front Cache)와 원격 캐시(Back Cache)를 함께 사용하는 2-Tier 캐시 구현체입니다.
@@ -58,6 +81,9 @@ class NearJCache<K: Any, V: Any>(
         /** 기본 원격 캐시 동기화 타임아웃 (500ms) */
         val DEFAULT_SYNC_REMOTE_TIMEOUT: Duration = Duration.ofMillis(500)
 
+        /** Back Cache bulk remove 작업의 배치 크기 */
+        private const val REMOVE_BATCH_SIZE = 100
+
         /**
          * NearCache 인스턴스를 생성합니다.
          *
@@ -95,6 +121,52 @@ class NearJCache<K: Any, V: Any>(
     }
 
     private val lock = ReentrantLock()
+    private data class BackCacheWriteState(
+        val operationId: Long,
+        val operation: String,
+        val completion: CompletableFuture<Unit>,
+    )
+
+    private val nextBackCacheWriteOperationId = AtomicLong()
+    private val lastBackCacheWrite = AtomicReference(
+        BackCacheWriteState(
+            operationId = 0L,
+            operation = "initial",
+            completion = CompletableFuture.completedFuture(Unit),
+        )
+    )
+    private val backCacheWriteListeners = CopyOnWriteArrayList<(BackCacheWriteCompletion) -> Unit>()
+
+    /**
+     * 마지막으로 예약한 Back Cache write-through의 완료 상태입니다.
+     *
+     * 동기 모드에서는 성공 또는 실패가 즉시 완료된 [CompletableFuture]로 기록되고,
+     * 비동기 모드에서는 bounded retry와 timeout을 포함한 Back Cache 작업의 성공·실패가
+     * 기록됩니다. 반환값은 내부 completion의 복사본이므로 호출자가 완료 상태를 변경할 수
+     * 없습니다.
+     */
+    val lastBackCacheWriteCompletion: CompletableFuture<Unit>
+        get() = lastBackCacheWrite.get().completion.copy()
+
+    /** 마지막 write-through 작업의 operation ID입니다. */
+    val lastBackCacheWriteOperationId: Long
+        get() = lastBackCacheWrite.get().operationId
+
+    /**
+     * 모든 write-through 작업의 operation별 completion을 관찰할 listener를 등록합니다.
+     *
+     * timeout은 terminal failure로 기록하며, timeout 시 이미 실행 중인 backend 작업은
+     * 취소되지 않을 수 있고 late completion은 재시도하지 않습니다. 즉, 중복 write를
+     * 피하면서 호출자가 timeout과 late write 가능성을 모두 관찰할 수 있습니다.
+     */
+    fun addBackCacheWriteListener(listener: (BackCacheWriteCompletion) -> Unit): AutoCloseable {
+        backCacheWriteListeners += listener
+        return object: AutoCloseable {
+            override fun close() {
+                backCacheWriteListeners.remove(listener)
+            }
+        }
+    }
 
     override fun iterator(): MutableIterator<Cache.Entry<K, V>> = frontCache.iterator()
 
@@ -122,8 +194,10 @@ class NearJCache<K: Any, V: Any>(
             "front cache, back cache 모두 clear 합니다. 단 back cache 를 공유한 다른 near cache에는 전파되지 않습니다. " +
                     "전파를 위해서는 removeAll을 사용하세요"
         }
-        runCatching { frontCache.clear() }
-        runCatching { backCache.clear() }
+        frontCache.clear()
+        syncBackCache("clearAllCache", synchronous = true) {
+            backCache.clear()
+        }
     }
 
     override fun close() {
@@ -197,25 +271,23 @@ class NearJCache<K: Any, V: Any>(
     }
 
     override fun put(key: K, value: V) {
-        frontCache.put(key, value).apply {
-            syncBackCache {
-                backCache.put(key, value)
-            }
+        frontCache.put(key, value)
+        syncBackCache("put") {
+            backCache.put(key, value)
         }
     }
 
     override fun putAll(map: Map<out K, V>) {
-        frontCache.putAll(map).apply {
-            syncBackCache {
-                backCache.putAll(map)
-            }
+        frontCache.putAll(map)
+        syncBackCache("putAll") {
+            backCache.putAll(map)
         }
     }
 
     override fun putIfAbsent(key: K, value: V): Boolean =
         frontCache.putIfAbsent(key, value).also {
             if (it) {
-                syncBackCache {
+                syncBackCache("putIfAbsent") {
                     if (!backCache.containsKey(key)) {
                         backCache.put(key, value)
                     }
@@ -226,7 +298,7 @@ class NearJCache<K: Any, V: Any>(
     override fun remove(key: K): Boolean =
         frontCache.remove(key).also {
             if (it) {
-                syncBackCache {
+                syncBackCache("remove") {
                     backCache.remove(key)
                 }
             }
@@ -235,7 +307,7 @@ class NearJCache<K: Any, V: Any>(
     override fun remove(key: K, oldValue: V): Boolean =
         frontCache.remove(key, oldValue).also {
             if (it) {
-                syncBackCache {
+                syncBackCache("remove(key, oldValue)") {
                     // Back cache listener 전파를 remove(key) 경로로 통일하기 위해 값 비교 후 단일 키 삭제를 사용한다.
                     if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
                         backCache.remove(key)
@@ -246,21 +318,22 @@ class NearJCache<K: Any, V: Any>(
 
     override fun removeAll() {
         frontCache.removeAll().apply {
-            syncBackCache {
+            syncBackCache("removeAll") {
                 // Redisson 에서는 bulk operation 의 경우 event 가 발생하지 않습니다!!!
-                backCache.chunked(100) { chunk ->
-                    chunk.forEach { runCatching { backCache.remove(it.key) } }
-                    // Thread.sleep(1)
-                }
+                val failures = backCache
+                    .chunked(REMOVE_BATCH_SIZE)
+                    .flatMap { chunk -> removeBackCacheEntries(chunk.map { it.key }) }
+                throwIfFailures("removeAll", failures)
             }
         }
     }
 
     override fun removeAll(keys: Set<K>) {
         frontCache.removeAll(keys).apply {
-            syncBackCache {
+            syncBackCache("removeAll(keys)") {
                 // Redisson 에서는 bulk operation 의 경우 event 가 발생하지 않습니다!!!
-                keys.forEach { runCatching { backCache.remove(it) } }
+                val failures = removeBackCacheEntries(keys)
+                throwIfFailures("removeAll(keys)", failures)
             }
         }
     }
@@ -284,7 +357,7 @@ class NearJCache<K: Any, V: Any>(
     override fun replace(key: K, oldValue: V, newValue: V): Boolean =
         frontCache.replace(key, oldValue, newValue).also {
             if (it) {
-                syncBackCache {
+                syncBackCache("replace(key, oldValue, newValue)") {
                     if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
                         backCache.put(key, newValue)
                     }
@@ -295,7 +368,7 @@ class NearJCache<K: Any, V: Any>(
     override fun replace(key: K, value: V): Boolean =
         frontCache.replace(key, value).also {
             if (it) {
-                syncBackCache {
+                syncBackCache("replace") {
                     // Redisson 에서는 replace 가 event 를 발생시키지 않습니다.
                     if (backCache.containsKey(key)) {
                         backCache.put(key, value)
@@ -311,14 +384,143 @@ class NearJCache<K: Any, V: Any>(
         return null
     }
 
-    private inline fun syncBackCache(crossinline syncTask: () -> Unit) {
-        if (config.isSynchronous) {
-            runCatching { syncTask() }
-        } else {
-            val timeoutMillis = config.syncRemoteTimeout.coerceAtLeast(NearJCacheConfig.DEFAULT_SYNC_REMOTE_TIMEOUT)
-            asyncRunWithTimeout(timeoutMillis) {
-                runCatching { syncTask() }
+    @Suppress("TooGenericExceptionCaught")
+    private fun removeBackCacheEntries(keys: Iterable<K>): List<RuntimeException> {
+        val failures = mutableListOf<RuntimeException>()
+        keys.forEach { key ->
+            try {
+                backCache.remove(key)
+            } catch (e: RuntimeException) {
+                failures += e
+            }
+        }
+        return failures
+    }
+
+    private fun throwIfFailures(operation: String, failures: List<RuntimeException>) {
+        if (failures.isEmpty()) return
+
+        val primary = failures.first()
+        failures.drop(1).forEach { failure ->
+            val suppressed =
+                if (failure === primary) {
+                    IllegalStateException("Repeated back cache failure", failure)
+                } else {
+                    failure
+                }
+            primary.addSuppressed(suppressed)
+        }
+        log.error(primary) {
+            "NearJCache back cache bulk write failed. operation=$operation, failureCount=${failures.size}"
+        }
+        throw primary
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun syncBackCache(
+        operation: String,
+        synchronous: Boolean = config.isSynchronous,
+        syncTask: () -> Unit,
+    ): CompletableFuture<Unit> {
+        val completion = CompletableFuture<Unit>()
+        publishBackCacheWrite(operation, completion)
+        if (synchronous) {
+            return try {
+                syncTask()
+                completion.complete(Unit)
+                completion
+            } catch (e: RuntimeException) {
+                completion.completeExceptionally(e)
+                throw e
+            }
+        }
+
+        val timeoutMillis = config.syncRemoteTimeout.coerceAtLeast(NearJCacheConfig.DEFAULT_SYNC_REMOTE_TIMEOUT)
+        runAsyncBackCacheWrite(
+            operation = operation,
+            timeoutMillis = timeoutMillis,
+            retriesRemaining = config.syncRemoteRetryCount.coerceIn(
+                0,
+                NearJCacheConfig.MAX_SYNC_REMOTE_RETRY_COUNT
+            ),
+            completion = completion,
+            syncTask = syncTask,
+        )
+        return completion
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun publishBackCacheWrite(
+        operation: String,
+        completion: CompletableFuture<Unit>,
+    ) {
+        val state = BackCacheWriteState(
+            operationId = nextBackCacheWriteOperationId.incrementAndGet(),
+            operation = operation,
+            completion = completion,
+        )
+        lastBackCacheWrite.set(state)
+        completion.whenComplete { _, _ ->
+            val result = BackCacheWriteCompletion(
+                operationId = state.operationId,
+                operation = state.operation,
+                completion = completion.minimalCompletionStage(),
+            )
+            backCacheWriteListeners.forEach { listener ->
+                try {
+                    listener(result)
+                } catch (e: RuntimeException) {
+                    log.error(e) {
+                        "NearJCache back cache write listener failed. operationId=${state.operationId}"
+                    }
+                }
             }
         }
     }
+
+    private fun runAsyncBackCacheWrite(
+        operation: String,
+        timeoutMillis: Long,
+        retriesRemaining: Int,
+        completion: CompletableFuture<Unit>,
+        syncTask: () -> Unit,
+    ) {
+        asyncRunWithTimeout(timeoutMillis) {
+            syncTask()
+        }.whenComplete { _, error ->
+            if (error == null) {
+                completion.complete(Unit)
+                return@whenComplete
+            }
+
+            val failure = unwrapCompletionFailure(error)
+            val retryable = failure is RuntimeException &&
+                    failure !is TimeoutException &&
+                    failure !is CancellationException
+            if (retryable && retriesRemaining > 0) {
+                log.warn(failure) {
+                    "NearJCache retrying asynchronous back cache write. " +
+                            "operation=$operation, retriesRemaining=${retriesRemaining - 1}"
+                }
+                runAsyncBackCacheWrite(
+                    operation = operation,
+                    timeoutMillis = timeoutMillis,
+                    retriesRemaining = retriesRemaining - 1,
+                    completion = completion,
+                    syncTask = syncTask,
+                )
+            } else {
+                log.error(failure) {
+                    "NearJCache asynchronous back cache write failed. operation=$operation"
+                }
+                completion.completeExceptionally(failure)
+            }
+        }
+    }
+
+    private fun unwrapCompletionFailure(error: Throwable): Throwable =
+        when (error) {
+            is CompletionException, is ExecutionException -> error.cause ?: error
+            else -> error
+        }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt
@@ -33,6 +33,7 @@ import javax.cache.expiry.Duration
  * @property frontCacheConfiguration Front Cache 설정 (만료 시간 등)
  * @property isSynchronous Front-Back 캐시 간 동기화 방식 (true: 동기, false: 비동기)
  * @property syncRemoteTimeout 원격 캐시 동기화 타임아웃 (밀리초)
+ * @property syncRemoteRetryCount 비동기 원격 캐시 write-through의 bounded retry 횟수
  *
  * @see NearJCache
  */
@@ -42,6 +43,7 @@ data class NearJCacheConfig<K: Any, V: Any>(
     val frontCacheConfiguration: MutableConfiguration<K, V> = getDefaultFrontCacheConfiguration(),
     val isSynchronous: Boolean = false,
     val syncRemoteTimeout: Long = NearJCacheConfig.DEFAULT_SYNC_REMOTE_TIMEOUT,
+    val syncRemoteRetryCount: Int = NearJCacheConfig.DEFAULT_SYNC_REMOTE_RETRY_COUNT,
 ): Serializable {
 
     companion object {
@@ -55,6 +57,12 @@ data class NearJCacheConfig<K: Any, V: Any>(
 
         /** 기본 원격 캐시 동기화 타임아웃 (500ms) */
         const val DEFAULT_SYNC_REMOTE_TIMEOUT = 500L
+
+        /** 비동기 원격 캐시 write-through의 기본 재시도 횟수 */
+        const val DEFAULT_SYNC_REMOTE_RETRY_COUNT = 1
+
+        /** 원격 캐시 write-through 재시도 횟수 상한 */
+        const val MAX_SYNC_REMOTE_RETRY_COUNT = 3
 
         /** Caffeine 캐시를 위한 기본 [CacheManager] 팩토리 */
         val CaffeineCacheManagerFactory = Factory {

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfigBuilder.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfigBuilder.kt
@@ -36,6 +36,9 @@ class NearJCacheConfigBuilder<K: Any, V: Any> {
     /** 원격 캐시 동기화 타임아웃 (밀리초). 기본값: 500ms */
     var syncRemoteTimeout: Long = NearJCacheConfig.DEFAULT_SYNC_REMOTE_TIMEOUT
 
+    /** 비동기 원격 캐시 write-through 재시도 횟수. 기본값: 1회 */
+    var syncRemoteRetryCount: Int = NearJCacheConfig.DEFAULT_SYNC_REMOTE_RETRY_COUNT
+
     /**
      * 설정값으로 [NearJCacheConfig] 인스턴스를 생성합니다.
      */
@@ -45,6 +48,7 @@ class NearJCacheConfigBuilder<K: Any, V: Any> {
         frontCacheConfiguration = frontCacheConfiguration,
         isSynchronous = isSynchronous,
         syncRemoteTimeout = syncRemoteTimeout,
+        syncRemoteRetryCount = syncRemoteRetryCount,
     )
 }
 

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfigBuilderTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfigBuilderTest.kt
@@ -16,6 +16,7 @@ class NearJCacheConfigBuilderTest {
         config.cacheName.shouldNotBeBlank()
         config.isSynchronous shouldBeEqualTo false
         config.syncRemoteTimeout shouldBeEqualTo NearJCacheConfig.DEFAULT_SYNC_REMOTE_TIMEOUT
+        config.syncRemoteRetryCount shouldBeEqualTo NearJCacheConfig.DEFAULT_SYNC_REMOTE_RETRY_COUNT
     }
 
     @Test
@@ -24,10 +25,12 @@ class NearJCacheConfigBuilderTest {
             cacheName = "test-cache"
             isSynchronous = true
             syncRemoteTimeout = 1000L
+            syncRemoteRetryCount = 2
         }
 
         config.cacheName shouldBeEqualTo "test-cache"
         config.isSynchronous shouldBeEqualTo true
         config.syncRemoteTimeout shouldBeEqualTo 1000L
+        config.syncRemoteRetryCount shouldBeEqualTo 2
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
@@ -1,0 +1,388 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.cache.jcache.JCache
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+import javax.cache.Cache
+
+class NearJCacheWriteThroughFailureTest {
+
+    private val failure = IllegalStateException("back cache is unavailable")
+
+    @Test
+    fun `동기 put은 back cache 실패를 호출자에게 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.put("key", "value") } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.put("key", "value")
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 putAll은 back cache 실패를 호출자에게 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.putAll(mapOf("key" to "value")) } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.putAll(mapOf("key" to "value"))
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 putIfAbsent는 back cache 실패를 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.putIfAbsent("key", "value") } returns true
+        every { backCache.containsKey("key") } returns false
+        every { backCache.put("key", "value") } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.putIfAbsent("key", "value")
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 remove는 back cache 실패를 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.remove("key") } returns true
+        every { backCache.remove("key") } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.remove("key")
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 조건부 remove는 back cache 실패를 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.remove("key", "old") } returns true
+        every { backCache.containsKey("key") } returns true
+        every { backCache.get("key") } returns "old"
+        every { backCache.remove("key") } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.remove("key", "old")
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 replace는 back cache 실패를 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.replace("key", "value") } returns true
+        every { backCache.containsKey("key") } returns true
+        every { backCache.put("key", "value") } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.replace("key", "value")
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 조건부 replace는 back cache 실패를 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.replace("key", "old", "new") } returns true
+        every { backCache.containsKey("key") } returns true
+        every { backCache.get("key") } returns "old"
+        every { backCache.put("key", "new") } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.replace("key", "old", "new")
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 removeAll은 부분 back cache 실패를 집계해 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.remove("key-1") } throws failure
+        every { backCache.remove("key-2") } throws IllegalArgumentException("second failure")
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        val error = assertFailsWith<IllegalStateException> {
+            nearCache.removeAll(setOf("key-1", "key-2"))
+        }
+        error.message shouldBeEqualTo failure.message
+        error.suppressed.size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `동기 removeAll은 back cache iterator 삭제 실패를 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val entry = mockk<Cache.Entry<String, String>>()
+        every { entry.key } returns "key"
+        every { backCache.iterator() } returns mutableListOf(entry).iterator()
+        every { backCache.remove("key") } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.removeAll()
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 removeAll은 동일 예외 인스턴스도 원래 실패를 보존한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val sameFailure = IllegalStateException("shared back cache failure")
+        every { backCache.remove(any()) } throws sameFailure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        val error = assertFailsWith<IllegalStateException> {
+            nearCache.removeAll(setOf("key-1", "key-2"))
+        }
+        error.message shouldBeEqualTo sameFailure.message
+        error.suppressed.size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `동기 clearAllCache는 back cache 실패를 호출자에게 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.clear() } throws failure
+
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> {
+            nearCache.clearAllCache()
+        }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `비동기 write-through는 back cache 예외를 completion으로 노출한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.put("key", "value") } throws failure
+
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false),
+            )
+
+        nearCache.put("key", "value")
+
+        val error = assertFailsWith<ExecutionException> {
+            nearCache.lastBackCacheWriteCompletion.get(2, TimeUnit.SECONDS)
+        }
+        error.cause?.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `비동기 write-through는 즉시 실패를 bounded retry 후 성공시킨다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val attempts = AtomicInteger()
+        every { backCache.put("key", "value") } answers {
+            if (attempts.incrementAndGet() == 1) {
+                throw failure
+            }
+        }
+
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false, syncRemoteRetryCount = 1),
+            )
+
+        nearCache.put("key", "value")
+
+        nearCache.lastBackCacheWriteCompletion.get(2, TimeUnit.SECONDS)
+        attempts.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `비동기 write-through는 Error를 재시도하지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val attempts = AtomicInteger()
+        val failure = AssertionError("backend linkage failure")
+        every { backCache.put("key", "value") } answers {
+            attempts.incrementAndGet()
+            throw failure
+        }
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false, syncRemoteRetryCount = 3),
+            )
+
+        nearCache.put("key", "value")
+
+        val error = assertFailsWith<ExecutionException> {
+            nearCache.lastBackCacheWriteCompletion.get(2, TimeUnit.SECONDS)
+        }
+        check(error.cause is AssertionError) { "Expected Error cause but got ${error.cause}" }
+        attempts.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `비동기 write-through retry 횟수는 3회로 제한된다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val attempts = AtomicInteger()
+        every { backCache.put("key", "value") } answers {
+            attempts.incrementAndGet()
+            throw failure
+        }
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false, syncRemoteRetryCount = 99),
+            )
+
+        nearCache.put("key", "value")
+
+        assertFailsWith<ExecutionException> {
+            nearCache.lastBackCacheWriteCompletion.get(2, TimeUnit.SECONDS)
+        }
+        attempts.get() shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `비동기 write-through는 operation별 completion을 listener로 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.put(any(), any()) } answers {
+            if (firstArg<String>() == "failed") {
+                throw failure
+            }
+        }
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false, syncRemoteRetryCount = 0),
+            )
+        val completions = CopyOnWriteArrayList<BackCacheWriteCompletion>()
+        val completed = CountDownLatch(2)
+        val registration = nearCache.addBackCacheWriteListener {
+            completions += it
+            completed.countDown()
+        }
+
+        try {
+            nearCache.put("failed", "value")
+            nearCache.put("succeeded", "value")
+
+            check(completed.await(2, TimeUnit.SECONDS)) { "write-through completions were not observed" }
+            completions.size shouldBeEqualTo 2
+            completions.map { it.operationId }.toSet().size shouldBeEqualTo 2
+            completions.single { it.completion.toCompletableFuture().isCompletedExceptionally }
+                .completion.toCompletableFuture().join()
+        } catch (e: java.util.concurrent.CompletionException) {
+            e.cause?.message shouldBeEqualTo failure.message
+        } finally {
+            registration.close()
+        }
+    }
+
+    @Test
+    fun `last completion 복사본을 변경해도 실제 write 결과는 보존된다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val release = CountDownLatch(1)
+        every { backCache.put("key", "value") } answers {
+            release.await()
+            throw failure
+        }
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false, syncRemoteRetryCount = 0),
+            )
+
+        try {
+            nearCache.put("key", "value")
+            nearCache.lastBackCacheWriteCompletion.complete(Unit)
+        } finally {
+            release.countDown()
+        }
+
+        val error = assertFailsWith<ExecutionException> {
+            nearCache.lastBackCacheWriteCompletion.get(2, TimeUnit.SECONDS)
+        }
+        error.cause?.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `비동기 write-through timeout은 completion 오류로 노출된다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val release = CountDownLatch(1)
+        val attempts = AtomicInteger()
+        every { backCache.put("key", "value") } answers {
+            attempts.incrementAndGet()
+            release.await()
+        }
+
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false, syncRemoteTimeout = 1L, syncRemoteRetryCount = 2),
+            )
+
+        try {
+            nearCache.put("key", "value")
+
+            val error = assertFailsWith<ExecutionException> {
+                nearCache.lastBackCacheWriteCompletion.get(2, TimeUnit.SECONDS)
+            }
+            check(error.cause is TimeoutException) {
+                "Expected timeout failure but got ${error.cause}"
+            }
+            attempts.get() shouldBeEqualTo 1
+        } finally {
+            release.countDown()
+        }
+    }
+
+    private fun newNearCache(
+        frontCache: JCache<String, String>,
+        backCache: JCache<String, String>,
+    ): NearJCache<String, String> =
+        NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+}

--- a/docs/lessons/2026-08-11-issue-1362-nearjcache-write-through.md
+++ b/docs/lessons/2026-08-11-issue-1362-nearjcache-write-through.md
@@ -1,0 +1,48 @@
+# #1362 NearJCache write-through 실패 관찰성
+
+## 배경
+
+`NearJCache`는 front cache mutation을 먼저 수행한 뒤 back cache에
+write-through를 적용합니다. 기존 경로는 동기 반영의 실패 결과를 버리거나 비동기
+작업의 completion을 호출자에게 노출하지 않아, front cache만 변경된 상태가
+성공처럼 보일 수 있었습니다. `removeAll`처럼 여러 key를 처리하는 작업은 일부
+실패도 단일 성공 결과로 축약될 수 있었습니다.
+
+## 결정 또는 발견
+
+- 동기 write-through는 back cache 예외를 원래 호출자에게 전파해 front 반영과
+  back 반영 완료를 같은 상태로 오인하지 않도록 합니다.
+- 비동기 write-through는 operation별 `CompletionStage`와 listener를 제공하고,
+  설정된 횟수 안에서만 재시도합니다. timeout, cancellation, `Error` 및 재시도
+  소진은 terminal failure로 completion에 기록합니다.
+- 최근 completion은 불변 snapshot으로 노출해 관찰자가 내부 mutable 상태를
+  변경할 수 없게 합니다.
+- bulk mutation은 실패 key와 원인 정보를 집계해 partial failure를 보존합니다.
+  특히 `removeAll`의 일부 실패를 전체 성공으로 축약하지 않습니다.
+- 기존 JCache mutation 메서드 시그니처는 유지하고, 별도의 completion/listener
+  경로로 비동기 결과를 관찰하게 합니다. 비동기 retry 상한은
+  `NearJCacheConfig.syncRemoteRetryCount`로 조정하며 최대 3회로 제한합니다.
+
+## 결과
+
+호출자는 동기 실패를 즉시 확인하고, 비동기 작업도 operation 식별자와 함께 성공,
+실패, timeout을 관찰할 수 있습니다. bulk 작업의 partial failure가 보존되어
+재시도·경보·복구 정책을 적용할 수 있고, front cache의 선행 변경이 back cache
+반영 성공으로 잘못 해석되지 않습니다.
+
+## 검증
+
+- write-through 실패·partial failure·retry·timeout·listener·불변 snapshot
+  회귀 테스트 18개와 설정 builder 테스트 2개를 통과했습니다.
+- `:bluetape4k-cache-core:test` 전체 525개 테스트 통과.
+- `:bluetape4k-cache-core:detekt` 성공. 기존 baseline warning 외 변경 파일의
+  신규 finding은 없습니다.
+- `git diff --check` 통과.
+- exact-model 독립 reviewer가 P0/P1/P2/P3 finding 없이 `APPROVE`했습니다.
+
+## 향후 지침
+
+새 NearJCache mutation 경로를 추가할 때는 동기·비동기 양쪽의 terminal completion,
+timeout과 retry 상한, bulk partial failure 집계를 함께 정의합니다. 로그만 남기고
+실패를 버리지 말며, front cache 선행 변경과 back cache 반영 완료를 서로 다른
+상태로 문서화하고 회귀 테스트로 고정합니다.


### PR DESCRIPTION
## Summary

Closes #1362

- PR 제목: [cache] NearJCache write-through 실패를 관찰 가능하게 한다

Closes #1362

`NearJCache` write-through mutation이 back cache 실패·timeout을 성공처럼 숨기지
않고, 동기 호출자와 비동기 관찰자에게 terminal 상태를 전달하도록 보장합니다.

## Background

front cache를 먼저 변경하는 JCache mutation 경로에서 동기 `syncBackCache` 실패가
무시되거나 비동기 completion이 호출자에게 노출되지 않았습니다. `removeAll`의
partial failure도 단일 성공으로 축약될 수 있어 장애 탐지와 복구가 어려웠습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 동기 write-through 실패를 원래 mutation 호출자에게 전파
- 비동기 operation별 `CompletionStage`와 listener 제공
- `syncRemoteRetryCount` 기반 bounded retry와 timeout·cancellation·`Error` terminal
  failure 처리
- 최근 completion의 immutable snapshot 제공
- bulk mutation의 partial failure 집계 및 원인 보존
- `put`, `putAll`, `putIfAbsent`, `remove`, `removeAll`, `replace`, `clearAllCache`
  실패 회귀 테스트 추가
- 후속 mutation 변경을 위한 Korean lesson 추가

## Validation

- write-through failure/retry/timeout/listener/immutable snapshot 회귀 테스트 18개와
  config builder 테스트 2개 통과
- `:bluetape4k-cache-core:test --no-configuration-cache`: 525 tests, failures 0,
  errors 0, skipped 0
- `:bluetape4k-cache-core:detekt --no-configuration-cache`: `BUILD SUCCESSFUL`
- `git diff --check`: 통과
- exact-model 독립 reviewer: `APPROVE`, P0/P1/P2/P3 finding 0

## Review Notes

- Issue: #1362
- Milestone: `1.13.0`
- Labels: `bug`, `test`, `tech-debt`, `cache`
- Assignee: `debop`
- Base: `develop`
- Head: `fix/issue-1362-nearjcache-write-through`
- Head SHA: `4210104e99fe71867e6d908f7d995e088ca7eafb`

## Metadata

- Issue: #1362, milestone `1.13.0`, assignee `debop`
- PR: #1365, head `4210104e99fe71867e6d908f7d995e088ca7eafb`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1362-nearjcache-write-through`
- Labels: `bug`, `test`, `tech-debt`, `cache`
- State: `MERGED`, merge commit `d373849d23a181b85559a2f80c9f208ac67b70ee`
- CI: - `:bluetape4k-cache-core:detekt --no-configuration-cache`: `BUILD SUCCESSFUL` / - [x] targeted/full test와 detekt 검증 / - [x] GitHub Actions CI run `31504520897` 성공(재실행 attempt 2 포함)

## DoD Status

- [x] Type C bugfix 범위와 issue acceptance criteria 반영
- [x] `$bluetape-workflow` 및 `$bluetape-kotlin-patterns` 적용
- [x] lesson gate(C-06) 기록
- [x] 독립 exact-model review 승인
- [x] targeted/full test와 detekt 검증
- [x] Korean PR metadata 및 exact head 고정
- [x] GitHub Actions CI run `31504520897` 성공(재실행 attempt 2 포함)
- [x] required checks 10개 pass, 변경 모듈 정책상 test matrix 8개 skipping
- [ ] merge 후 develop 동기화 및 worktree/branch 정리

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1365 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `d373849d23a181b85559a2f80c9f208ac67b70ee`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
