### PR TITLE
[cache][lettuce] LettuceJCache EntryProcessor 분산 원자성과 TTL 계약 정합성 확보

### DIFF
--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -216,7 +216,16 @@ Caffeine           |
 - Redis 8 이상에서는 `HSETEX`를 우선 사용하고 hash key `EXPIRE`도 함께 갱신합니다.
 - Redis 7 이하 서버에서는 자동으로 `HSET/HMSET + EXPIRE` 경로로 fallback 합니다.
 - TTL이 지나면 해당 cacheName에 속한 항목이 함께 만료됩니다.
-- 현재 JCache의 `EntryProcessor` 기반 `invoke` / `invokeAll`은 지원하지 않으며 호출 시 `CacheException`을 반환합니다.
+- JCache의 `EntryProcessor` 기반 `invoke` / `invokeAll`은 지원합니다. 같은 cache name을 공유하는
+  `LettuceJCache` 인스턴스의 모든 변경 작업은 Redis 분산 락으로 직렬화되므로,
+  `invoke`의 read-modify-write가 연결 간에도 원자적으로 실행됩니다.
+- `invokeAll`은 키별로 독립된 원자 구간을 만들며, 성공한 키의 결과와 실패한 키의
+  `EntryProcessorException`을 각각 `EntryProcessorResult`에 보존합니다. 프로세서가 예외를
+  던지면 해당 키에는 변경 내용을 커밋하지 않습니다.
+- `ttlSeconds`가 설정된 경우 `invoke`로 갱신한 값도 캐시 hash TTL을 다시 적용하고,
+  등록된 `CacheEntryUpdatedListener`에 갱신 이벤트를 전달합니다.
+- 분산 락의 기본 lease는 1분, 획득 대기는 5분입니다. 프로세서는 기본 lease 안에
+  완료되어야 하며, 더 긴 실행 시간을 허용하는 정책은 별도 설정 계약으로 다룹니다.
 
 ```kotlin
 import io.bluetape4k.cache.jcache.LettuceJCaching

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -62,6 +62,23 @@ by the near cache's back-write barrier.
 
 See the full [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).
 
+## JCache EntryProcessor Atomicity
+
+`LettuceJCache` supports JCache `EntryProcessor` operations. All mutating
+operations for the same cache name share a Redis distributed lock, so an
+`invoke` read-modify-write sequence remains atomic across independent Lettuce
+connections and cache instances.
+
+- `invokeAll` creates an independent atomic section for each key. Successful
+  values and `EntryProcessorException` failures are preserved per key through
+  `EntryProcessorResult`.
+- If a processor throws, its entry is not committed. A successful mutation
+  refreshes the configured cache hash TTL and dispatches the corresponding
+  cache-entry listener event.
+- The default lock lease is one minute and the default acquisition wait is five
+  minutes. Processors must finish within the default lease; a longer execution
+  policy is a separate configuration contract.
+
 ## Factory (`LettuceCaches`)
 
 `LettuceCaches` exposes factory methods for:

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceJCache.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceJCache.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec
 import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
 import io.bluetape4k.redis.lettuce.map.LettuceMap
 import java.time.Duration
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import javax.cache.Cache
 import javax.cache.CacheManager
@@ -62,6 +63,14 @@ class LettuceJCache<K: Any, V: Any>(
         check(!closed.value) { "LettuceCache[$cacheName]가 이미 닫혀 있습니다." }
     }
 
+    /**
+     * Redis hash 단위의 분산 락으로 JCache 쓰기 구간을 보호합니다.
+     * EntryProcessor의 read-modify-write와 일반 쓰기가 서로 다른 Lettuce 연결에서
+     * 실행되어도 같은 cacheName에 대해 직렬화되도록 호출마다 새 토큰을 사용합니다.
+     */
+    private fun <R> withWriteLock(block: () -> R): R =
+        map.withDistributedLock(UUID.randomUUID().toString().toByteArray(), block = block)
+
     private fun encodeKey(key: K): String = keyCodec(key)
 
     private fun decodeKey(field: String): K {
@@ -76,6 +85,17 @@ class LettuceJCache<K: Any, V: Any>(
     }
 
     private fun encodeValue(value: V): ByteArray = codec.serializer.serialize(value)
+
+    private fun putTtl(field: String, value: ByteArray): Boolean {
+        val added = map.putTtl(field, value, ttlDuration)
+        map.refreshTtl(ttlDuration)
+        return added
+    }
+
+    private fun putAllTtl(entries: Map<String, ByteArray>) {
+        map.putAllTtl(entries, ttlDuration)
+        map.refreshTtl(ttlDuration)
+    }
 
     @Suppress("UNCHECKED_CAST")
     private fun decodeValue(bytes: ByteArray): V = codec.serializer.deserialize(bytes)!!
@@ -117,150 +137,172 @@ class LettuceJCache<K: Any, V: Any>(
 
     override fun put(key: K, value: V) {
         checkNotClosed()
-        log.debug { "put: cacheName=$cacheName, key=$key" }
-        val field = encodeKey(key)
-        val bytes = encodeValue(value)
-        val existed = map.containsKey(field)
+        withWriteLock {
+            log.debug { "put: cacheName=$cacheName, key=$key" }
+            val field = encodeKey(key)
+            val bytes = encodeValue(value)
+            val existed = map.containsKey(field)
 
-        map.putTtl(field, bytes, ttlDuration)
+            putTtl(field, bytes)
 
-        val eventType = if (existed) EventType.UPDATED else EventType.CREATED
-        dispatchEvent(eventType, key, value)
+            val eventType = if (existed) EventType.UPDATED else EventType.CREATED
+            dispatchEvent(eventType, key, value)
+        }
     }
 
     override fun getAndPut(key: K, value: V): V? {
         checkNotClosed()
-        val field = encodeKey(key)
-        val oldBytes = map.get(field)
-        val existed = oldBytes != null
-        val bytes = encodeValue(value)
+        return withWriteLock {
+            val field = encodeKey(key)
+            val oldBytes = map.get(field)
+            val existed = oldBytes != null
+            val bytes = encodeValue(value)
 
-        map.putTtl(field, bytes, ttlDuration)
+            putTtl(field, bytes)
 
-        val eventType = if (existed) EventType.UPDATED else EventType.CREATED
-        dispatchEvent(eventType, key, value)
+            val eventType = if (existed) EventType.UPDATED else EventType.CREATED
+            dispatchEvent(eventType, key, value)
 
-        return oldBytes?.let { decodeValue(it) }
+            oldBytes?.let { decodeValue(it) }
+        }
     }
 
     override fun putAll(map: Map<out K, V>) {
         checkNotClosed()
         if (map.isEmpty()) return
-        val encodedMap = map.entries.associate { (k, v) -> encodeKey(k) to encodeValue(v) }
-        // 개선: 기존엔 `map.keys.filter { containsKey(it) }` 로 key 당 HEXISTS 한 번씩 호출해
-        //       N-round-trip 이 발생했습니다. 리스너가 있을 때만 단일 HMGET (`this.map.getAll`)
-        //       로 일괄 조회하여 round-trip 을 1회로 줄입니다.
-        val existingKeys: Set<K> = if (listeners.isNotEmpty()) {
-            val fetched = this.map.getAll(encodedMap.keys.toList())
-            map.keys.filter { fetched[encodeKey(it)] != null }.toSet()
-        } else {
-            emptySet()
-        }
-        this.map.putAllTtl(encodedMap, ttlDuration)
-        if (listeners.isNotEmpty()) {
-            map.forEach { (k, v) ->
-                val eventType = if (k in existingKeys) EventType.UPDATED else EventType.CREATED
-                dispatchEvent(eventType, k, v)
+        withWriteLock {
+            val encodedMap = map.entries.associate { (k, v) -> encodeKey(k) to encodeValue(v) }
+            // 개선: 기존엔 `map.keys.filter { containsKey(it) }` 로 key 당 HEXISTS 한 번씩 호출해
+            //       N-round-trip 이 발생했습니다. 리스너가 있을 때만 단일 HMGET (`this.map.getAll`)
+            //       로 일괄 조회하여 round-trip 을 1회로 줄입니다.
+            val existingKeys: Set<K> = if (listeners.isNotEmpty()) {
+                val fetched = this.map.getAll(encodedMap.keys.toList())
+                map.keys.filter { fetched[encodeKey(it)] != null }.toSet()
+            } else {
+                emptySet()
+            }
+            putAllTtl(encodedMap)
+            if (listeners.isNotEmpty()) {
+                map.forEach { (k, v) ->
+                    val eventType = if (k in existingKeys) EventType.UPDATED else EventType.CREATED
+                    dispatchEvent(eventType, k, v)
+                }
             }
         }
     }
 
     override fun putIfAbsent(key: K, value: V): Boolean {
         checkNotClosed()
-        val field = encodeKey(key)
-        val bytes = encodeValue(value)
-        val added = map.putIfAbsentTtl(field, bytes, ttlDuration)
-        if (added) {
-            dispatchEvent(EventType.CREATED, key, value)
+        return withWriteLock {
+            val field = encodeKey(key)
+            val bytes = encodeValue(value)
+            val added = map.putIfAbsentTtl(field, bytes, ttlDuration)
+            if (added) {
+                dispatchEvent(EventType.CREATED, key, value)
+            }
+            added
         }
-        return added
     }
 
     override fun remove(key: K): Boolean {
         checkNotClosed()
-        val field = encodeKey(key)
-        val removed = map.remove(field) > 0L
-        if (removed) {
-            dispatchEvent(EventType.REMOVED, key, null)
+        return withWriteLock {
+            val field = encodeKey(key)
+            val removed = map.remove(field) > 0L
+            if (removed) {
+                dispatchEvent(EventType.REMOVED, key, null)
+            }
+            removed
         }
-        return removed
     }
 
     override fun remove(key: K, oldValue: V): Boolean {
         checkNotClosed()
-        val field = encodeKey(key)
-        val currentBytes = map.get(field) ?: return false
-        val currentValue = decodeValue(currentBytes)
-        return if (currentValue == oldValue) {
-            val removed = map.remove(field) > 0L
-            if (removed) dispatchEvent(EventType.REMOVED, key, null)
-            removed
-        } else {
-            false
+        return withWriteLock {
+            val field = encodeKey(key)
+            val currentBytes = map.get(field) ?: return@withWriteLock false
+            val currentValue = decodeValue(currentBytes)
+            if (currentValue == oldValue) {
+                val removed = map.remove(field) > 0L
+                if (removed) dispatchEvent(EventType.REMOVED, key, null)
+                removed
+            } else {
+                false
+            }
         }
     }
 
     override fun getAndRemove(key: K): V? {
         checkNotClosed()
-        val field = encodeKey(key)
-        val bytes = map.get(field) ?: return null
-        map.remove(field)
-        dispatchEvent(EventType.REMOVED, key, null)
-        return decodeValue(bytes)
+        return withWriteLock {
+            val field = encodeKey(key)
+            val bytes = map.get(field) ?: return@withWriteLock null
+            map.remove(field)
+            dispatchEvent(EventType.REMOVED, key, null)
+            decodeValue(bytes)
+        }
     }
 
     override fun replace(key: K, oldValue: V, newValue: V): Boolean {
         checkNotClosed()
-        val field = encodeKey(key)
-        val currentBytes = map.get(field) ?: return false
-        val currentValue = decodeValue(currentBytes)
-        return if (currentValue == oldValue) {
-            val bytes = encodeValue(newValue)
-            map.putTtl(field, bytes, ttlDuration)
-            dispatchEvent(EventType.UPDATED, key, newValue)
-            true
-        } else {
-            false
+        return withWriteLock {
+            val field = encodeKey(key)
+            val currentBytes = map.get(field) ?: return@withWriteLock false
+            val currentValue = decodeValue(currentBytes)
+            if (currentValue == oldValue) {
+                val bytes = encodeValue(newValue)
+                putTtl(field, bytes)
+                dispatchEvent(EventType.UPDATED, key, newValue)
+                true
+            } else {
+                false
+            }
         }
     }
 
     override fun replace(key: K, value: V): Boolean {
         checkNotClosed()
-        if (!containsKey(key)) return false
-        val field = encodeKey(key)
-        val bytes = encodeValue(value)
-        map.putTtl(field, bytes, ttlDuration)
-        dispatchEvent(EventType.UPDATED, key, value)
-        return true
+        return withWriteLock {
+            if (!containsKey(key)) return@withWriteLock false
+            val field = encodeKey(key)
+            val bytes = encodeValue(value)
+            putTtl(field, bytes)
+            dispatchEvent(EventType.UPDATED, key, value)
+            true
+        }
     }
 
     override fun getAndReplace(key: K, value: V): V? {
         checkNotClosed()
-        val field = encodeKey(key)
-        val oldBytes = map.get(field) ?: return null
-        val bytes = encodeValue(value)
-        map.putTtl(field, bytes, ttlDuration)
-        dispatchEvent(EventType.UPDATED, key, value)
-        return decodeValue(oldBytes)
+        return withWriteLock {
+            val field = encodeKey(key)
+            val oldBytes = map.get(field) ?: return@withWriteLock null
+            val bytes = encodeValue(value)
+            putTtl(field, bytes)
+            dispatchEvent(EventType.UPDATED, key, value)
+            decodeValue(oldBytes)
+        }
     }
 
     override fun removeAll(keys: Set<K>) {
         checkNotClosed()
         if (keys.isEmpty()) return
-        keys.forEach { key ->
-            map.remove(encodeKey(key))
-            dispatchEvent(EventType.REMOVED, key, null)
+        withWriteLock {
+            keys.forEach { key ->
+                val removed = map.remove(encodeKey(key)) > 0L
+                if (removed) dispatchEvent(EventType.REMOVED, key, null)
+            }
         }
     }
 
     override fun removeAll() {
         checkNotClosed()
-        map.clear()
+        withWriteLock { map.clear() }
     }
 
     override fun clear() {
         checkNotClosed()
-        map.clear()
+        withWriteLock { map.clear() }
     }
 
     override fun iterator(): MutableIterator<Cache.Entry<K, V>> {
@@ -306,15 +348,17 @@ class LettuceJCache<K: Any, V: Any>(
         vararg arguments: Any?,
     ): T {
         checkNotClosed()
-        val field = encodeKey(key)
-        val entry = MutableEntryImpl(key, field)
-        val result = try {
-            entryProcessor.process(entry, *arguments)
-        } catch (e: Exception) {
-            throw EntryProcessorException(e)
+        return withWriteLock {
+            val field = encodeKey(key)
+            val entry = MutableEntryImpl(key, field)
+            val result = try {
+                entryProcessor.process(entry, *arguments)
+            } catch (e: Exception) {
+                throw EntryProcessorException(e)
+            }
+            entry.commit()
+            result
         }
-        entry.commit()
-        return result
     }
 
     override fun <T: Any> invokeAll(
@@ -424,9 +468,17 @@ class LettuceJCache<K: Any, V: Any>(
         fun commit() {
             ensureLoaded()
             when {
-                removeRequested && exists -> this@LettuceJCache.remove(key)
+                removeRequested && exists -> {
+                    val removed = map.remove(field) > 0L
+                    if (removed) dispatchEvent(EventType.REMOVED, key, null)
+                }
                 removeRequested -> Unit
-                updatedValue != null      -> this@LettuceJCache.put(key, updatedValue!!)
+                updatedValue != null      -> {
+                    val value = updatedValue ?: return
+                    putTtl(field, encodeValue(value))
+                    val eventType = if (exists) EventType.UPDATED else EventType.CREATED
+                    dispatchEvent(eventType, key, value)
+                }
             }
         }
 

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
@@ -1,7 +1,10 @@
 package io.bluetape4k.cache.jcache
 
 import io.bluetape4k.cache.RedisServers
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
+import io.bluetape4k.redis.lettuce.map.LettuceMap
 import io.lettuce.core.codec.StringCodec
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
@@ -16,9 +19,15 @@ import org.junit.jupiter.api.TestInstance
 import io.bluetape4k.assertions.assertFailsWith
 import java.net.URI
 import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.TimeUnit
 import javax.cache.CacheException
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration
+import javax.cache.event.CacheEntryEvent
+import javax.cache.event.CacheEntryUpdatedListener
 import javax.cache.processor.EntryProcessor
+import javax.cache.processor.EntryProcessorException
 import javax.cache.processor.MutableEntry
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -227,6 +236,132 @@ class LettuceJCacheTest {
         results["k2"]?.get() shouldBeEqualTo "v2-x"
         cache.get("k1") shouldBeEqualTo "v1-x"
         cache.get("k2") shouldBeEqualTo "v2-x"
+    }
+
+    @Test
+    fun `invoke serializes read modify write across cache instances`() {
+        val mapName = "invoke-atomic-" + UUID.randomUUID().toString().take(8)
+        val first = standaloneCache(mapName)
+        val second = standaloneCache(mapName)
+        val nextCache = AtomicInteger()
+        val totalInvocations = 8 * 10
+
+        try {
+            first.put("counter", 0)
+
+            MultithreadingTester()
+                .workers(8)
+                .rounds(10)
+                .add {
+                    val target = if (nextCache.getAndIncrement() % 2 == 0) first else second
+                    target.invoke(
+                        "counter",
+                        EntryProcessor<String, Int, Int> { entry: MutableEntry<String, Int>, _: Array<out Any?> ->
+                            val current = entry.value ?: 0
+                            Thread.sleep(2)
+                            val updated = current + 1
+                            entry.setValue(updated)
+                            updated
+                        }
+                    )
+                }
+                .run()
+
+            first.get("counter") shouldBeEqualTo totalInvocations
+        } finally {
+            runCatching { first.clear() }
+            runCatching { first.close() }
+            runCatching { second.close() }
+        }
+    }
+
+    @Test
+    fun `invoke exception does not commit a partial entry update`() {
+        cache.put("key1", "original")
+
+        assertFailsWith<EntryProcessorException> {
+            cache.invoke(
+                "key1",
+                EntryProcessor<String, String, String> { entry: MutableEntry<String, String>, _: Array<out Any?> ->
+                    entry.setValue("transient")
+                    error("processor failed")
+                }
+            )
+        }
+
+        cache.get("key1") shouldBeEqualTo "original"
+    }
+
+    @Test
+    fun `invokeAll keeps per key result and exception contracts`() {
+        cache.putAll(mapOf("ok" to "value", "bad" to "value").toMutableMap())
+
+        val results = cache.invokeAll(
+            setOf("ok", "bad"),
+            EntryProcessor<String, String, String> { entry: MutableEntry<String, String>, _: Array<out Any?> ->
+                if (entry.key == "bad") error("bad entry")
+                val updated = entry.value + "-updated"
+                entry.setValue(updated)
+                updated
+            }
+        )
+
+        results["ok"]?.get() shouldBeEqualTo "value-updated"
+        assertFailsWith<EntryProcessorException> { results["bad"]?.get() }
+        cache.get("ok") shouldBeEqualTo "value-updated"
+        cache.get("bad") shouldBeEqualTo "value"
+    }
+
+    @Test
+    fun `invoke refreshes ttl and dispatches updated listener event`() {
+        val ttlCache = manager.createCache(
+            "invoke-ttl-" + UUID.randomUUID().toString().take(8),
+            lettuceCacheConfigOf<String, String>(ttlSeconds = 60)
+        ) as LettuceJCache<String, String>
+        val updatedEvents = CopyOnWriteArrayList<String>()
+        val listener = object : CacheEntryUpdatedListener<String, String> {
+            override fun onUpdated(events: Iterable<CacheEntryEvent<out String, out String>>) {
+                events.forEach { event -> updatedEvents += "${event.key}:${event.value}" }
+            }
+        }
+
+        try {
+            ttlCache.registerCacheEntryListener(
+                MutableCacheEntryListenerConfiguration({ listener }, null, false, true)
+            )
+            ttlCache.put("key1", "value1")
+            updatedEvents.clear()
+
+            ttlCache.invoke(
+                "key1",
+                EntryProcessor<String, String, String> { entry: MutableEntry<String, String>, _: Array<out Any?> ->
+                    val updated = entry.value + "-updated"
+                    entry.setValue(updated)
+                    updated
+                }
+            )
+
+            ttlCache.get("key1") shouldBeEqualTo "value1-updated"
+            updatedEvents shouldBeEqualTo listOf("key1:value1-updated")
+            RedisServers.redisClient.connect(StringCodec.UTF8).use { connection ->
+                (connection.sync().ttl(ttlCache.name) > 0L).shouldBeTrue()
+            }
+        } finally {
+            runCatching { ttlCache.close() }
+        }
+    }
+
+    private fun standaloneCache(mapName: String): LettuceJCache<String, Int> {
+        val connection = RedisServers.redisClient.connect(LettuceCacheManager.STRING_BYTES_CODEC)
+        val map = LettuceMap<ByteArray>(connection, mapName)
+        val configuration = lettuceCacheConfigOf<String, Int>(codec = LettuceBinaryCodecs.lz4Fory<Int>())
+        return LettuceJCache(
+            map = map,
+            codec = LettuceBinaryCodecs.lz4Fory<Int>(),
+            cacheManager = manager as LettuceCacheManager,
+            configuration = configuration,
+            closeResource = { connection.close() },
+        )
     }
 
     @Test

--- a/docs/lessons/2026-08-15-issue-1348-lettuce-entryprocessor-atomicity.md
+++ b/docs/lessons/2026-08-15-issue-1348-lettuce-entryprocessor-atomicity.md
@@ -1,0 +1,51 @@
+# Issue #1348 — LettuceJCache EntryProcessor 원자성
+
+## 배경
+
+`LettuceJCache.invoke`는 `MutableEntry`를 Redis hash에서 읽은 뒤 프로세서가
+종료되면 별도의 `HSET` 또는 `HDEL`로 커밋했습니다. 서로 다른 Lettuce 연결이
+같은 키를 동시에 갱신하면 두 호출이 같은 값을 읽고 마지막 쓰기가 앞선 갱신을
+덮어쓰는 lost update가 발생했습니다. 기존 README의 `invoke`/`invokeAll` 미지원
+문구도 실제 구현과 맞지 않았습니다.
+
+## 결정
+
+이번 stacked train의 PR B는 PR A `#1432`의 exact head 위에 다음 계약을 고정합니다.
+
+- `LettuceMap`에 token-safe `SET NX PX` 분산 락과 소유 토큰 검증 Lua 해제를 추가합니다.
+- 같은 `mapKey`를 사용하는 `LettuceJCache`의 변경 작업은 하나의 락 구간에서
+  실행합니다. `invoke`는 프로세서 실행과 `MutableEntry` 커밋을 같은 구간에 둡니다.
+- 프로세서가 예외를 던지면 커밋하지 않습니다. `invokeAll`은 키별 원자성과
+  `EntryProcessorResult`별 성공/실패를 유지하며 전체 키 집합 트랜잭션은 약속하지 않습니다.
+- 커밋은 기존 TTL과 listener event 계약을 유지합니다. Redis 8 `HSETEX` 경로에서도
+  JCache가 약속한 hash-level TTL을 다시 적용합니다.
+
+락 lease는 기본 1분, 획득 대기는 기본 5분이며, lease는 프로세서가 중단된 경우의
+복구 상한입니다. 프로세서는 lease 안에 완료되어야 합니다.
+
+## 검증
+
+- RED: Ryuk 비활성화 조건에서 독립 연결 2개가 80회 동시 증가를 수행했을 때
+  기존 구현은 `11`로 종료되어 `80`을 충족하지 못했습니다.
+- GREEN: 같은 테스트가 분산 락 적용 후 `80`을 기록했습니다.
+- 회귀 테스트: 프로세서 예외 시 원래 값 보존, `invokeAll` 키별 결과/예외,
+  TTL 갱신, `CacheEntryUpdatedListener` 이벤트를 추가했습니다.
+- 일반 Testcontainers 실행은 Colima Ryuk 소켓 마운트 오류로 시작하지 못했고,
+  `TESTCONTAINERS_RYUK_DISABLED=true` 조건에서 전체 모듈 테스트를 재실행했습니다.
+
+## 후속 guard
+
+분산 락의 lease 만료 전파, 프로세서 실행 시간 정책, Redis Cluster hash-tag
+키 전략을 별도 이슈에서 검토합니다. `invokeAll` 전체 집합 원자성이 필요한 사용자는
+키별 결과 계약과 다른 API 경계를 사용해야 합니다.
+
+## Stacked PR Train
+
+```text
+develop
+└─ PR A #1432 / Issue #1426
+   └─ PR B #1348 (현재 문서)
+```
+
+PR B는 PR A가 병합되기 전까지 `fix/1426-nearcache-observation`을 base로 유지하며,
+두 PR의 병합은 별도 exact-head CI와 승인 게이트를 통과한 뒤에만 수행합니다.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMap.kt
@@ -4,11 +4,14 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.HSetExArgs
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.locks.LockSupport
 
 /**
  * Lettuce Redis 클라이언트를 이용한 분산 Map(Distributed Map) 구현체입니다.
@@ -40,7 +43,13 @@ open class LettuceMap<V: Any>(
     val mapKey: String,
     val supportsHSetEx: Boolean = false,
 ) {
-    companion object: KLogging()
+    companion object: KLogging() {
+        private const val LOCK_SUFFIX = ":__bluetape4k:lock"
+        private const val LOCK_RETRY_DELAY_MILLIS = 50L
+        private const val LOCK_RETRY_DELAY_NANOS = LOCK_RETRY_DELAY_MILLIS * 1_000_000L
+        private const val RELEASE_LOCK_SCRIPT =
+            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
+    }
 
     init {
         mapKey.requireNotBlank("mapKey")
@@ -233,6 +242,77 @@ open class LettuceMap<V: Any>(
         val count = syncCommands.del(mapKey)
         log.debug { "LettuceMap clear: mapKey=$mapKey" }
         return count
+    }
+
+    /**
+     * Hash 전체에 TTL을 적용합니다.
+     *
+     * [putTtl]이 Redis 8의 HSETEX 경로를 선택하면 field TTL만 갱신하므로,
+     * hash 키 수명 계약을 사용하는 상위 캐시가 필요할 때 이 메서드를 함께 호출합니다.
+     */
+    fun refreshTtl(ttl: Duration?) {
+        if (ttl != null) syncCommands.expire(mapKey, ttl)
+    }
+
+    /**
+     * Redis `SET NX PX` 기반 분산 락을 획득한 동안 [block]을 실행합니다.
+     *
+     * 락 키는 Hash 키와 분리되며, [token]과 일치할 때만 Lua 스크립트로 해제합니다.
+     * 따라서 서로 다른 Lettuce 연결을 사용하는 호출도 같은 [mapKey] 범위에서
+     * read-modify-write 구간을 직렬화할 수 있습니다. [leaseTime]은 호출자가 장애로
+     * 중단된 경우를 위한 상한이므로, 블록 실행 시간보다 충분히 길게 설정해야 합니다.
+     *
+     * @param token 호출마다 새로 생성해야 하는 락 소유 토큰
+     * @param leaseTime 락 자동 만료 시간 (기본 1분)
+     * @param waitTime 락 획득을 기다리는 최대 시간 (기본 5분)
+     * @param block 락을 보유한 상태에서 실행할 작업
+     * @return [block]의 반환 값
+     * @throws IllegalStateException [waitTime] 안에 락을 획득하지 못한 경우
+     */
+    fun <R> withDistributedLock(
+        token: V,
+        leaseTime: Duration = Duration.ofMinutes(1),
+        waitTime: Duration = Duration.ofMinutes(5),
+        block: () -> R,
+    ): R {
+        require(!leaseTime.isNegative && !leaseTime.isZero && leaseTime.toMillis() > 0) {
+            "leaseTime은 양수여야 합니다."
+        }
+        require(!waitTime.isNegative) {
+            "waitTime은 음수가 될 수 없습니다."
+        }
+
+        val lockKey = "$mapKey$LOCK_SUFFIX"
+        val deadline = System.nanoTime() + waitTime.toNanos()
+        val leaseMillis = leaseTime.toMillis()
+        val lockArgs = SetArgs().nx().px(leaseMillis)
+
+        while (syncCommands.set(lockKey, token, lockArgs) == null) {
+            if (System.nanoTime() >= deadline) {
+                throw IllegalStateException("LettuceMap[$mapKey] 분산 락 획득 시간이 초과되었습니다.")
+            }
+            LockSupport.parkNanos(LOCK_RETRY_DELAY_NANOS)
+        }
+
+        val blockResult = runCatching(block)
+        val releaseFailure = runCatching { releaseDistributedLock(lockKey, token) }.exceptionOrNull()
+        if (releaseFailure != null) {
+            blockResult.exceptionOrNull()?.addSuppressed(releaseFailure)
+                ?: throw releaseFailure
+        }
+        return blockResult.getOrThrow()
+    }
+
+    private fun releaseDistributedLock(lockKey: String, token: V) {
+        val released = syncCommands.eval<Long>(
+            RELEASE_LOCK_SCRIPT,
+            ScriptOutputType.INTEGER,
+            arrayOf(lockKey),
+            token,
+        )
+        check(released == 1L) {
+            "LettuceMap[$mapKey] 분산 락 해제에 실패했습니다. 토큰이 만료되었거나 소유자가 아닙니다."
+        }
     }
 
     /**

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.lettuce.core.codec.StringCodec
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
@@ -14,6 +15,7 @@ import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
 class LettuceMapTest: AbstractLettuceTest() {
 
@@ -135,6 +137,30 @@ class LettuceMapTest: AbstractLettuceTest() {
 
         map.clear() shouldBeEqualTo 1L
         map.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `withDistributedLock - 같은 mapKey의 연결 간 임계 구간을 직렬화`() {
+        val secondConnection = LettuceTestUtils.client.connect(StringCodec.UTF8)
+        val secondMap = LettuceMap<String>(secondConnection, map.mapKey)
+
+        try {
+            map.withDistributedLock("owner-1", waitTime = Duration.ZERO) {
+                assertFailsWith<IllegalStateException> {
+                    secondMap.withDistributedLock(
+                        token = "owner-2",
+                        waitTime = Duration.ofMillis(100),
+                    ) { }
+                }
+            }
+
+            secondMap.withDistributedLock("owner-2", waitTime = Duration.ofSeconds(1)) {
+                secondMap.put("field", "value")
+            }
+            map.get("field") shouldBeEqualTo "value"
+        } finally {
+            secondConnection.close()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1348

`LettuceJCache`의 `EntryProcessor` read-modify-write가 서로 다른 Lettuce 연결에서 lost update를 만들지 않도록 분산 원자성 계약을 고정합니다. 구현, 테스트, TTL/listener 동작, README를 같은 계약으로 정렬합니다.

## Background

Issue #1348는 기존 README의 `invoke`/`invokeAll` 미지원 설명과 실제 API 동작의 불일치, 그리고 여러 클라이언트가 같은 키를 동시에 갱신할 때의 원자성 미검증을 다룹니다. 이 PR은 stacked train의 PR B이며 PR A #1432의 exact head 위에 쌓입니다.

## What This Solves

- 같은 cache name을 공유하는 연결 간 `invoke` lost update를 방지합니다.
- 프로세서 예외 시 부분 커밋 없이 원래 값을 보존하고, `invokeAll`의 키별 성공·실패 결과를 유지합니다.
- `HSETEX` 경로의 hash-level TTL과 cache entry listener 이벤트를 문서·테스트와 일치시킵니다.

## Work Done

- `LettuceMap`에 token-safe `SET NX PX` 분산 락과 소유 토큰 검증 Lua 해제를 추가했습니다.
- `LettuceJCache`의 변경 작업과 `invoke` 프로세서·커밋을 같은 락 구간으로 직렬화하고, `invokeAll`은 키별 원자 구간으로 유지했습니다.
- 동시 증가, 예외 격리, 키별 `invokeAll`, TTL/listener, 연결 간 락 회귀 테스트와 영문·국문 README 및 lesson을 추가했습니다.

## Validation

- `TESTCONTAINERS_RYUK_DISABLED=true ./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`: PASS (448 tests)
- `TESTCONTAINERS_RYUK_DISABLED=true ./gradlew :bluetape4k-lettuce:test --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`: PASS (871 tests)
- `./gradlew :bluetape4k-lettuce:detekt :bluetape4k-cache-lettuce:detekt --no-configuration-cache --no-build-cache --rerun-tasks --max-workers=1`: PASS (기존 진단만 남음)
- `git diff --check`: PASS
- RED/GREEN concurrency: PASS (기존 11/80, 수정 후 80/80)

## Review Notes

- P0/P1: 0
- P2/P3: 분산 락 lease 연장·Redis Cluster hash-tag 정책은 후속 이슈로 분리했습니다.
- Review evidence: 로컬 Kotlin/정적 분석/회귀 테스트, lesson, PR live read-back(`reviews=0`, `comments=0`, `reviewDecision` empty, `MERGEABLE`)
- 일반 Testcontainers 경로는 Colima Ryuk 소켓 마운트 오류로 시작하지 못해 Ryuk 비활성화 조건의 결과를 별도 증적으로 남겼습니다.

## Metadata

- Issue: #1348, milestone `1.13.0`, assignee `debop`, labels `bug`, `tech-debt`, `cache`
- PR: #1433, base `develop` at `0b56ff58fafe819d34a4df43b42c5dd7a4bc5fbc`, head `513f70e785ea6975fc150844b6b8f23b9238031c`, milestone `1.13.0`, assignee `debop`
- Stack: PR A #1432는 merge commit `0b56ff58fafe819d34a4df43b42c5dd7a4bc5fbc`로 `develop`에 반영됐고, 이 PR은 `develop`로 자동 retarget됐으며 head `513f70e785ea6975fc150844b6b8f23b9238031c`를 유지
- CI: [workflow run 31933172397](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/31933172397) — PR A 머지 후 `develop` base에서 exact head 18/18 job success, `Coverage Report`와 final `CI Status` 성공.

## DoD Status

Required checks: 15/18; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 - Authority | 현재 AGENTS/skill/plan과 승인된 PR B 범위를 재확인 | PASS | `/Users/debop/.codex/AGENTS.md`, workspace/repo AGENTS, approved #1348 train | 없음 |
| CG-02 - Historical/current evidence | Issue #1348 및 PR A #1432 live metadata를 확인 | PASS | `gh issue view 1348`, `gh pr view 1432` | 없음 |
| CG-03 - Worktree boundary | 독립 `fix/...` worktree와 PR A base를 사용 | PASS | child worktree status, branch, base `fix/1426-nearcache-observation` | 없음 |
| CG-04 - Policy/language | Kotlin API·README·lesson·GitHub Korean 정책 적용 | PASS | workspace/repo AGENTS와 변경 diff | 없음 |
| CG-05 - Patterns | 기존 `LettuceMap`, JCache TTL/listener 패턴 재사용 | PASS | repo search 및 Kotlin pattern skill | 없음 |
| CG-06 - Public/docs contract | API 동작·README locale·lesson parity 고정 | PASS | 변경된 README 2종과 lesson | 없음 |
| CG-07 - Targeted proof | RED/GREEN, targeted tests, detekt 실행 | PASS | 위 Validation와 workflow check evidence | 없음 |
| CG-08 - Serialized heavyweight checks | Testcontainers 검증을 순차 실행 | PASS | Ryuk-disabled sequential module runs; original Ryuk failure retained | 없음 |
| CG-09 - Lesson | 재사용 가능한 실패·복구·설계 교훈을 커밋 | PASS | `docs/lessons/2026-08-15-issue-1348-lettuce-entryprocessor-atomicity.md` | 없음 |
| CG-10 - Pre-PR convergence | diff check, P0/P1 수렴, exact commit 생성 | PASS | commit `513f70e785ea6975fc150844b6b8f23b9238031c` | 없음 |
| CG-11 - PR authority | 승인된 repository/base/head로 PR 생성 | PASS | `bluetape4k/bluetape4k-projects`, base `fix/1426-nearcache-observation`, head branch | 없음 |
| CG-12 - Exact head publication | exact commit을 force 없이 push | PASS | remote branch head `513f70e785ea6975fc150844b6b8f23b9238031c` | 없음 |
| CG-12A - Guidance refresh | PR 직전 AGENTS, leaf, common gates, template, Issue #1348를 재독 | PASS | current path/content snapshot과 live issue metadata | drift 없음 |
| CG-13 - PR create/read-back | PR을 만들고 retarget 후 base/head/metadata/body를 live 검증 | PASS | PR #1433, base `develop` at `0b56ff58…`, exact head `513f70e785ea6975fc150844b6b8f23b9238031c`, final `## DoD Status` | 없음 |
| CG-14 - CI/review | 새 `develop` base에서 exact head CI와 최신 review/thread를 확인 | PASS | [run 31933172397](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/31933172397) 18/18 success; `Coverage Report`, `CI Status` success; unresolved thread 0, `MERGEABLE` | 없음 |
| CG-15 - Merge-ready report | counts와 exact head를 보고 | PASS | PR #1433 exact head `513f70e785ea6975fc150844b6b8f23b9238031c`, Required checks 15/18, Blocked 0 | CG-16 fresh merge approval 대기 |
| CG-16 - Fresh merge approval | exact head에 대한 새 merge 승인 | PENDING | 별도 사용자 승인 필요 | 머지하지 않고 대기 |
| CG-17 - Merge | 승인 후 merge 실행·검증 | PENDING | 현재 범위 밖 | CG-16 이후에만 실행 |
| CG-18 - Sync/cleanup | 병합 후 sync·proof-gated cleanup | PENDING | 현재 범위 밖 | CG-17 이후에만 실행 |

Final status: PENDING — CG-16 exact-head merge approval 대기

Unchecked required items: CG-16, CG-17, CG-18
