### PR TITLE
[core][bug] Future wrapper cancel 반환값 race 제거

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/FutureSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/FutureSupport.kt
@@ -64,9 +64,12 @@ private class FutureToCompletableFutureWrapper<T>(private val wrapped: Future<T>
     }
 
     override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
-        wrapped.cancel(mayInterruptIfRunning)
-        watcher.cancel(true)
-        return super.cancel(mayInterruptIfRunning)
+        val cancelled = super.cancel(mayInterruptIfRunning)
+        if (cancelled) {
+            wrapped.cancel(mayInterruptIfRunning)
+            watcher.cancel(true)
+        }
+        return cancelled
     }
 }
 

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/FutureSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/FutureSupportTest.kt
@@ -90,6 +90,51 @@ class FutureSupportTest {
     }
 
     @Test
+    fun `cancel returns true when wrapped Future cancellation races with watcher cancellation`() {
+        val watcherStarted = CountDownLatch(1)
+        val wrapperCompletionObserved = CountDownLatch(1)
+        val future = object : Future<String> {
+            private val cancelled = AtomicBoolean(false)
+            private val getterThread = AtomicReference<Thread>()
+
+            override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+                cancelled.set(true)
+                getterThread.get().interrupt()
+                wrapperCompletionObserved.await(1, TimeUnit.SECONDS).shouldBeTrue()
+                return true
+            }
+
+            override fun isCancelled(): Boolean = cancelled.get()
+
+            override fun isDone(): Boolean = cancelled.get()
+
+            override fun get(): String {
+                getterThread.set(Thread.currentThread())
+                watcherStarted.countDown()
+                CountDownLatch(1).await()
+                error("unreachable")
+            }
+
+            override fun get(timeout: Long, unit: TimeUnit): String {
+                getterThread.set(Thread.currentThread())
+                watcherStarted.countDown()
+                if (!CountDownLatch(1).await(timeout, unit)) {
+                    throw TimeoutException()
+                }
+                error("unreachable")
+            }
+        }
+        val completableFuture = future.asCompletableFuture()
+        watcherStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        completableFuture.whenComplete { _, _ -> wrapperCompletionObserved.countDown() }
+
+        completableFuture.cancel(true).shouldBeTrue()
+
+        future.isCancelled.shouldBeTrue()
+        completableFuture.isCancelled.shouldBeTrue()
+    }
+
+    @Test
     fun `Massive Future as CompletableFuture`() {
         val futures = List(ITEM_COUNT) {
             FutureTask {


### PR DESCRIPTION
## Summary

Closes #1395

- PR 제목: [core][bug] Future wrapper cancel 반환값 race 제거

- CompletableFuture wrapper의 자체 취소 상태를 먼저 확정한 뒤 wrapped Future와 watcher에 취소를 전파합니다.
- watcher가 wrapper 완료를 선점해 최초 `cancel()`이 false를 반환하는 race를 제거합니다.

Closes #1395

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 표준 Work Done 섹션이 없었던 역사적 PR입니다. 원문 제목과 본문 선행 내용을 보존했습니다.

### 원문 본문

### 요약

- CompletableFuture wrapper의 자체 취소 상태를 먼저 확정한 뒤 wrapped Future와 watcher에 취소를 전파합니다.
- watcher가 wrapper 완료를 선점해 최초 `cancel()`이 false를 반환하는 race를 제거합니다.

Closes #1395

### 검증

- 결정적 cancel race: 1/1
- `FutureSupportTest`: 8/8
- core 모듈: 1645/1645
- core Detekt 및 `git diff --check` 통과
- 통합 exact head 전체 `clean build` 통과

### DoD Status

- [x] 기존 구현 RED 재현
- [x] 취소 전파 및 반환값 계약 보존
- [x] targeted/module/static 검증
- [x] 전체 통합 빌드 검증
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

## Validation

- 결정적 cancel race: 1/1
- `FutureSupportTest`: 8/8
- core 모듈: 1645/1645
- core Detekt 및 `git diff --check` 통과
- 통합 exact head 전체 `clean build` 통과

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1395, milestone `1.13.0`, assignee debop
- PR: #1406, head `7aa8cb1ac593bd75f49060251262cc99d097a947`, milestone `1.13.0`, assignee debop
- Base: `develop`, head branch `fix/issue-1395-future-cancel`
- Labels: 없음
- State: `MERGED`, merge commit `88ebca5fe69312953b515f08f31a8ccb9bc99d0b`
- CI: - core Detekt 및 `git diff --check` 통과 / - [ ] CI 성공 확인## DoD Status

- [x] 기존 구현 RED 재현
- [x] 취소 전파 및 반환값 계약 보존
- [x] targeted/module/static 검증
- [x] 전체 통합 빌드 검증
- [ ] CI 성공 확인
- [ ] merge 승인 및 병합

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1406 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `88ebca5fe69312953b515f08f31a8ccb9bc99d0b`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
