### PR TITLE
[testcontainers] ZooKeeper readiness를 실제 Curator session으로 검증

### DIFF
--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServer.kt
@@ -9,8 +9,10 @@ import io.bluetape4k.utils.ShutdownQueue
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.retry.RetryOneTime
 import org.testcontainers.containers.GenericContainer
-import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
+
+private const val CURATOR_RETRY_DELAY_MS = 1_000
+private const val CURATOR_CONNECTION_TIMEOUT_MS = 10_000
 
 /**
  * [ZooKeeper](https://zookeeper.apache.org/) 서버의 docker image를 testcontainers 환경 하에서 실행하는 클래스입니다.
@@ -106,7 +108,7 @@ class ZooKeeperServer private constructor(
     init {
         withExposedPorts(PORT)
         withReuse(reuse)
-        waitingFor(Wait.forListeningPort())
+        waitingFor(ZooKeeperWaitStrategy())
 
         if (useDefaultPort) {
             exposeCustomPorts(PORT)
@@ -144,8 +146,8 @@ class ZooKeeperServer private constructor(
         fun getCuratorFramework(zookeeper: ZooKeeperServer): CuratorFramework {
             return curatorFrameworkOf {
                 connectString(zookeeper.url)
-                retryPolicy(RetryOneTime(1000))
-                connectionTimeoutMs(10_000)
+                retryPolicy(RetryOneTime(CURATOR_RETRY_DELAY_MS))
+                connectionTimeoutMs(CURATOR_CONNECTION_TIMEOUT_MS)
             }
         }
     }

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZookeeperServerSupport.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZookeeperServerSupport.kt
@@ -2,7 +2,15 @@ package io.bluetape4k.testcontainers.infra
 
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.retry.RetryForever
+import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy
+import java.time.Duration
 import java.util.concurrent.TimeUnit
+
+@PublishedApi
+internal const val CURATOR_BLOCK_TIMEOUT_SECONDS = 10
+private const val READINESS_CURATOR_RETRY_DELAY_MS = 1_000
+private const val READINESS_CURATOR_CONNECTION_TIMEOUT_MS = 10_000
 
 @PublishedApi
 internal inline fun curatorFrameworkOf(
@@ -18,7 +26,48 @@ internal inline fun <T> withCuratorFramework(
 ): T {
     return ZooKeeperServer.Launcher.getCuratorFramework(zookeeper).use { curator ->
         curator.start()
-        curator.blockUntilConnected(10, TimeUnit.SECONDS)
+        check(curator.blockUntilConnected(CURATOR_BLOCK_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            "ZooKeeper Curator session was not established at ${zookeeper.url}"
+        }
         curator.block()
     }
+}
+
+/**
+ * 컨테이너 포트가 아닌 Curator session 수립을 ZooKeeper readiness 기준으로 사용합니다.
+ *
+ * 컨테이너의 2181 포트는 ZooKeeper가 실제 요청을 처리하기 전에 열릴 수 있으므로,
+ * Testcontainers가 서버를 시작된 것으로 판정하기 전에 실제 애플리케이션 연결을 확인합니다.
+ */
+internal class ZooKeeperWaitStrategy(
+    private val curatorFactory: (String) -> CuratorFramework = ::createReadinessCurator,
+): AbstractWaitStrategy() {
+
+    init {
+        withStartupTimeout(READINESS_TIMEOUT)
+    }
+
+    override fun waitUntilReady() {
+        val target = waitStrategyTarget
+        val connectString = "${target.host}:${target.getMappedPort(ZooKeeperServer.PORT)}"
+
+        curatorFactory(connectString).use { curator ->
+            curator.start()
+            check(
+                curator.blockUntilConnected(READINESS_TIMEOUT.toMillis().toInt(), TimeUnit.MILLISECONDS),
+            ) {
+                "ZooKeeper Curator session was not established at $connectString"
+            }
+        }
+    }
+
+    private companion object {
+        val READINESS_TIMEOUT: Duration = Duration.ofMinutes(2)
+    }
+}
+
+private fun createReadinessCurator(connectString: String): CuratorFramework = curatorFrameworkOf {
+    connectString(connectString)
+    retryPolicy(RetryForever(READINESS_CURATOR_RETRY_DELAY_MS))
+    connectionTimeoutMs(READINESS_CURATOR_CONNECTION_TIMEOUT_MS)
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperWaitStrategyTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperWaitStrategyTest.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.testcontainers.infra
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.apache.curator.framework.CuratorFramework
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.wait.strategy.WaitStrategyTarget
+import java.util.concurrent.TimeUnit
+
+class ZooKeeperWaitStrategyTest {
+
+    @Test
+    fun `실제 Curator 세션이 연결된 뒤에만 readiness 를 통과한다`() {
+        val target = waitStrategyTarget()
+        val curator = mockk<CuratorFramework>(relaxed = true)
+        every { curator.blockUntilConnected(any<Int>(), any<TimeUnit>()) } returns true
+        var connectString: String? = null
+
+        ZooKeeperWaitStrategy {
+            connectString = it
+            curator
+        }.waitUntilReady(target)
+
+        connectString shouldBeEqualTo "127.0.0.1:32181"
+        verifyOrder {
+            curator.start()
+            curator.blockUntilConnected(any<Int>(), any<TimeUnit>())
+            curator.close()
+        }
+    }
+
+    @Test
+    fun `Curator 세션 연결에 실패하면 readiness 를 통과시키지 않는다`() {
+        val target = waitStrategyTarget()
+        val curator = mockk<CuratorFramework>(relaxed = true)
+        every { curator.blockUntilConnected(any<Int>(), any<TimeUnit>()) } returns false
+
+        val exception = assertFailsWith<IllegalStateException> {
+            ZooKeeperWaitStrategy { curator }.waitUntilReady(target)
+        }
+
+        exception.message shouldBeEqualTo "ZooKeeper Curator session was not established at 127.0.0.1:32181"
+        verify { curator.close() }
+    }
+
+    private fun waitStrategyTarget(): WaitStrategyTarget = mockk {
+        every { host } returns "127.0.0.1"
+        every { getMappedPort(ZooKeeperServer.PORT) } returns 32181
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1337

- PR 제목: [testcontainers] ZooKeeper readiness를 실제 Curator session으로 검증

- ZooKeeper 준비 상태를 listening port가 아니라 실제 Curator session 수립으로 판정합니다.
- `blockUntilConnected=false`를 무시하지 않고 명시적으로 실패시킵니다.
- #1337의 image family startup/workload gate 중 ZooKeeper readiness 하위 과제를 해결합니다.

Related to #1337

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 요약

- ZooKeeper 준비 상태를 listening port가 아니라 실제 Curator session 수립으로 판정합니다.
- `blockUntilConnected=false`를 무시하지 않고 명시적으로 실패시킵니다.
- #1337의 image family startup/workload gate 중 ZooKeeper readiness 하위 과제를 해결합니다.

Related to #1337

### 검증

- MockK readiness contract: 2/2
- 실제 ZooKeeper container/strategy: 6/6
- Testcontainers 모듈 전체: 451 tests, 0 failures, 25 skipped
- `compileTestKotlin`, Detekt, `git diff --check` 통과
- 통합 exact head 전체 `clean build` 통과

### DoD Status

- [x] 포트 조기-ready 원인 제거
- [x] 실제 Curator session gate 적용
- [x] targeted/Testcontainers module/static 검증
- [x] 전체 통합 빌드 검증
- [ ] #1337의 나머지 image family release gate
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

## Validation

- MockK readiness contract: 2/2
- 실제 ZooKeeper container/strategy: 6/6
- Testcontainers 모듈 전체: 451 tests, 0 failures, 25 skipped
- `compileTestKotlin`, Detekt, `git diff --check` 통과
- 통합 exact head 전체 `clean build` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1337, milestone `1.13.0`, assignee debop
- PR: #1404, head `609a40c799b59874c7fd617e4d613cd9fe8da29d`, milestone `1.13.0`, assignee debop
- Base: `develop`, head branch `fix/issue-1337-zookeeper-readiness`
- Labels: 없음
- State: `MERGED`, merge commit `b2b35cb3e6452440fda67f4bb7c6ab63fb1741b7`
- CI: - `compileTestKotlin`, Detekt, `git diff --check` 통과 / - [ ] CI 성공 확인## DoD Status

- [x] 포트 조기-ready 원인 제거
- [x] 실제 Curator session gate 적용
- [x] targeted/Testcontainers module/static 검증
- [x] 전체 통합 빌드 검증
- [ ] #1337의 나머지 image family release gate
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1404 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `b2b35cb3e6452440fda67f4bb7c6ab63fb1741b7`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
