### PR TITLE
test(mongodb): database 목록 조회 timeout을 안정화한다

### DIFF
--- a/data/mongodb/src/test/kotlin/io/bluetape4k/mongodb/MongoClientSupportTest.kt
+++ b/data/mongodb/src/test/kotlin/io/bluetape4k/mongodb/MongoClientSupportTest.kt
@@ -13,6 +13,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.shouldNotBeSameInstanceAs
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.mongodb.bson.documentOf
 import io.mockk.clearMocks
@@ -240,7 +241,7 @@ class MongoClientSupportTest: AbstractMongoTest() {
     }
 
     @Test
-    fun `listDatabaseNamesAsList 생성한 DB 포함 여부 확인`() = runTest(timeout = 30.seconds) {
+    fun `listDatabaseNamesAsList 생성한 DB 포함 여부 확인`() = runSuspendIO(timeout = 60.seconds) {
         // 컬렉션을 생성하면 해당 DB도 목록에 나타납니다
         val dbName = "db_list_test"
         val tempClient = mongoClientOf(mongoServer.url)


### PR DESCRIPTION
## Summary

Closes #1378

- PR 제목: test(mongodb): database 목록 조회 timeout을 안정화한다

실제 MongoDB Testcontainer 목록 조회가 virtual-time 30초 제한에 걸려 완료되지 않는 문제를 수정합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- database listing 테스트를 `runSuspendIO(timeout = 60.seconds)`로 실행합니다.
- MongoDB API의 결과·예외·취소 계약은 유지합니다.

## Validation

- MongoDB 전체 52개 테스트 통과
- `compileTestKotlin` 통과
- `git diff --check` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1378, milestone `1.13.0`, assignee `debop`
- PR: #1385, head `0b6bfb56e83d135f17faed4cd731a6c53e3850f6`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1378-mongodb-list-databases`
- Labels: `bug`, `test`, `build`
- State: `MERGED`, merge commit `64c8464c6c9fe98de075a4934ef74ab1ee373f27`
- CI: - [ ] PR exact head CI 및 리뷰

## DoD Status

- [x] 실패 재현 및 최소 테스트 수정
- [x] 회귀 테스트 통과
- [x] issue #1378 연결
- [ ] PR exact head CI 및 리뷰
- [ ] merge 후 로컬 sync/정리

Fixes #1378

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1385 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `64c8464c6c9fe98de075a4934ef74ab1ee373f27`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
