### PR TITLE
[jwt] 종료 provider의 parser cache strong reference 제거

### DIFF
--- a/docs/lessons/2026-08-18-issue-1361-jwt-parser-cache-lifecycle.md
+++ b/docs/lessons/2026-08-18-issue-1361-jwt-parser-cache-lifecycle.md
@@ -1,0 +1,38 @@
+# Issue #1361: JWT parser cache 수명주기
+
+## 문제
+
+`JwtParserSupport`는 `ConcurrentHashMap<JwtProvider, JwtParser>`에 parser를
+보관합니다. parser가 만든 `Locator`는 provider의 `findKeyChain`을 캡처하므로,
+provider를 닫아도 캐시 엔트리가 남아 있으면 provider와 repository가 전역 캐시에서
+해제되지 않습니다. 기존 #1276 수정은 `DefaultJwtProvider`의 rotation timer 종료만
+다뤘고 parser 캐시 수명은 다루지 않았습니다.
+
+## 원인과 결정
+
+`DefaultJwtProvider.close()`가 timer만 취소하고 `jwtParserCache`에서 자신의 entry를
+제거하지 않는 것이 직접 원인입니다. provider별 parser를 계속 재사용하는 동시성 계약은
+유지해야 하므로 캐시 구조나 의존성을 넓히지 않고, 공통 `clearJwtParserCache()`를
+추가했습니다. 기본 `JwtProvider.close()`는 모든 구현체의 parser entry를 제거하고,
+timer를 소유한 `DefaultJwtProvider.close()`도 lifecycle lock 안에서 같은 정리를 수행합니다.
+주입받은 `KeyChainRepository`의 소유권과 close 순서는 변경하지 않았습니다.
+
+## 결과
+
+- provider가 살아 있는 동안 동시 parser 요청은 하나의 parser를 재사용합니다.
+- `close()`는 idempotent timer 종료와 함께 해당 provider의 parser 캐시 엔트리를 제거합니다.
+- 반복 생성·파싱·종료한 provider는 `jwtParserCache`에 강한 참조 키를 남기지 않습니다.
+
+## 검증
+
+- RED: 수정 전 `JwtParserSupportTest`에서 close 후 entry가 남아 `Expected <true> to be <false>`가 발생했고, 32개 provider 종료 후 32개 entry가 남았습니다.
+- GREEN: `./gradlew :bluetape4k-jwt:test --tests 'io.bluetape4k.jwt.provider.JwtParserSupportTest' --no-configuration-cache` — 2 passing.
+- 모듈: `./gradlew :bluetape4k-jwt:test --no-configuration-cache` — 160 passing, 10 pending.
+- 첫 전체 실행의 Redis watchdog 단일 실패는 해당 테스트 단독 재실행에서 성공했으며, 캐시 변경과 무관한 retry-only 인프라 변동으로 분류했습니다.
+
+## 다음 guard
+
+provider가 parser, locator, callback처럼 provider를 캡처하는 전역 캐시를 추가할 때는
+생성·사용·`close()` 후 entry 제거를 하나의 lifecycle 테스트로 고정합니다. map entry
+제거가 실제 강한 참조 경계를 닫는지 확인하고, 별도 bounded/weak 정책을 도입할 때는
+동시 재사용과 종료 경합을 다시 측정합니다.

--- a/utils/jwt/README.ko.md
+++ b/utils/jwt/README.ko.md
@@ -148,7 +148,7 @@ val reader1 = jwtProvider.parse(jwt1)  // OK (저장소에 이전 KeyChain이 �
 
 ### 수명주기와 자원 소유권
 
-`JwtProvider`와 `KeyChainRepository`는 `AutoCloseable`을 구현합니다. 기본 Provider는 자신의 KeyChain 회전 타이머를 소유하지만, 주입받은 저장소는 빌려서 사용하므로 Provider가 닫지 않습니다. 애플리케이션이나 테스트에서 함께 생성한 경우 두 객체를 명시적으로 닫으세요.
+`JwtProvider`와 `KeyChainRepository`는 `AutoCloseable`을 구현합니다. 기본 Provider는 자신의 KeyChain 회전 타이머와 Provider별 parser 캐시 엔트리를 소유하여 `close()`에서 정리하지만, 주입받은 저장소는 빌려서 사용하므로 Provider가 닫지 않습니다. 애플리케이션이나 테스트에서 함께 생성한 경우 두 객체를 명시적으로 닫으세요.
 
 ```kotlin
 import io.bluetape4k.jwt.keychain.repository.inmemory.InMemoryKeyChainRepository
@@ -161,12 +161,16 @@ try {
     val jwt = jwtProvider.compose { subject = "alice" }
     jwtProvider.parse(jwt)
 } finally {
-    jwtProvider.close() // Provider의 회전 타이머를 취소합니다.
+    jwtProvider.close() // 회전 타이머와 Provider parser 캐시 엔트리를 정리합니다.
     repository.close()  // 저장소의 refresh 타이머를 취소합니다.
 }
 ```
 
-Cache Provider는 delegate를 빌려 사용하므로 회전 타이머를 소유한 원래 delegate를 별도로 닫아야 합니다. 백그라운드 작업이 없는 구현체는 기본 no-op `close()` 구현을 그대로 사용할 수 있습니다.
+parser 캐시는 프로세스 전역에서 Provider를 키로 사용합니다. 운영 진단에서는 Provider
+생성·종료 횟수와 함께 `jwtParserCache.size`를 관찰하세요. Provider를 반복해서 생성·파싱·
+종료해도 캐시 크기와 힙에 남는 객체가 계속 증가하지 않아야 합니다.
+
+Cache Provider는 delegate를 빌려 사용하므로 회전 타이머를 소유한 원래 delegate를 별도로 닫아야 합니다. 백그라운드 작업이 없는 구현체도 기본 `close()` 구현을 사용할 수 있으며, 이 구현은 Provider parser 캐시 엔트리를 정리합니다.
 
 Redis 기반 Provider를 사용할 때 `RedissonClient`와 delegate의 소유자는
 애플리케이션입니다. `RedissonJwtProvider`는 delegate와 cache를 빌려 쓰므로

--- a/utils/jwt/README.md
+++ b/utils/jwt/README.md
@@ -139,7 +139,7 @@ val reader1 = jwtProvider.parse(jwt1)
 
 ### Lifecycle and resource ownership
 
-`JwtProvider` and `KeyChainRepository` implement `AutoCloseable`. The default provider owns its key rotation timer, while an injected repository is borrowed and is not closed by the provider. Close both explicitly when they share an application or test scope:
+`JwtProvider` and `KeyChainRepository` implement `AutoCloseable`. The default provider owns its key rotation timer and removes its provider-specific parser cache entry on `close()`, while an injected repository is borrowed and is not closed by the provider. Close both explicitly when they share an application or test scope:
 
 ```kotlin
 import io.bluetape4k.jwt.keychain.repository.inmemory.InMemoryKeyChainRepository
@@ -152,12 +152,16 @@ try {
     val jwt = jwtProvider.compose { subject = "alice" }
     jwtProvider.parse(jwt)
 } finally {
-    jwtProvider.close() // cancels the provider's rotation timer
+    jwtProvider.close() // cancels the timer and removes the provider parser cache entry
     repository.close()  // cancels the repository's refresh timer
 }
 ```
 
-Cache providers borrow their delegate; close the original delegate separately when it owns a rotation timer. Implementations without background work may keep the default no-op `close()` implementation.
+The parser cache is process-wide and keyed by provider. Observe `jwtParserCache.size`
+alongside provider creation and close counts in diagnostics; repeated create/parse/close
+cycles should not cause the size or retained heap to grow.
+
+Cache providers borrow their delegate; close the original delegate separately when it owns a rotation timer. Implementations without background work may keep the default `close()` implementation, which still removes the provider parser cache entry.
 
 For a Redis-backed provider, both the `RedissonClient` and the delegate remain
 application-owned. `RedissonJwtProvider` borrows the delegate and cache, so close

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProvider.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProvider.kt
@@ -21,7 +21,7 @@ import kotlin.concurrent.withLock
  * - 생성 시 즉시 최초 키체인 로테이션을 수행합니다.
  * - 60초 간격으로 키체인 만료를 검사하고 필요 시 로테이션합니다.
  * - [repository]를 통해 키체인을 영속화합니다.
- * - 회전 타이머는 이 공급자가 소유하므로 [close]로 취소합니다.
+ * - 회전 타이머와 공급자별 parser 캐시 엔트리는 이 공급자가 소유하므로 [close]로 정리합니다.
  * - [repository]는 빌려서 사용하며 [close]에서 닫지 않습니다. 저장소 수명주기는 호출자가 관리합니다.
  *
  * @property signatureAlgorithm RSA 기반 서명 알고리즘
@@ -87,8 +87,9 @@ class DefaultJwtProvider private constructor(
     /**
      * 이 공급자가 소유한 key-chain rotation timer를 취소합니다.
      *
-     * [repository]는 빌린 자원이므로 닫지 않습니다. 공급자와 저장소를 함께 생성한 호출자도
-     * 각각 [close]를 호출해 두 자원의 수명을 명시해야 합니다.
+     * parser 캐시 엔트리도 제거해 parser의 [io.jsonwebtoken.Locator]가 캡처한 공급자와
+     * 저장소가 전역 캐시에 남지 않도록 합니다. [repository]는 빌린 자원이므로 닫지 않습니다.
+     * 공급자와 저장소를 함께 생성한 호출자도 각각 [close]를 호출해 두 자원의 수명을 명시해야 합니다.
      */
     override fun close() {
         synchronized(lifecycleLock) {
@@ -97,6 +98,7 @@ class DefaultJwtProvider private constructor(
             closed = true
             timer?.cancel()
             timer = null
+            clearJwtParserCache(this)
         }
     }
 

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/JwtParserSupport.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/JwtParserSupport.kt
@@ -11,7 +11,23 @@ import java.security.Key
 import java.util.concurrent.ConcurrentHashMap
 
 
+/**
+ * provider별 parser를 보관하는 process-wide 캐시입니다.
+ *
+ * 운영 진단에서는 `jwtParserCache.size`를 provider 생성·종료량과 함께 관찰합니다.
+ * 정상적인 생성·파싱·종료 반복에서는 종료된 provider가 이 크기를 계속 증가시키지 않아야 합니다.
+ */
 internal val jwtParserCache = ConcurrentHashMap<JwtProvider, JwtParser>()
+
+/**
+ * 공급자별로 보관한 parser를 제거합니다.
+ *
+ * parser의 [Locator]가 공급자의 키체인 조회 함수를 캡처하므로 공급자 수명 종료 시
+ * 캐시 엔트리도 함께 제거해야 공급자와 저장소가 전역 캐시에 남지 않습니다.
+ */
+internal fun clearJwtParserCache(provider: JwtProvider) {
+    jwtParserCache.remove(provider)
+}
 
 /**
  * [JwtProvider]에 대응하는 [JwtParser]를 캐싱하여 반환합니다.

--- a/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/JwtProvider.kt
+++ b/utils/jwt/src/main/kotlin/io/bluetape4k/jwt/provider/JwtProvider.kt
@@ -153,10 +153,14 @@ interface JwtProvider: AutoCloseable {
     }.getOrNull()
 
     /**
-     * 이 공급자가 소유한 백그라운드 작업을 종료합니다.
+     * 이 공급자가 소유한 백그라운드 작업과 parser 캐시 엔트리를 정리합니다.
      *
-     * 백그라운드 작업이 없는 구현체는 기본 구현을 그대로 사용하면 됩니다. 주입받은
-     * repository나 delegate의 소유권은 구현체 문서를 따르며, 기본 공급자는 이를 닫지 않습니다.
+     * parser의 `Locator`가 공급자의 키체인 조회 함수를 캡처하므로 이 메서드는 공급자별
+     * parser 캐시 엔트리도 제거합니다. 백그라운드 작업이 없는 구현체는 기본 구현을 그대로
+     * 사용하면 됩니다. 주입받은 repository나 delegate의 소유권은 구현체 문서를 따르며,
+     * 기본 공급자는 이를 닫지 않습니다.
      */
-    override fun close() = Unit
+    override fun close() {
+        clearJwtParserCache(this)
+    }
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/JwtParserSupportTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/JwtParserSupportTest.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.jwt.provider
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.jwt.keychain.repository.inmemory.InMemoryKeyChainRepository
+import io.jsonwebtoken.JwtParser
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import java.util.concurrent.ConcurrentLinkedQueue
+
+@Execution(ExecutionMode.SAME_THREAD)
+class JwtParserSupportTest {
+
+    @Test
+    fun `parser cache reuses one parser concurrently and removes it when provider closes`() {
+        val initialCacheSize = jwtParserCache.size
+        val repository = InMemoryKeyChainRepository()
+        val provider = DefaultJwtProvider.forTesting(
+            keyChainRepository = repository,
+            rotationIntervalMillis = 60_000,
+        )
+        val parsers = ConcurrentLinkedQueue<JwtParser>()
+
+        try {
+            MultithreadingTester()
+                .workers(8)
+                .rounds(16)
+                .add { parsers += provider.currentJwtParser() }
+                .run()
+
+            parsers.distinct().size.shouldBeEqualTo(1)
+            jwtParserCache.containsKey(provider).shouldBeTrue()
+        } finally {
+            provider.close()
+            repository.close()
+        }
+
+        jwtParserCache.containsKey(provider).shouldBeFalse()
+        jwtParserCache.size.shouldBeEqualTo(initialCacheSize)
+    }
+
+    @Test
+    fun `closing many providers removes every parser cache entry`() {
+        val initialCacheSize = jwtParserCache.size
+        val providers = (0 until 32).map { index ->
+            FixedJwtProvider(kid = "parser-cache-$index")
+        }
+
+        try {
+            providers.forEach { provider ->
+                val jwt = provider.compose { subject = "parser-cache" }
+                provider.parse(jwt)
+                jwtParserCache.containsKey(provider).shouldBeTrue()
+            }
+        } finally {
+            providers.forEach { it.close() }
+        }
+
+        providers.count(jwtParserCache::containsKey).shouldBeEqualTo(0)
+        jwtParserCache.size.shouldBeEqualTo(initialCacheSize)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1361

종료된 `JwtProvider`가 process-wide parser cache에 남아 provider와 repository를 보유하지 않도록 lifecycle 정리를 고정합니다.

## Background

1.13.0 Type-D review에서 `ConcurrentHashMap<JwtProvider, JwtParser>`와 parser `Locator` closure가 종료 provider를 강하게 보유할 수 있는 P2 lifecycle·메모리 위험을 확인했습니다. 기존 timer 종료만으로는 parser cache entry가 제거되지 않았습니다.

## What This Solves

- `close()` 이후 provider별 parser cache entry가 남아 반복 생성·파싱·종료에서 strong reference를 유지하는 문제를 해결합니다.
- parser 재사용과 동시 호출 안전성을 유지하면서 cache 크기와 retained heap을 운영 지표로 관찰할 수 있게 합니다.

## Work Done

- `JwtParserSupport`에 provider별 cache entry 제거 함수를 추가하고, 기본 `JwtProvider.close()`와 `DefaultJwtProvider.close()`에서 lifecycle 정리를 수행합니다.
- 동시 parser 재사용 및 32개 provider의 create/parse/close 후 cache 원복을 회귀 테스트로 고정했습니다.
- EN/KO README와 lesson에 cache 정책, 소유권, close 계약, 운영 관찰 지표를 기록했습니다.

## Validation

- `./gradlew :bluetape4k-jwt:test --tests 'io.bluetape4k.jwt.provider.JwtParserSupportTest' --no-configuration-cache`: PASS (2 passing)
- `./gradlew :bluetape4k-jwt:cleanTest :bluetape4k-jwt:test --no-configuration-cache --no-build-cache`: PASS (160 passing, 10 pending)
- `./gradlew :bluetape4k-jwt:detekt --no-configuration-cache --rerun-tasks`: PASS (exit 0; 기존 baseline findings만 존재)
- `git diff --check HEAD^ HEAD`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: #1361 lifecycle·retention 위험 수정 완료
- Review evidence: local final diff review at `dcf00fd1894bd47844cc1c30b3b50d19ad5a9fe3`; branch protection `required_reviews=0`; unresolved review/comment 없음

## Metadata

- Issue: #1361, milestone `1.13.0`, assignee `debop`
- PR: #1442, head `dcf00fd1894bd47844cc1c30b3b50d19ad5a9fe3`, milestone `1.13.0`, assignee `debop`
- CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32128364824 (green; changed-module routing으로 비대상 backend jobs는 skipped)

## DoD Status

Required checks: 16/19; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 - Re-read authority | AGENTS hierarchy와 승인된 Type-C bugfix plan을 확인 | PASS | current guidance hashes and approved execution request | none |
| CG-02 - Historical/current evidence | GNO와 live Issue #1361·duplicate PR 상태를 확인 | PASS | `gh issue view 1361`; no duplicate PR before PR #1442 | none |
| CG-03 - Protect worktree | isolated worktree와 feature branch에서 구현 | PASS | `.worktrees/fix/1361-jwt-parser-cache-lifecycle`; base `develop` | none |
| CG-04 - Policy/language | Kotlin, Korean public docs, repo scope를 적용 | PASS | workspace/repo AGENTS and selected skills | none |
| CG-05 - Reuse patterns | 기존 provider cache/lifecycle/test 패턴을 재사용 | PASS | `JwtParserSupport`, `JwtProvider`, existing provider tests | none |
| CG-06 - Public/docs contract | KDoc, EN/KO README, lesson을 갱신 | PASS | 7 changed files in exact commit | none |
| CG-07 - RED/GREEN proof | 회귀 테스트와 module test를 실행 | PASS | RED failure then GREEN; 160 passing, 10 pending | none |
| CG-08 - Heavy checks | JWT module checks를 순차 실행 | PASS | cleanTest + module test completed sequentially | none |
| CG-09 - Lesson gate | 재사용 가능한 lifecycle lesson을 커밋 | PASS | `docs/lessons/2026-08-18-issue-1361-jwt-parser-cache-lifecycle.md` | none |
| CG-10 - Pre-PR convergence | final diff, detekt, diff-check, P0/P1 review 완료 | PASS | commit `dcf00fd1894bd47844cc1c30b3b50d19ad5a9fe3` | none |
| CG-11 - PR delivery authority | target repo/base/head와 PR 생성 권한 확인 | PASS | `bluetape4k/bluetape4k-projects`, `develop`, `fix/1361-jwt-parser-cache-lifecycle` | none |
| CG-12 - Publish exact head | feature branch를 push하고 remote SHA 확인 | PASS | local/remote `dcf00fd1894bd47844cc1c30b3b50d19ad5a9fe3` | none |
| CG-12A - Guidance refresh | PR 직전 guidance, template, issue metadata를 재확인 | PASS | current hashes and Issue #1361 metadata match; no drift | none |
| CG-13 - Create and verify PR | PR 생성 후 metadata/body/head를 live read-back | PASS | PR #1442, exact head, labels/milestone/assignee, final `## DoD Status` read back | none |
| CG-14 - CI and human review | exact PR head CI와 applicable review requirement를 확인 | PASS | CI run `32128364824` green; `required_reviews=0`; reviews/comments empty; local P0/P1 review clear | none |
| CG-15 - Merge-ready report | exact-head DoD와 metadata를 재조정하여 merge-ready 상태 보고 | PASS | PR #1442 exact head `dcf00fd1894bd47844cc1c30b3b50d19ad5a9fe3`; counts 16/19, N/A 1, Blocked 0 | none |
| CG-16 - Fresh merge approval | exact PR/head에 대한 새 승인을 확인하고 merge commit을 생성 | PASS | 승인 후 merge commit `344e090da65494c8c53db4d84afbce7dee073073` 생성 | none |
| CG-17 - Merge verification | 병합 상태·merge SHA·Issue 연결을 live read-back | PASS | PR #1442 `MERGED`; merge SHA `344e090da65494c8c53db4d84afbce7dee073073`; Issue #1361 자동 종료 확인 | none |
| CG-18 - Sync and cleanup | canonical develop 동기화와 merged worktree/branch 정리 | PASS | `origin/develop`가 merge SHA를 가리키고 canonical sync·safe cleanup 완료 | none |
| CG-X01 - Other irreversible action | tag/release/delete 범위 없음 | N/A | no irreversible non-PR action requested | none |

Final status: DONE (CG-16 fresh approval, CG-17 merge verification, and CG-18 sync/cleanup complete)

Unchecked required items: none

