### PR TITLE
[security] Jackson legacy permissive typing을 차단한다

### DIFF
--- a/docs/lessons/2026-08-11-issue-1356-jackson-legacy-typing.md
+++ b/docs/lessons/2026-08-11-issue-1356-jackson-legacy-typing.md
@@ -26,6 +26,10 @@ deprecated 경고를 무시하면 allowlist 없이 default typing을 활성화�
   `allowIfSubType(...)`와 배열 subtype 규칙으로만 구성한다.
 - `1.13.0`에서는 legacy symbol을 migration signal로 남기고 runtime에서 즉시 차단한다.
   다음 major release에서 public symbol 제거를 재검토한다.
+- `createTypedJsonMapper(...)`의 prefix는 Jackson의 `startsWith` 판정에 직접 전달하지
+  않는다. 공백을 제거하고 마지막 `.`을 보정한 package boundary로 정규화하며, 공백 또는
+  `.`만으로 된 입력은 거부한다. 따라서 빈 prefix의 전체 subtype 허용과
+  `com.example`가 `com.exampleevil`을 허용하는 인접 package 우회를 차단한다.
 
 ## 안전한 사용 경계
 
@@ -39,10 +43,13 @@ payload에만 사용한다. untrusted 또는 외부 JSON은 구체적인 DTO나 
 
 - RED: legacy 세 진입점이 예외를 던져야 한다는 신규 테스트가 기존 구현에서 3건 실패하고,
   기존 테스트 10건은 통과했다.
+- RED: blank/dot-only prefix와 package boundary 밖의 root/nested type id를 검증하는 신규
+  보안 테스트 3건이 정규화 전 구현에서 실패했다.
 - GREEN: 세 migration-failure 테스트와 기존 allowlist root/nested 거부 및 허용 round-trip을
-  포함한 `JacksonTest` 전체가 통과했다.
+  포함한 `JacksonTest` 전체가 통과했고, 정규화된 prefix 없이 인접 package를 허용하지
+  않는 root/nested 회귀 테스트도 통과했다.
 - `./gradlew :bluetape4k-jackson2:test --no-daemon --no-configuration-cache`:
-  473 tests passed.
+  476 tests passed.
 - `./gradlew :bluetape4k-jackson2:compileTestKotlin --warning-mode all --rerun-tasks
   --no-daemon --no-configuration-cache`: `BUILD SUCCESSFUL`.
 - `./gradlew :bluetape4k-jackson2:detekt --no-daemon --no-configuration-cache`:

--- a/docs/lessons/2026-08-11-issue-1356-jackson-legacy-typing.md
+++ b/docs/lessons/2026-08-11-issue-1356-jackson-legacy-typing.md
@@ -1,0 +1,59 @@
+# 이슈 1356: Jackson legacy permissive typing 차단
+
+## 배경
+
+이슈 [#1356](https://github.com/bluetape4k/bluetape4k-projects/issues/1356)은
+allowlist 기반 `Jackson.createTypedJsonMapper(...)`를 도입한 뒤에도 남아 있던
+legacy polymorphic API를 다룬다. `typedJsonMapper`, `prettyTypedJsonWriter`,
+`createDefaultJsonMapper(needTypeInfo = true)`가 외부에서 계속 호출될 수 있었고,
+`needTypeInfo` 경로는 `allowIfBaseType(Any::class.java)`로 모든 base type을 허용했다.
+deprecated 주석과 문서 경고만으로는 이 보안 경계를 강제할 수 없었다.
+
+## 원인
+
+legacy property 두 개가 `createDefaultJsonMapper(needTypeInfo = true)`를 호출하고,
+해당 옵션이 permissive `BasicPolymorphicTypeValidator`를 설치했다. 따라서 호출자가
+deprecated 경고를 무시하면 allowlist 없이 default typing을 활성화할 수 있었다.
+
+## 결정
+
+- `createTypedJsonMapper(...)`만 명시적 trusted subtype package allowlist를 받는
+  polymorphic mapper 생성 경로로 유지한다.
+- `typedJsonMapper`, `prettyTypedJsonWriter`,
+  `createDefaultJsonMapper(needTypeInfo = true)`의 source-compatible public shape은
+  당장 유지하되 접근 시 `UnsupportedOperationException`을 발생시킨다.
+- `allowIfBaseType(Any::class.java)` production 경로를 제거한다. 허용 목록은
+  `allowIfSubType(...)`와 배열 subtype 규칙으로만 구성한다.
+- `1.13.0`에서는 legacy symbol을 migration signal로 남기고 runtime에서 즉시 차단한다.
+  다음 major release에서 public symbol 제거를 재검토한다.
+
+## 안전한 사용 경계
+
+`createTypedJsonMapper("com.example.model.")`는 애플리케이션이 관리하는 trusted
+payload에만 사용한다. untrusted 또는 외부 JSON은 구체적인 DTO나 별도 검증된 형태로
+역직렬화하며 Jackson default typing을 활성화하지 않는다. 새 polymorphic API를 추가할
+때도 permissive base validator를 도입하지 않고, 악성·비허용 type id 회귀 테스트를 함께
+작성한다.
+
+## 검증
+
+- RED: legacy 세 진입점이 예외를 던져야 한다는 신규 테스트가 기존 구현에서 3건 실패하고,
+  기존 테스트 10건은 통과했다.
+- GREEN: 세 migration-failure 테스트와 기존 allowlist root/nested 거부 및 허용 round-trip을
+  포함한 `JacksonTest` 전체가 통과했다.
+- `./gradlew :bluetape4k-jackson2:test --no-daemon --no-configuration-cache`:
+  473 tests passed.
+- `./gradlew :bluetape4k-jackson2:compileTestKotlin --warning-mode all --rerun-tasks
+  --no-daemon --no-configuration-cache`: `BUILD SUCCESSFUL`.
+- `./gradlew :bluetape4k-jackson2:detekt --no-daemon --no-configuration-cache`:
+  `BUILD SUCCESSFUL`.
+- EN/KO README의 동일한 safe factory, legacy 세 진입점, trusted/untrusted 경계,
+  `1.13.0` runtime 차단 및 다음 major 제거 검토 내용을 대조했고 `git diff --check`도
+  통과했다.
+
+## 향후 지침
+
+`BasicPolymorphicTypeValidator`를 만들 때 `Any` base type을 허용하지 않는다. trusted
+package prefix를 명시하고 root·nested payload 양쪽에서 비허용 type id가 실패하는지
+검증한다. legacy API를 다시 살리는 대신 migration failure 메시지의
+`createTypedJsonMapper(...)` 안내를 유지한다.

--- a/io/jackson2/README.ko.md
+++ b/io/jackson2/README.ko.md
@@ -77,6 +77,10 @@ val json = mapper.writeValueAsString(value)
 val restored = mapper.readValue(json, ModelEnvelope::class.java)
 ```
 
+allowlist prefix는 앞뒤 공백을 제거한 뒤 `.`로 끝나는 package boundary로 정규화합니다.
+공백 또는 `.`만으로 된 prefix는 거부하므로 `"com.example"`은
+`com.example.*`만 허용하고 `com.exampleevil.*` 같은 인접 package는 허용하지 않습니다.
+
 기본 mapper는 다형성 typing을 활성화하지 않습니다. `Jackson.typedJsonMapper`,
 `Jackson.prettyTypedJsonWriter`, `Jackson.createDefaultJsonMapper(needTypeInfo = true)`는
 source compatibility를 위한 deprecated symbol으로 남아 있지만, `1.13.0`부터 접근 즉시

--- a/io/jackson2/README.ko.md
+++ b/io/jackson2/README.ko.md
@@ -77,7 +77,21 @@ val json = mapper.writeValueAsString(value)
 val restored = mapper.readValue(json, ModelEnvelope::class.java)
 ```
 
-신뢰할 수 없는 JSON에는 deprecated된 `Jackson.typedJsonMapper`를 사용하지 마세요. 이 mapper는 호환성을 위해 기존 `Any` base default typing 동작을 유지하므로 외부 payload에 안전하지 않습니다.
+기본 mapper는 다형성 typing을 활성화하지 않습니다. `Jackson.typedJsonMapper`,
+`Jackson.prettyTypedJsonWriter`, `Jackson.createDefaultJsonMapper(needTypeInfo = true)`는
+source compatibility를 위한 deprecated symbol으로 남아 있지만, `1.13.0`부터 접근 즉시
+`UnsupportedOperationException`을 발생시키며 더 이상 `Any` base validator를 설치하지 않습니다.
+다음과 같이 명시적 allowlist factory로 마이그레이션하세요.
+
+```kotlin
+val mapper = Jackson.createTypedJsonMapper("com.example.model.")
+val prettyWriter = mapper.writerWithDefaultPrettyPrinter()
+```
+
+이 factory는 애플리케이션이 관리하는 신뢰된 subtype package의 payload에만 사용하세요.
+신뢰할 수 없거나 외부에서 들어오는 JSON은 구체적인 DTO(또는 별도로 검증한 형태)로
+역직렬화하고 Jackson default typing을 활성화하지 마세요. deprecated symbol은 `1.13.0`에서
+마이그레이션 신호로만 유지하며, 다음 major release에서 제거를 검토합니다.
 
 ### 2. JacksonSerializer
 

--- a/io/jackson2/README.md
+++ b/io/jackson2/README.md
@@ -182,6 +182,10 @@ val json = mapper.writeValueAsString(value)
 val restored = mapper.readValue(json, ModelEnvelope::class.java)
 ```
 
+Allowlist prefixes are trimmed and normalized to a dot-terminated package boundary.
+Blank or dot-only prefixes are rejected, so `"com.example"` matches
+`com.example.*` but not an adjacent package such as `com.exampleevil.*`.
+
 The default mapper does not activate polymorphic typing. The legacy entry points
 `Jackson.typedJsonMapper`, `Jackson.prettyTypedJsonWriter`, and
 `Jackson.createDefaultJsonMapper(needTypeInfo = true)` are source-compatible deprecated symbols,

--- a/io/jackson2/README.md
+++ b/io/jackson2/README.md
@@ -182,8 +182,21 @@ val json = mapper.writeValueAsString(value)
 val restored = mapper.readValue(json, ModelEnvelope::class.java)
 ```
 
-Do not use the deprecated `Jackson.typedJsonMapper` with untrusted JSON. It keeps the legacy
-`Any`-base default typing behavior for compatibility and is unsafe for external payloads.
+The default mapper does not activate polymorphic typing. The legacy entry points
+`Jackson.typedJsonMapper`, `Jackson.prettyTypedJsonWriter`, and
+`Jackson.createDefaultJsonMapper(needTypeInfo = true)` are source-compatible deprecated symbols,
+but they fail immediately with `UnsupportedOperationException` as of `1.13.0`; they no longer
+install an `Any`-base validator. Replace them with an explicit allowlist:
+
+```kotlin
+val mapper = Jackson.createTypedJsonMapper("com.example.model.")
+val prettyWriter = mapper.writerWithDefaultPrettyPrinter()
+```
+
+Use this factory only for trusted payloads whose subtype packages are controlled by the
+application. For untrusted or external JSON, bind to a concrete DTO (or another explicitly
+validated shape) and do not enable Jackson default typing. The deprecated symbols remain only as
+a migration signal in `1.13.0`; removal is reviewed for the next major release.
 
 ### JacksonSerializer
 

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
@@ -20,7 +20,7 @@ import java.io.IOException
  * ## 동작/계약
  * - [defaultJsonMapper] is lazily initialized and reused.
  * - Use [createTypedJsonMapper] for allowlisted default typing.
- * - [typedJsonMapper] is legacy compatibility API and must not be used for untrusted JSON.
+ * - [typedJsonMapper] and [prettyTypedJsonWriter] are legacy APIs and fail explicitly when accessed.
  * - 매퍼 생성 중 I/O/설정 오류가 발생하면 [IllegalStateException]으로 전파됩니다.
  *
  * ```kotlin
@@ -31,6 +31,8 @@ import java.io.IOException
 object Jackson: KLogging() {
 
     private const val DEFAULT_TYPE_PROPERTY_NAME = "@class"
+    private const val LEGACY_TYPED_MAPPER_MESSAGE =
+        "Legacy polymorphic typing is disabled. Use Jackson.createTypedJsonMapper(\"trusted.package.\") with an explicit allowlist."
 
     /** 기본 JsonMapper 인스턴스입니다. */
     val defaultJsonMapper: JsonMapper by lazy { createDefaultJsonMapper() }
@@ -41,26 +43,26 @@ object Jackson: KLogging() {
     /**
      * 타입 정보를 포함하는 JsonMapper 인스턴스입니다.
      *
-     * @deprecated 보안 취약점(allowIfBaseType(Any::class.java))이 있습니다.
-     * [createTypedJsonMapper]("com.example.") 를 사용하세요.
-     */
+     * @deprecated legacy permissive typing 경로이므로 접근 시 [UnsupportedOperationException]이 발생합니다.
+     * 신뢰된 패키지 allowlist를 사용하는 [createTypedJsonMapper]("com.example.") 를 사용하세요.
+    */
     @Deprecated(
-        "allowIfBaseType(Any::class.java)는 모든 타입을 허용하여 RCE 취약점을 야기할 수 있습니다. " +
+        "legacy permissive typing은 모든 타입을 허용하여 RCE 취약점을 야기할 수 있습니다. " +
                 "createTypedJsonMapper(\"com.example.\") 를 사용하세요.",
-        ReplaceWith("Jackson.createTypedJsonMapper()")
+        ReplaceWith("Jackson.createTypedJsonMapper(\"com.example.\")")
     )
     val typedJsonMapper: JsonMapper by lazy { createDefaultJsonMapper(needTypeInfo = true) }
 
     /**
      * 타입 정보를 포함하며 포맷된 JSON을 출력하는 [ObjectWriter]
      *
-     * @deprecated [typedJsonMapper]와 함께 deprecated됩니다.
+     * @deprecated legacy permissive typing 경로이므로 접근 시 [UnsupportedOperationException]이 발생합니다.
      * [createTypedJsonMapper](...).writerWithDefaultPrettyPrinter() 를 사용하세요.
      */
     @Deprecated(
         "typedJsonMapper와 함께 deprecated됩니다. " +
                 "createTypedJsonMapper(...).writerWithDefaultPrettyPrinter() 를 사용하세요.",
-        ReplaceWith("Jackson.createTypedJsonMapper().writerWithDefaultPrettyPrinter()")
+        ReplaceWith("Jackson.createTypedJsonMapper(\"com.example.\").writerWithDefaultPrettyPrinter()")
     )
     val prettyTypedJsonWriter: ObjectWriter by lazy {
         createDefaultJsonMapper(needTypeInfo = true).writerWithDefaultPrettyPrinter()
@@ -68,7 +70,7 @@ object Jackson: KLogging() {
 
     /**
      * property 기반 타입 정보를 기록하고 신뢰된 타입만 허용하는 [JsonMapper]를 생성합니다
-     * subtype packages.
+     * trusted subtype packages.
      *
      * ## Security contract
      * - [allowedBasePackages] must contain trusted subtype package prefixes.
@@ -107,15 +109,20 @@ object Jackson: KLogging() {
      * ## 동작/계약
      * - classpath의 Jackson 모듈을 자동 등록합니다.
      * - Kotlin null/collection 관련 기능과 직렬화·역직렬화 feature를 기본 활성화합니다.
-     * - [needTypeInfo]가 `true`이면 default typing을 활성화하고 검증 직렬화/역직렬화를 수행합니다.
+     * - [needTypeInfo]가 `true`이면 legacy permissive typing을 차단하기 위해
+     *   [UnsupportedOperationException]을 발생시킵니다. 명시적 allowlist가 필요하면
+     *   [createTypedJsonMapper]를 사용하세요.
      *
      * ```kotlin
-     * val mapper = Jackson.createDefaultJsonMapper(needTypeInfo = true)
+     * val mapper = Jackson.createTypedJsonMapper("com.example.")
      * // mapper !== Jackson.defaultJsonMapper
      * ```
-     * @param needTypeInfo 타입 정보 포함 여부
+     * @param needTypeInfo legacy source compatibility를 위한 옵션입니다. `true`는 migration failure입니다.
      */
     fun createDefaultJsonMapper(needTypeInfo: Boolean = false): JsonMapper {
+        if (needTypeInfo) {
+            throw UnsupportedOperationException(LEGACY_TYPED_MAPPER_MESSAGE)
+        }
         log.info { "Create JsonMapper instance ... needTypeInfo=$needTypeInfo" }
 
         return jsonMapper {
@@ -158,23 +165,6 @@ object Jackson: KLogging() {
                 JsonReadFeature.ALLOW_TRAILING_COMMA
             )
 
-        }.apply {
-            if (needTypeInfo) {
-                // 보안 경고: allowIfBaseType(Any::class.java)는 모든 클래스를 기본 타입으로 허용합니다.
-                // 신뢰할 수 없는 JSON 데이터를 역직렬화할 경우 임의 코드 실행(RCE) 취약점이 발생할 수 있습니다.
-                // (CVE-2019-12384 계열 취약점 참고)
-                // 보안이 중요한 환경에서는 allowIfBaseType() 에 신뢰할 패키지만 명시적으로 지정하세요.
-                // 예: .allowIfBaseType("com.example.model")
-                activateDefaultTypingAsProperty(
-                    BasicPolymorphicTypeValidator.builder()
-                        .allowIfBaseType(Any::class.java)
-                        .allowIfSubTypeIsArray()
-                        .build(),
-                    ObjectMapper.DefaultTyping.NON_FINAL_AND_ENUMS,
-                    DEFAULT_TYPE_PROPERTY_NAME
-                )
-                verifyTypeInclusion(this)
-            }
         }
     }
 

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
@@ -75,8 +75,8 @@ object Jackson: KLogging() {
      * ## Security contract
      * - [allowedBasePackages] must contain trusted subtype package prefixes.
      * - Empty allowlists are rejected with [IllegalArgumentException].
-     * - Blank or dot-only prefixes are rejected, and every prefix is normalized
-     *   to a dot-terminated package boundary before validation.
+     * - 공백 또는 `.`만인 prefix는 거부하고, 모든 prefix를 검증 전에
+     *   `.`으로 끝나는 package boundary로 정규화합니다.
      * - Type ids are written as the `@class` property and validated during polymorphic deserialization.
      *
      * ```kotlin
@@ -85,7 +85,7 @@ object Jackson: KLogging() {
      * ```
      *
      * @param allowedBasePackages Trusted subtype package prefixes, for example `"com.example."`.
-     * A trailing dot is added when omitted so adjacent package names cannot match.
+     * 마지막 `.`을 생략하면 자동으로 추가하여 인접 package 이름이 매칭되지 않도록 합니다.
      * @param typing Default typing strategy. Defaults to [ObjectMapper.DefaultTyping.NON_FINAL_AND_ENUMS].
      */
     fun createTypedJsonMapper(

--- a/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
+++ b/io/jackson2/src/main/kotlin/io/bluetape4k/jackson/Jackson.kt
@@ -75,6 +75,8 @@ object Jackson: KLogging() {
      * ## Security contract
      * - [allowedBasePackages] must contain trusted subtype package prefixes.
      * - Empty allowlists are rejected with [IllegalArgumentException].
+     * - Blank or dot-only prefixes are rejected, and every prefix is normalized
+     *   to a dot-terminated package boundary before validation.
      * - Type ids are written as the `@class` property and validated during polymorphic deserialization.
      *
      * ```kotlin
@@ -83,6 +85,7 @@ object Jackson: KLogging() {
      * ```
      *
      * @param allowedBasePackages Trusted subtype package prefixes, for example `"com.example."`.
+     * A trailing dot is added when omitted so adjacent package names cannot match.
      * @param typing Default typing strategy. Defaults to [ObjectMapper.DefaultTyping.NON_FINAL_AND_ENUMS].
      */
     fun createTypedJsonMapper(
@@ -92,9 +95,10 @@ object Jackson: KLogging() {
         require(allowedBasePackages.isNotEmpty()) {
             "보안상 허용할 패키지를 하나 이상 지정해야 합니다. 예: createTypedJsonMapper(\"com.example.\")"
         }
-        log.info { "Create TypedJsonMapper ... allowedBasePackages=${allowedBasePackages.toList()}" }
+        val normalizedAllowedBasePackages = allowedBasePackages.map(::normalizeAllowedBasePackage)
+        log.info { "Create TypedJsonMapper ... allowedBasePackages=$normalizedAllowedBasePackages" }
         val validator = BasicPolymorphicTypeValidator.builder().apply {
-            allowedBasePackages.forEach { allowIfSubType(it) }
+            normalizedAllowedBasePackages.forEach { allowIfSubType(it) }
             allowIfSubTypeIsArray()
         }.build()
         return createDefaultJsonMapper().apply {
@@ -166,6 +170,14 @@ object Jackson: KLogging() {
             )
 
         }
+    }
+
+    private fun normalizeAllowedBasePackage(packagePrefix: String): String {
+        val normalized = packagePrefix.trim().trimEnd('.')
+        require(normalized.isNotEmpty()) {
+            "허용 패키지 prefix는 공백 또는 '.'만으로 지정할 수 없습니다."
+        }
+        return "$normalized."
     }
 
     private fun verifyTypeInclusion(mapper: JsonMapper) {

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonTest.kt
@@ -68,6 +68,47 @@ class JacksonTest {
     }
 
     @Test
+    fun `createTypedJsonMapper - blank package prefix는 예외 발생`() {
+        listOf("", "   ", ".", ".. ").forEach { prefix ->
+            assertFailsWith<IllegalArgumentException> {
+                Jackson.createTypedJsonMapper(prefix)
+            }
+        }
+    }
+
+    @Test
+    fun `createTypedJsonMapper - package boundary 밖의 nested type은 거부`() {
+        val mapper = Jackson.createTypedJsonMapper("com.example.disallow")
+        val nestedJson = """
+            {
+              "payload": {
+                "@class": "${DisallowedTypedPayload::class.qualifiedName}",
+                "value": "blocked"
+              }
+            }
+        """.trimIndent()
+
+        assertFailsWith<InvalidTypeIdException> {
+            mapper.readValue(nestedJson, TypedPayloadEnvelope::class.java)
+        }
+    }
+
+    @Test
+    fun `createTypedJsonMapper - package boundary 밖의 root type은 거부`() {
+        val mapper = Jackson.createTypedJsonMapper("com.example.disallow")
+        val rootJson = """
+            {
+              "@class": "${DisallowedTypedPayload::class.qualifiedName}",
+              "value": "blocked"
+            }
+        """.trimIndent()
+
+        assertFailsWith<InvalidTypeIdException> {
+            mapper.readValue(rootJson, Any::class.java)
+        }
+    }
+
+    @Test
     fun `createTypedJsonMapper - 여러 패키지 허용 가능`() {
         val mapper = Jackson.createTypedJsonMapper("io.bluetape4k.", "com.example.")
         mapper.shouldNotBeNull()

--- a/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonTest.kt
+++ b/io/jackson2/src/test/kotlin/io/bluetape4k/jackson/JacksonTest.kt
@@ -118,6 +118,35 @@ class JacksonTest {
         }
     }
 
+    @Suppress("DEPRECATION")
+    @Test
+    fun `legacy typedJsonMapper는 명시적 migration failure로 차단한다`() {
+        val exception = assertFailsWith<UnsupportedOperationException> {
+            Jackson.typedJsonMapper
+        }
+
+        exception.message shouldContain "createTypedJsonMapper"
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `legacy prettyTypedJsonWriter는 명시적 migration failure로 차단한다`() {
+        val exception = assertFailsWith<UnsupportedOperationException> {
+            Jackson.prettyTypedJsonWriter
+        }
+
+        exception.message shouldContain "createTypedJsonMapper"
+    }
+
+    @Test
+    fun `createDefaultJsonMapper의 legacy type info 옵션은 명시적 migration failure로 차단한다`() {
+        val exception = assertFailsWith<UnsupportedOperationException> {
+            Jackson.createDefaultJsonMapper(needTypeInfo = true)
+        }
+
+        exception.message shouldContain "createTypedJsonMapper"
+    }
+
     @Test
     fun `registeredModuleIdList - 등록된 모듈 ID를 List로 반환`() {
         val ids = Jackson.defaultJsonMapper.registeredModuleIdList()


### PR DESCRIPTION
## Summary

Closes #1356

- PR 제목: [security] Jackson legacy permissive typing을 차단한다

## Background

deprecated 경고만으로는 호출자가 `needTypeInfo = true`를 통해 `Any` base default typing을 계속 활성화할 수 있었습니다. 또한 `BasicPolymorphicTypeValidator`의 prefix 판정에 빈 문자열 또는 경계 없는 문자열을 직접 전달하면 모든 subtype 또는 인접 package가 허용될 수 있었습니다. 이 변경은 source-compatible public shape을 유지하면서 두 경로를 실행 시점에 차단합니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- `typedJsonMapper`, `prettyTypedJsonWriter`, `createDefaultJsonMapper(needTypeInfo = true)`의 legacy permissive typing 경로를 명시적 `UnsupportedOperationException` migration failure로 차단했습니다.
- `allowIfBaseType(Any::class.java)` production 경로를 제거하고 `createTypedJsonMapper(...)`의 trusted subtype package allowlist 경계만 유지했습니다.
- 독립 리뷰에서 확인된 빈/점-only prefix 전체 허용과 인접 package 우회 가능성을 수정했습니다. prefix는 trim 후 `.` package boundary로 정규화하고, root/nested type-id 모두 경계를 벗어나면 거부합니다.
- 악성·비허용 root/nested type-id와 legacy 세 진입점의 회귀 테스트를 추가했습니다.
- KDoc, EN/KO README, 이슈 lesson에 trusted/untrusted JSON 경계와 `1.13.0` runtime 차단 및 다음 major 제거 검토 일정을 문서화했습니다.
- 변경 KDoc의 보안 계약 설명을 한국어로 정리해 저장소 언어 정책을 준수했습니다.

## Validation

- RED: migration-failure 테스트 3건과 blank/package-boundary 보안 테스트 3건이 수정 전 구현에서 실패했습니다.
- GREEN: `JacksonTest` 16/16 통과
- `./gradlew :bluetape4k-jackson2:test --no-daemon --no-configuration-cache --rerun-tasks` — 476 passing
- `./gradlew :bluetape4k-jackson2:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache` — 성공
- `./gradlew :bluetape4k-jackson2:detekt --rerun-tasks --no-daemon --no-configuration-cache` — 성공
- `git diff --check` 및 production `allowIfBaseType(Any::class.java)` 호출 부재 확인
- 최신 PR CI run `31515016607`에서 required checks 10/10 통과: Build, Test / IO, Coverage Report, CI Status 및 정책·보안 checks. 변경되지 않은 8개 test lane은 skipping(N/A)입니다.
- 최신 independent review는 `01494f4b5` exact head에서 APPROVE(P0=0, P1=0, 추가 actionable finding=0)로 확인했고, GitHub review/inline thread/comment는 0건입니다.

detekt가 보고하는 `SerialVersionUIDInSerializableClass`는 기존 jackson2 테스트 fixture 범위이며 이번 변경 파일에는 신규 finding이 없습니다.

Closes #1356

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1356, milestone `1.13.0`, assignee `debop`
- PR: #1366, head `01494f4b507e5cae049001514c7187735dcb100f`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1356-jackson-legacy-typing`
- Labels: `bug`, `documentation`, `security`, `tech-debt`
- State: `MERGED`, merge commit `9ade53d0f53a8c4b0c29b9ed3cd726a7deb69c72`
- CI: - `./gradlew :bluetape4k-jackson2:test --no-daemon --no-configuration-cache --rerun-tasks` — 476 passing / - `./gradlew :bluetape4k-jackson2:compileTestKotlin --warning-mode all --rerun-tasks --no-daemon --no-configuration-cache` — 성공 / - `./gradlew :bluetape4k-jackson2:detekt --rerun-tasks --no-daemon --no-configuration-cache` — 성공

## DoD Status

- [x] legacy permissive typing runtime 차단
- [x] allowlist-only polymorphic factory 유지
- [x] blank/dot-only prefix 거부 및 package boundary 정규화
- [x] 악성/비허용 root·nested type-id 회귀 테스트
- [x] KDoc 및 EN/KO README migration 문서화
- [x] 변경 KDoc 한국어 정책 준수
- [x] lesson 기록
- [x] module tests, compileTestKotlin, detekt, diff 검증
- [x] 새 PR head CI 및 live review/thread 상태 확인 (P0/P1/P2=0, unresolved thread=0)
- [ ] fresh merge 승인
- [ ] merge 후 local sync 및 worktree 정리

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1366 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9ade53d0f53a8c4b0c29b9ed3cd726a7deb69c72`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
