### PR TITLE
[security][io] SecureDirectoryStream으로 Zip Slip TOCTOU 경계를 닫는다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 버그 수정
 
+- `ZipFileSupport.unzip`이 정규화된 archive entry 경로와 `SecureDirectoryStream` 디렉토리 상대 handle을 사용하도록 강화했다. `NOFOLLOW_LINKS`와 디렉토리 식별자 검증으로 대상 조상·중간 디렉토리 교체와 최종 파일 symlink를 통한 외부 쓰기를 차단하며, secure directory handle을 지원하지 않는 파일 시스템에서는 `IOException`으로 fail-closed 한다. hard link·mount 변경·적대적인 파일 시스템 관리자는 여전히 caller가 통제해야 한다
+  ([#1413](https://github.com/bluetape4k/bluetape4k-projects/issues/1413)).
 - `HazelcastNearJCache(...)` 공개 factory가 Hazelcast JCache listener 직렬화 경계를 넘지 않도록 listener-free degraded 경로를 사용한다. read-through와 write-through는 유지하지만 peer front-cache propagation은 보장하지 않는다
   ([#1411](https://github.com/bluetape4k/bluetape4k-projects/issues/1411)).
 - `NearJCache`의 namespace-wide `clear()`, `clearAllCache()`, 인자 없는 `removeAll()`을 기본 `NearJCacheClearAuthority.DENY`로 fail-closed 처리하고, back namespace 독점 소유를 확인한 caller만 `EXCLUSIVE_BACK_CACHE`로 opt-in하도록 했다. key-scoped removal은 유지하며 runtime-only 권한은 `NearJCacheConfig` 직렬화에 포함하지 않는다. 기존 destructive clear 호출자는 명시적 owner overload로 전환해야 한다

--- a/docs/lessons/2026-08-17-issue-1413-zip-slip-toctou.md
+++ b/docs/lessons/2026-08-17-issue-1413-zip-slip-toctou.md
@@ -1,0 +1,54 @@
+# ZIP 추출 sink의 SecureDirectoryStream 경계
+
+## 배경
+
+CodeQL `java/zipslip` alert 46은 `ZipFileSupport.unzip`의 정규화된 entry 경로
+검사만으로는 실제 파일 sink의 TOCTOU 경계를 증명할 수 없다는 점을 드러냈다.
+대상 디렉토리의 조상 또는 중간 디렉토리를 심볼릭 링크로 바꾸면
+`Files.createDirectories`와 path 기반 `FileOutputStream`이 검사 뒤의 다른 위치를
+따라갈 수 있었다.
+
+## 결정
+
+- archive entry는 `Path.normalize()`와 destination `Path.startsWith`로 먼저
+  containment를 확인한다.
+- 대상 디렉토리와 각 중간 디렉토리는 `LinkOption.NOFOLLOW_LINKS`로 검증하고,
+  파일을 열기 직전에 file key를 다시 읽어 open 시점의 식별자와 비교한다.
+- 실제 출력 sink는 `SecureDirectoryStream`의 디렉토리 상대 `newByteChannel`과
+  `NOFOLLOW_LINKS`로 고정한다. 열린 디렉토리 handle은 경로가 교체되어도 원래
+  디렉토리에 상대적으로 동작하므로 path-only pre-check에 의존하지 않는다.
+- secure directory handle을 제공하지 않는 파일 시스템은 path 기반 fallback 없이
+  `IOException`으로 fail-closed 한다.
+
+## 검증
+
+- RED: 대상 조상 symlink 회귀 테스트가 기존 `createDirectories` 경로를 통해
+  외부 디렉토리에 도달하여 `IOException` 기대를 만족하지 못했다.
+- GREEN: 조상 symlink, 기존 중간 디렉토리 symlink, 최종 파일 symlink, 중간
+  디렉토리 교체 경합에서 외부 sentinel 파일이 바뀌지 않는 회귀 테스트를 고정했다.
+- `ZipFileSupportTest` 14개 테스트가 구현 전후 계약을 검증했고, 변경 후 전체
+  클래스 실행에서 모두 성공했다.
+- CodeQL `java/zipslip` 재분석은 PR의 hosted workflow에서 현재 head를 대상으로
+  확인한다. alert가 계속 열려 있으면 sink 경계와 workflow 결과를 함께 기록하고
+  임의로 dismiss하지 않는다.
+
+## 잔여 한계
+
+`SecureDirectoryStream`은 운영체제와 파일 시스템 provider가 제공해야 한다. 이를
+지원하지 않는 환경에서는 추출이 실패하며 안전하지 않은 path-only fallback을
+사용하지 않는다. hard link, mount 변경, 파일 시스템 관리자 수준의 동시 조작은
+이 API가 소유하지 않는 경계이므로 caller는 신뢰 가능한 전용 대상 디렉토리와
+최소 권한을 사용해야 한다.
+
+## 향후 가드
+
+ZIP extraction 변경에는 `../` traversal, sibling-prefix, 조상·중간 디렉토리
+symlink, 최종 파일 symlink, 디렉토리 교체 경합을 함께 유지한다. sink를 바꾸면
+`SecureDirectoryStream` relative handle, `NOFOLLOW_LINKS`, directory identity
+검증, CodeQL hosted rerun을 같은 PR에서 확인한다.
+
+## 참고
+
+- [CodeQL `java/zipslip` query help](https://codeql.github.com/codeql-query-help/java/java-zipslip/)
+- [Java `SecureDirectoryStream` API](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/nio/file/SecureDirectoryStream.html)
+- [ZipFileSupport.kt](../../io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZipFileSupport.kt)

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -357,7 +357,7 @@ unzip(File("project.zip"), File("output/"))
 unzip(File("project.zip"), File("output/"), "*.kt", "*.xml")
 ```
 
-`unzip`은 archive traversal 경로를 거부하고 출력 경로의 심볼릭 링크를 따라가지 않습니다. 기존 출력 디렉토리와 파일을 쓰기 전에 다시 검증하여 symlink 및 TOCTOU 위험을 줄입니다.
+`unzip`은 모든 archive entry를 정규화하고 대상 디렉토리 밖으로 벗어나는 경로를 거부합니다. 출력 바이트는 `SecureDirectoryStream`의 디렉토리 상대 handle과 `NOFOLLOW_LINKS`를 통해서만 열며, 쓰기 전에 대상 및 중간 디렉토리의 식별자를 확인합니다. secure directory handle을 지원하지 않는 파일 시스템에서는 path-only 쓰기로 우회하지 않고 `IOException`으로 fail-closed 합니다. 따라서 symlink 및 디렉토리 교체 TOCTOU 공격이 출력 sink까지 도달하는 것을 차단하지만, hard link·mount 변경·적대적인 파일 시스템 관리자는 이 계약의 범위 밖이므로 caller는 신뢰할 수 있는 대상 디렉토리와 적절한 권한을 사용해야 합니다.
 
 ### 직렬화
 

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -357,7 +357,7 @@ unzip(File("project.zip"), File("output/"))
 unzip(File("project.zip"), File("output/"), "*.kt", "*.xml")
 ```
 
-`unzip` rejects archive traversal paths and refuses to follow symbolic links in the output path. Existing output directories and files are revalidated before writing to reduce symlink and TOCTOU risks.
+`unzip` normalizes every archive entry and rejects traversal outside the destination. Output bytes are opened only through `SecureDirectoryStream` directory-relative handles with `NOFOLLOW_LINKS`, while destination and intermediate directory identities are checked before the write. A file system without secure directory-handle support fails closed with `IOException` instead of falling back to a path-only write. This protects the extraction sink from symlink and directory-replacement TOCTOU attacks; callers should still use a trusted destination with appropriate permissions because hard links, mount changes, and hostile filesystem administration remain outside this contract.
 
 ### Serialization
 

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZipFileSupport.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/ZipFileSupport.kt
@@ -19,7 +19,11 @@ import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
+import java.nio.file.PathMatcher
+import java.nio.file.SecureDirectoryStream
 import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.BasicFileAttributeView
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.zip.Deflater
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.GZIPInputStream
@@ -272,7 +276,11 @@ fun unzip(zipFilename: String, destDirName: String, vararg patterns: String) {
 /**
  * ZIP 파일을 대상 디렉토리에 압축 해제합니다.
  *
- * Zip Slip 공격을 방어하여, 엔트리 경로가 대상 디렉토리 외부를 가리키면 [IllegalArgumentException]을 발생시킵니다.
+ * Zip Slip 공격을 방어하여, 정규화한 엔트리 경로가 대상 디렉토리 외부를 가리키면
+ * [IllegalArgumentException]을 발생시킵니다. 출력 파일은 [SecureDirectoryStream]의
+ * 디렉토리 상대 handle과 [LinkOption.NOFOLLOW_LINKS]로 열고, 추출 중 디렉토리 식별자가
+ * 바뀌면 [IOException]으로 중단합니다. secure directory handle을 지원하지 않는 파일
+ * 시스템에서도 외부 경로에 쓰지 않고 [IOException]으로 실패합니다.
  *
  * 예시:
  * ```kotlin
@@ -291,6 +299,8 @@ fun unzip(zipFilename: String, destDirName: String, vararg patterns: String) {
  * @param destDir 대상 디렉토리
  * @param patterns glob 패턴 (비어 있으면 모든 엔트리 추출)
  * @throws IllegalArgumentException Zip Slip 공격이 감지되면 발생
+ * @throws IOException 출력 경로의 심볼릭 링크·디렉토리 경합이 감지되거나 파일 시스템이
+ * secure directory handle을 지원하지 않으면 발생
  */
 fun unzip(zipFile: File, destDir: File, vararg patterns: String) {
     val zip = ZipFile(zipFile)
@@ -306,48 +316,36 @@ fun unzip(zipFile: File, destDir: File, vararg patterns: String) {
         var entryCount = 0
         var declaredUncompressedSize = 0L
         var extractedUncompressedSize = 0L
-        val canonicalDestDir = prepareZipDestination(destDir)
+        val preparedDestination = prepareZipDestination(destDir)
+        val canonicalDestDir = preparedDestination.path
+        openSecureDirectory(canonicalDestDir).use { destinationDirectory ->
+            verifyDirectoryIdentity(preparedDestination, destinationDirectory)
 
-        while (entries.hasMoreElements()) {
-            val entry = entries.nextElement()
-            val entryName = entry.name
-
-            // zip bomb 방어: 엔트리 수 제한
-            entryCount++
-            require(entryCount <= ZIP_MAX_ENTRIES) {
-                "ZIP 엔트리 수가 허용 한도를 초과했습니다: $entryCount > $ZIP_MAX_ENTRIES"
-            }
-
-            // zip bomb 방어: 비압축 크기 제한 (엔트리 헤더의 크기 정보 기준)
-            if (entry.size > 0) {
-                declaredUncompressedSize += entry.size
-                require(declaredUncompressedSize <= ZIP_MAX_UNCOMPRESSED_SIZE) {
-                    "ZIP 비압축 총 크기가 허용 한도를 초과했습니다: $declaredUncompressedSize > $ZIP_MAX_UNCOMPRESSED_SIZE bytes"
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                // zip bomb 방어: 엔트리 수 제한
+                entryCount++
+                require(entryCount <= ZIP_MAX_ENTRIES) {
+                    "ZIP 엔트리 수가 허용 한도를 초과했습니다: $entryCount > $ZIP_MAX_ENTRIES"
                 }
-            }
 
-            // 패턴 필터링
-            if (matchers.isNotEmpty()) {
-                val entryPath = java.nio.file.Path.of(entryName)
-                val matched = matchers.any { it.matches(entryPath) }
-                if (!matched) continue
-            }
-
-            val target = resolveZipTarget(canonicalDestDir, entryName)
-
-            if (entry.isDirectory) {
-                createZipDirectories(canonicalDestDir, target)
-            } else {
-                createZipDirectories(canonicalDestDir, target.parent ?: canonicalDestDir)
-                verifyNoSymlinkPath(canonicalDestDir, target)
-                zip.getInputStream(entry).use { input ->
-                    openZipOutput(target).buffered().use { output ->
-                        extractedUncompressedSize += input.copyToLimited(
-                            output = output,
-                            remainingLimit = ZIP_MAX_UNCOMPRESSED_SIZE - extractedUncompressedSize,
-                        )
+                // zip bomb 방어: 비압축 크기 제한 (엔트리 헤더의 크기 정보 기준)
+                if (entry.size > 0) {
+                    declaredUncompressedSize += entry.size
+                    require(declaredUncompressedSize <= ZIP_MAX_UNCOMPRESSED_SIZE) {
+                        "ZIP 비압축 총 크기가 허용 한도를 초과했습니다: " +
+                            "$declaredUncompressedSize > $ZIP_MAX_UNCOMPRESSED_SIZE bytes"
                     }
                 }
+
+                extractedUncompressedSize += extractZipEntry(
+                    zip = zip,
+                    entry = entry,
+                    matchers = matchers,
+                    canonicalDestDir = canonicalDestDir,
+                    destinationDirectory = destinationDirectory,
+                    remainingLimit = ZIP_MAX_UNCOMPRESSED_SIZE - extractedUncompressedSize,
+                )
             }
         }
     } finally {
@@ -356,14 +354,19 @@ fun unzip(zipFile: File, destDir: File, vararg patterns: String) {
     }
 }
 
-private fun prepareZipDestination(destDir: File): Path {
-    val destination = destDir.toPath().toAbsolutePath().normalize()
-    if (Files.isSymbolicLink(destination)) {
-        throw IOException("ZIP 대상 디렉토리는 심볼릭 링크일 수 없습니다: $destDir")
+private data class PreparedZipDestination(val path: Path, val fileKey: Any)
+
+private fun prepareZipDestination(destDir: File): PreparedZipDestination {
+    val lexicalDestination = destDir.toPath().toAbsolutePath().normalize()
+    verifyNoSymlinkAncestors(lexicalDestination)
+    Files.createDirectories(lexicalDestination)
+    verifyNoSymlinkAncestors(lexicalDestination)
+    if (!Files.isDirectory(lexicalDestination, LinkOption.NOFOLLOW_LINKS)) {
+        throw IOException("ZIP 대상 경로는 디렉토리여야 합니다: $destDir")
     }
-    Files.createDirectories(destination)
-    verifyNoSymlinkPath(destination, destination)
-    return destination.toRealPath()
+    val destination = lexicalDestination.toRealPath()
+    val fileKey = readFileKey(destination)
+    return PreparedZipDestination(destination, fileKey)
 }
 
 private fun resolveZipTarget(canonicalDestDir: Path, entryName: String): Path {
@@ -384,18 +387,64 @@ private fun resolveZipTarget(canonicalDestDir: Path, entryName: String): Path {
     return targetPath
 }
 
+private fun extractZipEntry(
+    zip: ZipFile,
+    entry: ZipEntry,
+    matchers: List<PathMatcher>,
+    canonicalDestDir: Path,
+    destinationDirectory: SecureDirectoryStream<Path>,
+    remainingLimit: Long,
+): Long {
+    val entryName = entry.name
+    val matched = matchers.isEmpty() || matchers.any { it.matches(Path.of(entryName)) }
+    return when {
+        !matched -> 0L
+        entry.isDirectory -> {
+            createZipDirectories(canonicalDestDir, resolveZipTarget(canonicalDestDir, entryName))
+            0L
+        }
+
+        else -> {
+            val target = resolveZipTarget(canonicalDestDir, entryName)
+            val parent = target.parent ?: canonicalDestDir
+            createZipDirectories(canonicalDestDir, parent)
+            verifyNoSymlinkPath(canonicalDestDir, target)
+            val relativeTarget = canonicalDestDir.relativize(target)
+            val fileName = relativeTarget.fileName
+                ?: throw IOException("ZIP 대상 파일 이름이 비어 있습니다: $entryName")
+            val relativeParent = relativeTarget.parent
+            val expectedParentKeys = captureDirectoryKeys(canonicalDestDir, relativeParent)
+
+            withSecureParentDirectory(
+                destinationDirectory,
+                relativeParent,
+                expectedParentKeys,
+            ) { parentDirectory ->
+                zip.getInputStream(entry).use { input ->
+                    openZipOutput(parentDirectory, fileName).buffered().use { output ->
+                        input.copyToLimited(output = output, remainingLimit = remainingLimit)
+                    }
+                }
+            }
+        }
+    }
+}
+
 private fun createZipDirectories(canonicalDestDir: Path, target: Path) {
     val relative = canonicalDestDir.relativize(target)
     var current = canonicalDestDir
     for (part in relative) {
         val child = current.resolve(part)
+        verifyNoSymlinkPath(canonicalDestDir, child)
         if (!Files.exists(child, LinkOption.NOFOLLOW_LINKS)) {
             try {
                 Files.createDirectory(child)
             } catch (_: java.nio.file.FileAlreadyExistsException) {
-                // 동시 생성자가 먼저 만든 경우이며, 아래 no-follow 검사가 안전성을 판단합니다.
+                // 동시 생성자가 먼저 만든 경우이며, 아래 no-follow 검사가
+                // 안전성을 판단합니다.
             }
         }
+        verifyNoSymlinkPath(canonicalDestDir, child)
         if (Files.isSymbolicLink(child) || !Files.isDirectory(child, LinkOption.NOFOLLOW_LINKS)) {
             throw IOException("ZIP 대상 경로에 심볼릭 링크 또는 파일이 있습니다: $child")
         }
@@ -409,21 +458,145 @@ private fun verifyNoSymlinkPath(canonicalDestDir: Path, target: Path) {
         "ZIP 대상 경로가 대상 디렉토리 밖에 있습니다: $target"
     }
 
-    var current = canonicalDestDir
-    if (Files.isSymbolicLink(current)) {
-        throw IOException("ZIP 대상 디렉토리는 심볼릭 링크일 수 없습니다: $current")
-    }
-    for (part in canonicalDestDir.relativize(target)) {
-        current = current.resolve(part)
+    verifyNoSymlinkAncestors(target)
+}
+
+private fun verifyNoSymlinkAncestors(path: Path) {
+    val root = path.root ?: return
+    var current = path
+    while (current != root) {
         if (Files.isSymbolicLink(current)) {
-            throw IOException("ZIP 대상 경로에 심볼릭 링크가 있습니다: $current")
+            if (current == path || current.parent != root) {
+                throw IOException("ZIP 대상 경로에 심볼릭 링크가 있습니다: $current")
+            }
+            // macOS의 /var, /tmp 같은 루트 직계 alias는 real path로 고정한 뒤 허용합니다.
+            return
         }
+        current = current.parent ?: break
     }
 }
 
-private fun openZipOutput(target: Path): OutputStream {
-    val channel = Files.newByteChannel(
-        target,
+private fun readFileKey(path: Path): Any {
+    val attributes = Files.readAttributes(
+        path,
+        BasicFileAttributes::class.java,
+        LinkOption.NOFOLLOW_LINKS,
+    )
+    return attributes.fileKey()
+        ?: throw IOException("ZIP 대상 경로의 파일 식별자를 확인할 수 없습니다: $path")
+}
+
+private fun readDirectoryFileKey(directory: SecureDirectoryStream<Path>): Any {
+    val view = directory.getFileAttributeView(BasicFileAttributeView::class.java)
+        ?: throw IOException("ZIP 대상 디렉토리의 파일 속성 보기를 열 수 없습니다")
+    return view.readAttributes().fileKey()
+        ?: throw IOException("ZIP 대상 디렉토리의 파일 식별자를 확인할 수 없습니다")
+}
+
+private fun verifyDirectoryIdentity(
+    preparedDestination: PreparedZipDestination,
+    destinationDirectory: SecureDirectoryStream<Path>,
+) {
+    if (preparedDestination.fileKey != readDirectoryFileKey(destinationDirectory)) {
+        throw IOException("ZIP 대상 디렉토리가 열기 전에 교체되었습니다: ${preparedDestination.path}")
+    }
+}
+
+private fun openSecureDirectory(path: Path): SecureDirectoryStream<Path> {
+    val root = path.root ?: throw IOException("ZIP 대상 경로에 루트가 없습니다: $path")
+    val rootStream = Files.newDirectoryStream(root)
+    val rootDirectory = rootStream as? SecureDirectoryStream<Path>
+        ?: run {
+            rootStream.close()
+            throw IOException(
+                "ZIP 추출에 secure directory handle을 지원하는 파일 시스템이 필요합니다",
+            )
+        }
+
+    var current = rootDirectory
+    try {
+        for (part in root.relativize(path)) {
+            val next = current.newDirectoryStream(part, LinkOption.NOFOLLOW_LINKS)
+            current.close()
+            current = next
+        }
+        return current
+    } catch (error: IOException) {
+        current.close()
+        throw error
+    }
+}
+
+private fun captureDirectoryKeys(canonicalDestDir: Path, relativeParent: Path?): List<Any> {
+    val keys = mutableListOf(readFileKey(canonicalDestDir))
+    if (relativeParent == null) return keys
+
+    var current = canonicalDestDir
+    for (part in relativeParent) {
+        current = current.resolve(part)
+        keys += readFileKey(current)
+    }
+    return keys
+}
+
+private inline fun <T> withSecureParentDirectory(
+    destinationDirectory: SecureDirectoryStream<Path>,
+    relativeParent: Path?,
+    expectedKeys: List<Any>,
+    block: (SecureDirectoryStream<Path>) -> T,
+): T {
+    if (relativeParent == null) {
+        return block(destinationDirectory)
+    }
+
+    val parentDirectory = openSecureRelativeDirectory(destinationDirectory, relativeParent, expectedKeys)
+    return try {
+        block(parentDirectory)
+    } finally {
+        parentDirectory.close()
+    }
+}
+
+private fun openSecureRelativeDirectory(
+    destinationDirectory: SecureDirectoryStream<Path>,
+    relativeParent: Path,
+    expectedKeys: List<Any>,
+): SecureDirectoryStream<Path> {
+    var current = destinationDirectory
+    var owned = false
+    var expectedIndex = 1
+    try {
+        for (part in relativeParent) {
+            val next = current.newDirectoryStream(part, LinkOption.NOFOLLOW_LINKS)
+            try {
+                val actualKey = readDirectoryFileKey(next)
+                val expectedKey = expectedKeys.getOrNull(expectedIndex)
+                    ?: throw IOException("ZIP 대상 디렉토리 식별자 수가 일치하지 않습니다")
+                if (actualKey != expectedKey) {
+                    throw IOException("ZIP 대상 중간 디렉토리가 열기 전에 교체되었습니다: $part")
+                }
+            } catch (error: IOException) {
+                next.close()
+                throw error
+            }
+            if (owned) current.close()
+            current = next
+            owned = true
+            expectedIndex++
+        }
+        if (expectedIndex != expectedKeys.size) {
+            throw IOException("ZIP 대상 디렉토리 식별자 검증이 완료되지 않았습니다")
+        }
+        return current
+    } catch (error: IOException) {
+        if (owned) current.close()
+        throw error
+    }
+}
+
+private fun openZipOutput(parentDirectory: SecureDirectoryStream<Path>, fileName: Path): OutputStream {
+    val channel = parentDirectory.newByteChannel(
+        fileName,
         setOf(
             StandardOpenOption.CREATE,
             StandardOpenOption.TRUNCATE_EXISTING,
@@ -452,7 +625,8 @@ private fun InputStream.copyToLimited(output: OutputStream, remainingLimit: Long
 
         copied += read
         require(copied <= remainingLimit) {
-            "ZIP 실제 비압축 총 크기가 허용 한도를 초과했습니다: ${ZIP_MAX_UNCOMPRESSED_SIZE - remainingLimit + copied} > $ZIP_MAX_UNCOMPRESSED_SIZE bytes"
+            "ZIP 실제 비압축 총 크기가 허용 한도를 초과했습니다: " +
+                "${ZIP_MAX_UNCOMPRESSED_SIZE - remainingLimit + copied} > $ZIP_MAX_UNCOMPRESSED_SIZE bytes"
         }
         output.write(buffer, 0, read)
     }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZipFileSupportTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/compressor/ZipFileSupportTest.kt
@@ -6,11 +6,17 @@ import io.bluetape4k.support.closeSafe
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import io.bluetape4k.assertions.assertFailsWith
 
 class ZipFileSupportTest {
@@ -208,6 +214,93 @@ class ZipFileSupportTest {
         assertFailsWith<IOException> {
             unzip(zipFile, destDir)
         }
+
+        outsideFile.readText() shouldBeEqualTo "기존 안전한 내용"
+    }
+
+    @Test
+    fun `unzip은 대상 디렉토리의 조상 심볼릭 링크를 따라가지 않는다`() {
+        val outsideDir = File(tempDir.parentFile, "zip-slip-ancestor-outside-${System.nanoTime()}").apply {
+            mkdirs()
+        }
+        val destinationParent = File(tempDir, "destination-parent").apply { mkdirs() }
+        Files.createSymbolicLink(
+            File(destinationParent, "redirect").toPath(),
+            outsideDir.toPath(),
+        )
+        val destDir = File(destinationParent, "redirect/extracted")
+
+        val zipFile = File(tempDir, "symlink-ancestor.zip")
+        zipFile.writeBytes(
+            ZipBuilder.ofInMemory()
+                .add("악성 조상 경로 쓰기").path("evil.txt").save()
+                .toBytes(),
+        )
+
+        assertFailsWith<IOException> {
+            unzip(zipFile, destDir)
+        }
+
+        File(outsideDir, "extracted/evil.txt").exists() shouldBeEqualTo false
+    }
+
+    @Test
+    fun `unzip은 중간 디렉토리 교체 경합에서 외부 파일을 쓰지 않는다`() {
+        val outsideDir = File(tempDir.parentFile, "zip-slip-race-outside").apply { mkdirs() }
+        val outsideFile = File(outsideDir, "evil.txt").apply { writeText("기존 안전한 내용") }
+        val destDir = File(tempDir, "race-output").apply { mkdirs() }
+        File(destDir, "nested").mkdirs()
+        val parkedDir = File(destDir, "nested-parked")
+        val payload = ByteArray(8 * 1024 * 1024) { 'A'.code.toByte() }
+        val zipFile = File(tempDir, "symlink-directory-race.zip")
+        val builder = ZipBuilder.ofInMemory()
+        repeat(4) { index ->
+            builder.add(payload).path("nested/evil-$index.txt").save()
+        }
+        zipFile.writeBytes(builder.toBytes())
+
+        val ready = CountDownLatch(2)
+        val stop = AtomicBoolean(false)
+        MultithreadingTester()
+            .workers(2)
+            .rounds(1)
+            .add {
+                ready.countDown()
+                ready.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                try {
+                    unzip(zipFile, destDir)
+                } catch (_: IOException) {
+                    // 경합으로 추출이 중단되는 것은 허용하지만 외부 쓰기는 허용하지 않는다.
+                } finally {
+                    stop.set(true)
+                }
+            }
+            .add {
+                ready.countDown()
+                ready.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                while (!stop.get()) {
+                    try {
+                        val nested = File(destDir, "nested").toPath()
+                        val parked = parkedDir.toPath()
+                        if (Files.exists(nested, LinkOption.NOFOLLOW_LINKS)) {
+                            if (!Files.exists(parked, LinkOption.NOFOLLOW_LINKS)) {
+                                Files.move(nested, parked, StandardCopyOption.ATOMIC_MOVE)
+                            }
+                            if (!Files.isSymbolicLink(nested)) {
+                                Files.createSymbolicLink(nested, outsideDir.toPath())
+                            }
+                        } else if (Files.isSymbolicLink(nested)) {
+                            Files.deleteIfExists(nested)
+                            if (Files.exists(parked, LinkOption.NOFOLLOW_LINKS)) {
+                                Files.move(parked, nested, StandardCopyOption.ATOMIC_MOVE)
+                            }
+                        }
+                    } catch (_: IOException) {
+                        // 추출기와 디렉토리 교체가 동시에 진행되는 동안의 정상적인 충돌이다.
+                    }
+                }
+            }
+            .run()
 
         outsideFile.readText() shouldBeEqualTo "기존 안전한 내용"
     }


### PR DESCRIPTION
## Summary

Closes #1413

현재 `develop`의 CodeQL `java/zipslip` alert #46은 path 정규화만으로는
검사와 실제 파일 sink 사이의 디렉토리 교체 경합을 닫지 못했습니다. 이 PR은
ZIP 출력 sink를 secure directory handle에 고정하고, 공격 경로가 실제 외부 파일로
이어지지 않는 회귀 증거와 residual limitation을 함께 남깁니다.

## Background

`ZipFileSupport.unzip`은 `../` traversal과 sibling-prefix를 거부했지만,
destination ancestor symlink가 `Files.createDirectories`를 외부 위치로 유도하거나
중간 디렉토리가 검사 뒤 교체될 수 있었습니다. Issue #1413은 live CodeQL alert
#46과 이 경계를 현재 HEAD에서 종결하기 위한 Epic #1416의 PR1입니다.

## What This Solves

- destination ancestor/intermediate symlink와 directory replacement TOCTOU가 ZIP
  bytes를 외부 파일에 쓰는 경로를 차단합니다.
- final output symlink를 따라가지 않고, secure directory handle을 지원하지 않는
  provider에서는 안전하지 않은 path-only fallback 없이 fail-closed 합니다.

## Work Done

- `SecureDirectoryStream` relative handle, `NOFOLLOW_LINKS`, directory file-key
  identity 검증을 사용해 실제 output channel을 엽니다.
- ancestor symlink, 기존 중간 directory symlink, final file symlink, concurrent
  directory swap 회귀 테스트와 EN/KO README, CHANGELOG, security lesson을 추가했습니다.

## Validation

- `./gradlew :bluetape4k-io:test --tests 'io.bluetape4k.io.compressor.ZipFileSupportTest' --no-daemon --no-build-cache --console=plain -Pbluetape4kDependenciesCatalogPath=/Users/debop/work/bluetape4k/bluetape4k-dependencies/gradle/libs.versions.toml`: PASS (14/14)
- `./gradlew :bluetape4k-io:test --no-daemon --no-build-cache --console=plain -Pbluetape4kDependenciesCatalogPath=/Users/debop/work/bluetape4k/bluetape4k-dependencies/gradle/libs.versions.toml`: PASS (1,265 tests)
- `./gradlew :bluetape4k-io:detekt --no-daemon --no-build-cache --console=plain -Pbluetape4kDependenciesCatalogPath=/Users/debop/work/bluetape4k/bluetape4k-dependencies/gradle/libs.versions.toml`: PASS (변경된 `ZipFileSupport.kt` 신규 finding 없음; 기존 모듈 baseline은 로그에 잔존)
- `git diff --check`: PASS
- [Build](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32040379515/job/95570250719): PASS
- [Test / IO](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32040379515/job/95570250530): PASS (외부 `nick-fields/retry` archive 일시 다운로드 오류 이후 동일 head 재실행에서 Gradle과 IO 테스트 완료)
- [Coverage Report](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32040379515/job/95570996444): PASS
- [CI Status](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32040379515/job/95571041786): PASS
- [CodeQL 수동 분석](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32090045479): PASS (동일 head `ac69cdd5c5c035ef0d2582464aa628b93fd7fd07`, 7/7 matrix job 성공; branch analysis에서 `java/zipslip` 결과 0건)
- [CodeQL Workflow Policy](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32040379515/job/95570268351): PASS

## Review Notes

- 보안/코드 품질 독립 lane: P0/P1/P2/P3 모두 0, 구현·테스트 증거 범위에서 `APPROVE`.
- Architecture 독립 lane: `CLEAR`. `unzip(zipFile: File, destDir: File, ...)`는 JVM 기본 provider에 고정된 기존 공개 API이므로 provider 주입용 `Path` overload나 alternate-provider 의존성을 PR1에 추가하지 않았습니다. 미지원 provider는 path-only fallback 없이 `IOException`으로 fail-closed하며, EN/KO README와 KDoc에 이 경계를 명시했습니다. 따라서 provider negative fixture는 현재 API 계약상 `N/A`이고 PR1 blocker가 아닙니다. [최종 검토 기록](https://github.com/bluetape4k/bluetape4k-projects/pull/1439#issuecomment-5323403627)
- 1인 개발자 review 예외: `develop` branch protection의 required approving review count는 `0`, required status context도 없습니다. 보안·architecture native lane의 독립 검토 artifact를 보존했으며 GitHub formal review self-approval은 사용하지 않았으므로 formal GitHub review는 `N/A`입니다.
- 기본 브랜치의 [CodeQL alert #46](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/46)은 merge 후 `develop` CodeQL run `32097815766` 7/7 성공과 최신 scoped category 0건을 확인한 뒤 stale legacy instance로 명시적 dismiss됐습니다. dismissal read-back: `dismissed`, reason `won't fix`, comment에 merge SHA와 분석 근거 보존.
- 새 stacked child #1414는 PR1의 머지 SHA와 closeout evidence가 고정된 뒤에만 시작합니다.

## Metadata

- Issue: [#1413](https://github.com/bluetape4k/bluetape4k-projects/issues/1413), milestone `1.13.0`, assignee `debop`
- PR: [#1439](https://github.com/bluetape4k/bluetape4k-projects/pull/1439)
- Base: `develop` at `c608db9cd83bd9549dd5cf8b4be157d20f2e6852`
- Head: `fix/1413-zip-slip-toctou` at `ac69cdd5c5c035ef0d2582464aa628b93fd7fd07`
- Labels: `bug`, `security`, `tech-debt`
- Stack: Epic #1416 PR1 merged at `bbcf1e71381382d40f2d823c5261e468b899ed8a`; 다음 child #1414는 이 closeout 이후 별도 stacked PR2로 시작

## DoD Status

Required checks: 8/8; N/A: 2; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| guidance - workflow | 필수 workflow·Kotlin·TDD·debugging·writer guidance를 재확인 | PASS | 로컬 workflow receipt `guidance` check | none |
| live-state - issue/stack | #1413, #1416, CodeQL #46, base `develop`, 다음 child #1414를 live-read | PASS | issue/PR/stack read-back | none |
| worktree - isolation | `fix/1413-zip-slip-toctou` 격리 worktree에서만 구현 | PASS | branch/worktree status와 workflow mutation-check | none |
| red-tests - root cause | ancestor symlink 경로에서 기존 구현의 outside write를 재현 | PASS | pre-fix `Expected IOException but no exception was thrown` | none |
| green-tests - regression | secure sink 및 symlink/TOCTOU 회귀 실행 | PASS | ZipFileSupportTest 14/14, io module 1,265 tests | none |
| docs - security contract | EN/KO README, CHANGELOG, lesson에 secure handle·residual limitation 기록 | PASS | 변경 파일 read-back, locale parity | none |
| diff-check - hygiene | whitespace와 변경 경로 검증 | PASS | `git diff --check`, trailing-whitespace scan | none |
| delivery - hosted evidence | exact head merge, aggregate CI, develop CodeQL, alert closeout, sync, cleanup | PASS | PR #1439 merge SHA `bbcf1e71381382d40f2d823c5261e468b899ed8a`; CI `32040379515`; CodeQL `32097815766` 7/7; alert #46 dismissed read-back; Issue #1413 closed; canonical `develop` synced; feature worktree/local·remote branch absent | none |

Final status: DONE — PR1 구현·회귀 테스트·문서·hosted CI·branch/develop CodeQL·독립 review·alert closeout·merge·sync·cleanup을 모두 검증했습니다.

Unchecked required items: none
