### PR TITLE
[cache] NearJCache front cleanup lifecycle 관측성 보강

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -120,6 +120,14 @@ local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도�
 기본 front 설정은 store-by-reference입니다. 필터링된 provider별 copier 계약이
 정해지기 전에는 custom store-by-value front 설정을 생성 단계에서 거부합니다.
 
+`close()`는 이 wrapper가 등록한 listener와 소유한 front cache만 정리하며,
+전달받은 back cache 또는 provider는 닫지 않습니다. 정리 실패는 호출자에게
+관찰 가능하게 전달합니다. 첫 번째 실패는 주 예외로 유지하고 이후 정리 실패는
+suppressed 예외로 연결합니다. 성공한 `close()`는 idempotent이며, listener
+deregister 또는 front close가 실패하면 다음 호출에서 해당 정리를 재시도합니다.
+close가 시작된 뒤에는 listener 재등록을 거부합니다. front cache를 생성한 뒤
+생성이 실패한 경우에도 동일한 주 예외/suppressed 예외 정책으로 rollback합니다.
+
 ##### SuspendJCache 인터페이스
 
 ![SuspendJCache coroutine interface diagram](../../docs/images/readme-diagrams/cache-cache-core-diagram-04.png)

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -74,6 +74,15 @@ The default front configuration uses store-by-reference. A custom store-by-value
 front configuration is rejected until a filtered, provider-specific copier
 contract is supplied.
 
+`close()` deregisters the listener registered by this wrapper and closes only its
+owned front cache; it never closes the supplied back cache or provider. Cleanup
+failures are observable: the first failure is propagated and later cleanup
+failures are attached as suppressed exceptions. A successful `close()` is
+idempotent, while a listener-deregistration or front-close failure is retried by
+the next call. Listener registration is rejected once close has started. If
+construction fails after the front cache is created, the same
+primary/suppressed exception policy is applied during rollback.
+
 ## Near-Cache Capability Matrix
 
 The shared support boundary for native and JCache near-cache variants is tracked

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
@@ -134,9 +135,34 @@ class NearJCache<K: Any, V: Any>(
                 NearJCache(frontCache, backCache, nearCacheCfg).also {
                     it.registerBackCacheListener()
                 }
-            } catch (e: RuntimeException) {
-                runCatching { frontCache.close() }
+            } catch (e: Throwable) {
+                closeFrontCacheAfterFailure(
+                    frontCache = frontCache,
+                    primaryFailure = e,
+                    operation = "constructor-rollback",
+                    cacheName = nearCacheCfg.cacheName,
+                )
                 throw e
+            }
+        }
+
+        @Suppress("TooGenericExceptionCaught")
+        private fun closeFrontCacheAfterFailure(
+            frontCache: JCache<*, *>,
+            primaryFailure: Throwable,
+            operation: String,
+            cacheName: String,
+        ) {
+            try {
+                frontCache.close()
+            } catch (cleanupFailure: Throwable) {
+                if (cleanupFailure !== primaryFailure) {
+                    primaryFailure.addSuppressed(cleanupFailure)
+                }
+                log.error(cleanupFailure) {
+                    "NearJCache front cleanup failed. " +
+                            "operation=$operation, cache=$cacheName, provider=${frontCache.javaClass.name}"
+                }
             }
         }
     }
@@ -146,6 +172,9 @@ class NearJCache<K: Any, V: Any>(
     private val compoundGate = ReentrantLock()
     private val backWriteLock = ReentrantLock(true)
     private val listenerRegistrationLock = ReentrantLock()
+    private val frontCloseCompleted = AtomicBoolean(false)
+    private val closeStarted = AtomicBoolean(false)
+    private val closeCompleted = AtomicBoolean(false)
     private val mutationEpoch = AtomicLong()
     private val backWriteGeneration = AtomicLong()
     private class BackCacheListenerRegistration<K: Any, V: Any>(
@@ -251,32 +280,36 @@ class NearJCache<K: Any, V: Any>(
      */
     @Suppress("TooGenericExceptionCaught")
     fun registerBackCacheListener() {
-        listenerRegistrationLock.withLock {
-            if (backCacheListener.get() != null) return
+        compoundGate.withLock {
+            check(!closeStarted.get()) { "NearJCache listener registration is unavailable after close started" }
+            listenerRegistrationLock.withLock {
+                if (backCacheListener.get() != null) return
 
-            lateinit var registration: BackCacheListenerRegistration<K, V>
-            val listener = JCacheEntryEventListener<K, V>(frontCache) { eventType, events ->
-                applyBackCacheEvents(registration, eventType, events)
-            }
-            val configuration = MutableCacheEntryListenerConfiguration(
-                { listener },
-                null,
-                false,
-                config.isSynchronous
-            )
-            registration = BackCacheListenerRegistration(configuration)
-            backCacheListener.set(registration)
-            try {
-                log.info { "back cache 이벤트 listener 등록. cache=${config.cacheName}" }
-                backCache.registerCacheEntryListener(configuration)
-            } catch (e: Throwable) {
-                backCacheListener.compareAndSet(registration, null)
-                registration.active.set(false)
-                log.error(e) {
-                    "NearJCache back cache listener registration failed. " +
-                            "operation=register, cache=${config.cacheName}"
+                lateinit var registration: BackCacheListenerRegistration<K, V>
+                val listener = JCacheEntryEventListener<K, V>(frontCache) { eventType, events ->
+                    applyBackCacheEvents(registration, eventType, events)
                 }
-                throw e
+                val configuration = MutableCacheEntryListenerConfiguration(
+                    { listener },
+                    null,
+                    false,
+                    config.isSynchronous
+                )
+                registration = BackCacheListenerRegistration(configuration)
+                backCacheListener.set(registration)
+                try {
+                    log.info { "back cache 이벤트 listener 등록. cache=${config.cacheName}" }
+                    backCache.registerCacheEntryListener(configuration)
+                } catch (e: Throwable) {
+                    backCacheListener.compareAndSet(registration, null)
+                    registration.active.set(false)
+                    log.error(e) {
+                        "NearJCache back cache listener registration failed. " +
+                                "operation=register, cache=${config.cacheName}, " +
+                                "provider=${backCache.javaClass.name}"
+                    }
+                    throw e
+                }
             }
         }
     }
@@ -303,15 +336,54 @@ class NearJCache<K: Any, V: Any>(
         clear()
     }
 
+    /**
+     * 이 wrapper가 등록한 Back listener와 소유한 Front cache만 정리합니다.
+     * 전달받은 Back cache/provider는 닫지 않습니다.
+     *
+     * listener 또는 Front 정리 실패는 호출자에게 전달하며, 여러 정리 단계가 실패하면
+     * 첫 실패를 주 예외로 유지하고 이후 실패를 suppressed 예외로 연결합니다. 성공한
+     * close는 idempotent하며, listener 또는 Front 정리 실패 후에는 다음 호출에서
+     * 해당 정리를 재시도합니다. close가 시작된 뒤에는 listener를 다시 등록할 수 없습니다.
+     */
+    @Suppress("TooGenericExceptionCaught")
     override fun close() {
         compoundGate.withLock {
-            detachBackCacheListener()
-            lock.withLock {
-                log.debug { "Near Cache 의 Front Cache를 Close 합니다." }
-                runCatching {
-                    frontCache.close()
+            if (closeCompleted.get()) return
+            closeStarted.set(true)
+
+            var primaryFailure: Throwable? = null
+            try {
+                detachBackCacheListener()
+            } catch (listenerFailure: Throwable) {
+                primaryFailure = listenerFailure
+                log.error(listenerFailure) {
+                    "NearJCache cleanup failed. operation=close-listener, " +
+                            "cache=${config.cacheName}, provider=${backCache.javaClass.name}"
                 }
             }
+
+            if (!frontCloseCompleted.get()) {
+                try {
+                    lock.withLock {
+                        log.debug { "Near Cache 의 Front Cache를 Close 합니다." }
+                        frontCache.close()
+                    }
+                    frontCloseCompleted.set(true)
+                } catch (frontFailure: Throwable) {
+                    if (primaryFailure == null) {
+                        primaryFailure = frontFailure
+                    } else if (frontFailure !== primaryFailure) {
+                        primaryFailure.addSuppressed(frontFailure)
+                    }
+                    log.error(frontFailure) {
+                        "NearJCache front cleanup failed. operation=close, " +
+                                "cache=${config.cacheName}, provider=${frontCache.javaClass.name}"
+                    }
+                }
+            }
+
+            primaryFailure?.let { throw it }
+            closeCompleted.set(true)
         }
     }
 
@@ -805,9 +877,10 @@ class NearJCache<K: Any, V: Any>(
 
     private fun detachBackCacheListener() {
         listenerRegistrationLock.withLock {
-            val registration = backCacheListener.getAndSet(null) ?: return
+            val registration = backCacheListener.get() ?: return
             registration.active.set(false)
             backCache.deregisterCacheEntryListener(registration.configuration)
+            backCacheListener.compareAndSet(registration, null)
         }
     }
 

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
@@ -21,14 +21,244 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import javax.cache.Cache
+import javax.cache.CacheManager
 import javax.cache.configuration.CacheEntryListenerConfiguration
 import javax.cache.configuration.Configuration
+import javax.cache.configuration.Factory
 import javax.cache.configuration.MutableConfiguration
 import javax.cache.event.CacheEntryEvent
 import javax.cache.event.CacheEntryCreatedListener
 import javax.cache.event.CacheEntryUpdatedListener
 
 class NearJCacheContractTest {
+
+    @Test
+    fun `명시적 close는 front cleanup failure를 호출자에게 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val failure = IllegalStateException("front close failed")
+        every { frontCache.close() } throws failure
+        val nearCache = newNearCache(frontCache, backCache)
+
+        val error = assertFailsWith<IllegalStateException> { nearCache.close() }
+
+        (error === failure).shouldBeTrue()
+        verify(exactly = 1) { frontCache.close() }
+    }
+
+    @Test
+    fun `front cleanup failure 후 close는 다음 호출에서 front 정리를 재시도한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val failure = IllegalStateException("front close failed")
+        val closeAttempts = AtomicInteger()
+        every { frontCache.close() } answers {
+            if (closeAttempts.incrementAndGet() == 1) {
+                throw failure
+            }
+        }
+        val nearCache = newNearCache(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.close() }
+        nearCache.close()
+
+        verify(exactly = 2) { frontCache.close() }
+    }
+
+    @Test
+    fun `close cleanup 로그는 operation cache provider metadata를 기록한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val cacheName = "near-jcache-cleanup-log"
+        every { frontCache.close() } throws IllegalStateException("front unavailable")
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(cacheName = cacheName, isSynchronous = true),
+        )
+        val logger = NearJCache.log as Logger
+        val previousLevel = logger.level
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.level = Level.TRACE
+        logger.addAppender(appender)
+        try {
+            assertFailsWith<IllegalStateException> { nearCache.close() }
+            appender.list.map { it.formattedMessage }.any { message ->
+                message.contains("operation=close") &&
+                        message.contains("cache=$cacheName") &&
+                        message.contains("provider=")
+            }.shouldBeTrue()
+        } finally {
+            logger.detachAppender(appender)
+            appender.stop()
+            logger.level = previousLevel
+        }
+    }
+
+    @Test
+    fun `listener registration failure 로그는 operation cache provider metadata를 기록한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val cacheName = "near-jcache-registration-log"
+        val failure = IllegalStateException("listener unavailable")
+        every { backCache.registerCacheEntryListener(any()) } throws failure
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(cacheName = cacheName, isSynchronous = true),
+        )
+        val logger = NearJCache.log as Logger
+        val previousLevel = logger.level
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.level = Level.TRACE
+        logger.addAppender(appender)
+        try {
+            assertFailsWith<IllegalStateException> { nearCache.registerBackCacheListener() }
+            appender.list.map { it.formattedMessage }.any { message ->
+                message.contains("operation=register") &&
+                        message.contains("cache=$cacheName") &&
+                        message.contains("provider=")
+            }.shouldBeTrue()
+        } finally {
+            logger.detachAppender(appender)
+            appender.stop()
+            logger.level = previousLevel
+        }
+    }
+
+    @Test
+    fun `명시적 close는 listener와 front cleanup failure를 모두 보존한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val listenerFailure = IllegalStateException("listener close failed")
+        val frontFailure = IllegalArgumentException("front close failed")
+        every { backCache.registerCacheEntryListener(any()) } returns Unit
+        every { backCache.deregisterCacheEntryListener(any()) } throws listenerFailure
+        every { frontCache.close() } throws frontFailure
+        val nearCache = newNearCache(frontCache, backCache)
+        nearCache.registerBackCacheListener()
+
+        val error = assertFailsWith<IllegalStateException> { nearCache.close() }
+
+        (error === listenerFailure).shouldBeTrue()
+        error.suppressed.single() shouldBeEqualTo frontFailure
+        verify(exactly = 1) { frontCache.close() }
+    }
+
+    @Test
+    fun `성공한 close는 중복 호출해도 front와 listener를 한 번만 정리한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.registerCacheEntryListener(any()) } returns Unit
+        every { backCache.deregisterCacheEntryListener(any()) } returns Unit
+        every { frontCache.close() } returns Unit
+        val nearCache = newNearCache(frontCache, backCache)
+        nearCache.registerBackCacheListener()
+
+        nearCache.close()
+        nearCache.close()
+
+        verify(exactly = 1) { backCache.deregisterCacheEntryListener(any()) }
+        verify(exactly = 1) { frontCache.close() }
+    }
+
+    @Test
+    fun `listener cleanup failure 후 close는 다음 호출에서 listener 정리를 재시도한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val failure = IllegalStateException("listener close failed")
+        val deregisterAttempts = AtomicInteger()
+        every { backCache.registerCacheEntryListener(any()) } returns Unit
+        every { backCache.deregisterCacheEntryListener(any()) } answers {
+            if (deregisterAttempts.incrementAndGet() == 1) {
+                throw failure
+            }
+        }
+        every { frontCache.close() } returns Unit
+        val nearCache = newNearCache(frontCache, backCache)
+        nearCache.registerBackCacheListener()
+
+        assertFailsWith<IllegalStateException> { nearCache.close() }
+        nearCache.close()
+
+        verify(exactly = 2) { backCache.deregisterCacheEntryListener(any()) }
+        verify(exactly = 1) { frontCache.close() }
+    }
+
+    @Test
+    fun `listener와 front cleanup이 함께 실패해도 다음 close에서 둘 다 재시도한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val listenerFailure = IllegalStateException("listener close failed")
+        val frontFailure = IllegalArgumentException("front close failed")
+        val deregisterAttempts = AtomicInteger()
+        val closeAttempts = AtomicInteger()
+        every { backCache.registerCacheEntryListener(any()) } returns Unit
+        every { backCache.deregisterCacheEntryListener(any()) } answers {
+            if (deregisterAttempts.incrementAndGet() == 1) {
+                throw listenerFailure
+            }
+        }
+        every { frontCache.close() } answers {
+            if (closeAttempts.incrementAndGet() == 1) {
+                throw frontFailure
+            }
+        }
+        val nearCache = newNearCache(frontCache, backCache)
+        nearCache.registerBackCacheListener()
+
+        val error = assertFailsWith<IllegalStateException> { nearCache.close() }
+        (error === listenerFailure).shouldBeTrue()
+        error.suppressed.single() shouldBeEqualTo frontFailure
+
+        nearCache.close()
+
+        verify(exactly = 2) { backCache.deregisterCacheEntryListener(any()) }
+        verify(exactly = 2) { frontCache.close() }
+    }
+
+    @Test
+    fun `close 이후 listener 재등록은 거부한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val nearCache = newNearCache(frontCache, backCache)
+
+        nearCache.close()
+
+        assertFailsWith<IllegalStateException> { nearCache.registerBackCacheListener() }
+        verify(exactly = 0) { backCache.registerCacheEntryListener(any()) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `생성 rollback은 listener primary failure와 front cleanup failure를 함께 보존한다`() {
+        val cacheName = "near-jcache-construction-failure"
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val frontCacheManager = mockk<CacheManager>()
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val listenerFailure = IllegalStateException("listener registration failed")
+        val cleanupFailure = IllegalArgumentException("front close failed")
+        val configuration = MutableConfiguration<String, String>().setStoreByValue(false)
+        val configurationClass = Configuration::class.java as Class<Configuration<String, String>>
+        every { frontCache.getConfiguration(configurationClass) } returns configuration
+        every {
+            frontCacheManager.createCache<String, String, MutableConfiguration<String, String>>(cacheName, any())
+        } returns frontCache
+        every { backCache.registerCacheEntryListener(any()) } throws listenerFailure
+        every { frontCache.close() } throws cleanupFailure
+
+        val nearConfig = NearJCacheConfig<String, String>(
+            cacheManagerFactory = Factory { frontCacheManager },
+            cacheName = cacheName,
+            isSynchronous = true,
+        )
+
+        val error = assertFailsWith<IllegalStateException> { NearJCache(nearConfig, backCache) }
+
+        (error === listenerFailure).shouldBeTrue()
+        error.suppressed.single() shouldBeEqualTo cleanupFailure
+        verify(exactly = 1) { frontCache.close() }
+    }
 
     @Test
     fun `표준 Cache get은 back miss를 fallback하고 front를 채운다`() {

--- a/cache/cache-hazelcast/README.ko.md
+++ b/cache/cache-hazelcast/README.ko.md
@@ -144,6 +144,12 @@ Hazelcast JCache NearCache factory는 listener 없이 생성되는 degraded 모�
 read-through와 write-through는 지원하지만 peer front-cache propagation은 보장하지 않습니다.
 직접 listener-backed `NearJCache` / `SuspendNearJCache` 생성은 unsupported이며 active test로 고정합니다.
 
+팩토리가 반환한 wrapper가 lifecycle 관점에서 소유하는 것은 front cache뿐입니다.
+`close()`를 호출해도 전달받은 Hazelcast 인스턴스나 back cache는 닫지 않습니다.
+정리 실패는 첫 번째 실패를 주 예외로, 이후 실패를 suppressed 예외로 보존해
+전달하며, 성공한 close는 idempotent입니다. front 생성 이후 팩토리 생성이
+실패하면 동일한 예외 정책으로 rollback합니다.
+
 전체 행렬은 [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md)를 참고하세요.
 
 ### NearJCache 사용 예

--- a/cache/cache-hazelcast/README.md
+++ b/cache/cache-hazelcast/README.md
@@ -94,6 +94,12 @@ JCache near caches support read-through and write-through, but peer front-cache
 propagation is not promised. Direct listener-backed construction is unsupported
 and covered by explicit tests.
 
+The factory-created wrapper owns only its front cache for lifecycle purposes.
+Calling `close()` does not close the supplied Hazelcast instance or back cache.
+Cleanup failures are propagated with the first failure as primary and later
+failures as suppressed; a successful close is idempotent. If construction fails
+after front creation, rollback follows the same exception policy.
+
 See the full [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).
 
 ## Class Structure

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt
@@ -18,6 +18,7 @@ import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfigBuilder
 import io.bluetape4k.cache.nearcache.jcache.SuspendNearJCache
 import io.bluetape4k.cache.nearcache.jcache.nearJCacheConfig
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.error
 import io.bluetape4k.logging.info
 import java.util.concurrent.TimeUnit
 import javax.cache.configuration.Configuration
@@ -251,6 +252,10 @@ object HazelcastCaches: KLogging() {
      * @param hazelcastInstance Hazelcast 인스턴스
      * @param config [NearJCacheConfig] 설정
      * @return [NearJCache] 인스턴스
+     *
+     * 반환된 wrapper의 `close()`는 이 팩토리가 생성한 front cache만 닫고,
+     * 전달받은 Hazelcast 인스턴스와 back cache는 닫지 않습니다. 생성 rollback도
+     * front 정리 실패를 주 예외의 suppressed 예외로 보존합니다.
      */
     @Suppress("TooGenericExceptionCaught")
     inline fun <reified K: Any, reified V: Any> nearJCache(
@@ -278,8 +283,19 @@ object HazelcastCaches: KLogging() {
         log.info { "NearJCache 생성. config=$config" }
         return try {
             NearJCache(frontCache, backCache, config)
-        } catch (e: RuntimeException) {
-            runCatching { frontCache.close() }
+        } catch (e: Throwable) {
+            try {
+                frontCache.close()
+            } catch (cleanupFailure: Throwable) {
+                if (cleanupFailure !== e) {
+                    e.addSuppressed(cleanupFailure)
+                }
+                log.error(cleanupFailure) {
+                    "Hazelcast NearJCache front cleanup failed. " +
+                            "operation=constructor-rollback, cache=${config.cacheName}, " +
+                            "provider=${frontCache.javaClass.name}"
+                }
+            }
             throw e
         }
     }

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -11,9 +11,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import com.hazelcast.nio.serialization.HazelcastSerializationException
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.testcontainers.utility.Base58
@@ -56,11 +54,12 @@ class HazelcastNearJCacheTest {
         val storeByValueConfiguration = MutableConfiguration<String, String>().apply {
             setStoreByValue(true)
         }
+        val cleanupFailure = IllegalStateException("front close failed")
         val configurationClass = Configuration::class.java as Class<Configuration<String, String>>
         every {
             frontCache.getConfiguration(configurationClass)
         } returns storeByValueConfiguration
-        every { frontCache.close() } just runs
+        every { frontCache.close() } throws cleanupFailure
         every {
             frontCacheManager.createCache<String, String, MutableConfiguration<String, String>>(cacheName, any())
         } returns frontCache
@@ -70,10 +69,11 @@ class HazelcastNearJCacheTest {
             cacheManagerFactory = Factory { frontCacheManager },
         )
 
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             HazelcastCaches.nearJCache<String, String>(hazelcastClient, config)
         }
 
+        error.suppressed.single() shouldBeEqualTo cleanupFailure
         verify(exactly = 1) { frontCache.close() }
     }
 

--- a/docs/lessons/2026-08-13-issue-1371-nearcache-cleanup.md
+++ b/docs/lessons/2026-08-13-issue-1371-nearcache-cleanup.md
@@ -1,0 +1,67 @@
+# #1371 NearJCache front 정리 실패 관측성 교훈
+
+## 맥락
+
+`NearJCache.close()`와 생성 rollback이 front cache 정리 실패를 `runCatching`으로
+삼키고 있었다. listener deregister와 front close가 함께 실패하면 호출자는
+실패 원인을 알 수 없었고, 성공한 `close()`도 front 정리를 매번 다시 호출했다.
+Hazelcast `nearJCache` 팩토리도 생성 실패 시 같은 best-effort 정리 경계를
+사용하고 있었다.
+
+## 결정
+
+- 정리 단계의 첫 실패를 주 예외로 전달하고 이후 실패는 `suppressed` 예외로
+  연결한다.
+- `close()`는 wrapper가 등록한 listener와 소유한 front cache만 닫으며, 전달받은
+  back cache/provider는 닫지 않는다.
+- 성공한 `close()`는 idempotent로 처리한다. front close가 실패하면 성공할 때까지
+  다음 호출에서 front 정리를 재시도한다. listener deregister가 실패해도 등록
+  상태를 보존해 다음 호출에서 재시도한다.
+- close가 시작된 뒤에는 listener 재등록을 거부해, 닫힌 front를 다시 캡처하는
+  backend listener가 남지 않게 한다.
+- 생성 rollback도 동일한 예외 보존 정책을 사용하고, 로그에는
+  `operation`, `cache`, `provider` 메타데이터만 기록한다.
+
+## 결과
+
+`NearJCache`는 listener 정리와 front 정리를 독립적으로 시도한 뒤 실패 체인을
+호출자에게 보존한다. listener 정리 실패는 pending registration으로 남겨 다음
+`close()`에서 재시도하며, close 이후 재등록은 거부한다. Hazelcast 팩토리는
+`NearJCache` 생성 실패 뒤 front 정리 실패를 원래 예외의 `suppressed` 예외로
+남긴다. 두 README와 public KDoc에 front와 back의 lifecycle 소유 경계를 명시했다.
+
+## 검증
+
+- RED: 기존 구현에서 cleanup 예외 전파, suppressed 보존, idempotent close 계약
+  테스트 4개가 실패했다.
+- GREEN: `NearJCacheContractTest` 34개 통과. listener deregister 재시도,
+  combined cleanup 재시도, close 이후 재등록 거부, registration failure 로그
+  metadata 회귀 테스트를 포함한다.
+- `./gradlew :bluetape4k-cache-core:test --no-configuration-cache --no-build-cache
+  --rerun-tasks --max-workers=1` 결과 570개 통과. 최초 캐시 미강제 실행은
+  570개 통과 후 Gradle test-result `EOFException`으로 종료되어 fresh rerun으로
+  확인했다.
+- `TESTCONTAINERS_RYUK_DISABLED=true ./gradlew :bluetape4k-cache-hazelcast:test
+  --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` 결과
+  226개 통과. 기본 Ryuk 경로는 원격 Docker context에서 `/Users/debop/.colima/default/docker.sock`
+  mount 오류가 발생해 비활성화했으며, Testcontainers/Hazelcast 계열 검증은 다른
+  모듈과 병렬 실행하지 않았다.
+- 두 모듈의 `detekt` 태스크는 성공했다. 출력에는 `NearJCache.kt:82`의
+  `LargeClass`와 기존 테스트의 generic exception 위반이 포함됐지만, 모두 이번
+  변경 hunk와 무관한 baseline 결과로 확인했다.
+- `git diff --check` 통과.
+
+## 향후 지침
+
+새로운 resource lifecycle cleanup을 추가할 때는 `runCatching`으로 예외를
+숨기지 말고, (1) 각 cleanup 단계를 독립 실행하고, (2) 첫 실패와 후속 실패를
+분리해 보존하며, (3) 성공/실패 후 재호출과 close 이후 재등록 거부 정책을
+테스트하고, (4) 로그에 키·값·페이로드를 넣지 않는지 확인한다. shared back cache의 tenant/owner 권한과
+`getAll` residency 상한은 각각 #1368과 #1369의 별도 설계를 따른다.
+
+## 참고
+
+- [Issue #1371](https://github.com/bluetape4k/bluetape4k-projects/issues/1371)
+- [Epic #1408](https://github.com/bluetape4k/bluetape4k-projects/issues/1408)
+- `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt`
+- `cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt`


### PR DESCRIPTION
## Summary

Closes #1371

- PR 제목: [cache] NearJCache front cleanup lifecycle 관측성 보강

Issue #1371의 NearJCache front resource cleanup 관측성 및 lifecycle 계약을 보강합니다. Epic #1408의 cache stability train에 포함됩니다.

## Background

- `NearJCache.close()`와 생성 rollback이 cleanup 예외를 best-effort로 삼켜 호출자와 운영 로그에서 원인을 잃었습니다.
- listener deregistration 실패 시 등록 상태를 먼저 잃어 다음 `close()`가 재시도하지 못했습니다.
- `close()` 이후 listener 재등록이 가능해 닫힌 front를 캡처한 backend listener가 남을 수 있었습니다.

## What This Solves

- 원문 Summary, Work Done, 제목에 기록된 목적과 해결 범위를 보존했습니다.

## Work Done

- primary cleanup failure는 호출자에게 전달하고 후속 failure는 `suppressed`로 보존합니다.
- front cleanup은 성공할 때까지 재시도하고, listener deregistration도 성공 전 registration을 보존해 재시도합니다.
- `close()`와 listener registration을 `compoundGate`로 직렬화하고 close 시작 후 재등록을 거부합니다.
- cleanup/registration 로그에 `operation`, `cache`, `provider` metadata만 기록하며 payload는 기록하지 않습니다.
- Hazelcast factory rollback의 front cleanup 예외 보존을 동일한 정책으로 고정합니다.
- English/Korean README, public KDoc, Korean lesson을 동기화했습니다.

## Validation

- RED: 기존 cleanup 계약 테스트 4개 실패.
- GREEN: `NearJCacheContractTest` 34개 통과(등록 실패 metadata, listener/front combined retry 포함).
- cache-core 전체 테스트 570개 통과.
- `TESTCONTAINERS_RYUK_DISABLED=true` cache-hazelcast targeted 3개 및 전체 226개 통과.
- cache-core/cache-hazelcast detekt task 성공. 출력된 `NearJCache.kt:82 LargeClass`와 기존 테스트 generic exception은 변경 hunk와 무관한 baseline입니다.
- `git diff --check` 통과.

기본 Ryuk 경로는 원격 Docker context에서 `/Users/debop/.colima/default/docker.sock` mount 오류가 발생해 비활성화했습니다. Testcontainers 검증은 순차 실행했습니다.

## Review Notes

- 독립 architect: `CLEAR`.
- 독립 code-reviewer: lifecycle P0/P1=0; provider metadata 및 lesson 증거 문구 P2를 수정 후 재검증했습니다.
- Public JVM signature/ABI 변경 없음(정식 ABI 도구는 미실행).

## Metadata

- Issue: #1371, milestone `1.13.0`, assignee `debop`
- PR: #1415, head `32be3cc9372984deebd63a14f0d7aed1a5184002`, milestone `1.13.0`, assignee `debop`
- Base: `develop`, head branch `fix/issue-1371-nearcache-cleanup`
- Labels: `bug`, `test`, `tech-debt`, `cache`
- State: `MERGED`, merge commit `49ffe31c2834345d25e4d146814070ff506c748a`
- CI: - cache-core/cache-hazelcast detekt task 성공. 출력된 `NearJCache.kt:82 LargeClass`와 기존 테스트 generic exception은 변경 hunk와 무관한 baseline입니다. / - [x] PR required CI 성공 (run 31663095696; 10개 성공, 8개 영향 없음으로 skipped)

## DoD Status

- [x] issue #1371 범위와 Epic #1408 연결
- [x] cleanup primary/suppressed 예외 계약 구현
- [x] listener cleanup retry 및 post-close registration guard 구현
- [x] 회귀·모듈·정적 분석·diff 검증 완료
- [x] README/KDoc/lesson 동기화
- [x] Lore commit `32be3cc9372984deebd63a14f0d7aed1a5184002`
- [x] PR required CI 성공 (run 31663095696; 10개 성공, 8개 영향 없음으로 skipped)
- [ ] 최신 head에 대한 최종 human review 대기
- [ ] CG-16 명시적 merge 승인
- [ ] merge 후 develop sync 및 worktree cleanup

Required checks: 3/3; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| PR-BODY-01 - Original record | 원문 의미와 미지원 섹션을 표준 섹션 아래에 보존 | PASS | 변환 전·후 본문을 메모리에서 비교 | none |
| PR-BODY-02 - Live metadata | 라이브 PR·issue 메타데이터를 본문에 반영 | PASS | gh pr #1415 read 및 issue 참조 | none |
| PR-BODY-03 - Final section | DoD Status를 마지막 H2로 배치하고 필수 줄을 확인 | PASS | 정규화기 전수 감사 | none |

Final status: MERGED (merge commit `49ffe31c2834345d25e4d146814070ff506c748a`; historical body normalized)

Unchecked required items: none (메타데이터 정규화이며 새 실행 게이트를 추가하지 않음)
