### PR TITLE
security: repo-local 취약 전이 의존성을 제거한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 버그 수정
 
+- WireMock client-only 경로에서 사용하지 않는 Handlebars와 Jetty 11 embedded server 전이를 제외하고, 사용되지 않는 Kafka 4 generator를 제거해 JGit 취약 전이를 차단했다. Dokka와 dependency-check repo tooling의 jsoup은 first patched `1.23.1` 이상으로 해석되며 중앙 catalog와 publication dependency constraint는 변경하지 않는다
+  ([#1414](https://github.com/bluetape4k/bluetape4k-projects/issues/1414)).
 - `ZipFileSupport.unzip`이 정규화된 archive entry 경로와 `SecureDirectoryStream` 디렉토리 상대 handle을 사용하도록 강화했다. `NOFOLLOW_LINKS`와 디렉토리 식별자 검증으로 대상 조상·중간 디렉토리 교체와 최종 파일 symlink를 통한 외부 쓰기를 차단하며, secure directory handle을 지원하지 않는 파일 시스템에서는 `IOException`으로 fail-closed 한다. hard link·mount 변경·적대적인 파일 시스템 관리자는 여전히 caller가 통제해야 한다
   ([#1413](https://github.com/bluetape4k/bluetape4k-projects/issues/1413)).
 - `HazelcastNearJCache(...)` 공개 factory가 Hazelcast JCache listener 직렬화 경계를 넘지 않도록 listener-free degraded 경로를 사용한다. read-through와 write-through는 유지하지만 peer front-cache propagation은 보장하지 않는다

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,19 @@ allprojects {
         // UCAR/Unidata — NetCDF/CDM 라이브러리
         maven("https://artifacts.unidata.ucar.edu/repository/unidata-all/")
     }
+
+    configurations.matching { it.name.startsWith("dokka") }.configureEach {
+        resolutionStrategy.eachDependency {
+            if (
+                requested.group == "org.jsoup" &&
+                requested.name == "jsoup" &&
+                requested.version == "1.16.1"
+            ) {
+                useVersion("1.23.1")
+                because("CVE-2026-71497: Dokka tooling must use the first patched jsoup release")
+            }
+        }
+    }
 }
 
 // Capture root-project catalog reference once; used inside subprojects {} closures

--- a/infra/kafka4/build.gradle.kts
+++ b/infra/kafka4/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     // Kafka (kafka4: 4.2.x — spring-kafka 4.x compatible)
     api(bt4k.kafka4.clients)
     compileOnly(bt4k.kafka4.streams)
-    compileOnly(bt4k.kafka4.generator)
     testImplementation(bt4k.kafka4.streams.test.utils)
     testRuntimeOnly(bt4k.kafka4.server.common)
     testImplementation(libs.testcontainers.kafka)

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/cache/NearCacheJCacheCoroutineTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/cache/NearCacheJCacheCoroutineTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.resilience4j.cache
 
 import io.bluetape4k.cache.jcache.RedissonJCaching
 import io.bluetape4k.cache.nearcache.jcache.NearJCache
+import io.bluetape4k.cache.nearcache.jcache.NearJCacheClearAuthority
 import io.bluetape4k.cache.nearcache.jcache.NearJCacheConfig
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.testcontainers.storage.RedisServer
@@ -20,7 +21,7 @@ class NearCacheJCacheCoroutineTest: AbstractJCacheCoroutinesTest() {
     override val jcache: NearJCache<String, String> by lazy {
         val nearCacheCfg = NearJCacheConfig<String, String>()
         val backCache = RedissonJCaching.getOrCreate<String, String>("back-coroutines", redisson)
-        NearJCache(nearCacheCfg, backCache)
+        NearJCache(nearCacheCfg, backCache, NearJCacheClearAuthority.EXCLUSIVE_BACK_CACHE)
     }
 
     @BeforeEach

--- a/io/http/build.gradle.kts
+++ b/io/http/build.gradle.kts
@@ -100,7 +100,12 @@ dependencies {
     api(project(":bluetape4k-resilience4j"))
     testImplementation(project(":bluetape4k-junit5"))
     testImplementation(project(":bluetape4k-testcontainers"))
-    testImplementation(bt4k.wiremock)
+    testImplementation(bt4k.wiremock) {
+        // 이 모듈은 Docker WireMock의 client API만 사용하므로 embedded server 전이는 필요하지 않다.
+        exclude(group = "com.github.jknack")
+        exclude(group = "org.eclipse.jetty")
+        exclude(group = "org.eclipse.jetty.http2")
+    }
 
     // Benchmark
     testImplementation(bt4k.kotlinx.benchmark.runtime)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,14 @@ pluginManagement {
         mavenCentral()
         google()
     }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "org.owasp.dependencycheck" && requested.version == "12.2.2") {
+                // Repo tooling 전이의 CVE-2026-71497을 제거한다. 중앙 catalog의 공통 버전 권한은 변경하지 않는다.
+                useVersion("13.0.0")
+            }
+        }
+    }
     plugins {
         // https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention
         id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0")

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -245,7 +245,12 @@ dependencies {
     compileOnly(libs.testcontainers.nginx)
 
     // Wiremock
-    compileOnly(bt4k.wiremock)
+    compileOnly(bt4k.wiremock) {
+        // WireMock container client만 노출하며 embedded server와 template engine은 사용하지 않는다.
+        exclude(group = "com.github.jknack")
+        exclude(group = "org.eclipse.jetty")
+        exclude(group = "org.eclipse.jetty.http2")
+    }
 
     // Keycloak
     compileOnly(bt4k.keycloak.testcontainers)


### PR DESCRIPTION
## 요약

Epic #1416의 두 번째 stacked child로, `bluetape4k-projects`가 직접 소유한 repo-local 의존성 경로에서 Handlebars, Jetty 11, JGit, jsoup 취약 전이를 제거합니다.

## 배경

- Parent: #1439 merge commit `bbcf1e71381382d40f2d823c5261e468b899ed8a`
- Child issue: #1414
- 중앙 catalog/BOM 경고는 `bluetape4k-dependencies` #194가 소유합니다.
- 이 PR은 중앙 version catalog와 publication dependency constraint를 변경하지 않습니다.

## 해결 내용

- Docker WireMock client API만 사용하는 HTTP/testcontainers 경로에서 Handlebars와 Jetty embedded server 전이를 제외했습니다.
- 사용되지 않는 Kafka 4 generator compile-only 선언을 제거해 JGit 전이를 차단했습니다.
- repo tooling에서 dependency-check `13.0.0`, Dokka jsoup `1.23.1`이 선택되도록 정확한 기존 요청 버전에만 한정한 임시 해석 규칙을 추가했습니다.
- 직전 stack parent가 도입한 `NearJCache` fail-closed 기본값에 맞춰, 독점 back cache를 사용하는 resilience4j test fixture에 `EXCLUSIVE_BACK_CACHE`를 명시했습니다.
- CHANGELOG에 #1414 보안 경계와 중앙 catalog 비변경 원칙을 기록했습니다.

## 검증

- WireMock classpath: Handlebars/Jetty 11 embedded server 전이 없음
- Kafka4 compile classpath: Kafka generator/JGit 전이 없음
- Dokka/runtime tooling: jsoup `1.23.1`, dependency-check `13.0.0`
- 테스트: WireMock 11건, HTTP 2건, Kafka4 297건, resilience4j 280건, Vert.x 227건 통과
- publication POM: 취약 Handlebars/Jetty/JGit/jsoup 좌표·버전 없음
- 전체 빌드: `./gradlew --no-daemon --no-configuration-cache --max-workers=1 build --console=plain` 성공 (1016 tasks)
- `git diff --check` 통과

## 검토 메모

- exact head `52c78e47e66840eedf874ec764aef5c429fb762c` 독립 코드 검토: P0=0, P1=0, P2=0, P3=0 (`CLEAR`)
- 정확한 기존 요청 버전에만 적용되는 repo-local override는 중앙 catalog가 patched version을 제공하는 즉시 제거하고, merge 후 Dependabot 재수집으로 실제 alert 상태를 확인합니다.
- 전체 빌드 중 Lettuce 성능 probe와 Vert.x local HTTP 요청이 각각 1회 간헐 실패했으나, 격리 재실행과 모듈 재실행 및 최종 전체 빌드에서 모두 통과했습니다.

## 메타데이터

- Closes #1414
- Epic: #1416
- Milestone: `1.13.0`
- Labels: `chore`, `security`, `dependencies`
- Assignee: `debop`

## DoD Status

Required checks: 8/8; N/A: 0; Blocked: 0

| 항목 | 상태 | 증적 |
| --- | --- | --- |
| scope-baseline | PASS | parent `bbcf1e7138`, 중앙 catalog 비변경 경계 |
| red-graph | PASS | Dependency Submission에서 WireMock/Kafka generator/Dokka/dependency-check 전이 확인 |
| green-graph | PASS | Handlebars/Jetty/JGit 제거, jsoup `1.23.1`, dependency-check `13.0.0` |
| module-tests | PASS | 대상 테스트 및 parent 회귀 fixture 통과 |
| publication-boundary | PASS | 3개 publication POM 음성 검증 |
| diff-check | PASS | `git diff --check` |
| pr-metadata | PASS | base/head, assignee, milestone, labels, Issue metadata live read-back 일치 |
| ci-review | PASS | exact head `52c78e47e...`, hosted CI 19개 통과, 독립 검토 `CLEAR` |

최종 상태: PENDING (fresh merge 승인)

미확인 항목:

- fresh exact-head merge 승인
- merge 후 Dependabot 재수집과 `develop` sync
