### PR TITLE
test(pulsar): 컨테이너 readiness와 coroutine timeout을 안정화한다

### DIFF
--- a/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/PulsarClientSupportTest.kt
+++ b/infra/pulsar/src/test/kotlin/io/bluetape4k/pulsar/PulsarClientSupportTest.kt
@@ -1,14 +1,15 @@
 package io.bluetape4k.pulsar
 
-import io.bluetape4k.logging.KLogging
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.runTest
 import org.apache.pulsar.client.api.ClientBuilder
 import org.apache.pulsar.client.api.PulsarClient
 import org.apache.pulsar.client.api.Schema
@@ -38,7 +39,7 @@ class PulsarClientSupportTest : AbstractPulsarTest() {
     }
 
     @Test
-    fun `withPulsarClient - 블록 실행 후 자동 close`() = runTest(timeout = 30.seconds) {
+    fun `withPulsarClient - 블록 실행 후 자동 close`() = runSuspendIO(timeout = 120.seconds) {
         var clientRef: org.apache.pulsar.client.api.PulsarClient? = null
         withPulsarClient(pulsar.url) {
             clientRef = this
@@ -50,7 +51,7 @@ class PulsarClientSupportTest : AbstractPulsarTest() {
     }
 
     @Test
-    fun `withPulsarClient - setup-only 오버로드`() = runTest(timeout = 30.seconds) {
+    fun `withPulsarClient - setup-only 오버로드`() = runSuspendIO(timeout = 120.seconds) {
         val url = pulsar.url
         withPulsarClient({ serviceUrl(url) }) {
             shouldNotBeNull()

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/PulsarServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/PulsarServer.kt
@@ -10,6 +10,7 @@ import org.apache.pulsar.client.api.ClientBuilder
 import org.apache.pulsar.client.api.PulsarClient
 import org.testcontainers.pulsar.PulsarContainer
 import org.testcontainers.utility.DockerImageName
+import java.time.Duration
 
 /**
  * Apache Pulsar 테스트 서버 컨테이너를 실행하고 브로커 연결 정보를 제공합니다.
@@ -122,6 +123,13 @@ class PulsarServer private constructor(
     override fun start() {
         super.start()
         writeToSystemProperties()
+    }
+
+    override fun configure() {
+        super.configure()
+        // Pulsar의 standalone broker가 JVM/컨테이너 자원 경합 환경에서
+        // 기본 30초보다 늦게 HTTP admin endpoint를 열 수 있습니다.
+        getWaitStrategy().withStartupTimeout(Duration.ofMinutes(2))
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #1380

- PR 제목: test(pulsar): 컨테이너 readiness와 coroutine timeout을 안정화한다

Pulsar Testcontainer readiness와 실제 broker I/O 테스트가 기본 30초 virtual/startup timeout에 걸리는 문제를 수정합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Pulsar `WaitAllStrategy` startup timeout을 2분으로 확장합니다.
- 실제 broker 호출 테스트를 `runSuspendIO(timeout = 120.seconds)`로 실행합니다.

## Validation

- Pulsar 전체 37개 테스트 통과
- `PulsarServerTest` 4개 통과
- `git diff --check` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1380, milestone `1.13.0`, assignee `debop`
- PR: #1387, head `eb784905a7002777a7ddcaf3b7674cc9117ebe43`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1380-pulsar-startup`
- Labels: `bug`, `test`, `build`
- State: `MERGED`, merge commit `f60969ce1def1bcfb374b4501e41df5fc5d43379`
- CI: - [ ] PR exact head CI 및 리뷰

## DoD Status

- [x] 실패 원인 확인 및 최소 수정
- [x] 회귀 테스트 통과
- [x] issue #1380 연결
- [ ] PR exact head CI 및 리뷰
- [ ] merge 후 로컬 sync/정리

Fixes #1380

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1387 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `f60969ce1def1bcfb374b4501e41df5fc5d43379`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
