### PR TITLE
[kafka][test] 전체 빌드 부하에서 batch listener 대기를 안정화

### DIFF
--- a/infra/kafka/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -62,7 +62,7 @@ class BatchListenerConversionTests {
 
     companion object: KLoggingChannel() {
         private const val DEFAULT_TEST_GROUP_ID = "blc"
-        private const val AWAIT_TIME_SECONDS = 3L
+        private const val AWAIT_TIME_SECONDS = 10L
     }
 
     @Autowired

--- a/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
+++ b/infra/kafka4/src/test/kotlin/org/springframework/kafka/annotation/BatchListenerConversionTests.kt
@@ -62,7 +62,7 @@ class BatchListenerConversionTests {
 
     companion object: KLoggingChannel() {
         private const val DEFAULT_TEST_GROUP_ID = "blc"
-        private const val AWAIT_TIME_SECONDS = 3L
+        private const val AWAIT_TIME_SECONDS = 10L
     }
 
     @Autowired


### PR DESCRIPTION
## Summary

Closes #1392

- PR 제목: [kafka][test] 전체 빌드 부하에서 batch listener 대기를 안정화

- Kafka 3/4 batch listener 테스트의 Awaitility 상한을 전체 빌드 부하에서도 유효한 10초로 조정합니다.
- production 동작이나 polling 조건은 변경하지 않습니다.

Closes #1392

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 요약

- Kafka 3/4 batch listener 테스트의 Awaitility 상한을 전체 빌드 부하에서도 유효한 10초로 조정합니다.
- production 동작이나 polling 조건은 변경하지 않습니다.

Closes #1392

### 검증

- Kafka targeted class: 6/6
- Kafka4 targeted class: 6/6
- `:bluetape4k-kafka:test`: 265/265
- `:bluetape4k-kafka4:test`: 297/297
- 양 모듈 Detekt 통과
- 통합 exact head 전체 `clean build` 통과

### DoD Status

- [x] 실패 재현 및 원인 분류
- [x] Kafka 3/4 동일 계약 반영
- [x] targeted/module/static 검증
- [x] 전체 통합 빌드 검증
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

## Validation

- Kafka targeted class: 6/6
- Kafka4 targeted class: 6/6
- `:bluetape4k-kafka:test`: 265/265
- `:bluetape4k-kafka4:test`: 297/297
- 양 모듈 Detekt 통과
- 통합 exact head 전체 `clean build` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1392, milestone `1.13.0`, assignee debop
- PR: #1403, head `baad644071367c58f6c3c06fd99cbc0cfff85527`, milestone `1.13.0`, assignee debop
- Base: `develop`, head branch `fix/issue-1392-kafka-readiness`
- Labels: 없음
- State: `MERGED`, merge commit `e8699f5e758ad71539c92669404d553b309e8f84`
- CI: - 양 모듈 Detekt 통과 / - [ ] CI 성공 확인## DoD Status

- [x] 실패 재현 및 원인 분류
- [x] Kafka 3/4 동일 계약 반영
- [x] targeted/module/static 검증
- [x] 전체 통합 빌드 검증
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1403 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `e8699f5e758ad71539c92669404d553b309e8f84`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
