### PR TITLE
[cache] clear 실패와 listener 재등록 예외를 함께 보존한다

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -198,9 +198,11 @@ class NearJCache<K: Any, V: Any>(
 
     override fun iterator(): MutableIterator<Cache.Entry<K, V>> = frontCache.iterator()
 
+    @Suppress("TooGenericExceptionCaught")
     override fun clear() {
         val hadBackCacheListener = backCacheListener.get() != null
         detachBackCacheListener()
+        var primaryFailure: Throwable? = null
         try {
             mutationGate.withLock {
                 mutationEpoch.incrementAndGet()
@@ -215,9 +217,21 @@ class NearJCache<K: Any, V: Any>(
                     backCache.clear()
                 }
             }
-        } finally {
-            if (hadBackCacheListener) registerBackCacheListener()
+        } catch (e: Throwable) {
+            primaryFailure = e
         }
+        if (hadBackCacheListener) {
+            try {
+                registerBackCacheListener()
+            } catch (registrationFailure: Throwable) {
+                if (primaryFailure == null) {
+                    primaryFailure = registrationFailure
+                } else if (registrationFailure !== primaryFailure) {
+                    primaryFailure.addSuppressed(registrationFailure)
+                }
+            }
+        }
+        primaryFailure?.let { throw it }
     }
 
     /**
@@ -247,9 +261,13 @@ class NearJCache<K: Any, V: Any>(
             try {
                 log.info { "back cache 이벤트 listener 등록. cache=${config.cacheName}" }
                 backCache.registerCacheEntryListener(configuration)
-            } catch (e: RuntimeException) {
+            } catch (e: Throwable) {
                 backCacheListener.compareAndSet(registration, null)
                 registration.active.set(false)
+                log.error(e) {
+                    "NearJCache back cache listener registration failed. " +
+                            "operation=register, cache=${config.cacheName}"
+                }
                 throw e
             }
         }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import javax.cache.Cache
 import javax.cache.configuration.CacheEntryListenerConfiguration
 import javax.cache.configuration.Configuration
@@ -358,6 +359,46 @@ class NearJCacheContractTest {
         assertFailsWith<IllegalStateException> { nearCache.clear() }
 
         verify(exactly = 0) { backCache.clear() }
+    }
+
+    @Test
+    fun `clear primary failure는 listener 재등록 failure를 suppressed로 보존한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val primaryFailure = IllegalStateException("front unavailable")
+        val registrationFailure = IllegalArgumentException("listener unavailable")
+        val registrationCount = AtomicInteger()
+        every { backCache.registerCacheEntryListener(any()) } answers {
+            if (registrationCount.incrementAndGet() == 2) throw registrationFailure
+        }
+        every { frontCache.clear() } throws primaryFailure
+        val nearCache = newNearCache(frontCache, backCache)
+        nearCache.registerBackCacheListener()
+
+        val error = assertFailsWith<IllegalStateException> { nearCache.clear() }
+
+        (error === primaryFailure).shouldBeTrue()
+        error.suppressed.single() shouldBeEqualTo registrationFailure
+        verify(exactly = 0) { backCache.clear() }
+    }
+
+    @Test
+    fun `clear 성공 후 listener 재등록 failure는 호출자에게 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val registrationFailure = IllegalArgumentException("listener unavailable")
+        val registrationCount = AtomicInteger()
+        every { backCache.registerCacheEntryListener(any()) } answers {
+            if (registrationCount.incrementAndGet() == 2) throw registrationFailure
+        }
+        val nearCache = newNearCache(frontCache, backCache)
+        nearCache.registerBackCacheListener()
+
+        val error = assertFailsWith<IllegalArgumentException> { nearCache.clear() }
+
+        (error === registrationFailure).shouldBeTrue()
+        verify(exactly = 1) { frontCache.clear() }
+        verify(exactly = 1) { backCache.clear() }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1370

- PR 제목: [cache] clear 실패와 listener 재등록 예외를 함께 보존한다

## Background

기존 `finally` 블록에서 listener 재등록 예외를 직접 던져, clear 본문에서 발생한 primary exception을 가릴 수 있었습니다. 이로 인해 장애 원인과 재시도 판단에 필요한 예외가 손실될 수 있었습니다.

## What This Solves

shared back cache owner/tenant 권한(#1368), `getAll` bulk residency 제한(#1369), front cleanup 관측성(#1371)은 별도 후속 과제로 유지합니다.

Fixes #1370

## Work Done

- `NearJCache.clear()`가 clear primary failure를 유지하도록 수정했습니다.
- listener 재등록이 추가로 실패하면 원래 예외의 `suppressed` 예외로 보존합니다.
- clear가 성공한 뒤 listener 재등록만 실패한 경우에는 재등록 예외를 호출자에게 전달합니다.
- listener 등록 실패 시 listener 상태를 정리하고 key/value/payload 없는 `cache`·`operation` 메타데이터만 로그에 남깁니다.
- 두 실패 경계를 `NearJCacheContractTest`에 추가했습니다.

## Validation

- `NearJCacheContractTest`: 24/24 통과
- `:bluetape4k-cache-core:test --no-configuration-cache`: 549 tests, failures 0, errors 0, skipped 0
- `:bluetape4k-cache-core:detekt --no-configuration-cache`: 성공; 변경 파일 신규 finding 없음
- `git diff --check`: 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1370, milestone `1.13.0`, assignee debop
- PR: #1372, head `c6056dbeb0c8eb0abe65b5726a636c83411735a5`, milestone `1.13.0`, assignee debop
- Base: `develop`, head branch `fix/nearcache-clear-error-preservation`
- Labels: 없음
- State: `MERGED`, merge commit `ed46364437adc2fa4815feae9dc51456f1ad10a6`
- CI: - `:bluetape4k-cache-core:detekt --no-configuration-cache`: 성공; 변경 파일 신규 finding 없음## DoD Status

- 원문 DoD Status가 없었던 역사적 PR입니다. 새로 실행한 형식 검증 항목만 아래에 기록합니다.

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1372 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ed46364437adc2fa4815feae9dc51456f1ad10a6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
