### PR TITLE
[cache][concurrency] NearJCache 동기 write-through의 listener 재진입 교착을 차단한다

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -117,6 +117,15 @@ local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도�
 왕복을 사용하지 않으며, back provider 실패 시 front를 변경하기 전에
 예외를 전달합니다.
 
+`NearJCacheConfig.isSynchronous=true`이면 동기 write-through의 blocking provider 호출을
+전용 virtual thread에서 실행하고, 500ms 이상으로 보정된 `syncRemoteTimeout`까지만
+기다립니다. provider가 같은 write의 listener를 inline으로 호출하는 경우 write worker가
+self-event를 front에 직접 반영하고 `mutationGate`를 다시 획득하지 않아 self-deadlock을
+차단합니다. 다른 wrapper나 외부 write의 event는 계속 `mutationGate`로 직렬화하며,
+비동기 write-through도 기존 gate 경로를 유지합니다. provider가 interrupt를 무시하면
+호출자가 timeout을 관찰한 뒤 back write가 완료될 수 있으며, `backWriteLock`이 해당
+late completion과 후속 write의 순서를 직렬화합니다.
+
 `SuspendNearJCache`의 일반 mutation도 동일한 back-first 규칙을 적용합니다.
 `put`, `putAll`, `putIfAbsent`, `remove`, `replace`는 back cache를 먼저
 변경한 뒤 local front를 조정합니다. back 실패 시 front는 변경하지 않으며,

--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -121,8 +121,9 @@ local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도�
 전용 virtual thread에서 실행하고, 500ms 이상으로 보정된 `syncRemoteTimeout`까지만
 기다립니다. provider가 같은 write의 listener를 inline 또는 synchronous callback thread에서
 호출하는 경우 key/type/value 상관관계가 맞는 self-event를 front에 직접 반영하고
-`mutationGate`를 다시 획득하지 않아 self-deadlock을 차단합니다. 다른 wrapper나 외부 write의 event는 계속 `mutationGate`로 직렬화하며,
-비동기 write-through도 기존 gate 경로를 유지합니다. provider가 interrupt를 무시하면
+`mutationGate`를 다시 획득하지 않아 self-deadlock을 차단합니다. 매칭되지 않는 다른 wrapper나 외부 write의 event는 계속
+`mutationGate`로 직렬화하며, 비동기 write-through도 기존 gate 경로를 유지합니다. JCache event에는 operation ID가 없으므로
+동일 key/type/value의 외부 event는 활성 self-event와 구분할 수 없습니다. provider가 interrupt를 무시하면
 호출자가 timeout을 관찰한 뒤 back write가 완료될 수 있으며, `backWriteLock`이 해당
 late completion과 후속 write의 순서를 직렬화합니다.
 

--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -119,9 +119,9 @@ local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도�
 
 `NearJCacheConfig.isSynchronous=true`이면 동기 write-through의 blocking provider 호출을
 전용 virtual thread에서 실행하고, 500ms 이상으로 보정된 `syncRemoteTimeout`까지만
-기다립니다. provider가 같은 write의 listener를 inline으로 호출하는 경우 write worker가
-self-event를 front에 직접 반영하고 `mutationGate`를 다시 획득하지 않아 self-deadlock을
-차단합니다. 다른 wrapper나 외부 write의 event는 계속 `mutationGate`로 직렬화하며,
+기다립니다. provider가 같은 write의 listener를 inline 또는 synchronous callback thread에서
+호출하는 경우 key/type/value 상관관계가 맞는 self-event를 front에 직접 반영하고
+`mutationGate`를 다시 획득하지 않아 self-deadlock을 차단합니다. 다른 wrapper나 외부 write의 event는 계속 `mutationGate`로 직렬화하며,
 비동기 write-through도 기존 gate 경로를 유지합니다. provider가 interrupt를 무시하면
 호출자가 timeout을 관찰한 뒤 back write가 완료될 수 있으며, `backWriteLock`이 해당
 late completion과 후속 write의 순서를 직렬화합니다.

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -70,6 +70,16 @@ provider's atomic compound operation and then reconcile the local front cache;
 they do not implement a front-read/back-write round trip. A provider failure is
 propagated before the front cache is changed.
 
+When `NearJCacheConfig.isSynchronous=true`, synchronous write-through runs the
+blocking provider call on a dedicated virtual thread and waits only up to the
+bounded `syncRemoteTimeout` (with a 500 ms minimum). If a provider invokes the
+listener for that same write inline, the write worker reconciles the self-event
+directly to the front cache instead of reacquiring `mutationGate`; this prevents
+self-deadlock. Peer or external events still use `mutationGate`, and asynchronous
+write-through keeps the existing gated path. A provider that ignores interruption
+may complete after the caller observes a timeout; `backWriteLock` serializes that
+late completion with following writes.
+
 `SuspendNearJCache` uses the same back-first rule for ordinary mutations:
 `put`, `putAll`, `putIfAbsent`, `remove`, and `replace` update the back cache
 before reconciling the local front cache. A back failure leaves the front

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -76,8 +76,10 @@ bounded `syncRemoteTimeout` (with a 500 ms minimum). If a provider invokes the
 listener for that same write inline or on a synchronous callback thread,
 `NearJCache` uses an operation-scoped key/type/value match to reconcile the
 self-event directly to the front cache instead of reacquiring `mutationGate`;
-this prevents self-deadlock. Peer or external events still use `mutationGate`,
-and asynchronous write-through keeps the existing gated path. A provider that
+this prevents self-deadlock. Non-matching peer or external events still use
+`mutationGate`, and asynchronous write-through keeps the existing gated path.
+JCache events do not carry an operation ID, so an external event with the same
+key/type/value cannot be distinguished from the active self-event. A provider that
 ignores interruption may complete after the caller observes a timeout;
 `backWriteLock` serializes that late completion with following writes.
 

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -73,12 +73,13 @@ propagated before the front cache is changed.
 When `NearJCacheConfig.isSynchronous=true`, synchronous write-through runs the
 blocking provider call on a dedicated virtual thread and waits only up to the
 bounded `syncRemoteTimeout` (with a 500 ms minimum). If a provider invokes the
-listener for that same write inline, the write worker reconciles the self-event
-directly to the front cache instead of reacquiring `mutationGate`; this prevents
-self-deadlock. Peer or external events still use `mutationGate`, and asynchronous
-write-through keeps the existing gated path. A provider that ignores interruption
-may complete after the caller observes a timeout; `backWriteLock` serializes that
-late completion with following writes.
+listener for that same write inline or on a synchronous callback thread,
+`NearJCache` uses an operation-scoped key/type/value match to reconcile the
+self-event directly to the front cache instead of reacquiring `mutationGate`;
+this prevents self-deadlock. Peer or external events still use `mutationGate`,
+and asynchronous write-through keeps the existing gated path. A provider that
+ignores interruption may complete after the caller observes a timeout;
+`backWriteLock` serializes that late completion with following writes.
 
 `SuspendNearJCache` uses the same back-first rule for ordinary mutations:
 `put`, `putAll`, `putIfAbsent`, `remove`, and `replace` update the back cache

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CompletionStage
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
@@ -182,7 +183,35 @@ class NearJCache<K: Any, V: Any>(
         val configuration: CacheEntryListenerConfiguration<K, V>,
         val active: AtomicReference<Boolean> = AtomicReference(true),
     )
+    private class SelfEventMatcher<K: Any, V: Any>(
+        val keys: Set<K>,
+        private val eventTypes: Set<EventType>,
+        private val values: Map<K, V>? = null,
+    ) {
+        fun matches(eventType: EventType, events: List<CacheEntryEvent<out K, out V>>): Boolean {
+            if (events.isEmpty() || eventType !in eventTypes) return false
+            return events.all { event ->
+                event.key in keys &&
+                    (values == null || (values.containsKey(event.key) && values[event.key] == event.value))
+            }
+        }
+    }
+
+    private class ActiveSelfEventContext<K: Any, V: Any>(
+        val matcher: SelfEventMatcher<K, V>,
+    ) {
+        private val remainingKeys = ConcurrentHashMap.newKeySet<K>().apply { addAll(matcher.keys) }
+
+        @Synchronized
+        fun matchesAndConsume(eventType: EventType, events: List<CacheEntryEvent<out K, out V>>): Boolean {
+            if (!matcher.matches(eventType, events) || events.any { it.key !in remainingKeys }) return false
+            events.forEach { remainingKeys.remove(it.key) }
+            return true
+        }
+    }
+
     private val backCacheListener = AtomicReference<BackCacheListenerRegistration<K, V>?>(null)
+    private val activeSelfEventContexts = CopyOnWriteArrayList<ActiveSelfEventContext<K, V>>()
     private data class BackCacheWriteState(
         val operationId: Long,
         val operation: String,
@@ -538,9 +567,15 @@ class NearJCache<K: Any, V: Any>(
         mutationGate.withLock {
             mutationEpoch.incrementAndGet()
             frontCache.put(key, value)
-            syncBackCache("put", expectedBackWriteGeneration = backWriteGeneration.get()) {
-                backCache.put(key, value)
-            }
+            syncBackCache(
+                operation = "put",
+                expectedBackWriteGeneration = backWriteGeneration.get(),
+                selfEventMatcher = SelfEventMatcher(
+                    keys = setOf(key),
+                    eventTypes = setOf(EventType.CREATED, EventType.UPDATED),
+                    values = mapOf(key to value),
+                ),
+            ) { backCache.put(key, value) }
         }
     }
 
@@ -548,9 +583,15 @@ class NearJCache<K: Any, V: Any>(
         mutationGate.withLock {
             mutationEpoch.incrementAndGet()
             frontCache.putAll(map)
-            syncBackCache("putAll", expectedBackWriteGeneration = backWriteGeneration.get()) {
-                backCache.putAll(map)
-            }
+            syncBackCache(
+                operation = "putAll",
+                expectedBackWriteGeneration = backWriteGeneration.get(),
+                selfEventMatcher = SelfEventMatcher(
+                    keys = map.keys,
+                    eventTypes = setOf(EventType.CREATED, EventType.UPDATED),
+                    values = map.entries.associate { it.key to it.value },
+                ),
+            ) { backCache.putAll(map) }
         }
     }
 
@@ -558,7 +599,15 @@ class NearJCache<K: Any, V: Any>(
         frontCache.putIfAbsent(key, value).also { inserted ->
             if (inserted) {
                 mutationEpoch.incrementAndGet()
-                syncBackCache("putIfAbsent", expectedBackWriteGeneration = backWriteGeneration.get()) {
+                syncBackCache(
+                    operation = "putIfAbsent",
+                    expectedBackWriteGeneration = backWriteGeneration.get(),
+                    selfEventMatcher = SelfEventMatcher(
+                        keys = setOf(key),
+                        eventTypes = setOf(EventType.CREATED),
+                        values = mapOf(key to value),
+                    ),
+                ) {
                     if (!backCache.containsKey(key)) {
                         backCache.put(key, value)
                     }
@@ -571,9 +620,14 @@ class NearJCache<K: Any, V: Any>(
         frontCache.remove(key).also { removed ->
             if (removed) {
                 mutationEpoch.incrementAndGet()
-                syncBackCache("remove", expectedBackWriteGeneration = backWriteGeneration.get()) {
-                    backCache.remove(key)
-                }
+                syncBackCache(
+                    operation = "remove",
+                    expectedBackWriteGeneration = backWriteGeneration.get(),
+                    selfEventMatcher = SelfEventMatcher(
+                        keys = setOf(key),
+                        eventTypes = setOf(EventType.REMOVED),
+                    ),
+                ) { backCache.remove(key) }
             }
         }
     }
@@ -582,7 +636,14 @@ class NearJCache<K: Any, V: Any>(
         frontCache.remove(key, oldValue).also { removed ->
             if (removed) {
                 mutationEpoch.incrementAndGet()
-                syncBackCache("remove(key, oldValue)", expectedBackWriteGeneration = backWriteGeneration.get()) {
+                syncBackCache(
+                    operation = "remove(key, oldValue)",
+                    expectedBackWriteGeneration = backWriteGeneration.get(),
+                    selfEventMatcher = SelfEventMatcher(
+                        keys = setOf(key),
+                        eventTypes = setOf(EventType.REMOVED),
+                    ),
+                ) {
                     // Back cache listener 전파를 remove(key) 경로로 통일하기 위해 값 비교 후 단일 키 삭제를 사용한다.
                     if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
                         backCache.remove(key)
@@ -610,7 +671,14 @@ class NearJCache<K: Any, V: Any>(
         mutationGate.withLock {
             mutationEpoch.incrementAndGet()
             frontCache.removeAll(keys)
-            syncBackCache("removeAll(keys)", expectedBackWriteGeneration = backWriteGeneration.get()) {
+            syncBackCache(
+                operation = "removeAll(keys)",
+                expectedBackWriteGeneration = backWriteGeneration.get(),
+                selfEventMatcher = SelfEventMatcher(
+                    keys = keys,
+                    eventTypes = setOf(EventType.REMOVED),
+                ),
+            ) {
                 // Redisson 에서는 bulk operation 의 경우 event 가 발생하지 않습니다!!!
                 val failures = removeBackCacheEntries(keys)
                 throwIfFailures("removeAll(keys)", failures)
@@ -639,8 +707,13 @@ class NearJCache<K: Any, V: Any>(
             if (replaced) {
                 mutationEpoch.incrementAndGet()
                 syncBackCache(
-                    "replace(key, oldValue, newValue)",
-                    expectedBackWriteGeneration = backWriteGeneration.get()
+                    operation = "replace(key, oldValue, newValue)",
+                    expectedBackWriteGeneration = backWriteGeneration.get(),
+                    selfEventMatcher = SelfEventMatcher(
+                        keys = setOf(key),
+                        eventTypes = setOf(EventType.UPDATED),
+                        values = mapOf(key to newValue),
+                    ),
                 ) {
                     if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
                         backCache.put(key, newValue)
@@ -654,7 +727,15 @@ class NearJCache<K: Any, V: Any>(
         frontCache.replace(key, value).also { replaced ->
             if (replaced) {
                 mutationEpoch.incrementAndGet()
-                syncBackCache("replace", expectedBackWriteGeneration = backWriteGeneration.get()) {
+                syncBackCache(
+                    operation = "replace",
+                    expectedBackWriteGeneration = backWriteGeneration.get(),
+                    selfEventMatcher = SelfEventMatcher(
+                        keys = setOf(key),
+                        eventTypes = setOf(EventType.UPDATED),
+                        values = mapOf(key to value),
+                    ),
+                ) {
                     // Redisson 에서는 replace 가 event 를 발생시키지 않습니다.
                     if (backCache.containsKey(key)) {
                         backCache.put(key, value)
@@ -708,6 +789,7 @@ class NearJCache<K: Any, V: Any>(
         operation: String,
         synchronous: Boolean = config.isSynchronous,
         expectedBackWriteGeneration: Long = backWriteGeneration.get(),
+        selfEventMatcher: SelfEventMatcher<K, V>? = null,
         syncTask: () -> Unit,
     ): CompletableFuture<Unit> {
         val completion = CompletableFuture<Unit>()
@@ -716,10 +798,16 @@ class NearJCache<K: Any, V: Any>(
         val guardedSyncTask = {
             backWriteLock.withLock {
                 if (expectedBackWriteGeneration == backWriteGeneration.get()) {
-                    if (reconcileInlineSelfEvent) {
-                        withInlineSelfEventReconciliation(syncTask)
-                    } else {
-                        syncTask()
+                    val context = selfEventMatcher?.let { ActiveSelfEventContext(it) }
+                    context?.let(activeSelfEventContexts::add)
+                    try {
+                        if (reconcileInlineSelfEvent) {
+                            withInlineSelfEventReconciliation(syncTask)
+                        } else {
+                            syncTask()
+                        }
+                    } finally {
+                        context?.let(activeSelfEventContexts::remove)
                     }
                 }
             }
@@ -771,9 +859,10 @@ class NearJCache<K: Any, V: Any>(
      * 늦게 완료될 수 있으므로 [backWriteLock]이 완료 순서를 계속 직렬화합니다.
      *
      * 동기 mutation이 호출자 [mutationGate]를 잡은 동안 provider가 같은 write의 listener를
-     * inline으로 호출하면, 해당 self-event는 write worker가 직접 Front에 반영합니다. 이
-     * 경우에만 worker가 [mutationGate]를 다시 획득하지 않으며, 다른 wrapper나 외부 write의
-     * listener event는 기존처럼 [mutationGate]를 통해 직렬화됩니다.
+     * inline 또는 synchronous callback thread에서 호출하면, key/type/value가 일치하는
+     * self-event는 write worker 또는 active operation context를 통해 Front에 직접 반영합니다.
+     * 다른 wrapper나 외부 write의 listener event는 기존처럼 [mutationGate]를 통해
+     * 직렬화됩니다.
      */
     @Suppress("ThrowsCount")
     private fun runSynchronousBackCacheWrite(timeoutMillis: Long, syncTask: () -> Unit) {
@@ -915,7 +1004,10 @@ class NearJCache<K: Any, V: Any>(
         events: List<CacheEntryEvent<out K, out V>>,
     ) {
         if (!registration.active.get()) return
-        if (inlineSelfEventReconciliation.get() == true) {
+        val activeSelfEvent = activeSelfEventContexts.any { context ->
+            context.matchesAndConsume(eventType, events)
+        }
+        if (inlineSelfEventReconciliation.get() == true || activeSelfEvent) {
             applyBackCacheEventsToFront(registration, eventType, events)
         } else {
             mutationGate.withLock {

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -171,6 +171,7 @@ class NearJCache<K: Any, V: Any>(
     private val mutationGate = ReentrantLock()
     private val compoundGate = ReentrantLock()
     private val backWriteLock = ReentrantLock(true)
+    private val inlineSelfEventReconciliation = ThreadLocal<Boolean>()
     private val listenerRegistrationLock = ReentrantLock()
     private val frontCloseCompleted = AtomicBoolean(false)
     private val closeStarted = AtomicBoolean(false)
@@ -711,10 +712,15 @@ class NearJCache<K: Any, V: Any>(
     ): CompletableFuture<Unit> {
         val completion = CompletableFuture<Unit>()
         publishBackCacheWrite(operation, completion)
+        val reconcileInlineSelfEvent = synchronous && mutationGate.isHeldByCurrentThread()
         val guardedSyncTask = {
             backWriteLock.withLock {
                 if (expectedBackWriteGeneration == backWriteGeneration.get()) {
-                    syncTask()
+                    if (reconcileInlineSelfEvent) {
+                        withInlineSelfEventReconciliation(syncTask)
+                    } else {
+                        syncTask()
+                    }
                 }
             }
         }
@@ -763,6 +769,11 @@ class NearJCache<K: Any, V: Any>(
      * timeout 시 작업을 interrupt하고 executor를 즉시 종료해 테스트/애플리케이션 lifecycle에
      * 남는 전용 실행기를 최소화합니다. Provider가 interrupt를 무시하면 실제 backend 작업은
      * 늦게 완료될 수 있으므로 [backWriteLock]이 완료 순서를 계속 직렬화합니다.
+     *
+     * 동기 mutation이 호출자 [mutationGate]를 잡은 동안 provider가 같은 write의 listener를
+     * inline으로 호출하면, 해당 self-event는 write worker가 직접 Front에 반영합니다. 이
+     * 경우에만 worker가 [mutationGate]를 다시 획득하지 않으며, 다른 wrapper나 외부 write의
+     * listener event는 기존처럼 [mutationGate]를 통해 직렬화됩니다.
      */
     @Suppress("ThrowsCount")
     private fun runSynchronousBackCacheWrite(timeoutMillis: Long, syncTask: () -> Unit) {
@@ -798,6 +809,20 @@ class NearJCache<K: Any, V: Any>(
         }
         @Suppress("UNCHECKED_CAST")
         return value as R
+    }
+
+    private inline fun <R> withInlineSelfEventReconciliation(block: () -> R): R {
+        val previous = inlineSelfEventReconciliation.get()
+        inlineSelfEventReconciliation.set(true)
+        return try {
+            block()
+        } finally {
+            if (previous == null) {
+                inlineSelfEventReconciliation.remove()
+            } else {
+                inlineSelfEventReconciliation.set(previous)
+            }
+        }
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -890,15 +915,27 @@ class NearJCache<K: Any, V: Any>(
         events: List<CacheEntryEvent<out K, out V>>,
     ) {
         if (!registration.active.get()) return
-        mutationGate.withLock {
-            if (!registration.active.get() || backCacheListener.get() !== registration) return
-            mutationEpoch.incrementAndGet()
-            when (eventType) {
-                EventType.CREATED, EventType.UPDATED ->
-                    frontCache.putAll(events.associate { it.key to it.value })
-                EventType.REMOVED, EventType.EXPIRED ->
-                    frontCache.removeAll(events.map { it.key }.toSet())
+        if (inlineSelfEventReconciliation.get() == true) {
+            applyBackCacheEventsToFront(registration, eventType, events)
+        } else {
+            mutationGate.withLock {
+                applyBackCacheEventsToFront(registration, eventType, events)
             }
+        }
+    }
+
+    private fun applyBackCacheEventsToFront(
+        registration: BackCacheListenerRegistration<K, V>,
+        eventType: EventType,
+        events: List<CacheEntryEvent<out K, out V>>,
+    ) {
+        if (!registration.active.get() || backCacheListener.get() !== registration) return
+        mutationEpoch.incrementAndGet()
+        when (eventType) {
+            EventType.CREATED, EventType.UPDATED ->
+                frontCache.putAll(events.associate { it.key to it.value })
+            EventType.REMOVED, EventType.EXPIRED ->
+                frontCache.removeAll(events.map { it.key }.toSet())
         }
     }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -796,25 +796,12 @@ class NearJCache<K: Any, V: Any>(
         publishBackCacheWrite(operation, completion)
         val reconcileInlineSelfEvent = synchronous && mutationGate.isHeldByCurrentThread()
         val guardedSyncTask = {
-            backWriteLock.withLock {
-                if (expectedBackWriteGeneration == backWriteGeneration.get()) {
-                    // 호출자가 mutationGate를 잡은 동기 mutation만 operation context를 사용합니다.
-                    // 비동기 write는 provider callback 전에 gate를 해제하므로 기존 순서 경로를 유지합니다.
-                    val context = selfEventMatcher
-                        ?.takeIf { reconcileInlineSelfEvent }
-                        ?.let { ActiveSelfEventContext(it) }
-                    context?.let(activeSelfEventContexts::add)
-                    try {
-                        if (reconcileInlineSelfEvent) {
-                            withInlineSelfEventReconciliation(syncTask)
-                        } else {
-                            syncTask()
-                        }
-                    } finally {
-                        context?.let(activeSelfEventContexts::remove)
-                    }
-                }
-            }
+            runGuardedBackCacheWrite(
+                expectedBackWriteGeneration = expectedBackWriteGeneration,
+                selfEventMatcher = selfEventMatcher,
+                reconcileInlineSelfEvent = reconcileInlineSelfEvent,
+                syncTask = syncTask,
+            )
         }
         if (synchronous) {
             val timeoutMillis = config.syncRemoteTimeout.coerceAtLeast(NearJCacheConfig.DEFAULT_SYNC_REMOTE_TIMEOUT)
@@ -854,6 +841,33 @@ class NearJCache<K: Any, V: Any>(
             syncTask = guardedSyncTask,
         )
         return completion
+    }
+
+    private fun runGuardedBackCacheWrite(
+        expectedBackWriteGeneration: Long,
+        selfEventMatcher: SelfEventMatcher<K, V>?,
+        reconcileInlineSelfEvent: Boolean,
+        syncTask: () -> Unit,
+    ) {
+        backWriteLock.withLock {
+            if (expectedBackWriteGeneration != backWriteGeneration.get()) return@withLock
+
+            // 호출자가 mutationGate를 잡은 동기 mutation만 operation context를 사용합니다.
+            // 비동기 write는 provider callback 전에 gate를 해제하므로 기존 순서 경로를 유지합니다.
+            val context = selfEventMatcher
+                ?.takeIf { reconcileInlineSelfEvent }
+                ?.let { ActiveSelfEventContext(it) }
+            context?.let(activeSelfEventContexts::add)
+            try {
+                if (reconcileInlineSelfEvent) {
+                    withInlineSelfEventReconciliation(syncTask)
+                } else {
+                    syncTask()
+                }
+            } finally {
+                context?.let(activeSelfEventContexts::remove)
+            }
+        }
     }
 
     /**

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -798,7 +798,11 @@ class NearJCache<K: Any, V: Any>(
         val guardedSyncTask = {
             backWriteLock.withLock {
                 if (expectedBackWriteGeneration == backWriteGeneration.get()) {
-                    val context = selfEventMatcher?.let { ActiveSelfEventContext(it) }
+                    // 호출자가 mutationGate를 잡은 동기 mutation만 operation context를 사용합니다.
+                    // 비동기 write는 provider callback 전에 gate를 해제하므로 기존 순서 경로를 유지합니다.
+                    val context = selfEventMatcher
+                        ?.takeIf { reconcileInlineSelfEvent }
+                        ?.let { ActiveSelfEventContext(it) }
                     context?.let(activeSelfEventContexts::add)
                     try {
                         if (reconcileInlineSelfEvent) {
@@ -861,8 +865,9 @@ class NearJCache<K: Any, V: Any>(
      * 동기 mutation이 호출자 [mutationGate]를 잡은 동안 provider가 같은 write의 listener를
      * inline 또는 synchronous callback thread에서 호출하면, key/type/value가 일치하는
      * self-event는 write worker 또는 active operation context를 통해 Front에 직접 반영합니다.
-     * 다른 wrapper나 외부 write의 listener event는 기존처럼 [mutationGate]를 통해
-     * 직렬화됩니다.
+     * 매칭되지 않는 다른 wrapper나 외부 write의 listener event와 비동기 write는 기존처럼
+     * [mutationGate]를 통해 직렬화됩니다. JCache event에는 operation ID가 없으므로
+     * 동일 key/type/value의 외부 event는 self-event와 구분할 수 없습니다.
      */
     @Suppress("ThrowsCount")
     private fun runSynchronousBackCacheWrite(timeoutMillis: Long, syncTask: () -> Unit) {

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt
@@ -7,9 +7,12 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.runs
+import io.mockk.verify
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import javax.cache.configuration.CacheEntryListenerConfiguration
 import javax.cache.event.CacheEntryCreatedListener
@@ -21,7 +24,15 @@ import javax.cache.event.EventType
 class NearJCacheWriteThroughReentrancyTest {
 
     @Test
-    fun `동기 CRUD write-through의 inline listener 재진입이 교착되지 않는다`() {
+    fun `동기 CRUD listener 재진입이 교착되지 않는다`() {
+        testPut()
+        testPutAll()
+        testPutIfAbsent()
+        testRemove()
+        testReplace()
+    }
+
+    private fun testPut() {
         runInlineListenerOperation(
             operation = "put",
             configureBack = { backCache, fire ->
@@ -30,7 +41,13 @@ class NearJCacheWriteThroughReentrancyTest {
                 }
             },
             invoke = { it.put("key", "value") },
+            assertFrontReconciled = { frontCache ->
+                verify { frontCache.putAll(mapOf("key" to "value")) }
+            },
         )
+    }
+
+    private fun testPutAll() {
         runInlineListenerOperation(
             operation = "putAll",
             configureBack = { backCache, fire ->
@@ -39,7 +56,13 @@ class NearJCacheWriteThroughReentrancyTest {
                 }
             },
             invoke = { it.putAll(mapOf("key" to "value")) },
+            assertFrontReconciled = { frontCache ->
+                verify { frontCache.putAll(mapOf("key" to "value")) }
+            },
         )
+    }
+
+    private fun testPutIfAbsent() {
         runInlineListenerOperation(
             operation = "putIfAbsent",
             configureFront = { frontCache ->
@@ -52,7 +75,13 @@ class NearJCacheWriteThroughReentrancyTest {
                 }
             },
             invoke = { it.putIfAbsent("key", "value") },
+            assertFrontReconciled = { frontCache ->
+                verify { frontCache.putAll(mapOf("key" to "value")) }
+            },
         )
+    }
+
+    private fun testRemove() {
         runInlineListenerOperation(
             operation = "remove",
             configureFront = { frontCache ->
@@ -65,7 +94,13 @@ class NearJCacheWriteThroughReentrancyTest {
                 }
             },
             invoke = { it.remove("key") },
+            assertFrontReconciled = { frontCache ->
+                verify { frontCache.removeAll(setOf("key")) }
+            },
         )
+    }
+
+    private fun testReplace() {
         runInlineListenerOperation(
             operation = "replace",
             configureFront = { frontCache ->
@@ -78,7 +113,82 @@ class NearJCacheWriteThroughReentrancyTest {
                 }
             },
             invoke = { it.replace("key", "value") },
+            assertFrontReconciled = { frontCache ->
+                verify { frontCache.putAll(mapOf("key" to "value")) }
+            },
         )
+    }
+
+    @Test
+    fun `동기 provider의 별도 callback thread도 self-event를 재조정한다`() {
+        runInlineListenerOperation(
+            operation = "separate-thread",
+            configureBack = { backCache, fire ->
+                every { backCache.put("key", "value") } answers {
+                    dispatchListenerOnSeparateThread(fire, EventType.CREATED)
+                }
+            },
+            invoke = { it.put("key", "value") },
+            assertFrontReconciled = { frontCache ->
+                verify { frontCache.putAll(mapOf("key" to "value")) }
+            },
+        )
+    }
+
+    @Test
+    fun `timeout 뒤 late back completion은 후속 write보다 먼저 종료된다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val secondFinished = CountDownLatch(1)
+        val calls = AtomicInteger()
+        val values = CopyOnWriteArrayList<String>()
+        every { backCache.put("key", any()) } answers {
+            val value = secondArg<String>()
+            values += value
+            if (calls.incrementAndGet() == 1) {
+                firstStarted.countDown()
+                var released = false
+                while (!released) {
+                    try {
+                        released = releaseFirst.await(10, TimeUnit.MILLISECONDS)
+                    } catch (_: InterruptedException) {
+                        // Ignore interruption to model a provider that completes after the caller timeout.
+                    }
+                }
+            }
+        }
+
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true, syncRemoteTimeout = 50L),
+        )
+        try {
+            check(runCatching { nearCache.put("key", "first") }.isFailure)
+            check(firstStarted.await(1, TimeUnit.SECONDS)) { "first back write did not start" }
+
+            val secondWorker = virtualThread(start = false, name = "near-jcache-late-completion-follow-up") {
+                nearCache.put("key", "second")
+                secondFinished.countDown()
+            }
+            secondWorker.start()
+            check(!secondFinished.await(100, TimeUnit.MILLISECONDS)) {
+                "follow-up write bypassed the late back completion barrier"
+            }
+
+            releaseFirst.countDown()
+            check(secondFinished.await(2, TimeUnit.SECONDS)) {
+                "follow-up write did not complete after late back completion"
+            }
+            check(values.toList() == listOf("first", "second")) {
+                "back writes were reordered: ${values.toList()}"
+            }
+        } finally {
+            releaseFirst.countDown()
+            nearCache.close()
+        }
     }
 
     private fun runInlineListenerOperation(
@@ -86,6 +196,7 @@ class NearJCacheWriteThroughReentrancyTest {
         configureFront: (JCache<String, String>) -> Unit = {},
         configureBack: (JCache<String, String>, (EventType) -> Unit) -> Unit,
         invoke: (NearJCache<String, String>) -> Unit,
+        assertFrontReconciled: (JCache<String, String>) -> Unit = {},
     ) {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
@@ -131,6 +242,7 @@ class NearJCacheWriteThroughReentrancyTest {
                 "synchronous $operation did not complete; inline listener likely re-entered mutationGate"
             }
             failure.get()?.let { throw AssertionError("synchronous $operation failed", it) }
+            assertFrontReconciled(frontCache)
         } finally {
             if (worker.isAlive) {
                 worker.interrupt()
@@ -138,5 +250,27 @@ class NearJCacheWriteThroughReentrancyTest {
             }
             nearCache.close()
         }
+    }
+
+    private fun dispatchListenerOnSeparateThread(
+        fire: (EventType) -> Unit,
+        eventType: EventType,
+    ) {
+        val finished = CountDownLatch(1)
+        val failure = AtomicReference<Throwable?>()
+        val listenerThread = virtualThread(start = false, name = "near-jcache-listener-callback") {
+            try {
+                fire(eventType)
+            } catch (error: Throwable) {
+                failure.set(error)
+            } finally {
+                finished.countDown()
+            }
+        }
+        listenerThread.start()
+        check(finished.await(2, TimeUnit.SECONDS)) {
+            "synchronous listener callback did not complete on its separate thread"
+        }
+        failure.get()?.let { throw AssertionError("synchronous listener callback failed", it) }
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt
@@ -136,6 +136,71 @@ class NearJCacheWriteThroughReentrancyTest {
     }
 
     @Test
+    fun `비동기 self-event는 mutation gate 순서를 유지한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val listenerConfiguration = slot<CacheEntryListenerConfiguration<String, String>>()
+        val event = mockk<CacheEntryEvent<String, String>>(relaxed = true)
+        every { event.key } returns "key"
+        every { event.value } returns "value"
+        every { backCache.registerCacheEntryListener(capture(listenerConfiguration)) } just runs
+
+        val backWriteStarted = CountDownLatch(1)
+        val releaseBackWrite = CountDownLatch(1)
+        val callbackStarted = CountDownLatch(1)
+        val callbackReturned = CountDownLatch(1)
+        val blockerStarted = CountDownLatch(1)
+        val releaseBlocker = CountDownLatch(1)
+        every { frontCache.put("blocker", "value") } answers {
+            blockerStarted.countDown()
+            releaseBlocker.await(2, TimeUnit.SECONDS)
+        }
+
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = false, syncRemoteTimeout = 100L),
+        )
+        nearCache.registerBackCacheListener()
+        val listener = listenerConfiguration.captured.cacheEntryListenerFactory!!.create()
+            as CacheEntryCreatedListener<String, String>
+        every { backCache.put("key", "value") } answers {
+            backWriteStarted.countDown()
+            releaseBackWrite.await(2, TimeUnit.SECONDS)
+            callbackStarted.countDown()
+            listener.onCreated(listOf(event))
+            callbackReturned.countDown()
+        }
+
+        try {
+            nearCache.put("key", "value")
+            check(backWriteStarted.await(2, TimeUnit.SECONDS)) { "async back write did not start" }
+
+            val blocker = virtualThread(start = false, name = "near-jcache-async-gate-blocker") {
+                nearCache.put("blocker", "value")
+            }
+            blocker.start()
+            check(blockerStarted.await(2, TimeUnit.SECONDS)) { "mutation gate blocker did not start" }
+
+            releaseBackWrite.countDown()
+            check(callbackStarted.await(2, TimeUnit.SECONDS)) { "async self-event did not start" }
+            check(!callbackReturned.await(100, TimeUnit.MILLISECONDS)) {
+                "async self-event bypassed mutationGate ordering"
+            }
+            verify(exactly = 0) { frontCache.putAll(mapOf("key" to "value")) }
+
+            releaseBlocker.countDown()
+            check(callbackReturned.await(2, TimeUnit.SECONDS)) { "async self-event did not complete" }
+            blocker.join(2_000)
+            verify(exactly = 1) { frontCache.putAll(mapOf("key" to "value")) }
+        } finally {
+            releaseBackWrite.countDown()
+            releaseBlocker.countDown()
+            nearCache.close()
+        }
+    }
+
+    @Test
     fun `timeout 뒤 late back completion은 후속 write보다 먼저 종료된다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt
@@ -1,0 +1,142 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.concurrent.virtualthread.virtualThread
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.runs
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.cache.configuration.CacheEntryListenerConfiguration
+import javax.cache.event.CacheEntryCreatedListener
+import javax.cache.event.CacheEntryEvent
+import javax.cache.event.CacheEntryRemovedListener
+import javax.cache.event.CacheEntryUpdatedListener
+import javax.cache.event.EventType
+
+class NearJCacheWriteThroughReentrancyTest {
+
+    @Test
+    fun `동기 CRUD write-through의 inline listener 재진입이 교착되지 않는다`() {
+        runInlineListenerOperation(
+            operation = "put",
+            configureBack = { backCache, fire ->
+                every { backCache.put("key", "value") } answers {
+                    fire(EventType.CREATED)
+                }
+            },
+            invoke = { it.put("key", "value") },
+        )
+        runInlineListenerOperation(
+            operation = "putAll",
+            configureBack = { backCache, fire ->
+                every { backCache.putAll(mapOf("key" to "value")) } answers {
+                    fire(EventType.CREATED)
+                }
+            },
+            invoke = { it.putAll(mapOf("key" to "value")) },
+        )
+        runInlineListenerOperation(
+            operation = "putIfAbsent",
+            configureFront = { frontCache ->
+                every { frontCache.putIfAbsent("key", "value") } returns true
+            },
+            configureBack = { backCache, fire ->
+                every { backCache.containsKey("key") } returns false
+                every { backCache.put("key", "value") } answers {
+                    fire(EventType.CREATED)
+                }
+            },
+            invoke = { it.putIfAbsent("key", "value") },
+        )
+        runInlineListenerOperation(
+            operation = "remove",
+            configureFront = { frontCache ->
+                every { frontCache.remove("key") } returns true
+            },
+            configureBack = { backCache, fire ->
+                every { backCache.remove("key") } answers {
+                    fire(EventType.REMOVED)
+                    true
+                }
+            },
+            invoke = { it.remove("key") },
+        )
+        runInlineListenerOperation(
+            operation = "replace",
+            configureFront = { frontCache ->
+                every { frontCache.replace("key", "value") } returns true
+            },
+            configureBack = { backCache, fire ->
+                every { backCache.containsKey("key") } returns true
+                every { backCache.put("key", "value") } answers {
+                    fire(EventType.UPDATED)
+                }
+            },
+            invoke = { it.replace("key", "value") },
+        )
+    }
+
+    private fun runInlineListenerOperation(
+        operation: String,
+        configureFront: (JCache<String, String>) -> Unit = {},
+        configureBack: (JCache<String, String>, (EventType) -> Unit) -> Unit,
+        invoke: (NearJCache<String, String>) -> Unit,
+    ) {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val listenerConfiguration = slot<CacheEntryListenerConfiguration<String, String>>()
+        val event = mockk<CacheEntryEvent<String, String>>(relaxed = true)
+        every { event.key } returns "key"
+        every { event.value } returns "value"
+        every { backCache.registerCacheEntryListener(capture(listenerConfiguration)) } just runs
+        configureFront(frontCache)
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true, syncRemoteTimeout = 1L),
+        )
+        nearCache.registerBackCacheListener()
+        configureBack(backCache) { eventType ->
+            val listener = listenerConfiguration.captured.cacheEntryListenerFactory!!.create()
+            when (eventType) {
+                EventType.CREATED ->
+                    (listener as CacheEntryCreatedListener<String, String>).onCreated(listOf(event))
+                EventType.UPDATED ->
+                    (listener as CacheEntryUpdatedListener<String, String>).onUpdated(listOf(event))
+                EventType.REMOVED ->
+                    (listener as CacheEntryRemovedListener<String, String>).onRemoved(listOf(event))
+                EventType.EXPIRED -> error("unexpected event type")
+            }
+        }
+
+        val failure = AtomicReference<Throwable?>()
+        val finished = CountDownLatch(1)
+        val worker = virtualThread(start = false, name = "near-jcache-reentrancy-$operation") {
+            try {
+                invoke(nearCache)
+            } catch (error: Throwable) {
+                failure.set(error)
+            } finally {
+                finished.countDown()
+            }
+        }
+        try {
+            worker.start()
+            check(finished.await(2, TimeUnit.SECONDS)) {
+                "synchronous $operation did not complete; inline listener likely re-entered mutationGate"
+            }
+            failure.get()?.let { throw AssertionError("synchronous $operation failed", it) }
+        } finally {
+            if (worker.isAlive) {
+                worker.interrupt()
+                worker.join(2_000)
+            }
+            nearCache.close()
+        }
+    }
+}

--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -97,8 +97,9 @@ JCache 변형은 cache-entry listener로 peer front-cache 전파를 지원합니
 `replace`는 제한된 `syncRemoteTimeout` 안에서 Lettuce write-through 완료를 기다립니다.
 Lettuce가 write worker에서 해당 write의 listener를 inline 호출할 수 있으므로,
 `NearJCache`는 operation-scoped key/type/value 상관관계로 self-event를 front에 직접
-반영해 callback이 caller가 잡은 mutation gate를 다시 획득하지 않도록 합니다. 다른 wrapper나 외부 write의 event는 계속 gate로
-직렬화하며 비동기 모드의 기존 순서도 유지합니다. timeout 이후 provider가 늦게 완료하는
+반영해 callback이 caller가 잡은 mutation gate를 다시 획득하지 않도록 합니다. 매칭되지 않는 다른 wrapper나 외부 write의 event는 계속 gate로
+직렬화하며 비동기 모드의 기존 순서도 유지합니다. JCache event에는 operation ID가 없으므로 동일 key/type/value의 외부 event는
+활성 self-event와 구분할 수 없습니다. timeout 이후 provider가 늦게 완료하는
 경우에도 near cache의 back-write barrier가 후속 write와 순서를 보장합니다.
 
 전체 행렬은 [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md)를 참고하세요.

--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -96,8 +96,8 @@ JCache 변형은 cache-entry listener로 peer front-cache 전파를 지원합니
 `isSynchronous=true`인 JCache NearCache의 `put`, `putAll`, `putIfAbsent`, `remove`,
 `replace`는 제한된 `syncRemoteTimeout` 안에서 Lettuce write-through 완료를 기다립니다.
 Lettuce가 write worker에서 해당 write의 listener를 inline 호출할 수 있으므로,
-`NearJCache`는 self-event를 front에 직접 반영해 caller가 잡은 mutation gate를 worker가
-다시 획득하지 않도록 합니다. 다른 wrapper나 외부 write의 event는 계속 gate로
+`NearJCache`는 operation-scoped key/type/value 상관관계로 self-event를 front에 직접
+반영해 callback이 caller가 잡은 mutation gate를 다시 획득하지 않도록 합니다. 다른 wrapper나 외부 write의 event는 계속 gate로
 직렬화하며 비동기 모드의 기존 순서도 유지합니다. timeout 이후 provider가 늦게 완료하는
 경우에도 near cache의 back-write barrier가 후속 write와 순서를 보장합니다.
 

--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -93,6 +93,14 @@ Lettuce native/JCache NearCache는 공통 conformance suite에서 supported로 �
 Native `LettuceNearCache` / `LettuceSuspendNearCache`는 Redis RESP3 `CLIENT TRACKING`과 write-through를 사용합니다.
 JCache 변형은 cache-entry listener로 peer front-cache 전파를 지원합니다.
 
+`isSynchronous=true`인 JCache NearCache의 `put`, `putAll`, `putIfAbsent`, `remove`,
+`replace`는 제한된 `syncRemoteTimeout` 안에서 Lettuce write-through 완료를 기다립니다.
+Lettuce가 write worker에서 해당 write의 listener를 inline 호출할 수 있으므로,
+`NearJCache`는 self-event를 front에 직접 반영해 caller가 잡은 mutation gate를 worker가
+다시 획득하지 않도록 합니다. 다른 wrapper나 외부 write의 event는 계속 gate로
+직렬화하며 비동기 모드의 기존 순서도 유지합니다. timeout 이후 provider가 늦게 완료하는
+경우에도 near cache의 back-write barrier가 후속 write와 순서를 보장합니다.
+
 전체 행렬은 [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md)를 참고하세요.
 
 `LettuceCacheConfig`/`LettuceNearCacheConfig` 사용 시:

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -54,9 +54,10 @@ For a JCache near cache configured with `isSynchronous=true`, `put`, `putAll`,
 the bounded `syncRemoteTimeout`. Lettuce may dispatch the write's listener inline
 on the write worker; `NearJCache` uses an operation-scoped key/type/value match to
 reconcile that self-event directly to the front cache so the callback does not
-reacquire the caller-held mutation gate. Peer
-or external events still use the gate, and asynchronous mode keeps its existing
-ordering. A provider that completes after an observed timeout remains serialized
+reacquire the caller-held mutation gate. Non-matching peer or external events
+still use the gate, and asynchronous mode keeps its existing ordering. JCache
+events do not carry an operation ID, so an external event with the same
+key/type/value cannot be distinguished from the active self-event. A provider that completes after an observed timeout remains serialized
 by the near cache's back-write barrier.
 
 See the full [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -52,8 +52,9 @@ register cache-entry listeners and support peer front-cache propagation.
 For a JCache near cache configured with `isSynchronous=true`, `put`, `putAll`,
 `putIfAbsent`, `remove`, and `replace` wait for the Lettuce write-through with
 the bounded `syncRemoteTimeout`. Lettuce may dispatch the write's listener inline
-on the write worker; `NearJCache` reconciles that self-event directly to the
-front cache so the worker does not reacquire the caller-held mutation gate. Peer
+on the write worker; `NearJCache` uses an operation-scoped key/type/value match to
+reconcile that self-event directly to the front cache so the callback does not
+reacquire the caller-held mutation gate. Peer
 or external events still use the gate, and asynchronous mode keeps its existing
 ordering. A provider that completes after an observed timeout remains serialized
 by the near cache's back-write barrier.

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -49,6 +49,15 @@ conformance suites. Native `LettuceNearCache` and `LettuceSuspendNearCache` use
 Redis RESP3 `CLIENT TRACKING` plus explicit write-through. JCache variants
 register cache-entry listeners and support peer front-cache propagation.
 
+For a JCache near cache configured with `isSynchronous=true`, `put`, `putAll`,
+`putIfAbsent`, `remove`, and `replace` wait for the Lettuce write-through with
+the bounded `syncRemoteTimeout`. Lettuce may dispatch the write's listener inline
+on the write worker; `NearJCache` reconciles that self-event directly to the
+front cache so the worker does not reacquire the caller-held mutation gate. Peer
+or external events still use the gate, and asynchronous mode keeps its existing
+ordering. A provider that completes after an observed timeout remains serialized
+by the near cache's back-write barrier.
+
 See the full [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).
 
 ## Factory (`LettuceCaches`)

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceNearJCacheWriteThroughReentrancyTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceNearJCacheWriteThroughReentrancyTest.kt
@@ -37,7 +37,7 @@ class LettuceNearJCacheWriteThroughReentrancyTest {
             cache.get("replace-key") shouldBeEqualTo "new-value"
             cache.get("remove-key") shouldBeEqualTo null
         } finally {
-            runCatching { cache.close() }
+            cache.close()
         }
     }
 }

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceNearJCacheWriteThroughReentrancyTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceNearJCacheWriteThroughReentrancyTest.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.cache.LettuceCaches
+import io.bluetape4k.cache.RedisServers
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+class LettuceNearJCacheWriteThroughReentrancyTest {
+
+    @Test
+    fun `동기 Lettuce write-through은 inline listener 재진입으로 timeout되지 않는다`() {
+        val cache = LettuceCaches.nearJCache<String, String>(RedisServers.redisClient) {
+            cacheName = "near-jcache-reentrancy-${UUID.randomUUID()}"
+            isSynchronous = true
+            syncRemoteTimeout = 100L
+        }
+
+        try {
+            val startedAt = System.nanoTime()
+            cache.put("key", "value")
+            cache.putAll(mapOf("bulk-key" to "bulk-value"))
+            check(cache.putIfAbsent("absent-key", "absent-value"))
+            cache.put("replace-key", "old-value")
+            check(cache.replace("replace-key", "new-value"))
+            cache.put("remove-key", "remove-value")
+            check(cache.remove("remove-key"))
+            val elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+
+            check(elapsedMillis < 2_000L) {
+                "synchronous Lettuce CRUD write-through exceeded bounded completion: ${elapsedMillis}ms"
+            }
+            cache.get("key") shouldBeEqualTo "value"
+            cache.get("bulk-key") shouldBeEqualTo "bulk-value"
+            cache.get("absent-key") shouldBeEqualTo "absent-value"
+            cache.get("replace-key") shouldBeEqualTo "new-value"
+            cache.get("remove-key") shouldBeEqualTo null
+        } finally {
+            runCatching { cache.close() }
+        }
+    }
+}

--- a/docs/lessons/2026-08-15-issue-1410-nearcache-listener-reentrancy.md
+++ b/docs/lessons/2026-08-15-issue-1410-nearcache-listener-reentrancy.md
@@ -1,0 +1,44 @@
+# NearJCache 동기 write-through listener 재진입 교착
+
+## 맥락
+
+`NearJCache`의 동기 mutation은 호출자 스레드가 `mutationGate`를 잡은 상태에서
+back provider write를 전용 virtual thread에 위임하고 완료를 기다립니다. Lettuce
+JCache provider는 `isSynchronous=true` listener를 같은 write worker에서 inline으로
+호출하므로, listener가 front reconciliation을 위해 같은 `mutationGate`를 다시
+획득하면 호출자는 worker를 기다리고 worker는 호출자를 기다리는 교착이 발생했습니다.
+
+## 결정 또는 발견
+
+- 동기 write-through의 self-event만 write worker에서 front에 직접 반영하도록
+  thread-local reconciliation 경계를 추가했습니다.
+- 다른 wrapper 또는 외부 write의 listener event와 비동기 경로는 기존처럼
+  `mutationGate`를 통해 직렬화합니다.
+- provider 호출은 기존 `backWriteLock`과 bounded timeout을 그대로 사용해 timeout,
+  cancellation, late completion의 순서 계약을 변경하지 않았습니다.
+- 호출자 gate를 provider I/O 전에 무조건 해제하는 대안은 late completion과 후속
+  write의 순서를 약화할 수 있어 채택하지 않았습니다.
+
+## 결과
+
+Lettuce의 동기 `put`, `putAll`, `putIfAbsent`, `remove`, `replace`가 inline listener
+재진입으로 timeout되지 않고 완료되며, peer invalidation과 비동기 ordering 경계는
+유지됩니다.
+
+## 검증
+
+- RED: 실제 Lettuce/Testcontainers 경로에서 기존 구현이 `TimeoutException`으로
+  실패했습니다.
+- GREEN: cache-core mock provider가 inline CREATED/UPDATED/REMOVED event를 호출하는
+  다섯 CRUD 회귀 테스트가 통과했습니다.
+- cache-core NearJCache 패키지 regression suite가 통과했습니다.
+- 실제 Lettuce integration test도 다섯 CRUD 연산 모두 통과했습니다. 최초 실행은
+  Colima의 Docker socket mount 오류로 중단되었고, `TESTCONTAINERS_RYUK_DISABLED=true`
+  조건부 재실행에서 Redis 8.8.1 경로를 확인했습니다.
+
+## 향후 지침
+
+새 synchronous listener-backed write 경로를 추가할 때는 호출자 lock을 잡은 채
+provider callback을 기다리는 역방향 대기를 먼저 점검합니다. self-event와 외부 event의
+경계를 분리하고, timeout 이후 late completion 및 후속 write 순서를 함께 회귀 테스트로
+고정합니다.

--- a/docs/lessons/2026-08-15-issue-1410-nearcache-listener-reentrancy.md
+++ b/docs/lessons/2026-08-15-issue-1410-nearcache-listener-reentrancy.md
@@ -5,13 +5,17 @@
 `NearJCache`의 동기 mutation은 호출자 스레드가 `mutationGate`를 잡은 상태에서
 back provider write를 전용 virtual thread에 위임하고 완료를 기다립니다. Lettuce
 JCache provider는 `isSynchronous=true` listener를 같은 write worker에서 inline으로
-호출하므로, listener가 front reconciliation을 위해 같은 `mutationGate`를 다시
-획득하면 호출자는 worker를 기다리고 worker는 호출자를 기다리는 교착이 발생했습니다.
+호출할 수 있고, 다른 provider는 synchronous callback thread를 사용할 수 있습니다.
+listener가 front reconciliation을 위해 같은 `mutationGate`를 다시 획득하면 호출자는
+worker를 기다리고 worker는 호출자를 기다리는 교착이 발생했습니다.
 
 ## 결정 또는 발견
 
-- 동기 write-through의 self-event만 write worker에서 front에 직접 반영하도록
-  thread-local reconciliation 경계를 추가했습니다.
+- 동기 write-through의 self-event를 operation-scoped key/type/value 상관관계로 식별하고
+  callback thread에서 front에 직접 반영하도록 context reconciliation 경계를 추가했습니다.
+- inline callback은 thread-local fast path를 사용하고, 별도 synchronous callback thread는
+  active operation context를 사용합니다. 한 operation에서 이미 소비한 key의 후속 event는
+  다시 self-event로 처리하지 않습니다.
 - 다른 wrapper 또는 외부 write의 listener event와 비동기 경로는 기존처럼
   `mutationGate`를 통해 직렬화합니다.
 - provider 호출은 기존 `backWriteLock`과 bounded timeout을 그대로 사용해 timeout,
@@ -29,12 +33,14 @@ Lettuce의 동기 `put`, `putAll`, `putIfAbsent`, `remove`, `replace`가 inline 
 
 - RED: 실제 Lettuce/Testcontainers 경로에서 기존 구현이 `TimeoutException`으로
   실패했습니다.
-- GREEN: cache-core mock provider가 inline CREATED/UPDATED/REMOVED event를 호출하는
-  다섯 CRUD 회귀 테스트가 통과했습니다.
+- GREEN: cache-core mock provider가 inline 및 별도 callback thread에서 CREATED/UPDATED/REMOVED
+  event를 호출하는 다섯 CRUD 회귀 테스트가 통과했습니다.
 - cache-core NearJCache 패키지 regression suite가 통과했습니다.
 - 실제 Lettuce integration test도 다섯 CRUD 연산 모두 통과했습니다. 최초 실행은
   Colima의 Docker socket mount 오류로 중단되었고, `TESTCONTAINERS_RYUK_DISABLED=true`
   조건부 재실행에서 Redis 8.8.1 경로를 확인했습니다.
+- timeout 뒤 provider가 interrupt를 무시하는 mock과 후속 write의 backWriteLock 순서를
+  회귀 테스트로 고정했습니다.
 
 ## 향후 지침
 

--- a/docs/lessons/2026-08-15-issue-1410-nearcache-listener-reentrancy.md
+++ b/docs/lessons/2026-08-15-issue-1410-nearcache-listener-reentrancy.md
@@ -18,6 +18,9 @@ worker를 기다리고 worker는 호출자를 기다리는 교착이 발생했�
   다시 self-event로 처리하지 않습니다.
 - 다른 wrapper 또는 외부 write의 listener event와 비동기 경로는 기존처럼
   `mutationGate`를 통해 직렬화합니다.
+- JCache event에는 operation ID가 없으므로 동일 key/type/value의 외부 event는
+  active self-event와 구분할 수 없습니다. 엄격한 operation correlation이 필요한
+  provider는 이 heuristic 경계를 별도로 검토해야 합니다.
 - provider 호출은 기존 `backWriteLock`과 bounded timeout을 그대로 사용해 timeout,
   cancellation, late completion의 순서 계약을 변경하지 않았습니다.
 - 호출자 gate를 provider I/O 전에 무조건 해제하는 대안은 late completion과 후속

--- a/docs/manual/en/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
+++ b/docs/manual/en/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
@@ -34,6 +34,19 @@ check(found.keys == setOf("a", "b"))
 
 `replace(key, old, new)` and `remove(key, old)` read and compare before issuing another Redis command. They are not distributed compare-and-set operations. Use the near-cache Lua CAS or a dedicated Redis script when the comparison must be atomic.
 
+## Synchronous near-cache write-through
+
+For `NearJCache` configured with `isSynchronous=true`, `put`, `putAll`,
+`putIfAbsent`, `remove`, and `replace` wait for the Lettuce back write with the
+bounded `syncRemoteTimeout` (at least 500 ms). Lettuce can dispatch the listener
+for that write inline on the write worker. `NearJCache` applies this self-event
+directly to the front cache instead of reacquiring the caller-held mutation gate,
+so the write cannot wait on its own listener. Events from another wrapper or
+external write still acquire the mutation gate, and asynchronous write-through
+keeps the normal gated path. If a provider ignores interruption, a late backend
+completion can follow a caller-visible timeout; the back-write barrier preserves
+ordering with subsequent writes.
+
 ## Listeners and EntryProcessor
 
 Entry listeners observe CREATED, UPDATED, and REMOVED operations executed by this cache instance. Writes from another Redis client do not automatically become JCache listener events.

--- a/docs/manual/en/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
+++ b/docs/manual/en/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
@@ -39,7 +39,8 @@ check(found.keys == setOf("a", "b"))
 For `NearJCache` configured with `isSynchronous=true`, `put`, `putAll`,
 `putIfAbsent`, `remove`, and `replace` wait for the Lettuce back write with the
 bounded `syncRemoteTimeout` (at least 500 ms). Lettuce can dispatch the listener
-for that write inline on the write worker. `NearJCache` applies this self-event
+for that write inline on the write worker or on a synchronous callback thread.
+`NearJCache` uses an operation-scoped key/type/value match to apply this self-event
 directly to the front cache instead of reacquiring the caller-held mutation gate,
 so the write cannot wait on its own listener. Events from another wrapper or
 external write still acquire the mutation gate, and asynchronous write-through

--- a/docs/manual/en/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
+++ b/docs/manual/en/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
@@ -42,9 +42,11 @@ bounded `syncRemoteTimeout` (at least 500 ms). Lettuce can dispatch the listener
 for that write inline on the write worker or on a synchronous callback thread.
 `NearJCache` uses an operation-scoped key/type/value match to apply this self-event
 directly to the front cache instead of reacquiring the caller-held mutation gate,
-so the write cannot wait on its own listener. Events from another wrapper or
-external write still acquire the mutation gate, and asynchronous write-through
-keeps the normal gated path. If a provider ignores interruption, a late backend
+so the write cannot wait on its own listener. Non-matching events from another
+wrapper or external write still acquire the mutation gate, and asynchronous
+write-through keeps the normal gated path. JCache events do not carry an operation
+ID, so an external event with the same key/type/value cannot be distinguished from
+the active self-event. If a provider ignores interruption, a late backend
 completion can follow a caller-visible timeout; the back-write barrier preserves
 ordering with subsequent writes.
 

--- a/docs/manual/ko/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
+++ b/docs/manual/ko/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
@@ -41,6 +41,18 @@ check(sessions.putIfAbsent("a", another) == false)
 
 `replace(key, old, new)`와 `remove(key, old)`는 읽고 비교한 뒤 별도 Redis 명령을 수행합니다. 여러 client가 같은 key를 동시에 바꾸는 상황에서 원자적 compare-and-set을 보장하지 않습니다. 원자적 조건 변경은 Near Cache의 Lua CAS나 별도 Redis script를 사용합니다.
 
+## 동기 NearCache write-through
+
+`isSynchronous=true`로 설정한 `NearJCache`의 `put`, `putAll`, `putIfAbsent`, `remove`,
+`replace`는 500ms 이상으로 보정된 `syncRemoteTimeout` 안에서 Lettuce back write가
+끝나기를 기다립니다. Lettuce는 write worker에서 해당 write의 listener를 inline으로
+호출할 수 있습니다. `NearJCache`는 이 self-event를 caller가 잡은 mutation gate를
+다시 획득하지 않고 front에 직접 반영하므로 write가 자기 listener를 기다리는 교착을
+막습니다. 다른 wrapper나 외부 write의 event는 계속 mutation gate를 획득하며, 비동기
+write-through도 기존 gate 경로를 유지합니다. provider가 interrupt를 무시하면 호출자가
+timeout을 관찰한 뒤 back completion이 늦게 도착할 수 있지만, back-write barrier가
+후속 write와 순서를 보존합니다.
+
 ## listener와 EntryProcessor
 
 cache entry listener는 이 `LettuceJCache` instance가 수행한 CREATED·UPDATED·REMOVED 이벤트를 process 안에서 호출합니다. Redis의 다른 client가 값을 바꿔도 JCache listener가 자동으로 알림을 받는 구조는 아닙니다.

--- a/docs/manual/ko/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
+++ b/docs/manual/ko/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
@@ -45,9 +45,10 @@ check(sessions.putIfAbsent("a", another) == false)
 
 `isSynchronous=true`로 설정한 `NearJCache`의 `put`, `putAll`, `putIfAbsent`, `remove`,
 `replace`는 500ms 이상으로 보정된 `syncRemoteTimeout` 안에서 Lettuce back write가
-끝나기를 기다립니다. Lettuce는 write worker에서 해당 write의 listener를 inline으로
-호출할 수 있습니다. `NearJCache`는 이 self-event를 caller가 잡은 mutation gate를
-다시 획득하지 않고 front에 직접 반영하므로 write가 자기 listener를 기다리는 교착을
+끝나기를 기다립니다. Lettuce는 write worker 또는 synchronous callback thread에서 해당
+write의 listener를 호출할 수 있습니다. `NearJCache`는 operation-scoped key/type/value
+상관관계가 맞는 self-event를 caller가 잡은 mutation gate를 다시 획득하지 않고 front에
+직접 반영하므로 write가 자기 listener를 기다리는 교착을
 막습니다. 다른 wrapper나 외부 write의 event는 계속 mutation gate를 획득하며, 비동기
 write-through도 기존 gate 경로를 유지합니다. provider가 interrupt를 무시하면 호출자가
 timeout을 관찰한 뒤 back completion이 늦게 도착할 수 있지만, back-write barrier가

--- a/docs/manual/ko/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
+++ b/docs/manual/ko/modules/bluetape4k-cache-lettuce/sync-suspend-jcache.md
@@ -49,8 +49,9 @@ check(sessions.putIfAbsent("a", another) == false)
 write의 listener를 호출할 수 있습니다. `NearJCache`는 operation-scoped key/type/value
 상관관계가 맞는 self-event를 caller가 잡은 mutation gate를 다시 획득하지 않고 front에
 직접 반영하므로 write가 자기 listener를 기다리는 교착을
-막습니다. 다른 wrapper나 외부 write의 event는 계속 mutation gate를 획득하며, 비동기
-write-through도 기존 gate 경로를 유지합니다. provider가 interrupt를 무시하면 호출자가
+막습니다. 매칭되지 않는 다른 wrapper나 외부 write의 event는 계속 mutation gate를 획득하며, 비동기
+write-through도 기존 gate 경로를 유지합니다. JCache event에는 operation ID가 없으므로 동일 key/type/value의 외부 event는
+활성 self-event와 구분할 수 없습니다. provider가 interrupt를 무시하면 호출자가
 timeout을 관찰한 뒤 back completion이 늦게 도착할 수 있지만, back-write barrier가
 후속 write와 순서를 보존합니다.
 

--- a/docs/testlogs/2026-08.md
+++ b/docs/testlogs/2026-08.md
@@ -1,0 +1,7 @@
+# 테스트 실행 기록
+
+| 날짜 | 이슈 | 검증 범위 | 결과 | 비고 |
+|---|---|---|---|---|
+| 2026-08-15 | #1410 | `:bluetape4k-cache-core:test` | PASS — 588 passing | inline CRUD, 별도 synchronous callback thread, 비동기 mutation-gate 순서, late completion 회귀 포함 |
+| 2026-08-15 | #1410 | `:bluetape4k-cache-lettuce:test` | PASS — 444 passing | Redis/Testcontainers 실제 검증; Colima Ryuk socket mount 실패 뒤 `TESTCONTAINERS_RYUK_DISABLED=true` 조건부 재시도 |
+| 2026-08-15 | #1410 | `:bluetape4k-cache-core:detekt :bluetape4k-cache-lettuce:detekt` | PASS — task 완료 | 기존 baseline finding만 남고 변경 파일 신규 finding 없음 |


### PR DESCRIPTION
## 변경 요약

`NearJCache` 동기 write-through에서 provider listener가 같은 write를 inline 또는 synchronous callback thread로 재진입할 때 발생하는 self-deadlock과 timeout을 차단합니다.

Fixes #1410
Epic: #1408

## 원인과 해결

- 호출자가 `mutationGate`를 보유한 상태로 `backCache` write completion을 기다리고, listener callback도 같은 gate를 요구해 lock inversion이 발생했습니다.
- 동기 caller-held mutation에서만 operation-scoped key/type/value self-event context를 열어 front reconciliation을 직접 수행합니다.
- 비동기 write와 매칭되지 않는 peer/external event는 기존 `mutationGate` 경로를 유지합니다.
- `backWriteLock`을 유지해 timeout 이후 늦게 끝나는 provider write와 후속 write의 순서를 보존합니다.
- JCache event에 operation ID가 없으므로 동일 key/type/value 외부 event를 완전히 구분할 수 없는 heuristic 한계를 KDoc/README/manual에 명시했습니다.

## 변경 파일

- `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt`
- `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt`
- `cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceNearJCacheWriteThroughReentrancyTest.kt`
- cache-core/cache-lettuce `README.md` 및 `README.ko.md`, EN/KO manual, Korean KDoc
- `docs/lessons/2026-08-15-issue-1410-nearcache-listener-reentrancy.md`
- `docs/testlogs/2026-08.md`

## Stacked PR train

- base: `develop` (`a8d599701a3870e41b9365d06dd9a02961a513ad`)
- predecessor: #1411 / PR #1430 merged into `develop`
- current stage: 6 — #1410 synchronous listener reentrancy
- next child: #1426 (선행: #1410)

## 검증

- 최초 실제 Lettuce 재현: `NearJCache synchronous back cache write timed out` (`CacheException` caused by `TimeoutException`) 발생.
- `./gradlew :bluetape4k-cache-core:test --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` → **588 passing**, 0 failures/errors/skips.
- `./gradlew :bluetape4k-cache-core:test --tests 'io.bluetape4k.cache.nearcache.jcache.NearJCacheWriteThroughReentrancyTest' --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` → **4 passing**.
- `TESTCONTAINERS_RYUK_DISABLED=true ./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` → **444 passing**, 0 failures/errors/skips.
- 실제 Redis 테스트 `LettuceNearJCacheWriteThroughReentrancyTest` → **1 passing**. Colima Docker socket mount로 Ryuk가 시작되지 않은 원본 실패를 보존하고, 해당 환경에서만 bounded Ryuk-disabled 재시도를 사용했습니다.
- `./gradlew :bluetape4k-cache-core:detekt :bluetape4k-cache-lettuce:detekt --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1` → task 완료; 기존 baseline finding만 남고 변경 파일 신규 finding 없음.
- `git diff --check` → PASS.
- hosted CI run `31861515322` exact head `741ebdf316d4` → **PASS**: Build, publication metadata, Key Utils, Infra (Redis), Coverage Report, CI Status 및 정책/보안/catalog 검증 성공. Manual Documentation run `31861515332`도 **PASS**.
- CI path filter에 따른 비대상 모듈 테스트는 `SKIPPED`로 완료되었고, 변경 모듈은 로컬 cache-core 588개/cache-lettuce 444개 전체 테스트와 targeted/실제 Redis 테스트로 보강했습니다.
- hosted review read-back → 리뷰 0건, 댓글/inline thread 0건, mergeable `MERGEABLE`; 로컬 리뷰 P0/P1 0건.

## DoD Status

| 항목 | 상태 | 증거 / 다음 조치 |
|---|---|---|
| Type-C 원인·범위·RED | PASS | #1410 live metadata, 실제 Lettuce timeout 재현, lock inversion 분석 |
| 동기 self-event 수정 | PASS | `NearJCache.kt`, inline/separate-thread CRUD 회귀 |
| 비동기 gate 순서 | PASS | async self-event가 `mutationGate`를 우회하지 않는 회귀 |
| timeout/cancellation/late completion | PASS | core full suite 및 late-completion ordering 회귀 |
| 문서·lesson·testlog | PASS | bilingual README/manual, Korean KDoc, lesson, `docs/testlogs/2026-08.md` |
| 로컬 리뷰 | PASS | P0/P1 없음; 동일 key/type/value operation-ID 부재는 문서화된 P2 WATCH |
| PR/CI exact-head | PASS | PR #1431, `741ebdf316d4`; hosted CI/manual documentation 성공, reviews/comments 0건, mergeable `MERGEABLE` |
| merge approval | PENDING | CI/review가 green인 exact head에 대해 사용자 fresh approval 대기; auto-merge 미사용 |

현재 상태: **PENDING (MERGE-READY)** — PR/CI/review 증거는 수렴했으며 CG-16 fresh merge approval에서 대기합니다.
