### PR TITLE
[cache][coroutines] SuspendNearJCache mutation back-first 정합성 고정

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -117,6 +117,13 @@ local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도�
 왕복을 사용하지 않으며, back provider 실패 시 front를 변경하기 전에
 예외를 전달합니다.
 
+`SuspendNearJCache`의 일반 mutation도 동일한 back-first 규칙을 적용합니다.
+`put`, `putAll`, `putIfAbsent`, `remove`, `replace`는 back cache를 먼저
+변경한 뒤 local front를 조정합니다. back 실패 시 front는 변경하지 않으며,
+back commit 후 front 조정이 실패하면 해당 front key를 invalidate하여
+미커밋 값을 반환하지 않습니다. 코루틴 cancellation은 fallback이나 retry로
+대체하지 않고 호출자에게 재전파합니다.
+
 기본 front 설정은 store-by-reference입니다. 필터링된 provider별 copier 계약이
 정해지기 전에는 custom store-by-value front 설정을 생성 단계에서 거부합니다.
 

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -70,6 +70,13 @@ provider's atomic compound operation and then reconcile the local front cache;
 they do not implement a front-read/back-write round trip. A provider failure is
 propagated before the front cache is changed.
 
+`SuspendNearJCache` uses the same back-first rule for ordinary mutations:
+`put`, `putAll`, `putIfAbsent`, `remove`, and `replace` update the back cache
+before reconciling the local front cache. A back failure leaves the front
+unchanged; if front reconciliation fails after a back commit, the affected
+front key(s) are invalidated so an uncommitted value is not returned. Coroutine
+cancellation is propagated without fallback or retry.
+
 The default front configuration uses store-by-reference. A custom store-by-value
 front configuration is rejected until a filtered, provider-specific copier
 contract is supplied.

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt
@@ -22,6 +22,12 @@ import javax.cache.configuration.MutableCacheEntryListenerConfiguration
  * @param V Cache entry value type
  * @property frontCache 로컬 캐시
  * @property backCache 분산환경에서 사용할 원격 캐시
+ *
+ * 일반 mutation은 back cache를 기준 데이터 원본으로 삼아 back-first 순서로
+ * 수행합니다. back mutation이 실패하면 front cache를 변경하지 않으며, back
+ * mutation 후 front 반영이 실패하면 front key를 invalidate하여 미커밋 값을
+ * 반환하지 않도록 합니다. [kotlinx.coroutines.CancellationException]은
+ * fallback이나 retry로 대체하지 않고 호출자에게 재전파합니다.
  * @constructor Create empty Co near cache
  */
 class SuspendNearJCache<K: Any, V: Any> internal constructor(
@@ -179,15 +185,13 @@ class SuspendNearJCache<K: Any, V: Any> internal constructor(
     }
 
     override suspend fun put(key: K, value: V) {
-        frontCache.put(key, value).apply {
-            backCache.put(key, value)
-        }
+        backCache.put(key, value)
+        syncFrontAfterBack({ frontCache.put(key, value) }, { invalidateFront(key) })
     }
 
     override suspend fun putAll(map: Map<K, V>) {
-        frontCache.putAll(map).apply {
-            backCache.putAll(map)
-        }
+        backCache.putAll(map)
+        syncFrontAfterBack({ frontCache.putAll(map) }) { invalidateFront(map.keys) }
     }
 
     override suspend fun putAllFlow(entries: Flow<Pair<K, V>>) {
@@ -195,23 +199,26 @@ class SuspendNearJCache<K: Any, V: Any> internal constructor(
     }
 
     override suspend fun putIfAbsent(key: K, value: V): Boolean {
-        return frontCache.putIfAbsent(key, value).apply {
-            backCache.putIfAbsent(key, value)
+        val inserted = backCache.putIfAbsent(key, value)
+        if (inserted) {
+            syncFrontAfterBack({ frontCache.put(key, value) }, { invalidateFront(key) })
+        } else {
+            // Back가 이미 보유한 값이 front의 stale 값보다 우선하므로 miss로 되돌립니다.
+            syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
         }
+        return inserted
     }
 
     override suspend fun remove(key: K): Boolean {
-        return frontCache.remove(key).apply {
-            backCache.remove(key)
-        }
+        val removed = backCache.remove(key)
+        syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
+        return removed
     }
 
     override suspend fun remove(key: K, oldValue: V): Boolean {
-        frontCache.remove(key, oldValue)
-        if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
-            return backCache.remove(key)
-        }
-        return false
+        val removed = backCache.remove(key, oldValue)
+        syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
+        return removed
     }
 
     override suspend fun removeAll() {
@@ -233,24 +240,51 @@ class SuspendNearJCache<K: Any, V: Any> internal constructor(
     }
 
     override suspend fun replace(key: K, oldValue: V, newValue: V): Boolean {
-        frontCache.replace(key, oldValue, newValue)
-
-        // NOTE: Redisson에서는 replace 가 event 를 발생시키지 않습니다!!!
-        if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
-            put(key, newValue)
-            return true
+        val replaced = backCache.replace(key, oldValue, newValue)
+        if (replaced) {
+            syncFrontAfterBack({ frontCache.put(key, newValue) }, { invalidateFront(key) })
+        } else {
+            syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
         }
-        return false
+        return replaced
     }
 
     override suspend fun replace(key: K, value: V): Boolean {
-        frontCache.replace(key, value)
-
-        // NOTE: Redisson에서는 replace 가 event 를 발생시키지 않습니다!!!
-        if (backCache.containsKey(key)) {
-            put(key, value)
-            return true
+        val replaced = backCache.replace(key, value)
+        if (replaced) {
+            syncFrontAfterBack({ frontCache.put(key, value) }, { invalidateFront(key) })
+        } else {
+            syncFrontAfterBack({ frontCache.remove(key) }) { invalidateFront(key) }
         }
-        return false
+        return replaced
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun syncFrontAfterBack(
+        sync: suspend () -> Unit,
+        invalidate: suspend () -> Unit,
+    ) {
+        try {
+            sync()
+        } catch (failure: Throwable) {
+            try {
+                invalidate()
+            } catch (invalidateFailure: Throwable) {
+                if (invalidateFailure !== failure) {
+                    failure.addSuppressed(invalidateFailure)
+                }
+            }
+            throw failure
+        }
+    }
+
+    private suspend fun invalidateFront(key: K) {
+        frontCache.remove(key)
+    }
+
+    private suspend fun invalidateFront(keys: Set<K>) {
+        if (keys.isNotEmpty()) {
+            frontCache.removeAll(keys)
+        }
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCacheBackFirstContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCacheBackFirstContractTest.kt
@@ -1,0 +1,164 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.cache.jcache.SuspendJCache
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+
+class SuspendNearJCacheBackFirstContractTest {
+
+    private val failure = IllegalStateException("back cache is unavailable")
+
+    @Test
+    fun `put은 back 성공 후 front를 반영한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.put("key", "value") } just runs
+
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        nearCache.put("key", "value")
+
+        coVerifyOrder {
+            backCache.put("key", "value")
+            frontCache.put("key", "value")
+        }
+    }
+
+    @Test
+    fun `put은 back 실패 시 front에 미커밋 값을 남기지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.put("key", "value") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.put("key", "value") }
+
+        coVerify(exactly = 0) { frontCache.put("key", "value") }
+    }
+
+    @Test
+    fun `putAll은 back 실패 시 front에 미커밋 값을 남기지 않는다`() = runSuspendIO {
+        val entries = mapOf("key" to "value")
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.putAll(entries) } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.putAll(entries) }
+
+        coVerify(exactly = 0) { frontCache.putAll(entries) }
+    }
+
+    @Test
+    fun `putIfAbsent는 back 실패 시 front에 미커밋 값을 남기지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.putIfAbsent("key", "value") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.putIfAbsent("key", "value") }
+
+        coVerify(exactly = 0) { frontCache.putIfAbsent("key", "value") }
+    }
+
+    @Test
+    fun `remove는 back 실패 시 front를 변경하지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.remove("key") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.remove("key") }
+
+        coVerify(exactly = 0) { frontCache.remove("key") }
+    }
+
+    @Test
+    fun `조건부 remove는 back 실패 시 front를 변경하지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.remove("key", "old") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.remove("key", "old") }
+
+        coVerify(exactly = 0) { frontCache.remove("key", "old") }
+    }
+
+    @Test
+    fun `replace는 back 실패 시 front를 변경하지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.replace("key", "value") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.replace("key", "value") }
+
+        coVerify(exactly = 0) { frontCache.replace("key", "value") }
+    }
+
+    @Test
+    fun `조건부 replace는 back 실패 시 front를 변경하지 않는다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { backCache.replace("key", "old", "value") } throws failure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        assertFailsWith<IllegalStateException> { nearCache.replace("key", "old", "value") }
+
+        coVerify(exactly = 0) { frontCache.replace("key", "old", "value") }
+    }
+
+    @Test
+    fun `back cancellation은 front 변경 없이 재전파된다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val cancellation = CancellationException("back cache cancelled")
+        coEvery { backCache.put("key", "value") } throws cancellation
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val error = assertFailsWith<CancellationException> { nearCache.put("key", "value") }
+
+        error.message shouldBeEqualTo cancellation.message
+        coVerify(exactly = 0) { frontCache.put("key", "value") }
+    }
+
+    @Test
+    fun `back commit 후 front 반영 실패는 front를 invalidate하고 원래 예외를 전달한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val frontFailure = IllegalStateException("front cache is unavailable")
+        coEvery { backCache.put("key", "value") } just runs
+        coEvery { frontCache.put("key", "value") } throws frontFailure
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val error = assertFailsWith<IllegalStateException> { nearCache.put("key", "value") }
+
+        error.message shouldBeEqualTo frontFailure.message
+        coVerify(exactly = 1) { frontCache.remove("key") }
+    }
+
+    @Test
+    fun `front 반영 중 cancellation도 front를 invalidate하고 재전파한다`() = runSuspendIO {
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val cancellation = CancellationException("front cache cancelled")
+        coEvery { backCache.put("key", "value") } just runs
+        coEvery { frontCache.put("key", "value") } throws cancellation
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val error = assertFailsWith<CancellationException> { nearCache.put("key", "value") }
+
+        error.message shouldBeEqualTo cancellation.message
+        coVerify(exactly = 1) { frontCache.remove("key") }
+    }
+}

--- a/docs/lessons/2026-08-14-issue-1425-suspend-nearjcache-back-first.md
+++ b/docs/lessons/2026-08-14-issue-1425-suspend-nearjcache-back-first.md
@@ -1,0 +1,39 @@
+# #1425 SuspendNearJCache back-first mutation 계약
+
+## 맥락
+
+`SuspendNearJCache`의 일반 mutation이 front를 먼저 변경한 뒤 back cache를
+호출하고 있어, back 작업이 실패해도 front에 미커밋 값이나 삭제 상태가
+남을 수 있었다. 이는 back cache를 기준 데이터 원본으로 사용하는 near-cache
+계약과 맞지 않았다.
+
+## 원인
+
+`put`, `putAll`, `putIfAbsent`, `remove`, `replace`가 compound API와 달리
+front-first 순서를 사용했다. 특히 `replace`와 조건부 `remove`는 front 결과를
+먼저 버린 뒤 back 상태를 별도로 조회하여 원자성도 보장하지 못했다.
+
+## 결정
+
+- 일반 mutation은 back-first로 수행하고 back 결과가 성공한 뒤 front를
+  reconcile한다.
+- back 실패 시 front를 호출하지 않는다.
+- back commit 후 front reconcile이 실패하면 대상 front key를 invalidate하고
+  원래 예외를 호출자에게 전달한다. invalidate 실패는 suppressed 예외로
+  보존한다.
+- `CancellationException`은 fallback이나 retry로 바꾸지 않고 재전파한다.
+
+## 검증
+
+- RED: 기존 구현에서 back 실패 시 front가 먼저 호출되어 9개 계약 테스트가
+  실패함.
+- GREEN: `SuspendNearJCacheBackFirstContractTest` 11개 PASS.
+- 기존 `SuspendNearJCacheTest`와 `NearJCacheCompoundOperationContractTest`
+  35개 PASS.
+- `detekt` task는 BUILD SUCCESSFUL이며 cache-core 기존 findings가 남아 있다.
+
+## 후속 지침
+
+새로운 SuspendNearJCache mutation은 front-first write를 추가하지 말고,
+back authoritative 결과와 front invalidate/reconcile 경계를 테스트로
+고정한다. cancellation은 항상 별도 회귀 사례로 검증한다.


### PR DESCRIPTION
## 변경 요약

`SuspendNearJCache` 일반 mutation의 부분 실패 정합성 계약을 back-first로 고정합니다. Epic #1408의 stacked train에서 선행 PR #1428 (`#1412`) exact head `f9265816c357eac796119fe7a494079cd7fc11ac` 위에 쌓이는 #1425 단계입니다.

`back` cache를 기준 데이터 원본으로 먼저 변경하고, 성공한 경우에만 `front`를 reconcile합니다. back 실패 시 front를 호출하지 않으며, back commit 뒤 front 반영이 실패하면 대상 key를 invalidate하고 원래 예외를 전달합니다. `CancellationException`은 fallback/retry 없이 재전파합니다.

Fixes #1425

## 원인 및 수정

- 기존 `put`, `putAll`, `putIfAbsent`, `remove`, `replace`가 front-first여서 back 실패 후 front에 미커밋 상태가 남을 수 있었습니다.
- 조건부 mutation은 back의 원자 연산 결과를 사용하고, false 결과에도 stale front를 invalidate하도록 정리했습니다.
- front reconcile 실패 시 invalidate 실패를 suppressed exception으로 보존합니다.
- EN/KO README, Korean KDoc, 재사용 가능한 lesson을 함께 갱신했습니다.

## 회귀 검증

- RED: 기존 front-first 구현에서 back 실패·순서 계약 9개가 의도대로 실패했습니다.
- GREEN: `SuspendNearJCacheBackFirstContractTest` 11개 PASS.
- 기존 관련 테스트 `SuspendNearJCacheTest`와 `NearJCacheCompoundOperationContractTest` 35개 PASS.
- cache-core 전체 테스트 584개 PASS.
- `./gradlew :bluetape4k-cache-core:detekt --rerun-tasks --no-build-cache --no-configuration-cache` → `BUILD SUCCESSFUL` (기존 findings는 남아 있음).
- `git diff --check` PASS.

## Stacked train

- 선행: #1428 / `fix/1412-nearjcache-abi-serialization` / `f9265816c357eac796119fe7a494079cd7fc11ac`
- 현재: #1425 / `fix/1425-suspend-nearjcache-back-first`
- 후속 예정: #1411

## DoD Status

- [x] Type C bugfix root cause와 RED 재현을 기록했습니다.
- [x] back-first mutation과 front invalidate 보상 경계를 구현했습니다.
- [x] ordinary exception 및 coroutine cancellation 회귀 계약을 검증했습니다.
- [x] EN/KO README와 KDoc/lesson을 동기화했습니다.
- [x] 로컬 테스트·detekt·diff 검증을 완료했습니다.
- [ ] GitHub Actions 필수 CI 및 hosted review — PR 생성 후 대기
- [ ] CG-16 fresh merge approval — 별도 승인 필요
- [ ] merge/sync/cleanup — merge approval 이후 수행

현재 PR은 선행 PR #1428 위의 stacked 변경이며, merge하지 않고 CI·review 결과를 기다립니다.
