### PR TITLE
[jwt][test] Redis 장애 검증을 실제 timeout 계약에 정렬

### DIFF
--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/redis/RedisKeyChainRepository.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/keychain/repository/redis/RedisKeyChainRepository.kt
@@ -123,7 +123,8 @@ class RedisKeyChainRepository private constructor(
     }
 }
 
-private const val ROTATION_LOCK_WAIT_SECONDS = 5L
+/** Redis key-chain rotation lock 획득을 기다리는 최대 시간(초)입니다. */
+internal const val REDIS_ROTATION_LOCK_WAIT_SECONDS = 5L
 
 /**
  * Redis rotation 작업을 Redisson watchdog 기반 lock 소유권 안에서 실행합니다.
@@ -133,7 +134,7 @@ private const val ROTATION_LOCK_WAIT_SECONDS = 5L
  * 해제 오류를 suppressed exception으로 보존해 원래 오류를 주 오류로 유지합니다.
  */
 internal fun <T> withRedisRotationLock(lock: RLock, action: () -> T): T {
-    check(lock.tryLock(ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS)) {
+    check(lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS)) {
         "Failed to acquire Redis keychain rotation lock."
     }
 

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.jwt.keychain.AbstractKeyChainRepositoryTest
 import io.bluetape4k.jwt.keychain.KeyChain
 import io.bluetape4k.jwt.keychain.KeyChainDto
 import io.bluetape4k.jwt.keychain.repository.KeyChainRepository
+import io.bluetape4k.jwt.keychain.repository.redis.REDIS_ROTATION_LOCK_WAIT_SECONDS
 import io.bluetape4k.jwt.keychain.repository.redis.RedisKeyChainRepository
 import io.bluetape4k.jwt.keychain.repository.redis.withRedisRotationLock
 import io.bluetape4k.testcontainers.storage.RedisServer
@@ -45,18 +46,18 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         val redisson = mockk<RedissonClient>(relaxed = true)
         every { redisson.getDeque<KeyChainDto>(any<String>()) } returns queue
         every { redisson.getLock(any<String>()) } returns lock
-        every { lock.tryLock(5, TimeUnit.SECONDS) } returns true
+        every { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) } returns true
         every { lock.isHeldByCurrentThread } returns true
 
         RedisKeyChainRepository(redisson).forcedRotate(KeyChain()).shouldBeTrue()
 
-        verify(exactly = 1) { lock.tryLock(5, TimeUnit.SECONDS) }
+        verify(exactly = 1) { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) }
     }
 
     @Test
     fun `rotation reports ownership loss before commit`() {
         val lock = mockk<RLock>()
-        every { lock.tryLock(5, TimeUnit.SECONDS) } returns true
+        every { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) } returns true
         every { lock.isHeldByCurrentThread } returns false
 
         val failure = assertFailsWith<IllegalStateException> {
@@ -71,7 +72,7 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         val lock = mockk<RLock>()
         val primaryFailure = IllegalStateException("commit failed")
         val unlockFailure = IllegalStateException("unlock failed")
-        every { lock.tryLock(5, TimeUnit.SECONDS) } returns true
+        every { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) } returns true
         every { lock.isHeldByCurrentThread } returns true
         every { lock.unlock() } throws unlockFailure
 

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedisJwtShutdownIntegrationTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/cache/RedisJwtShutdownIntegrationTest.kt
@@ -4,8 +4,10 @@ import eu.rekawek.toxiproxy.Proxy
 import eu.rekawek.toxiproxy.ToxiproxyClient
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeLessThan
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.jwt.keychain.KeyChain
+import io.bluetape4k.jwt.keychain.repository.redis.REDIS_ROTATION_LOCK_WAIT_SECONDS
 import io.bluetape4k.jwt.keychain.repository.redis.RedisKeyChainRepository
 import io.bluetape4k.jwt.provider.DefaultJwtProvider
 import io.bluetape4k.testcontainers.infra.ToxiproxyServer
@@ -18,7 +20,6 @@ import org.redisson.api.RedissonClient
 import org.testcontainers.containers.Network
 import java.time.Duration
 import java.util.UUID
-import kotlin.test.assertTrue
 
 @Execution(ExecutionMode.SAME_THREAD)
 class RedisJwtShutdownIntegrationTest {
@@ -33,9 +34,9 @@ class RedisJwtShutdownIntegrationTest {
                     val proxy = createRedisProxy(toxiproxy)
                     val redisson = createRedisson(toxiproxy)
                     val repository = createRepository(redisson)
-                    val delegate = DefaultJwtProvider.forTesting(
+                    // 네트워크 실패 시간은 짧은 test timer의 경쟁 없이 단일 caller operation으로 측정한다.
+                    val delegate = DefaultJwtProvider(
                         keyChainRepository = repository,
-                        rotationIntervalMillis = ROTATION_INTERVAL_MILLIS,
                     )
                     val provider = RedissonJwtProvider(delegate, redisson)
 
@@ -92,11 +93,8 @@ class RedisJwtShutdownIntegrationTest {
         proxy.disable()
         val interruptedAt = System.nanoTime()
         provider.forcedRotate().shouldBeFalse()
-        val interruptedMillis = Duration.ofNanos(System.nanoTime() - interruptedAt).toMillis()
-        assertTrue(
-            interruptedMillis < 5_000,
-            "proxy interruption must remain bounded: ${interruptedMillis}ms",
-        )
+        val interruptedDuration = Duration.ofNanos(System.nanoTime() - interruptedAt)
+        interruptedDuration shouldBeLessThan MAX_PROXY_INTERRUPTION
 
         proxy.enable()
         provider.forcedRotate().shouldBeTrue()
@@ -109,7 +107,6 @@ class RedisJwtShutdownIntegrationTest {
         delegate.close()
         val expiredKeyChain = KeyChain(expiredTtl = Duration.ofMillis(1))
         repository.forcedRotate(expiredKeyChain).shouldBeTrue()
-        Thread.sleep(ROTATION_INTERVAL_MILLIS * 5)
         repository.current().id shouldBeEqualTo expiredKeyChain.id
 
         repository.close()
@@ -134,6 +131,9 @@ class RedisJwtShutdownIntegrationTest {
     }
 
     private companion object {
-        const val ROTATION_INTERVAL_MILLIS = 50L
+        val MAX_PROXY_INTERRUPTION: Duration =
+            Duration.ofSeconds(REDIS_ROTATION_LOCK_WAIT_SECONDS + TRANSPORT_MARGIN_SECONDS)
+
+        const val TRANSPORT_MARGIN_SECONDS = 2L
     }
 }


### PR DESCRIPTION
## Summary

Closes #1393

- PR 제목: [jwt][test] Redis 장애 검증을 실제 timeout 계약에 정렬

- Redis rotation lock 대기 상수를 테스트와 production 코드가 공유하도록 합니다.
- ToxiProxy 장애 검증을 실제 `DefaultJwtProvider` timeout 계약과 2초 transport 여유에 맞춥니다.

Closes #1393

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 요약

- Redis rotation lock 대기 상수를 테스트와 production 코드가 공유하도록 합니다.
- ToxiProxy 장애 검증을 실제 `DefaultJwtProvider` timeout 계약과 2초 transport 여유에 맞춥니다.

Closes #1393

### 검증

- Redis JWT shutdown integration: 1/1
- JWT 모듈: 168/168
- Detekt 및 `git diff --check` 통과
- 통합 exact head 전체 `clean build` 통과

### DoD Status

- [x] 실제 timeout 경계 재현
- [x] production 상수와 테스트 계약 정렬
- [x] targeted/module/static 검증
- [x] 전체 통합 빌드 검증
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

## Validation

- Redis JWT shutdown integration: 1/1
- JWT 모듈: 168/168
- Detekt 및 `git diff --check` 통과
- 통합 exact head 전체 `clean build` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1393, milestone `1.13.0`, assignee debop
- PR: #1405, head `e8dc2fb39d62792e931f496d25ae4dd031121dd8`, milestone `1.13.0`, assignee debop
- Base: `develop`, head branch `fix/issue-1393-jwt-proxy-bound`
- Labels: 없음
- State: `MERGED`, merge commit `33393c67f5683816afc5ddc00d1f162e21a72f46`
- CI: - Detekt 및 `git diff --check` 통과 / - [ ] CI 성공 확인## DoD Status

- [x] 실제 timeout 경계 재현
- [x] production 상수와 테스트 계약 정렬
- [x] targeted/module/static 검증
- [x] 전체 통합 빌드 검증
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1405 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `33393c67f5683816afc5ddc00d1f162e21a72f46`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
