### PR TITLE
[cache][security] NearJCache shared back clear 권한을 명시적 owner 경계로 제한한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - `HazelcastNearJCache(...)` 공개 factory가 Hazelcast JCache listener 직렬화 경계를 넘지 않도록 listener-free degraded 경로를 사용한다. read-through와 write-through는 유지하지만 peer front-cache propagation은 보장하지 않는다
   ([#1411](https://github.com/bluetape4k/bluetape4k-projects/issues/1411)).
+- `NearJCache`의 namespace-wide `clear()`, `clearAllCache()`, 인자 없는 `removeAll()`을 기본 `NearJCacheClearAuthority.DENY`로 fail-closed 처리하고, back namespace 독점 소유를 확인한 caller만 `EXCLUSIVE_BACK_CACHE`로 opt-in하도록 했다. key-scoped removal은 유지하며 runtime-only 권한은 `NearJCacheConfig` 직렬화에 포함하지 않는다. 기존 destructive clear 호출자는 명시적 owner overload로 전환해야 한다
+  ([#1368](https://github.com/bluetape4k/bluetape4k-projects/issues/1368)).
 - Maven Central에 없는 benchmark 또는 application 전용 모듈이 BOM에 포함되지 않도록 publication과 BOM module classifier를 통일했다. 생성한 BOM inventory와 publication POM inventory가 다르면 publication validation이 실패한다
   ([#1313](https://github.com/bluetape4k/bluetape4k-projects/issues/1313)).
 - Java platform은 library publication 설정 밖에 두되 `Bluetape4k` publication을 NMCP aggregate에 포함했다. 따라서 snapshot과 stable bundle은 74개 publishable library module과 함께 BOM을 포함한다

--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -107,8 +107,17 @@ val value = memo("recover")      // 새로 계산하여 7 반환
 관찰합니다. `get`, `containsKey`, `getAll`은 front를 먼저 확인하고 miss이면
 back을 조회하며 두 계층에서 찾은 값을 모두 반환합니다. bulk back hit의 front
 residency는 아래 설정 정책을 따릅니다. `clear`는 해당 wrapper가
-소유한 front와 back의 매핑을 함께 삭제합니다. 기존 `getDeeply`와
-`clearAllCache` 이름은 각각 표준 `get`과 `clear`의 소스 호환 alias로 유지됩니다.
+소유한 front와 back의 매핑을 함께 삭제합니다. 기존 생성자와 provider factory는
+`NearJCacheClearAuthority.DENY`를 사용하므로 `clear()`, `clearAllCache()`, 인자 없는
+`removeAll()`은 어느 계층도 바꾸기 전에 `SecurityException`으로 실패합니다. back
+namespace를 독점한다고 확인한 caller만 `NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE`를
+명시적으로 선택해야 합니다. key 범위를 받는 `removeAll(keys)`와 단일 key `remove`는
+이 권한 없이도 사용할 수 있습니다. 이 권한은 runtime-only이며 `NearJCacheConfig`
+직렬화에 포함되지 않습니다. `nearCache.backCache.clear()` 같은 provider 직접 호출은
+이 wrapper guard 밖의 caller-owned escape hatch이므로 권한 없는 코드에 back-cache
+reference를 전달하지 마세요. `ResilientNearJCache`와 `ResilientSuspendNearJCache`의
+`ClearBack` 경로는 이번 계약 범위가 아닙니다. 기존 `getDeeply`와 `clearAllCache`
+이름은 각각 표준 `get`과 `clear`의 소스 호환 alias로 유지됩니다.
 
 <!-- issue-1369-bulk-policy:start -->
 ### Bulk `getAll` 결과의 front 저장 정책
@@ -195,6 +204,7 @@ credential, token, 개인정보를 넣지 않습니다.
 
 ```kotlin
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheConfigurationMXBean
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheTierStatisticsMXBean
@@ -211,7 +221,12 @@ val configuration = MutableConfiguration<String, String>()
     .setStoreByValue(false)
 val front = manager.createCache("orders-front", configuration)
 val back = manager.createCache("orders-back", configuration)
-val nearCache = NearJCache(front, back, NearJCacheConfig(frontCacheConfiguration = configuration))
+val nearCache = NearJCache(
+    front,
+    back,
+    NearJCacheConfig(frontCacheConfiguration = configuration),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
 val server = ManagementFactory.getPlatformMBeanServer()
 val registration = nearCache.registerMBeans(server, "orders-service", "orders-v1")
 val names = registration.activeObjectNames.associateBy { it.getKeyProperty("type") }
@@ -251,6 +266,27 @@ cache, cache manager, provider는 소유하지 않습니다. Handle이 활성인
 JMX compare-and-swap은 아닙니다. Rollout 분류와 cleanup 증거는
 [운영 가이드](../../docs/operations/issue-1351-nearcache-management.md)를 따릅니다.
 <!-- issue-1351-nearcache-management:end -->
+
+<!-- nearjcache-clear-authority-contract -->
+### #1368 shared-back clear authority
+
+기본 wrapper는 공유 back namespace에서 안전하게 동작합니다. tenant가 소유한 key
+목록은 key-scoped removal로 처리하고, namespace-wide clear는 독점 소유를 확인한
+caller만 명시적으로 선택합니다. 이 enum은 runtime-only이며 직렬화되는
+`NearJCacheConfig`를 바꾸지 않습니다.
+
+```kotlin
+val shared = NearJCache(front, back, NearJCacheConfig(), NearJCacheClearAuthority.DENY)
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = NearJCache(
+    front,
+    back,
+    NearJCacheConfig(),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
+owner.clearAllCache()
+```
+<!-- /nearjcache-clear-authority-contract -->
 
 ##### SuspendJCache 인터페이스
 

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -60,8 +60,18 @@ Standard `get`, `containsKey`, and `getAll` check the front cache first, fall
 back to the back cache on a miss, and return every hit from both tiers. Front
 residency for bulk back hits follows the configured policy described below.
 Standard `clear` removes mappings from both layers owned by the wrapper. The
-`getDeeply` and `clearAllCache` names remain source-compatible aliases for the
-standard `get` and `clear` behavior.
+legacy constructors and provider factories use
+`NearJCacheClearAuthority.DENY`, so `clear()`, `clearAllCache()`, and no-argument
+`removeAll()` fail with `SecurityException` before mutating either tier. A caller
+that has verified exclusive ownership of the back namespace must opt in with
+`NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE`; key-scoped `removeAll(keys)` and
+single-key `remove` remain available without that authority. The authority is
+runtime-only and is not part of `NearJCacheConfig` serialization. A direct
+`nearCache.backCache.clear()` call is a caller-owned escape hatch outside this
+wrapper guard, so do not pass the back-cache reference to untrusted code. The
+`ResilientNearJCache` and `ResilientSuspendNearJCache` `ClearBack` paths are not
+covered by this contract. The `getDeeply` and `clearAllCache` names remain
+source-compatible aliases for the standard `get` and `clear` behavior.
 
 <!-- issue-1369-bulk-policy:start -->
 ### Bulk `getAll` front residency policy
@@ -156,6 +166,7 @@ personal data.
 
 ```kotlin
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheConfigurationMXBean
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheTierStatisticsMXBean
@@ -172,7 +183,12 @@ val configuration = MutableConfiguration<String, String>()
     .setStoreByValue(false)
 val front = manager.createCache("orders-front", configuration)
 val back = manager.createCache("orders-back", configuration)
-val nearCache = NearJCache(front, back, NearJCacheConfig(frontCacheConfiguration = configuration))
+val nearCache = NearJCache(
+    front,
+    back,
+    NearJCacheConfig(frontCacheConfiguration = configuration),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
 val server = ManagementFactory.getPlatformMBeanServer()
 val registration = nearCache.registerMBeans(server, "orders-service", "orders-v1")
 val names = registration.activeObjectNames.associateBy { it.getKeyProperty("type") }
@@ -215,6 +231,27 @@ token is a best-effort stale-owner defense, not an atomic JMX compare-and-swap.
 See the [operations guide](../../docs/operations/issue-1351-nearcache-management.md)
 for rollout classification and cleanup evidence.
 <!-- issue-1351-nearcache-management:end -->
+
+<!-- nearjcache-clear-authority-contract -->
+### #1368 shared-back clear authority
+
+The default wrapper is safe for a shared back namespace. Use key-scoped removal
+for a tenant-owned key set; only an explicitly verified exclusive owner may use
+namespace-wide clear operations. The enum is runtime-only and does not change
+the serializable `NearJCacheConfig`.
+
+```kotlin
+val shared = NearJCache(front, back, NearJCacheConfig(), NearJCacheClearAuthority.DENY)
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = NearJCache(
+    front,
+    back,
+    NearJCacheConfig(),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
+owner.clearAllCache()
+```
+<!-- /nearjcache-clear-authority-contract -->
 
 ## Near-Cache Capability Matrix
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -87,6 +87,9 @@ data class BackCacheWriteCompletion(
  * @property frontCache 로컬 캐시 (예: Caffeine, Ehcache)
  * @property backCache 원격 캐시 (예: Redis, Hazelcast)
  * @property config NearCache 설정
+ * @property clearAuthority namespace-wide `clear()` 권한. 기존 생성 경로의 기본값은
+ *     [NearJCacheClearAuthority.DENY]이며, caller가 back namespace 독점을 확인한 경우에만
+ *     [NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE]를 명시합니다.
  *
  * @see NearJCacheConfig
  * @see io.bluetape4k.cache.jcache.JCacheEntryEventListener
@@ -96,10 +99,34 @@ class NearJCache<K: Any, V: Any> private constructor(
     val frontCache: JCache<K, V>,
     val backCache: JCache<K, V>,
     private val config: NearJCacheConfig<K, V>,
+    val clearAuthority: NearJCacheClearAuthority,
     timeSource: NearJCacheTimeSource,
 ): JCache<K, V> by backCache {
+
+    private constructor(
+        frontCache: JCache<K, V>,
+        backCache: JCache<K, V>,
+        config: NearJCacheConfig<K, V>,
+        timeSource: NearJCacheTimeSource,
+    ) : this(frontCache, backCache, config, NearJCacheClearAuthority.DENY, timeSource)
+
     internal val configurationSnapshot: NearJCacheConfigurationSnapshot
     internal val statisticsRecorder: NearJCacheStatisticsRecorder
+
+    /**
+     * Caller가 back namespace 독점 여부를 확인한 상태로 front/back wrapper를 생성합니다.
+     * [NearJCacheClearAuthority.DENY]는 namespace-wide clear를 fail-closed로 차단하며,
+     * [NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE]만 명시적으로 destructive clear를
+     * 허용합니다. 이 authority는 [NearJCacheConfig]에 저장되거나 직렬화되지 않습니다.
+     *
+     * @param clearAuthority namespace-wide destructive operation 권한
+     */
+    constructor(
+        frontCache: JCache<K, V>,
+        backCache: JCache<K, V>,
+        config: NearJCacheConfig<K, V>,
+        clearAuthority: NearJCacheClearAuthority,
+    ) : this(frontCache, backCache, config, clearAuthority, SystemNearJCacheTimeSource)
 
     constructor(
         frontCache: JCache<K, V>,
@@ -121,6 +148,7 @@ class NearJCache<K: Any, V: Any> private constructor(
             suppliedFront = config.frontCacheConfiguration,
             actualBack = backCache,
             bulkFrontPopulationPolicy = config.bulkFrontPopulationPolicy,
+            clearAuthority = clearAuthority,
         )
         statisticsRecorder = if (configurationSnapshot.statisticsEnabled) {
             ActiveNearJCacheStatisticsRecorder(timeSource)
@@ -136,7 +164,8 @@ class NearJCache<K: Any, V: Any> private constructor(
             backCache: JCache<K, V>,
             config: NearJCacheConfig<K, V>,
             timeSource: NearJCacheTimeSource,
-        ): NearJCache<K, V> = NearJCache(frontCache, backCache, config, timeSource)
+            clearAuthority: NearJCacheClearAuthority = NearJCacheClearAuthority.DENY,
+        ): NearJCache<K, V> = NearJCache(frontCache, backCache, config, clearAuthority, timeSource)
 
         /** Redis SCAN 명령의 배치 크기 */
         const val SCAN_BATCH_SIZE = 100L
@@ -160,6 +189,24 @@ class NearJCache<K: Any, V: Any> private constructor(
         operator fun <K: Any, V: Any> invoke(
             nearCacheCfg: NearJCacheConfig<K, V>,
             backCache: JCache<K, V>,
+        ): NearJCache<K, V> = invoke(nearCacheCfg, backCache, NearJCacheClearAuthority.DENY)
+
+        /**
+         * 명시적으로 back namespace 독점 권한을 전달해 NearJCache를 생성합니다.
+         *
+         * factory가 back cache를 생성하거나 재사용했다는 사실만으로 권한을 승격하지
+         * 않으며, caller가 [clearAuthority]를 직접 선택해야 합니다.
+         * `EXCLUSIVE_BACK_CACHE`를 선택하면 `clear()`, `clearAllCache()`, no-arg
+         * `removeAll()`이 이 wrapper의 front와 back namespace를 함께 삭제할 수 있습니다.
+         * key-scoped `removeAll(keys)`는 authority와 무관하게 사용할 수 있습니다.
+         *
+         * @param clearAuthority namespace-wide destructive operation 권한
+         */
+        @Suppress("TooGenericExceptionCaught")
+        operator fun <K: Any, V: Any> invoke(
+            nearCacheCfg: NearJCacheConfig<K, V>,
+            backCache: JCache<K, V>,
+            clearAuthority: NearJCacheClearAuthority,
         ): NearJCache<K, V> {
             require(!nearCacheCfg.frontCacheConfiguration.isStoreByValue) {
                 "NearJCache front cache must use store-by-reference; " +
@@ -174,7 +221,7 @@ class NearJCache<K: Any, V: Any> private constructor(
 
             log.info { "Create NearCache instance. config=$nearCacheCfg" }
             return try {
-                NearJCache(frontCache, backCache, nearCacheCfg).also {
+                NearJCache(frontCache, backCache, nearCacheCfg, clearAuthority).also {
                     it.registerBackCacheListener()
                 }
             } catch (e: Throwable) {
@@ -343,6 +390,7 @@ class NearJCache<K: Any, V: Any> private constructor(
 
     @Suppress("TooGenericExceptionCaught")
     override fun clear() {
+        requireClearAuthority("clear")
         compoundGate.withLock {
             val hadBackCacheListener = backCacheListener.get() != null
             detachBackCacheListener()
@@ -437,6 +485,7 @@ class NearJCache<K: Any, V: Any> private constructor(
      * ```
      */
     fun clearAllCache() {
+        requireClearAuthority("clearAllCache")
         log.debug {
             "front cache, back cache 모두 clear 합니다. 단 back cache 를 공유한 다른 near cache에는 전파되지 않습니다. " +
                     "전파를 위해서는 removeAll을 사용하세요"
@@ -920,6 +969,7 @@ class NearJCache<K: Any, V: Any> private constructor(
     }
 
     override fun removeAll() {
+        requireClearAuthority("removeAll")
         mutationGate.withLock {
             mutationEpoch.incrementAndGet()
             frontCache.removeAll()
@@ -930,6 +980,15 @@ class NearJCache<K: Any, V: Any> private constructor(
                     .flatMap { chunk -> removeBackCacheEntries(chunk.map { it.key }) }
                 throwIfFailures("removeAll", failures)
             }
+        }
+    }
+
+    private fun requireClearAuthority(operation: String) {
+        if (clearAuthority == NearJCacheClearAuthority.DENY) {
+            throw SecurityException(
+                "NearJCache operation=$operation requires clearAuthority=EXCLUSIVE_BACK_CACHE; " +
+                        "configured authority=DENY"
+            )
         }
     }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheClearAuthority.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheClearAuthority.kt
@@ -1,0 +1,16 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+/**
+ * 공유될 수 있는 back namespace 전체 삭제에 대한 runtime 권한입니다.
+ *
+ * 이 값은 [NearJCacheConfig]에 포함되지 않으며 직렬화되는 설정이나 provider
+ * ownership을 나타내지 않습니다. `EXCLUSIVE_BACK_CACHE`는 caller가 back cache
+ * namespace를 독점적으로 관리한다는 명시적 판단일 때만 선택해야 합니다.
+ */
+enum class NearJCacheClearAuthority {
+    /** `clear()` 계열의 namespace-wide destructive operation을 거부합니다. */
+    DENY,
+
+    /** caller가 back cache namespace를 독점한다고 명시한 경우에만 허용합니다. */
+    EXCLUSIVE_BACK_CACHE,
+}

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheConfigurationMXBean.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheConfigurationMXBean.kt
@@ -21,4 +21,7 @@ interface NearJCacheConfigurationMXBean: CacheMXBean {
 
     /** bulk front population에 허용되는 최대 entry 수를 반환하며, 적용 불가이면 `0`입니다. */
     fun getBulkFrontPopulationMaximumEntryCount(): Int
+
+    /** namespace-wide clear 권한을 stable token으로 반환하며, 기존 구현의 기본값은 `DENY`입니다. */
+    fun getClearAuthority(): String = "DENY"
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheConfigurationSnapshot.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheConfigurationSnapshot.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.cache.nearcache.jcache.management
 
 import io.bluetape4k.cache.nearcache.jcache.BulkFrontPopulationPolicy
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import javax.cache.Cache
 import javax.cache.configuration.CompleteConfiguration
 import javax.cache.configuration.Configuration
@@ -25,6 +26,7 @@ internal data class NearJCacheConfigurationSnapshot(
     val managementEnabled: Boolean,
     val bulkFrontPopulationPolicy: String,
     val bulkFrontPopulationMaximumEntryCount: Int,
+    val clearAuthority: String = NearJCacheClearAuthority.DENY.name,
 )
 
 /**
@@ -38,6 +40,7 @@ internal fun nearJCacheConfigurationSnapshot(
     suppliedFront: Configuration<*, *>,
     actualBack: Cache<*, *>,
     bulkFrontPopulationPolicy: BulkFrontPopulationPolicy,
+    clearAuthority: NearJCacheClearAuthority = NearJCacheClearAuthority.DENY,
 ): NearJCacheConfigurationSnapshot {
     val actualFrontConfiguration = actualFront.configurationOrNull()
     val (typePair, source, exact) = sequenceOf(
@@ -76,6 +79,7 @@ internal fun nearJCacheConfigurationSnapshot(
         managementEnabled = completeConfiguration?.isManagementEnabled ?: false,
         bulkFrontPopulationPolicy = bulkFrontPopulationMetadata.policy,
         bulkFrontPopulationMaximumEntryCount = bulkFrontPopulationMetadata.maximumEntryCount,
+        clearAuthority = clearAuthority.name,
     )
 }
 

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt
@@ -35,6 +35,8 @@ class NearJCacheManagementMXBean private constructor(
     override fun getBulkFrontPopulationMaximumEntryCount(): Int =
         snapshot.bulkFrontPopulationMaximumEntryCount
 
+    override fun getClearAuthority(): String = snapshot.clearAuthority
+
     override fun isReadThrough(): Boolean = snapshot.readThrough
 
     override fun isWriteThrough(): Boolean = snapshot.writeThrough

--- a/cache/cache-core/src/test/java/io/bluetape4k/cache/nearcache/jcache/LegacyNearJCacheConfigurationMXBean.java
+++ b/cache/cache-core/src/test/java/io/bluetape4k/cache/nearcache/jcache/LegacyNearJCacheConfigurationMXBean.java
@@ -1,0 +1,66 @@
+package io.bluetape4k.cache.nearcache.jcache;
+
+import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheConfigurationMXBean;
+
+/**
+ * 기존 consumer가 컴파일한 configuration MXBean 구현체를 흉내 내는 fixture입니다.
+ *
+ * 새 getter를 구현하지 않아도 Kotlin JVM default method가 기본 토큰을 제공해야 합니다.
+ */
+public final class LegacyNearJCacheConfigurationMXBean implements NearJCacheConfigurationMXBean {
+
+    @Override
+    public String getKeyType() {
+        return String.class.getName();
+    }
+
+    @Override
+    public String getValueType() {
+        return String.class.getName();
+    }
+
+    @Override
+    public boolean isReadThrough() {
+        return false;
+    }
+
+    @Override
+    public boolean isWriteThrough() {
+        return false;
+    }
+
+    @Override
+    public boolean isStoreByValue() {
+        return true;
+    }
+
+    @Override
+    public boolean isStatisticsEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isManagementEnabled() {
+        return false;
+    }
+
+    @Override
+    public String getTypeResolutionSource() {
+        return "legacy-fixture";
+    }
+
+    @Override
+    public boolean isTypeResolutionExact() {
+        return false;
+    }
+
+    @Override
+    public String getBulkFrontPopulationPolicy() {
+        return "DISABLED";
+    }
+
+    @Override
+    public int getBulkFrontPopulationMaximumEntryCount() {
+        return 0;
+    }
+}

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheClearAuthorityContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheClearAuthorityContractTest.kt
@@ -1,0 +1,108 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheManagementMXBean
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import javax.cache.Cache
+
+class NearJCacheClearAuthorityContractTest {
+
+    @Test
+    fun `기존 direct constructor는 namespace-wide clear를 기본 거부하고 mutation 전에 실패한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val cacheName = "near-jcache-authority-contract"
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(cacheName = cacheName),
+        )
+
+        listOf(
+            "clear" to { nearCache.clear() },
+            "clearAllCache" to { nearCache.clearAllCache() },
+            "removeAll" to { nearCache.removeAll() },
+        ).forEach { (operation, invoke) ->
+            val error = assertFailsWith<SecurityException> { invoke() }
+
+            error.message.orEmpty().contains(operation).shouldBeEqualTo(true)
+            error.message.orEmpty().contains("DENY").shouldBeEqualTo(true)
+            error.message.orEmpty().contains(cacheName).shouldBeEqualTo(false)
+            verify(exactly = 0) { frontCache.clear() }
+            verify(exactly = 0) { frontCache.removeAll() }
+            verify(exactly = 0) { backCache.clear() }
+            verify(exactly = 0) { backCache.remove(any()) }
+        }
+    }
+
+    @Test
+    fun `기존 config factory도 기본 DENY를 유지한다`() {
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val nearCache = NearJCache(
+            nearCacheCfg = NearJCacheConfig(cacheName = "near-jcache-default-factory"),
+            backCache = backCache,
+        )
+
+        assertFailsWith<SecurityException> { nearCache.clear() }
+
+        verify(exactly = 0) { backCache.clear() }
+    }
+
+    @Test
+    fun `explicit exclusive owner는 세 namespace-wide operation을 수행한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.iterator() } returns mutableListOf<Cache.Entry<String, String>>().iterator()
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+            clearAuthority = NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+        )
+
+        nearCache.clear()
+        nearCache.clearAllCache()
+        nearCache.removeAll()
+
+        verify(exactly = 2) { frontCache.clear() }
+        verify(exactly = 1) { frontCache.removeAll() }
+        verify(exactly = 2) { backCache.clear() }
+    }
+
+    @Test
+    fun `key-scoped removeAll은 DENY에서도 기존 범위로 동작한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        nearCache.removeAll(setOf("key"))
+
+        verify(exactly = 1) { frontCache.removeAll(setOf("key")) }
+        verify(exactly = 1) { backCache.remove("key") }
+    }
+
+    @Test
+    fun `management snapshot은 authority를 stable token으로 노출한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val denied = NearJCache(frontCache, backCache, NearJCacheConfig())
+        val exclusive = NearJCache(
+            frontCache,
+            backCache,
+            NearJCacheConfig(),
+            NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+        )
+
+        NearJCacheManagementMXBean(denied).getClearAuthority() shouldBeEqualTo "DENY"
+        NearJCacheManagementMXBean(exclusive).getClearAuthority() shouldBeEqualTo "EXCLUSIVE_BACK_CACHE"
+    }
+}

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfigCompatibilityTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConfigCompatibilityTest.kt
@@ -25,9 +25,16 @@ class NearJCacheConfigCompatibilityTest {
     @Test
     fun `NearJCache와 management bean의 public constructor ABI를 유지한다`() {
         val publicConstructors = NearJCache::class.java.constructors.filterNot { it.isSynthetic }
-        publicConstructors.size shouldBeEqualTo 1
-        publicConstructors.single().parameterTypes.toList() shouldBeEqualTo
-            listOf(Cache::class.java, Cache::class.java, NearJCacheConfig::class.java)
+        publicConstructors.size shouldBeEqualTo 2
+        publicConstructors.map { it.parameterTypes.toList() }.toSet() shouldBeEqualTo setOf(
+            listOf(Cache::class.java, Cache::class.java, NearJCacheConfig::class.java),
+            listOf(
+                Cache::class.java,
+                Cache::class.java,
+                NearJCacheConfig::class.java,
+                NearJCacheClearAuthority::class.java,
+            ),
+        )
         NearJCacheManagementMXBean::class.java.getConstructor(NearJCache::class.java).shouldNotBeNull()
         NearJCacheConfigurationMXBean::class.java
             .getMethod("getBulkFrontPopulationPolicy")
@@ -45,6 +52,11 @@ class NearJCacheConfigCompatibilityTest {
         NearJCacheStatisticsMXBean::class.java
             .getMethod("addRemovals", Long::class.javaPrimitiveType)
             .returnType shouldBeEqualTo Void.TYPE
+    }
+
+    @Test
+    fun `기존 Java MXBean 구현체는 새 authority getter의 DENY 기본값을 사용한다`() {
+        LegacyNearJCacheConfigurationMXBean().getClearAuthority() shouldBeEqualTo "DENY"
     }
 
     @Test

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt
@@ -707,6 +707,7 @@ class NearJCacheContractTest {
                 frontCache = frontCache,
                 backCache = backCache,
                 config = NearJCacheConfig(isSynchronous = false, syncRemoteTimeout = 1L),
+                clearAuthority = NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
             )
         nearCache.put("key", "value")
         writeStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
@@ -967,6 +968,7 @@ class NearJCacheContractTest {
                 frontCache = frontCache,
                 backCache = backCache,
                 config = NearJCacheConfig(isSynchronous = true),
+                clearAuthority = NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
             )
         }
     }
@@ -1019,5 +1021,6 @@ class NearJCacheContractTest {
             frontCache = frontCache,
             backCache = backCache,
             config = config,
+            clearAuthority = NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
         )
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheDocumentationTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheDocumentationTest.kt
@@ -31,6 +31,7 @@ class NearJCacheDocumentationTest {
             frontCache = front,
             backCache = back,
             config = NearJCacheConfig(frontCacheConfiguration = configuration),
+            clearAuthority = NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
         )
         val server = MBeanServerFactory.newMBeanServer()
         val registration = nearCache.registerMBeans(server, "docs-manager", "docs-cache-$suffix")
@@ -53,6 +54,7 @@ class NearJCacheDocumentationTest {
             statistics.getStatisticsScope() shouldBeEqualTo "NEAR_JCACHE_WRAPPER_V1"
             statistics.getSupportedOperations().contains("getAndPut").shouldBeTrue()
             management.isStatisticsEnabled.shouldBeTrue()
+            management.getClearAuthority() shouldBeEqualTo "EXCLUSIVE_BACK_CACHE"
 
             statistics.clear()
             nearCache.get("42") shouldBeEqualTo "Ada"
@@ -284,6 +286,21 @@ class NearJCacheDocumentationTest {
         }
     }
 
+    @Test
+    fun `clear authority marker는 EN KO 문서 쌍의 계약을 동일하게 고정한다`() {
+        AUTHORITY_CONTRACT_DOCUMENTS.forEach { (englishPath, koreanPath) ->
+            val english = authorityContractSection(read(englishPath))
+            val korean = authorityContractSection(read(koreanPath))
+
+            headingSignature(english) shouldBeEqualTo headingSignature(korean)
+            fencedCodeBlocks(english) shouldBeEqualTo fencedCodeBlocks(korean)
+            numericTokens(english) shouldBeEqualTo numericTokens(korean)
+            authorityTokenOccurrences(english) shouldBeEqualTo authorityTokenOccurrences(korean)
+            STALE_AUTHORITY_CLEAR_PHRASE.containsMatchIn(english).shouldBeFalse()
+            STALE_AUTHORITY_CLEAR_PHRASE.containsMatchIn(korean).shouldBeFalse()
+        }
+    }
+
     private fun read(relativePath: String): String = Files.readString(repositoryRoot.resolve(relativePath))
 
     private fun markedSection(document: String): String {
@@ -302,6 +319,14 @@ class NearJCacheDocumentationTest {
         return document.substring(start, end + BULK_POLICY_END_MARKER.length)
     }
 
+    private fun authorityContractSection(document: String): String {
+        val start = document.indexOf(AUTHORITY_START_MARKER)
+        val end = document.indexOf(AUTHORITY_END_MARKER)
+        (start >= 0).shouldBeTrue()
+        (end > start).shouldBeTrue()
+        return document.substring(start, end + AUTHORITY_END_MARKER.length)
+    }
+
     private fun fencedCodeBlocks(document: String): List<String> = FENCED_CODE.findAll(document)
         .map { it.groupValues[1].trim() }
         .toList()
@@ -317,6 +342,11 @@ class NearJCacheDocumentationTest {
     private fun tokenOccurrences(document: String): Map<String, Int> = PARITY_TOKENS.associateWith { token ->
         document.windowed(token.length).count(token::equals)
     }
+
+    private fun authorityTokenOccurrences(document: String): Map<String, Int> =
+        AUTHORITY_PARITY_TOKENS.associateWith { token ->
+            document.windowed(token.length).count(token::equals)
+        }
 
     private fun canaryQueriesAreComplete(template: String): Boolean {
         val queries = flatJsonObjectsInArray(template, "queries")
@@ -351,6 +381,8 @@ class NearJCacheDocumentationTest {
         private const val END_MARKER = "<!-- issue-1351-nearcache-management:end -->"
         private const val BULK_POLICY_START_MARKER = "<!-- issue-1369-bulk-policy:start -->"
         private const val BULK_POLICY_END_MARKER = "<!-- issue-1369-bulk-policy:end -->"
+        private const val AUTHORITY_START_MARKER = "<!-- nearjcache-clear-authority-contract -->"
+        private const val AUTHORITY_END_MARKER = "<!-- /nearjcache-clear-authority-contract -->"
         private val FENCED_CODE = Regex("```(?:kotlin)?\\n(.*?)```", RegexOption.DOT_MATCHES_ALL)
         private val NUMBER = Regex("\\b\\d[\\d_]*\\b")
         private val HEADING = Regex("^#{1,6} ", RegexOption.MULTILINE)
@@ -375,6 +407,25 @@ class NearJCacheDocumentationTest {
         private val STALE_CLEAR_PHRASE = Regex(
             "front-only|front cache only|clear\\(\\).*front.{0,20}only|clear\\(\\).*front.{0,20}비우",
             setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+        )
+        private val STALE_AUTHORITY_CLEAR_PHRASE = Regex(
+            "front[ -]only|프론트만|front-only",
+            RegexOption.IGNORE_CASE,
+        )
+        private val AUTHORITY_PARITY_TOKENS = listOf(
+            "NearJCacheClearAuthority",
+            "DENY",
+            "EXCLUSIVE_BACK_CACHE",
+            "clearAllCache",
+            "removeAll",
+            "SecurityException",
+            "NearJCache",
+            "LettuceCaches.nearJCache",
+            "HazelcastCaches.nearJCache",
+            "RedissonCaches.nearJCache",
+            "128",
+            "1368",
+            "1369",
         )
         private val FLAT_JSON_OBJECT = Regex("""\{[^{}]*}""", RegexOption.DOT_MATCHES_ALL)
         private val EXPECTED_CANARY_QUERY_IDS = setOf(
@@ -424,6 +475,16 @@ class NearJCacheDocumentationTest {
             "docs/manual/en/modules/bluetape4k-cache-core/near-cache-semantics.md",
             "docs/manual/ko/modules/bluetape4k-cache-core/near-cache-semantics.md",
             "docs/cache/near-cache-capability-matrix.md",
+        )
+        private val AUTHORITY_CONTRACT_DOCUMENTS = listOf(
+            "cache/cache-core/README.md" to "cache/cache-core/README.ko.md",
+            "cache/cache-lettuce/README.md" to "cache/cache-lettuce/README.ko.md",
+            "cache/cache-hazelcast/README.md" to "cache/cache-hazelcast/README.ko.md",
+            "cache/cache-redisson/README.md" to "cache/cache-redisson/README.ko.md",
+            "docs/manual/en/modules/bluetape4k-cache-core/near-cache-semantics.md" to
+                    "docs/manual/ko/modules/bluetape4k-cache-core/near-cache-semantics.md",
+            "docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md" to
+                    "docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md",
         )
         private val repositoryRoot: Path by lazy {
             generateSequence(Path.of("").toAbsolutePath()) { it.parent }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
@@ -483,5 +483,6 @@ class NearJCacheWriteThroughFailureTest {
             frontCache = frontCache,
             backCache = backCache,
             config = NearJCacheConfig(isSynchronous = true),
+            clearAuthority = NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
         )
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheOperationStatisticsTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheOperationStatisticsTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.cache.nearcache.jcache.BackCacheWriteCompletion
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.mockk.every
 import io.mockk.mockk
@@ -368,6 +369,7 @@ class NearJCacheOperationStatisticsTest {
                 syncRemoteRetryCount = retryCount,
             ),
             timeSource = timeSource,
+            clearAuthority = NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
         )
         return StatisticsFixture(
             cache = cache,

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheStatisticsRecorderTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheStatisticsRecorderTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.mockk.every
 import io.mockk.mockk
@@ -135,14 +136,22 @@ class NearJCacheStatisticsRecorderTest {
     @Test
     fun `public constructor descriptor와 synthetic test factory를 유지한다`() {
         val cacheConstructors = NearJCache::class.java.constructors.filterNot { it.isSynthetic }
-        cacheConstructors.size shouldBeEqualTo 1
-        cacheConstructors.single().parameterTypes.toList() shouldBeEqualTo listOf(
-            javax.cache.Cache::class.java,
-            javax.cache.Cache::class.java,
-            NearJCacheConfig::class.java,
+        cacheConstructors.size shouldBeEqualTo 2
+        cacheConstructors.map { it.parameterTypes.toList() }.toSet() shouldBeEqualTo setOf(
+            listOf(
+                javax.cache.Cache::class.java,
+                javax.cache.Cache::class.java,
+                NearJCacheConfig::class.java,
+            ),
+            listOf(
+                javax.cache.Cache::class.java,
+                javax.cache.Cache::class.java,
+                NearJCacheConfig::class.java,
+                NearJCacheClearAuthority::class.java,
+            ),
         )
         NearJCache.Companion::class.java.declaredMethods
-            .single { it.name.startsWith("withTimeSource") }
+            .single { it.name.startsWith("withTimeSource") && !it.name.contains("default") }
             .isSynthetic.shouldBeTrue()
 
         val beanConstructors = NearJCacheStatisticsMXBean::class.java.constructors.filterNot { it.isSynthetic }

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt
@@ -44,8 +44,12 @@ abstract class AbstractNearJCacheTest {
     open val nearCacheCfg1 = NearJCacheConfig<String, Any>()
     open val nearCacheCfg2 = NearJCacheConfig<String, Any>()
 
-    protected open val nearJCache1: NearJCache<String, Any> by lazy { NearJCache(nearCacheCfg1, backCache) }
-    protected open val nearJCache2: NearJCache<String, Any> by lazy { NearJCache(nearCacheCfg2, backCache) }
+    protected open val nearJCache1: NearJCache<String, Any> by lazy {
+        NearJCache(nearCacheCfg1, backCache, NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE)
+    }
+    protected open val nearJCache2: NearJCache<String, Any> by lazy {
+        NearJCache(nearCacheCfg2, backCache, NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE)
+    }
 
     @BeforeEach
     fun setup() {

--- a/cache/cache-hazelcast/README.ko.md
+++ b/cache/cache-hazelcast/README.ko.md
@@ -177,6 +177,27 @@ Configuration MXBean은 `BYPASS_FRONT` 또는 `POPULATE_IF_AT_MOST`와
 적용하지 않는다는 뜻입니다. Caffeine 용량과 로컬 heap 예산을 검토한 뒤 상한을 선택합니다.
 <!-- issue-1369-bulk-policy:end -->
 
+<!-- nearjcache-clear-authority-contract -->
+### #1368 Hazelcast NearJCache clear authority
+
+`HazelcastCaches.nearJCache`의 기본값은 `NearJCacheClearAuthority.DENY`이며
+Hazelcast namespace ownership을 추론하지 않습니다. `clear()`, `clearAllCache()`, 인자
+없는 `removeAll()`은 `SecurityException`을 발생시키며, 독점 owner만
+`NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE`로 opt-in합니다. 공유 namespace에는
+key-scoped `removeAll(keys)`를 사용합니다. Listener-free factory 생성은 권한을 바꾸지
+않으며 `close()`는 wrapper front만 닫고 Hazelcast back과 instance는 닫지 않습니다.
+
+```kotlin
+val shared = HazelcastCaches.nearJCache<String, User>(hazelcastInstance)
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = HazelcastCaches.nearJCache<String, User>(
+    hazelcastInstance,
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+) { cacheName = "users-owner" }
+owner.clear()
+```
+<!-- /nearjcache-clear-authority-contract -->
+
 ### NearJCache 사용 예
 
 ```kotlin

--- a/cache/cache-hazelcast/README.md
+++ b/cache/cache-hazelcast/README.md
@@ -127,6 +127,28 @@ The configuration MXBean reports `BYPASS_FRONT` or `POPULATE_IF_AT_MOST` and
 Choose a bound only after reviewing Caffeine capacity and local heap budget.
 <!-- issue-1369-bulk-policy:end -->
 
+<!-- nearjcache-clear-authority-contract -->
+### #1368 Hazelcast NearJCache clear authority
+
+`HazelcastCaches.nearJCache` defaults to `NearJCacheClearAuthority.DENY` and does
+not infer Hazelcast namespace ownership. `clear()`, `clearAllCache()`, and no-arg
+`removeAll()` raise `SecurityException`; an exclusive owner must opt in with
+`NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE`. Key-scoped `removeAll(keys)` is
+safe for a shared namespace. Listener-free factory creation does not change this
+authority, and `close()` closes only the wrapper front, not the Hazelcast back or
+instance.
+
+```kotlin
+val shared = HazelcastCaches.nearJCache<String, User>(hazelcastInstance)
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = HazelcastCaches.nearJCache<String, User>(
+    hazelcastInstance,
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+) { cacheName = "users-owner" }
+owner.clear()
+```
+<!-- /nearjcache-clear-authority-contract -->
+
 ## Class Structure
 
 The main pieces are:

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt
@@ -13,6 +13,7 @@ import io.bluetape4k.cache.nearcache.NearCacheOperations
 import io.bluetape4k.cache.nearcache.SuspendNearCacheOperations
 import io.bluetape4k.cache.nearcache.hazelcastNearCacheConfig
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfigBuilder
 import io.bluetape4k.cache.nearcache.jcache.SuspendNearJCache
@@ -34,6 +35,7 @@ import javax.cache.configuration.MutableConfiguration
  * val near  = HazelcastCaches.nearCache<String>(hazelcast) { cacheName = "my-near" }
  * ```
  */
+@Suppress("TooManyFunctions")
 object HazelcastCaches: KLogging() {
     // ─────────────────────────────────────────────
     // JCache
@@ -231,9 +233,23 @@ object HazelcastCaches: KLogging() {
     inline fun <reified K: Any, reified V: Any> nearJCache(
         hazelcastInstance: HazelcastInstance,
         block: NearJCacheConfigBuilder<K, V>.() -> Unit,
+    ): NearJCache<K, V> = nearJCache(hazelcastInstance, NearJCacheClearAuthority.DENY, block)
+
+    /**
+     * 명시적인 clear authority로 Hazelcast 기반 [NearJCache]를 생성합니다.
+     * 기존 overload는 [NearJCacheClearAuthority.DENY]를 사용하며 factory가 Hazelcast
+     * back namespace ownership을 추론하지 않습니다. `EXCLUSIVE_BACK_CACHE`는 caller가
+     * back namespace를 독점한다고 확인한 경우에만 전달합니다.
+     *
+     * @param clearAuthority caller가 확인한 back namespace 권한
+     */
+    inline fun <reified K: Any, reified V: Any> nearJCache(
+        hazelcastInstance: HazelcastInstance,
+        clearAuthority: NearJCacheClearAuthority,
+        block: NearJCacheConfigBuilder<K, V>.() -> Unit,
     ): NearJCache<K, V> {
         val config = nearJCacheConfig(block)
-        return nearJCache(hazelcastInstance, config)
+        return nearJCache(hazelcastInstance, config, clearAuthority)
     }
 
     /**
@@ -261,6 +277,21 @@ object HazelcastCaches: KLogging() {
     inline fun <reified K: Any, reified V: Any> nearJCache(
         hazelcastInstance: HazelcastInstance,
         config: NearJCacheConfig<K, V>,
+    ): NearJCache<K, V> = nearJCache(hazelcastInstance, config, NearJCacheClearAuthority.DENY)
+
+    /**
+     * [NearJCacheClearAuthority]를 명시하는 Hazelcast [NearJCache] 설정 factory입니다.
+     * 기존 overload는 [NearJCacheClearAuthority.DENY]를 사용합니다. 반환된 wrapper의
+     * `close()`는 factory가 만든 front만 닫고 Hazelcast back cache와
+     * [hazelcastInstance]는 닫지 않습니다.
+     *
+     * @param clearAuthority caller가 확인한 back namespace 권한
+     */
+    @Suppress("TooGenericExceptionCaught")
+    inline fun <reified K: Any, reified V: Any> nearJCache(
+        hazelcastInstance: HazelcastInstance,
+        config: NearJCacheConfig<K, V>,
+        clearAuthority: NearJCacheClearAuthority,
     ): NearJCache<K, V> {
         require(!config.frontCacheConfiguration.isStoreByValue) {
             "NearJCache front cache must use store-by-reference; " +
@@ -282,7 +313,7 @@ object HazelcastCaches: KLogging() {
 
         log.info { "NearJCache 생성. config=$config" }
         return try {
-            NearJCache(frontCache, backCache, config)
+            NearJCache(frontCache, backCache, config, clearAuthority)
         } catch (e: Throwable) {
             try {
                 frontCache.close()

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt
@@ -54,11 +54,33 @@ object HazelcastNearJCache: KLogging() {
         hazelcastInstance: HazelcastInstance,
         configuration: Configuration<K, V> = getDefaultJCacheConfiguration(),
         nearCacheCfg: NearJCacheConfig<K, V>,
+    ): NearJCache<K, V> = invoke(
+        frontCache = frontCache,
+        hazelcastInstance = hazelcastInstance,
+        configuration = configuration,
+        nearCacheCfg = nearCacheCfg,
+        clearAuthority = NearJCacheClearAuthority.DENY,
+    )
+
+    /**
+     * caller가 명시한 clear authority를 사용하는 listener-free factory입니다.
+     * 기존 overload는 [NearJCacheClearAuthority.DENY]를 사용합니다. 이 overload는
+     * caller가 공급한 front cache를 wrapper `close()`에서 닫고, factory가 생성하거나
+     * 재사용한 Hazelcast back cache와 [HazelcastInstance]는 닫지 않습니다.
+     *
+     * @param clearAuthority caller가 확인한 back namespace 권한
+     */
+    inline operator fun <reified K: Any, reified V: Any> invoke(
+        frontCache: JCache<K, V>,
+        hazelcastInstance: HazelcastInstance,
+        configuration: Configuration<K, V> = getDefaultJCacheConfiguration(),
+        nearCacheCfg: NearJCacheConfig<K, V>,
+        clearAuthority: NearJCacheClearAuthority,
     ): NearJCache<K, V> {
         val backCache: JCache<K, V> =
             HazelcastJCaching.getOrCreate(hazelcastInstance, nearCacheCfg.cacheName, configuration)
 
         log.info { "Create NearCache instance. config=$nearCacheCfg" }
-        return NearJCache(frontCache, backCache, nearCacheCfg)
+        return NearJCache(frontCache, backCache, nearCacheCfg, clearAuthority)
     }
 }

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCacheTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.cache.HazelcastServers
 import io.bluetape4k.cache.HazelcastServers.hazelcastClient
 import io.bluetape4k.cache.jcache.JCaching
 import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldContain
@@ -75,11 +76,8 @@ class HazelcastNearJCacheTest {
             nearCache.get("back-only") shouldBeEqualTo "from-back"
             nearCache.frontCache.get("back-only") shouldBeEqualTo "from-back"
         } finally {
-            try {
-                nearCache.clearAllCache()
-            } finally {
-                nearCache.close()
-            }
+            nearCache.removeAll(setOf("k", "back-only"))
+            nearCache.close()
         }
 
         frontCache.isClosed shouldBeEqualTo true
@@ -123,7 +121,7 @@ class HazelcastNearJCacheTest {
     fun `factory creates listener-free NearJCache with read-through and write-through`() {
         val cacheName = "hazelcast-near-jcache-" + Base58.randomString(6)
         val cache =
-            HazelcastCaches.nearJCache<String, String>(hazelcastClient) {
+            HazelcastCaches.nearJCache<String, String>(hazelcastClient, EXCLUSIVE_BACK_CACHE) {
                 this.cacheName = cacheName
             }
 
@@ -143,6 +141,36 @@ class HazelcastNearJCacheTest {
             cache.getDeeply("k").shouldBeNull()
         } finally {
             cache.clearAllCache()
+            cache.close()
+        }
+    }
+
+    @Test
+    fun `기존 Hazelcast factory는 clear authority를 기본 거부한다`() {
+        val cache = HazelcastCaches.nearJCache<String, String>(hazelcastClient) {
+            cacheName = "hazelcast-near-jcache-default-authority-" + Base58.randomString(6)
+        }
+
+        try {
+            assertFailsWith<SecurityException> { cache.clear() }
+        } finally {
+            cache.close()
+        }
+    }
+
+    @Test
+    fun `Hazelcast factory는 explicit exclusive authority overload를 전달한다`() {
+        val cache = HazelcastCaches.nearJCache<String, String>(
+            hazelcastClient,
+            EXCLUSIVE_BACK_CACHE,
+        ) {
+            cacheName = "hazelcast-near-jcache-exclusive-authority-" + Base58.randomString(6)
+        }
+
+        try {
+            cache.clearAllCache()
+            cache.removeAll()
+        } finally {
             cache.close()
         }
     }

--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -128,6 +128,29 @@ Configuration MXBean은 `BYPASS_FRONT` 또는 `POPULATE_IF_AT_MOST`와
 적용하지 않는다는 뜻입니다. Caffeine 용량과 로컬 heap 예산을 검토한 뒤 상한을 선택합니다.
 <!-- issue-1369-bulk-policy:end -->
 
+<!-- nearjcache-clear-authority-contract -->
+### #1368 Lettuce NearJCache clear authority
+
+`LettuceCaches.nearJCache`의 기본값은 `NearJCacheClearAuthority.DENY`이며 Redis
+namespace ownership을 추론하지 않습니다. 따라서 `clear()`, `clearAllCache()`, 인자
+없는 `removeAll()`은 `SecurityException`을 발생시킵니다. 독점 owner일 때만 명시적
+`NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE` overload를 선택하고, 공유 namespace는
+key-scoped `removeAll(keys)`로 처리합니다. wrapper `close()`는 front만 닫고 Redis back
+cache와 client는 닫지 않습니다.
+
+```kotlin
+val shared = LettuceCaches.nearJCache<String, User>(redisClient) {
+    cacheName = "users"
+}
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = LettuceCaches.nearJCache<String, User>(
+    redisClient,
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+) { cacheName = "users-owner" }
+owner.clear()
+```
+<!-- /nearjcache-clear-authority-contract -->
+
 `LettuceCacheConfig`/`LettuceNearCacheConfig` 사용 시:
 
 - 배치 크기, 큐 크기, 재시도 횟수, local cache 크기는 0보다 커야 합니다.

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -86,6 +86,29 @@ The configuration MXBean reports `BYPASS_FRONT` or `POPULATE_IF_AT_MOST` and
 Choose a bound only after reviewing Caffeine capacity and local heap budget.
 <!-- issue-1369-bulk-policy:end -->
 
+<!-- nearjcache-clear-authority-contract -->
+### #1368 Lettuce NearJCache clear authority
+
+`LettuceCaches.nearJCache` defaults to `NearJCacheClearAuthority.DENY` and does
+not infer Redis namespace ownership. `clear()`, `clearAllCache()`, and no-arg
+`removeAll()` therefore raise `SecurityException`; use the explicit
+`NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE` overload only for an exclusive
+owner. Key-scoped `removeAll(keys)` remains the shared-namespace path. The
+wrapper `close()` closes its front but not the Redis back cache or client.
+
+```kotlin
+val shared = LettuceCaches.nearJCache<String, User>(redisClient) {
+    cacheName = "users"
+}
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = LettuceCaches.nearJCache<String, User>(
+    redisClient,
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+) { cacheName = "users-owner" }
+owner.clear()
+```
+<!-- /nearjcache-clear-authority-contract -->
+
 ## JCache EntryProcessor Atomicity
 
 `LettuceJCache` supports JCache `EntryProcessor` operations. All mutating

--- a/cache/cache-lettuce/src/benchmark/kotlin/io/bluetape4k/cache/nearcache/benchmark/NearJCacheStatisticsBenchmark.kt
+++ b/cache/cache-lettuce/src/benchmark/kotlin/io/bluetape4k/cache/nearcache/benchmark/NearJCacheStatisticsBenchmark.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.cache.jcache.JCaching
 import io.bluetape4k.cache.jcache.jcacheConfiguration
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
@@ -57,6 +58,7 @@ open class NearJCacheStatisticsBenchmark {
             frontCache = front,
             backCache = backCache,
             config = NearJCacheConfig(frontCacheConfiguration = frontConfig, isSynchronous = true),
+            clearAuthority = NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
         )
         nearCache.putAll(entries)
     }

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/LettuceCaches.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/LettuceCaches.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.cache.nearcache.LettuceSuspendNearCache
 import io.bluetape4k.cache.nearcache.NearCacheOperations
 import io.bluetape4k.cache.nearcache.SuspendNearCacheOperations
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfigBuilder
 import io.bluetape4k.cache.nearcache.jcache.SuspendNearJCache
@@ -38,6 +39,7 @@ import java.util.concurrent.TimeUnit
  * }
  * ```
  */
+@Suppress("TooManyFunctions")
 object LettuceCaches: KLogging() {
     // -------------------------------------------------------------------------
     // JCache
@@ -105,7 +107,27 @@ object LettuceCaches: KLogging() {
         block: NearJCacheConfigBuilder<K, V>.() -> Unit,
     ): NearJCache<K, V> {
         val config = nearJCacheConfig(block)
-        return nearJCache(redisClient, config, codec)
+        return nearJCache(redisClient, config, NearJCacheClearAuthority.DENY, codec)
+    }
+
+    /**
+     * 명시적인 clear authority로 Lettuce 기반 [NearJCache]를 생성합니다.
+     * factory가 back namespace의 ownership을 판정하지 않으므로 독점 owner만
+     * [NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE]를 전달해야 합니다.
+     * 기존 overload는 [NearJCacheClearAuthority.DENY]를 사용합니다. 반환된 wrapper의
+     * `close()`는 wrapper가 생성한 front만 정리하며 Redis back cache와 [redisClient]는
+     * caller 소유로 남습니다.
+     *
+     * @param clearAuthority caller가 확인한 back namespace 권한
+     */
+    inline fun <reified K: Any, reified V: Any> nearJCache(
+        redisClient: RedisClient,
+        clearAuthority: NearJCacheClearAuthority,
+        codec: LettuceBinaryCodec<V> = LettuceBinaryCodecs.default<V>(),
+        block: NearJCacheConfigBuilder<K, V>.() -> Unit,
+    ): NearJCache<K, V> {
+        val config = nearJCacheConfig(block)
+        return nearJCache(redisClient, config, clearAuthority, codec)
     }
 
     /**
@@ -121,10 +143,25 @@ object LettuceCaches: KLogging() {
         redisClient: RedisClient,
         config: NearJCacheConfig<K, V>,
         codec: LettuceBinaryCodec<V> = LettuceBinaryCodecs.default<V>(),
+    ): NearJCache<K, V> = nearJCache(redisClient, config, NearJCacheClearAuthority.DENY, codec)
+
+    /**
+     * [NearJCacheClearAuthority]를 명시하는 Lettuce [NearJCache] 설정 factory입니다.
+     * factory가 Redis namespace ownership을 추론하지 않으므로 기존 overload는
+     * [NearJCacheClearAuthority.DENY]를 사용합니다. `close()`는 wrapper front만 닫고
+     * Redis back cache와 [redisClient]는 닫지 않습니다.
+     *
+     * @param clearAuthority caller가 확인한 back namespace 권한
+     */
+    inline fun <reified K: Any, reified V: Any> nearJCache(
+        redisClient: RedisClient,
+        config: NearJCacheConfig<K, V>,
+        clearAuthority: NearJCacheClearAuthority,
+        codec: LettuceBinaryCodec<V> = LettuceBinaryCodecs.default<V>(),
     ): NearJCache<K, V> {
         val backCache = jcache<K, V>(redisClient, config.cacheName, codec = codec)
         log.info { "Lettuce NearJCache 생성. cacheName=${config.cacheName}" }
-        return NearJCache(config, backCache)
+        return NearJCache(config, backCache, clearAuthority)
     }
 
     // -------------------------------------------------------------------------

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceNearJJCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/LettuceNearJJCacheTest.kt
@@ -3,7 +3,10 @@ package io.bluetape4k.cache.nearcache.jcache
 import io.bluetape4k.cache.LettuceCaches
 import io.bluetape4k.cache.RedisServers
 import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE
 import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
 
 /**
  * Lettuce JCache 백엔드를 사용하는 [AbstractNearJCacheTest] 구현체입니다.
@@ -19,4 +22,35 @@ class LettuceNearJJCacheTest: AbstractNearJCacheTest() {
             RedisServers.redisClient,
             "lettuce-near-jcache-back-" + randomKey()
         )
+
+    @Test
+    fun `기존 Lettuce factory는 clear authority를 기본 거부한다`() {
+        val nearCache = LettuceCaches.nearJCache<String, String>(RedisServers.redisClient) {
+            cacheName = "lettuce-near-jcache-default-authority-" + randomKey()
+        }
+
+        try {
+            assertFailsWith<SecurityException> { nearCache.clear() }
+        } finally {
+            nearCache.close()
+        }
+    }
+
+    @Test
+    fun `Lettuce factory는 explicit exclusive authority overload를 전달한다`() {
+        val nearCache = LettuceCaches.nearJCache<String, String>(
+            RedisServers.redisClient,
+            EXCLUSIVE_BACK_CACHE,
+        ) {
+            cacheName = "lettuce-near-jcache-exclusive-authority-" + randomKey()
+            isSynchronous = true
+        }
+
+        try {
+            nearCache.clearAllCache()
+            nearCache.removeAll()
+        } finally {
+            nearCache.close()
+        }
+    }
 }

--- a/cache/cache-redisson/README.ko.md
+++ b/cache/cache-redisson/README.ko.md
@@ -38,6 +38,29 @@ JCache 변형은 cache-entry listener를 등록하며, Redisson bulk event가 �
 
 전체 행렬은 [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md)를 참고하세요.
 
+<!-- nearjcache-clear-authority-contract -->
+### #1368 Redisson NearJCache clear authority
+
+`RedissonCaches.nearJCache`의 기본값은 `NearJCacheClearAuthority.DENY`이며 Redis
+namespace ownership을 추론하지 않습니다. `clear()`, `clearAllCache()`, 인자 없는
+`removeAll()`은 `SecurityException`을 발생시키므로, 전체 back namespace를 caller가
+소유한다고 확인한 경우에만 `NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE`를 전달합니다.
+공유 tenant에는 key-scoped `removeAll(keys)`를 사용합니다. wrapper `close()`는 front만
+닫고 전달받은 back cache나 Redisson provider는 닫지 않습니다. Native
+`RedissonNearCache.clearAll()`은 별도 API입니다.
+
+```kotlin
+val shared = RedissonCaches.nearJCache(backCache, NearJCacheConfig())
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = RedissonCaches.nearJCache(
+    backCache,
+    NearJCacheConfig(cacheName = "users-owner"),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
+owner.clearAllCache()
+```
+<!-- /nearjcache-clear-authority-contract -->
+
 ## 의존성
 
 ```kotlin

--- a/cache/cache-redisson/README.md
+++ b/cache/cache-redisson/README.md
@@ -40,6 +40,29 @@ Redisson does not emit bulk events.
 
 See the full [Near-Cache Backend Capability Matrix](../../docs/cache/near-cache-capability-matrix.md).
 
+<!-- nearjcache-clear-authority-contract -->
+### #1368 Redisson NearJCache clear authority
+
+`RedissonCaches.nearJCache` defaults to `NearJCacheClearAuthority.DENY` and does
+not infer Redis namespace ownership. `clear()`, `clearAllCache()`, and no-arg
+`removeAll()` raise `SecurityException`; pass
+`NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE` only when the caller owns the
+entire back namespace. Key-scoped `removeAll(keys)` remains safe for shared
+tenants. The wrapper `close()` closes its front but not the supplied back cache
+or Redisson provider. Native `RedissonNearCache.clearAll()` is a separate API.
+
+```kotlin
+val shared = RedissonCaches.nearJCache(backCache, NearJCacheConfig())
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = RedissonCaches.nearJCache(
+    backCache,
+    NearJCacheConfig(cacheName = "users-owner"),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
+owner.clearAllCache()
+```
+<!-- /nearjcache-clear-authority-contract -->
+
 ## Dependency
 
 ```kotlin

--- a/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/RedissonCaches.kt
+++ b/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/RedissonCaches.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.cache.nearcache.RedissonNearCacheConfig
 import io.bluetape4k.cache.nearcache.RedissonSuspendNearCache
 import io.bluetape4k.cache.nearcache.SuspendNearCacheOperations
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.bluetape4k.cache.nearcache.jcache.SuspendNearJCache
 import io.bluetape4k.logging.KLogging
@@ -34,6 +35,7 @@ import javax.cache.configuration.MutableConfiguration
  * val suspendNear = RedissonCaches.suspendNearCache<String>("my-near", redisson)
  * ```
  */
+@Suppress("TooManyFunctions")
 object RedissonCaches: KLogging() {
     // ─────────────────────────────────────────────
     // JCache
@@ -165,7 +167,21 @@ object RedissonCaches: KLogging() {
     fun <K: Any, V: Any> nearJCache(
         backCache: JCache<K, V>,
         nearJCacheConfig: NearJCacheConfig<K, V> = NearJCacheConfig(),
-    ): NearJCache<K, V> = NearJCache(nearJCacheConfig, backCache)
+    ): NearJCache<K, V> = nearJCache(backCache, nearJCacheConfig, NearJCacheClearAuthority.DENY)
+
+    /**
+     * [NearJCacheClearAuthority]를 명시하는 기존 back-cache 기반 factory입니다.
+     * 기존 overload는 [NearJCacheClearAuthority.DENY]를 사용하며, factory가 Redisson
+     * back namespace ownership을 추론하지 않습니다. wrapper `close()`는 생성한 front만
+     * 닫고 supplied [backCache]와 Redisson provider는 caller가 관리합니다.
+     *
+     * @param clearAuthority caller가 확인한 back namespace 권한
+     */
+    fun <K: Any, V: Any> nearJCache(
+        backCache: JCache<K, V>,
+        nearJCacheConfig: NearJCacheConfig<K, V>,
+        clearAuthority: NearJCacheClearAuthority,
+    ): NearJCache<K, V> = NearJCache(nearJCacheConfig, backCache, clearAuthority)
 
     /**
      * RedissonClient로 백엔드 캐시를 생성하고 [NearJCache]를 반환합니다.
@@ -193,9 +209,34 @@ object RedissonCaches: KLogging() {
                 setTypes(K::class.java, V::class.java)
             },
         nearJCacheConfig: NearJCacheConfig<K, V> = NearJCacheConfig(),
+    ): NearJCache<K, V> = nearJCache(
+        backCacheName = backCacheName,
+        redisson = redisson,
+        clearAuthority = NearJCacheClearAuthority.DENY,
+        backCacheConfiguration = backCacheConfiguration,
+        nearJCacheConfig = nearJCacheConfig,
+    )
+
+    /**
+     * Redisson client 기반 [NearJCache]에 명시적 clear authority를 전달합니다.
+     * 기존 overload는 [NearJCacheClearAuthority.DENY]를 사용합니다. `EXCLUSIVE_BACK_CACHE`
+     * 는 caller가 해당 Redisson back namespace를 독점한다고 확인한 경우에만 선택합니다.
+     * wrapper `close()`는 생성한 front만 닫고 [redisson] provider와 back cache는 닫지 않습니다.
+     *
+     * @param clearAuthority caller가 확인한 back namespace 권한
+     */
+    inline fun <reified K: Any, reified V: Any> nearJCache(
+        backCacheName: String,
+        redisson: RedissonClient,
+        clearAuthority: NearJCacheClearAuthority,
+        backCacheConfiguration: Configuration<K, V> =
+            MutableConfiguration<K, V>().apply {
+                setTypes(K::class.java, V::class.java)
+            },
+        nearJCacheConfig: NearJCacheConfig<K, V> = NearJCacheConfig(),
     ): NearJCache<K, V> {
         val backCache = RedissonJCaching.getOrCreate(backCacheName, redisson, backCacheConfiguration)
-        return NearJCache(nearJCacheConfig, backCache)
+        return NearJCache(nearJCacheConfig, backCache, clearAuthority)
     }
 
     // ─────────────────────────────────────────────

--- a/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/RedissonNearJCacheTest.kt
+++ b/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/RedissonNearJCacheTest.kt
@@ -3,7 +3,10 @@ package io.bluetape4k.cache.nearcache.jcache
 import io.bluetape4k.cache.RedisServers
 import io.bluetape4k.cache.RedissonCaches
 import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE
 import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
 
 /**
  * Redisson JCache 백엔드를 사용하는 [AbstractNearJCacheTest] 구현체입니다.
@@ -19,4 +22,34 @@ class RedissonNearJCacheTest: AbstractNearJCacheTest() {
             RedisServers.redisson,
             "redisson-jcache-back-" + randomKey(),
         )
+
+    @Test
+    fun `기존 Redisson direct-back factory는 clear authority를 기본 거부한다`() {
+        val nearCache = RedissonCaches.nearJCache(
+            backCache,
+            NearJCacheConfig<String, Any>(cacheName = "redisson-near-jcache-default-authority-" + randomKey()),
+        )
+
+        try {
+            assertFailsWith<SecurityException> { nearCache.clear() }
+        } finally {
+            nearCache.close()
+        }
+    }
+
+    @Test
+    fun `Redisson direct-back factory는 explicit exclusive authority overload를 전달한다`() {
+        val nearCache = RedissonCaches.nearJCache(
+            backCache,
+            NearJCacheConfig<String, Any>(cacheName = "redisson-near-jcache-exclusive-authority-" + randomKey()),
+            EXCLUSIVE_BACK_CACHE,
+        )
+
+        try {
+            nearCache.clearAllCache()
+            nearCache.removeAll()
+        } finally {
+            nearCache.close()
+        }
+    }
 }

--- a/docs/cache/near-cache-capability-matrix.md
+++ b/docs/cache/near-cache-capability-matrix.md
@@ -46,6 +46,25 @@ back atomic operation을 먼저 완료한 뒤 front를 reconciliation하는 계�
 populate는 mutation epoch로 stale 값을 차단하고, clear는 timeout-late backend
 write가 끝난 뒤 back을 지우는 barrier를 사용한다.
 
+### Blocking `NearJCache` destructive clear authority
+
+`NearJCacheClearAuthority`는 `NearJCacheConfig`와 분리된 runtime-only 권한이다.
+기존 constructor와 provider factory의 기본값은 `DENY`이며, caller가 back namespace
+전체를 독점한다고 확인한 경우에만 `EXCLUSIVE_BACK_CACHE`를 명시한다.
+
+| operation | default `DENY` | `EXCLUSIVE_BACK_CACHE` | shared-back rule |
+| --- | --- | --- | --- |
+| `remove(key)` / `removeAll(keys)` | 허용 | 허용 | tenant 또는 key 목록 범위만 삭제 |
+| `clear()` / `clearAllCache()` | `SecurityException`, mutation 없음 | wrapper front와 back namespace 삭제 | peer wrapper의 이미 채워진 front는 보장하지 않음 |
+| no-arg `removeAll()` | `SecurityException`, mutation 없음 | wrapper front와 back namespace 삭제 | namespace 독점 caller만 사용 |
+| `close()` | front/listener/MXBean 정리 | 동일 | back cache, provider, `MBeanServer`는 닫지 않음 |
+
+`nearCache.backCache.clear()` 같은 caller-owned provider 직접 호출은 이 wrapper
+guard의 대상이 아니다. 따라서 back-cache reference를 권한 없는 코드에 전달하지 않는다.
+`ResilientNearJCache`와 `ResilientSuspendNearJCache`의 `ClearBack`은 이 PR2 matrix의
+보장 범위가 아니며 별도 follow-up으로 다룬다. Configuration MXBean은
+`getClearAuthority()`에서 `DENY` 또는 `EXCLUSIVE_BACK_CACHE` stable token만 노출한다.
+
 <!-- issue-1369-bulk-policy:start -->
 ### Bulk `getAll` 결과의 front 저장 정책
 

--- a/docs/manual/en/modules/bluetape4k-cache-core/near-cache-semantics.md
+++ b/docs/manual/en/modules/bluetape4k-cache-core/near-cache-semantics.md
@@ -25,6 +25,18 @@ This path moves data between cache tiers; it does not load source data. The call
 
 `NearJCache.clear()` and its compatibility alias `clearAllCache()` both clear this wrapper's front and back caches. A plain back-cache clear may not notify another Near Cache that shares it. Use provider-backed key removal or invalidation when remote local entries must be removed.
 
+The legacy `NearJCache` constructors and provider factories default to
+`NearJCacheClearAuthority.DENY`. Therefore `clear()`, `clearAllCache()`, and
+no-argument `removeAll()` throw `SecurityException` before changing either tier.
+Choose `NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE` only after verifying that
+the caller exclusively owns the back namespace. Key-scoped `removeAll(keys)` and
+single-key `remove` remain available for tenant-scoped cleanup. The authority is
+runtime-only and is not serialized with `NearJCacheConfig`. A direct
+`nearCache.backCache.clear()` call is outside the wrapper guard and must remain
+caller-owned; do not expose that reference to untrusted code. `ClearBack` on
+`ResilientNearJCache` and `ResilientSuspendNearJCache` is outside this PR2
+contract.
+
 ## A cache-tier write is not persistence write-through
 
 The common `put` contract requires a provider to update local and back caches along one operation path. It does not mention a database, JDBC repository, or Exposed table.
@@ -82,6 +94,7 @@ keeps `setStoreByValue(false)`.
 
 ```kotlin
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheConfigurationMXBean
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheTierStatisticsMXBean
@@ -98,7 +111,12 @@ val configuration = MutableConfiguration<String, String>()
     .setStoreByValue(false)
 val front = manager.createCache("orders-front", configuration)
 val back = manager.createCache("orders-back", configuration)
-val nearCache = NearJCache(front, back, NearJCacheConfig(frontCacheConfiguration = configuration))
+val nearCache = NearJCache(
+    front,
+    back,
+    NearJCacheConfig(frontCacheConfiguration = configuration),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
 val server = ManagementFactory.getPlatformMBeanServer()
 val registration = nearCache.registerMBeans(server, "orders-service", "orders-v1")
 val names = registration.activeObjectNames.associateBy { it.getKeyProperty("type") }
@@ -139,6 +157,27 @@ replacement. Keep the JMX namespace exclusive, investigate collisions, and
 treat `RECOVERY_REQUIRED` as immediate cleanup work. The ownership token only
 provides best-effort stale-owner protection.
 <!-- issue-1351-nearcache-management:end -->
+
+<!-- nearjcache-clear-authority-contract -->
+### #1368 shared-back clear authority
+
+The default wrapper is safe for a shared back namespace. Use key-scoped removal
+for a tenant-owned key set; only an explicitly verified exclusive owner may use
+namespace-wide clear operations. The enum is runtime-only and does not change
+the serializable `NearJCacheConfig`.
+
+```kotlin
+val shared = NearJCache(front, back, NearJCacheConfig(), NearJCacheClearAuthority.DENY)
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = NearJCache(
+    front,
+    back,
+    NearJCacheConfig(),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
+owner.clearAllCache()
+```
+<!-- /nearjcache-clear-authority-contract -->
 
 ## Sources and tests
 

--- a/docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
+++ b/docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
@@ -17,8 +17,22 @@ Release tests explicitly expect `HazelcastSerializationException` with an underl
 
 `HazelcastCaches.nearJCache` creates a Caffeine front JCache and Hazelcast back JCache without listener registration. The public `HazelcastNearJCache(...)` factory combines the caller-supplied front JCache with a Hazelcast back JCache through the same listener-free path. `suspendNearJCache` also creates a fixed Caffeine front and calls `SuspendNearJCache.withoutListener`.
 
+Serialization-safe `NearJCacheConfig` and the destructive-clear authority are
+separate contracts. Existing Hazelcast factory calls default to
+`NearJCacheClearAuthority.DENY`; use a key-scoped `removeAll(keys)` for shared
+namespaces. Pass `NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE` only when the
+caller owns the entire back namespace before calling `clear()` or
+`clearAllCache()`. The authority is runtime-only and is not sent through
+Hazelcast configuration serialization. The wrapper closes only its supplied
+front cache; it does not close the Hazelcast back cache or provider.
+
 ```kotlin
-val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
+
+val cache = HazelcastCaches.nearJCache<String, User>(
+    hazelcast,
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+) {
     cacheName = "users-v1"
 }
 
@@ -43,6 +57,24 @@ When peer invalidation is required, use the `IMap.addEntryListener` path in `Haz
 ## Fixed suspend-front settings
 
 The 1.12.1 `suspendNearJCache` factory builds Caffeine with a 10,000-entry maximum and 30-minute expire-after-access. It uses the supplied cache name for the back cache but does not apply custom front capacity and expiry from `NearJCacheConfig` to this fixed front.
+
+<!-- nearjcache-clear-authority-contract -->
+### #1368 shared-back clear authority
+
+The listener-free factory still defaults to `DENY`; a key-scoped operation is the
+safe path for a shared namespace. An exclusive owner may opt in to a namespace
+clear, while the runtime-only authority remains outside serialized configuration.
+
+```kotlin
+val shared = HazelcastCaches.nearJCache<String, User>(hazelcast)
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = HazelcastCaches.nearJCache<String, User>(
+    hazelcast,
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+) { cacheName = "users-owner" }
+owner.clear()
+```
+<!-- /nearjcache-clear-authority-contract -->
 
 ## Sources and tests
 

--- a/docs/manual/ko/modules/bluetape4k-cache-core/near-cache-semantics.md
+++ b/docs/manual/ko/modules/bluetape4k-cache-core/near-cache-semantics.md
@@ -25,6 +25,17 @@ get(key)
 
 `NearJCache.clear()`와 호환 alias `clearAllCache()`는 모두 이 wrapper의 front와 back을 비웁니다. 하지만 공유 back cache를 사용하는 다른 Near Cache의 front까지 event로 비운다고 보장하지 않습니다. 다른 process의 local entry까지 없애야 한다면 provider가 보장하는 `removeAll` 또는 invalidation channel을 사용합니다.
 
+기존 `NearJCache` 생성자와 provider factory의 기본 권한은
+`NearJCacheClearAuthority.DENY`입니다. 따라서 `clear()`, `clearAllCache()`, 인자 없는
+`removeAll()`은 어느 계층도 바꾸기 전에 `SecurityException`을 던집니다. caller가 back
+namespace를 독점한다고 확인한 경우에만
+`NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE`를 선택합니다. tenant별 정리에는
+key-scoped `removeAll(keys)`와 단일 key `remove`를 사용합니다. 이 권한은 runtime-only이며
+`NearJCacheConfig`와 함께 직렬화되지 않습니다. `nearCache.backCache.clear()` 같은 직접
+호출은 wrapper guard 밖의 caller-owned 경로이므로 권한 없는 코드에 reference를
+노출하지 마세요. `ResilientNearJCache`와 `ResilientSuspendNearJCache`의 `ClearBack`은
+이번 PR2 계약 범위가 아닙니다.
+
 ## 쓰기는 persistence write-through가 아니다
 
 공통 interface의 `put`은 provider 구현이 local과 back cache를 같은 연산 경로에서 갱신하도록 요구합니다. 이는 cache tier 간 동기화입니다. database, JDBC repository, Exposed table은 이 interface에 등장하지 않으므로 persistence write-through가 아닙니다.
@@ -81,6 +92,7 @@ front 용량과 로컬 heap 예산을 검토한 뒤 명시적 상한을 사용�
 
 ```kotlin
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheConfigurationMXBean
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheTierStatisticsMXBean
@@ -97,7 +109,12 @@ val configuration = MutableConfiguration<String, String>()
     .setStoreByValue(false)
 val front = manager.createCache("orders-front", configuration)
 val back = manager.createCache("orders-back", configuration)
-val nearCache = NearJCache(front, back, NearJCacheConfig(frontCacheConfiguration = configuration))
+val nearCache = NearJCache(
+    front,
+    back,
+    NearJCacheConfig(frontCacheConfiguration = configuration),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
 val server = ManagementFactory.getPlatformMBeanServer()
 val registration = nearCache.registerMBeans(server, "orders-service", "orders-v1")
 val names = registration.activeObjectNames.associateBy { it.getKeyProperty("type") }
@@ -136,6 +153,27 @@ old cache close, replacement 등록 순서로 수행합니다. JMX namespace를 
 기존 owner를 확인하며 `RECOVERY_REQUIRED`를 즉시 cleanup 대상으로 처리합니다. Ownership
 token은 stale owner를 줄이는 best-effort 방어입니다.
 <!-- issue-1351-nearcache-management:end -->
+
+<!-- nearjcache-clear-authority-contract -->
+### #1368 shared-back clear authority
+
+기본 wrapper는 공유 back namespace에서 안전하게 동작합니다. tenant가 소유한 key
+목록은 key-scoped removal로 처리하고, namespace-wide clear는 독점 소유를 확인한
+caller만 명시적으로 선택합니다. 이 enum은 runtime-only이며 직렬화되는
+`NearJCacheConfig`를 바꾸지 않습니다.
+
+```kotlin
+val shared = NearJCache(front, back, NearJCacheConfig(), NearJCacheClearAuthority.DENY)
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = NearJCache(
+    front,
+    back,
+    NearJCacheConfig(),
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+)
+owner.clearAllCache()
+```
+<!-- /nearjcache-clear-authority-contract -->
 
 ## Source와 tests
 

--- a/docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
+++ b/docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md
@@ -17,8 +17,21 @@ release tests는 직접 listener-backed 구성이 `HazelcastSerializationExcepti
 
 `HazelcastCaches.nearJCache`는 Caffeine front JCache와 Hazelcast back JCache를 직접 조합하고 listener를 등록하지 않습니다. 공개 `HazelcastNearJCache(...)` factory는 호출자가 제공한 front JCache와 Hazelcast back JCache를 같은 listener-free 경로로 조합합니다. `suspendNearJCache`도 고정된 Caffeine front를 만들고 `SuspendNearJCache.withoutListener`를 사용합니다.
 
+직렬화 가능한 `NearJCacheConfig`와 destructive clear 권한은 별도 계약입니다. 기존
+Hazelcast factory 호출의 기본값은 `NearJCacheClearAuthority.DENY`이므로 공유 namespace에는
+key-scoped `removeAll(keys)`를 사용합니다. `clear()` 또는 `clearAllCache()`를 호출하려면
+back namespace 전체를 caller가 소유한다고 확인한 뒤
+`NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE`를 전달합니다. 이 권한은 runtime-only이며
+Hazelcast configuration 직렬화로 전송되지 않습니다. wrapper `close()`는 전달받은 front만
+닫고 Hazelcast back cache나 provider는 닫지 않습니다.
+
 ```kotlin
-val cache = HazelcastCaches.nearJCache<String, User>(hazelcast) {
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
+
+val cache = HazelcastCaches.nearJCache<String, User>(
+    hazelcast,
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+) {
     cacheName = "users-v1"
 }
 
@@ -43,6 +56,24 @@ peer 변경 무효화가 필요하면 JCache factory 대신 `HazelcastNearCache`
 ## suspend factory의 고정 front 설정
 
 1.12.1의 `suspendNearJCache` factory는 Caffeine front를 최대 10,000개, 접근 후 30분 만료로 직접 만듭니다. 전달한 `NearJCacheConfig`의 cache 이름은 back cache에 쓰지만 front 용량과 만료는 이 고정 구성입니다. 다른 정책이 필요하면 지원 capability를 확인한 별도 구성을 사용합니다.
+
+<!-- nearjcache-clear-authority-contract -->
+### #1368 shared-back clear authority
+
+Listener-free factory도 기본값은 `DENY`입니다. 공유 namespace에서는 key-scoped
+operation을 사용하고, 독점 owner만 namespace clear를 opt-in합니다. runtime-only
+권한은 직렬화되는 configuration에 포함되지 않습니다.
+
+```kotlin
+val shared = HazelcastCaches.nearJCache<String, User>(hazelcast)
+shared.removeAll(setOf("tenant-a:key-1"))
+val owner = HazelcastCaches.nearJCache<String, User>(
+    hazelcast,
+    NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE,
+) { cacheName = "users-owner" }
+owner.clear()
+```
+<!-- /nearjcache-clear-authority-contract -->
 
 ## Source와 tests
 

--- a/docs/superpowers/plans/2026-08-17-issue-1368-nearcache-clear-authority-plan.md
+++ b/docs/superpowers/plans/2026-08-17-issue-1368-nearcache-clear-authority-plan.md
@@ -1,0 +1,349 @@
+# NearJCache shared back cache destructive clear authority Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 공유될 수 있는 JCache back namespace의 destructive operation을 기본적으로 거부하고, 독점 owner가 명시한 runtime authority에서만 `clear()` 계열을 허용한다. 기존 key-scoped remove, read/write 경로, listener generation barrier, public ABI와 serialization 계약은 보존한다.
+
+**Architecture:** `NearJCacheClearAuthority`를 `NearJCacheConfig`와 분리된 runtime-only enum으로 추가한다. 기존 constructor와 provider factory는 `DENY`로 위임하고, 새 explicit overload만 `EXCLUSIVE_BACK_CACHE`를 전달한다. 세 namespace-wide operation은 첫 상태 변경보다 앞에서 공통 guard를 통과해야 한다. management snapshot과 MXBean에는 stable token만 노출하며 cache name, key, value, provider payload는 노출하지 않는다.
+
+**Tech Stack:** Kotlin 2.4, Java 25, JCache (`javax.cache`), JMX (`javax.management`), Caffeine, Lettuce, Hazelcast, Redisson, JUnit 5, MockK, Kluent, Gradle 9.7, Detekt, Testcontainers
+
+**Source of truth:**
+
+- Issue [#1368](https://github.com/bluetape4k/bluetape4k-projects/issues/1368)
+- Epic [#1408](https://github.com/bluetape4k/bluetape4k-projects/issues/1408)
+- Approved design: `docs/superpowers/specs/2026-08-16-epic-1408-nearjcache-safety-tail-design.md`
+- Predecessor contract: [#1363](https://github.com/bluetape4k/bluetape4k-projects/issues/1363)
+- Compound-operation boundary: [#1355](https://github.com/bluetape4k/bluetape4k-projects/issues/1355)
+- Stacked train predecessor: [#1369](https://github.com/bluetape4k/bluetape4k-projects/issues/1369)
+
+**Stack:** `develop` → `fix/1369-nearcache-bounded-bulk` → `fix/1368-nearcache-clear-authority`
+
+**현재 source ledger (PR1 head 기준):**
+
+| 주장 | 현재 근거 |
+| --- | --- |
+| public front/back constructor와 immutable configuration snapshot | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt:95-124` |
+| destructive `clear()`가 listener detach와 epoch/generation 변경 뒤 mutation을 수행 | `NearJCache.kt:345-379` |
+| public back reference가 wrapper guard와 별도 caller-owned 경계를 만듦 | `NearJCache.kt:95-100` |
+| `clearAllCache()`가 `clear()` alias임 | `NearJCache.kt:425-445` |
+| no-arg `removeAll()`가 front와 back namespace를 순회 삭제함 | `NearJCache.kt:922-934` |
+| key-scoped `removeAll(keys)`는 별도 경로임 | `NearJCache.kt:936-952` |
+| config에는 현재 bulk policy만 있고 authority가 없음 | `NearJCacheConfig.kt:45-146`, `NearJCacheConfigurationSnapshot.kt:16-28` |
+| management stable attributes의 현재 shape | `NearJCacheConfigurationMXBean.kt:11-23` |
+| Hazelcast factory는 listener-free `NearJCache(front, back, config)`를 사용함 | `cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt:261-303`, `cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt:52-62` |
+
+---
+
+## 실행 경계와 완료 조건
+
+- [ ] PR2는 #1369의 exact head 위에서만 구현한다. #1369가 merge되면 PR2 base를 `develop`으로 재설정하고 동일한 검증을 다시 수행한다.
+- [ ] 사용자의 현재 실행 승인(`좋아 진행해`)은 이 plan의 계획·RED slice와 승인 설계의 구현 시작을 허용한다. API/serialization/non-goal을 바꾸는 material finding이 나오면 구현을 멈추고 새 승인을 받는다.
+- [ ] `NearJCacheConfig`의 Serializable shape, existing constructor/copy/synthetic descriptor, serialVersionUID와 legacy stream 동작을 변경하지 않는다.
+- [ ] `SuspendNearJCache`, compound operation atomicity, provider dependency, tenant protocol, `close()`의 back/provider lifecycle ownership은 변경하지 않는다.
+- [ ] 권한 guard는 `NearJCache` wrapper를 통해 호출되는 `clear()`, `clearAllCache()`, no-arg `removeAll()`에 한정한다. 기존 public `backCache` reference에서 호출하는 `nearCache.backCache.clear()`는 provider 직접 호출이라는 별도 caller-owned 경계이며, ABI를 깨지 않고 library-level ACL로 가로채지 않는다. 문서에는 이 escape hatch를 untrusted caller에 노출하지 말아야 한다고 명시한다.
+- [ ] `ResilientNearJCache`와 `ResilientSuspendNearJCache`의 자체 `clearAll()`/`ClearBack` command는 별도 wrapper 계약으로 inventory하고 이번 PR2의 non-goal로 고정한다. 이 경로까지 shared-back authority를 주장하지 않으며, 후속 issue 후보를 lesson에 기록한다.
+- [ ] 기존 3-argument `NearJCache(front, back, config)`와 `NearJCache(config, backCache)`, 기존 Lettuce/Hazelcast/Redisson factory signature는 유지하고 기본 `DENY`로 동작한다.
+- [ ] 새 explicit authority overload는 runtime-only 값을 받아 immutable instance state에 저장한다. factory가 cache를 생성하거나 `getOrCreate`했다는 이유로 owner를 추론하지 않는다.
+- [ ] `clear()`, `clearAllCache()`, no-argument `removeAll()`은 공통 guard를 사용한다. `removeAll(keys)`와 single-key `remove`는 기존 계약으로 남긴다.
+- [ ] `DENY`는 `compoundGate`, listener detach, epoch/generation 증가, front/back 호출 이전에 `SecurityException`을 던진다.
+- [ ] `EXCLUSIVE_BACK_CACHE`는 기존 front/back clear 순서와 listener generation barrier, primary/suppressed failure 복구를 그대로 사용한다.
+- [ ] 문서와 KDoc은 한국어 reader-facing prose로 작성하고, README 영어/한글 쌍과 manual 영어/한글 쌍의 의미를 일치시킨다.
+- [ ] core 테스트와 Detekt를 먼저 통과시킨 뒤 Lettuce → Hazelcast → Redisson Testcontainers 검증을 순차 실행한다.
+- [ ] 구현 완료 후 독립 perspective review, lesson, `git diff --check`, exact head/CI/review read-back을 남긴다. PR 생성과 merge는 별도 승인 이후에만 수행한다.
+
+## 대상 파일과 책임
+
+| 구분 | 파일 | 책임 |
+| --- | --- | --- |
+| 공개 runtime API | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheClearAuthority.kt` | `DENY`, `EXCLUSIVE_BACK_CACHE` enum과 authority 의미/KDoc |
+| core 구현 | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt` | constructor/companion overload, immutable authority, 공통 guard, destructive operation 연결 |
+| management | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheConfigurationSnapshot.kt` | stable clear-authority token snapshot |
+| management | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheConfigurationMXBean.kt` | `getClearAuthority(): String` 공개 계약 |
+| management | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheManagementMXBean.kt` 및 adapter/registration 관련 파일 | snapshot 값의 실제 MBean read-back |
+| core RED/회귀 | `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheClearAuthorityContractTest.kt` | guard, pre-mutation 불변성, owner/비-owner destructive 계약 |
+| core 기존 fixture | `cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/nearcache/jcache/AbstractNearJCacheTest.kt` 및 영향받는 core tests | cleanup 의도에는 explicit `EXCLUSIVE_BACK_CACHE`를 주입하고 shared/default 경로는 `DENY`를 고정 |
+| core management tests | `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/management/*` | snapshot/MXBean token, 실제 MBeanServer read-back |
+| Lettuce | `cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/LettuceCaches.kt` 및 near-cache 계약 테스트 | 기존 default와 explicit authority overload |
+| Hazelcast | `cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/HazelcastCaches.kt`, `cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/HazelcastNearJCache.kt` 및 테스트 | listener-free factory, default/explicit authority, peer-data 보존 |
+| Redisson | `cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/RedissonCaches.kt` 및 계약 테스트 | 기존 overload 보존과 explicit authority 전달 |
+| reader docs | `cache/cache-core/README.md`, `cache/cache-core/README.ko.md`, `docs/cache/near-cache-capability-matrix.md` | default DENY, exclusive owner migration, tenant boundary |
+| provider docs | `cache/cache-lettuce/README.md`, `cache/cache-lettuce/README.ko.md`, `cache/cache-hazelcast/README.md`, `cache/cache-hazelcast/README.ko.md`, `cache/cache-redisson/README.md`, `cache/cache-redisson/README.ko.md` | 실제 factory 예제의 default DENY와 explicit owner migration; Redisson에 blocking `NearJCache` 예제가 없으면 inventory에서 N/A 근거를 기록 |
+| manuals | `docs/manual/en/modules/bluetape4k-cache-core/near-cache-semantics.md`, `docs/manual/ko/modules/bluetape4k-cache-core/near-cache-semantics.md`, `docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md`, `docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md` | factory/config examples, clear 범위, close ownership |
+| release note | `CHANGELOG.md` | behavior migration과 explicit authority 안내 |
+| lesson | `docs/lessons/2026-08-17-issue-1368-nearcache-clear-authority.md` | 결과, 검증, 실패/놀람, 후속 경계 기록 |
+
+symbol search에서 추가 public factory 또는 destructive clear 예제가 발견되면 같은 PR에서 EN/KO parity를 맞춘다. 새 module/dependency 또는 tenant authorization protocol이 필요해지면 이 계획의 범위를 중단하고 별도 설계로 분리한다.
+
+## Task 1 — baseline, 영향도와 frozen contract inventory
+
+**Depends on:** 승인된 design spec과 PR1 exact head 확인
+
+**Files:** read-only source, tests, provider factories, docs, live Issue/PR metadata
+
+- [ ] 현재 worktree와 canonical `develop`의 base/head를 확인하고 PR1의 exact head, CI, review blocker, mergeability를 live-read한다.
+- [ ] `rg -n "NearJCache\\(|clearAllCache|removeAll\\(|fun clear\\(" cache/cache-core cache/cache-lettuce cache/cache-hazelcast cache/cache-redisson`으로 public constructor/factory와 destructive call site를 inventory한다.
+- [ ] `NearJCacheConfig`의 fields, constructors, `copy`/`copy$default`, `readObject`, serialVersionUID를 기록해 authority가 config에 들어가지 않음을 확인한다.
+- [ ] `clear()`의 현재 `compoundGate`·listener detach·mutation epoch·back write generation·front/back clear·listener restore 순서를 읽고 테스트의 observable boundary를 고정한다.
+- [ ] public `backCache` 직접 호출과 `ResilientNearJCache.kt`/`ResilientSuspendNearJCache.kt`의 `clearAll()`/`ClearBack` 경로를 별도로 inventory한다. 이 PR2의 wrapper-only authority 주장과 후속 issue 후보를 혼동하지 않도록 source ledger에 기록한다.
+- [ ] `AbstractNearJCacheTest` setup/teardown과 management tests의 cleanup call은 explicit owner가 필요하다는 migration 목록에 넣는다.
+- [ ] `docs/superpowers/specs/2026-08-16-epic-1408-nearjcache-safety-tail-design.md`의 PR2 API, failure mode, non-goal과 차이가 없음을 표로 기록한다.
+
+**Evidence:** inventory 명령 output, exact base/head read-back, design line references, 수정 없는 `git diff --check`.
+
+## Task 2 — RED 테스트: authority guard와 public contract
+
+**Depends on:** Task 1
+
+**Pattern skills:** `$test-driven-development`, `$bluetape-kotlin-patterns`, `bluetape-kotlin-patterns/references/testing.md`
+
+**Create:** `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheClearAuthorityContractTest.kt`
+
+- [ ] 새 테스트에 minimal fake front/back/listener harness를 만들고, private implementation detail에 의존하지 않고 contents, listener registration, epoch/generation test hook 또는 package-visible probe로 pre-mutation 불변성을 관찰한다.
+- [ ] 기존 3-argument constructor와 `NearJCache(config, backCache)`가 authority를 지정하지 않으면 `DENY`임을 고정한다.
+- [ ] `DENY`에서 `clear()`, `clearAllCache()`, no-arg `removeAll()` 각각이 operation token을 포함한 `SecurityException`을 던지는지 검증한다. message에 cache name, key, value, provider payload가 포함되지 않는지도 검증한다.
+- [ ] 거부 전후 front contents, back contents, listener registration, mutation epoch, back write generation이 동일하고 front/back clear/remove 호출이 0회임을 검증한다.
+- [ ] `DENY` guard가 compound lock 또는 listener detach보다 먼저 평가되도록 reentrant/blocking fake로 순서를 고정한다.
+- [ ] explicit `EXCLUSIVE_BACK_CACHE` constructor에서 `clear()`가 front와 back을 모두 지우고 listener generation barrier를 유지하는지 검증한다.
+- [ ] explicit owner에서 `clearAllCache()`와 no-arg `removeAll()`도 각각 front/back namespace를 지우고 동일한 listener/epoch/generation barrier를 사용하는지 검증한다.
+- [ ] owner clear의 back failure에서 primary throwable과 listener restore/cleanup failure의 suppressed throwable 순서가 기존 계약과 동일함을 검증한다.
+- [ ] owner `clearAllCache()`와 owner no-arg `removeAll()`의 back failure/restore failure도 operation별로 primary/suppressed 계약을 유지하는지 검증한다.
+- [ ] owner clear에서 listener re-registration failure가 원래 clear failure를 가리지 않는지 검증한다.
+- [ ] `removeAll(keys)`와 single-key `remove`는 `DENY`에서도 기존 범위 안에서 성공하고 다른 key/peer data를 삭제하지 않는지 검증한다.
+- [ ] management snapshot/MXBean read-back이 `DENY`와 `EXCLUSIVE_BACK_CACHE`를 각각 stable token으로 반환하도록 RED test를 추가한다.
+- [ ] RED 확인 command를 실행한다:
+
+```bash
+./gradlew :bluetape4k-cache-core:test \
+  --tests "io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthorityContractTest" \
+  --no-configuration-cache
+```
+
+**Expected RED:** enum/constructor/guard/MXBean API가 아직 없으므로 컴파일 실패 또는 assertion failure가 발생한다. 실패 output을 저장하고 production implementation 전까지 보존한다.
+
+### Task 2A — provider factory RED
+
+**Depends on:** Task 2 core RED
+
+**Files:** 기존 provider 계약 테스트에 추가할 default/explicit authority cases
+
+- [ ] Lettuce `LettuceNearJJCacheTest`, Hazelcast `HazelcastNearJCacheTest`, Redisson `RedissonNearJCacheTest`에 기존 factory default `DENY`, explicit owner success, shared peer-data preservation RED cases를 추가한다.
+- [ ] 각 provider에서 `clear()`, `clearAllCache()`, no-arg `removeAll()` 세 operation을 default/explicit owner 양쪽에 고정한다. Testcontainers가 필요한 peer-data assertion은 production API가 컴파일된 뒤 실행한다.
+- [ ] production provider overload를 아직 작성하지 않은 상태에서 compile RED를 확인한다:
+
+```bash
+./gradlew :bluetape4k-cache-lettuce:compileTestKotlin \
+  :bluetape4k-cache-hazelcast:compileTestKotlin \
+  :bluetape4k-cache-redisson:compileTestKotlin \
+  --no-configuration-cache
+```
+
+**Expected RED:** `NearJCacheClearAuthority` import와 explicit factory overload가 없어 provider test compile이 실패한다. 이 실패 output을 Task 3/5 production edit 전에 보존한다.
+
+## Task 3 — core runtime authority 구현
+
+**Depends on:** Task 2 and Task 2A RED
+
+**Files:** enum, `NearJCache.kt`, affected core constructors and test fixture call sites
+
+- [ ] `NearJCacheClearAuthority`를 runtime-only enum으로 추가하고, serialized config/property/stream에 들어가지 않는다는 KDoc을 쓴다.
+- [ ] `NearJCache` public constructor `(frontCache, backCache, config, clearAuthority)`를 추가하고 기존 3-argument constructor는 `DENY`로 위임한다.
+- [ ] companion factory `NearJCache(config, backCache, clearAuthority)`를 추가하고 기존 factory는 `DENY`로 위임한다. 기존 listener registration semantics는 owner/default behavior가 정해진 경로에 맞춰 보존한다.
+- [ ] authority를 immutable property와 configuration snapshot 입력으로 보존한다. factory가 만든 back cache의 생성 여부나 provider lifecycle로 authority를 자동 승격하지 않는다.
+- [ ] 공통 private/package-visible guard를 구현해 `clear()`, `clearAllCache()`, no-arg `removeAll()`의 첫 줄 경계에서 호출한다. `DENY`는 compoundGate, listener detach, epoch/generation, front/back mutation보다 먼저 실패한다.
+- [ ] `EXCLUSIVE_BACK_CACHE`에서는 기존 clear sequence와 listener generation barrier를 재사용한다. 실패 시 primary/suppressed throwable 및 listener restoration 계약을 바꾸지 않는다.
+- [ ] `clearAllCache()`와 no-arg `removeAll()`도 동일 guard를 통과한 뒤 기존 back mutation/error path를 실행하도록 하고, 세 operation 각각의 owner success/failure 테스트를 green으로 만든다.
+- [ ] key-scoped `removeAll(keys)`와 single-key `remove`에는 authority guard를 추가하지 않는다.
+- [ ] fixture setup/teardown과 기존 destructive cleanup tests에는 explicit `EXCLUSIVE_BACK_CACHE`를 주입하되, default-deny/provider/shared-back contract tests는 별도 factory helper로 `DENY`를 생성한다. 하나의 fixture가 owner cleanup으로 default 거부 assertion을 가리지 않도록 test names와 helper ownership을 분리한다.
+- [ ] Task 2 RED test를 다시 실행해 green으로 전환한다.
+
+**Implementation checks:** `rg`로 모든 namespace-wide call path가 guard를 거치는지 확인하고, `git diff --check`를 실행한다.
+
+## Task 4 — stable management metadata
+
+**Depends on:** Task 3 green core contract
+
+- [ ] `NearJCacheConfigurationSnapshot`에 `clearAuthority` stable token을 추가하되 owner identity, credential, cache payload를 포함하지 않는다.
+- [ ] `NearJCacheConfigurationMXBean`에 `getClearAuthority(): String`를 `-jvm-default=enable` default method로 추가해 기존 외부 implementor의 binary/source compatibility를 보존한다. 기본 method는 `DENY`를 반환하고 NearJCache management implementation/adapter는 snapshot 값을 override해 반환한다.
+- [ ] management registration이 실제 `MBeanServer`에서 `DENY`/`EXCLUSIVE_BACK_CACHE`를 read-back하는 테스트를 추가한다.
+- [ ] 기존 logical/tier statistics와 management registration lifecycle이 변하지 않는지 기존 tests를 수정 없이 또는 최소 변경으로 유지한다.
+- [ ] MXBean method signature와 descriptor를 `javap`/reflection으로 확인하고, 새 method를 구현하지 않는 precompiled-style Java implementor fixture가 current interface에서 로드되는지 검증한다.
+
+**Evidence:** management unit test, real MBeanServer read-back, descriptor output, diff check.
+
+## Task 5 — provider factory overload와 shared-back 계약
+
+**Depends on:** Task 3, Task 4
+
+- [ ] Lettuce `nearJCache` DSL/config factory의 기존 signature를 `DENY`로 유지하고, authority를 필수로 받는 overload를 추가한다. DSL overload는 `(redisClient, clearAuthority, codec, block)`, config overload는 `(redisClient, config, clearAuthority, codec)` 순서로 고정해 기존 `codec` positional call과 충돌하지 않게 한다. KDoc에 factory creation이 ownership proof가 아님을 쓴다.
+- [ ] Hazelcast `HazelcastCaches.nearJCache`와 `HazelcastNearJCache` public factory에 기존 listener-free 경로를 유지한 explicit authority overload를 추가한다. DSL은 `(hazelcastInstance, clearAuthority, block)`, config는 `(hazelcastInstance, config, clearAuthority)`, public object factory는 기존 required args 뒤에 필수 authority를 둔다. supplied front close ownership과 back/provider non-ownership KDoc을 유지한다.
+- [ ] Redisson direct-back/client factory에도 기존 default와 explicit authority overload를 추가한다. direct-back은 `(backCache, nearJCacheConfig, clearAuthority)`, client factory는 authority를 required enum slot으로 두어 기존 optional `Configuration`/`NearJCacheConfig` positional call을 보존한다.
+- [ ] 각 provider contract test에서 default factory의 `clear()`/`clearAllCache()`/no-arg `removeAll()` 거부와 explicit owner clear를 검증한다.
+- [ ] shared back fixture에 peer cache data를 채우고 non-owner/default 호출 후 peer data가 보존되는지 검증한다.
+- [ ] Testcontainers-backed provider tests는 Lettuce → Hazelcast → Redisson 순서로 하나씩 실행한다. Docker host/Ryuk 설정은 현재 repository/user configuration을 그대로 사용하고 테스트 간 daemon overlap을 만들지 않는다.
+- [ ] public JVM signature를 `javap` 또는 Kotlin reflection으로 확인해 기존 overload가 사라지지 않았음을 증명한다.
+- [ ] 각 provider의 기존 positional call, default `DENY` call, explicit owner call을 작은 compile-only fixture로 각각 컴파일해 overload ambiguity와 default authority 누락을 조기에 잡는다.
+
+**Provider test commands:**
+
+```bash
+./gradlew :bluetape4k-cache-lettuce:test \
+  --tests "io.bluetape4k.cache.nearcache.jcache.LettuceNearJJCacheTest" \
+  --tests "io.bluetape4k.cache.nearcache.jcache.LettuceNearJCacheWriteThroughReentrancyTest" \
+  --no-configuration-cache
+./gradlew :bluetape4k-cache-hazelcast:test \
+  --tests "io.bluetape4k.cache.nearcache.jcache.HazelcastNearJCacheTest" \
+  --no-configuration-cache
+./gradlew :bluetape4k-cache-redisson:test \
+  --tests "io.bluetape4k.cache.nearcache.jcache.RedissonNearJCacheTest" \
+  --no-configuration-cache
+```
+
+## Task 6 — 문서, KDoc, migration과 release-facing note
+
+**Depends on:** Task 4 API/token stable, Task 5 factory signatures stable
+
+- [ ] core README 영어/한글에 default `DENY`, explicit exclusive owner example, key-scoped remove와 namespace clear의 차이를 추가한다.
+- [ ] Lettuce/Hazelcast/Redisson provider README 영어/한글의 실제 `NearJCache` factory surface를 갱신한다. blocking factory 예제가 없는 locale/provider는 검색 결과와 N/A 사유를 evidence로 남기고, 존재하는 예제에는 default `DENY`, explicit authority overload, `close()` ownership을 반영한다.
+- [ ] capability matrix에 destructive operation authority, default, owner path, shared-back restriction, `close()` non-deletion을 기록한다.
+- [ ] core manual 영어/한글에 constructor/factory migration, SecurityException, tenant는 namespace/key list로 분리해야 한다는 경계를 기록한다.
+- [ ] 문서에는 `nearCache.backCache.clear()` 같은 provider 직접 호출이 이 wrapper guard의 대상이 아니며, `backCache` reference를 권한 없는 코드에 전달하면 안 된다는 caller-owned 경계를 명시한다. `ResilientNearJCache`/`ResilientSuspendNearJCache`의 `ClearBack`는 이번 PR2 보장 범위가 아니라는 문구도 추가한다.
+- [ ] Hazelcast serialization manual 영어/한글에서 serialization-safe config와 runtime authority를 분리하고, `clear()`가 front/back를 모두 지우는 사실과 `close()` ownership을 정확히 설명한다.
+- [ ] public constructor/factory parameter와 MXBean getter KDoc에 ownership/capability 전달과 default semantics를 명시한다.
+- [ ] `CHANGELOG.md`에 behavior migration을 한국어로 기록하되 API identifiers와 exception token은 그대로 보존한다.
+- [ ] 변경한 EN/KO 문서 쌍에는 동일한 `<!-- nearjcache-clear-authority-contract -->` / `<!-- /nearjcache-clear-authority-contract -->` marker를 넣고, marker block 안의 heading level 순서, fenced-code block 내용, API identifier·숫자 occurrence map, stale clear 범위 문구 부재를 검증한다. provider별 pair와 Redisson N/A inventory를 결과에 포함한다.
+
+**Documentation checks:** Markdown links, code fences, `git diff --check`, relevant documentation tests, exact `clear()` result examples, EN/KO normalized heading/code-fence/token parity read-back.
+
+```bash
+python3 - <<'PY'
+from collections import Counter
+from pathlib import Path
+import re
+
+pairs = [
+    ("cache/cache-core/README.md", "cache/cache-core/README.ko.md"),
+    ("cache/cache-lettuce/README.md", "cache/cache-lettuce/README.ko.md"),
+    ("cache/cache-hazelcast/README.md", "cache/cache-hazelcast/README.ko.md"),
+    ("cache/cache-redisson/README.md", "cache/cache-redisson/README.ko.md"),
+    ("docs/manual/en/modules/bluetape4k-cache-core/near-cache-semantics.md", "docs/manual/ko/modules/bluetape4k-cache-core/near-cache-semantics.md"),
+    ("docs/manual/en/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md", "docs/manual/ko/modules/bluetape4k-cache-hazelcast/jcache-near-cache-serialization.md"),
+]
+technical = re.compile(r"`[^`]+`|#(?:1355|1363|1368|1369|1408)|[0-9]+")
+start, end = "<!-- nearjcache-clear-authority-contract -->", "<!-- /nearjcache-clear-authority-contract -->"
+def contract(text):
+    block = text.split(start, 1)[1].split(end, 1)[0]
+    levels = re.findall(r"^(#{1,6}) ", block, re.M)
+    fences = re.findall(r"```[^\n]*\n(.*?)```", block, re.S)
+    return levels, [Counter(technical.findall(fence)) for fence in fences], Counter(technical.findall(block))
+
+for left, right in pairs:
+    left_text, right_text = Path(left).read_text(), Path(right).read_text()
+    assert start in left_text and end in left_text and start in right_text and end in right_text, (left, right, "marker")
+    assert contract(left_text) == contract(right_text), (left, right, "contract-block")
+    assert not re.search(r"front[ -]only|프론트만|front-only", left_text + right_text, re.I), (left, right, "stale-clear-scope")
+print(f"validated {len(pairs)} EN/KO pairs: heading/fence/token parity")
+PY
+```
+
+## Task 7 — 순차 검증과 independent review
+
+**Depends on:** Tasks 2–6
+
+- [ ] core targeted authority/management tests를 실행한다.
+- [ ] `./gradlew :bluetape4k-cache-core:test --no-configuration-cache`를 실행한다.
+- [ ] `./gradlew detekt --no-configuration-cache`를 실행한다.
+- [ ] provider tests를 Task 5 순서로 순차 실행하고 Docker/Testcontainers evidence를 기록한다.
+- [ ] public API/ABI descriptor와 serialization compatibility를 확인한다.
+- [ ] `git diff --check`와 worktree status를 확인한다.
+- [ ] six perspective review를 독립 lane으로 요청한다: architecture/security, API/ABI, tests/failure modes, provider integration, documentation/Korean parity, operations/stack boundaries. 각 lane은 read-only이며 현재 plan/code exact head를 읽는다.
+- [ ] P0/P1 finding, ABI break, peer-data deletion, listener barrier regression이 있으면 해당 task로 돌아가 수정 후 영향을 받은 review와 검증을 다시 실행한다.
+
+## Task 8 — lesson, stacked-train handoff, stop boundary
+
+**Depends on:** Task 7 clear
+
+- [ ] `docs/lessons/2026-08-17-issue-1368-nearcache-clear-authority.md`에 결정, 검증 명령, 실제 결과, 실패/놀람, 후속 guard를 한국어로 기록한다.
+- [ ] implementation branch가 PR1 exact head 위에 있고, PR1 merge 후 base rebase가 필요한 경우 rebase 전후 commit/tree를 기록한다.
+- [ ] PR body를 작성할 경우 마지막 section은 정확히 `## DoD Status`로 하고, `Required checks: X/Y; N/A: N; Blocked: N` 형식과 evidence table, final status, unchecked items를 포함한다. PR 생성은 사용자에게 대상 repo/base/head와 검증 evidence를 보고한 뒤 별도 authority로 처리한다.
+- [ ] merge는 하지 않는다. merge 전에 exact head, CI, review threads, mergeability, linked issue와 fresh merge approval를 다시 읽는다.
+- [ ] canonical `develop`을 변경하지 않았고 isolated worktree가 clean인지 확인한다.
+
+## 실패 모드와 rollback/risk 표
+
+| 위험 | 방지 계약 | 검증 | rollback |
+| --- | --- | --- | --- |
+| 기존 caller의 destructive clear가 갑자기 실패함 | 기존 overload는 `DENY`, 명시적 owner만 opt-in, migration docs/KDoc | default-deny tests, docs parity, changelog | caller가 명시적 owner overload로 전환; shared caller는 key-list/namespace 전략 사용 |
+| `NearJCacheConfig` serialization/ABI가 깨짐 | authority를 config 밖 runtime state로 분리하고 기존 constructor/copy/stream을 유지 | reflection/javap, serialization tests, precompiled consumer | production code를 revert해도 config wire format은 그대로 유지 |
+| provider factory가 ownership을 과도하게 부여함 | 모든 기존 factory default `DENY`, explicit overload만 authority 전달 | Lettuce/Hazelcast/Redisson default + explicit tests | factory overload를 제거하지 않고 caller migration을 되돌림 |
+| listener barrier 순서가 변함 | guard는 pre-mutation, owner path는 기존 sequence 재사용 | listener registration/epoch/generation and failure tests | authority guard와 overload만 revert하고 기존 clear sequence 복원 |
+| fixture cleanup이 전부 거부됨 | cleanup 의도에 explicit `EXCLUSIVE_BACK_CACHE` 주입, shared tests는 deny 유지 | core fixture/full module tests | fixture injection commit만 revert하고 public default는 유지 |
+| shared peer data가 삭제됨 | non-owner/default guard와 peer-data preservation test | provider shared-back tests | 해당 branch를 중단하고 offending factory/guard path 수정 |
+| public `backCache` 직접 호출이 wrapper guard를 우회함 | caller-owned escape hatch를 문서화하고 untrusted caller에 reference를 노출하지 않음 | source inventory, docs/KDoc negative boundary, no false global-ACL claim | wrapper API surface를 숨기는 별도 ABI/design issue로 분리 |
+| Resilient wrapper의 `ClearBack` 경로가 별도 authority 없이 back을 지움 | 이번 PR2의 non-goal과 후속 issue 후보를 lesson에 고정 | Resilient source inventory와 scope review | 별도 authority design 없이는 PR2에 포함하지 않음 |
+| management metadata가 unstable payload를 노출함 | 두 stable enum token만 snapshot/MXBean에 공개 | MBeanServer read-back and descriptor test | metadata getter change만 revert; runtime authority contract 유지 |
+| #1355 atomicity와 scope가 섞임 | compound atomicity/SuspendNearJCache를 명시적 non-goal로 고정 | plan review and symbol diff | 별도 issue/design으로 분리; PR2에 추가하지 않음 |
+
+## 실행 명령 요약
+
+```bash
+git -C .worktrees/fix-1368-nearcache-clear-authority status --short --branch
+git -C .worktrees/fix-1368-nearcache-clear-authority diff --check
+
+./gradlew :bluetape4k-cache-core:test \
+  --tests "io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthorityContractTest" \
+  --no-configuration-cache
+./gradlew :bluetape4k-cache-core:test --no-configuration-cache
+./gradlew detekt --no-configuration-cache
+./gradlew :bluetape4k-cache-lettuce:test \
+  --tests "io.bluetape4k.cache.nearcache.jcache.LettuceNearJJCacheTest" \
+  --tests "io.bluetape4k.cache.nearcache.jcache.LettuceNearJCacheWriteThroughReentrancyTest" \
+  --no-configuration-cache
+./gradlew :bluetape4k-cache-hazelcast:test \
+  --tests "io.bluetape4k.cache.nearcache.jcache.HazelcastNearJCacheTest" \
+  --no-configuration-cache
+./gradlew :bluetape4k-cache-redisson:test \
+  --tests "io.bluetape4k.cache.nearcache.jcache.RedissonNearJCacheTest" \
+  --no-configuration-cache
+```
+
+각 명령은 실제 exit code와 relevant test summary를 기록한다. Testcontainers 명령은 병렬 실행하지 않는다. 실패하면 실패한 명령, 첫 원인, 재현 조건, 수정 후 재실행 결과를 lesson과 final DoD에 남긴다.
+
+## 요구사항 traceability
+
+| 승인된 설계 요구 | 계획 task | 구현/검증 증거 |
+| --- | --- | --- |
+| serializable config와 runtime authority 분리 | Task 1, Task 3 | enum 파일, 기존 constructor/stream 불변성, reflection/serialization read-back |
+| 세 namespace-wide operation fail-closed | Task 2, Task 3 | `NearJCacheClearAuthorityContractTest`, pre-mutation call-count와 state snapshot |
+| exclusive owner의 기존 clear barrier 보존 | Task 2, Task 3 | listener detach/restore, epoch/generation, primary/suppressed failure tests |
+| key-scoped remove는 유지 | Task 2, Task 3 | `removeAll(keys)`·single-key `remove` 허용 및 peer-data 보존 tests |
+| provider가 ownership을 추론하지 않음 | Task 5 | Lettuce/Hazelcast/Redisson default DENY와 explicit overload tests |
+| stable management visibility | Task 4 | snapshot/MXBean token, real `MBeanServer` read-back, descriptor evidence |
+| reader migration과 tenant boundary | Task 6 | README/manual/matrix/CHANGELOG EN/KO parity, close ownership 문서 |
+| wrapper/provider direct-call 경계와 Resilient non-goal | Task 1, Task 6, Task 8 | source inventory, explicit negative docs, 후속 issue 후보 lesson |
+| stacked PR train과 별도 merge gate | Task 1, Task 7, Task 8 | exact base/head, CI/review read-back, PR/merge hold |
+
+## SPW writer gate 기록
+
+- [x] **SPW-01:** 독자는 구현자·리뷰어·운영자이고 목적은 #1368 PR2의 실행 순서와 증거를 고정하는 것이다. 기준 원본은 Issue #1368/#1408, 승인된 safety-tail spec, #1363 lesson, #1355 boundary와 현재 source/factory/test/docs inventory다. 미확정 사항은 implementation/test 결과로 남기며 계획에서 사실로 단정하지 않는다.
+- [x] **SPW-02:** goal, architecture, scope/non-goal, exact file map, dependency order, RED/green actions, commands/evidence, rollback/rerun points, review/approval gates와 stop boundary를 포함했다.
+- [x] **SPW-03:** 한국어 기술 문체, 고정 용어(`authority`, `namespace`, `front/back`, `listener generation barrier`, `SecurityException`)와 exact identifiers/commands를 보존하고 KO-01..KO-06 자연스러움 점검을 계획 read-back에서 수행했다.
+- [x] **SPW-04:** 승인 spec-to-plan traceability 표와 현재 source symbol inventory를 기준으로 API/ABI, failure mode, provider ownership, management token, EN/KO migration을 대조했고, 독립 spec review가 CLEAR를 반환했다.
+- [x] **SPW-05:** 최종 Markdown read-back에서 heading/table/list/code fence, 링크와 unchecked item을 확인하고, 독립 review disposition을 반영했다.
+
+## Plan review disposition
+
+- [x] architecture/API/stack review: 이전 public `backCache` escape와 Resilient `ClearBack` 누락을 wrapper-only boundary 및 explicit non-goal로 보완한 뒤 CLEAR.
+- [x] quality/TDD review: provider RED, exact Lettuce FQCN, owner/default fixture 분리, 세 operation의 owner failure coverage와 MXBean default bridge를 보완한 뒤 CLEAR 조건 충족.
+- [x] writer/Korean review: provider README 6개 surface, marker-scoped exact EN/KO parity, stale clear-scope negative assertion과 검증 순서를 보완한 뒤 CLEAR.
+
+## Plan self-review checklist
+
+- [x] 모든 구현 단계가 정확한 파일과 선행 조건을 가진다.
+- [x] RED → production → management → provider → docs → verification 순서가 의존성을 만족한다.
+- [x] default deny, pre-mutation guard, owner barrier, peer-data preservation이 독립 테스트로 고정된다.
+- [x] old API/serialization shape와 new explicit overload의 경계가 명시되어 있다.
+- [x] EN/KO 문서와 KDoc의 migration/close ownership/tenant non-goal이 포함되어 있다.
+- [x] provider Testcontainers 순서, Docker/Ryuk 운영 경계, stacked PR base/head가 포함되어 있다.
+- [x] 미완료 placeholder나 임시 보류 표식이 없다.
+- [x] plan read-back, Korean naturalness, traceability, `git diff --check`가 완료된 뒤 commit한다.


### PR DESCRIPTION
## 변경 목적

`NearJCache`가 공유 `backCache`를 파괴적으로 비우는 경로를 기본 차단하고, 실제 back 소유자가 명시적으로 권한을 부여한 경우에만 허용합니다. 이 PR은 [#1368](https://github.com/bluetape4k/bluetape4k-projects/issues/1368)의 보안 경계를 구현합니다.

## Stacked PR train

- 선행 PR: #1435 (`fix/1369-nearcache-bounded-bulk`) — `develop`에 병합 완료
- base: `develop` @ `fcda05a350812ab7f359e8b018c2b28fa6c83b3d`
- head: `fix/1368-nearcache-clear-authority` @ `acd8f28370568180a43eb328fcd3bcf2803f840b`
- 후속 단계: hosted CI 확인 → fresh merge approval → merge/sync/cleanup

## 구현 계약

- 기본 `NearJCacheClearAuthority.DENY`를 사용해 `clear()`, `clearAllCache()`, 무인자 `removeAll()`을 fail-closed로 제한합니다.
- 공유 back을 독점 소유한 호출자만 `EXCLUSIVE_BACK_CACHE`를 명시해 전체 clear를 사용할 수 있습니다.
- key-scoped `remove(key)`와 `removeAll(keys)`는 기존 계약을 유지합니다.
- 권한은 runtime-only이며 config/serialization surface에 추가하지 않았습니다.
- Lettuce/Hazelcast/Redisson factory의 기존 overload는 안전한 `DENY`를 유지하고, 명시적 권한 overload만 opt-in합니다.
- public KDoc, MXBean snapshot, EN/KO 문서와 capability matrix에 동일한 소유권·close 계약을 반영했습니다.

## 검증 증거

- RED: authority enum/constructor/ABI가 없는 상태에서 core/provider compile 실패를 확인한 뒤 구현했습니다.
- Core: `NearJCacheClearAuthorityContractTest` 5건 및 전체 테스트 687건 통과
- Provider: Lettuce 74건, Hazelcast 6건, Redisson 73건 통과
- Documentation: EN/KO marker·fence·numeric·technical-token parity 테스트 6건 통과
- ABI: 기존 3-arg constructor와 Java legacy MXBean 구현체 호환 확인
- Static/benchmark: core/Lettuce/Hazelcast/Redisson detekt 통과, `compileBenchmarkKotlin` 통과
- `git diff --check` 통과

Fixes #1368

## DoD Status

Required checks: 5/5; N/A: 0; Blocked: 0

| Check | Evidence | Status |
|---|---|---|
| RED-to-green authority contract | Core authority contract 5 tests; default DENY and explicit owner opt-in assertions | PASS |
| Provider and compatibility coverage | Lettuce 74, Hazelcast 6, Redisson 73; ABI and legacy MXBean fixture | PASS |
| Documentation and management surface | EN/KO parity 6 tests; MXBean snapshot/KDoc/capability matrix | PASS |
| Static analysis and benchmark source | Four-module detekt; `compileBenchmarkKotlin` | PASS |
| Stacked base/head integrity | `develop` @ `fcda05a...`; head @ `acd8f283...`; 선행 PR #1435 merged | PASS |

Merge evidence: merge commit `c608db9cd83bd9549dd5cf8b4be157d20f2e6852`; remote and canonical `develop` both point to this SHA; Issue #1368 is closed; merged feature worktree and local branch were removed after ancestry/cleanliness proof.

Final status: DONE

Unchecked items:

- [x] hosted CI green and required checks read back
- [x] fresh merge approval for exact head
- [x] merge and canonical `develop` sync verification
- [x] merged/stale branch and isolated worktree cleanup proof
