### PR TITLE
[cache] NearJCache의 JCache 표준 read/clear 계약 정합성 확보

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -103,6 +103,22 @@ val value = memo("recover")      // 새로 계산하여 7 반환
 `JCache<K,V>` / `SuspendJCache<K,V>` 인터페이스를 직접 구현하는 2-tier 캐시입니다. `JCache<K,V> by backCache` 위임으로 JCache 호환성을 유지하며,
 `NearJCacheConfig` Builder DSL로 설정할 수 있습니다.
 
+`NearJCache<K,V>`의 표준 `javax.cache.Cache` 메서드는 논리적 2-tier 캐시를
+관찰합니다. `get`, `containsKey`, `getAll`은 front를 먼저 확인하고 miss이면
+back을 조회하며, back hit는 front에 populate합니다. `clear`는 해당 wrapper가
+소유한 front와 back의 매핑을 함께 삭제합니다. 기존 `getDeeply`와
+`clearAllCache` 이름은 각각 표준 `get`과 `clear`의 소스 호환 alias로 유지됩니다.
+
+공유 back cache를 사용하는 다른 wrapper의 front에 이미 들어간 값까지
+`clear`가 listener로 지운다고 보장하지 않습니다. peer 무효화가 필요하면
+기존 per-entry `removeAll` 경로를 사용하세요. `getAndRemove`와
+`getAndReplace`는 기존 front-only read 왕복을 유지하며, cross-tier compound
+원자성은 [#1355](https://github.com/bluetape4k/bluetape4k-projects/issues/1355)에서
+별도로 다룹니다.
+
+기본 front 설정은 store-by-reference입니다. 필터링된 provider별 copier 계약이
+정해지기 전에는 custom store-by-value front 설정을 생성 단계에서 거부합니다.
+
 ##### SuspendJCache 인터페이스
 
 ![SuspendJCache coroutine interface diagram](../../docs/images/readme-diagrams/cache-cache-core-diagram-04.png)

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -53,6 +53,26 @@ Add the appropriate provider module if you need distributed caching.
 
 ## Detailed Features
 
+### JCache NearCache contract
+
+`NearJCache<K,V>` is a logical two-tier implementation of `javax.cache.Cache`.
+Standard `get`, `containsKey`, and `getAll` check the front cache first, fall
+back to the back cache on a miss, and populate the front cache with back hits.
+Standard `clear` removes mappings from both layers owned by the wrapper. The
+`getDeeply` and `clearAllCache` names remain source-compatible aliases for the
+standard `get` and `clear` behavior.
+
+The clear operation does not promise invalidation of another wrapper's already
+populated front cache when the back cache is shared or listener propagation is
+unavailable. Use the existing per-entry `removeAll` path when peer invalidation
+is required. `getAndRemove` and `getAndReplace` keep their existing front-only
+read round trips; cross-tier compound atomicity is tracked separately in issue
+[#1355](https://github.com/bluetape4k/bluetape4k-projects/issues/1355).
+
+The default front configuration uses store-by-reference. A custom store-by-value
+front configuration is rejected until a filtered, provider-specific copier
+contract is supplied.
+
 ## Near-Cache Capability Matrix
 
 The shared support boundary for native and JCache near-cache variants is tracked

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/JCacheEntryEventListener.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/JCacheEntryEventListener.kt
@@ -29,7 +29,7 @@ import javax.cache.event.CacheEntryUpdatedListener
  * @property targetCache [javax.cache.event.CacheEntryEvent]가 반영될 Local Cache
  * @property eventHandler 선택적으로 이벤트 적용 경계를 호출하는 핸들러
  */
-class JCacheEntryEventListener<K, V>(
+class JCacheEntryEventListener<K, V> @JvmOverloads constructor(
     private val targetCache: JCache<K, V>,
     private val eventHandler: ((EventType, List<CacheEntryEvent<out K, out V>>) -> Unit)? = null,
 ): CacheEntryCreatedListener<K, V>,

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/JCacheEntryEventListener.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/JCacheEntryEventListener.kt
@@ -3,8 +3,10 @@ package io.bluetape4k.cache.jcache
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.logging.trace
+import java.util.concurrent.CancellationException
 import javax.cache.event.CacheEntryCreatedListener
 import javax.cache.event.CacheEntryEvent
+import javax.cache.event.EventType
 import javax.cache.event.CacheEntryExpiredListener
 import javax.cache.event.CacheEntryRemovedListener
 import javax.cache.event.CacheEntryUpdatedListener
@@ -25,9 +27,11 @@ import javax.cache.event.CacheEntryUpdatedListener
  * ```
  *
  * @property targetCache [javax.cache.event.CacheEntryEvent]가 반영될 Local Cache
+ * @property eventHandler 선택적으로 이벤트 적용 경계를 호출하는 핸들러
  */
 class JCacheEntryEventListener<K, V>(
     private val targetCache: JCache<K, V>,
+    private val eventHandler: ((EventType, List<CacheEntryEvent<out K, out V>>) -> Unit)? = null,
 ): CacheEntryCreatedListener<K, V>,
    CacheEntryUpdatedListener<K, V>,
    CacheEntryRemovedListener<K, V>,
@@ -36,57 +40,48 @@ class JCacheEntryEventListener<K, V>(
     companion object: KLogging()
 
     override fun onCreated(events: Iterable<CacheEntryEvent<out K, out V>>) {
-        log.trace {
-            "Back cache entry is created. targetCache=${targetCache.name}, events=${events.joinToString { it.asText() }}"
-        }
-        if (!targetCache.isClosed) {
-            runCatching {
-                targetCache.putAll(events.associate { it.key to it.value })
-            }.onFailure { e ->
-                log.error(e) { "Fail to put all created cache entries." }
-            }
+        handleEvents(EventType.CREATED, events) { eventList ->
+            targetCache.putAll(eventList.associate { it.key to it.value })
         }
     }
 
     override fun onUpdated(events: Iterable<CacheEntryEvent<out K, out V>>) {
-        log.trace {
-            "Back cache entry is updated. targetCache=${targetCache.name}, events=${events.joinToString { it.asText() }}"
-        }
-        if (!targetCache.isClosed) {
-            runCatching {
-                targetCache.putAll(events.associate { it.key to it.value })
-            }.onFailure { e ->
-                log.error(e) { "Fail to put all updated cache entries." }
-            }
+        handleEvents(EventType.UPDATED, events) { eventList ->
+            targetCache.putAll(eventList.associate { it.key to it.value })
         }
     }
 
     override fun onRemoved(events: Iterable<CacheEntryEvent<out K, out V>>) {
-        log.trace {
-            "Back cache entry is removed. targetCache=${targetCache.name}, events=${events.joinToString { it.asText() }}"
-        }
-        if (!targetCache.isClosed) {
-            runCatching {
-                targetCache.removeAll(events.map { it.key }.toSet())
-            }.onFailure { e ->
-                log.error(e) { "Fail to remove all removed cache entries." }
-            }
+        handleEvents(EventType.REMOVED, events) { eventList ->
+            targetCache.removeAll(eventList.map { it.key }.toSet())
         }
     }
 
     override fun onExpired(events: Iterable<CacheEntryEvent<out K, out V>>) {
-        log.trace {
-            "Back cache entry is expired. targetCache=${targetCache.name}, events=${events.joinToString { it.asText() }}"
-        }
-        if (!targetCache.isClosed) {
-            runCatching {
-                targetCache.removeAll(events.map { it.key }.toSet())
-            }.onFailure { e ->
-                log.error(e) { "Fail to remove all expired cache entries." }
-            }
+        handleEvents(EventType.EXPIRED, events) { eventList ->
+            targetCache.removeAll(eventList.map { it.key }.toSet())
         }
     }
 
-    private fun <K, V> CacheEntryEvent<K, V>.asText(): String =
-        "source=$source, key=$key, value=$value"
+    @Suppress("TooGenericExceptionCaught")
+    private fun handleEvents(
+        eventType: EventType,
+        events: Iterable<CacheEntryEvent<out K, out V>>,
+        defaultHandler: (List<CacheEntryEvent<out K, out V>>) -> Unit,
+    ) {
+        val eventList = events.toList()
+        log.trace {
+            "Back cache event received. type=$eventType, targetCache=${targetCache.name}, " +
+                    "eventCount=${eventList.size}"
+        }
+        if (targetCache.isClosed) return
+
+        try {
+            eventHandler?.invoke(eventType, eventList) ?: defaultHandler(eventList)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: RuntimeException) {
+            log.error(e) { "Failed to apply back cache event. type=$eventType, eventCount=${eventList.size}" }
+        }
+    }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -74,6 +74,13 @@ class NearJCache<K: Any, V: Any>(
     val backCache: JCache<K, V>,
     private val config: NearJCacheConfig<K, V>,
 ): JCache<K, V> by backCache {
+    init {
+        require(!config.frontCacheConfiguration.isStoreByValue) {
+            "NearJCache front cache must use store-by-reference; " +
+                    "configure a filtered copier before enabling store-by-value"
+        }
+    }
+
     companion object: KLogging() {
         /** Redis SCAN 명령의 배치 크기 */
         const val SCAN_BATCH_SIZE = 100L
@@ -121,6 +128,10 @@ class NearJCache<K: Any, V: Any>(
     }
 
     private val lock = ReentrantLock()
+    private val mutationGate = ReentrantLock()
+    private val backWriteLock = ReentrantLock(true)
+    private val mutationEpoch = AtomicLong()
+    private val backWriteGeneration = AtomicLong()
     private data class BackCacheWriteState(
         val operationId: Long,
         val operation: String,
@@ -171,8 +182,19 @@ class NearJCache<K: Any, V: Any>(
     override fun iterator(): MutableIterator<Cache.Entry<K, V>> = frontCache.iterator()
 
     override fun clear() {
-        log.debug { "Near Cache의 Front cache를 Clear합니다." }
-        runCatching { frontCache.clear() }
+        mutationGate.withLock {
+            mutationEpoch.incrementAndGet()
+            val expectedBackWriteGeneration = backWriteGeneration.incrementAndGet()
+            log.debug { "Near Cache의 Front와 Back cache를 Clear합니다." }
+            frontCache.clear()
+            syncBackCache(
+                operation = "clear",
+                synchronous = true,
+                expectedBackWriteGeneration = expectedBackWriteGeneration,
+            ) {
+                backCache.clear()
+            }
+        }
     }
 
     /**
@@ -194,10 +216,7 @@ class NearJCache<K: Any, V: Any>(
             "front cache, back cache 모두 clear 합니다. 단 back cache 를 공유한 다른 near cache에는 전파되지 않습니다. " +
                     "전파를 위해서는 removeAll을 사용하세요"
         }
-        frontCache.clear()
-        syncBackCache("clearAllCache", synchronous = true) {
-            backCache.clear()
-        }
+        clear()
     }
 
     override fun close() {
@@ -211,44 +230,99 @@ class NearJCache<K: Any, V: Any>(
 
     override fun isClosed(): Boolean = frontCache.isClosed
 
-    // clear()는 front만 비우므로 containsKey()도 front만 확인하는 것이 의도된 동작
-    override fun containsKey(key: K): Boolean = frontCache.containsKey(key)
-
-    override operator fun get(key: K): V? { // 모든 조회는 Front 에서만 한다
-        return frontCache.get(key)
+    /**
+     * 논리적 2-tier 캐시에서 키의 존재 여부를 확인합니다.
+     *
+     * 값 자체를 읽거나 Front Cache를 채우지 않고 Front, Back 순서로 확인합니다.
+     */
+    override fun containsKey(key: K): Boolean {
+        if (mutationGate.withLock { frontCache.containsKey(key) }) {
+            return true
+        }
+        return backCache.containsKey(key)
     }
 
     /**
-     * Front Cache에서 값을 우선 조회하고, 없으면 Back Cache까지 조회합니다.
+     * Front Cache를 먼저 조회하고 miss이면 Back Cache에서 읽어 Front Cache에 채웁니다.
      *
-     * Back Cache에서 값을 찾은 경우 Front Cache에 채워 넣어 이후 조회를 빠르게 처리합니다.
+     * Back 조회와 Front mutation이 겹쳐 epoch가 변경되면 오래된 값을 Front에 채우지
+     * 않습니다. Front populate 실패 중 [RuntimeException]은 Back에서 확보한 값을
+     * 호출자에게 반환하고, [Error]와 Back 조회 예외는 숨기지 않습니다.
+     */
+    override operator fun get(key: K): V? {
+        val (frontValue, observedEpoch) = mutationGate.withLock {
+            frontCache.get(key) to mutationEpoch.get()
+        }
+        if (frontValue != null) {
+            return frontValue
+        }
+
+        val backValue = backCache.get(key) ?: return null
+        mutationGate.withLock {
+            if (mutationEpoch.get() == observedEpoch) {
+                try {
+                    frontCache.put(key, backValue)
+                } catch (e: RuntimeException) {
+                    log.warn(e) {
+                        "NearJCache front populate failed. operation=get, " +
+                                "cache=${config.cacheName}, provider=${frontCache.javaClass.name}"
+                    }
+                }
+            }
+        }
+        return backValue
+    }
+
+    /**
+     * 표준 [Cache.get]과 동일한 논리적 2-tier read-through를 수행합니다.
      *
      * ```kotlin
      * val nearCache = NearJCache(frontCache, backCache, config)
      * nearCache.put("hello", 5)
-     * nearCache.clear()  // front만 비움
+     * nearCache.clear()
      * val value = nearCache.getDeeply("hello")
-     * // value == 5  (back cache에서 조회 후 front에 채워 넣음)
+     * // value == null
      * ```
      *
      * @param key 조회할 캐시 키
      * @return 조회된 값, 없으면 `null`
      */
-    fun getDeeply(key: K): V? =
-        frontCache.get(key)
-            ?: backCache.get(key)?.also { value ->
-                runCatching { frontCache.put(key, value) }
-            }
+    fun getDeeply(key: K): V? = get(key)
 
     fun getAll(vararg keys: K): MutableMap<K, V> = getAll(keys.toSet())
 
-    override fun getAll(keys: Set<K>): MutableMap<K, V> { // 모든 조회는 Front 에서만 한다
-        return frontCache.getAll(keys)
+    override fun getAll(keys: Set<K>): MutableMap<K, V> {
+        val (frontValues, missingKeys, observedEpoch) = mutationGate.withLock {
+            val values = frontCache.getAll(keys)
+            val missing = keys.filterNot(values::containsKey).toSet()
+            Triple(values, missing, mutationEpoch.get())
+        }
+        if (missingKeys.isEmpty()) {
+            return frontValues
+        }
+
+        val backValues = backCache.getAll(missingKeys)
+        if (backValues.isNotEmpty()) {
+            mutationGate.withLock {
+                if (mutationEpoch.get() == observedEpoch) {
+                    try {
+                        frontCache.putAll(backValues)
+                    } catch (e: RuntimeException) {
+                        log.warn(e) {
+                            "NearJCache front populate failed. operation=getAll, " +
+                                    "cache=${config.cacheName}, provider=${frontCache.javaClass.name}"
+                        }
+                    }
+                }
+            }
+        }
+
+        return frontValues.toMutableMap().apply { putAll(backValues) }
     }
 
     override fun getAndRemove(key: K): V? {
-        if (containsKey(key)) {
-            val oldValue = get(key)
+        if (frontContainsKey(key)) {
+            val oldValue = frontGet(key)
             remove(key)
             return oldValue
         }
@@ -257,9 +331,9 @@ class NearJCache<K: Any, V: Any>(
 
     override fun getAndReplace(key: K, value: V): V? {
         log.trace { "get and replace. key=$key" }
-        if (containsKey(key)) {
+        if (frontContainsKey(key)) {
             log.trace { "get entry, and put new value. key=$key, new value=$value" }
-            val oldValue = get(key)
+            val oldValue = frontGet(key)
             put(key, value)
             return oldValue
         }
@@ -271,43 +345,54 @@ class NearJCache<K: Any, V: Any>(
     }
 
     override fun put(key: K, value: V) {
-        frontCache.put(key, value)
-        syncBackCache("put") {
-            backCache.put(key, value)
+        mutationGate.withLock {
+            mutationEpoch.incrementAndGet()
+            frontCache.put(key, value)
+            syncBackCache("put", expectedBackWriteGeneration = backWriteGeneration.get()) {
+                backCache.put(key, value)
+            }
         }
     }
 
     override fun putAll(map: Map<out K, V>) {
-        frontCache.putAll(map)
-        syncBackCache("putAll") {
-            backCache.putAll(map)
+        mutationGate.withLock {
+            mutationEpoch.incrementAndGet()
+            frontCache.putAll(map)
+            syncBackCache("putAll", expectedBackWriteGeneration = backWriteGeneration.get()) {
+                backCache.putAll(map)
+            }
         }
     }
 
-    override fun putIfAbsent(key: K, value: V): Boolean =
-        frontCache.putIfAbsent(key, value).also {
-            if (it) {
-                syncBackCache("putIfAbsent") {
+    override fun putIfAbsent(key: K, value: V): Boolean = mutationGate.withLock {
+        frontCache.putIfAbsent(key, value).also { inserted ->
+            if (inserted) {
+                mutationEpoch.incrementAndGet()
+                syncBackCache("putIfAbsent", expectedBackWriteGeneration = backWriteGeneration.get()) {
                     if (!backCache.containsKey(key)) {
                         backCache.put(key, value)
                     }
                 }
             }
         }
+    }
 
-    override fun remove(key: K): Boolean =
-        frontCache.remove(key).also {
-            if (it) {
-                syncBackCache("remove") {
+    override fun remove(key: K): Boolean = mutationGate.withLock {
+        frontCache.remove(key).also { removed ->
+            if (removed) {
+                mutationEpoch.incrementAndGet()
+                syncBackCache("remove", expectedBackWriteGeneration = backWriteGeneration.get()) {
                     backCache.remove(key)
                 }
             }
         }
+    }
 
-    override fun remove(key: K, oldValue: V): Boolean =
-        frontCache.remove(key, oldValue).also {
-            if (it) {
-                syncBackCache("remove(key, oldValue)") {
+    override fun remove(key: K, oldValue: V): Boolean = mutationGate.withLock {
+        frontCache.remove(key, oldValue).also { removed ->
+            if (removed) {
+                mutationEpoch.incrementAndGet()
+                syncBackCache("remove(key, oldValue)", expectedBackWriteGeneration = backWriteGeneration.get()) {
                     // Back cache listener 전파를 remove(key) 경로로 통일하기 위해 값 비교 후 단일 키 삭제를 사용한다.
                     if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
                         backCache.remove(key)
@@ -315,10 +400,13 @@ class NearJCache<K: Any, V: Any>(
                 }
             }
         }
+    }
 
     override fun removeAll() {
-        frontCache.removeAll().apply {
-            syncBackCache("removeAll") {
+        mutationGate.withLock {
+            mutationEpoch.incrementAndGet()
+            frontCache.removeAll()
+            syncBackCache("removeAll", expectedBackWriteGeneration = backWriteGeneration.get()) {
                 // Redisson 에서는 bulk operation 의 경우 event 가 발생하지 않습니다!!!
                 val failures = backCache
                     .chunked(REMOVE_BATCH_SIZE)
@@ -329,8 +417,10 @@ class NearJCache<K: Any, V: Any>(
     }
 
     override fun removeAll(keys: Set<K>) {
-        frontCache.removeAll(keys).apply {
-            syncBackCache("removeAll(keys)") {
+        mutationGate.withLock {
+            mutationEpoch.incrementAndGet()
+            frontCache.removeAll(keys)
+            syncBackCache("removeAll(keys)", expectedBackWriteGeneration = backWriteGeneration.get()) {
                 // Redisson 에서는 bulk operation 의 경우 event 가 발생하지 않습니다!!!
                 val failures = removeBackCacheEntries(keys)
                 throwIfFailures("removeAll(keys)", failures)
@@ -354,21 +444,27 @@ class NearJCache<K: Any, V: Any>(
         removeAll(keys.toSet())
     }
 
-    override fun replace(key: K, oldValue: V, newValue: V): Boolean =
-        frontCache.replace(key, oldValue, newValue).also {
-            if (it) {
-                syncBackCache("replace(key, oldValue, newValue)") {
+    override fun replace(key: K, oldValue: V, newValue: V): Boolean = mutationGate.withLock {
+        frontCache.replace(key, oldValue, newValue).also { replaced ->
+            if (replaced) {
+                mutationEpoch.incrementAndGet()
+                syncBackCache(
+                    "replace(key, oldValue, newValue)",
+                    expectedBackWriteGeneration = backWriteGeneration.get()
+                ) {
                     if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
                         backCache.put(key, newValue)
                     }
                 }
             }
         }
+    }
 
-    override fun replace(key: K, value: V): Boolean =
-        frontCache.replace(key, value).also {
-            if (it) {
-                syncBackCache("replace") {
+    override fun replace(key: K, value: V): Boolean = mutationGate.withLock {
+        frontCache.replace(key, value).also { replaced ->
+            if (replaced) {
+                mutationEpoch.incrementAndGet()
+                syncBackCache("replace", expectedBackWriteGeneration = backWriteGeneration.get()) {
                     // Redisson 에서는 replace 가 event 를 발생시키지 않습니다.
                     if (backCache.containsKey(key)) {
                         backCache.put(key, value)
@@ -376,6 +472,7 @@ class NearJCache<K: Any, V: Any>(
                 }
             }
         }
+    }
 
     override fun <T: Any> unwrap(clazz: Class<T>): T? {
         if (clazz.isAssignableFrom(javaClass)) {
@@ -420,13 +517,21 @@ class NearJCache<K: Any, V: Any>(
     private fun syncBackCache(
         operation: String,
         synchronous: Boolean = config.isSynchronous,
+        expectedBackWriteGeneration: Long = backWriteGeneration.get(),
         syncTask: () -> Unit,
     ): CompletableFuture<Unit> {
         val completion = CompletableFuture<Unit>()
         publishBackCacheWrite(operation, completion)
+        val guardedSyncTask = {
+            backWriteLock.withLock {
+                if (expectedBackWriteGeneration == backWriteGeneration.get()) {
+                    syncTask()
+                }
+            }
+        }
         if (synchronous) {
             return try {
-                syncTask()
+                guardedSyncTask()
                 completion.complete(Unit)
                 completion
             } catch (e: RuntimeException) {
@@ -444,9 +549,17 @@ class NearJCache<K: Any, V: Any>(
                 NearJCacheConfig.MAX_SYNC_REMOTE_RETRY_COUNT
             ),
             completion = completion,
-            syncTask = syncTask,
+            syncTask = guardedSyncTask,
         )
         return completion
+    }
+
+    private fun frontContainsKey(key: K): Boolean = mutationGate.withLock {
+        frontCache.containsKey(key)
+    }
+
+    private fun frontGet(key: K): V? = mutationGate.withLock {
+        frontCache.get(key)
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.cache.jcache.JCacheEntryEventListener
+import io.bluetape4k.cache.jcache.getConfiguration
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
@@ -21,7 +22,11 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import javax.cache.Cache
+import javax.cache.configuration.CacheEntryListenerConfiguration
+import javax.cache.configuration.Configuration
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration
+import javax.cache.event.CacheEntryEvent
+import javax.cache.event.EventType
 import kotlin.concurrent.withLock
 
 /**
@@ -69,6 +74,7 @@ data class BackCacheWriteCompletion(
  * @see NearJCacheConfig
  * @see io.bluetape4k.cache.jcache.JCacheEntryEventListener
  */
+@Suppress("TooManyFunctions")
 class NearJCache<K: Any, V: Any>(
     val frontCache: JCache<K, V>,
     val backCache: JCache<K, V>,
@@ -78,6 +84,10 @@ class NearJCache<K: Any, V: Any>(
         require(!config.frontCacheConfiguration.isStoreByValue) {
             "NearJCache front cache must use store-by-reference; " +
                     "configure a filtered copier before enabling store-by-value"
+        }
+        require(!frontCache.getConfiguration<K, V, Configuration<K, V>>().isStoreByValue) {
+            "NearJCache actual front cache must use store-by-reference; " +
+                    "the supplied cache configuration is store-by-value"
         }
     }
 
@@ -100,10 +110,15 @@ class NearJCache<K: Any, V: Any>(
          * @param backCache 분산 환경에서 사용할 원격 캐시 인스턴스
          * @return [NearJCache] 인스턴스
          */
+        @Suppress("TooGenericExceptionCaught")
         operator fun <K: Any, V: Any> invoke(
             nearCacheCfg: NearJCacheConfig<K, V>,
             backCache: JCache<K, V>,
         ): NearJCache<K, V> {
+            require(!nearCacheCfg.frontCacheConfiguration.isStoreByValue) {
+                "NearJCache front cache must use store-by-reference; " +
+                        "configure a filtered copier before enabling store-by-value"
+            }
             val frontCacheManager = nearCacheCfg.cacheManagerFactory.create()
 
             // back cache의 event를 수신하여 반영할 front cache 생성
@@ -111,27 +126,29 @@ class NearJCache<K: Any, V: Any>(
             val frontCache =
                 frontCacheManager.createCache(nearCacheCfg.cacheName, nearCacheCfg.frontCacheConfiguration)
 
-            // back cache의 event를 받아 front cache에 반영합니다.
-            val jCacheEntryEventListenerCfg =
-                MutableCacheEntryListenerConfiguration(
-                    { JCacheEntryEventListener(frontCache) },
-                    null,
-                    false,
-                    nearCacheCfg.isSynchronous
-                )
-            log.info { "back cache의 이벤트를 수신할 수 있도록 listener 등록. listenerCfg=$jCacheEntryEventListenerCfg" }
-            backCache.registerCacheEntryListener(jCacheEntryEventListenerCfg)
-
             log.info { "Create NearCache instance. config=$nearCacheCfg" }
-            return NearJCache(frontCache, backCache, nearCacheCfg)
+            return try {
+                NearJCache(frontCache, backCache, nearCacheCfg).also {
+                    it.registerBackCacheListener()
+                }
+            } catch (e: RuntimeException) {
+                runCatching { frontCache.close() }
+                throw e
+            }
         }
     }
 
     private val lock = ReentrantLock()
     private val mutationGate = ReentrantLock()
     private val backWriteLock = ReentrantLock(true)
+    private val listenerRegistrationLock = ReentrantLock()
     private val mutationEpoch = AtomicLong()
     private val backWriteGeneration = AtomicLong()
+    private class BackCacheListenerRegistration<K: Any, V: Any>(
+        val configuration: CacheEntryListenerConfiguration<K, V>,
+        val active: AtomicReference<Boolean> = AtomicReference(true),
+    )
+    private val backCacheListener = AtomicReference<BackCacheListenerRegistration<K, V>?>(null)
     private data class BackCacheWriteState(
         val operationId: Long,
         val operation: String,
@@ -182,17 +199,58 @@ class NearJCache<K: Any, V: Any>(
     override fun iterator(): MutableIterator<Cache.Entry<K, V>> = frontCache.iterator()
 
     override fun clear() {
-        mutationGate.withLock {
-            mutationEpoch.incrementAndGet()
-            val expectedBackWriteGeneration = backWriteGeneration.incrementAndGet()
-            log.debug { "Near Cache의 Front와 Back cache를 Clear합니다." }
-            frontCache.clear()
-            syncBackCache(
-                operation = "clear",
-                synchronous = true,
-                expectedBackWriteGeneration = expectedBackWriteGeneration,
-            ) {
-                backCache.clear()
+        val hadBackCacheListener = backCacheListener.get() != null
+        detachBackCacheListener()
+        try {
+            mutationGate.withLock {
+                mutationEpoch.incrementAndGet()
+                val expectedBackWriteGeneration = backWriteGeneration.incrementAndGet()
+                log.debug { "Near Cache의 Front와 Back cache를 Clear합니다." }
+                frontCache.clear()
+                syncBackCache(
+                    operation = "clear",
+                    synchronous = true,
+                    expectedBackWriteGeneration = expectedBackWriteGeneration,
+                ) {
+                    backCache.clear()
+                }
+            }
+        } finally {
+            if (hadBackCacheListener) registerBackCacheListener()
+        }
+    }
+
+    /**
+     * Back Cache 이벤트를 이 NearJCache의 mutation gate로 연결합니다.
+     *
+     * 기본 팩토리는 자동으로 호출합니다. 직접 생성자를 사용하는 외부 팩토리는
+     * 이벤트 기반 Front 동기화가 필요할 때 한 번 호출해야 하며, 이미 등록된 경우
+     * 중복 등록하지 않습니다.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    fun registerBackCacheListener() {
+        listenerRegistrationLock.withLock {
+            if (backCacheListener.get() != null) return
+
+            lateinit var registration: BackCacheListenerRegistration<K, V>
+            val listener = JCacheEntryEventListener<K, V>(frontCache) { eventType, events ->
+                applyBackCacheEvents(registration, eventType, events)
+            }
+            val configuration = MutableCacheEntryListenerConfiguration(
+                { listener },
+                null,
+                false,
+                config.isSynchronous
+            )
+            registration = BackCacheListenerRegistration(configuration)
+            backCacheListener.set(registration)
+            try {
+                log.info { "back cache 이벤트 listener 등록. cache=${config.cacheName}" }
+                backCache.registerCacheEntryListener(configuration)
+            } catch (e: RuntimeException) {
+                backCacheListener.compareAndSet(registration, null)
+                registration.active.set(false)
+                throw e
             }
         }
     }
@@ -220,6 +278,7 @@ class NearJCache<K: Any, V: Any>(
     }
 
     override fun close() {
+        detachBackCacheListener()
         lock.withLock {
             log.debug { "Near Cache 의 Front Cache를 Close 합니다." }
             runCatching {
@@ -249,6 +308,7 @@ class NearJCache<K: Any, V: Any>(
      * 않습니다. Front populate 실패 중 [RuntimeException]은 Back에서 확보한 값을
      * 호출자에게 반환하고, [Error]와 Back 조회 예외는 숨기지 않습니다.
      */
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
     override operator fun get(key: K): V? {
         val (frontValue, observedEpoch) = mutationGate.withLock {
             frontCache.get(key) to mutationEpoch.get()
@@ -262,6 +322,8 @@ class NearJCache<K: Any, V: Any>(
             if (mutationEpoch.get() == observedEpoch) {
                 try {
                     frontCache.put(key, backValue)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: RuntimeException) {
                     log.warn(e) {
                         "NearJCache front populate failed. operation=get, " +
@@ -291,6 +353,7 @@ class NearJCache<K: Any, V: Any>(
 
     fun getAll(vararg keys: K): MutableMap<K, V> = getAll(keys.toSet())
 
+    @Suppress("TooGenericExceptionCaught")
     override fun getAll(keys: Set<K>): MutableMap<K, V> {
         val (frontValues, missingKeys, observedEpoch) = mutationGate.withLock {
             val values = frontCache.getAll(keys)
@@ -307,6 +370,8 @@ class NearJCache<K: Any, V: Any>(
                 if (mutationEpoch.get() == observedEpoch) {
                     try {
                         frontCache.putAll(backValues)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: RuntimeException) {
                         log.warn(e) {
                             "NearJCache front populate failed. operation=getAll, " +
@@ -536,6 +601,10 @@ class NearJCache<K: Any, V: Any>(
                 completion
             } catch (e: RuntimeException) {
                 completion.completeExceptionally(e)
+                log.error(e) {
+                    "NearJCache synchronous back cache write failed. operation=$operation, " +
+                            "cache=${config.cacheName}, provider=${backCache.javaClass.name}"
+                }
                 throw e
             }
         }
@@ -636,4 +705,30 @@ class NearJCache<K: Any, V: Any>(
             is CompletionException, is ExecutionException -> error.cause ?: error
             else -> error
         }
+
+    private fun detachBackCacheListener() {
+        listenerRegistrationLock.withLock {
+            val registration = backCacheListener.getAndSet(null) ?: return
+            registration.active.set(false)
+            backCache.deregisterCacheEntryListener(registration.configuration)
+        }
+    }
+
+    private fun applyBackCacheEvents(
+        registration: BackCacheListenerRegistration<K, V>,
+        eventType: EventType,
+        events: List<CacheEntryEvent<out K, out V>>,
+    ) {
+        if (!registration.active.get()) return
+        mutationGate.withLock {
+            if (!registration.active.get() || backCacheListener.get() !== registration) return
+            mutationEpoch.incrementAndGet()
+            when (eventType) {
+                EventType.CREATED, EventType.UPDATED ->
+                    frontCache.putAll(events.associate { it.key to it.value })
+                EventType.REMOVED, EventType.EXPIRED ->
+                    frontCache.removeAll(events.map { it.key }.toSet())
+            }
+        }
+    }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt
@@ -85,6 +85,7 @@ data class NearJCacheConfig<K: Any, V: Any>(
          */
         fun <K, V> getDefaultFrontCacheConfiguration(): MutableConfiguration<K, V> =
             MutableConfiguration<K, V>().apply {
+                setStoreByValue(false)
                 setExpiryPolicyFactory { AccessedExpiryPolicy(Duration.THIRTY_MINUTES) }
             }
     }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
@@ -304,7 +304,9 @@ class NearJCacheContractTest {
         every { frontCache.putAll(mapOf("key" to "value")) } throws failure
         val nearCache = newNearCache(frontCache, backCache)
 
-        assertFailsWith<CancellationException> { nearCache.getAll(setOf("key")) }.message shouldBeEqualTo failure.message
+        assertFailsWith<CancellationException> {
+            nearCache.getAll(setOf("key"))
+        }.message shouldBeEqualTo failure.message
     }
 
     @Test

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
@@ -1,0 +1,308 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.concurrent.virtualthread.virtualThread
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.cache.Cache
+import javax.cache.configuration.MutableConfiguration
+
+class NearJCacheContractTest {
+
+    @Test
+    fun `표준 Cache get은 back miss를 fallback하고 front를 채운다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.get("remote") } returns null
+        every { backCache.get("remote") } returns "back-value"
+        val standardCache: Cache<String, String> = newNearCache(frontCache, backCache)
+
+        standardCache.get("remote") shouldBeEqualTo "back-value"
+
+        verify(exactly = 1) { frontCache.put("remote", "back-value") }
+    }
+
+    @Test
+    fun `표준 Cache containsKey는 front miss를 back에서 확인한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.containsKey("remote") } returns false
+        every { backCache.containsKey("remote") } returns true
+        val standardCache: Cache<String, String> = newNearCache(frontCache, backCache)
+
+        standardCache.containsKey("remote").shouldBeTrue()
+
+        verify(exactly = 1) { backCache.containsKey("remote") }
+        verify(exactly = 0) { backCache.get("remote") }
+    }
+
+    @Test
+    fun `표준 Cache getAll은 front와 back 결과를 한 번씩 병합하고 populate한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.getAll(setOf("front", "remote")) } returns
+                mutableMapOf("front" to "front-value")
+        every { backCache.getAll(setOf("remote")) } returns
+                mutableMapOf("remote" to "back-value")
+        val standardCache: Cache<String, String> = newNearCache(frontCache, backCache)
+
+        val result = standardCache.getAll(setOf("front", "remote"))
+
+        result shouldBeEqualTo mapOf("front" to "front-value", "remote" to "back-value")
+        verify(exactly = 1) { backCache.getAll(setOf("remote")) }
+        verify(exactly = 1) { frontCache.putAll(mapOf("remote" to "back-value")) }
+    }
+
+    @Test
+    fun `표준 Cache getAll은 front hit만 있으면 back을 조회하지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.getAll(setOf("front")) } returns mutableMapOf("front" to "front-value")
+        val standardCache: Cache<String, String> = newNearCache(frontCache, backCache)
+
+        standardCache.getAll(setOf("front")) shouldBeEqualTo mapOf("front" to "front-value")
+
+        verify(exactly = 0) { backCache.getAll(any()) }
+        verify(exactly = 0) { frontCache.putAll(any()) }
+    }
+
+    @Test
+    fun `표준 Cache clear는 front와 back을 함께 지운다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val standardCache: Cache<String, String> = newNearCache(frontCache, backCache)
+
+        standardCache.clear()
+
+        verify(exactly = 1) { frontCache.clear() }
+        verify(exactly = 1) { backCache.clear() }
+    }
+
+    @Test
+    fun `기존 getDeeply와 clearAllCache는 표준 get과 clear alias다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.get("remote") } returns null
+        every { backCache.get("remote") } returns "back-value"
+        val nearCache = newNearCache(frontCache, backCache)
+
+        nearCache.getDeeply("remote") shouldBeEqualTo "back-value"
+        nearCache.clearAllCache()
+
+        verify(exactly = 1) { frontCache.put("remote", "back-value") }
+        verify(exactly = 1) { frontCache.clear() }
+        verify(exactly = 1) { backCache.clear() }
+    }
+
+    @Test
+    fun `read-through가 mutation 이후 완료되면 stale 값을 front에 넣지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val readStarted = CountDownLatch(1)
+        val releaseRead = CountDownLatch(1)
+        every { frontCache.get("key") } returns null
+        every { backCache.get("key") } answers {
+            readStarted.countDown()
+            releaseRead.await(2, TimeUnit.SECONDS)
+            "stale"
+        }
+        val nearCache = newNearCache(frontCache, backCache)
+        val result = arrayOfNulls<String>(1)
+        val reader = virtualThread(start = false, name = "near-jcache-stale-read") {
+            result[0] = nearCache.get("key")
+        }
+
+        reader.start()
+        readStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+        nearCache.put("key", "fresh")
+        releaseRead.countDown()
+        reader.join(2_000)
+
+        result[0] shouldBeEqualTo "stale"
+        verify(exactly = 1) { frontCache.put("key", "fresh") }
+        verify(exactly = 0) { frontCache.put("key", "stale") }
+    }
+
+    @Test
+    fun `getAll read-through가 mutation 이후 완료되면 stale 값을 front에 넣지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val readStarted = CountDownLatch(1)
+        val releaseRead = CountDownLatch(1)
+        every { frontCache.getAll(setOf("key")) } returns mutableMapOf()
+        every { backCache.getAll(setOf("key")) } answers {
+            readStarted.countDown()
+            releaseRead.await(2, TimeUnit.SECONDS)
+            mutableMapOf("key" to "stale")
+        }
+        val nearCache = newNearCache(frontCache, backCache)
+        val result = arrayOfNulls<MutableMap<String, String>>(1)
+        val reader = virtualThread(start = false, name = "near-jcache-stale-get-all") {
+            result[0] = nearCache.getAll(setOf("key"))
+        }
+
+        reader.start()
+        readStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+        nearCache.put("key", "fresh")
+        releaseRead.countDown()
+        reader.join(2_000)
+
+        result[0] shouldBeEqualTo mapOf("key" to "stale")
+        verify(exactly = 1) { frontCache.put("key", "fresh") }
+        verify(exactly = 0) { frontCache.putAll(mapOf("key" to "stale")) }
+    }
+
+    @Test
+    fun `read-through가 clear 이후 완료되면 stale 값을 front에 넣지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val readStarted = CountDownLatch(1)
+        val releaseRead = CountDownLatch(1)
+        every { frontCache.get("key") } returns null
+        every { backCache.get("key") } answers {
+            readStarted.countDown()
+            releaseRead.await(2, TimeUnit.SECONDS)
+            "stale"
+        }
+        val nearCache = newNearCache(frontCache, backCache)
+        val result = arrayOfNulls<String>(1)
+        val reader = virtualThread(start = false, name = "near-jcache-clear-read") {
+            result[0] = nearCache.get("key")
+        }
+
+        reader.start()
+        readStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+        nearCache.clear()
+        releaseRead.countDown()
+        reader.join(2_000)
+
+        result[0] shouldBeEqualTo "stale"
+        verify(exactly = 0) { frontCache.put("key", "stale") }
+    }
+
+    @Test
+    fun `clear는 timeout 이후에도 실행 중인 back write가 끝날 때까지 기다린다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val writeStarted = CountDownLatch(1)
+        val releaseWrite = CountDownLatch(1)
+        every { backCache.put("key", "value") } answers {
+            writeStarted.countDown()
+            releaseWrite.await(2, TimeUnit.SECONDS)
+        }
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false, syncRemoteTimeout = 1L),
+            )
+        nearCache.put("key", "value")
+        writeStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+
+        val clearFinished = CountDownLatch(1)
+        val clearer = virtualThread(start = false, name = "near-jcache-clear-barrier") {
+            nearCache.clear()
+            clearFinished.countDown()
+        }
+        clearer.start()
+        clearFinished.await(100, TimeUnit.MILLISECONDS).shouldBeFalse()
+
+        releaseWrite.countDown()
+        clearFinished.await(2, TimeUnit.SECONDS).shouldBeTrue()
+        verify(exactly = 1) { backCache.clear() }
+    }
+
+    @Test
+    fun `front populate RuntimeException은 back read 결과를 숨기지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.get("key") } returns null
+        every { backCache.get("key") } returns "value"
+        every { frontCache.put("key", "value") } throws IllegalStateException("front unavailable")
+        val nearCache = newNearCache(frontCache, backCache)
+
+        nearCache.get("key") shouldBeEqualTo "value"
+    }
+
+    @Test
+    fun `front populate Error는 숨기지 않고 재전파한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val failure = AssertionError("front linkage failure")
+        every { frontCache.get("key") } returns null
+        every { backCache.get("key") } returns "value"
+        every { frontCache.put("key", "value") } throws failure
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<AssertionError> { nearCache.get("key") }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `front clear 실패는 back clear를 실행하지 않고 호출자에게 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.clear() } throws IllegalStateException("front unavailable")
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.clear() }
+
+        verify(exactly = 0) { backCache.clear() }
+    }
+
+    @Test
+    fun `기본 front 설정은 store by reference다`() {
+        NearJCacheConfig.getDefaultFrontCacheConfiguration<String, String>().isStoreByValue.shouldBeFalse()
+    }
+
+    @Test
+    fun `store by value front 설정은 생성 단계에서 거부한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val configuration = MutableConfiguration<String, String>().setStoreByValue(true)
+
+        assertFailsWith<IllegalArgumentException> {
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(frontCacheConfiguration = configuration, isSynchronous = true),
+            )
+        }
+    }
+
+    @Test
+    fun `compound getAndRemove와 getAndReplace는 front-only read 왕복을 유지한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.containsKey("remove") } returns true
+        every { frontCache.get("remove") } returns "remove-value"
+        every { frontCache.remove("remove") } returns true
+        every { frontCache.containsKey("replace") } returns true
+        every { frontCache.get("replace") } returns "old-value"
+        every { frontCache.put("replace", "new-value") } returns Unit
+        val nearCache = newNearCache(frontCache, backCache)
+
+        nearCache.getAndRemove("remove") shouldBeEqualTo "remove-value"
+        nearCache.getAndReplace("replace", "new-value") shouldBeEqualTo "old-value"
+
+        verify(exactly = 0) { backCache.containsKey(any()) }
+        verify(exactly = 0) { backCache.get(any()) }
+    }
+
+    private fun newNearCache(
+        frontCache: JCache<String, String>,
+        backCache: JCache<String, String>,
+    ): NearJCache<String, String> =
+        NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+}

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
@@ -1,19 +1,31 @@
 package io.bluetape4k.cache.nearcache.jcache
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.cache.jcache.JCacheEntryEventListener
 import io.bluetape4k.concurrent.virtualthread.virtualThread
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.cache.Cache
+import javax.cache.configuration.CacheEntryListenerConfiguration
+import javax.cache.configuration.Configuration
 import javax.cache.configuration.MutableConfiguration
+import javax.cache.event.CacheEntryEvent
+import javax.cache.event.CacheEntryCreatedListener
+import javax.cache.event.CacheEntryUpdatedListener
 
 class NearJCacheContractTest {
 
@@ -189,6 +201,43 @@ class NearJCacheContractTest {
     }
 
     @Test
+    fun `listener update가 read-through 중간에 완료되면 stale 값을 front에 넣지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val readStarted = CountDownLatch(1)
+        val releaseRead = CountDownLatch(1)
+        val listenerConfiguration = slot<CacheEntryListenerConfiguration<String, String>>()
+        every { frontCache.get("key") } returns null
+        every { backCache.get("key") } answers {
+            readStarted.countDown()
+            releaseRead.await(2, TimeUnit.SECONDS)
+            "stale"
+        }
+        every { backCache.registerCacheEntryListener(capture(listenerConfiguration)) } returns Unit
+        val nearCache = newNearCache(frontCache, backCache)
+        nearCache.registerBackCacheListener()
+        val listener = listenerConfiguration.captured.cacheEntryListenerFactory.create()
+                as CacheEntryUpdatedListener<String, String>
+        val event = mockk<CacheEntryEvent<String, String>>(relaxed = true)
+        every { event.key } returns "key"
+        every { event.value } returns "fresh-from-listener"
+        val result = arrayOfNulls<String>(1)
+        val reader = virtualThread(start = false, name = "near-jcache-listener-read") {
+            result[0] = nearCache.get("key")
+        }
+
+        reader.start()
+        readStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+        listener.onUpdated(listOf(event))
+        releaseRead.countDown()
+        reader.join(2_000)
+
+        result[0] shouldBeEqualTo "stale"
+        verify(exactly = 1) { frontCache.putAll(mapOf("key" to "fresh-from-listener")) }
+        verify(exactly = 0) { frontCache.put("key", "stale") }
+    }
+
+    @Test
     fun `clear는 timeout 이후에도 실행 중인 back write가 끝날 때까지 기다린다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
@@ -233,6 +282,32 @@ class NearJCacheContractTest {
     }
 
     @Test
+    fun `front populate CancellationException은 호출자에게 재전파한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val failure = CancellationException("caller cancelled")
+        every { frontCache.get("key") } returns null
+        every { backCache.get("key") } returns "value"
+        every { frontCache.put("key", "value") } throws failure
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<CancellationException> { nearCache.get("key") }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `getAll front populate CancellationException은 호출자에게 재전파한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val failure = CancellationException("caller cancelled")
+        every { frontCache.getAll(setOf("key")) } returns mutableMapOf()
+        every { backCache.getAll(setOf("key")) } returns mutableMapOf("key" to "value")
+        every { frontCache.putAll(mapOf("key" to "value")) } throws failure
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<CancellationException> { nearCache.getAll(setOf("key")) }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
     fun `front populate Error는 숨기지 않고 재전파한다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
@@ -243,6 +318,32 @@ class NearJCacheContractTest {
         val nearCache = newNearCache(frontCache, backCache)
 
         assertFailsWith<AssertionError> { nearCache.get("key") }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `front populate 로그에는 raw key와 value를 포함하지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.name } returns "front-cache"
+        val secretKey = "secret-key-should-not-log"
+        val secretValue = "secret-value-should-not-log"
+        val event = mockk<CacheEntryEvent<String, String>>(relaxed = true)
+        every { event.key } returns secretKey
+        every { event.value } returns secretValue
+        val logger = JCacheEntryEventListener.log as Logger
+        val previousLevel = logger.level
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.level = Level.TRACE
+        logger.addAppender(appender)
+        try {
+            JCacheEntryEventListener(frontCache).onCreated(listOf(event))
+            appender.list.map { it.formattedMessage }.all { message ->
+                !message.contains(secretKey) && !message.contains(secretValue)
+            }.shouldBeTrue()
+        } finally {
+            logger.detachAppender(appender)
+            appender.stop()
+            logger.level = previousLevel
+        }
     }
 
     @Test
@@ -275,6 +376,46 @@ class NearJCacheContractTest {
                 config = NearJCacheConfig(frontCacheConfiguration = configuration, isSynchronous = true),
             )
         }
+    }
+
+    @Test
+    fun `실제 front cache가 store by value면 설정과 무관하게 생성 단계에서 거부한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val actualConfiguration = MutableConfiguration<String, String>().setStoreByValue(true)
+        @Suppress("UNCHECKED_CAST")
+        val configurationType = Configuration::class.java as Class<Configuration<String, String>>
+        every { frontCache.getConfiguration(configurationType) } returns actualConfiguration
+
+        assertFailsWith<IllegalArgumentException> {
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = true),
+            )
+        }
+    }
+
+    @Test
+    fun `clear 이후 지연된 이전 listener event는 front를 재점유하지 않는다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val listenerConfiguration = slot<CacheEntryListenerConfiguration<String, String>>()
+        every { backCache.registerCacheEntryListener(capture(listenerConfiguration)) } returns Unit
+        val nearCache = newNearCache(frontCache, backCache)
+        nearCache.registerBackCacheListener()
+        val oldListener = listenerConfiguration.captured.cacheEntryListenerFactory.create()
+                as CacheEntryCreatedListener<String, String>
+        val event = mockk<CacheEntryEvent<String, String>>(relaxed = true)
+        every { event.key } returns "stale-key"
+        every { event.value } returns "stale-value"
+
+        nearCache.clear()
+        oldListener.onCreated(listOf(event))
+
+        verify(exactly = 0) { frontCache.putAll(any()) }
+        verify(exactly = 1) { backCache.deregisterCacheEntryListener(any()) }
+        verify(exactly = 2) { backCache.registerCacheEntryListener(any()) }
     }
 
     @Test

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt
@@ -89,7 +89,8 @@ abstract class AbstractNearJCacheTest {
 
         try {
             backCache.put(key, value)
-            nearJCache.containsKey(key).shouldBeFalse()
+            // 표준 containsKey는 Back Cache까지 조회하므로 front miss만 직접 확인합니다.
+            nearJCache.frontCache.containsKey(key).shouldBeFalse()
 
             nearJCache.getDeeply(key) shouldBeEqualTo value
             nearJCache[key] shouldBeEqualTo value
@@ -504,7 +505,7 @@ abstract class AbstractNearJCacheTest {
     }
 
     @RepeatedTest(TEST_SIZE)
-    fun `clear - cache를 clear 합니다 - front cache만 clear 될 뿐 back cache는 유지됩니다`() {
+    fun `clear - 표준 Cache clear는 현재 wrapper의 front와 back을 함께 삭제합니다`() {
         val key1 = randomKey()
         val value1 = randomValue()
         val key2 = randomKey()
@@ -516,14 +517,17 @@ abstract class AbstractNearJCacheTest {
         nearJCache2.put(key2, value2)
         await atMost (awaitTimeout) until { nearJCache1.containsKey(key2) }
 
-        // 로컬 캐시만 삭제됩니다. backCache는 삭제되지 않습니다.
         nearJCache1.clear()
 
-        // frontCache에서 containsKey 를 조회합니다.
+        // 호출한 wrapper에서는 표준 containsKey도 front/back 모두 miss입니다.
         nearJCache1.containsKey(key1).shouldBeFalse()
         nearJCache1.containsKey(key2).shouldBeFalse()
+        backCache.containsKey(key1).shouldBeFalse()
+        backCache.containsKey(key2).shouldBeFalse()
 
-        // 다른 캐시에는 전파되지 않습니다
+        // listener 없는 peer front에는 clear가 전파된다고 보장하지 않습니다.
+        nearJCache2.frontCache.containsKey(key1).shouldBeTrue()
+        nearJCache2.frontCache.containsKey(key2).shouldBeTrue()
         nearJCache2.containsKey(key1).shouldBeTrue()
         nearJCache2.containsKey(key2).shouldBeTrue()
     }

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt
@@ -252,10 +252,15 @@ object HazelcastCaches: KLogging() {
      * @param config [NearJCacheConfig] 설정
      * @return [NearJCache] 인스턴스
      */
+    @Suppress("TooGenericExceptionCaught")
     inline fun <reified K: Any, reified V: Any> nearJCache(
         hazelcastInstance: HazelcastInstance,
         config: NearJCacheConfig<K, V>,
     ): NearJCache<K, V> {
+        require(!config.frontCacheConfiguration.isStoreByValue) {
+            "NearJCache front cache must use store-by-reference; " +
+                    "configure a filtered copier before enabling store-by-value"
+        }
         val configuration = MutableConfiguration<K, V>().apply {
             setTypes(K::class.java, V::class.java)
         }
@@ -271,7 +276,12 @@ object HazelcastCaches: KLogging() {
             frontCacheManager.createCache(config.cacheName, config.frontCacheConfiguration)
 
         log.info { "NearJCache 생성. config=$config" }
-        return NearJCache(frontCache, backCache, config)
+        return try {
+            NearJCache(frontCache, backCache, config)
+        } catch (e: RuntimeException) {
+            runCatching { frontCache.close() }
+            throw e
+        }
     }
 
     /**

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
@@ -3,12 +3,10 @@ package io.bluetape4k.cache.nearcache.jcache
 import com.hazelcast.core.HazelcastInstance
 import io.bluetape4k.cache.jcache.HazelcastJCaching
 import io.bluetape4k.cache.jcache.JCache
-import io.bluetape4k.cache.jcache.JCacheEntryEventListener
 import io.bluetape4k.cache.jcache.getDefaultJCacheConfiguration
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import javax.cache.configuration.Configuration
-import javax.cache.configuration.MutableCacheEntryListenerConfiguration
 
 /**
  * Hazelcast JCache 기반 [NearJCache] 팩토리 오브젝트입니다.
@@ -54,21 +52,12 @@ object HazelcastNearJCache: KLogging() {
         configuration: Configuration<K, V> = getDefaultJCacheConfiguration(),
         nearCacheCfg: NearJCacheConfig<K, V>,
     ): NearJCache<K, V> {
-        // back cache의 event를 받아 front cache에 반영합니다.
-        val cacheEntryEventListenerCfg =
-            MutableCacheEntryListenerConfiguration(
-                { JCacheEntryEventListener(frontCache) },
-                null,
-                false,
-                nearCacheCfg.isSynchronous
-            )
-
         val backCache: JCache<K, V> =
             HazelcastJCaching.getOrCreate(hazelcastInstance, nearCacheCfg.cacheName, configuration)
-        log.info { "back cache의 이벤트를 수신할 수 있도록 listener 등록. listenerCfg=$cacheEntryEventListenerCfg" }
-        backCache.registerCacheEntryListener(cacheEntryEventListenerCfg)
 
         log.info { "Create NearCache instance. config=$nearCacheCfg" }
-        return NearJCache(frontCache, backCache, nearCacheCfg)
+        return NearJCache(frontCache, backCache, nearCacheCfg).also {
+            it.registerBackCacheListener()
+        }
     }
 }

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -36,7 +36,7 @@ class HazelcastNearJCacheTest {
         }
         failure.message shouldContain "MutableCacheEntryListenerConfiguration"
         failure.stackTraceToString() shouldContain "NotSerializableException"
-        failure.stackTraceToString() shouldContain "com.github.benmanes.caffeine.jcache.CacheProxy"
+        failure.stackTraceToString() shouldContain "JCacheEntryEventListener"
     }
 
     @Test

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -10,8 +10,16 @@ import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import com.hazelcast.nio.serialization.HazelcastSerializationException
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.testcontainers.utility.Base58
+import javax.cache.CacheManager
+import javax.cache.configuration.Configuration
+import javax.cache.configuration.Factory
 import javax.cache.configuration.MutableConfiguration
 
 class HazelcastNearJCacheTest {
@@ -37,6 +45,36 @@ class HazelcastNearJCacheTest {
         failure.message shouldContain "MutableCacheEntryListenerConfiguration"
         failure.stackTraceToString() shouldContain "NotSerializableException"
         failure.stackTraceToString() shouldContain "JCacheEntryEventListener"
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `factory closes front cache when NearJCache construction fails`() {
+        val cacheName = "hazelcast-near-jcache-failure-" + Base58.randomString(6)
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val frontCacheManager = mockk<CacheManager>()
+        val storeByValueConfiguration = MutableConfiguration<String, String>().apply {
+            setStoreByValue(true)
+        }
+        val configurationClass = Configuration::class.java as Class<Configuration<String, String>>
+        every {
+            frontCache.getConfiguration(configurationClass)
+        } returns storeByValueConfiguration
+        every { frontCache.close() } just runs
+        every {
+            frontCacheManager.createCache<String, String, MutableConfiguration<String, String>>(cacheName, any())
+        } returns frontCache
+
+        val config = NearJCacheConfig<String, String>(
+            cacheName = cacheName,
+            cacheManagerFactory = Factory { frontCacheManager },
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            HazelcastCaches.nearJCache<String, String>(hazelcastClient, config)
+        }
+
+        verify(exactly = 1) { frontCache.close() }
     }
 
     @Test

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -53,7 +53,7 @@ class HazelcastNearJCacheTest {
 
             cache.clear()
             cache.get("k").shouldBeNull()
-            cache.getDeeply("k") shouldBeEqualTo "v"
+            cache.getDeeply("k").shouldBeNull()
         } finally {
             cache.clearAllCache()
             cache.close()

--- a/docs/cache/near-cache-capability-matrix.md
+++ b/docs/cache/near-cache-capability-matrix.md
@@ -31,10 +31,23 @@ Native API는 `NearCacheOperations<V>` 또는 `SuspendNearCacheOperations<V>`를
 
 JCache API는 `NearJCache<K,V>` 또는 `SuspendNearJCache<K,V>`를 구현한다.
 
+동기 `NearJCache`의 표준 `get`, `containsKey`, `getAll`은 front miss를 back에서
+읽고 back hit를 front에 채우는 논리적 2-tier read 계약을 따른다. 표준 `clear`와
+호환 alias `clearAllCache`는 현재 wrapper의 front와 back을 함께 지운다. 공유
+back을 사용하는 peer wrapper의 기존 front까지 listener로 지우는 것은 보장하지
+않는다. `getDeeply`는 표준 `get`의 alias이며, compound 원자성은
+[#1355](https://github.com/bluetape4k/bluetape4k-projects/issues/1355)의 별도
+계약이다.
+
+`NearJCacheConfig`의 기본 front는 store-by-reference이며, 안전한 filtered copier
+계약이 없는 custom store-by-value 설정은 생성 단계에서 거부한다. read-through
+populate는 mutation epoch로 stale 값을 차단하고, clear는 timeout-late backend
+write가 끝난 뒤 back을 지우는 barrier를 사용한다.
+
 | back provider | 동기 `NearJCache` | suspend `SuspendNearJCache` | listener 등록 | peer front 전파 | removeAll 의미 | back cache 범위 | conformance |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Lettuce JCache | Supported | Supported | Supported | Supported | Supported through per-entry removal where needed | Distributed Redis | `AbstractNearJCacheTest`, `AbstractSuspendNearJCacheTest` |
-| Redisson JCache | Supported | Supported | Supported | Supported | Supported through per-entry removal where needed | Distributed Redis via Redisson | `AbstractNearJCacheTest`, `AbstractSuspendNearJCacheTest` |
+| Lettuce JCache | Supported | Supported | Supported | Supported for per-entry mutations; clear peer-front invalidation is not promised | Supported through per-entry removal where needed | Distributed Redis | `AbstractNearJCacheTest`, `AbstractSuspendNearJCacheTest` |
+| Redisson JCache | Supported | Supported | Supported | Supported for per-entry mutations; clear peer-front invalidation is not promised | Supported through per-entry removal where needed | Distributed Redis via Redisson | `AbstractNearJCacheTest`, `AbstractSuspendNearJCacheTest` |
 | Hazelcast JCache direct listener construction | Unsupported | Unsupported | Unsupported: listener configuration must be serializable for cluster distribution | Unsupported | Unsupported in listener-backed direct construction | Distributed Hazelcast JCache | Explicit unsupported tests in `cache-hazelcast` |
 | Hazelcast factory methods | Factory degraded | Factory degraded | Not registered intentionally | Not promised | `clearAllCache` / `clearAll` clear front and back for the local wrapper; listener propagation is not promised | Distributed Hazelcast JCache | Explicit factory behavior tests in `cache-hazelcast` |
 | Cache2k JCache | Supported except whole-cache `removeAll()` propagation | Not provided | Local provider listener | Same-JVM only | Whole-cache `removeAll()` propagation is explicitly unsupported by conformance test | Local JVM | `AbstractNearJCacheTest` with explicit unsupported override |

--- a/docs/lessons/2026-08-12-issue-1363-nearjcache-contract.md
+++ b/docs/lessons/2026-08-12-issue-1363-nearjcache-contract.md
@@ -1,0 +1,39 @@
+# #1363 NearJCache 표준 read/clear 계약 교훈
+
+## 결정
+
+`NearJCache`가 `javax.cache.Cache`로 노출될 때 표준 `get`, `containsKey`,
+`getAll`, `clear`도 front/back을 합친 하나의 논리적 캐시를 관찰해야 한다.
+기존 `getDeeply`와 `clearAllCache`는 각각 표준 `get`과 `clear`의 호환 alias로
+유지한다.
+
+## 실패 원인과 복구
+
+- front-only 표준 read는 back-only 값을 숨겨 JCache 호출자에게 provider마다 다른
+  결과를 보였다. 표준 read는 front miss에서 back fallback과 front populate를
+  수행하고, `getAll`은 miss set을 한 번의 back bulk 호출로 처리한다.
+- read-through 결과를 전역 mutation epoch로 fencing하되, backend write도 같은
+  epoch로 무효화하면 서로 다른 키의 정상적인 비동기 write가 사라진다. 따라서
+  read populate에는 `mutationEpoch`, clear 이전 write를 무효화하는 backend
+  barrier에는 `backWriteGeneration`을 별도로 사용한다.
+- `clear`는 mutation gate와 공정한 backend write lock을 사용한다. timeout이 먼저
+  completion을 실패시켜도 실제 backend 호출이 끝날 때까지 기다린 뒤 back을
+  삭제하므로 late write가 clear 이후 값을 부활시키지 않는다.
+- 기본 front 설정은 store-by-reference로 고정하고, 안전한 filtered copier 계약이
+  없는 custom store-by-value 설정은 생성 단계에서 거부한다. populate 실패 로그는
+  operation/provider/cache 메타데이터만 남긴다.
+
+## 검증
+
+- `NearJCacheContractTest`는 표준 `Cache` 참조의 read/clear, bulk 호출 수,
+  compound front-only 왕복, read-vs-mutation/clear latch 경합, timeout-late
+  barrier, populate 예외 경계, serialization 설정을 검증한다.
+- `cache-core` fixture는 호출 wrapper의 front/back 삭제와 listener 없는 peer
+  front의 전파 한계를 분리해 검증한다.
+- provider 검증은 Cache2k, Hazelcast, Lettuce, Redisson 순서로 실행한다.
+
+## 후속 주의
+
+공유 back cache의 tenant/owner 권한 경계와 `getAll` front residency 상한은 이번
+이슈에서 공개 설정으로 추가하지 않았다. destructive shared clear 또는 대량 bulk
+populate 정책을 바꿀 때는 별도 설계와 보안 검토를 먼저 수행해야 한다.

--- a/docs/superpowers/plans/2026-08-12-issue-1363-nearjcache-contract-plan.md
+++ b/docs/superpowers/plans/2026-08-12-issue-1363-nearjcache-contract-plan.md
@@ -63,6 +63,7 @@ Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` curr
   waits for the actual backend call before returning. Add tests that front
   population catches `RuntimeException` but rethrows `Error`, and that captured
   logs contain operation/provider metadata only (no key/value/payload). Add
+  listener update/clear-generation tests and cancellation rethrow tests. Add
   call-count tests for `getAndRemove` and `getAndReplace` proving their
   front-only helpers do not introduce the new standard back read round trips.
 
@@ -71,8 +72,9 @@ Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` curr
   Assert the default `NearJCacheConfig` sets `isStoreByValue == false` and that
   constructing `NearJCache` with a custom store-by-value front configuration
   fails closed with a clear `IllegalArgumentException` before any back value is
-  read or populated. This keeps the default auto-populate path away from an
-  unfiltered Java serialization copier.
+  read or populated. Also reject a directly supplied front cache whose actual
+  `Configuration.isStoreByValue` is true. This keeps the default auto-populate
+  path away from an unfiltered Java serialization copier.
 
 ## Task 2: Implement the two-tier contract with epoch and backend barriers (GREEN)
 

--- a/docs/superpowers/plans/2026-08-12-issue-1363-nearjcache-contract-plan.md
+++ b/docs/superpowers/plans/2026-08-12-issue-1363-nearjcache-contract-plan.md
@@ -1,0 +1,274 @@
+# NearJCache 표준 read/clear 계약 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `NearJCache`가 `javax.cache.Cache`로 참조될 때 front/back을 하나의 논리적 2-tier 캐시로 제공하도록 표준 `get`, `containsKey`, `getAll`, `clear` 계약을 구현·검증·문서화한다.
+
+**Architecture:** 기존 `NearJCache<K,V> : JCache<K,V> by backCache` 공개 타입과 `getDeeply`/`clearAllCache` 이름은 유지한다. 표준 read는 front 우선, back fallback, back 값의 front populate로 통일하고, 표준 `clear`는 현재 near-cache의 front와 back을 동기적으로 지운다. Compound operation 원자성은 이 계획에서 변경하지 않고 #1355로 분리한다.
+
+**Tech Stack:** Kotlin, JCache 1.1 (`javax.cache.Cache`), JUnit 5, MockK, Awaitility, Gradle/Kover.
+
+---
+
+## 파일 영향과 소유권
+
+- Modify: `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt` — 표준 read/clear 구현과 Korean KDoc.
+- Modify: `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt` — 기본 front cache를 store-by-reference로 고정.
+- Create: `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt` — `Cache<K,V>` 타입 경계의 결정적 mock 기반 회귀 테스트.
+- Modify: `cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt` — 기존 front-only `clear` 가정을 표준 front/back 계약과 peer 전파 경계로 전환.
+- Modify: 영향이 확인된 backend tests, 최소 `cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt` — factory degraded 조합의 clear 기대치를 새 계약에 맞춤.
+- Modify: `cache/cache-core/README.md`, `cache/cache-core/README.ko.md` — JCache 표준 메서드 의미와 `getDeeply`/`clearAllCache` 호환 alias, peer 전파 제한.
+- Modify: `docs/cache/near-cache-capability-matrix.md` — JCache read/clear 계약과 listener/degraded 전파 경계를 추가.
+- Create: `docs/lessons/2026-08-12-issue-1363-nearjcache-contract.md` only if the lesson gate finds reusable new guidance; otherwise record concrete N/A evidence in the workflow report.
+
+No new module, dependency, catalog version, public type removal, or compound-operation
+atomicity implementation is in scope. Do not touch unrelated dirty files. The
+front-capacity limit and shared-back tenant/owner authority model remain explicit
+follow-up work; this change documents those boundaries but does not add a public
+configuration surface for them.
+
+## Task 1: Add deterministic standard-Cache regression tests (RED)
+
+**Files:**
+- Create: `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt`
+
+- [ ] **Step 1: Add a `Cache<String, String>` read-through test**
+
+Use the existing `JCache` typealias, relaxed MockK caches, and a `NearJCacheConfig(isSynchronous = true)` constructor. Stub `front.get("remote")` to return null, `back.get("remote")` to return `"value"`, assign the near cache to `val standardCache: Cache<String, String>`, call `standardCache.get("remote")`, then assert the value and verify `front.put("remote", "value")` once.
+
+- [ ] **Step 2: Add contains-key and mixed getAll tests**
+
+Stub front `containsKey("remote")` false and back true, then assert `standardCache.containsKey("remote")` true. For `getAll`, stub front to return `mutableMapOf("front" to "front-value")`, back to return `mutableMapOf("remote" to "back-value")` for the missing-key set, call through `Cache`, assert both mappings, and verify only the back value is populated into front.
+
+- [ ] **Step 3: Add clear and compatibility-alias tests**
+
+Stub `front.clear()` and `back.clear()`, call `standardCache.clear()`, and verify both exactly once. Add a test that `getDeeply` follows the standard `get` path and a test that `clearAllCache` clears both layers through the same implementation. Use existing Bluetape assertions and `io.mockk.verify` rather than raw JUnit assertions where ecosystem helpers cover the assertion.
+
+- [ ] **Step 4: Run the new tests before implementation**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-cache-core:test --tests '*NearJCacheContractTest' --no-configuration-cache
+```
+
+Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` currently remain front-only/clear-front behavior. Preserve the raw failure evidence in the task log; do not implement before observing RED.
+
+- [ ] **Step 5: Add concurrency, failure, and boundary tests**
+
+  Add deterministic `CountDownLatch` tests for `get`/`getAll` racing with
+  `put`, `replace`, `remove`, and `clear`; the stale back value may be returned
+  to the in-flight caller but must never be populated into front after the
+  epoch changes. Add a timeout-late asynchronous write test proving `clear()`
+  waits for the actual backend call before returning. Add tests that front
+  population catches `RuntimeException` but rethrows `Error`, and that captured
+  logs contain operation/provider metadata only (no key/value/payload). Add
+  call-count tests for `getAndRemove` and `getAndReplace` proving their
+  front-only helpers do not introduce the new standard back read round trips.
+
+- [ ] **Step 6: Add serialization trust-boundary tests**
+
+  Assert the default `NearJCacheConfig` sets `isStoreByValue == false` and that
+  constructing `NearJCache` with a custom store-by-value front configuration
+  fails closed with a clear `IllegalArgumentException` before any back value is
+  read or populated. This keeps the default auto-populate path away from an
+  unfiltered Java serialization copier.
+
+## Task 2: Implement the two-tier contract with epoch and backend barriers (GREEN)
+
+**Files:**
+- Modify: `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt` around lines 173-247.
+- Modify: `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt` default front configuration.
+
+- [ ] **Step 1: Add mutation gate, epoch, and backend write lock**
+
+  Introduce a `ReentrantLock` mutation gate, a monotonic `AtomicLong` epoch,
+  and a separate `ReentrantLock` around every backend mutation. Every front
+  mutation increments the epoch before changing front state and passes the
+  captured epoch to `syncBackCache`. A backend task that acquires the lock
+  skips itself when its expected epoch is stale. Keep the existing timeout and
+  retry behavior, but ensure the lock is held until the real backend call ends,
+  including after an async completion timeout.
+
+- [ ] **Step 2: Implement standard get with back fallback and fenced populate**
+
+  Make `get(key)` read front first, capture the observed epoch, then read back on
+  miss. When back returns a value, populate front only if the epoch is unchanged;
+  return the back value regardless of a local `RuntimeException` during
+  populate, but propagate `Error` and back-read failures. Warning logs contain
+  only stable operation/provider/cache metadata and never raw key/value/payload.
+  Keep the code non-suspending and do not introduce `!!` or new dependencies.
+
+- [ ] **Step 3: Implement containsKey and getAll over the logical cache**
+
+  Implement `containsKey` as front lookup followed by back lookup without calling
+  `get` or triggering population. Implement `getAll(keys)` by fetching front
+  values once, calculating missing keys, calling `backCache.getAll(missedKeys)`
+  once, and calling `frontCache.putAll(backValues)` once when the epoch is still
+  current. Merge front and back maps without changing the existing `MutableMap`
+  return type; return early without a back call when all keys are front hits.
+
+- [ ] **Step 4: Make clear and aliases share one implementation**
+
+ Implement `clear()` as a mutation-gate operation: publish a new epoch, clear
+ front, then synchronously acquire the backend-write lock and clear back. This
+ waits for any timed-out async backend call that is still executing, so a late
+ write cannot resurrect a value after `clear()` returns. Preserve visible
+ front/back exceptions and the documented partial-state order. Make
+ `clearAllCache()` delegate to `clear()` and make `getDeeply(key)` delegate to
+ `get(key)`. Update Korean KDoc to describe standard semantics, peer-front
+ propagation limits, and the alias relationship.
+
+- [ ] **Step 5: Preserve compound-operation round trips**
+
+  Add private `frontContainsKey`/`frontGet` helpers and update
+  `getAndRemove`/`getAndReplace` to use them, leaving #1355's cross-tier
+  atomicity boundary unchanged. Their subsequent mutation still participates
+  in the epoch/backend barrier, but they must not call the newly logical
+  standard `containsKey`/`get` and add an extra back round trip.
+
+- [ ] **Step 6: Enforce the serialization boundary in configuration**
+
+  Set `setStoreByValue(false)` on the default front configuration. In the
+  `NearJCache` constructor reject a custom front configuration whose
+  `isStoreByValue` is true. Do not add a bypass flag; providers that need
+  serialized values require a separate filtered-copy design.
+
+- [ ] **Step 7: Run the focused tests GREEN**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-cache-core:test --tests '*NearJCacheContractTest' --no-configuration-cache
+```
+
+Expected: all contract tests pass. If a test fails, inspect the exact mock interaction before changing production code; do not weaken assertions.
+
+## Task 3: Reconcile shared conformance fixtures and backend-specific expectations
+
+**Files:**
+- Modify: `cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt` around the existing `clear` test.
+- Modify: any exact callers found by `git grep -n 'clear().*getDeeply\|getDeeply.*clear' -- cache`.
+- Modify: `cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt` if the factory test still expects a back value after `clear()`.
+
+- [ ] **Step 1: Replace front-only fixture assumptions**
+
+Rename the existing front-only `clear` test to assert that the invoking near cache has no front or back mapping after `clear()`. Keep the explicit peer-front assertion only where it proves the documented non-guarantee: a peer may retain a stale front entry when listener propagation is unavailable. Add a standard `Cache`-typed fixture assertion if the deterministic contract test does not cover a real provider path.
+
+- [ ] **Step 2: Update factory/degraded backend tests**
+
+For Hazelcast factory degraded mode, assert `cache.clear()` removes the local wrapper’s front and back value and that `cache.getDeeply(key)` is null afterward. Preserve the separate unsupported direct-listener test and do not claim peer propagation for the degraded factory.
+
+- [ ] **Step 3: Run cache-core and affected backend tests sequentially**
+
+Run in this order, waiting for each command to finish before the next:
+
+```bash
+./gradlew :bluetape4k-cache-core:test --no-configuration-cache
+./gradlew :bluetape4k-cache-hazelcast:test --no-configuration-cache
+./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache
+./gradlew :bluetape4k-cache-redisson:test --no-configuration-cache
+```
+
+If a Testcontainers-backed command is unavailable or fails for environment reasons, capture the exact failure and run the provider-neutral contract tests plus compile checks; do not label the backend proof PASS.
+
+- [ ] **Step 4: Recheck timeout and peer propagation boundaries**
+
+  Confirm a shared-back peer can retain a stale front entry after another near
+  cache calls `clear()`, while the invoking wrapper's own front and back are
+  empty. Confirm a timed-out asynchronous write cannot repopulate that back
+  after the clear barrier. These are distinct guarantees and must not be
+  conflated in the fixtures or documentation.
+
+## Task 4: Align public documentation and capability matrix
+
+**Files:**
+- Modify: `cache/cache-core/README.md` in the JCache NearCache feature section.
+- Modify: `cache/cache-core/README.ko.md` lines 101-156 and the class table.
+- Modify: `docs/cache/near-cache-capability-matrix.md` JCache NearCache section.
+
+- [ ] **Step 1: Document identical standard read/clear semantics in both locales**
+
+State that `NearJCache` is a JCache-compatible logical 2-tier cache: standard `get`/`containsKey`/`getAll` read front then back, back hits populate front, and `clear` clears the wrapper’s front and back. State that `getDeeply` and `clearAllCache` remain compatibility aliases and that compound operations are tracked separately by #1355.
+
+- [ ] **Step 2: Document peer propagation and degraded boundaries**
+
+Explain that JCache `clear` does not promise listener-based peer-front invalidation; use `removeAll` when per-entry propagation is required. Keep Hazelcast factory degraded/unsupported rows precise and ensure English and Korean claims match.
+
+- [ ] **Step 3: Verify docs and link contracts**
+
+Run:
+
+```bash
+git diff --check
+rg -n 'front-only|Front Cache만|JCache 호환|JCache-compatible|clearAllCache|getDeeply' cache/cache-core/README.md cache/cache-core/README.ko.md docs/cache/near-cache-capability-matrix.md
+```
+
+Expected: no stale statement says standard `clear` or standard reads are front-only; `getDeeply`/`clearAllCache` are described as compatibility names, not required alternatives.
+
+## Task 5: Final verification, lesson gate, and branch commit
+
+- [ ] **Step 1: Run proportional Kotlin verification**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-cache-core:test :bluetape4k-cache-core:detekt --no-configuration-cache
+git diff --check
+git status --short
+```
+
+Read all results. The cache-core test task, detekt, and diff check must pass before pre-PR review. No new warnings, deprecated imports, or `!!` may be introduced in touched Kotlin files.
+
+- [ ] **Step 2: Complete the Kotlin checklist and lesson decision**
+
+Load `bluetape-kotlin-patterns/references/checklist.md` and the testing reference because Kotlin tests/fixtures are touched. Record KT-01 through KT-05 evidence, including public KDoc/README parity, mock contract coverage, and exact backend-test gaps. Create a Korean durable lesson only if this change yields reusable guidance not already covered by the existing cache consistency rule; otherwise record why no novel failure/recovery/design/operational guidance exists.
+
+- [ ] **Step 3: Commit the converged implementation**
+
+Use a Lore-formatted Korean commit message after final diff review:
+
+```text
+JCache 표준 read/clear 호출이 2-tier 캐시를 일관되게 관찰하도록 보장한다
+
+Constraint: javax.cache.Cache 공개 호환성과 기존 alias 사용자를 유지해야 한다.
+Rejected: compound operation 원자성 변경 | #1355 범위와 중복된다.
+Confidence: high
+Scope-risk: moderate
+Directive: 새 compound API 수정은 #1355의 원자성 계약을 먼저 따른다.
+Tested: cache-core focused/full tests, affected backend tests, detekt, git diff --check
+Not-tested: 명시한 환경 제약으로 실행하지 못한 backend 증거를 실제 결과로 기록한다.
+```
+
+Expected DoD: exact local head SHA recorded, only approved files changed, P0=0/P1=0, and branch ready for independent pre-PR review.
+
+## Task 6: PR delivery and closeout gates (separate approvals)
+
+- [ ] **Step 1: Pre-PR review and PR creation**
+
+Complete Type-A final checklist and independent 7-Tier review on the exact head. Create PR only after CG-10 and CG-11 authority are PASS, target `bluetape4k/bluetape4k-projects`, base `develop`, head `fix/nearcache-jcache-contract`, assign `debop`, mirror issue #1363 milestone/labels, and end the Korean PR body with `## DoD Status`.
+
+- [ ] **Step 2: CI and merge-ready report**
+
+Wait for required CI on the exact PR head, reread reviews/threads, and report `Required checks: X/Y; N/A: N; Blocked: 0`, exact PR/head, P0/P1 status, test evidence, and unchecked merge rows. Do not merge at this step.
+
+- [ ] **Step 3: Fresh merge approval, merge, sync, cleanup**
+
+After a fresh user approval tied to the exact merge-ready PR/head, merge using the approved strategy, verify the live merge SHA, sync local `develop`, and remove only the proven merged feature worktree/branch. Preserve any ambiguous or dirty state.
+
+## Traceability
+
+| Design requirement | Plan task |
+| --- | --- |
+| Standard `get` fallback/populate | Task 1, Task 2 |
+| Standard `containsKey` back visibility | Task 1, Task 2 |
+| Standard `getAll` merge/populate | Task 1, Task 2 |
+| `clear` front/back and failure visibility | Task 1, Task 2, Task 3 |
+| Epoch fencing and timeout-late barrier | Task 1, Task 2, Task 3 |
+| Serialization trust boundary | Task 1, Task 2 |
+| `getDeeply`/`clearAllCache` compatibility | Task 1, Task 2, Task 4 |
+| Peer propagation/degraded boundaries | Task 3, Task 4 |
+| Compound round-trip boundary / #1355 handoff | Task 1, Task 2 |
+| README locale parity and capability matrix | Task 4 |
+| Backend and static verification | Task 3, Task 5 |
+| P0/P1 convergence, lesson, rollback, PR gates | Task 5, Task 6 |

--- a/docs/superpowers/plans/2026-08-12-issue-1363-nearjcache-contract-plan.md
+++ b/docs/superpowers/plans/2026-08-12-issue-1363-nearjcache-contract-plan.md
@@ -32,19 +32,19 @@ configuration surface for them.
 **Files:**
 - Create: `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt`
 
-- [ ] **Step 1: Add a `Cache<String, String>` read-through test**
+- [x] **Step 1: Add a `Cache<String, String>` read-through test**
 
 Use the existing `JCache` typealias, relaxed MockK caches, and a `NearJCacheConfig(isSynchronous = true)` constructor. Stub `front.get("remote")` to return null, `back.get("remote")` to return `"value"`, assign the near cache to `val standardCache: Cache<String, String>`, call `standardCache.get("remote")`, then assert the value and verify `front.put("remote", "value")` once.
 
-- [ ] **Step 2: Add contains-key and mixed getAll tests**
+- [x] **Step 2: Add contains-key and mixed getAll tests**
 
 Stub front `containsKey("remote")` false and back true, then assert `standardCache.containsKey("remote")` true. For `getAll`, stub front to return `mutableMapOf("front" to "front-value")`, back to return `mutableMapOf("remote" to "back-value")` for the missing-key set, call through `Cache`, assert both mappings, and verify only the back value is populated into front.
 
-- [ ] **Step 3: Add clear and compatibility-alias tests**
+- [x] **Step 3: Add clear and compatibility-alias tests**
 
 Stub `front.clear()` and `back.clear()`, call `standardCache.clear()`, and verify both exactly once. Add a test that `getDeeply` follows the standard `get` path and a test that `clearAllCache` clears both layers through the same implementation. Use existing Bluetape assertions and `io.mockk.verify` rather than raw JUnit assertions where ecosystem helpers cover the assertion.
 
-- [ ] **Step 4: Run the new tests before implementation**
+- [x] **Step 4: Run the new tests before implementation**
 
 Run:
 
@@ -54,7 +54,7 @@ Run:
 
 Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` currently remain front-only/clear-front behavior. Preserve the raw failure evidence in the task log; do not implement before observing RED.
 
-- [ ] **Step 5: Add concurrency, failure, and boundary tests**
+- [x] **Step 5: Add concurrency, failure, and boundary tests**
 
   Add deterministic `CountDownLatch` tests for `get`/`getAll` racing with
   `put`, `replace`, `remove`, and `clear`; the stale back value may be returned
@@ -66,7 +66,7 @@ Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` curr
   call-count tests for `getAndRemove` and `getAndReplace` proving their
   front-only helpers do not introduce the new standard back read round trips.
 
-- [ ] **Step 6: Add serialization trust-boundary tests**
+- [x] **Step 6: Add serialization trust-boundary tests**
 
   Assert the default `NearJCacheConfig` sets `isStoreByValue == false` and that
   constructing `NearJCache` with a custom store-by-value front configuration
@@ -80,17 +80,19 @@ Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` curr
 - Modify: `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt` around lines 173-247.
 - Modify: `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt` default front configuration.
 
-- [ ] **Step 1: Add mutation gate, epoch, and backend write lock**
+- [x] **Step 1: Add mutation gate, epoch, and backend write lock**
 
-  Introduce a `ReentrantLock` mutation gate, a monotonic `AtomicLong` epoch,
-  and a separate `ReentrantLock` around every backend mutation. Every front
-  mutation increments the epoch before changing front state and passes the
-  captured epoch to `syncBackCache`. A backend task that acquires the lock
-  skips itself when its expected epoch is stale. Keep the existing timeout and
-  retry behavior, but ensure the lock is held until the real backend call ends,
-  including after an async completion timeout.
+  Introduce a `ReentrantLock` mutation gate, a monotonic `AtomicLong`
+  `mutationEpoch` for read-through fencing, a separate `AtomicLong`
+  `backWriteGeneration` advanced only by `clear`, and a `ReentrantLock` around
+  every backend mutation. Every front mutation increments `mutationEpoch` before
+  changing front state. A backend task captures the current generation and
+  skips itself only when a later clear has advanced it; different-key async
+  writes must not be discarded merely because another mutation occurred. Keep
+  the existing timeout and retry behavior, but ensure the lock is held until
+  the real backend call ends, including after an async completion timeout.
 
-- [ ] **Step 2: Implement standard get with back fallback and fenced populate**
+- [x] **Step 2: Implement standard get with back fallback and fenced populate**
 
   Make `get(key)` read front first, capture the observed epoch, then read back on
   miss. When back returns a value, populate front only if the epoch is unchanged;
@@ -99,7 +101,7 @@ Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` curr
   only stable operation/provider/cache metadata and never raw key/value/payload.
   Keep the code non-suspending and do not introduce `!!` or new dependencies.
 
-- [ ] **Step 3: Implement containsKey and getAll over the logical cache**
+- [x] **Step 3: Implement containsKey and getAll over the logical cache**
 
   Implement `containsKey` as front lookup followed by back lookup without calling
   `get` or triggering population. Implement `getAll(keys)` by fetching front
@@ -108,7 +110,7 @@ Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` curr
   current. Merge front and back maps without changing the existing `MutableMap`
   return type; return early without a back call when all keys are front hits.
 
-- [ ] **Step 4: Make clear and aliases share one implementation**
+- [x] **Step 4: Make clear and aliases share one implementation**
 
  Implement `clear()` as a mutation-gate operation: publish a new epoch, clear
  front, then synchronously acquire the backend-write lock and clear back. This
@@ -119,7 +121,7 @@ Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` curr
  `get(key)`. Update Korean KDoc to describe standard semantics, peer-front
  propagation limits, and the alias relationship.
 
-- [ ] **Step 5: Preserve compound-operation round trips**
+- [x] **Step 5: Preserve compound-operation round trips**
 
   Add private `frontContainsKey`/`frontGet` helpers and update
   `getAndRemove`/`getAndReplace` to use them, leaving #1355's cross-tier
@@ -127,14 +129,14 @@ Expected: FAIL because standard `get`, `containsKey`, `getAll`, and `clear` curr
   in the epoch/backend barrier, but they must not call the newly logical
   standard `containsKey`/`get` and add an extra back round trip.
 
-- [ ] **Step 6: Enforce the serialization boundary in configuration**
+- [x] **Step 6: Enforce the serialization boundary in configuration**
 
   Set `setStoreByValue(false)` on the default front configuration. In the
   `NearJCache` constructor reject a custom front configuration whose
   `isStoreByValue` is true. Do not add a bypass flag; providers that need
   serialized values require a separate filtered-copy design.
 
-- [ ] **Step 7: Run the focused tests GREEN**
+- [x] **Step 7: Run the focused tests GREEN**
 
 Run:
 
@@ -151,15 +153,15 @@ Expected: all contract tests pass. If a test fails, inspect the exact mock inter
 - Modify: any exact callers found by `git grep -n 'clear().*getDeeply\|getDeeply.*clear' -- cache`.
 - Modify: `cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt` if the factory test still expects a back value after `clear()`.
 
-- [ ] **Step 1: Replace front-only fixture assumptions**
+- [x] **Step 1: Replace front-only fixture assumptions**
 
 Rename the existing front-only `clear` test to assert that the invoking near cache has no front or back mapping after `clear()`. Keep the explicit peer-front assertion only where it proves the documented non-guarantee: a peer may retain a stale front entry when listener propagation is unavailable. Add a standard `Cache`-typed fixture assertion if the deterministic contract test does not cover a real provider path.
 
-- [ ] **Step 2: Update factory/degraded backend tests**
+- [x] **Step 2: Update factory/degraded backend tests**
 
 For Hazelcast factory degraded mode, assert `cache.clear()` removes the local wrapper’s front and back value and that `cache.getDeeply(key)` is null afterward. Preserve the separate unsupported direct-listener test and do not claim peer propagation for the degraded factory.
 
-- [ ] **Step 3: Run cache-core and affected backend tests sequentially**
+- [x] **Step 3: Run cache-core and affected backend tests sequentially**
 
 Run in this order, waiting for each command to finish before the next:
 
@@ -172,7 +174,7 @@ Run in this order, waiting for each command to finish before the next:
 
 If a Testcontainers-backed command is unavailable or fails for environment reasons, capture the exact failure and run the provider-neutral contract tests plus compile checks; do not label the backend proof PASS.
 
-- [ ] **Step 4: Recheck timeout and peer propagation boundaries**
+- [x] **Step 4: Recheck timeout and peer propagation boundaries**
 
   Confirm a shared-back peer can retain a stale front entry after another near
   cache calls `clear()`, while the invoking wrapper's own front and back are
@@ -187,15 +189,15 @@ If a Testcontainers-backed command is unavailable or fails for environment reaso
 - Modify: `cache/cache-core/README.ko.md` lines 101-156 and the class table.
 - Modify: `docs/cache/near-cache-capability-matrix.md` JCache NearCache section.
 
-- [ ] **Step 1: Document identical standard read/clear semantics in both locales**
+- [x] **Step 1: Document identical standard read/clear semantics in both locales**
 
 State that `NearJCache` is a JCache-compatible logical 2-tier cache: standard `get`/`containsKey`/`getAll` read front then back, back hits populate front, and `clear` clears the wrapper’s front and back. State that `getDeeply` and `clearAllCache` remain compatibility aliases and that compound operations are tracked separately by #1355.
 
-- [ ] **Step 2: Document peer propagation and degraded boundaries**
+- [x] **Step 2: Document peer propagation and degraded boundaries**
 
 Explain that JCache `clear` does not promise listener-based peer-front invalidation; use `removeAll` when per-entry propagation is required. Keep Hazelcast factory degraded/unsupported rows precise and ensure English and Korean claims match.
 
-- [ ] **Step 3: Verify docs and link contracts**
+- [x] **Step 3: Verify docs and link contracts**
 
 Run:
 
@@ -208,7 +210,7 @@ Expected: no stale statement says standard `clear` or standard reads are front-o
 
 ## Task 5: Final verification, lesson gate, and branch commit
 
-- [ ] **Step 1: Run proportional Kotlin verification**
+- [x] **Step 1: Run proportional Kotlin verification**
 
 Run:
 
@@ -220,9 +222,9 @@ git status --short
 
 Read all results. The cache-core test task, detekt, and diff check must pass before pre-PR review. No new warnings, deprecated imports, or `!!` may be introduced in touched Kotlin files.
 
-- [ ] **Step 2: Complete the Kotlin checklist and lesson decision**
+- [x] **Step 2: Complete the Kotlin checklist and lesson decision**
 
-Load `bluetape-kotlin-patterns/references/checklist.md` and the testing reference because Kotlin tests/fixtures are touched. Record KT-01 through KT-05 evidence, including public KDoc/README parity, mock contract coverage, and exact backend-test gaps. Create a Korean durable lesson only if this change yields reusable guidance not already covered by the existing cache consistency rule; otherwise record why no novel failure/recovery/design/operational guidance exists.
+Load `bluetape-kotlin-patterns/references/checklist.md` and the testing reference because Kotlin tests/fixtures are touched. Record KT-01 through KT-05 evidence, including public KDoc/README parity, mock contract coverage, and exact backend-test gaps. This change yielded reusable read-epoch/backend-generation and clear-barrier guidance, recorded in `docs/lessons/2026-08-12-issue-1363-nearjcache-contract.md`.
 
 - [ ] **Step 3: Commit the converged implementation**
 

--- a/docs/superpowers/specs/2026-08-12-issue-1363-nearjcache-contract-design.md
+++ b/docs/superpowers/specs/2026-08-12-issue-1363-nearjcache-contract-design.md
@@ -1,0 +1,156 @@
+# NearJCache 표준 read/clear 계약 정합성 설계
+
+- 이슈: [#1363](https://github.com/bluetape4k/bluetape4k-projects/issues/1363)
+- 날짜: 2026-08-12
+- 상태: 승인된 구현 방향의 설계 초안
+- 대상: `cache/cache-core`
+- 분류: Type-A Full Feature (공개 JCache API·2-tier 의미론 변경)
+
+## 문제
+
+`NearJCache`는 `javax.cache.Cache`를 구현하지만 표준 메서드의 대상이
+front cache로만 제한되어 있다. back cache에만 존재하는 값을 표준 `get`,
+`containsKey`, `getAll`로 관찰할 수 없고, `clear()`도 front만 지운다.
+back까지 조회하는 동작은 비표준 확장 메서드인 `getDeeply()`에만 존재한다.
+
+이 상태에서 호출자가 `NearJCache`를 `Cache<K, V>`로 받으면 동일한 논리적
+캐시에서 값이 누락되거나 `clear()` 이후 back 값이 다시 나타나는 예측 불가능한
+결과를 얻는다. README는 현재 구현을 JCache 호환 2-tier 캐시로 설명하므로
+문서·타입·실행 의미가 서로 어긋난다.
+
+## 현재 근거
+
+| 영역 | 근거 | 관찰 |
+| --- | --- | --- |
+| 공개 타입 | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/JCacheType.kt:6` | `JCache`는 `javax.cache.Cache` typealias다. |
+| clear | `NearJCache.kt:173-176` | `clear()`가 `frontCache.clear()`만 호출한다. |
+| contains/get | `NearJCache.kt:214-219` | `containsKey`와 `get`이 front만 조회한다. |
+| getAll | `NearJCache.kt:243-247` | `getAll`이 front 결과만 반환한다. |
+| 비표준 fallback | `NearJCache.kt:221-241` | `getDeeply`만 back 조회 후 front를 채운다. |
+| 기존 테스트 | `AbstractNearJCacheTest.kt:81-99, 531-553` | front-only 동작과 별도 `clearAllCache`가 고정되어 있다. |
+| 사용자 문서 | `cache/cache-core/README.ko.md:101-104, 151-156` | JCache 호환 2-tier 구현으로 설명한다. |
+| capability 문서 | `docs/cache/near-cache-capability-matrix.md:30-42` | backend별 listener/degraded 경계를 정의하지만 표준 read 계약은 고정하지 않는다. |
+
+JCache 1.1 API는 `get`, `containsKey`, `getAll`, `clear`를 캐시 인스턴스의
+표준 메서드로 정의하고, `getAndRemove`·`getAndReplace` 등 compound 메서드는
+원자성을 별도로 요구한다. 본 설계는 [공식 Cache API 문서](https://www.javadoc.io/static/javax.cache/cache-api/1.1.0/javax/cache/Cache.html)의
+read/clear 항목만 직접 다루며 compound 원자성은 #1355의 범위로 남긴다.
+
+## 목표
+
+1. `NearJCache`를 `Cache<K, V>`로 참조하는 호출자가 논리적 2-tier 캐시를 일관되게 관찰하게 한다.
+2. 표준 `get`, `containsKey`, `getAll`, `clear` 의미를 구현·테스트·문서에 동일하게 고정한다.
+3. 기존 `getDeeply`와 `clearAllCache` 사용자의 소스 호환성을 유지한다.
+4. back cache 공유 인스턴스에 대한 listener 전파 여부를 `clear` 계약과 분리해 명시한다.
+
+## 비목표 및 경계
+
+- `getAndPut`, `getAndRemove`, `getAndReplace`, `putIfAbsent`, `replace`의
+  cross-tier 원자성은 구현하지 않는다. 해당 범위는 [#1355](https://github.com/bluetape4k/bluetape4k-projects/issues/1355)에서 다룬다.
+- `iterator`, `invoke`, `loadAll` 등 아직 front/back 경계가 별도로 정의되지 않은
+  메서드의 확장은 본 작업에서 하지 않는다. 표준 read/clear 범위를 문서에서
+  명시하고 후속 이슈 후보로 남긴다.
+- 새로운 의존성, 모듈, catalog 버전, backend provider를 추가하지 않는다.
+- `SuspendNearJCache`의 동작을 동기 API 변경에 맞춰 임의로 변경하지 않는다.
+  다만 문서에서 동기·suspend 계약의 차이가 오해를 만들지 않는지 확인한다.
+
+## 선택한 설계
+
+### 논리적 2-tier 표준 Cache 유지
+
+`NearJCache`가 계속 `JCache<K, V>`를 구현하도록 유지하고, 표준 메서드의
+조회 대상은 front와 back을 합친 논리적 캐시로 정의한다.
+
+| 메서드 | 계약 |
+| --- | --- |
+| `get(key)` | front hit를 먼저 반환한다. front miss면 back을 조회하고, 값을 찾으면 front에 populate한 뒤 반환한다. |
+| `containsKey(key)` | front hit 또는 back hit이면 `true`다. back 조회를 위해 값을 읽지 않는다. |
+| `getAll(keys)` | front 결과를 먼저 취하고, 누락 키만 back에서 조회한다. back 결과는 front에 populate하고 두 결과를 병합한다. |
+| `clear()` | 해당 `NearJCache`가 소유한 front와 back의 모든 매핑을 삭제한다. JCache `clear`처럼 listener를 통한 peer 전파는 보장하지 않는다. |
+| `getDeeply(key)` | 기존 소스 호환성을 위해 유지하며 표준 `get(key)`와 동일한 동작을 사용한다. |
+| `clearAllCache()` | 기존 소스 호환성을 위해 유지하며 표준 `clear()`와 동일한 front/back 삭제 계약을 사용한다. |
+
+`clear()`가 공유 back cache를 지워도 다른 NearJCache 인스턴스의 front가
+listener 없는 factory/degraded 조합에서 이미 보유한 값을 자동으로 지운다는
+뜻은 아니다. capability matrix와 README에 이 경계를 명시하고, peer 전파가
+필요한 경우 기존 `removeAll()` 경로를 사용하도록 안내한다.
+
+back read 실패는 현재 JCache provider가 노출하는 예외를 호출자에게 전달한다.
+back에서 읽은 값을 front에 populate하지 못하더라도 이미 확보한 back 값은
+반환하되, 기존 로깅 규칙을 사용해 populate 실패를 관찰 가능하게 한다. 이
+정책은 read availability와 local warm-up 실패를 분리한다.
+
+### 고려했지만 채택하지 않은 대안
+
+1. **front-only 타입으로 분리**: `javax.cache.Cache` 구현을 제거하고 별도
+   `FrontOnlyNearCache` 타입을 노출한다. 의미는 가장 명확하지만 기존 반환
+   타입·사용자 캐스팅·README 예제를 깨뜨리는 공개 API 변경이므로 거부한다.
+2. **표준 타입은 유지하되 현재 front-only 의미를 문서화**: 구현 변경은 작지만
+   JCache 호출자에게 표준 계약 위반을 계속 노출하고 #1363의 결함을 해결하지
+   못하므로 거부한다.
+3. **표준 메서드와 front-only 메서드를 모두 별도 이름으로 유지**: `get`과
+   `getDeeply`를 병행하면 호출자가 어떤 메서드를 써야 하는지 다시 판단해야
+   하며 표준 `Cache` 참조에서는 문제를 해결하지 못하므로 거부한다.
+
+## 구현 경계
+
+예상 변경 파일은 다음과 같다.
+
+- `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt`
+- `cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt`
+- `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/*` 중 계약 회귀가 필요한 테스트
+- `cache/cache-core/README.md`
+- `cache/cache-core/README.ko.md`
+- `docs/cache/near-cache-capability-matrix.md`
+- Hazelcast factory 테스트 등 `clear()` 후 `getDeeply()`를 직접 검증하는 영향받은 테스트
+
+모듈 등록, dependency catalog, Gradle workflow, API artifact 이름은 변경하지
+않는다. 실제 symbol search에서 추가 caller가 발견되면 계획 문서에 영향 범위를
+갱신하고, 승인된 범위를 넘는 공개 API 변경은 중단한다.
+
+## 테스트 설계
+
+테스트는 현재 공용 `AbstractNearJCacheTest` fixture를 재사용하고, 표준 타입
+참조를 통해 동작을 검증한다.
+
+1. `val cache: Cache<String, Any> = nearJCache` 컴파일/실행 경계에서 back-only
+   key에 `get`이 값을 반환하고 front를 populate하는지 검증한다.
+2. back-only key에 `containsKey`가 `true`인지, 없는 key가 `false`인지 검증한다.
+3. front hit와 back-only key가 섞인 `getAll`이 병합 결과를 반환하고 back 값을
+   front에 populate하는지 검증한다.
+4. `clear()`가 해당 front와 back 모두를 비우는지 검증하고, listener 없는
+   peer front에 대한 전파를 계약에서 보장하지 않는지 확인한다.
+5. `getDeeply`와 `clearAllCache`가 표준 메서드와 의미가 갈라지지 않는지 검증한다.
+6. 기존 backend fixture(Lettuce, Redisson, Hazelcast, Cache2k, Ehcache)의
+   지원/degraded/unsupported 경계를 깨지 않는지 순차 검증한다.
+
+compound operation 테스트는 #1355에 중복 등록하지 않으며, 이번 변경으로
+새롭게 노출되는 경계가 있으면 해당 이슈에 연결만 남긴다.
+
+## 실패 모드와 대응
+
+| 실패 모드 | 대응 |
+| --- | --- |
+| back read가 실패함 | provider 예외를 숨기지 않고 호출자에게 전달; 대상 테스트에서 예외 계약 확인 |
+| front populate가 실패함 | back에서 확보한 값은 반환하고 경고 로그 기록; 다음 read가 재시도 가능해야 함 |
+| 공유 back `clear` 후 peer front가 stale함 | `clear`는 peer listener 전파를 보장하지 않는다고 문서·matrix에 명시; peer 전파는 `removeAll` 사용 |
+| 기존 테스트가 front-only 가정을 고정함 | 계약 테스트를 표준 `Cache` 기준으로 전환하고, peer/degraded 테스트는 의도한 경계를 분리 |
+| compound 메서드가 새 read 계약과 충돌함 | 이번 작업에서 원자성 개선을 주장하지 않고 #1355 후속으로 추적; P0/P1 regression이면 구현 범위를 재승인 |
+
+## 수용 기준과 DoD
+
+- [ ] 표준 `Cache`의 `get`, `containsKey`, `getAll`, `clear` 의미가 위 표와 구현에 일치한다.
+- [ ] back fallback과 front populate 회귀 테스트가 `Cache<K,V>` 참조를 통해 통과한다.
+- [ ] `clear`가 해당 front/back를 지우고 peer 전파 한계를 문서화한다.
+- [ ] `getDeeply`·`clearAllCache` 호환 동작이 고정된다.
+- [ ] `README.md`, `README.ko.md`, capability matrix가 동일한 계약을 설명한다.
+- [ ] `:bluetape4k-cache-core:test`와 영향 backend 검증이 통과한다.
+- [ ] `git diff --check`, Kotlin checklist, Type-A pre-PR review에서 P0/P1이 0건이다.
+
+## 롤백 및 중단 조건
+
+구현 중 public API 삭제, 새로운 backend 의존성, compound atomicity 보장이
+필요해지면 이 설계를 중단하고 별도 승인/이슈로 분리한다. 표준 `Cache` 타입
+참조에서 기존 동작과 호환되지 않는 P0/P1 회귀가 발견되면 feature branch에서
+수정하고, 설계 범위를 바꾸기 전 사용자 재승인을 받는다.
+

--- a/docs/superpowers/specs/2026-08-12-issue-1363-nearjcache-contract-design.md
+++ b/docs/superpowers/specs/2026-08-12-issue-1363-nearjcache-contract-design.md
@@ -93,13 +93,17 @@ epoch를 캡처하고, back 조회가 끝난 뒤 동일 epoch일 때만 front po
 수행한다. epoch가 바뀌었으면 back에서 읽은 값은 호출 결과로 반환할 수 있지만
 front에는 저장하지 않는다. 모든 front mutation과 `clear`는 epoch를 증가시킨다.
 
-back mutation은 `backWriteLock` 아래에서 실행한다. 비동기 write는 예약 시
-epoch를 캡처하고 lock을 얻은 뒤 현재 epoch가 다르면 backend 작업을 건너뛴다.
-`clear`는 mutation gate를 잡고 새 epoch를 발행한 다음 front를 지우고, 기존
-write가 실제 backend 호출을 끝내 lock을 놓을 때까지 기다린 뒤 back을 지운다.
-따라서 timeout으로 completion이 먼저 실패해도 late backend write가
-`clear()` 반환 뒤 back 값을 되살릴 수 없다. clear 중 새 mutation은 gate가
-풀린 뒤 새 epoch로 시작한다.
+back mutation은 `backWriteLock` 아래에서 실행한다. 표준 mutation마다 전역
+`mutationEpoch`를 증가시키지만, 서로 다른 키의 정상적인 비동기 write를
+무효화하지 않도록 backend 작업에는 별도의 `backWriteGeneration`을 사용한다.
+일반 write는 현재 generation을 캡처하고, `clear`만 generation을 증가시킨다.
+따라서 clear 전에 예약되어 아직 실행되지 않은 write는 건너뛰고, clear 중
+실행 중인 write는 실제 backend 호출을 끝낼 때까지 lock을 유지한다.
+`clear`는 mutation gate를 잡고 새 mutation/read epoch와 backend generation을
+발행한 다음 front를 지우고, 기존 write가 실제 backend 호출을 끝내 lock을
+놓을 때까지 기다린 뒤 back을 지운다. timeout으로 completion이 먼저 실패해도
+late backend write가 `clear()` 반환 뒤 back 값을 되살릴 수 없다. clear 중 새
+mutation은 gate가 풀린 뒤 새 generation으로 시작한다.
 
 ### compound operation 경계
 

--- a/docs/superpowers/specs/2026-08-12-issue-1363-nearjcache-contract-design.md
+++ b/docs/superpowers/specs/2026-08-12-issue-1363-nearjcache-contract-design.md
@@ -105,6 +105,13 @@ back mutation은 `backWriteLock` 아래에서 실행한다. 표준 mutation마�
 late backend write가 `clear()` 반환 뒤 back 값을 되살릴 수 없다. clear 중 새
 mutation은 gate가 풀린 뒤 새 generation으로 시작한다.
 
+NearJCache가 등록한 back listener는 동일한 `mutationGate`를 통해 front를 갱신하고
+이벤트 적용 때마다 `mutationEpoch`를 증가시킨다. 따라서 listener update/remove와
+동시 진행 중인 read-through도 stale 값을 front에 덮어쓰지 않는다. `clear()`는
+listener를 먼저 비활성화·deregister하고 front/back clear barrier를 완료한 뒤
+새 registration을 설치한다. 이미 큐에 들어온 이전 registration의 callback은
+active 세대 검사를 통과하지 못하므로 clear 이후 front를 재점유할 수 없다.
+
 ### compound operation 경계
 
 `getAndPut`, `getAndRemove`, `getAndReplace`, `putIfAbsent`, `replace`의
@@ -119,7 +126,8 @@ back을 조회하게 되더라도 compound 메서드는 내부 `frontContainsKey
 `NearJCacheConfig.getDefaultFrontCacheConfiguration()`은
 `setStoreByValue(false)`를 사용해 기본 Caffeine front cache를
 store-by-reference로 만든다. `NearJCache`는 `frontCacheConfiguration`이
-store-by-value로 설정된 custom config를 fail-closed로 거부한다. 따라서
+store-by-value로 설정된 custom config와 실제 전달된 front cache의
+`Configuration.isStoreByValue`가 true인 경우를 모두 fail-closed로 거부한다. 따라서
 back 값을 자동 populate할 때 필터 없는 Java serialization copier가 기본
 경로에 들어오지 않는다. 운영자가 별도 provider/copy 정책을 선택해야 하는
 경우에는 해당 provider의 안전한 serialization/filter 정책을 별도 설계해야
@@ -181,6 +189,11 @@ key, value, raw payload, credential 또는 provider payload를 기록하지 않�
    추가하지 않는지 호출 수로 검증한다.
 11. 기존 backend fixture(Lettuce, Redisson, Hazelcast, Cache2k, Ehcache)의
    지원/degraded/unsupported 경계를 깨지 않는지 순차 검증한다.
+12. clear 전에 전달된 listener update/create/remove 이벤트가 clear 이후
+   front를 재점유하지 않는지, listener update와 read-through 경합에서 stale
+   populate가 차단되는지 검증한다.
+13. `get`/`getAll` front populate에서 `CancellationException`이 재전파되고,
+   listener/populate 로그에 raw key/value/payload가 포함되지 않는지 검증한다.
 
 compound operation 테스트는 #1355에 중복 등록하지 않으며, 이번 변경으로
 새롭게 노출되는 경계가 있으면 해당 이슈에 연결만 남긴다.
@@ -192,6 +205,7 @@ compound operation 테스트는 #1355에 중복 등록하지 않으며, 이번 �
 | back read가 실패함 | provider 예외를 숨기지 않고 호출자에게 전달; 대상 테스트에서 예외 계약 확인 |
 | front populate가 실패함 | back에서 확보한 값은 반환하고 경고 로그 기록; 다음 read가 재시도 가능해야 함 |
 | read-through와 mutation이 경합함 | epoch가 바뀌면 populate를 건너뛰고, stale 값을 front에 저장하지 않음 |
+| listener event가 read/clear와 경합함 | listener를 mutation gate에 연결하고 epoch/active registration 세대로 stale 적용을 차단 |
 | timeout-late write가 clear와 경합함 | backWriteLock과 epoch barrier로 실제 backend 호출 종료 후 clear를 수행 |
 | 공유 back `clear` 후 peer front가 stale함 | `clear`는 peer listener 전파를 보장하지 않는다고 문서·matrix에 명시; peer 전파는 `removeAll` 사용 |
 | 기존 테스트가 front-only 가정을 고정함 | 계약 테스트를 표준 `Cache` 기준으로 전환하고, peer/degraded 테스트는 의도한 경계를 분리 |
@@ -206,8 +220,11 @@ compound operation 테스트는 #1355에 중복 등록하지 않으며, 이번 �
 - [ ] `clear`가 해당 front/back를 지우고 peer 전파 한계를 문서화한다.
 - [ ] `getDeeply`·`clearAllCache` 호환 동작이 고정된다.
 - [ ] mutation epoch와 back-write barrier가 동시 read/clear 및 timeout-late write의 stale 재삽입을 차단한다.
+- [ ] listener event가 동일한 mutation gate/epoch와 clear 세대 경계를 통과한다.
 - [ ] `getAll` bulk 호출 수와 compound front-only 경계가 회귀 테스트로 고정된다.
 - [ ] 기본 front config가 store-by-reference이며 store-by-value custom config를 fail-closed한다.
+- [ ] 실제 front cache configuration도 store-by-value이면 생성이 fail-closed한다.
+- [ ] cancellation 재전파와 raw payload 없는 로그 회귀 테스트가 통과한다.
 - [ ] `README.md`, `README.ko.md`, capability matrix가 동일한 계약을 설명한다.
 - [ ] `:bluetape4k-cache-core:test`와 영향 backend 검증이 통과한다.
 - [ ] `git diff --check`, Kotlin checklist, Type-A pre-PR review에서 P0/P1이 0건이다.

--- a/docs/superpowers/specs/2026-08-12-issue-1363-nearjcache-contract-design.md
+++ b/docs/superpowers/specs/2026-08-12-issue-1363-nearjcache-contract-design.md
@@ -2,7 +2,7 @@
 
 - 이슈: [#1363](https://github.com/bluetape4k/bluetape4k-projects/issues/1363)
 - 날짜: 2026-08-12
-- 상태: 승인된 구현 방향의 설계 초안
+- 상태: 독립 검토 P1 보강안 승인됨
 - 대상: `cache/cache-core`
 - 분류: Type-A Full Feature (공개 JCache API·2-tier 의미론 변경)
 
@@ -42,6 +42,8 @@ read/clear 항목만 직접 다루며 compound 원자성은 #1355의 범위로 �
 2. 표준 `get`, `containsKey`, `getAll`, `clear` 의미를 구현·테스트·문서에 동일하게 고정한다.
 3. 기존 `getDeeply`와 `clearAllCache` 사용자의 소스 호환성을 유지한다.
 4. back cache 공유 인스턴스에 대한 listener 전파 여부를 `clear` 계약과 분리해 명시한다.
+5. 비동기 write와 동시 read-through가 `clear` 이후 stale 값을 재삽입하지 않도록 한다.
+6. 기본 front cache의 자동 populate가 필터 없는 Java serialization 경계를 만들지 않도록 한다.
 
 ## 비목표 및 경계
 
@@ -53,6 +55,10 @@ read/clear 항목만 직접 다루며 compound 원자성은 #1355의 범위로 �
 - 새로운 의존성, 모듈, catalog 버전, backend provider를 추가하지 않는다.
 - `SuspendNearJCache`의 동작을 동기 API 변경에 맞춰 임의로 변경하지 않는다.
   다만 문서에서 동기·suspend 계약의 차이가 오해를 만들지 않는지 확인한다.
+- 이번 이슈에서는 front cache 용량 상한과 공유 back cache의 tenant/owner 권한 모델을
+  새 공개 설정으로 추가하지 않는다. 현재는 명시적인 문서 계약과 provider별 기존
+  capacity 설정을 사용하며, 무제한 bulk residency와 destructive shared clear는
+  후속 이슈 후보로 기록한다.
 
 ## 선택한 설계
 
@@ -79,6 +85,44 @@ back read 실패는 현재 JCache provider가 노출하는 예외를 호출자�
 back에서 읽은 값을 front에 populate하지 못하더라도 이미 확보한 back 값은
 반환하되, 기존 로깅 규칙을 사용해 populate 실패를 관찰 가능하게 한다. 이
 정책은 read availability와 local warm-up 실패를 분리한다.
+
+### 동시성·비동기 write barrier
+
+read-through는 `mutationEpoch`를 관찰한다. `get`과 `getAll`은 front 조회 후
+epoch를 캡처하고, back 조회가 끝난 뒤 동일 epoch일 때만 front populate를
+수행한다. epoch가 바뀌었으면 back에서 읽은 값은 호출 결과로 반환할 수 있지만
+front에는 저장하지 않는다. 모든 front mutation과 `clear`는 epoch를 증가시킨다.
+
+back mutation은 `backWriteLock` 아래에서 실행한다. 비동기 write는 예약 시
+epoch를 캡처하고 lock을 얻은 뒤 현재 epoch가 다르면 backend 작업을 건너뛴다.
+`clear`는 mutation gate를 잡고 새 epoch를 발행한 다음 front를 지우고, 기존
+write가 실제 backend 호출을 끝내 lock을 놓을 때까지 기다린 뒤 back을 지운다.
+따라서 timeout으로 completion이 먼저 실패해도 late backend write가
+`clear()` 반환 뒤 back 값을 되살릴 수 없다. clear 중 새 mutation은 gate가
+풀린 뒤 새 epoch로 시작한다.
+
+### compound operation 경계
+
+`getAndPut`, `getAndRemove`, `getAndReplace`, `putIfAbsent`, `replace`의
+cross-tier 원자성은 #1355의 범위다. 이번 변경으로 표준 `containsKey`/`get`이
+back을 조회하게 되더라도 compound 메서드는 내부 `frontContainsKey`/
+`frontGet` helper를 사용해 기존 front-only 왕복 수와 동작을 유지한다. 이
+경계를 문서와 호출 수 회귀 테스트에 고정하고, 원자성 개선을 이번 PR에서
+주장하지 않는다.
+
+### front cache serialization 신뢰 경계
+
+`NearJCacheConfig.getDefaultFrontCacheConfiguration()`은
+`setStoreByValue(false)`를 사용해 기본 Caffeine front cache를
+store-by-reference로 만든다. `NearJCache`는 `frontCacheConfiguration`이
+store-by-value로 설정된 custom config를 fail-closed로 거부한다. 따라서
+back 값을 자동 populate할 때 필터 없는 Java serialization copier가 기본
+경로에 들어오지 않는다. 운영자가 별도 provider/copy 정책을 선택해야 하는
+경우에는 해당 provider의 안전한 serialization/filter 정책을 별도 설계해야
+하며, 이 이슈에서는 우회 플래그를 추가하지 않는다.
+
+populate 실패 로그는 operation/provider/cache lifecycle 메타데이터만 기록하고
+key, value, raw payload, credential 또는 provider payload를 기록하지 않는다.
 
 ### 고려했지만 채택하지 않은 대안
 
@@ -121,7 +165,17 @@ back에서 읽은 값을 front에 populate하지 못하더라도 이미 확보�
 4. `clear()`가 해당 front와 back 모두를 비우는지 검증하고, listener 없는
    peer front에 대한 전파를 계약에서 보장하지 않는지 확인한다.
 5. `getDeeply`와 `clearAllCache`가 표준 메서드와 의미가 갈라지지 않는지 검증한다.
-6. 기존 backend fixture(Lettuce, Redisson, Hazelcast, Cache2k, Ehcache)의
+6. `getAll`이 `backCache.getAll(missedKeys)`와 `frontCache.putAll(backValues)`를
+   각각 최대 한 번 사용하고, front hit만 있으면 back을 호출하지 않는지 검증한다.
+7. latch 기반으로 `get`/`getAll`과 `put`/`replace`/`remove`/`clear`가 겹칠 때
+   stale front populate가 발생하지 않는지 검증한다.
+8. 비동기 write의 timeout-late completion이 `clear()` 후 back을 재삽입하지
+   않는지 검증한다.
+9. 기본 config가 store-by-reference이고 store-by-value custom config가
+   생성 단계에서 거부되는지 검증한다.
+10. compound 메서드가 front-only helper를 사용해 불필요한 back round-trip을
+   추가하지 않는지 호출 수로 검증한다.
+11. 기존 backend fixture(Lettuce, Redisson, Hazelcast, Cache2k, Ehcache)의
    지원/degraded/unsupported 경계를 깨지 않는지 순차 검증한다.
 
 compound operation 테스트는 #1355에 중복 등록하지 않으며, 이번 변경으로
@@ -133,9 +187,13 @@ compound operation 테스트는 #1355에 중복 등록하지 않으며, 이번 �
 | --- | --- |
 | back read가 실패함 | provider 예외를 숨기지 않고 호출자에게 전달; 대상 테스트에서 예외 계약 확인 |
 | front populate가 실패함 | back에서 확보한 값은 반환하고 경고 로그 기록; 다음 read가 재시도 가능해야 함 |
+| read-through와 mutation이 경합함 | epoch가 바뀌면 populate를 건너뛰고, stale 값을 front에 저장하지 않음 |
+| timeout-late write가 clear와 경합함 | backWriteLock과 epoch barrier로 실제 backend 호출 종료 후 clear를 수행 |
 | 공유 back `clear` 후 peer front가 stale함 | `clear`는 peer listener 전파를 보장하지 않는다고 문서·matrix에 명시; peer 전파는 `removeAll` 사용 |
 | 기존 테스트가 front-only 가정을 고정함 | 계약 테스트를 표준 `Cache` 기준으로 전환하고, peer/degraded 테스트는 의도한 경계를 분리 |
 | compound 메서드가 새 read 계약과 충돌함 | 이번 작업에서 원자성 개선을 주장하지 않고 #1355 후속으로 추적; P0/P1 regression이면 구현 범위를 재승인 |
+| store-by-value custom config가 전달됨 | 생성 단계에서 fail-closed하고 안전한 copier/filter 정책을 별도 설계하도록 안내 |
+| clear의 front 또는 back 삭제가 실패함 | 수행 순서와 부분 상태를 로그·예외로 노출하고, 호출자가 같은 clear를 재시도할 수 있도록 유지 |
 
 ## 수용 기준과 DoD
 
@@ -143,6 +201,9 @@ compound operation 테스트는 #1355에 중복 등록하지 않으며, 이번 �
 - [ ] back fallback과 front populate 회귀 테스트가 `Cache<K,V>` 참조를 통해 통과한다.
 - [ ] `clear`가 해당 front/back를 지우고 peer 전파 한계를 문서화한다.
 - [ ] `getDeeply`·`clearAllCache` 호환 동작이 고정된다.
+- [ ] mutation epoch와 back-write barrier가 동시 read/clear 및 timeout-late write의 stale 재삽입을 차단한다.
+- [ ] `getAll` bulk 호출 수와 compound front-only 경계가 회귀 테스트로 고정된다.
+- [ ] 기본 front config가 store-by-reference이며 store-by-value custom config를 fail-closed한다.
 - [ ] `README.md`, `README.ko.md`, capability matrix가 동일한 계약을 설명한다.
 - [ ] `:bluetape4k-cache-core:test`와 영향 backend 검증이 통과한다.
 - [ ] `git diff --check`, Kotlin checklist, Type-A pre-PR review에서 P0/P1이 0건이다.
@@ -153,4 +214,3 @@ compound operation 테스트는 #1355에 중복 등록하지 않으며, 이번 �
 필요해지면 이 설계를 중단하고 별도 승인/이슈로 분리한다. 표준 `Cache` 타입
 참조에서 기존 동작과 호환되지 않는 P0/P1 회귀가 발견되면 feature branch에서
 수정하고, 설계 범위를 바꾸기 전 사용자 재승인을 받는다.
-


### PR DESCRIPTION
## Summary

Closes #1363

- PR 제목: [cache] NearJCache의 JCache 표준 read/clear 계약 정합성 확보

이 PR은 #1363의 NearJCache 표준 계약을 구현합니다.

- 표준 `get`, `containsKey`, `getAll`, `clear`를 front/back 2-tier 의미론으로 정합화
- read-through stale populate와 clear/listener 경계를 mutation epoch·generation으로 보호
- front store-by-value를 선언 설정과 실제 cache configuration 모두에서 fail-closed 검증
- front populate 실패 시 취소 전파·payload 비노출 로그 경계 추가
- `JCacheEntryEventListener`의 기존 1-인자 JVM 생성자 ABI 보존
- Hazelcast factory 생성 실패 시 front cache 리소스 정리
- NearJCache 계약·동시성·보안 경계 문서와 회귀 테스트 추가

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 요약

이 PR은 #1363의 NearJCache 표준 계약을 구현합니다.

- 표준 `get`, `containsKey`, `getAll`, `clear`를 front/back 2-tier 의미론으로 정합화
- read-through stale populate와 clear/listener 경계를 mutation epoch·generation으로 보호
- front store-by-value를 선언 설정과 실제 cache configuration 모두에서 fail-closed 검증
- front populate 실패 시 취소 전파·payload 비노출 로그 경계 추가
- `JCacheEntryEventListener`의 기존 1-인자 JVM 생성자 ABI 보존
- Hazelcast factory 생성 실패 시 front cache 리소스 정리
- NearJCache 계약·동시성·보안 경계 문서와 회귀 테스트 추가

### 검증

- `:bluetape4k-cache-core:test`: 547개 통과한 fresh run 증거 보유
- NearJCache/JCacheEntryEventListener 집중 테스트: 26개 통과
- Hazelcast 전체 테스트: 226개 통과
- Lettuce 전체 테스트: 443개 통과
- Redisson 전체 테스트: 440개 통과
- cache-core 및 cache-hazelcast detekt task 성공; 변경 파일 신규 finding 없음
- `javap`로 `JCacheEntryEventListener(Cache)` ABI 확인
- `git diff --check` 통과
- 독립 코드·보안 검토: exact HEAD `18c1785a7a7b6cb0bcbd6ca06341621e811c2ee3`, P0/P1/blocking P2 없음

### 알려진 제한

- shared back cache의 tenant/owner 권한 모델은 후속 보안 경계로 문서화되어 있습니다.
- `clear()` 실패와 listener 재등록 실패 동시 발생 시 예외 보존 강화는 후속 과제입니다.
- 전체 cache-core `--rerun-tasks` 재실행 중 일부 환경성 upstream test classpath 누락이 관찰되었으나, 재시도 및 targeted/full provider 검증은 통과했습니다.

Closes #1363

### DoD Status

- [x] 승인된 설계·구현·문서·회귀 테스트 완료
- [x] exact-head 독립 코드/보안 검토 PASS
- [x] worktree clean 및 Lore commit 검증
- [ ] PR required CI
- [ ] 머지 및 로컬 develop 동기화
- [ ] 병합 후 feature worktree/branch 정리

## Validation

- `:bluetape4k-cache-core:test`: 547개 통과한 fresh run 증거 보유
- NearJCache/JCacheEntryEventListener 집중 테스트: 26개 통과
- Hazelcast 전체 테스트: 226개 통과
- Lettuce 전체 테스트: 443개 통과
- Redisson 전체 테스트: 440개 통과
- cache-core 및 cache-hazelcast detekt task 성공; 변경 파일 신규 finding 없음
- `javap`로 `JCacheEntryEventListener(Cache)` ABI 확인
- `git diff --check` 통과
- 독립 코드·보안 검토: exact HEAD `18c1785a7a7b6cb0bcbd6ca06341621e811c2ee3`, P0/P1/blocking P2 없음

## Review Notes

- shared back cache의 tenant/owner 권한 모델은 후속 보안 경계로 문서화되어 있습니다.
- `clear()` 실패와 listener 재등록 실패 동시 발생 시 예외 보존 강화는 후속 과제입니다.
- 전체 cache-core `--rerun-tasks` 재실행 중 일부 환경성 upstream test classpath 누락이 관찰되었으나, 재시도 및 targeted/full provider 검증은 통과했습니다.

Closes #1363

## Metadata

- Issue: #1363, milestone `1.13.0`, assignee `debop`
- PR: #1367, head `18c1785a7a7b6cb0bcbd6ca06341621e811c2ee3`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/nearcache-jcache-contract`
- Labels: `bug`, `documentation`, `test`, `tech-debt`, `cache`
- State: `MERGED`, merge commit `9fea71300cd53b796dbcf7b6fa363ce35be03f7d`
- CI: - cache-core 및 cache-hazelcast detekt task 성공; 변경 파일 신규 finding 없음 / - [ ] PR required CI

## DoD Status

- [x] 승인된 설계·구현·문서·회귀 테스트 완료
- [x] exact-head 독립 코드/보안 검토 PASS
- [x] worktree clean 및 Lore commit 검증
- [ ] PR required CI
- [ ] 머지 및 로컬 develop 동기화
- [ ] 병합 후 feature worktree/branch 정리

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1367 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9fea71300cd53b796dbcf7b6fa363ce35be03f7d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
