### PR TITLE
[testcontainers] Elasticsearch 9.5.0 readiness를 실제 인증 API로 검증

### DIFF
--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt
@@ -7,8 +7,10 @@ import io.bluetape4k.testcontainers.GenericServer
 import io.bluetape4k.testcontainers.PropertyExportingServer
 import io.bluetape4k.testcontainers.exposeCustomPorts
 import io.bluetape4k.utils.ShutdownQueue
+import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 import org.testcontainers.utility.DockerImageName
+import java.time.Duration
 
 
 /**
@@ -113,6 +115,18 @@ class ElasticsearchServer private constructor(
         withReuse(reuse)
         withPassword(password)
         withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+
+        // Elasticsearch 9.x는 로그의 `started` 메시지보다 실제 HTTPS API 응답이
+        // 준비 상태를 더 정확하게 나타냅니다. 이미지 cold-start가 긴 CI에서도
+        // 인증된 API가 200을 반환할 때까지 기다려 로그 타이밍 경쟁을 피합니다.
+        waitingFor(
+            Wait.forHttps("/")
+                .forPort(PORT)
+                .withBasicCredentials("elastic", password)
+                .allowInsecure()
+                .forStatusCode(200)
+                .withStartupTimeout(Duration.ofMinutes(3))
+        )
 
         if (useDefaultPort) {
             exposeCustomPorts(PORT, TCP_PORT)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.testcontainers.exposeCustomPorts
 import io.bluetape4k.utils.ShutdownQueue
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.elasticsearch.ElasticsearchContainer
+import org.testcontainers.utility.ComparableVersion
 import org.testcontainers.utility.DockerImageName
 import java.time.Duration
 
@@ -116,17 +117,17 @@ class ElasticsearchServer private constructor(
         withPassword(password)
         withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
 
-        // Elasticsearch 9.x는 로그의 `started` 메시지보다 실제 HTTPS API 응답이
-        // 준비 상태를 더 정확하게 나타냅니다. 이미지 cold-start가 긴 CI에서도
-        // 인증된 API가 200을 반환할 때까지 기다려 로그 타이밍 경쟁을 피합니다.
-        waitingFor(
-            Wait.forHttps("/")
-                .forPort(PORT)
-                .withBasicCredentials("elastic", password)
-                .allowInsecure()
-                .forStatusCode(200)
-                .withStartupTimeout(Duration.ofMinutes(3))
-        )
+        // Elasticsearch 8+는 HTTPS 보안을 기본 활성화하므로 실제 인증 API 응답을
+        // 확인합니다. 구버전 사용자 지정 이미지는 기존 HTTP 계약을 유지합니다.
+        val readiness = Wait.forHttp("/")
+            .forPort(PORT)
+            .withBasicCredentials("elastic", password)
+            .forStatusCode(200)
+        if (ComparableVersion(imageName.versionPart).isGreaterThanOrEqualTo("8.0.0")) {
+            readiness.usingTls().allowInsecure()
+        }
+        readiness.withStartupTimeout(Duration.ofMinutes(3))
+        waitingFor(readiness)
 
         if (useDefaultPort) {
             exposeCustomPorts(PORT, TCP_PORT)


### PR DESCRIPTION
## Summary

Closes #1388

- PR 제목: [testcontainers] Elasticsearch 9.5.0 readiness를 실제 인증 API로 검증

## Background

#1388에서 Elasticsearch 9.5.0 컨테이너가 inherited log-message wait의 `started` 정규식에 의존해 cold-start 시 전체 빌드 readiness timeout을 일으켰습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- Elasticsearch 8+는 `https://<host>:<port>/` 인증 API가 HTTP 200을 반환할 때까지 대기합니다.
- self-signed 인증서는 Testcontainers readiness에서만 `allowInsecure`로 허용하고, 사용자 클라이언트의 TLS 설정은 변경하지 않습니다.
- 8 미만 사용자 지정 이미지에는 기존 HTTP 계약을 유지합니다.
- readiness startup timeout을 3분으로 bounded 설정했습니다.

## Validation

- `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.storage.ElasticsearchServerTest --no-configuration-cache --no-parallel --max-workers=1 --console=plain`
  - 4 tests 통과
- `./gradlew :bluetape4k-elasticsearch:test --no-configuration-cache --no-parallel --max-workers=1 --console=plain`
  - 34 tests 통과
- `./gradlew :bluetape4k-testcontainers:detekt --no-configuration-cache --no-parallel --max-workers=1 --console=plain`
  - BUILD SUCCESSFUL (기존 모듈 경고는 별도 범위)
- `git diff --check` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1388, milestone `1.13.0`, assignee `debop`
- PR: #1390, head `b7c959fe18f2185c13b000506b330407c195a36f`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1388-elasticsearch-readiness`
- Labels: `bug`, `test`, `build`
- State: `MERGED`, merge commit `574c54ea8612501087e1ada0daa6e8ef36721804`
- CI: - `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.storage.ElasticsearchServerTest --no-configuration-cache --no-parallel --max-workers=1 --console=plain` / - `./gradlew :bluetape4k-elasticsearch:test --no-configuration-cache --no-parallel --max-workers=1 --console=plain` / - `./gradlew :bluetape4k-testcontainers:detekt --no-configuration-cache --no-parallel --max-workers=1 --console=plain`

## DoD Status

- [x] 실제 Elasticsearch API 기반 bounded readiness
- [x] 기본/사용자 지정 비밀번호·고정 포트 컨테이너 회귀 테스트
- [x] infra/elasticsearch 모듈 테스트
- [x] 정적 분석 실행
- [ ] 두 잔여 PR 병합 후 전체 `build --continue` 재검증
- 상태: PENDING — PR CI 및 merge gate 대기

Fixes #1388

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1390 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `574c54ea8612501087e1ada0daa6e8ef36721804`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
