### PR TITLE
fix(coroutines): buffering debounce 윈도우 경계를 안정화한다

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/bufferingDebounce.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/bufferingDebounce.kt
@@ -48,7 +48,9 @@ fun <T> Flow<T>.bufferingDebounce(timeout: Duration): Flow<List<T>> = flow {
                 }
                 itemChannel.onReceiveCatching { result ->
                     val receiveTimeNs = System.nanoTime()
-                    deboundedTimeout -= (receiveTimeNs - prevTimeNs).nanoseconds
+                    if (bufferedItems.isNotEmpty()) {
+                        deboundedTimeout -= (receiveTimeNs - prevTimeNs).nanoseconds
+                    }
                     prevTimeNs = receiveTimeNs
                     result
                         .onSuccess { item -> bufferedItems.add(item) }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/BufferingDebouncedTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/BufferingDebouncedTest.kt
@@ -41,6 +41,18 @@ class BufferingDebouncedTest: AbstractFlowTest() {
     }
 
     @Test
+    fun `첫 요소를 수신하기 전의 지연은 디바운스 윈도우를 소진시키지 않습니다`() = runSuspendIO {
+        val source = flow {
+            delay(250.milliseconds)
+            emit(1)
+            delay(50.milliseconds)
+            emit(2)
+        }
+
+        source.bufferingDebounce(100.milliseconds).toList() shouldBeEqualTo listOf(listOf(1, 2))
+    }
+
+    @Test
     fun `flow 에서 예외를 발생 시키면, 그동안 버퍼링한 것들을 발행한다`() = runSuspendIO {
         val source =
             flow {


### PR DESCRIPTION
## Summary

Closes #1375

- PR 제목: fix(coroutines): buffering debounce 윈도우 경계를 안정화한다

첫 요소 이전의 유휴 시간이 `bufferingDebounce` 윈도우를 소진시켜 배치 경계를 비결정적으로 만드는 문제를 수정합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 버퍼가 비어 있는 동안의 경과 시간은 debounce budget에서 제외합니다.
- 첫 수신 지연을 고정하는 회귀 테스트를 추가합니다.

## Validation

- Coroutines 전체 617개 테스트 통과
- `detekt` task 실행
- `git diff --check` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1375, milestone `1.13.0`, assignee `debop`
- PR: #1382, head `4fc1616ca8e7f4ab36455a95e7fa40b1d9f886f6`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1375-buffering-debounce`
- Labels: `bug`, `test`, `coroutines`
- State: `MERGED`, merge commit `471e878fbb6ba4fc2ce989c70530e88cb8c29a6a`
- CI: - `detekt` task 실행 / - [ ] PR exact head CI 및 리뷰

## DoD Status

- [x] RED 재현 및 최소 수정
- [x] 회귀 테스트 통과
- [x] issue #1375 연결
- [ ] PR exact head CI 및 리뷰
- [ ] merge 후 로컬 sync/정리

Fixes #1375

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1382 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `471e878fbb6ba4fc2ce989c70530e88cb8c29a6a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
