### PR TITLE
[cache][observability] NearJCache write-through 관찰 스냅숏을 원자적으로 노출

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -117,6 +117,17 @@ local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도�
 왕복을 사용하지 않으며, back provider 실패 시 front를 변경하기 전에
 예외를 전달합니다.
 
+마지막 write-through의 operation ID·operation 이름·completion을 함께 상관관계로
+관찰하려면 `nearCache.lastBackCacheWrite`를 사용하세요. 이 값은 하나의 원자
+스냅숏이며 completion stage는 읽기 전용입니다. 기존
+`lastBackCacheWriteOperationId`와 `lastBackCacheWriteCompletion` property는 소스
+호환성을 위해 유지하지만, 두 값을 따로 읽어 상관관계를 구성하지는 마세요.
+
+```kotlin
+val observation = nearCache.lastBackCacheWrite
+observation.completion.toCompletableFuture().join()
+```
+
 `NearJCacheConfig.isSynchronous=true`이면 동기 write-through의 blocking provider 호출을
 전용 virtual thread에서 실행하고, 500ms 이상으로 보정된 `syncRemoteTimeout`까지만
 기다립니다. provider가 같은 write의 listener를 inline 또는 synchronous callback thread에서

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -70,6 +70,18 @@ provider's atomic compound operation and then reconcile the local front cache;
 they do not implement a front-read/back-write round trip. A provider failure is
 propagated before the front cache is changed.
 
+Use `nearCache.lastBackCacheWrite` when correlating the latest write-through
+operation ID, operation name, and completion. It is one atomic observation
+snapshot, and its completion stage is read-only. The legacy
+`lastBackCacheWriteOperationId` and `lastBackCacheWriteCompletion` properties
+remain for source compatibility, but separate reads are not a correlated
+snapshot.
+
+```kotlin
+val observation = nearCache.lastBackCacheWrite
+observation.completion.toCompletableFuture().join()
+```
+
 When `NearJCacheConfig.isSynchronous=true`, synchronous write-through runs the
 blocking provider call on a dedicated virtual thread and waits only up to the
 bounded `syncRemoteTimeout` (with a 500 ms minimum). If a provider invokes the

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -218,8 +218,15 @@ class NearJCache<K: Any, V: Any>(
         val completion: CompletableFuture<Unit>,
     )
 
+    private fun BackCacheWriteState.toCompletion(): BackCacheWriteCompletion =
+        BackCacheWriteCompletion(
+            operationId = operationId,
+            operation = operation,
+            completion = completion.minimalCompletionStage(),
+        )
+
     private val nextBackCacheWriteOperationId = AtomicLong()
-    private val lastBackCacheWrite = AtomicReference(
+    private val lastBackCacheWriteState = AtomicReference(
         BackCacheWriteState(
             operationId = 0L,
             operation = "initial",
@@ -231,19 +238,36 @@ class NearJCache<K: Any, V: Any>(
     private object CompoundResultUnset
 
     /**
+     * 마지막으로 예약한 Back Cache write-through의 operation ID, 이름, 완료 상태를
+     * 하나의 원자 스냅숏으로 반환합니다.
+     *
+     * `completion`은 내부 future를 변경할 수 없는 관찰 전용 단계입니다. 여러
+     * property를 따로 읽어 operation 상관관계를 맞추지 말고, 상관관계가 필요한
+     * 모니터링·재시도·감사 코드에서는 이 스냅숏을 한 번 읽어 사용하세요.
+     */
+    val lastBackCacheWrite: BackCacheWriteCompletion
+        get() = lastBackCacheWriteState.get().toCompletion()
+
+    /**
      * 마지막으로 예약한 Back Cache write-through의 완료 상태입니다.
      *
      * 동기 모드에서는 성공 또는 실패가 즉시 완료된 [CompletableFuture]로 기록되고,
      * 비동기 모드에서는 bounded retry와 timeout을 포함한 Back Cache 작업의 성공·실패가
-     * 기록됩니다. 반환값은 내부 completion의 복사본이므로 호출자가 완료 상태를 변경할 수
-     * 없습니다.
+     * 기록됩니다. 이 property는 기존 호출자 호환성을 위한 단일 값 접근자이며,
+     * operation ID와 함께 관찰해야 하면 [lastBackCacheWrite]를 사용하세요. 반환값은
+     * 내부 completion의 복사본이므로 호출자가 완료 상태를 변경할 수 없습니다.
      */
     val lastBackCacheWriteCompletion: CompletableFuture<Unit>
-        get() = lastBackCacheWrite.get().completion.copy()
+        get() = lastBackCacheWriteState.get().completion.copy()
 
-    /** 마지막 write-through 작업의 operation ID입니다. */
+    /**
+     * 마지막 write-through 작업의 operation ID입니다.
+     *
+     * 기존 호환성을 위한 접근자이며 operation 결과와 함께 읽을 때는
+     * [lastBackCacheWrite]를 사용하세요.
+     */
     val lastBackCacheWriteOperationId: Long
-        get() = lastBackCacheWrite.get().operationId
+        get() = lastBackCacheWriteState.get().operationId
 
     /**
      * 모든 write-through 작업의 operation별 completion을 관찰할 listener를 등록합니다.
@@ -943,7 +967,7 @@ class NearJCache<K: Any, V: Any>(
             operation = operation,
             completion = completion,
         )
-        lastBackCacheWrite.set(state)
+        lastBackCacheWriteState.set(state)
         completion.whenComplete { _, _ ->
             val result = BackCacheWriteCompletion(
                 operationId = state.operationId,

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
@@ -2,10 +2,13 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ExecutionException
@@ -354,6 +357,57 @@ class NearJCacheWriteThroughFailureTest {
     }
 
     @Test
+    fun `동시 write 중 snapshot은 동일 operation의 completion과 함께 관찰된다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val sequence = AtomicInteger()
+        val snapshots = CopyOnWriteArrayList<BackCacheWriteCompletion>()
+        val observed = ConcurrentHashMap<Long, BackCacheWriteCompletion>()
+        val expectedWrites = 4 * 16
+        val completed = CountDownLatch(expectedWrites)
+        every { backCache.put(any(), any()) } answers {
+            if (firstArg<String>().contains("-failed-")) throw failure
+        }
+        val nearCache =
+            NearJCache(
+                frontCache = frontCache,
+                backCache = backCache,
+                config = NearJCacheConfig(isSynchronous = false, syncRemoteRetryCount = 0),
+            )
+        val registration = nearCache.addBackCacheWriteListener {
+            observed[it.operationId] = it
+            completed.countDown()
+        }
+
+        try {
+            MultithreadingTester()
+                .workers(4)
+                .rounds(16)
+                .add {
+                    val ordinal = sequence.incrementAndGet()
+                    val outcome = if (ordinal % 2 == 0) "failed" else "succeeded"
+                    nearCache.put("key-$ordinal-$outcome", "value")
+                    snapshots.add(nearCache.lastBackCacheWrite)
+                }
+                .run()
+
+            completed.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            snapshots.size shouldBeEqualTo expectedWrites
+            observed.size shouldBeEqualTo expectedWrites
+            snapshots.forEach { snapshot ->
+                val completion = observed[snapshot.operationId]
+                checkNotNull(completion) { "snapshot operation was not observed: ${snapshot.operationId}" }
+                snapshot.operation shouldBeEqualTo "put"
+                snapshot.operation shouldBeEqualTo completion.operation
+                snapshot.completion.toCompletableFuture().isCompletedExceptionally shouldBeEqualTo
+                    completion.completion.toCompletableFuture().isCompletedExceptionally
+            }
+        } finally {
+            registration.close()
+        }
+    }
+
+    @Test
     fun `last completion 복사본을 변경해도 실제 write 결과는 보존된다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
@@ -371,15 +425,21 @@ class NearJCacheWriteThroughFailureTest {
 
         try {
             nearCache.put("key", "value")
+            val snapshot = nearCache.lastBackCacheWrite
             nearCache.lastBackCacheWriteCompletion.complete(Unit)
+            snapshot.completion.toCompletableFuture().complete(Unit)
         } finally {
             release.countDown()
         }
 
         val error = assertFailsWith<ExecutionException> {
-            nearCache.lastBackCacheWriteCompletion.get(2, TimeUnit.SECONDS)
+            nearCache.lastBackCacheWrite.completion.toCompletableFuture().get(2, TimeUnit.SECONDS)
         }
         error.cause?.message shouldBeEqualTo failure.message
+        val legacyError = assertFailsWith<ExecutionException> {
+            nearCache.lastBackCacheWriteCompletion.get(2, TimeUnit.SECONDS)
+        }
+        legacyError.cause?.message shouldBeEqualTo failure.message
     }
 
     @Test

--- a/docs/lessons/2026-08-15-issue-1426-nearcache-observation.md
+++ b/docs/lessons/2026-08-15-issue-1426-nearcache-observation.md
@@ -1,0 +1,31 @@
+# #1426 NearJCache write-through 관찰 스냅숏
+
+## 배경
+
+`NearJCache`는 마지막 Back Cache write-through의 operation ID와 completion을
+하나의 `AtomicReference`에 저장하지만, 기존 public property는 값을 서로 다른
+시점에 읽을 수 있었습니다. concurrent write가 끼어들면 모니터링·재시도·감사
+코드가 서로 다른 operation을 하나의 결과로 결합할 위험이 있었습니다.
+
+## 결정
+
+- `lastBackCacheWrite`가 operation ID·operation 이름·completion을 한 번에 반환하는
+  `BackCacheWriteCompletion` observation snapshot을 제공합니다.
+- snapshot의 completion은 `minimalCompletionStage()`로 노출해 호출자가 내부 future를
+  완료하거나 실패 상태를 바꿀 수 없게 합니다.
+- 기존 `lastBackCacheWriteOperationId`와 `lastBackCacheWriteCompletion` property는
+  source compatibility를 위해 유지하고, 상관관계가 필요한 호출자는 snapshot을
+  사용하도록 KDoc과 EN/KO README에 명시합니다.
+
+## 검증
+
+- concurrent write 회귀 테스트가 snapshot의 operation ID를 listener completion과
+  대조해 operation과 completion이 같은 state에서 왔음을 확인합니다.
+- snapshot과 기존 completion copy를 호출자가 변경해도 실제 write 결과가 보존되는
+  불변성 계약을 확인합니다.
+
+## Stacked train
+
+- 선행: #1410 / PR #1431 / `fix/1410-nearcache-listener-reentrancy`
+- 현재: #1426 / `fix/1426-nearcache-observation`
+- 후속: #1348은 #1426 exact head를 base로 삼는 child PR로만 쌓습니다.


### PR DESCRIPTION
## Summary

Closes #1426

NearJCache write-through의 operation ID와 completion을 하나의 원자 관찰
스냅숏으로 노출해 concurrent write에서 상관관계가 어긋나는 P2 결함을
해결합니다.

## Background

1.13.0 Type-D 7-Tier 리뷰에서 기존 `lastBackCacheWriteOperationId`와
`lastBackCacheWriteCompletion`이 같은 `AtomicReference`를 서로 다른 시점에
읽어 서로 다른 write operation을 하나의 결과로 결합할 수 있음을 확인했습니다.

## What This Solves

- operation ID·operation name·completion을 같은 `BackCacheWriteCompletion`
  스냅숏에서 관찰합니다.
- 호출자가 completion stage를 변경해 내부 write 결과를 오염시키지 못하게
  하면서 기존 property source compatibility를 유지합니다.

## Work Done

- `NearJCache.lastBackCacheWrite`를 추가하고 기존 두 property의 사용 범위와
  상관관계 규칙을 Korean KDoc 및 EN/KO README에 기록했습니다.
- concurrent write, listener correlation, completion copy mutation 회귀 테스트와
  재사용 가능한 lesson을 추가했습니다.
- 이 PR은 `develop` 기반 PR A입니다. 후속 #1348 PR B는 이 PR의 exact head를
  base로 삼아 stacked train으로 생성하며, PR A를 먼저 merge하지 않습니다.

## Validation

- `:bluetape4k-cache-core:test --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`: PASS (589 passing)
- `:bluetape4k-cache-core:detekt --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`: PASS (기존 비변경 파일 findings만 존재)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 현재 범위에서 없음; 기존 property는 호환성을 위해 유지
- Review evidence: `docs/lessons/2026-08-15-issue-1426-nearcache-observation.md`

## Metadata

- Issue: #1426, milestone `1.13.0`, assignee `debop`
- PR: #1432, head `ba8599d693e77a4144cd4c53d590ac8c07dc038a`, milestone `1.13.0`, assignee `debop`
- CI: [run 31867943271](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/31867943271) required aggregate checks 성공; changed-module matrix skip는 아래에 기록

## DoD Status

Required checks: 14/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-00..WF-06 | 분류, 승인, 실행, 검증 게이트 수행 | PASS | 승인된 Type-B plan, run `20260815T051033Z-a508693d`, local receipts | none |
| B-01..B-07 | Type-B scope, Kotlin contract, RED/GREEN, docs, lesson | PASS | `ba8599d693`, 589 tests, detekt, lesson path | none |
| CG-11 - PR delivery authority | 승인된 repo/base/head와 PR A 생성 범위 확인 | PASS | `bluetape4k/bluetape4k-projects`, `develop`, `fix/1426-nearcache-observation` | none |
| CG-12 - Exact head publish | exact branch push 및 원격 SHA read-back | PASS | local/remote `ba8599d693e77a4144cd4c53d590ac8c07dc038a` | none |
| CG-12A - Guidance refresh | AGENTS, leaf, common gates, template, Issue #1426 재확인 | PASS | current guidance/issue metadata read-back | none |
| CG-13 - PR read-back | PR metadata/body/head live 확인 | PASS | PR #1432, base `develop`, head `ba8599d693e77a4144cd4c53d590ac8c07dc038a`, labels/milestone/assignee read-back | none |
| CG-14 - CI and review | exact PR head CI와 최신 review/thread 확인 | PASS | run `31867943271`: Build, CI Status, Coverage, Key Utils, policy/security/wrapper/catalog checks 성공; 8개 matrix job skip; review/thread 0 | none; skipped matrix는 로컬 cache-core 589개 테스트로 보완 |
| CG-15 - Merge-ready report | exact head와 phase-aware counts 보고 | PENDING | CG-14 이후 수행 | fresh merge approval 전까지 대기 |
| CG-16..CG-18 | fresh merge approval, merge, sync/cleanup | PENDING | 사용자 승인 및 CI 이후 범위 | PR A merge는 별도 승인 필요 |

Final status: PENDING (CG-14 exact-head CI and CG-15 remain before the #1348 child stack)

Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18; PR B stack-readback
