### PR TITLE
test(http): 병렬 coroutine 요청 timeout을 실시간으로 검증한다

### DIFF
--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientCoroutinesTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientCoroutinesTest.kt
@@ -10,14 +10,12 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.test.runTest
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder
 import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer
 import org.apache.hc.client5.http.protocol.HttpClientContext
 import org.apache.hc.core5.http.HttpHost
 import org.junit.jupiter.api.Test
 import java.net.URI
-import kotlin.time.Duration.Companion.seconds
 
 class AsyncHttpClientCoroutinesTest: AbstractHc5Test() {
 
@@ -34,7 +32,7 @@ class AsyncHttpClientCoroutinesTest: AbstractHc5Test() {
     }
 
     @Test
-    fun `여러 URL 병렬 coroutine GET 요청 모두 200`() = runTest(timeout = 30.seconds) {
+    fun `여러 URL 병렬 coroutine GET 요청 모두 200`() = runSuspendIO(timeout = 60.seconds) {
         httpAsyncClient {}.use { client ->
             val responses = coroutineScope {
                 urisToGet.map { uri ->

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientCoroutinesTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/async/AsyncHttpClientCoroutinesTest.kt
@@ -15,6 +15,7 @@ import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer
 import org.apache.hc.client5.http.protocol.HttpClientContext
 import org.apache.hc.core5.http.HttpHost
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
 import java.net.URI
 
 class AsyncHttpClientCoroutinesTest: AbstractHc5Test() {


### PR DESCRIPTION
## Summary

Closes #1377

- PR 제목: test(http): 병렬 coroutine 요청 timeout을 실시간으로 검증한다

실제 HTTP 병렬 요청이 `runTest` virtual-time 30초 제한에 걸려 전체 build를 중단하는 문제를 수정합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 외부 HTTP I/O를 `runSuspendIO(timeout = 60.seconds)`로 실행합니다.
- timeout duration import를 명시적으로 유지합니다.

## Validation

- HTTP 전체 456개 테스트 통과, 기존 skip 3개
- `compileTestKotlin` 통과
- `git diff --check` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1377, milestone `1.13.0`, assignee `debop`
- PR: #1384, head `b23049b8326075e98eaf0da062904a6885ff5e47`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1377-http-parallel-test`
- Labels: `bug`, `test`, `build`
- State: `MERGED`, merge commit `9aed4927b68d6d8a59e97c79453a697f4c975fd6`
- CI: - [ ] PR exact head CI 및 리뷰

## DoD Status

- [x] 실패 재현 및 최소 테스트 수정
- [x] 회귀 테스트 통과
- [x] issue #1377 연결
- [ ] PR exact head CI 및 리뷰
- [ ] merge 후 로컬 sync/정리

Fixes #1377

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1384 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `9aed4927b68d6d8a59e97c79453a697f4c975fd6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
