### PR TITLE
[cache] NearJCache compound operation 원자성·front/back 계약 보강

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -111,10 +111,11 @@ back을 조회하며, back hit는 front에 populate합니다. `clear`는 해당 
 
 공유 back cache를 사용하는 다른 wrapper의 front에 이미 들어간 값까지
 `clear`가 listener로 지운다고 보장하지 않습니다. peer 무효화가 필요하면
-기존 per-entry `removeAll` 경로를 사용하세요. `getAndRemove`와
-`getAndReplace`는 기존 front-only read 왕복을 유지하며, cross-tier compound
-원자성은 [#1355](https://github.com/bluetape4k/bluetape4k-projects/issues/1355)에서
-별도로 다룹니다.
+기존 per-entry `removeAll` 경로를 사용하세요. `getAndPut`, `getAndRemove`,
+`getAndReplace`는 back provider의 원자 compound 연산을 먼저 수행한 뒤
+local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도로 쓰는
+왕복을 사용하지 않으며, back provider 실패 시 front를 변경하기 전에
+예외를 전달합니다.
 
 기본 front 설정은 store-by-reference입니다. 필터링된 provider별 copier 계약이
 정해지기 전에는 custom store-by-value front 설정을 생성 단계에서 거부합니다.

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -65,9 +65,10 @@ standard `get` and `clear` behavior.
 The clear operation does not promise invalidation of another wrapper's already
 populated front cache when the back cache is shared or listener propagation is
 unavailable. Use the existing per-entry `removeAll` path when peer invalidation
-is required. `getAndRemove` and `getAndReplace` keep their existing front-only
-read round trips; cross-tier compound atomicity is tracked separately in issue
-[#1355](https://github.com/bluetape4k/bluetape4k-projects/issues/1355).
+is required. `getAndPut`, `getAndRemove`, and `getAndReplace` use the back
+provider's atomic compound operation and then reconcile the local front cache;
+they do not implement a front-read/back-write round trip. A provider failure is
+propagated before the front cache is changed.
 
 The default front configuration uses store-by-reference. A custom store-by-value
 front configuration is rejected until a filtered, provider-specific copier

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -143,6 +143,7 @@ class NearJCache<K: Any, V: Any>(
 
     private val lock = ReentrantLock()
     private val mutationGate = ReentrantLock()
+    private val compoundGate = ReentrantLock()
     private val backWriteLock = ReentrantLock(true)
     private val listenerRegistrationLock = ReentrantLock()
     private val mutationEpoch = AtomicLong()
@@ -167,6 +168,8 @@ class NearJCache<K: Any, V: Any>(
         )
     )
     private val backCacheWriteListeners = CopyOnWriteArrayList<(BackCacheWriteCompletion) -> Unit>()
+
+    private object CompoundResultUnset
 
     /**
      * 마지막으로 예약한 Back Cache write-through의 완료 상태입니다.
@@ -203,38 +206,40 @@ class NearJCache<K: Any, V: Any>(
 
     @Suppress("TooGenericExceptionCaught")
     override fun clear() {
-        val hadBackCacheListener = backCacheListener.get() != null
-        detachBackCacheListener()
-        var primaryFailure: Throwable? = null
-        try {
-            mutationGate.withLock {
-                mutationEpoch.incrementAndGet()
-                val expectedBackWriteGeneration = backWriteGeneration.incrementAndGet()
-                log.debug { "Near Cache의 Front와 Back cache를 Clear합니다." }
-                frontCache.clear()
-                syncBackCache(
-                    operation = "clear",
-                    synchronous = true,
-                    expectedBackWriteGeneration = expectedBackWriteGeneration,
-                ) {
-                    backCache.clear()
-                }
-            }
-        } catch (e: Throwable) {
-            primaryFailure = e
-        }
-        if (hadBackCacheListener) {
+        compoundGate.withLock {
+            val hadBackCacheListener = backCacheListener.get() != null
+            detachBackCacheListener()
+            var primaryFailure: Throwable? = null
             try {
-                registerBackCacheListener()
-            } catch (registrationFailure: Throwable) {
-                if (primaryFailure == null) {
-                    primaryFailure = registrationFailure
-                } else if (registrationFailure !== primaryFailure) {
-                    primaryFailure.addSuppressed(registrationFailure)
+                mutationGate.withLock {
+                    mutationEpoch.incrementAndGet()
+                    val expectedBackWriteGeneration = backWriteGeneration.incrementAndGet()
+                    log.debug { "Near Cache의 Front와 Back cache를 Clear합니다." }
+                    frontCache.clear()
+                    syncBackCache(
+                        operation = "clear",
+                        synchronous = true,
+                        expectedBackWriteGeneration = expectedBackWriteGeneration,
+                    ) {
+                        backCache.clear()
+                    }
+                }
+            } catch (e: Throwable) {
+                primaryFailure = e
+            }
+            if (hadBackCacheListener) {
+                try {
+                    registerBackCacheListener()
+                } catch (registrationFailure: Throwable) {
+                    if (primaryFailure == null) {
+                        primaryFailure = registrationFailure
+                    } else if (registrationFailure !== primaryFailure) {
+                        primaryFailure.addSuppressed(registrationFailure)
+                    }
                 }
             }
+            primaryFailure?.let { throw it }
         }
-        primaryFailure?.let { throw it }
     }
 
     /**
@@ -299,11 +304,13 @@ class NearJCache<K: Any, V: Any>(
     }
 
     override fun close() {
-        detachBackCacheListener()
-        lock.withLock {
-            log.debug { "Near Cache 의 Front Cache를 Close 합니다." }
-            runCatching {
-                frontCache.close()
+        compoundGate.withLock {
+            detachBackCacheListener()
+            lock.withLock {
+                log.debug { "Near Cache 의 Front Cache를 Close 합니다." }
+                runCatching {
+                    frontCache.close()
+                }
             }
         }
     }
@@ -406,24 +413,48 @@ class NearJCache<K: Any, V: Any>(
         return frontValues.toMutableMap().apply { putAll(backValues) }
     }
 
-    override fun getAndRemove(key: K): V? {
-        if (frontContainsKey(key)) {
-            val oldValue = frontGet(key)
-            remove(key)
-            return oldValue
+    /**
+     * Back Cache의 원자 compound 연산 결과를 기준으로 Front Cache를 동기화합니다.
+     *
+     * JCache compound 연산은 호출자가 이전 값을 즉시 받아야 하므로 설정의
+     * 비동기 write-through 여부와 무관하게 Back Cache 원자 연산을 완료한 뒤
+     * Front Cache를 갱신합니다. Back provider가 호출 중 동기 listener를
+     * 실행할 수 있으므로 Back 호출 중에는 mutation gate를 잡지 않고,
+     * 동일 wrapper의 compound 순서만 별도 gate로 직렬화합니다. Back provider가
+     * 제공하는 `getAnd*` 경계를 우회하는 front read/put 조합은 사용하지 않습니다.
+     */
+    override fun getAndPut(key: K, value: V): V? = compoundGate.withLock {
+        mutationGate.withLock { mutationEpoch.incrementAndGet() }
+        val oldValue = runCompoundBackCacheOperation("getAndPut") {
+            backCache.getAndPut(key, value)
         }
-        return null
+        mutationGate.withLock { frontCache.put(key, value) }
+        oldValue
     }
 
-    override fun getAndReplace(key: K, value: V): V? {
-        log.trace { "get and replace. key=$key" }
-        if (frontContainsKey(key)) {
-            log.trace { "get entry, and put new value. key=$key, new value=$value" }
-            val oldValue = frontGet(key)
-            put(key, value)
-            return oldValue
+    override fun getAndRemove(key: K): V? = compoundGate.withLock {
+        mutationGate.withLock { mutationEpoch.incrementAndGet() }
+        val oldValue = runCompoundBackCacheOperation("getAndRemove") {
+            backCache.getAndRemove(key)
         }
-        return null
+        mutationGate.withLock { frontCache.remove(key) }
+        oldValue
+    }
+
+    override fun getAndReplace(key: K, value: V): V? = compoundGate.withLock {
+        log.trace { "get and replace. key=$key" }
+        mutationGate.withLock { mutationEpoch.incrementAndGet() }
+        val oldValue = runCompoundBackCacheOperation("getAndReplace") {
+            backCache.getAndReplace(key, value)
+        }
+        mutationGate.withLock {
+            if (oldValue == null) {
+                frontCache.remove(key)
+            } else {
+                frontCache.put(key, value)
+            }
+        }
+        oldValue
     }
 
     operator fun set(key: K, value: V) {
@@ -680,12 +711,21 @@ class NearJCache<K: Any, V: Any>(
         }
     }
 
-    private fun frontContainsKey(key: K): Boolean = mutationGate.withLock {
-        frontCache.containsKey(key)
-    }
-
-    private fun frontGet(key: K): V? = mutationGate.withLock {
-        frontCache.get(key)
+    private fun <R> runCompoundBackCacheOperation(operation: String, operationBlock: () -> R): R {
+        val result = AtomicReference<Any?>(CompoundResultUnset)
+        syncBackCache(
+            operation = operation,
+            synchronous = true,
+            expectedBackWriteGeneration = backWriteGeneration.get(),
+        ) {
+            result.set(operationBlock())
+        }
+        val value = result.get()
+        check(value !== CompoundResultUnset) {
+            "NearJCache compound operation completed without a result. operation=$operation"
+        }
+        @Suppress("UNCHECKED_CAST")
+        return value as R
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt
@@ -149,20 +149,33 @@ class SuspendNearJCache<K: Any, V: Any> internal constructor(
         return frontCache.getAll(keys)
     }
 
+    /**
+     * Back Cache의 원자 compound 연산 결과를 기준으로 Front Cache를 동기화합니다.
+     * Front Cache만 먼저 조회하거나 `get` 후 변경하는 조합은 front miss와
+     * 동시 호출에서 JCache 반환값·정합성을 보장하지 못하므로 사용하지 않습니다.
+     */
     override suspend fun getAndPut(key: K, value: V): V? {
-        return frontCache.getAndPut(key, value)?.apply {
-            backCache.putIfAbsent(key, value)
-        }
+        val oldValue = backCache.getAndPut(key, value)
+        frontCache.put(key, value)
+        return oldValue
     }
 
     override suspend fun getAndRemove(key: K): V? {
         log.trace { "get and remove if exists cache entry. key=$key" }
-        return get(key)?.apply { remove(key) }
+        val oldValue = backCache.getAndRemove(key)
+        frontCache.remove(key)
+        return oldValue
     }
 
     override suspend fun getAndReplace(key: K, value: V): V? {
         log.trace { "get entry, and put new value if exists. key=$key, new value=$value" }
-        return get(key)?.apply { put(key, value) }
+        val oldValue = backCache.getAndReplace(key, value)
+        if (oldValue == null) {
+            frontCache.remove(key)
+        } else {
+            frontCache.put(key, value)
+        }
+        return oldValue
     }
 
     override suspend fun put(key: K, value: V) {

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheCompoundOperationContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheCompoundOperationContractTest.kt
@@ -1,0 +1,223 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.cache.jcache.SuspendJCache
+import io.bluetape4k.concurrent.virtualthread.virtualThread
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.cache.configuration.CacheEntryListenerConfiguration
+import javax.cache.event.CacheEntryCreatedListener
+import javax.cache.event.CacheEntryEvent
+
+class NearJCacheCompoundOperationContractTest {
+
+    @Test
+    fun `동기 getAndPut은 back 원자 연산 결과를 반환하고 front를 새 값으로 갱신한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.getAndPut("key", "new") } returns "old"
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        nearCache.getAndPut("key", "new") shouldBeEqualTo "old"
+
+        verify(exactly = 1) { backCache.getAndPut("key", "new") }
+        verify(exactly = 1) { frontCache.put("key", "new") }
+    }
+
+    @Test
+    fun `동기 getAndRemove는 front miss에서도 back 원자 연산 결과를 반환하고 front를 제거한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.getAndRemove("key") } returns "old"
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        nearCache.getAndRemove("key") shouldBeEqualTo "old"
+
+        verify(exactly = 1) { backCache.getAndRemove("key") }
+        verify(exactly = 1) { frontCache.remove("key") }
+    }
+
+    @Test
+    fun `동기 getAndReplace는 front miss에서도 back 원자 연산 결과를 반환하고 front를 새 값으로 갱신한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.getAndReplace("key", "new") } returns "old"
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        nearCache.getAndReplace("key", "new") shouldBeEqualTo "old"
+
+        verify(exactly = 1) { backCache.getAndReplace("key", "new") }
+        verify(exactly = 1) { frontCache.put("key", "new") }
+    }
+
+    @Test
+    fun `동기 compound back 실패는 front를 변경하지 않고 호출자에게 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val failure = IllegalStateException("back failure")
+        every { backCache.getAndPut("key", "new") } throws failure
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        assertFailsWith<IllegalStateException> { nearCache.getAndPut("key", "new") }
+
+        verify(exactly = 0) { frontCache.put(any(), any()) }
+    }
+
+    @Test
+    fun `동기 listener를 호출하는 back compound 연산도 deadlock 없이 front를 갱신한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val listenerConfiguration = slot<CacheEntryListenerConfiguration<String, String>>()
+        val event = mockk<CacheEntryEvent<String, String>>(relaxed = true)
+        every { event.key } returns "key"
+        every { event.value } returns "new"
+        every { backCache.registerCacheEntryListener(capture(listenerConfiguration)) } just runs
+        every { backCache.getAndPut("key", "new") } answers {
+            val listener = listenerConfiguration.captured.cacheEntryListenerFactory!!.create()
+            (listener as CacheEntryCreatedListener<String, String>).onCreated(listOf(event))
+            "old"
+        }
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+        nearCache.registerBackCacheListener()
+
+        nearCache.getAndPut("key", "new") shouldBeEqualTo "old"
+
+        verify(exactly = 1) { backCache.getAndPut("key", "new") }
+        verify(atLeast = 1) { frontCache.put("key", "new") }
+    }
+
+    @Test
+    fun `동일 wrapper의 replace와 remove는 front reconciliation 순서를 직렬화한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val replaceStarted = CountDownLatch(1)
+        val releaseReplace = CountDownLatch(1)
+        val removeStarted = CountDownLatch(1)
+        every { backCache.getAndReplace("key", "new") } answers {
+            replaceStarted.countDown()
+            releaseReplace.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            "old"
+        }
+        every { backCache.getAndRemove("key") } answers {
+            removeStarted.countDown()
+            "new"
+        }
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+        val replaceResult = AtomicReference<String?>()
+        val removeResult = AtomicReference<String?>()
+        val replaceThread = virtualThread(start = false, name = "near-jcache-compound-replace") {
+            replaceResult.set(nearCache.getAndReplace("key", "new"))
+        }
+        val removeThread = virtualThread(start = false, name = "near-jcache-compound-remove") {
+            removeResult.set(nearCache.getAndRemove("key"))
+        }
+
+        replaceThread.start()
+        replaceStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+        removeThread.start()
+        removeStarted.await(200, TimeUnit.MILLISECONDS).shouldBeFalse()
+
+        releaseReplace.countDown()
+        replaceThread.join(2_000)
+        removeThread.join(2_000)
+
+        replaceResult.get() shouldBeEqualTo "old"
+        removeResult.get() shouldBeEqualTo "new"
+        verifyOrder {
+            frontCache.put("key", "new")
+            frontCache.remove("key")
+        }
+    }
+
+    @Test
+    fun `suspend getAndPut은 back 원자 연산 결과를 반환하고 front를 새 값으로 갱신한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.getAndPut("key", "new") } returns "old"
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        nearCache.getAndPut("key", "new") shouldBeEqualTo "old"
+
+        coVerify(exactly = 1) { backCache.getAndPut("key", "new") }
+        coVerify(exactly = 1) { frontCache.put("key", "new") }
+    }
+
+    @Test
+    fun `suspend compound back 실패는 front를 변경하지 않고 호출자에게 전달한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val failure = IllegalStateException("back failure")
+        coEvery { backCache.getAndPut("key", "new") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.getAndPut("key", "new") }
+
+        coVerify(exactly = 0) { frontCache.put(any(), any()) }
+    }
+
+    @Test
+    fun `suspend getAndRemove는 front miss에서도 back 원자 연산 결과를 반환하고 front를 제거한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.getAndRemove("key") } returns "old"
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        nearCache.getAndRemove("key") shouldBeEqualTo "old"
+
+        coVerify(exactly = 1) { backCache.getAndRemove("key") }
+        coVerify(exactly = 1) { frontCache.remove("key") }
+    }
+
+    @Test
+    fun `suspend getAndReplace는 front miss에서도 back 원자 연산 결과를 반환하고 front를 새 값으로 갱신한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.getAndReplace("key", "new") } returns "old"
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        nearCache.getAndReplace("key", "new") shouldBeEqualTo "old"
+
+        coVerify(exactly = 1) { backCache.getAndReplace("key", "new") }
+        coVerify(exactly = 1) { frontCache.put("key", "new") }
+    }
+}

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
@@ -462,22 +462,20 @@ class NearJCacheContractTest {
     }
 
     @Test
-    fun `compound getAndRemove와 getAndReplace는 front-only read 왕복을 유지한다`() {
+    fun `compound operation은 back 원자 연산 후 front를 동기화한다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
-        every { frontCache.containsKey("remove") } returns true
-        every { frontCache.get("remove") } returns "remove-value"
-        every { frontCache.remove("remove") } returns true
-        every { frontCache.containsKey("replace") } returns true
-        every { frontCache.get("replace") } returns "old-value"
-        every { frontCache.put("replace", "new-value") } returns Unit
+        every { backCache.getAndRemove("remove") } returns "remove-value"
+        every { backCache.getAndReplace("replace", "new-value") } returns "old-value"
         val nearCache = newNearCache(frontCache, backCache)
 
         nearCache.getAndRemove("remove") shouldBeEqualTo "remove-value"
         nearCache.getAndReplace("replace", "new-value") shouldBeEqualTo "old-value"
 
-        verify(exactly = 0) { backCache.containsKey(any()) }
-        verify(exactly = 0) { backCache.get(any()) }
+        verify(exactly = 1) { backCache.getAndRemove("remove") }
+        verify(exactly = 1) { backCache.getAndReplace("replace", "new-value") }
+        verify(exactly = 1) { frontCache.remove("remove") }
+        verify(exactly = 1) { frontCache.put("replace", "new-value") }
     }
 
     private fun newNearCache(

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -89,6 +89,13 @@ class HazelcastNearJCacheTest {
             cache.put("k", "v")
             cache.get("k") shouldBeEqualTo "v"
 
+            cache.getAndPut("compound", "v1").shouldBeNull()
+            cache.getAndPut("compound", "v2") shouldBeEqualTo "v1"
+            cache.getAndReplace("compound", "v3") shouldBeEqualTo "v2"
+            cache.getAndRemove("compound") shouldBeEqualTo "v3"
+            cache.get("compound").shouldBeNull()
+            cache.backCache.get("compound").shouldBeNull()
+
             cache.clear()
             cache.get("k").shouldBeNull()
             cache.getDeeply("k").shouldBeNull()

--- a/docs/cache/near-cache-capability-matrix.md
+++ b/docs/cache/near-cache-capability-matrix.md
@@ -32,12 +32,13 @@ Native API는 `NearCacheOperations<V>` 또는 `SuspendNearCacheOperations<V>`를
 JCache API는 `NearJCache<K,V>` 또는 `SuspendNearJCache<K,V>`를 구현한다.
 
 동기 `NearJCache`의 표준 `get`, `containsKey`, `getAll`은 front miss를 back에서
-읽고 back hit를 front에 채우는 논리적 2-tier read 계약을 따른다. 표준 `clear`와
+읽고 back hit를 front에 채우는 논리적 2-tier read 계약을 따른다. `getAndPut`,
+`getAndRemove`, `getAndReplace`는 back provider의 원자 compound 연산을
+수행한 뒤 front를 갱신한다. 표준 `clear`와
 호환 alias `clearAllCache`는 현재 wrapper의 front와 back을 함께 지운다. 공유
 back을 사용하는 peer wrapper의 기존 front까지 listener로 지우는 것은 보장하지
-않는다. `getDeeply`는 표준 `get`의 alias이며, compound 원자성은
-[#1355](https://github.com/bluetape4k/bluetape4k-projects/issues/1355)의 별도
-계약이다.
+않는다. `getDeeply`는 표준 `get`의 alias이며, compound 원자성은 provider의
+back atomic operation을 먼저 완료한 뒤 front를 reconciliation하는 계약으로 고정한다.
 
 `NearJCacheConfig`의 기본 front는 store-by-reference이며, 안전한 filtered copier
 계약이 없는 custom store-by-value 설정은 생성 단계에서 거부한다. read-through

--- a/docs/lessons/2026-08-13-issue-1355-nearcache-compound.md
+++ b/docs/lessons/2026-08-13-issue-1355-nearcache-compound.md
@@ -1,0 +1,41 @@
+# NearJCache compound operation의 back 원자성 보장
+
+## 배경
+
+`NearJCache`와 `SuspendNearJCache`의 `getAndPut`, `getAndRemove`,
+`getAndReplace`가 front 조회·변경 조합에 의존해 front miss에서 표준 JCache
+반환값을 잃고, front와 back 사이의 compound 계약을 보장하지 못했다.
+
+## 결정
+
+- 세 연산은 front를 먼저 읽지 않고 back provider의 `getAnd*` 원자 연산을
+  호출한다.
+- back 연산이 성공한 뒤에만 front를 새 값으로 반영하거나 제거한다.
+- 동기 구현은 기존 write-through timeout·generation barrier를 재사용하되,
+  compound 반환값을 보존하기 위해 완료까지 기다린다.
+- suspend 구현은 back 결과를 받은 뒤 front를 반영하며, 별도 provider 의존성을
+  추가하지 않는다.
+
+## 검증
+
+- RED: `NearJCacheCompoundOperationContractTest` 초기 6개가 기존 구현에서 실패했다.
+  front miss 시 back `getAnd*`가 호출되지 않거나 front 반영이 없었다.
+- GREEN: back 장애 전파 회귀를 포함한 현재 7개가 성공했다.
+- 기존 `NearJCacheContractTest` 24개와 cache-core 전체 125개도 성공했다.
+- `git diff --check`를 통과했다.
+
+## 경계와 후속 작업
+
+provider의 back 원자성은 provider 계약에 위임하며, 서로 다른 NearJCache
+wrapper 사이의 다중 키 transaction은 보장하지 않는다. cleanup 관측성은
+[#1371](https://github.com/bluetape4k/bluetape4k-projects/issues/1371),
+`getAll` residency 예산은
+[#1369](https://github.com/bluetape4k/bluetape4k-projects/issues/1369),
+shared back clear 권한은
+[#1368](https://github.com/bluetape4k/bluetape4k-projects/issues/1368)에서
+별도로 다룬다.
+
+## 참고
+
+- [JCache `Cache` API](https://www.javadoc.io/static/javax.cache/cache-api/1.1.0/javax/cache/Cache.html)
+- [Epic #1408](https://github.com/bluetape4k/bluetape4k-projects/issues/1408)


### PR DESCRIPTION
## Summary

이 PR에는 라이브 메타데이터상 연결된 closing issue가 없습니다.

- PR 제목: [cache] NearJCache compound operation 원자성·front/back 계약 보강

`NearJCache`와 `SuspendNearJCache`의 `getAndPut`, `getAndRemove`,
`getAndReplace`를 front 선조회 조합이 아닌 back provider `getAnd*` 원자
연산 이후 front reconciliation 계약으로 고정합니다.

## Background

- 원문 본문에 별도 Background 섹션이 없었던 역사적 PR입니다. 라이브 제목·상태·연결 issue를 Metadata에 보강했습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- 동기·suspend near-cache compound API를 명시적으로 override했습니다.
- 동기 구현은 기존 back write timeout/generation barrier를 재사용하고,
  compound 반환값을 위해 back 완료를 기다립니다.
- provider 동기 listener callback이 compound 호출을 교착시키지 않도록
  back 호출 중 mutation gate를 보유하지 않고, 동일 wrapper의 compound·clear·close
  순서는 별도 gate로 직렬화했습니다.
- back 실패 시 front를 변경하지 않는 회귀 테스트를 추가했습니다.
- front miss/back hit, listener callback, 동시 replace/remove 순서와 suspend
  동일 계약을 테스트로 고정했습니다.
- Lettuce near-cache fixture와 Hazelcast listener-free factory의 반환값 및
  front/back 정합성 회귀를 보강했습니다.
- README, capability matrix, lesson을 현재 계약에 맞게 갱신했습니다.

## Validation

- `./gradlew :bluetape4k-cache-core:test --tests io.bluetape4k.cache.nearcache.jcache.NearJCacheCompoundOperationContractTest --no-daemon --no-build-cache --console=plain`
  - 10 tests passed
- `./gradlew :bluetape4k-cache-core:test :bluetape4k-cache-core:detekt --no-daemon --no-build-cache --console=plain`
  - 125 tests passed, detekt passed
- `./gradlew :bluetape4k-cache-lettuce:test --tests io.bluetape4k.cache.nearcache.jcache.LettuceNearJJCacheTest --no-daemon --no-build-cache --console=plain`
  - 71 tests passed
- `./gradlew :bluetape4k-cache-hazelcast:test --tests io.bluetape4k.cache.nearcache.jcache.HazelcastNearJCacheTest --no-daemon --no-build-cache --console=plain`
  - 3 tests passed
- `git diff HEAD^ HEAD --check` 통과
- PR CI run `31614628857`의 job-level 필수 checks 모두 성공 또는 조건부 skipped
  - Build, Central Catalog Governance, Test / Key Utils, Coverage Report, CI Status 포함

## Review Notes

- P0/P1: N/A (메타데이터 본문 정규화만 수행했으며 코드 변경은 없습니다).
- P2/P3: 원문 Review Notes가 없어 N/A입니다.
- Review evidence: 라이브 PR 본문 전수 감사와 read-back으로 형식만 검증했습니다.

## Metadata

- Issue: #1355, milestone `1.13.0`, assignee debop
- PR: #1409, head `1799d0df8ab776d83490944ed24e5b9d2ea7aade`, milestone `1.13.0`, assignee debop
- Base: `develop`, head branch `fix/issue-1355-nearcache-compound`
- Labels: `bug`, `test`, `tech-debt`, `cache`
- State: `MERGED`, merge commit `ea35f34ecb2a7675f1a0f4b9fb44f070578fd328`
- CI: 연산 이후 front reconciliation 계약으로 고정합니다. / - `./gradlew :bluetape4k-cache-core:test --tests io.bluetape4k.cache.nearcache.jcache.NearJCacheCompoundOperationContractTest --no-daemon --no-build-cache --console=plain` / - `./gradlew :bluetape4k-cache-core:test :bluetape4k-cache-core:detekt --no-daemon --no-build-cache --console=plain`## DoD Status

- 상태: 구현·로컬 검증·PR CI 완료, 별도 merge 승인 대기
- [x] sync/suspend compound operation 명시적 override 및 순서 계약
- [x] front miss/back hit, back failure, 동시 replace/remove, listener callback 회귀
- [x] Lettuce·Hazelcast factory 반환값/front-back 정합성 회귀
- [x] 문서·lesson 갱신
- [x] PR CI job-level checks 성공 확인
- [ ] 별도 승인 후 merge 및 로컬 sync/정리

관련 이슈: #1355
Epic: #1408

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1409 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `ea35f34ecb2a7675f1a0f4b9fb44f070578fd328`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
