### PR TITLE
[mock-webflux][test] HTTPS lifecycle 테스트 포트를 격리

### DIFF
--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/config/HttpsServerLifecycle.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/config/HttpsServerLifecycle.kt
@@ -17,7 +17,7 @@ import javax.net.ssl.KeyManagerFactory
  * Reactor Netty를 사용해 HTTPS 보조 서버를 [SmartLifecycle]로 구동하는 컴포넌트.
  *
  * 기존 HTTP 포트(80)는 그대로 유지하고,
- * [httpsPort](기본값 443)에 SSL이 활성화된 별도 Netty 서버를 추가한다.
+ * [httpsPort]에 SSL이 활성화된 별도 Netty 서버를 추가한다.
  * 인증서는 `src/main/resources/certs/localhost.p12`에 번들되어 있다.
  */
 @Component
@@ -31,20 +31,26 @@ class HttpsServerLifecycle(
 
     private var disposableServer: DisposableServer? = null
 
+    /** 현재 HTTPS 서버에 실제로 바인딩된 포트. 시작 전이나 종료 후에는 0이다. */
+    val boundPort: Int
+        get() = disposableServer?.port() ?: 0
+
     override fun start() {
         val sslContext = buildSslContext()
-        disposableServer = HttpServer.create()
+        val server = HttpServer.create()
             .port(httpsPort)
             .secure { spec -> spec.sslContext(sslContext) }
             .handle(ReactorHttpHandlerAdapter(httpHandler))
             .bindNow()
-        log.info { "HTTPS 보조 서버 시작: port=$httpsPort" }
+        disposableServer = server
+        log.info { "HTTPS 보조 서버 시작: configuredPort=$httpsPort, boundPort=${server.port()}" }
     }
 
     override fun stop() {
+        val stoppedPort = boundPort
         disposableServer?.dispose()
         disposableServer = null
-        log.info { "HTTPS 보조 서버 종료: port=$httpsPort" }
+        log.info { "HTTPS 보조 서버 종료: port=$stoppedPort" }
     }
 
     override fun isRunning(): Boolean = disposableServer?.isDisposed == false

--- a/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/config/HttpsServerLifecycleContractTest.kt
+++ b/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/config/HttpsServerLifecycleContractTest.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.mockwebflux.config
+
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.mockwebflux.AbstractMockWebfluxServerTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.server.reactive.HttpHandler
+
+/**
+ * 테스트 HTTPS lifecycle의 포트 격리 계약을 검증한다.
+ */
+class HttpsServerLifecycleContractTest : AbstractMockWebfluxServerTest() {
+
+    @Autowired
+    private lateinit var lifecycle: HttpsServerLifecycle
+
+    @Test
+    fun `test HTTPS lifecycle binds an ephemeral port`() {
+        lifecycle.isRunning.shouldBeTrue()
+
+        lifecycle.boundPort shouldBeGreaterThan 0
+        lifecycle.boundPort shouldNotBeEqualTo 8443
+    }
+
+    @Test
+    fun `standalone HTTPS lifecycle stops and clears its bound port`() {
+        val standalone = HttpsServerLifecycle(
+            HttpHandler { _, response -> response.setComplete() },
+            0,
+            "changeit",
+        )
+
+        standalone.start()
+        try {
+            standalone.isRunning.shouldBeTrue()
+            standalone.boundPort shouldBeGreaterThan 0
+        } finally {
+            standalone.stop()
+        }
+
+        standalone.isRunning.shouldBeFalse()
+        standalone.boundPort shouldBeEqualTo 0
+    }
+}

--- a/testing/mock-webflux-server/src/test/resources/application.yml
+++ b/testing/mock-webflux-server/src/test/resources/application.yml
@@ -1,3 +1,3 @@
 bluetape4k:
     https:
-        port: 8443
+        port: 0


### PR DESCRIPTION
## Summary

Closes #1396

- PR 제목: [mock-webflux][test] HTTPS lifecycle 테스트 포트를 격리

- mock-webflux 테스트 프로필의 보조 HTTPS 포트를 ephemeral port로 전환합니다.
- lifecycle이 실제 bound port를 노출하고 종료 후 포트 상태를 초기화하는 계약을 추가합니다.

Closes #1396

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 요약

- mock-webflux 테스트 프로필의 보조 HTTPS 포트를 ephemeral port로 전환합니다.
- lifecycle이 실제 bound port를 노출하고 종료 후 포트 상태를 초기화하는 계약을 추가합니다.

Closes #1396

### 검증

- lifecycle contract 2/2
- mock-webflux 모듈: 54/54
- mock-web-server와 병렬 검증: 119/119
- Detekt 통과
- 필수 `jibDockerBuild --no-configuration-cache` 통과
- 통합 exact head 전체 `clean build` 통과

### DoD Status

- [x] 고정 8443 충돌 재현
- [x] ephemeral bind/stop 계약 추가
- [x] module/parallel/Jib/static 검증
- [x] 전체 통합 빌드 검증
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

## Validation

- lifecycle contract 2/2
- mock-webflux 모듈: 54/54
- mock-web-server와 병렬 검증: 119/119
- Detekt 통과
- 필수 `jibDockerBuild --no-configuration-cache` 통과
- 통합 exact head 전체 `clean build` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1396, milestone `1.13.0`, assignee debop
- PR: #1400, head `29490275c2eb18852f8ead7d553e9db5e00b01b2`, milestone `1.13.0`, assignee debop
- Base: `develop`, head branch `fix/issue-1396-mock-webflux-ephemeral-https`
- Labels: 없음
- State: `MERGED`, merge commit `ce37ed6d2bd1375b34b26406887c5780a79f7ff6`
- CI: - Detekt 통과 / - [ ] CI 성공 확인## DoD Status

- [x] 고정 8443 충돌 재현
- [x] ephemeral bind/stop 계약 추가
- [x] module/parallel/Jib/static 검증
- [x] 전체 통합 빌드 검증
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1400 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ce37ed6d2bd1375b34b26406887c5780a79f7ff6`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
