### PR TITLE
[resilience4j][lifecycle] caller-owned scheduler 수명주기를 보존한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   ([#1411](https://github.com/bluetape4k/bluetape4k-projects/issues/1411)).
 - `NearJCache`의 namespace-wide `clear()`, `clearAllCache()`, 인자 없는 `removeAll()`을 기본 `NearJCacheClearAuthority.DENY`로 fail-closed 처리하고, back namespace 독점 소유를 확인한 caller만 `EXCLUSIVE_BACK_CACHE`로 opt-in하도록 했다. key-scoped removal은 유지하며 runtime-only 권한은 `NearJCacheConfig` 직렬화에 포함하지 않는다. 기존 destructive clear 호출자는 명시적 owner overload로 전환해야 한다
   ([#1368](https://github.com/bluetape4k/bluetape4k-projects/issues/1368)).
+- Resilience4j 비동기 `Retry`와 `TimeLimiter` 확장의 caller-owned `ScheduledExecutorService`를 데코레이터가 종료하지 않도록 하고, scheduler를 생략한 호출은 invocation별 전용 scheduler를 terminal completion 뒤 정리하도록 고정했다. 따라서 동일한 decorated function의 반복 호출과 scheduler 공유가 성공·실패·timeout 경계에서 안전하다
+  ([#1424](https://github.com/bluetape4k/bluetape4k-projects/issues/1424)).
 - Maven Central에 없는 benchmark 또는 application 전용 모듈이 BOM에 포함되지 않도록 publication과 BOM module classifier를 통일했다. 생성한 BOM inventory와 publication POM inventory가 다르면 publication validation이 실패한다
   ([#1313](https://github.com/bluetape4k/bluetape4k-projects/issues/1313)).
 - Java platform은 library publication 설정 밖에 두되 `Bluetape4k` publication을 NMCP aggregate에 포함했다. 따라서 snapshot과 stable bundle은 74개 publishable library module과 함께 BOM을 포함한다

--- a/infra/resilience4j/README.ko.md
+++ b/infra/resilience4j/README.ko.md
@@ -222,6 +222,33 @@ val decorated = timeLimiter.decorateSuspendFunction1 { id: String ->
 }
 ```
 
+### 비동기 scheduler 소유권
+
+비동기 `Retry` 및 `TimeLimiter` 확장 함수(`completionStage`, `completableFuture`,
+`completableFutureFunction`, `withRetry`)는 선택적인 `ScheduledExecutorService`를 받습니다.
+스케줄러를 생략하거나 `null`로 전달하면 호출마다 전용 스케줄러를 만들고 terminal completion 후 종료합니다.
+스케줄러를 전달하면 성공·실패·timeout을 포함해 데코레이터가 종료하지 않으며 caller가 계속 소유합니다.
+따라서 데코레이트한 함수를 반복 호출할 수 있고 여러 데코레이터가 하나의 스케줄러를 공유할 수 있습니다.
+
+```kotlin
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+
+val scheduler = Executors.newScheduledThreadPool(2)
+try {
+    val protectedCall = timeLimiter.completableFuture(scheduler) { input: Int ->
+        CompletableFuture.completedFuture(input * 2)
+    }
+    protectedCall(21).get() // 42
+    protectedCall(22).get() // 44
+} finally {
+    scheduler.shutdown()
+}
+```
+
+전달한 스케줄러의 모든 데코레이트 호출이 끝나면 caller가 직접 종료해야 합니다. 같은 소유권 규칙은
+`decorateCompletableFutureFunction(...).withRetry(retry, scheduler)`에도 적용됩니다.
+
 ### 6. SuspendDecorators (조합 데코레이터)
 
 여러 Resilience4j 컴포넌트를 조합하여 사용합니다.

--- a/infra/resilience4j/README.md
+++ b/infra/resilience4j/README.md
@@ -222,6 +222,34 @@ val decorated = timeLimiter.decorateSuspendFunction1 { id: String ->
 }
 ```
 
+### Async scheduler ownership
+
+The async `Retry` and `TimeLimiter` extensions (`completionStage`, `completableFuture`,
+`completableFutureFunction`, and `withRetry`) accept an optional `ScheduledExecutorService`.
+When the scheduler is omitted (or `null`), a private scheduler is created for each invocation and shut down
+after terminal completion. When a scheduler is supplied, it remains caller-owned and is never shut down by the
+decorator, including on success, failure, or timeout. This makes a decorated function safe to invoke repeatedly and
+allows one scheduler to be shared by multiple decorators.
+
+```kotlin
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+
+val scheduler = Executors.newScheduledThreadPool(2)
+try {
+    val protectedCall = timeLimiter.completableFuture(scheduler) { input: Int ->
+        CompletableFuture.completedFuture(input * 2)
+    }
+    protectedCall(21).get() // 42
+    protectedCall(22).get() // 44
+} finally {
+    scheduler.shutdown()
+}
+```
+
+The caller must close a supplied scheduler after all decorated calls finish. The same ownership rule applies to
+`decorateCompletableFutureFunction(...).withRetry(retry, scheduler)`.
+
 ### 6. SuspendDecorators (Composable Decorators)
 
 Compose multiple Resilience4j components together.

--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/DecoratorsSupport.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/DecoratorsSupport.kt
@@ -9,7 +9,6 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import io.github.resilience4j.ratelimiter.RateLimiter
 import io.github.resilience4j.retry.Retry
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
 /**
@@ -98,12 +97,13 @@ class DecorateCompletableFutureFunction<T, R>(
      * [Retry]를 적용합니다.
      *
      * @param retry 적용할 retry 인스턴스
-     * @param scheduler 재시도 스케줄링에 사용할 executor
+     * @param scheduler 재시도 스케줄링에 사용할 executor. `null`이면 호출마다 전용 executor를 만들고 terminal completion
+     * 후 종료하며, 제공된 executor는 종료하지 않으므로 호출자가 수명주기를 관리해야 합니다.
      * @return 현재 데코레이터 빌더
      */
     fun withRetry(
         retry: Retry,
-        scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+        scheduler: ScheduledExecutorService? = null,
     ): DecorateCompletableFutureFunction<T, R> =
         apply {
             func = retry.completableFuture(scheduler, func)

--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SchedulerHandle.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SchedulerHandle.kt
@@ -1,0 +1,39 @@
+package io.bluetape4k.resilience4j
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+
+/**
+ * 비동기 resilience4j 확장 함수가 사용할 스케줄러와 소유권을 함께 보관합니다.
+ *
+ * 호출자가 스케줄러를 제공하지 않으면 호출마다 전용 스케줄러를 만들고 terminal completion 뒤에 종료합니다.
+ * 호출자가 제공한 스케줄러는 호출자가 계속 소유하므로 이 객체는 종료하지 않습니다.
+ */
+@PublishedApi
+internal class SchedulerHandle private constructor(
+    val scheduler: ScheduledExecutorService,
+    private val owned: Boolean,
+) {
+
+    fun close() {
+        if (owned) {
+            scheduler.shutdown()
+        }
+    }
+
+    @PublishedApi
+    @Suppress("TooGenericExceptionCaught")
+    internal fun <T> execute(block: (ScheduledExecutorService) -> T): T =
+        try {
+            block(scheduler)
+        } catch (cause: Throwable) {
+            close()
+            throw cause
+        }
+
+    companion object {
+        fun acquire(scheduler: ScheduledExecutorService?): SchedulerHandle =
+            scheduler?.let { SchedulerHandle(it, owned = false) }
+                ?: SchedulerHandle(Executors.newSingleThreadScheduledExecutor(), owned = true)
+    }
+}

--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SchedulerHandle.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/SchedulerHandle.kt
@@ -34,6 +34,26 @@ internal class SchedulerHandle private constructor(
     companion object {
         fun acquire(scheduler: ScheduledExecutorService?): SchedulerHandle =
             scheduler?.let { SchedulerHandle(it, owned = false) }
-                ?: SchedulerHandle(Executors.newSingleThreadScheduledExecutor(), owned = true)
+                ?: SchedulerHandle(defaultSchedulerFactory.get().invoke(), owned = true)
+
+        /**
+         * 기본 스케줄러의 소유권 계약을 검증하기 위한 내부 테스트 seam입니다.
+         */
+        internal fun <T> withDefaultSchedulerFactory(
+            factory: () -> ScheduledExecutorService,
+            block: () -> T,
+        ): T {
+            val previous = defaultSchedulerFactory.get()
+            defaultSchedulerFactory.set(factory)
+            return try {
+                block()
+            } finally {
+                defaultSchedulerFactory.set(previous)
+            }
+        }
+
+        private val defaultSchedulerFactory = ThreadLocal.withInitial<() -> ScheduledExecutorService> {
+            { Executors.newSingleThreadScheduledExecutor() }
+        }
     }
 }

--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/retry/RetryExtensions.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/retry/RetryExtensions.kt
@@ -1,12 +1,11 @@
 package io.bluetape4k.resilience4j.retry
 
+import io.bluetape4k.resilience4j.SchedulerHandle
 import io.github.resilience4j.core.functions.CheckedRunnable
 import io.github.resilience4j.retry.Retry
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
 
 /**
  * [runnable] 실행 시, [Retry] 를 적용합니다.
@@ -177,24 +176,23 @@ inline fun <T, R> Retry.checkedFunction(
  * ```
  *
  * @param retry [Retry] 인스턴스
- * @param scheduler [ScheduledExecutorService] 인스턴스
+ * @param scheduler 호출자가 소유한 [ScheduledExecutorService]. `null`이면 호출마다 전용 스케줄러를 만들고
+ * terminal completion 후 종료하며, 제공된 스케줄러는 종료하지 않으므로 호출자가 수명주기를 관리해야 합니다.
  * @param supplier 실행할 비동기 Supplier
  * @return Retry 를 적용한 비동기 Supplier
  */
 inline fun <T, R> withRetry(
     retry: Retry,
-    scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    scheduler: ScheduledExecutorService? = null,
     crossinline supplier: (T) -> CompletableFuture<R>,
 ): (T) -> CompletableFuture<R> = { input: T ->
-    Retry.decorateCompletionStage(retry, scheduler) { supplier.invoke(input) }
-        .get()
-        .toCompletableFuture()
-        .whenComplete { _, _ ->
-            runCatching {
-                scheduler.shutdown()
-                scheduler.awaitTermination(3, TimeUnit.SECONDS)
-            }
-        }
+    val handle = SchedulerHandle.acquire(scheduler)
+    handle.execute { executor ->
+        Retry.decorateCompletionStage(retry, executor) { supplier.invoke(input) }
+            .get()
+            .toCompletableFuture()
+            .whenComplete { _, _ -> handle.close() }
+    }
 }
 
 
@@ -210,21 +208,21 @@ inline fun <T, R> withRetry(
  * val result = supplier().get()  // 42
  * ```
  *
+ * @param scheduler 호출자가 소유한 스케줄러. `null`이면 호출마다 전용 스케줄러를 만들고 terminal completion 후 종료하며,
+ * 제공된 스케줄러는 종료하지 않으므로 호출자가 수명주기를 관리해야 합니다.
  * @param supplier 실행할 작업
  * @return Retry 를 적용한 Supplier
  */
 inline fun <T> Retry.completionStage(
-    scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    scheduler: ScheduledExecutorService? = null,
     crossinline supplier: () -> CompletionStage<T>,
 ): () -> CompletionStage<T> = {
-    Retry.decorateCompletionStage(this, scheduler) { supplier() }
-        .get()
-        .whenComplete { _, _ ->
-            runCatching {
-                scheduler.shutdown()
-                scheduler.awaitTermination(1, TimeUnit.SECONDS)
-            }
-        }
+    val handle = SchedulerHandle.acquire(scheduler)
+    handle.execute { executor ->
+        Retry.decorateCompletionStage(this, executor) { supplier() }
+            .get()
+            .whenComplete { _, _ -> handle.close() }
+    }
 }
 
 
@@ -237,12 +235,13 @@ inline fun <T> Retry.completionStage(
  * val result = func(21).get()  // 42
  * ```
  *
- * @param scheduler [ScheduledExecutorService] 인스턴스
+ * @param scheduler 호출자가 소유한 [ScheduledExecutorService]. `null`이면 호출마다 전용 스케줄러를 만들고
+ * terminal completion 후 종료하며, 제공된 스케줄러는 종료하지 않으므로 호출자가 수명주기를 관리해야 합니다.
  * @param func 실행할 비동기 작업
  * @return Retry 를 적용한 비동기 Function
  */
 inline fun <T, R> Retry.completableFutureFunction(
-    scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    scheduler: ScheduledExecutorService? = null,
     crossinline func: (T) -> CompletableFuture<R>,
 ): (T) -> CompletableFuture<R> {
     return completableFuture(scheduler, func)
@@ -257,20 +256,19 @@ inline fun <T, R> Retry.completableFutureFunction(
  * val result = func(21).get()  // 42
  * ```
  *
- * @param scheduler [ScheduledExecutorService] 인스턴스
+ * @param scheduler 호출자가 소유한 [ScheduledExecutorService]. `null`이면 호출마다 전용 스케줄러를 만들고
+ * terminal completion 후 종료하며, 제공된 스케줄러는 종료하지 않으므로 호출자가 수명주기를 관리해야 합니다.
  * @param func 실행할 비동기 작업
  * @return Retry 를 적용한 비동기 Function
  */
 inline fun <T, R> Retry.completableFuture(
-    scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    scheduler: ScheduledExecutorService? = null,
     crossinline func: (T) -> CompletableFuture<R>,
 ): (T) -> CompletableFuture<R> = { input: T ->
-    this.executeCompletionStage<R>(scheduler) { func.invoke(input) }
-        .toCompletableFuture()
-        .whenComplete { _, _ ->
-            runCatching {
-                scheduler.shutdown()
-                scheduler.awaitTermination(1, TimeUnit.SECONDS)
-            }
-        }
+    val handle = SchedulerHandle.acquire(scheduler)
+    handle.execute { executor ->
+        this.executeCompletionStage<R>(executor) { func.invoke(input) }
+            .toCompletableFuture()
+            .whenComplete { _, _ -> handle.close() }
+    }
 }

--- a/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/timelimiter/TimeLimiterExtensions.kt
+++ b/infra/resilience4j/src/main/kotlin/io/bluetape4k/resilience4j/timelimiter/TimeLimiterExtensions.kt
@@ -1,12 +1,11 @@
 package io.bluetape4k.resilience4j.timelimiter
 
+import io.bluetape4k.resilience4j.SchedulerHandle
 import io.github.resilience4j.timelimiter.TimeLimiter
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
-import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
 
 /**
  * [futureSupplier] 를 실행할 때 [TimeLimiter] 를 적용하여 실행합니다.
@@ -42,24 +41,23 @@ inline fun <T, F: Future<T>> TimeLimiter.futureSupplier(
  * ```
  *
  * @receiver [TimeLimiter] 인스턴스
- * @param scheduler 스케줄러
+ * @param scheduler 호출자가 소유한 스케줄러. `null`이면 호출마다 전용 스케줄러를 만들고 완료 후 종료하며,
+ * 제공된 스케줄러는 종료하지 않으므로 호출자가 수명주기를 관리해야 합니다.
  * @param futureSupplier 실행할 CompletionStage 를 생성하는 함수
  */
 inline fun <T, F: CompletionStage<T>> TimeLimiter.completionStage(
-    scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    scheduler: ScheduledExecutorService? = null,
     crossinline futureSupplier: () -> F,
 ): () -> T = {
-    TimeLimiter
-        .decorateCompletionStage(this, scheduler) { futureSupplier.invoke() }
-        .get()
-        .whenComplete { _, _ ->
-            runCatching {
-                scheduler.shutdown()
-                scheduler.awaitTermination(1, TimeUnit.SECONDS)
-            }
-        }
-        .toCompletableFuture()
-        .get()
+    val handle = SchedulerHandle.acquire(scheduler)
+    handle.execute { executor ->
+        TimeLimiter
+            .decorateCompletionStage(this, executor) { futureSupplier.invoke() }
+            .get()
+            .whenComplete { _, _ -> handle.close() }
+            .toCompletableFuture()
+            .get()
+    }
 }
 
 /**
@@ -75,11 +73,12 @@ inline fun <T, F: CompletionStage<T>> TimeLimiter.completionStage(
  * ```
  *
  * @receiver [TimeLimiter] 인스턴스
- * @param scheduler 스케줄러
+ * @param scheduler 호출자가 소유한 스케줄러. `null`이면 호출마다 전용 스케줄러를 만들고 terminal completion 후 종료하며,
+ * 제공된 스케줄러는 종료하지 않으므로 호출자가 수명주기를 관리해야 합니다.
  * @param func 실행할 CompletableFuture 를 생성하는 함수
  */
 inline fun <T, R: CompletableFuture<T>> TimeLimiter.completableFuture(
-    scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    scheduler: ScheduledExecutorService? = null,
     crossinline func: (T) -> R,
 ): (T) -> R {
     return decorateCompletableFuture(scheduler, func)
@@ -98,20 +97,19 @@ inline fun <T, R: CompletableFuture<T>> TimeLimiter.completableFuture(
  * ```
  *
  * @receiver [TimeLimiter] 인스턴스
- * @param scheduler 스케줄러
+ * @param scheduler 호출자가 소유한 스케줄러. `null`이면 호출마다 전용 스케줄러를 만들고 terminal completion 후 종료하며,
+ * 제공된 스케줄러는 종료하지 않으므로 호출자가 수명주기를 관리해야 합니다.
  * @param func 실행할 CompletableFuture 를 생성하는 함수
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <T, R: CompletableFuture<T>> TimeLimiter.decorateCompletableFuture(
-    scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    scheduler: ScheduledExecutorService? = null,
     crossinline func: (T) -> R,
 ): (T) -> R = { input: T ->
-    this.executeCompletionStage<T, R>(scheduler) { func(input) }
-        .toCompletableFuture()
-        .whenComplete { _, _ ->
-            runCatching {
-                scheduler.shutdown()
-                scheduler.awaitTermination(1, TimeUnit.SECONDS)
-            }
-        } as R
+    val handle = SchedulerHandle.acquire(scheduler)
+    handle.execute { executor ->
+        this.executeCompletionStage<T, R>(executor) { func(input) }
+            .toCompletableFuture()
+            .whenComplete { _, _ -> handle.close() } as R
+    }
 }

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/DecoratorExtensionsTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/DecoratorExtensionsTest.kt
@@ -39,23 +39,28 @@ class DecoratorsExtensionsTest {
             futureOf { helloWorldService.returnHelloWorldWithName(name) }
         }
 
-        val decorated = decorateCompletableFutureFunction(func)
-            .withRetry(Retry.ofDefaults("defaults"), Executors.newSingleThreadScheduledExecutor())
-            .withCircuitBreaker(circuitBreaker)
-            .withBulkhead(Bulkhead.ofDefaults("default"))
-            .withRateLimiter(RateLimiter.ofDefaults("default"))
-            .decorate()
+        val scheduler = Executors.newSingleThreadScheduledExecutor()
+        try {
+            val decorated = decorateCompletableFutureFunction(func)
+                .withRetry(Retry.ofDefaults("defaults"), scheduler)
+                .withCircuitBreaker(circuitBreaker)
+                .withBulkhead(Bulkhead.ofDefaults("default"))
+                .withRateLimiter(RateLimiter.ofDefaults("default"))
+                .decorate()
 
-        val result = decorated.invoke("world").join()
-        result shouldBeEqualTo "Hello world!"
+            val result = decorated.invoke("world").join()
+            result shouldBeEqualTo "Hello world!"
 
-        with(circuitBreaker.metrics) {
-            numberOfBufferedCalls shouldBeEqualTo 1
-            numberOfSuccessfulCalls shouldBeEqualTo 1
-            numberOfFailedCalls shouldBeEqualTo 0
+            with(circuitBreaker.metrics) {
+                numberOfBufferedCalls shouldBeEqualTo 1
+                numberOfSuccessfulCalls shouldBeEqualTo 1
+                numberOfFailedCalls shouldBeEqualTo 0
+            }
+
+            verify(exactly = 1) { helloWorldService.returnHelloWorldWithName("world") }
+            confirmVerified(helloWorldService)
+        } finally {
+            scheduler.shutdownNow()
         }
-
-        verify(exactly = 1) { helloWorldService.returnHelloWorldWithName("world") }
-        confirmVerified(helloWorldService)
     }
 }

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/SchedulerOwnershipContractTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/SchedulerOwnershipContractTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.resilience4j
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.resilience4j.retry.completableFuture
 import io.bluetape4k.resilience4j.retry.completableFutureFunction
 import io.bluetape4k.resilience4j.retry.completionStage
@@ -20,6 +21,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 class SchedulerOwnershipContractTest {
@@ -165,6 +167,40 @@ class SchedulerOwnershipContractTest {
     }
 
     @Test
+    fun `TimeLimiter default schedulers terminate after success and timeout`() {
+        withTrackedDefaultSchedulers { schedulers ->
+            val successful = timeLimiter().completableFuture { input: Int ->
+                CompletableFuture.completedFuture(input * 2)
+            }
+            successful(21).get() shouldBeEqualTo 42
+
+            val timedOut = timeLimiter().completableFuture { _: Int ->
+                CompletableFuture<Int>()
+            }
+            assertFailsWith<ExecutionException> { timedOut(1).get(1, TimeUnit.SECONDS) }
+
+            schedulers.size shouldBeEqualTo 2
+        }
+    }
+
+    @Test
+    fun `Retry default schedulers terminate after success and failure`() {
+        withTrackedDefaultSchedulers { schedulers ->
+            val successful = retry().completableFuture { input: Int ->
+                CompletableFuture.completedFuture(input * 2)
+            }
+            successful(21).get() shouldBeEqualTo 42
+
+            val failed = retry().completableFuture<Int, Int> {
+                CompletableFuture.failedFuture(IOException("failure"))
+            }
+            assertFailsWith<ExecutionException> { failed(1).get(1, TimeUnit.SECONDS) }
+
+            schedulers.size shouldBeEqualTo 2
+        }
+    }
+
+    @Test
     fun `decorator builder preserves caller scheduler ownership`() {
         val scheduler = newScheduler()
         try {
@@ -183,6 +219,27 @@ class SchedulerOwnershipContractTest {
 
     private fun newScheduler(): ScheduledExecutorService =
         Executors.newScheduledThreadPool(2)
+
+    private fun withTrackedDefaultSchedulers(
+        block: (List<ScheduledThreadPoolExecutor>) -> Unit,
+    ) {
+        val schedulers = mutableListOf<ScheduledThreadPoolExecutor>()
+        SchedulerHandle.withDefaultSchedulerFactory(
+            factory = {
+                ScheduledThreadPoolExecutor(1).also(schedulers::add)
+            },
+            block = {
+                try {
+                    block(schedulers)
+                } finally {
+                    schedulers.forEach { scheduler ->
+                        scheduler.isShutdown.shouldBeTrue()
+                        scheduler.awaitTermination(1, TimeUnit.SECONDS).shouldBeTrue()
+                    }
+                }
+            },
+        )
+    }
 
     private fun retry(): Retry = Retry.of(
         "scheduler-${System.nanoTime()}",

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/SchedulerOwnershipContractTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/SchedulerOwnershipContractTest.kt
@@ -1,0 +1,201 @@
+package io.bluetape4k.resilience4j
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.resilience4j.retry.completableFuture
+import io.bluetape4k.resilience4j.retry.completableFutureFunction
+import io.bluetape4k.resilience4j.retry.completionStage
+import io.bluetape4k.resilience4j.retry.withRetry
+import io.bluetape4k.resilience4j.timelimiter.completableFuture
+import io.bluetape4k.resilience4j.timelimiter.completionStage
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import io.github.resilience4j.timelimiter.TimeLimiter
+import io.github.resilience4j.timelimiter.TimeLimiterConfig
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+class SchedulerOwnershipContractTest {
+
+    @Test
+    fun `TimeLimiter caller scheduler remains open after successful repeated calls`() {
+        val scheduler = newScheduler()
+        try {
+            val function = timeLimiter().completableFuture(scheduler) { input: Int ->
+                CompletableFuture.completedFuture(input * 2)
+            }
+
+            function(21).get() shouldBeEqualTo 42
+            scheduler.isShutdown.shouldBeFalse()
+            function(22).get() shouldBeEqualTo 44
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `TimeLimiter caller scheduler remains open after timeout`() {
+        val scheduler = newScheduler()
+        try {
+            val function = timeLimiter().completableFuture(scheduler) { _: Int ->
+                CompletableFuture<Int>()
+            }
+
+            assertFailsWith<ExecutionException> {
+                function(1).get(1, TimeUnit.SECONDS)
+            }
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `Retry caller scheduler remains open after failed completion`() {
+        val scheduler = newScheduler()
+        try {
+            val function = retry().completableFuture<Int, Int>(scheduler) {
+                CompletableFuture.failedFuture(IOException("failure"))
+            }
+
+            assertFailsWith<ExecutionException> {
+                function(1).get(1, TimeUnit.SECONDS)
+            }
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `Retry completionStage caller scheduler remains open after success`() {
+        val scheduler = newScheduler()
+        try {
+            val supplier = retry().completionStage(scheduler) {
+                CompletableFuture.completedFuture(42)
+            }
+
+            supplier().toCompletableFuture().get() shouldBeEqualTo 42
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `TimeLimiter completionStage caller scheduler remains open after success`() {
+        val scheduler = newScheduler()
+        try {
+            val supplier = timeLimiter().completionStage(scheduler) {
+                CompletableFuture.completedFuture(42)
+            }
+
+            supplier() shouldBeEqualTo 42
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `Retry completableFutureFunction caller scheduler remains open after success`() {
+        val scheduler = newScheduler()
+        try {
+            val function = retry().completableFutureFunction<Int, Int>(scheduler) { input ->
+                CompletableFuture.completedFuture(input * 2)
+            }
+
+            function(21).get() shouldBeEqualTo 42
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `withRetry caller scheduler remains open after success`() {
+        val scheduler = newScheduler()
+        try {
+            val function = withRetry<Int, Int>(retry(), scheduler) { input ->
+                CompletableFuture.completedFuture(input * 2)
+            }
+
+            function(21).get() shouldBeEqualTo 42
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `Retry and TimeLimiter can share a caller scheduler`() {
+        val scheduler = newScheduler()
+        try {
+            val retried = retry().completableFuture<Int, Int>(scheduler) {
+                CompletableFuture.completedFuture(21)
+            }
+            val timed = timeLimiter().completableFuture<Int, CompletableFuture<Int>>(scheduler) {
+                CompletableFuture.completedFuture(42)
+            }
+
+            retried(1).get() shouldBeEqualTo 21
+            timed(1).get() shouldBeEqualTo 42
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `TimeLimiter default scheduler supports repeated decorated calls`() {
+        val function = timeLimiter().completableFuture { input: Int ->
+            CompletableFuture.completedFuture(input * 2)
+        }
+
+        function(21).get() shouldBeEqualTo 42
+        function(22).get() shouldBeEqualTo 44
+    }
+
+    @Test
+    fun `decorator builder preserves caller scheduler ownership`() {
+        val scheduler = newScheduler()
+        try {
+            val decorated = decorateCompletableFutureFunction<Int, Int> {
+                CompletableFuture.completedFuture(it * 2)
+            }
+                .withRetry(retry(), scheduler)
+                .decorate()
+
+            decorated(21).get() shouldBeEqualTo 42
+            scheduler.isShutdown.shouldBeFalse()
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    private fun newScheduler(): ScheduledExecutorService =
+        Executors.newScheduledThreadPool(2)
+
+    private fun retry(): Retry = Retry.of(
+        "scheduler-${System.nanoTime()}",
+        RetryConfig.custom<Any?>()
+            .maxAttempts(2)
+            .waitDuration(Duration.ofMillis(10))
+            .build()
+    )
+
+    private fun timeLimiter(): TimeLimiter = TimeLimiter.of(
+        "scheduler-${System.nanoTime()}",
+        TimeLimiterConfig.custom()
+            .timeoutDuration(Duration.ofMillis(50))
+            .build()
+    )
+}


### PR DESCRIPTION
## Summary

Fixes #1424

Epic #1416의 세 번째 stacked child로, #1414(PR #1440) merge head 위에서 Resilience4j 비동기 decorator의 scheduler ownership lifecycle을 수정합니다.

## Background

1.13.0 Type-D 리뷰에서 `Retry`와 `TimeLimiter` async extension이 caller가 제공한 `ScheduledExecutorService`를 completion 뒤 `shutdown()`하여 공유 scheduler와 재사용 가능한 decorated function을 깨뜨리는 결함을 확인했습니다.

## What This Solves

- caller-provided scheduler는 성공·실패·timeout 이후에도 decorator가 종료하지 않습니다.
- scheduler를 생략하면 invocation마다 private scheduler를 만들고 terminal completion 뒤 종료해 반복 호출 시 재사용 실패와 영구 스레드 누수를 피합니다.

## Work Done

- `SchedulerHandle`로 scheduler와 ownership을 분리하고 Retry/TimeLimiter async API 및 `DecorateCompletableFutureFunction.withRetry`에 일관되게 적용했습니다.
- caller-owned 반복 호출·공유·success/failure/timeout과 default scheduler의 success/failure/timeout termination을 계약 테스트로 고정했습니다.
- EN/KO README, public KDoc, `CHANGELOG.md`에 ownership과 caller close 책임을 기록했습니다.
- 독립 review 후속 P2 두 건을 반영해 기본 scheduler 관찰 seam과 기존 caller-owned 테스트의 `try/finally` cleanup을 추가했습니다.

## Validation

- RED: 기존 구현에서 caller scheduler 종료와 default 재호출 `RejectedExecutionException`으로 6개 lifecycle 테스트가 실패했습니다.
- `./gradlew --no-daemon --no-configuration-cache --max-workers=1 :bluetape4k-resilience4j:test --tests "io.bluetape4k.resilience4j.SchedulerOwnershipContractTest" --tests "io.bluetape4k.resilience4j.DecoratorsExtensionsTest" --console=plain`: PASS (13 tests)
- `./gradlew --no-daemon --no-configuration-cache --max-workers=1 :bluetape4k-resilience4j:test --console=plain`: PASS (292 tests)
- `git diff --check 2de51438fe3230cf977b01aae75c13d5c6bcac76..a1e5dca729b581173386bef05140379c7e6eb6bd`: PASS
- `detektMain`/`detektTest`: repository baseline issues (38/28)로 FAIL; 변경 파일에는 추가 지적 없음
- Hosted CI run [32121809747](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32121809747): Build, CI Status, policy checks PASS; 변경 모듈 외 test matrix는 경로 필터로 SKIPPED

## Review Notes

- 이전 exact-head 독립 review: P0/P1 0, P2 2 (기본 scheduler 종료 관찰·caller-owned 테스트 cleanup)
- 후속 수정 commit `a1e5dca729b581173386bef05140379c7e6eb6bd`에서 두 finding을 보강했습니다.
- fresh exact-head 독립 re-review: CLEAR (P0/P1/P2/P3 모두 0); merge는 수행하지 않습니다.
- Lesson: 기존 `docs/security-review/2026-04-28-wave4-performance.md` C5가 scheduler lifecycle 일반 규칙을 이미 보존하고 있어 별도 lesson은 N/A입니다.

## Metadata

- Issue: #1424, milestone `1.13.0`, assignee `debop`
- Epic: #1416
- Parent: PR #1440 merge commit `2de51438fe3230cf977b01aae75c13d5c6bcac76`
- PR: #1441, head `a1e5dca729b581173386bef05140379c7e6eb6bd`, base `develop`
- Labels: `bug`, `tech-debt`
- CI: hosted run `32121809747` exact-head green

## DoD Status

Required checks: 8/8; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| root-cause - scheduler ownership | 기존 shutdown callback과 재호출 실패를 추적 | PASS | Issue #1424 근거와 RED stack trace | none |
| red-test - lifecycle regression | caller-owned/default/reuse 계약 테스트를 먼저 실행 | PASS | 기존 구현에서 6개 의도된 behavior failure | none |
| green-test - focused contract | ownership 계약 테스트 실행 | PASS | targeted 13 tests PASS | none |
| module-test - resilience4j blast radius | 전체 모듈 테스트 실행 | PASS | 292 tests PASS | none |
| docs - EN/KO/KDoc/CHANGELOG | ownership과 caller close 책임 기록 | PASS | README fence parity 30/30, KDoc, CHANGELOG | none |
| diff-check - patch hygiene | trailing whitespace와 malformed patch 확인 | PASS | full stacked-child range `git diff --check` PASS | none |
| pr-metadata - live issue/PR contract | Issue metadata를 읽고 PR assign·label·milestone mirror | PASS | PR #1441 live read-back: base/head, assignee, labels, milestone 일치 | none |
| ci-review - exact head hosted proof | CI와 독립 review 수렴 | PASS | hosted run 32121809747 PASS; exact-head re-review CLEAR (P0/P1/P2/P3=0) | none |

Final status: PENDING (fresh exact-head merge approval remains)

Unchecked required items: fresh exact-head merge approval, merge verification, canonical sync, cleanup
