### PR TITLE
[cache][api] NearJCacheConfig prior-release ABI·serialization 호환성 보존

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@
 
 - [ ] 변경된 모듈의 `README.md` + `README.ko.md` 업데이트
 - [ ] 공개 API에 KDoc 추가
+- [ ] `cache/` 공개 설정/직렬화 변경 시 prior-release ABI(Java/Kotlin) fixture와 serialized fixture evidence 첨부 (증거가 없으면 stable publication을 진행하지 않음)
 - [ ] `spring-boot/` 모듈 변경 시 Spring Boot 4 BOM 적용 및 Spring Framework 7.x 호환성 확인
 - [ ] `spring-boot/` 모듈 변경 시 `.github/workflows/nightly-tests.yml`의 독립 test task 및 비-demo kover task 등록 확인
 - [ ] `worktree`에서 작업 후 PR 생성

--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -117,6 +117,13 @@ local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도�
 왕복을 사용하지 않으며, back provider 실패 시 front를 변경하기 전에
 예외를 전달합니다.
 
+`SuspendNearJCache`의 일반 mutation도 동일한 back-first 규칙을 적용합니다.
+`put`, `putAll`, `putIfAbsent`, `remove`, `replace`는 back cache를 먼저
+변경한 뒤 local front를 조정합니다. back 실패 시 front는 변경하지 않으며,
+back commit 후 front 조정이 실패하면 해당 front key를 invalidate하여
+미커밋 값을 반환하지 않습니다. 코루틴 cancellation은 fallback이나 retry로
+대체하지 않고 호출자에게 재전파합니다.
+
 기본 front 설정은 store-by-reference입니다. 필터링된 provider별 copier 계약이
 정해지기 전에는 custom store-by-value front 설정을 생성 단계에서 거부합니다.
 

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -70,6 +70,13 @@ provider's atomic compound operation and then reconcile the local front cache;
 they do not implement a front-read/back-write round trip. A provider failure is
 propagated before the front cache is changed.
 
+`SuspendNearJCache` uses the same back-first rule for ordinary mutations:
+`put`, `putAll`, `putIfAbsent`, `remove`, and `replace` update the back cache
+before reconciling the local front cache. A back failure leaves the front
+unchanged; if front reconciliation fails after a back commit, the affected
+front key(s) are invalidated so an uncommitted value is not returned. Coroutine
+cancellation is propagated without fallback or retry.
+
 The default front configuration uses store-by-reference. A custom store-by-value
 front configuration is rejected until a filtered, provider-specific copier
 contract is supplied.

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfig.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.cache.jcache.jcacheManagerOf
 import io.bluetape4k.codec.Base58
+import java.io.IOException
+import java.io.ObjectInputStream
 import java.io.Serializable
 import javax.cache.CacheManager
 import javax.cache.configuration.Factory
@@ -45,6 +47,70 @@ data class NearJCacheConfig<K: Any, V: Any>(
     val syncRemoteTimeout: Long = NearJCacheConfig.DEFAULT_SYNC_REMOTE_TIMEOUT,
     val syncRemoteRetryCount: Int = NearJCacheConfig.DEFAULT_SYNC_REMOTE_RETRY_COUNT,
 ): Serializable {
+
+    /**
+     * prior-release의 5-인자 JVM constructor descriptor를 유지합니다.
+     */
+    constructor(
+        cacheManagerFactory: Factory<CacheManager>,
+        cacheName: String,
+        frontCacheConfiguration: MutableConfiguration<K, V>,
+        isSynchronous: Boolean,
+        syncRemoteTimeout: Long,
+    ) : this(
+        cacheManagerFactory = cacheManagerFactory,
+        cacheName = cacheName,
+        frontCacheConfiguration = frontCacheConfiguration,
+        isSynchronous = isSynchronous,
+        syncRemoteTimeout = syncRemoteTimeout,
+        syncRemoteRetryCount = DEFAULT_SYNC_REMOTE_RETRY_COUNT,
+    )
+
+    /** prior-release의 5-인자 JVM copy descriptor를 유지합니다. */
+    fun copy(
+        cacheManagerFactory: Factory<CacheManager>,
+        cacheName: String,
+        frontCacheConfiguration: MutableConfiguration<K, V>,
+        isSynchronous: Boolean,
+        syncRemoteTimeout: Long,
+    ): NearJCacheConfig<K, V> = NearJCacheConfig(
+        cacheManagerFactory = cacheManagerFactory,
+        cacheName = cacheName,
+        frontCacheConfiguration = frontCacheConfiguration,
+        isSynchronous = isSynchronous,
+        syncRemoteTimeout = syncRemoteTimeout,
+        syncRemoteRetryCount = DEFAULT_SYNC_REMOTE_RETRY_COUNT,
+    )
+
+    /**
+     * Java serialization은 constructor를 호출하지 않으므로, 기존 stream의 누락 필드를
+     * [ObjectInputStream.GetField.defaulted]로 구분해 새 정책 기본값을 복원합니다.
+     */
+    @Suppress("UNCHECKED_CAST")
+    @Throws(IOException::class, ClassNotFoundException::class)
+    private fun readObject(input: ObjectInputStream) {
+        val fields = input.readFields()
+        setSerializedField("cacheManagerFactory", fields.get("cacheManagerFactory", null) as Factory<CacheManager>)
+        setSerializedField("cacheName", fields.get("cacheName", null) as String)
+        setSerializedField(
+            "frontCacheConfiguration",
+            fields.get("frontCacheConfiguration", null) as MutableConfiguration<K, V>,
+        )
+        setSerializedField("isSynchronous", fields.get("isSynchronous", false))
+        setSerializedField("syncRemoteTimeout", fields.get("syncRemoteTimeout", DEFAULT_SYNC_REMOTE_TIMEOUT))
+        setSerializedField("syncRemoteRetryCount", if (fields.defaulted("syncRemoteRetryCount")) {
+            DEFAULT_SYNC_REMOTE_RETRY_COUNT
+        } else {
+            fields.get("syncRemoteRetryCount", DEFAULT_SYNC_REMOTE_RETRY_COUNT)
+        })
+    }
+
+    private fun setSerializedField(name: String, value: Any?) {
+        javaClass.getDeclaredField(name).apply {
+            isAccessible = true
+            set(this@NearJCacheConfig, value)
+        }
+    }
 
     companion object {
         private const val serialVersionUID: Long = 1L

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt
@@ -22,6 +22,12 @@ import javax.cache.configuration.MutableCacheEntryListenerConfiguration
  * @param V Cache entry value type
  * @property frontCache 로컬 캐시
  * @property backCache 분산환경에서 사용할 원격 캐시
+ *
+ * 일반 mutation은 back cache를 기준 데이터 원본으로 삼아 back-first 순서로
+ * 수행합니다. back mutation이 실패하면 front cache를 변경하지 않으며, back
+ * mutation 후 front 반영이 실패하면 front key를 invalidate하여 미커밋 값을
+ * 반환하지 않도록 합니다. [kotlinx.coroutines.CancellationException]은
+ * fallback이나 retry로 대체하지 않고 호출자에게 재전파합니다.
  * @constructor Create empty Co near cache
  */
 class SuspendNearJCache<K: Any, V: Any> internal constructor(
@@ -179,15 +185,13 @@ class SuspendNearJCache<K: Any, V: Any> internal constructor(
     }
 
     override suspend fun put(key: K, value: V) {
-        frontCache.put(key, value).apply {
-            backCache.put(key, value)
-        }
+        backCache.put(key, value)
+        syncFrontAfterBack({ frontCache.put(key, value) }, { invalidateFront(key) })
     }
 
     override suspend fun putAll(map: Map<K, V>) {
-        frontCache.putAll(map).apply {
-            backCache.putAll(map)
-        }
+        backCache.putAll(map)
+        syncFrontAfterBack({ frontCache.putAll(map) }) { invalidateFront(map.keys) }
     }
 
     override suspend fun putAllFlow(entries: Flow<Pair<K, V>>) {
@@ -195,23 +199,26 @@ class SuspendNearJCache<K: Any, V: Any> internal constructor(
     }
 
     override suspend fun putIfAbsent(key: K, value: V): Boolean {
-        return frontCache.putIfAbsent(key, value).apply {
-            backCache.putIfAbsent(key, value)
+        val inserted = backCache.putIfAbsent(key, value)
+        if (inserted) {
+            syncFrontAfterBack({ frontCache.put(key, value) }, { invalidateFront(key) })
+        } else {
+            // Back가 이미 보유한 값이 front의 stale 값보다 우선하므로 miss로 되돌립니다.
+            syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
         }
+        return inserted
     }
 
     override suspend fun remove(key: K): Boolean {
-        return frontCache.remove(key).apply {
-            backCache.remove(key)
-        }
+        val removed = backCache.remove(key)
+        syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
+        return removed
     }
 
     override suspend fun remove(key: K, oldValue: V): Boolean {
-        frontCache.remove(key, oldValue)
-        if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
-            return backCache.remove(key)
-        }
-        return false
+        val removed = backCache.remove(key, oldValue)
+        syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
+        return removed
     }
 
     override suspend fun removeAll() {
@@ -233,24 +240,51 @@ class SuspendNearJCache<K: Any, V: Any> internal constructor(
     }
 
     override suspend fun replace(key: K, oldValue: V, newValue: V): Boolean {
-        frontCache.replace(key, oldValue, newValue)
-
-        // NOTE: Redisson에서는 replace 가 event 를 발생시키지 않습니다!!!
-        if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
-            put(key, newValue)
-            return true
+        val replaced = backCache.replace(key, oldValue, newValue)
+        if (replaced) {
+            syncFrontAfterBack({ frontCache.put(key, newValue) }, { invalidateFront(key) })
+        } else {
+            syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
         }
-        return false
+        return replaced
     }
 
     override suspend fun replace(key: K, value: V): Boolean {
-        frontCache.replace(key, value)
-
-        // NOTE: Redisson에서는 replace 가 event 를 발생시키지 않습니다!!!
-        if (backCache.containsKey(key)) {
-            put(key, value)
-            return true
+        val replaced = backCache.replace(key, value)
+        if (replaced) {
+            syncFrontAfterBack({ frontCache.put(key, value) }, { invalidateFront(key) })
+        } else {
+            syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
         }
-        return false
+        return replaced
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun syncFrontAfterBack(
+        sync: suspend () -> Unit,
+        invalidate: suspend () -> Unit,
+    ) {
+        try {
+            sync()
+        } catch (failure: Throwable) {
+            try {
+                invalidate()
+            } catch (invalidateFailure: Throwable) {
+                if (invalidateFailure !== failure) {
+                    failure.addSuppressed(invalidateFailure)
+                }
+            }
+            throw failure
+        }
+    }
+
+    private suspend fun invalidateFront(key: K) {
+        frontCache.remove(key)
+    }
+
+    private suspend fun invalidateFront(keys: Set<K>) {
+        if (keys.isNotEmpty()) {
+            frontCache.removeAll(keys)
+        }
     }
 }

--- a/cache/cache-core/src/test/java/io/bluetape4k/cache/nearcache/jcache/LegacyNearJCacheConfigConsumer.java
+++ b/cache/cache-core/src/test/java/io/bluetape4k/cache/nearcache/jcache/LegacyNearJCacheConfigConsumer.java
@@ -1,0 +1,45 @@
+package io.bluetape4k.cache.nearcache.jcache;
+
+import javax.cache.CacheManager;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.MutableConfiguration;
+
+/** prior-release 5-인자 NearJCacheConfig ABI를 컴파일하는 소비자 fixture입니다. */
+public final class LegacyNearJCacheConfigConsumer {
+
+    private LegacyNearJCacheConfigConsumer() {
+    }
+
+    public static NearJCacheConfig<String, String> construct(
+        Factory<CacheManager> cacheManagerFactory,
+        String cacheName,
+        MutableConfiguration<String, String> frontCacheConfiguration,
+        boolean isSynchronous,
+        long syncRemoteTimeout
+    ) {
+        return new NearJCacheConfig<>(
+            cacheManagerFactory,
+            cacheName,
+            frontCacheConfiguration,
+            isSynchronous,
+            syncRemoteTimeout
+        );
+    }
+
+    public static NearJCacheConfig<String, String> copy(
+        NearJCacheConfig<String, String> source,
+        Factory<CacheManager> cacheManagerFactory,
+        String cacheName,
+        MutableConfiguration<String, String> frontCacheConfiguration,
+        boolean isSynchronous,
+        long syncRemoteTimeout
+    ) {
+        return source.copy(
+            cacheManagerFactory,
+            cacheName,
+            frontCacheConfiguration,
+            isSynchronous,
+            syncRemoteTimeout
+        );
+    }
+}

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfigCompatibilityTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfigCompatibilityTest.kt
@@ -1,0 +1,151 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.ObjectStreamClass
+import java.io.ObjectStreamConstants
+import java.io.Serializable
+import javax.cache.CacheManager
+import javax.cache.configuration.Factory
+import javax.cache.configuration.MutableConfiguration
+
+class NearJCacheConfigCompatibilityTest {
+
+    @Test
+    fun `prior five argument Java consumer ABI remains callable`() {
+        val factory = SerializableCacheManagerFactory()
+        val frontConfiguration = MutableConfiguration<String, String>()
+        val configClass = NearJCacheConfig::class.java
+
+        assertEquals(
+            Int::class.javaPrimitiveType,
+            configClass.getMethod("getSyncRemoteRetryCount").returnType,
+        )
+        assertEquals(
+            Int::class.javaPrimitiveType,
+            configClass.getMethod("component6").returnType,
+        )
+
+        val config = LegacyNearJCacheConfigConsumer.construct(
+            factory,
+            "legacy-cache",
+            frontConfiguration,
+            true,
+            250L,
+        )
+        val copy = LegacyNearJCacheConfigConsumer.copy(
+            config,
+            factory,
+            "legacy-copy",
+            frontConfiguration,
+            false,
+            500L,
+        )
+        val kotlinConfig = NearJCacheConfig<String, String>(
+            factory,
+            "kotlin-legacy-cache",
+            frontConfiguration,
+            true,
+            250L,
+        )
+        val kotlinCopy = kotlinConfig.copy(
+            factory,
+            "kotlin-legacy-copy",
+            frontConfiguration,
+            false,
+            500L,
+        )
+
+        assertEquals("legacy-cache", config.cacheName)
+        assertEquals(NearJCacheConfig.DEFAULT_SYNC_REMOTE_RETRY_COUNT, config.syncRemoteRetryCount)
+        assertEquals("legacy-copy", copy.cacheName)
+        assertEquals(NearJCacheConfig.DEFAULT_SYNC_REMOTE_RETRY_COUNT, copy.syncRemoteRetryCount)
+        assertEquals("kotlin-legacy-cache", kotlinConfig.cacheName)
+        assertEquals("kotlin-legacy-copy", kotlinCopy.cacheName)
+    }
+
+    @Test
+    fun `legacy serialized stream restores the new retry policy default`() {
+        val legacy = LegacyNearJCacheConfig(
+            cacheManagerFactory = SerializableCacheManagerFactory(),
+            cacheName = "legacy-stream",
+            frontCacheConfiguration = MutableConfiguration<String, String>(),
+            isSynchronous = false,
+            syncRemoteTimeout = 500L,
+        )
+
+        val restored = deserializeAsCurrent(serialize(legacy))
+
+        assertEquals("legacy-stream", restored.cacheName)
+        assertEquals(NearJCacheConfig.DEFAULT_SYNC_REMOTE_RETRY_COUNT, restored.syncRemoteRetryCount)
+    }
+
+    @Test
+    fun `current serialization preserves an explicit zero retry policy`() {
+        val original = NearJCacheConfig<String, String>(syncRemoteRetryCount = 0)
+
+        val restored = deserializeAsCurrent(serialize(original))
+
+        assertEquals(0, restored.syncRemoteRetryCount)
+    }
+
+    private fun serialize(value: Any): ByteArray = ByteArrayOutputStream().use { bytes ->
+        LegacyObjectOutputStream(bytes).use { output -> output.writeObject(value) }
+        bytes.toByteArray()
+    }
+
+    private fun deserializeAsCurrent(bytes: ByteArray): NearJCacheConfig<String, String> =
+        MappingObjectInputStream(ByteArrayInputStream(bytes)).use { input ->
+            input.readObject() as NearJCacheConfig<String, String>
+        }
+
+    private class MappingObjectInputStream(input: ByteArrayInputStream) : ObjectInputStream(input) {
+        override fun resolveClass(desc: ObjectStreamClass): Class<*> = super.resolveClass(desc)
+    }
+
+    private class LegacyObjectOutputStream(output: ByteArrayOutputStream) : ObjectOutputStream(output) {
+        override fun writeClassDescriptor(desc: ObjectStreamClass) {
+            if (desc.name != LegacyNearJCacheConfig::class.java.name) {
+                super.writeClassDescriptor(desc)
+                return
+            }
+
+            writeUTF(NearJCacheConfig::class.java.name)
+            writeLong(1L)
+            writeByte(ObjectStreamConstants.SC_SERIALIZABLE.toInt())
+            val fields = desc.fields
+            writeShort(fields.size)
+            fields.forEach { field ->
+                writeByte(field.typeCode.code)
+                writeUTF(field.name)
+                if (field.typeCode == 'L' || field.typeCode == '[') {
+                    writeObject(field.typeString)
+                }
+            }
+        }
+    }
+
+    private data class LegacyNearJCacheConfig(
+        val cacheManagerFactory: Factory<CacheManager>,
+        val cacheName: String,
+        val frontCacheConfiguration: MutableConfiguration<String, String>,
+        val isSynchronous: Boolean,
+        val syncRemoteTimeout: Long,
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    private class SerializableCacheManagerFactory : Factory<CacheManager>, Serializable {
+        override fun create(): CacheManager = error("fixture factory must not be invoked")
+
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+}

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCacheBackFirstContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCacheBackFirstContractTest.kt
@@ -1,0 +1,164 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.cache.jcache.SuspendJCache
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+
+class SuspendNearJCacheBackFirstContractTest {
+
+    private val failure = IllegalStateException("back cache is unavailable")
+
+    @Test
+    fun `put은 back 성공 후 front를 반영한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.put("key", "value") } just runs
+
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        nearCache.put("key", "value")
+
+        coVerifyOrder {
+            backCache.put("key", "value")
+            frontCache.put("key", "value")
+        }
+    }
+
+    @Test
+    fun `put은 back 실패 시 front에 미커밋 값을 남기지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.put("key", "value") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.put("key", "value") }
+
+        coVerify(exactly = 0) { frontCache.put("key", "value") }
+    }
+
+    @Test
+    fun `putAll은 back 실패 시 front에 미커밋 값을 남기지 않는다`() = runSuspendIO {
+        val entries = mapOf("key" to "value")
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.putAll(entries) } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.putAll(entries) }
+
+        coVerify(exactly = 0) { frontCache.putAll(entries) }
+    }
+
+    @Test
+    fun `putIfAbsent는 back 실패 시 front에 미커밋 값을 남기지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.putIfAbsent("key", "value") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.putIfAbsent("key", "value") }
+
+        coVerify(exactly = 0) { frontCache.putIfAbsent("key", "value") }
+    }
+
+    @Test
+    fun `remove는 back 실패 시 front를 변경하지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.remove("key") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.remove("key") }
+
+        coVerify(exactly = 0) { frontCache.remove("key") }
+    }
+
+    @Test
+    fun `조건부 remove는 back 실패 시 front를 변경하지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.remove("key", "old") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.remove("key", "old") }
+
+        coVerify(exactly = 0) { frontCache.remove("key", "old") }
+    }
+
+    @Test
+    fun `replace는 back 실패 시 front를 변경하지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.replace("key", "value") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.replace("key", "value") }
+
+        coVerify(exactly = 0) { frontCache.replace("key", "value") }
+    }
+
+    @Test
+    fun `조건부 replace는 back 실패 시 front를 변경하지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.replace("key", "old", "value") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.replace("key", "old", "value") }
+
+        coVerify(exactly = 0) { frontCache.replace("key", "old", "value") }
+    }
+
+    @Test
+    fun `back cancellation은 front 변경 없이 재전파된다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val cancellation = CancellationException("back cache cancelled")
+        coEvery { backCache.put("key", "value") } throws cancellation
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val error = assertFailsWith<CancellationException> { nearCache.put("key", "value") }
+
+        error.message shouldBeEqualTo cancellation.message
+        coVerify(exactly = 0) { frontCache.put("key", "value") }
+    }
+
+    @Test
+    fun `back commit 후 front 반영 실패는 front를 invalidate하고 원래 예외를 전달한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val frontFailure = IllegalStateException("front cache is unavailable")
+        coEvery { backCache.put("key", "value") } just runs
+        coEvery { frontCache.put("key", "value") } throws frontFailure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val error = assertFailsWith<IllegalStateException> { nearCache.put("key", "value") }
+
+        error.message shouldBeEqualTo frontFailure.message
+        coVerify(exactly = 1) { frontCache.remove("key") }
+    }
+
+    @Test
+    fun `front 반영 중 cancellation도 front를 invalidate하고 재전파한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val cancellation = CancellationException("front cache cancelled")
+        coEvery { backCache.put("key", "value") } just runs
+        coEvery { frontCache.put("key", "value") } throws cancellation
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val error = assertFailsWith<CancellationException> { nearCache.put("key", "value") }
+
+        error.message shouldBeEqualTo cancellation.message
+        coVerify(exactly = 1) { frontCache.remove("key") }
+    }
+}

--- a/docs/lessons/2026-08-14-issue-1412-nearjcache-abi-serialization.md
+++ b/docs/lessons/2026-08-14-issue-1412-nearjcache-abi-serialization.md
@@ -1,0 +1,24 @@
+# 이슈 #1412 NearJCacheConfig ABI·직렬화 호환성 교훈
+
+## 맥락
+
+`NearJCacheConfig`에 `syncRemoteRetryCount`를 data class 주 생성자에 추가하면서
+1.12.1 소비자가 호출하던 5-인자 JVM constructor와 `copy()` descriptor가
+사라졌다. `serialVersionUID`를 유지해도 기존 stream에는 새 primitive field가
+없으므로 JVM default `0`이 새 정책 기본값 `1`을 대체할 수 있었다.
+
+## 결정
+
+- 새 정책은 유지하되 5-인자 constructor와 `copy()`를 additive overload로
+  복원한다.
+- `ObjectInputStream.GetField.defaulted("syncRemoteRetryCount")`로 legacy
+  stream의 누락과 명시적 `0`을 구분해 기본값을 복원한다.
+- `cache/` 공개 설정·직렬화 변경은 prior-release Java/Kotlin fixture와
+  serialized fixture evidence 없이는 stable publication을 진행하지 않는다.
+
+## 검증
+
+- Java fixture가 5-인자 constructor/copy를 직접 컴파일·호출한다.
+- Kotlin fixture, getter/component metadata, legacy stream default, 명시적 `0`
+  round-trip을 검증한다.
+- cache-core 영향 테스트 58개와 compatibility 테스트 3개가 통과했다.

--- a/docs/lessons/2026-08-14-issue-1425-suspend-nearjcache-back-first.md
+++ b/docs/lessons/2026-08-14-issue-1425-suspend-nearjcache-back-first.md
@@ -1,0 +1,39 @@
+# #1425 SuspendNearJCache back-first mutation 계약
+
+## 맥락
+
+`SuspendNearJCache`의 일반 mutation이 front를 먼저 변경한 뒤 back cache를
+호출하고 있어, back 작업이 실패해도 front에 미커밋 값이나 삭제 상태가
+남을 수 있었다. 이는 back cache를 기준 데이터 원본으로 사용하는 near-cache
+계약과 맞지 않았다.
+
+## 원인
+
+`put`, `putAll`, `putIfAbsent`, `remove`, `replace`가 compound API와 달리
+front-first 순서를 사용했다. 특히 `replace`와 조건부 `remove`는 front 결과를
+먼저 버린 뒤 back 상태를 별도로 조회하여 원자성도 보장하지 못했다.
+
+## 결정
+
+- 일반 mutation은 back-first로 수행하고 back 결과가 성공한 뒤 front를
+  reconcile한다.
+- back 실패 시 front를 호출하지 않는다.
+- back commit 후 front reconcile이 실패하면 대상 front key를 invalidate하고
+  원래 예외를 호출자에게 전달한다. invalidate 실패는 suppressed 예외로
+  보존한다.
+- `CancellationException`은 fallback이나 retry로 바꾸지 않고 재전파한다.
+
+## 검증
+
+- RED: 기존 구현에서 back 실패 시 front가 먼저 호출되어 9개 계약 테스트가
+  실패함.
+- GREEN: `SuspendNearJCacheBackFirstContractTest` 11개 PASS.
+- 기존 `SuspendNearJCacheTest`와 `NearJCacheCompoundOperationContractTest`
+  35개 PASS.
+- `detekt` task는 BUILD SUCCESSFUL이며 cache-core 기존 findings가 남아 있다.
+
+## 후속 지침
+
+새로운 SuspendNearJCache mutation은 front-first write를 추가하지 말고,
+back authoritative 결과와 front invalidate/reconcile 경계를 테스트로
+고정한다. cancellation은 항상 별도 회귀 사례로 검증한다.


### PR DESCRIPTION
## Summary

Closes #1412

`NearJCacheConfig`의 `1.12.1` 소비자 ABI와 기존 Java serialization 의미를 `1.13.0`에서도 보존합니다.

## Background

`syncRemoteRetryCount`를 data class primary constructor에 추가하면서 기존 5-인자 JVM constructor/copy descriptor가 사라졌고, `serialVersionUID`를 유지한 legacy stream에서는 새 필드가 JVM default `0`으로 복원될 수 있었습니다. 이 변경은 Epic #1408 stacked PR train의 3단계이며, #1355/#1371 이후에 쌓입니다.

## What This Solves

- 기존 Java/Kotlin 소비자의 5-인자 constructor와 `copy` 호출이 `NoSuchMethodError`로 깨지는 위험
- legacy serialized config에서 retry 기본값 `1`이 `0`으로 바뀌는 의미 drift
- stable publication 전에 prior-release ABI·serialization evidence가 누락되는 release gate

## Work Done

- `NearJCacheConfig`에 기존 5-인자 constructor와 `copy(...)` overload를 additive하게 복원했습니다.
- legacy stream의 누락 필드는 `readObject`에서 기본값 `1`로 복원하고, 현재 stream의 명시적 `0`은 보존했습니다.
- Java direct compiled consumer fixture와 Kotlin/serialization regression test를 추가했습니다.
- PR template에 cache 공개 설정/직렬화 변경의 prior-release evidence checklist를 추가하고, 결정 근거를 lesson으로 기록했습니다.

## Validation

- `./gradlew :bluetape4k-cache-core:test --tests '*NearJCacheConfigCompatibilityTest' --tests '*NearJCacheConfigBuilderTest' --tests '*NearJCacheConfigWriteThroughFailureTest' --tests '*NearJCacheConfigContractTest' --rerun-tasks --no-build-cache --no-configuration-cache`: PASS (58 tests)
- `javap -s` 및 Java direct consumer fixture: PASS (5-인자 constructor/copy, getter, `component6` 확인)
- `git diff --check`: PASS
- `detekt`: PASS (기존 cache-core findings 보고, 신규 P0/P1 없음)

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: 로컬 Kotlin checklist 및 targeted test evidence; PR CI/review는 생성 후 확인

## Metadata

- Issue: #1412, milestone `1.13.0`, assignee `debop`
- PR: #1428, milestone `1.13.0`, assignee `debop`
- Head: `fix/1412-nearjcache-abi-serialization` @ `f9265816c357eac796119fe7a494079cd7fc11ac`
- Base: `develop`
- Stacked train: Epic #1408 3단계; 선행 #1355/#1371, 후속 #1425
- CI: [PR #1428 checks](https://github.com/bluetape4k/bluetape4k-projects/pull/1428/checks)에서 exact head 기준으로 진행 중

## DoD Status

Required checks: 5/7; N/A: 3; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-10 - Pre-PR proof | guidance, issue history, isolated worktree, implementation, tests, lesson, final diff를 검증 | PASS | local head `f9265816c357eac796119fe7a494079cd7fc11ac`, 58 tests, clean diff | none |
| CG-11 - PR delivery authority | 승인된 NearJCache stacked PR train의 #1412를 `develop`에 게시 | PASS | 현재 요청, issue #1412, Epic #1408 | none |
| CG-12 - Exact head publish | `fix/1412-nearjcache-abi-serialization`을 force 없이 게시 | PASS | remote `f9265816c357eac796119fe7a494079cd7fc11ac`와 local head 일치 | none |
| CG-12A - Guidance refresh | 생성 직전 current guidance, leaf skill, common gates, template, issue metadata 재확인 | PASS | guidance SHA와 live issue #1412 확인 | none |
| CG-13 - Create and verify PR | Korean body, assignee/labels/milestone, final `## DoD Status`를 live 검증 | PASS | [PR #1428](https://github.com/bluetape4k/bluetape4k-projects/pull/1428), labels `bug`, `tech-debt`, `cache`, milestone `1.13.0`, assignee `debop`, body final heading 확인 | none |
| CG-14 - CI and review | exact head required checks와 최신 review blocker 확인 | PENDING | PR 생성 후 GitHub checks/reviews 확인 | wait/repair |
| CG-15 - Merge-ready report | CI/review/lesson/artifact evidence를 재집계 | PENDING | CI/review 완료 후 보고 | merge approval 대기 |
| CG-16~CG-18 - Merge/sync/cleanup | merge approval 이후 merge·동기화·cleanup 수행 | N/A | 현재 요청은 PR 생성과 stacked train handoff까지이며 merge authority 없음 | fresh merge approval 이후 별도 gate |

Final status: PENDING (required CI/review 대기)

Unchecked required items: CG-14, CG-15
