### PR TITLE
[cache][hazelcast] 공개 NearJCache factory의 listener 경계를 정합화한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 버그 수정
 
+- `HazelcastNearJCache(...)` 공개 factory가 Hazelcast JCache listener 직렬화 경계를 넘지 않도록 listener-free degraded 경로를 사용한다. read-through와 write-through는 유지하지만 peer front-cache propagation은 보장하지 않는다
+  ([#1411](https://github.com/bluetape4k/bluetape4k-projects/issues/1411)).
 - Maven Central에 없는 benchmark 또는 application 전용 모듈이 BOM에 포함되지 않도록 publication과 BOM module classifier를 통일했다. 생성한 BOM inventory와 publication POM inventory가 다르면 publication validation이 실패한다
   ([#1313](https://github.com/bluetape4k/bluetape4k-projects/issues/1313)).
 - Java platform은 library publication 설정 밖에 두되 `Bluetape4k` publication을 NMCP aggregate에 포함했다. 따라서 snapshot과 stable bundle은 74개 publishable library module과 함께 BOM을 포함한다

--- a/cache/cache-hazelcast/README.ko.md
+++ b/cache/cache-hazelcast/README.ko.md
@@ -140,8 +140,9 @@ val resilient = HazelcastCaches.resilientNearCache<String>(hazelcastInstance, ne
 Hazelcast IMap native NearCache는 공통 `NearCacheOperations` /
 `SuspendNearCacheOperations` conformance suite에서 supported로 검증됩니다.
 
-Hazelcast JCache NearCache factory는 listener 없이 생성되는 degraded 모드입니다.
-read-through와 write-through는 지원하지만 peer front-cache propagation은 보장하지 않습니다.
+`HazelcastCaches.nearJCache(...)`와 `HazelcastNearJCache(...)`를 포함한 Hazelcast JCache
+NearCache factory는 listener 없이 생성되는 degraded 모드입니다. read-through와
+write-through는 지원하지만 peer front-cache propagation은 보장하지 않습니다.
 직접 listener-backed `NearJCache` / `SuspendNearJCache` 생성은 unsupported이며 active test로 고정합니다.
 
 팩토리가 반환한 wrapper가 lifecycle 관점에서 소유하는 것은 front cache뿐입니다.

--- a/cache/cache-hazelcast/README.md
+++ b/cache/cache-hazelcast/README.md
@@ -90,9 +90,10 @@ Hazelcast IMap native near caches are fully supported by the shared
 Hazelcast JCache near-cache factories are intentionally listener-free because
 Hazelcast distributes JCache listener configuration through serialization and
 the current listener captures non-serializable front-cache state. Factory-created
-JCache near caches support read-through and write-through, but peer front-cache
-propagation is not promised. Direct listener-backed construction is unsupported
-and covered by explicit tests.
+JCache near caches, including `HazelcastCaches.nearJCache(...)` and
+`HazelcastNearJCache(...)`, support read-through and write-through, but peer
+front-cache propagation is not promised. Direct listener-backed construction is
+unsupported and covered by explicit tests.
 
 The factory-created wrapper owns only its front cache for lifecycle purposes.
 Calling `close()` does not close the supplied Hazelcast instance or back cache.

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
@@ -43,7 +43,7 @@ object HazelcastNearJCache: KLogging() {
      * ```
      *
      * @param frontCache 프론트 JCache (로컬 캐시). [NearJCache.close] 호출 시 이 캐시가 닫히며,
-     * 호출자가 제공한 Hazelcast back cache와 [HazelcastInstance]는 닫지 않습니다.
+     * factory가 생성하거나 재사용한 Hazelcast back cache와 [HazelcastInstance]는 닫지 않습니다.
      * @param hazelcastInstance 연결된 Hazelcast 인스턴스
      * @param configuration JCache 설정
      * @param nearCacheCfg [NearJCacheConfig] 설정

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
@@ -11,7 +11,9 @@ import javax.cache.configuration.Configuration
 /**
  * Hazelcast JCache 기반 [NearJCache] 팩토리 오브젝트입니다.
  *
- * Hazelcast ICache 백엔드와 프론트 캐시 간 이벤트 기반 동기화를 수행합니다.
+ * Hazelcast JCache의 직렬화 경계에 맞춰 listener 없이 동작하는 degraded 모드의
+ * [NearJCache] 팩토리입니다. read-through와 write-through는 제공하지만 peer
+ * front-cache 전파는 보장하지 않습니다.
  *
  * ```kotlin
  * val nearCache = HazelcastNearJCache(
@@ -44,7 +46,7 @@ object HazelcastNearJCache: KLogging() {
      * @param hazelcastInstance 연결된 Hazelcast 인스턴스
      * @param configuration JCache 설정
      * @param nearCacheCfg [NearJCacheConfig] 설정
-     * @return 이벤트 리스너가 등록된 [NearJCache] 인스턴스
+     * @return listener가 등록되지 않은 degraded [NearJCache] 인스턴스
      */
     inline operator fun <reified K: Any, reified V: Any> invoke(
         frontCache: JCache<K, V>,
@@ -56,8 +58,6 @@ object HazelcastNearJCache: KLogging() {
             HazelcastJCaching.getOrCreate(hazelcastInstance, nearCacheCfg.cacheName, configuration)
 
         log.info { "Create NearCache instance. config=$nearCacheCfg" }
-        return NearJCache(frontCache, backCache, nearCacheCfg).also {
-            it.registerBackCacheListener()
-        }
+        return NearJCache(frontCache, backCache, nearCacheCfg)
     }
 }

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
@@ -42,7 +42,8 @@ object HazelcastNearJCache: KLogging() {
      * // value == "v"
      * ```
      *
-     * @param frontCache 프론트 JCache (로컬 캐시)
+     * @param frontCache 프론트 JCache (로컬 캐시). [NearJCache.close] 호출 시 이 캐시가 닫히며,
+     * 호출자가 제공한 Hazelcast back cache와 [HazelcastInstance]는 닫지 않습니다.
      * @param hazelcastInstance 연결된 Hazelcast 인스턴스
      * @param configuration JCache 설정
      * @param nearCacheCfg [NearJCacheConfig] 설정

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -38,12 +38,16 @@ class HazelcastNearJCacheTest {
         val config = NearJCacheConfig<String, Any>(cacheName = "hazelcast-front-" + Base58.randomString(6))
         val backCache = backCache(cacheName)
 
-        val failure = assertFailsWith<HazelcastSerializationException> {
-            NearJCache(config, backCache)
+        try {
+            val failure = assertFailsWith<HazelcastSerializationException> {
+                NearJCache(config, backCache)
+            }
+            failure.message shouldContain "MutableCacheEntryListenerConfiguration"
+            failure.stackTraceToString() shouldContain "NotSerializableException"
+            failure.stackTraceToString() shouldContain "JCacheEntryEventListener"
+        } finally {
+            backCache.close()
         }
-        failure.message shouldContain "MutableCacheEntryListenerConfiguration"
-        failure.stackTraceToString() shouldContain "NotSerializableException"
-        failure.stackTraceToString() shouldContain "JCacheEntryEventListener"
     }
 
     @Test
@@ -64,10 +68,21 @@ class HazelcastNearJCacheTest {
         try {
             nearCache.put("k", "v")
             nearCache.get("k") shouldBeEqualTo "v"
+            nearCache.backCache.get("k") shouldBeEqualTo "v"
+
+            nearCache.backCache.put("back-only", "from-back")
+            nearCache.frontCache.clear()
+            nearCache.get("back-only") shouldBeEqualTo "from-back"
+            nearCache.frontCache.get("back-only") shouldBeEqualTo "from-back"
         } finally {
-            nearCache.clearAllCache()
-            nearCache.close()
+            try {
+                nearCache.clearAllCache()
+            } finally {
+                nearCache.close()
+            }
         }
+
+        frontCache.isClosed shouldBeEqualTo true
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.cache.nearcache.jcache
 import io.bluetape4k.cache.HazelcastCaches
 import io.bluetape4k.cache.HazelcastServers
 import io.bluetape4k.cache.HazelcastServers.hazelcastClient
+import io.bluetape4k.cache.jcache.JCaching
 import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.assertFailsWith
@@ -43,6 +44,30 @@ class HazelcastNearJCacheTest {
         failure.message shouldContain "MutableCacheEntryListenerConfiguration"
         failure.stackTraceToString() shouldContain "NotSerializableException"
         failure.stackTraceToString() shouldContain "JCacheEntryEventListener"
+    }
+
+    @Test
+    fun `public factory creates listener-free NearJCache on Hazelcast JCache`() {
+        val cacheName = "hazelcast-public-near-jcache-" + Base58.randomString(6)
+        val frontConfiguration = NearJCacheConfig.getDefaultFrontCacheConfiguration<String, String>()
+        val frontCache = JCaching.Caffeine.getOrCreate<String, String>(
+            "hazelcast-public-front-" + Base58.randomString(6),
+            frontConfiguration,
+        )
+        val config = NearJCacheConfig<String, String>(cacheName = cacheName)
+        val nearCache = HazelcastNearJCache(
+            frontCache = frontCache,
+            hazelcastInstance = hazelcastClient,
+            nearCacheCfg = config,
+        )
+
+        try {
+            nearCache.put("k", "v")
+            nearCache.get("k") shouldBeEqualTo "v"
+        } finally {
+            nearCache.clearAllCache()
+            nearCache.close()
+        }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -83,6 +83,8 @@ class HazelcastNearJCacheTest {
         }
 
         frontCache.isClosed shouldBeEqualTo true
+        nearCache.backCache.isClosed shouldBeEqualTo false
+        hazelcastClient.lifecycleService.isRunning shouldBeEqualTo true
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/docs/lessons/2026-08-14-issue-1411-hazelcast-factory-listener.md
+++ b/docs/lessons/2026-08-14-issue-1411-hazelcast-factory-listener.md
@@ -17,7 +17,8 @@ Hazelcast JCache listener 설정은 cluster 배포를 위해 직렬화되어야 
 - RED: `JAVA_HOME=/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home ./gradlew :bluetape4k-cache-hazelcast:test --tests 'io.bluetape4k.cache.nearcache.jcache.HazelcastNearJCacheTest.public factory creates listener-free NearJCache on Hazelcast JCache' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` — 기존 구현은 listener 직렬화 때문에 `HazelcastSerializationException`으로 실패했다.
 - GREEN: 같은 targeted test가 `BUILD SUCCESSFUL in 23s`로 통과했다.
 - 회귀: `:bluetape4k-cache-hazelcast:test` 전체가 `BUILD SUCCESSFUL in 29s`로 통과했고, direct listener unsupported test와 두 listener-free factory test를 함께 실행했다.
+- 리뷰 보완 후 `HazelcastNearJCacheTest` 전체가 `BUILD SUCCESSFUL in 48s`로 통과했고, write-through back 저장, back-only read-through, front 소유권 close, listener-backed cleanup을 추가로 검증했다. `:bluetape4k-cache-hazelcast:test` 전체도 같은 변경 상태에서 순차 재실행했다.
 
 ## 놓친 점과 다음 guard
 
-기존 unsupported test는 `NearJCache(config, backCache)` 직접 생성 경로만 고정하고 공개 factory 호출은 검증하지 않았다. 또한 새 integration test는 Caffeine front가 store-by-reference여야 하므로 `NearJCacheConfig.getDefaultFrontCacheConfiguration()`을 사용해야 했다. 앞으로 Hazelcast JCache factory를 추가하거나 변경할 때는 listener capability를 KDoc와 capability matrix에 명시하고, 공개 factory integration test와 direct listener unsupported test를 모두 유지한다. Testcontainers 기반 검증은 모듈 간 동시 실행 없이 순차적으로 수행한다.
+기존 unsupported test는 `NearJCache(config, backCache)` 직접 생성 경로만 고정하고 공개 factory 호출은 검증하지 않았다. 또한 새 integration test는 Caffeine front가 store-by-reference여야 하므로 `NearJCacheConfig.getDefaultFrontCacheConfiguration()`을 사용해야 했다. public factory 문서에서는 supplied front의 ownership과 `clear()`의 front/back 범위를 명시해야 한다. 앞으로 Hazelcast JCache factory를 추가하거나 변경할 때는 listener capability를 KDoc와 capability matrix에 명시하고, 공개 factory integration test와 direct listener unsupported test를 모두 유지한다. Testcontainers 기반 검증은 모듈 간 동시 실행 없이 순차적으로 수행한다.

--- a/docs/lessons/2026-08-14-issue-1411-hazelcast-factory-listener.md
+++ b/docs/lessons/2026-08-14-issue-1411-hazelcast-factory-listener.md
@@ -17,7 +17,7 @@ Hazelcast JCache listener 설정은 cluster 배포를 위해 직렬화되어야 
 - RED: `JAVA_HOME=/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home ./gradlew :bluetape4k-cache-hazelcast:test --tests 'io.bluetape4k.cache.nearcache.jcache.HazelcastNearJCacheTest.public factory creates listener-free NearJCache on Hazelcast JCache' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` — 기존 구현은 listener 직렬화 때문에 `HazelcastSerializationException`으로 실패했다.
 - GREEN: 같은 targeted test가 `BUILD SUCCESSFUL in 23s`로 통과했다.
 - 회귀: `:bluetape4k-cache-hazelcast:test` 전체가 `BUILD SUCCESSFUL in 29s`로 통과했고, direct listener unsupported test와 두 listener-free factory test를 함께 실행했다.
-- 리뷰 보완 후 `HazelcastNearJCacheTest` 전체가 `BUILD SUCCESSFUL in 48s`로 통과했고, write-through back 저장, back-only read-through, front 소유권 close, listener-backed cleanup을 추가로 검증했다. `:bluetape4k-cache-hazelcast:test` 전체도 같은 변경 상태에서 순차 재실행했다.
+- 리뷰 보완 후 `HazelcastNearJCacheTest` 전체가 `BUILD SUCCESSFUL in 38s`로 통과했고, write-through back 저장, back-only read-through, front 소유권 close, back/provider 비소유권, listener-backed cleanup을 추가로 검증했다. `:bluetape4k-cache-hazelcast:test` 전체도 같은 변경 상태에서 순차 재실행했다.
 
 ## 놓친 점과 다음 guard
 

--- a/docs/lessons/2026-08-14-issue-1411-hazelcast-factory-listener.md
+++ b/docs/lessons/2026-08-14-issue-1411-hazelcast-factory-listener.md
@@ -1,0 +1,23 @@
+# HazelcastNearJCache 공개 factory의 listener 경계 (#1411)
+
+## 배경
+
+Hazelcast JCache listener 설정은 cluster 배포를 위해 직렬화되어야 한다. 기존 공개 `HazelcastNearJCache(...)` factory는 `NearJCache`를 만든 뒤 back-cache listener를 등록했으므로, listener factory가 Caffeine front cache를 캡처하는 순간 `MutableCacheEntryListenerConfiguration` 직렬화가 시작됐다. Hazelcast client JCache 경로에서는 `HazelcastSerializationException`과 내부 `NotSerializableException`이 발생했고, stack trace에는 `JCacheEntryEventListener`가 포함됐다.
+
+## 결정
+
+공개 `HazelcastNearJCache(...)` factory는 `NearJCache(frontCache, backCache, nearCacheCfg)` listener-free 생성 경로를 사용한다. `HazelcastCaches.nearJCache(...)`와 동일하게 read-through와 write-through는 제공하지만 peer front-cache propagation은 보장하지 않는다. listener를 직접 등록하는 `NearJCache(config, backCache)` 생성 경로는 Hazelcast JCache에서 계속 unsupported로 둔다.
+
+## 결과
+
+공개 factory가 Hazelcast JCache back cache를 사용해 정상적으로 생성되고 put/get을 수행한다. API signature는 바꾸지 않았으며, Kotlin KDoc, README, EN/KO manual, capability matrix, CHANGELOG가 factory의 degraded capability와 direct listener 경계를 같은 의미로 설명한다.
+
+## 검증
+
+- RED: `JAVA_HOME=/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home ./gradlew :bluetape4k-cache-hazelcast:test --tests 'io.bluetape4k.cache.nearcache.jcache.HazelcastNearJCacheTest.public factory creates listener-free NearJCache on Hazelcast JCache' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` — 기존 구현은 listener 직렬화 때문에 `HazelcastSerializationException`으로 실패했다.
+- GREEN: 같은 targeted test가 `BUILD SUCCESSFUL in 23s`로 통과했다.
+- 회귀: `:bluetape4k-cache-hazelcast:test` 전체가 `BUILD SUCCESSFUL in 29s`로 통과했고, direct listener unsupported test와 두 listener-free factory test를 함께 실행했다.
+
+## 놓친 점과 다음 guard
+
+기존 unsupported test는 `NearJCache(config, backCache)` 직접 생성 경로만 고정하고 공개 factory 호출은 검증하지 않았다. 또한 새 integration test는 Caffeine front가 store-by-reference여야 하므로 `NearJCacheConfig.getDefaultFrontCacheConfiguration()`을 사용해야 했다. 앞으로 Hazelcast JCache factory를 추가하거나 변경할 때는 listener capability를 KDoc와 capability matrix에 명시하고, 공개 factory integration test와 direct listener unsupported test를 모두 유지한다. Testcontainers 기반 검증은 모듈 간 동시 실행 없이 순차적으로 수행한다.

--- a/docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
+++ b/docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
@@ -23,8 +23,9 @@ val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
 }
 
 cache.put("42", user)
-cache.clear()             // front and back
 check(cache.getDeeply("42") == user)
+cache.clear()             // front and back
+check(cache.getDeeply("42") == null)
 ```
 
 Read-through and two-tier writes work, but another process can change the back cache without evicting this front cache. Factory success does not imply peer invalidation support.

--- a/docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
+++ b/docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
@@ -15,7 +15,7 @@ Release tests explicitly expect `HazelcastSerializationException` with an underl
 
 ## Hazelcast factory methods create a listener-free composition
 
-Both `HazelcastCaches.nearJCache` and the public `HazelcastNearJCache(...)` factory create a Caffeine front JCache and Hazelcast back JCache without listener registration. `suspendNearJCache` also creates a fixed Caffeine front and calls `SuspendNearJCache.withoutListener`.
+`HazelcastCaches.nearJCache` creates a Caffeine front JCache and Hazelcast back JCache without listener registration. The public `HazelcastNearJCache(...)` factory combines the caller-supplied front JCache with a Hazelcast back JCache through the same listener-free path. `suspendNearJCache` also creates a fixed Caffeine front and calls `SuspendNearJCache.withoutListener`.
 
 ```kotlin
 val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
@@ -23,7 +23,7 @@ val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
 }
 
 cache.put("42", user)
-cache.clear()             // front only
+cache.clear()             // front and back
 check(cache.getDeeply("42") == user)
 ```
 

--- a/docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
+++ b/docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
@@ -9,13 +9,13 @@ chapterId: jcache-near-cache-serialization
 
 ## Why direct listener registration fails
 
-`HazelcastNearJCache` registers a `MutableCacheEntryListenerConfiguration` so back-cache events can update the front cache. When the listener factory captures a Caffeine cache proxy, Hazelcast cannot serialize that configuration for the cluster.
+Direct `NearJCache(config, backCache)` construction registers a `MutableCacheEntryListenerConfiguration` so back-cache events can update the front cache. When the listener factory captures a Caffeine cache proxy, Hazelcast cannot serialize that configuration for the cluster. The public `HazelcastNearJCache(...)` factory no longer takes this listener-backed path.
 
-Release tests explicitly expect `HazelcastSerializationException` with an underlying `NotSerializableException`. Although the factory expresses the intended composition, it is not a supported client JCache path in 1.12.1.
+Release tests explicitly expect `HazelcastSerializationException` with an underlying `NotSerializableException` from the direct listener-backed construction. That constructor remains unsupported for a Hazelcast client JCache back cache.
 
-## HazelcastCaches creates a listener-free composition
+## Hazelcast factory methods create a listener-free composition
 
-`HazelcastCaches.nearJCache` creates a Caffeine front JCache and Hazelcast back JCache directly without listener registration. `suspendNearJCache` also creates a fixed Caffeine front and calls `SuspendNearJCache.withoutListener`.
+Both `HazelcastCaches.nearJCache` and the public `HazelcastNearJCache(...)` factory create a Caffeine front JCache and Hazelcast back JCache without listener registration. `suspendNearJCache` also creates a fixed Caffeine front and calls `SuspendNearJCache.withoutListener`.
 
 ```kotlin
 val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
@@ -36,7 +36,7 @@ When peer invalidation is required, use the `IMap.addEntryListener` path in `Haz
 | Choice | Benefit | Limit |
 | --- | --- | --- |
 | factory JCache near cache | Reuses JCache front/back contracts | No listener or peer L1 propagation |
-| direct listener-backed JCache factory | Intended event propagation | Serialization failure in 1.12.1 |
+| direct listener-backed JCache construction | Intended event propagation | Serialization failure in 1.12.1 |
 | native IMap near cache | Client-side listener invalidation | String keys and no JCache API |
 
 ## Fixed suspend-front settings

--- a/docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
+++ b/docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
@@ -9,13 +9,13 @@ chapterId: jcache-near-cache-serialization
 
 ## 직접 listener를 등록하면 왜 실패하는가
 
-`HazelcastNearJCache`는 back JCache event를 받아 front cache를 갱신하려고 `MutableCacheEntryListenerConfiguration`을 등록합니다. listener factory가 Caffeine cache proxy를 캡처하면 Hazelcast가 이 구성을 cluster로 보내는 과정에서 직렬화하지 못합니다.
+직접 `NearJCache(config, backCache)`를 생성하면 back JCache event로 front cache를 갱신하려고 `MutableCacheEntryListenerConfiguration`을 등록합니다. listener factory가 Caffeine cache proxy를 캡처하면 Hazelcast가 이 구성을 cluster로 보내는 과정에서 직렬화하지 못합니다. 공개 `HazelcastNearJCache(...)` factory는 더 이상 이 listener-backed 경로를 사용하지 않습니다.
 
-release tests는 이 경로가 `HazelcastSerializationException`과 내부 `NotSerializableException`으로 실패하는 것을 명시적으로 검증합니다. 즉, 이 factory는 문서상 가능한 조합처럼 보여도 1.12.1 client JCache 구성에서는 지원 경로가 아닙니다.
+release tests는 직접 listener-backed 구성이 `HazelcastSerializationException`과 내부 `NotSerializableException`으로 실패하는 것을 명시적으로 검증합니다. 따라서 이 생성자는 Hazelcast client JCache back cache에서 계속 지원하지 않습니다.
 
-## HazelcastCaches factory는 listener를 빼고 만든다
+## Hazelcast factory는 listener를 빼고 만든다
 
-`HazelcastCaches.nearJCache`는 Caffeine front JCache와 Hazelcast back JCache를 직접 조합하고 listener를 등록하지 않습니다. `suspendNearJCache`도 고정된 Caffeine front를 만들고 `SuspendNearJCache.withoutListener`를 사용합니다.
+`HazelcastCaches.nearJCache`와 공개 `HazelcastNearJCache(...)` factory는 Caffeine front JCache와 Hazelcast back JCache를 직접 조합하고 listener를 등록하지 않습니다. `suspendNearJCache`도 고정된 Caffeine front를 만들고 `SuspendNearJCache.withoutListener`를 사용합니다.
 
 ```kotlin
 val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
@@ -36,7 +36,7 @@ peer 변경 무효화가 필요하면 JCache factory 대신 `HazelcastNearCache`
 | 선택 | 장점 | 제한 |
 | --- | --- | --- |
 | factory JCache Near Cache | JCache front/back 계약 재사용 | listener 없음, peer L1 propagation 없음 |
-| direct listener-backed JCache factory | 의도는 event propagation | 1.12.1에서 직렬화 실패 |
+| direct listener-backed JCache construction | 의도는 event propagation | 1.12.1에서 직렬화 실패 |
 | native IMap Near Cache | client-side entry listener 무효화 | String key, JCache API가 아님 |
 
 ## suspend factory의 고정 front 설정

--- a/docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
+++ b/docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
@@ -15,7 +15,7 @@ release tests는 직접 listener-backed 구성이 `HazelcastSerializationExcepti
 
 ## Hazelcast factory는 listener를 빼고 만든다
 
-`HazelcastCaches.nearJCache`와 공개 `HazelcastNearJCache(...)` factory는 Caffeine front JCache와 Hazelcast back JCache를 직접 조합하고 listener를 등록하지 않습니다. `suspendNearJCache`도 고정된 Caffeine front를 만들고 `SuspendNearJCache.withoutListener`를 사용합니다.
+`HazelcastCaches.nearJCache`는 Caffeine front JCache와 Hazelcast back JCache를 직접 조합하고 listener를 등록하지 않습니다. 공개 `HazelcastNearJCache(...)` factory는 호출자가 제공한 front JCache와 Hazelcast back JCache를 같은 listener-free 경로로 조합합니다. `suspendNearJCache`도 고정된 Caffeine front를 만들고 `SuspendNearJCache.withoutListener`를 사용합니다.
 
 ```kotlin
 val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
@@ -23,7 +23,7 @@ val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
 }
 
 cache.put("42", user)
-cache.clear()             // front only
+cache.clear()             // front and back
 check(cache.getDeeply("42") == user)
 ```
 

--- a/docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
+++ b/docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
@@ -23,8 +23,9 @@ val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
 }
 
 cache.put("42", user)
-cache.clear()             // front and back
 check(cache.getDeeply("42") == user)
+cache.clear()             // front and back
+check(cache.getDeeply("42") == null)
 ```
 
 read-through와 두 계층 write는 동작하지만 다른 process가 back cache를 바꿔도 이 front cache를 지울 listener가 없습니다. factory 성공을 peer invalidation 지원으로 해석하면 안 됩니다.


### PR DESCRIPTION
## Summary

Closes #1411

공개 `HazelcastNearJCache(...)` factory가 Hazelcast JCache listener 직렬화 경계에서 실패하지 않도록 listener-free degraded 경로로 고정합니다.

## Background

기존 public factory는 Caffeine front cache를 캡처한 JCache listener를 Hazelcast cluster로 전파하려고 해 `MutableCacheEntryListenerConfiguration` 직렬화에 실패했습니다. 같은 저장소의 지원 factory는 이미 listener-free 동작을 사용하고 있었으므로 public entry point의 capability 계약이 달랐습니다.

## What This Solves

- public `HazelcastNearJCache(...)` 생성 단계의 `HazelcastSerializationException`을 제거합니다.
- read-through와 write-through는 유지하고 peer front-cache propagation은 보장하지 않는 degraded capability를 명시합니다.
- direct listener-backed `NearJCache(config, backCache)` 경로는 unsupported 테스트와 문서로 계속 고정합니다.

## Work Done

- `HazelcastNearJCache(...)`에서 `registerBackCacheListener()` 호출을 제거하고 listener-free `NearJCache(frontCache, backCache, nearCacheCfg)`를 사용합니다.
- public factory integration test에 write-through, back-only read-through, front close, back/provider 비소유권과 cleanup 검증을 추가했습니다.
- Kotlin KDoc, capability README, EN/KO manual, capability matrix 설명, CHANGELOG와 reusable lesson을 정합화했습니다.

## Validation

- `./gradlew :bluetape4k-cache-hazelcast:test --tests 'io.bluetape4k.cache.nearcache.jcache.HazelcastNearJCacheTest' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`: PASS (최종 38초)
- `./gradlew :bluetape4k-cache-hazelcast:test --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`: PASS (영향 모듈 전체, 순차 실행)
- `./gradlew :bluetape4k-cache-hazelcast:detekt --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`: PASS (기존 비변경 파일 findings만 보고)
- `git diff --check HEAD^ HEAD`: PASS
- Hosted PR CI run `31810888365` 및 manual contract run `31810888449`: PASS. `Build`, `Coverage Report`, `CI Status`, 정책/보안 검사가 모두 성공했고, `Detect changed modules`가 cache-hazelcast 경로를 CI 매트릭스에 매핑하지 않아 9개 비관련 테스트 job은 N/A(skipping)로 남았습니다. 영향 모듈 전체 테스트는 위 로컬 검증으로 보완했습니다.
- `gh pr view 1430`: exact head `ec3ded8c5b612fdcac6af4085ec23f583df9afb5`, `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`; hosted review/thread blocker 없음.

## Review Notes

- P0/P1/P2: 0
- P3: 없음. direct listener unsupported와 public factory success를 함께 유지했습니다.
- Review evidence: 독립 code-reviewer findings 0, architect status `CLEAR`; 두 lane 모두 exact head를 읽었습니다.

## Metadata

- Issue: #1411, milestone `1.13.0`, assignee `debop`
- PR: #1430, head `ec3ded8c5b612fdcac6af4085ec23f583df9afb5`, milestone `1.13.0`, assignee `debop`
- CI: [PR #1430 checks](https://github.com/bluetape4k/bluetape4k-projects/pull/1430/checks) — exact head checks complete; 10 PASS, 9 N/A(path-filtered), 0 Blocked
- Merge: `a8d599701a3870e41b9365d06dd9a02961a513ad`; `develop` fast-forward sync와 merge 후 모듈 테스트/GNO 재색인을 완료했습니다.

## DoD Status

Hosted checks: 10 PASS; N/A: 9 (path-filtered); Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - Root cause | Hazelcast listener serialization failure를 RED로 재현 | PASS | `HazelcastSerializationException`, `MutableCacheEntryListenerConfiguration`, `NotSerializableException`, `JCacheEntryEventListener` | none |
| C-02 - Issue scope | live #1411 acceptance와 metadata 확인 | PASS | OPEN, `debop`, `1.13.0`, `bug/tech-debt/cache` | none |
| C-03 - RED | public factory regression test를 기존 구현에서 실패시킴 | PASS | targeted RED evidence in workflow receipt | none |
| C-04 - Surgical fix | public factory listener registration 제거 | PASS | commit `ec3ded8c5b612fdcac6af4085ec23f583df9afb5` | none |
| C-05 - GREEN/blast radius | targeted/module test, compile, detekt 실행 | PASS | Validation commands above | none |
| C-06 - Lesson | reusable Hazelcast capability 경계 기록 | PASS | `docs/lessons/2026-08-14-issue-1411-hazelcast-factory-listener.md` | GNO update/embed 완료; worktree 제외로 merge 후 재색인 필요 |
| C-07 - Review | 독립 code/architecture review 수행 | PASS | findings 0, architect `CLEAR` | none |
| C-08 - Pre-merge proof | final diff와 exact head 수렴 | PASS | clean worktree, `git diff --check`, head `ec3ded8c5b612fdcac6af4085ec23f583df9afb5` | none |
| CG-11 - PR authority | approved plan의 repo/base/head 확인 | PASS | `bluetape4k/bluetape4k-projects`, `develop`, `fix/1411-hazelcast-factory-listener` | none |
| CG-12 - Publish exact head | branch push 및 remote read-back | PASS | local/remote `ec3ded8c5b612fdcac6af4085ec23f583df9afb5` | none |
| CG-12A - Guidance refresh | AGENTS hierarchy, bugfix leaf, common gates, PR template, issue metadata 재확인 | PASS | current workspace/repo scope and live #1411 metadata | none |
| CG-13 - Create and verify PR | live PR 생성 및 metadata/body read-back | PASS | PR #1430, head `ec3ded8c5b612fdcac6af4085ec23f583df9afb5`, labels/milestone/assignee/body read-back | none |
| CG-14 - CI and review | exact PR head CI/review 확인 | PASS | CI run `31810888365`: Build/Coverage/CI Status/policy/security PASS; 9 unrelated matrix jobs N/A by changed-module filter; manual contract `31810888449` PASS; no hosted review/thread blocker | N/A matrix jobs are covered by path-filter evidence and local cache-hazelcast module test |
| CG-15 - Merge-ready report | exact head merge-ready 보고 | PASS | head `ec3ded8c5b612fdcac6af4085ec23f583df9afb5`, `MERGEABLE`, `CLEAN`, independent findings 0/architect `CLEAR` | stop for fresh merge approval |
| CG-16 - Fresh merge approval | current PR/head approval 확보 | PASS | user fresh approval 이후 exact head 재확인 | none |
| CG-17 - Merge | approved strategy로 merge | PASS | `gh pr merge 1430 --rebase --delete-branch=false`; merge commit `a8d599701a3870e41b9365d06dd9a02961a513ad` | none |
| CG-18 - Sync/cleanup | develop sync and safe preservation | PASS | `git pull --ff-only origin develop`; post-merge module test PASS; GNO update 2 added/7 updated, embed current, #1411 lesson search read-back; worktrees preserved | none |

Final status: DONE (merged, synced, indexed, and safely preserved)

Unchecked required items: none
