### PR TITLE
[cache][jwt] 동기 near-cache write-through timeout과 테스트 lifecycle을 보장

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -17,11 +17,14 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import javax.cache.Cache
+import javax.cache.CacheException
 import javax.cache.configuration.CacheEntryListenerConfiguration
 import javax.cache.configuration.Configuration
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration
@@ -613,17 +616,28 @@ class NearJCache<K: Any, V: Any>(
             }
         }
         if (synchronous) {
+            val timeoutMillis = config.syncRemoteTimeout.coerceAtLeast(NearJCacheConfig.DEFAULT_SYNC_REMOTE_TIMEOUT)
             return try {
-                guardedSyncTask()
+                runSynchronousBackCacheWrite(timeoutMillis, guardedSyncTask)
                 completion.complete(Unit)
                 completion
-            } catch (e: RuntimeException) {
-                completion.completeExceptionally(e)
-                log.error(e) {
+            } catch (e: Throwable) {
+                val failure = unwrapCompletionFailure(e)
+                val callerFailure = if (failure is TimeoutException) {
+                    CacheException(
+                        "NearJCache synchronous back cache write timed out after ${timeoutMillis}ms. " +
+                                "operation=$operation, cache=${config.cacheName}",
+                        failure
+                    )
+                } else {
+                    failure
+                }
+                completion.completeExceptionally(callerFailure)
+                log.error(callerFailure) {
                     "NearJCache synchronous back cache write failed. operation=$operation, " +
                             "cache=${config.cacheName}, provider=${backCache.javaClass.name}"
                 }
-                throw e
+                throw callerFailure
             }
         }
 
@@ -639,6 +653,31 @@ class NearJCache<K: Any, V: Any>(
             syncTask = guardedSyncTask,
         )
         return completion
+    }
+
+    /**
+     * 동기 write-through도 호출자 스레드를 원격 provider의 blocking wait에 묶지 않습니다.
+     * timeout 시 작업을 interrupt하고 executor를 즉시 종료해 테스트/애플리케이션 lifecycle에
+     * 남는 전용 실행기를 최소화합니다. Provider가 interrupt를 무시하면 실제 backend 작업은
+     * 늦게 완료될 수 있으므로 [backWriteLock]이 완료 순서를 계속 직렬화합니다.
+     */
+    @Suppress("ThrowsCount")
+    private fun runSynchronousBackCacheWrite(timeoutMillis: Long, syncTask: () -> Unit) {
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val future = executor.submit { syncTask() }
+        try {
+            future.get(timeoutMillis, TimeUnit.MILLISECONDS)
+        } catch (e: ExecutionException) {
+            throw unwrapCompletionFailure(e)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw CancellationException("Synchronous back cache write was interrupted").also { it.initCause(e) }
+        } catch (e: TimeoutException) {
+            future.cancel(true)
+            throw e
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     private fun frontContainsKey(key: K): Boolean = mutationGate.withLock {

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import javax.cache.Cache
+import javax.cache.CacheException
 
 class NearJCacheWriteThroughFailureTest {
 
@@ -179,6 +180,44 @@ class NearJCacheWriteThroughFailureTest {
         assertFailsWith<IllegalStateException> {
             nearCache.clearAllCache()
         }.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `동기 write-through timeout은 호출자와 completion을 bounded failure로 완료한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val release = CountDownLatch(1)
+        every { backCache.put("key", "value") } answers {
+            release.await()
+        }
+
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = true, syncRemoteTimeout = 50L),
+            )
+
+        try {
+            val startedAt = System.nanoTime()
+            val error = assertFailsWith<CacheException> {
+                nearCache.put("key", "value")
+            }
+            val elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+
+            check(elapsedMillis < 1_000L) { "synchronous write-through exceeded bounded timeout: ${elapsedMillis}ms" }
+            check(error.cause is TimeoutException) {
+                "Expected timeout cause but got ${error.cause}"
+            }
+            val completionError = assertFailsWith<ExecutionException> {
+                nearCache.lastBackCacheWriteCompletion.get(1, TimeUnit.SECONDS)
+            }
+            check(completionError.cause is CacheException) {
+                "Expected completion CacheException but got ${completionError.cause}"
+            }
+        } finally {
+            release.countDown()
+        }
     }
 
     @Test

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/reader/JwtReaderCachingTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/reader/JwtReaderCachingTest.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.testcontainers.storage.RedisServer
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.RepeatedTest
 import org.redisson.codec.LZ4Codec
 import java.util.*
@@ -124,21 +125,36 @@ class JwtReaderCachingTest: AbstractJwtTest() {
 
     @RepeatedTest(REPEAT_SIZE)
     fun `caching reader with two near cache`() {
-        val nearJCacheConfig1 = NearJCacheConfig<String, JwtReaderDto>(isSynchronous = true)
-        val nearJCacheConfig2 = NearJCacheConfig<String, JwtReaderDto>(isSynchronous = true)
+        // Redisson JCache의 blocking `put`은 provider 내부 lock까지 포함하므로
+        // 테스트에서는 bounded async write-through를 사용하고 back 반영을 await한다.
+        val nearJCacheConfig1 = NearJCacheConfig<String, JwtReaderDto>(isSynchronous = false)
+        val nearJCacheConfig2 = NearJCacheConfig<String, JwtReaderDto>(isSynchronous = false)
         val nearJCache1 = NearJCache(nearJCacheConfig1, backCache)
         val nearJCache2 = NearJCache(nearJCacheConfig2, backCache)
 
-        // Cache 1 에서 저장
-        nearJCache1.put(jwt, reader.toDto())
-        assertSameReader(reader, nearJCache1.get(jwt)!!.toJwtReader())
+        try {
+            // Cache 1 에서 저장
+            nearJCache1.put(jwt, reader.toDto())
+            nearJCache1.lastBackCacheWriteCompletion.toCompletableFuture().join()
+            assertSameReader(reader, nearJCache1.get(jwt)!!.toJwtReader())
 
-        await atMost 10.seconds until { nearJCache2.containsKey(jwt) }
+            await atMost 10.seconds until { nearJCache2.containsKey(jwt) }
 
-        // Cache 2 에서 조회
-        val actual = nearJCache2.get(jwt)!!.toJwtReader()
+            // Cache 2 에서 조회
+            val actual = nearJCache2.get(jwt)!!.toJwtReader()
 
-        assertSameReader(reader, actual)
+            assertSameReader(reader, actual)
+        } finally {
+            nearJCache1.close()
+            nearJCache2.close()
+        }
+    }
+
+    @AfterAll
+    fun closeCaches() {
+        runCatching { backCache.close() }
+        runCatching { frontCache1.close() }
+        runCatching { frontCache2.close() }
     }
 
     private fun assertSameReader(expected: JwtReader, actual: JwtReader) {


### PR DESCRIPTION
## Summary

Closes #1389

- PR 제목: [cache][jwt] 동기 near-cache write-through timeout과 테스트 lifecycle을 보장

## Background

#1389에서 Redisson JCache의 provider 내부 blocking lock 대기가 `NearJCache.put` 동기 write-through에서 무기한 지속되어 `JwtReaderCachingTest`와 전체 build가 멈췄습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 동기 write-through도 `syncRemoteTimeout` 안에서 실행하고 timeout 시 `CacheException`과 completion failure로 관찰합니다.
- 전용 virtual-thread 작업을 timeout 시 interrupt/cancel하고 executor를 즉시 종료합니다.
- provider가 interrupt를 무시하는 late backend 작업은 기존 `backWriteLock` 직렬화로 경계를 유지합니다.
- JWT 두-near-cache 테스트는 bounded async write-through 결과를 await하고 각 near cache와 static cache를 정리합니다.
- 동기 timeout 및 completion 회귀 테스트를 추가했습니다.

## Validation

- `./gradlew :bluetape4k-cache-core:test --tests io.bluetape4k.cache.nearcache.jcache.NearJCacheWriteThroughFailureTest --tests io.bluetape4k.cache.nearcache.jcache.NearJCacheContractTest --no-configuration-cache --no-parallel --max-workers=1 --console=plain`
  - 43 tests 통과
- `./gradlew :bluetape4k-jwt:test --tests io.bluetape4k.jwt.reader.JwtReaderCachingTest --no-configuration-cache --no-parallel --max-workers=1 --console=plain`
  - 15 tests 통과, 두 near-cache 3 repetitions 포함
- `./gradlew :bluetape4k-cache-core:detekt --no-configuration-cache --no-parallel --max-workers=1 --console=plain`
  - BUILD SUCCESSFUL (기존 모듈 경고는 별도 범위)
- `git diff --check` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1389, milestone `1.13.0`, assignee `debop`
- PR: #1391, head `bd951ee7231d603189c37d3740d9caeb9299012b`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1389-near-cache-write-timeout`
- Labels: `bug`, `test`, `cache`
- State: `MERGED`, merge commit `a8484a81f80bceefb9dfc18e01ca131e7164ba5c`
- CI: - `./gradlew :bluetape4k-cache-core:test --tests io.bluetape4k.cache.nearcache.jcache.NearJCacheWriteThroughFailureTest --tests io.bluetape4k.cache.nearcache.jcache.NearJCacheContractTest --no-configuration-cache --no-parallel --max-workers=1 --console=plain` / - `./gradlew :bluetape4k-jwt:test --tests io.bluetape4k.jwt.reader.JwtReaderCachingTest --no-configuration-cache --no-parallel --max-workers=1 --console=plain` / - `./gradlew :bluetape4k-cache-core:detekt --no-configuration-cache --no-parallel --max-workers=1 --console=plain`

## DoD Status

- [x] 동기 write-through bounded timeout/cancellation
- [x] caller-visible completion과 기존 동기 예외 전파 계약 보존
- [x] JWT near-cache 테스트의 명시적 lifecycle 정리
- [x] cache-core·jwt 회귀 테스트 및 정적 분석
- [ ] 두 잔여 PR 병합 후 전체 `build --continue` 재검증
- 상태: PENDING — PR CI 및 merge gate 대기

Fixes #1389

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1391 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `a8484a81f80bceefb9dfc18e01ca131e7164ba5c`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
