### PR TITLE
fix(bucket4j): CompletableFuture 취소 원인을 보존한다

### DIFF
--- a/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedSuspendRateLimiter.kt
+++ b/infra/bucket4j/src/main/kotlin/io/bluetape4k/bucket4j/ratelimit/distributed/DistributedSuspendRateLimiter.kt
@@ -81,6 +81,14 @@ class DistributedSuspendRateLimiter @JvmOverloads constructor(
             }
             toRateLimitResult(probe, numToken)
         } catch (e: CancellationException) {
+            // CompletableFuture.get() converts an exceptional completion with a
+            // CancellationException into a new CancellationException and keeps
+            // the original coroutine cancellation as its cause. Restore that
+            // cause so callers observe the cancellation they actually supplied.
+            val cause = e.cause
+            if (cause is CancellationException && cause !== e) {
+                throw cause
+            }
             throw e
         } catch (e: Exception) {
             log.warn(e) { "Rate Limiter 적용에 실패했습니다. key=$key" }


### PR DESCRIPTION
## Summary

Closes #1374

- PR 제목: fix(bucket4j): CompletableFuture 취소 원인을 보존한다

`CompletableFuture`가 `CancellationException`을 감싸면서 분산 RateLimiter 호출자가 실제 `TimeoutCancellationException` 원인을 잃는 문제를 수정합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 감싼 `CancellationException`의 coroutine 원인을 복원합니다.
- 기존 일반 예외·취소 처리 계약은 유지합니다.

## Validation

- Bucket4j 전체 125개 테스트 통과
- `detekt` task 실행
- `git diff --check` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1374, milestone `1.13.0`, assignee `debop`
- PR: #1381, head `3fd6640212c8d9d0fa4c232501f782bb2a82ae55`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1374-future-cancellation`
- Labels: `bug`, `test`
- State: `MERGED`, merge commit `2524209e0dcc503877e5bea3701faf57b0a4048d`
- CI: - `detekt` task 실행 / - [ ] PR exact head CI 및 리뷰

## DoD Status

- [x] RED 재현 및 최소 수정
- [x] 회귀 테스트 통과
- [x] issue #1374 연결
- [ ] PR exact head CI 및 리뷰
- [ ] merge 후 로컬 sync/정리

Fixes #1374

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1381 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `2524209e0dcc503877e5bea3701faf57b0a4048d`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
