### PR TITLE
[build] Gradle 10 제거 예정 경고를 명시 API와 CI gate로 차단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,15 @@ jobs:
       - name: Resolve Gradle catalog from checked-out source
         env:
           BLUETAPE4K_DEPENDENCIES_CATALOG_PATH: ${{ github.workspace }}/.catalog/bluetape4k-dependencies/gradle/libs.versions.toml
-        run: ./gradlew help --no-daemon
+        run: |
+          set -euo pipefail
+          warning_log="$(mktemp)"
+          trap 'rm -f "$warning_log"' EXIT
+          ./gradlew help --no-daemon --no-configuration-cache --warning-mode all --console=plain 2>&1 | tee "$warning_log"
+          if grep -Eq 'scheduled to be removed in Gradle 10|will fail with an error in Gradle 10' "$warning_log"; then
+            echo 'Gradle 10 removal warnings detected.' >&2
+            exit 1
+          fi
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,10 +211,32 @@ jobs:
           BLUETAPE4K_DEPENDENCIES_CATALOG_PATH: ${{ github.workspace }}/.catalog/bluetape4k-dependencies/gradle/libs.versions.toml
         run: |
           set -euo pipefail
+          gradle10_removal_pattern='(scheduled (to be removed|for removal)|will (be )?removed|will become (an )?error|will fail with an error)[^[:cntrl:]]*Gradle 10([.][0-9]+){0,2}'
+          positive_gradle10_warnings=(
+            'This behavior is scheduled to be removed in Gradle 10.'
+            'This behavior will be removed in Gradle 10.0.0.'
+            'This behavior is scheduled for removal in Gradle 10.'
+            'This behavior will become an error in Gradle 10.'
+            'This behavior will fail with an error in Gradle 10.'
+          )
+          for warning in "${positive_gradle10_warnings[@]}"; do
+            if ! grep -Eiq "$gradle10_removal_pattern" <<<"$warning"; then
+              echo "Gradle 10 warning fixture was not detected: $warning" >&2
+              exit 1
+            fi
+          done
+          if grep -Eiq "$gradle10_removal_pattern" <<< 'This behavior will be removed in Gradle 9.7.'; then
+            echo 'Gradle 9 warning fixture was incorrectly detected.' >&2
+            exit 1
+          fi
+          if grep -Eiq "$gradle10_removal_pattern" <<< 'Gradle 10 supports this behavior.'; then
+            echo 'Non-removal Gradle 10 fixture was incorrectly detected.' >&2
+            exit 1
+          fi
           warning_log="$(mktemp)"
           trap 'rm -f "$warning_log"' EXIT
           ./gradlew help --no-daemon --no-configuration-cache --warning-mode all --console=plain 2>&1 | tee "$warning_log"
-          if grep -Eq 'scheduled to be removed in Gradle 10|will fail with an error in Gradle 10' "$warning_log"; then
+          if grep -Eiq "$gradle10_removal_pattern" "$warning_log"; then
             echo 'Gradle 10 removal warnings detected.' >&2
             exit 1
           fi

--- a/bluetape4k/bom/build.gradle.kts
+++ b/bluetape4k/bom/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     constraints {
         rootProject.subprojects {
             if (isPublishableLibraryProject()) {
-                api(this)
+                api(rootProject.dependencies.project(path))
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,9 +69,9 @@ val centralSnapshotsParallelism: Int = providers
     .orElse(8)
     .get()
 
-val projectGroup: String by project
-val baseVersion: String by project
-val snapshotVersion: String by project
+val projectGroup: String = providers.gradleProperty("projectGroup").get()
+val baseVersion: String = providers.gradleProperty("baseVersion").get()
+val snapshotVersion: String = providers.gradleProperty("snapshotVersion").get()
 
 abstract class TestcontainersMutexService: BuildService<BuildServiceParameters.None>
 
@@ -969,13 +969,13 @@ subprojects {
     }
 
     dependencies {
-        val api by configurations
-        val implementation by configurations
-        val testImplementation by configurations
+        val api = configurations.getByName("api")
+        val implementation = configurations.getByName("implementation")
+        val testImplementation = configurations.getByName("testImplementation")
 
-        val compileOnly by configurations
-        val testCompileOnly by configurations
-        val testRuntimeOnly by configurations
+        val compileOnly = configurations.getByName("compileOnly")
+        val testCompileOnly = configurations.getByName("testCompileOnly")
+        val testRuntimeOnly = configurations.getByName("testRuntimeOnly")
 
         api(rootBt4k.jetbrains.annotations)
 
@@ -1031,12 +1031,12 @@ subprojects {
                 create<MavenPublication>("Bluetape4k") {
                     val binaryJar = components["java"]
 
-                    val sourcesJar by tasks.registering(Jar::class) {
+                    val sourcesJar = tasks.register<Jar>("sourcesJar") {
                         archiveClassifier.set("sources")
                         from(sourceSets["main"].allSource)
                     }
 
-                    val javadocJar by tasks.registering(Jar::class) {
+                    val javadocJar = tasks.register<Jar>("javadocJar") {
                         archiveClassifier.set("javadoc")
                         val javadocDir = layout.buildDirectory.asFile.get().resolve("javadoc")
                         from(javadocDir.path)
@@ -1099,7 +1099,7 @@ val detektTargetProjects = subprojects
 val detektSourceCoverageReport = layout.buildDirectory.file("reports/detekt/source-coverage.md")
 val detektSourceFilesByProject = detektTargetProjects.associateWith { it.detektKotlinSourceFiles() }
 
-val detektSourceCoverage by tasks.registering {
+val detektSourceCoverage = tasks.register("detektSourceCoverage") {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     description = "Verifies and reports the Kotlin source scope analyzed by Detekt."
 
@@ -1170,7 +1170,7 @@ val detektModuleTasks = detektTargetProjects.map { module ->
     module.tasks.named<Detekt>("detekt")
 }
 
-val detektReportMerge by tasks.registering(ReportMergeTask::class) {
+val detektReportMerge = tasks.register<ReportMergeTask>("detektReportMerge") {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     description = "Merges XML reports from all Detekt Kotlin subprojects."
     output.set(layout.buildDirectory.file("reports/detekt/merged.xml"))
@@ -1292,7 +1292,7 @@ dependencies {
 }
 
 // ── Disabled Test Release Gate ──────────────────────────────────────────────
-val checkDisabledTests by tasks.registering(DisabledTestReportTask::class) {
+val checkDisabledTests = tasks.register<DisabledTestReportTask>("checkDisabledTests") {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     description = "Scans JUnit disabled tests and fails known-bug skips without GitHub issue references."
     sourceRoot.set(layout.projectDirectory)

--- a/data/hibernate/build.gradle.kts
+++ b/data/hibernate/build.gradle.kts
@@ -70,12 +70,12 @@ configurations {
     create("testJar")
 }
 
-val consumerRuntimeTest by sourceSets.creating {
+val consumerRuntimeTest = sourceSets.create("consumerRuntimeTest") {
     compileClasspath += sourceSets.main.get().output + configurations.runtimeClasspath.get()
     runtimeClasspath += output + compileClasspath
 }
 
-val consumerRuntimeTestImplementation by configurations.getting
+val consumerRuntimeTestImplementation = configurations.getByName("consumerRuntimeTestImplementation")
 
 tasks.register<Test>("consumerRuntimeTest") {
     description = "Runs Hibernate converter smoke tests with the published runtime classpath."

--- a/docs/lessons/2026-08-18-issue-1344-gradle10-warning-cleanup.md
+++ b/docs/lessons/2026-08-18-issue-1344-gradle10-warning-cleanup.md
@@ -1,0 +1,52 @@
+# Issue #1344: Gradle 10 제거 예정 경고를 fail-closed로 관리하기
+
+## 맥락
+
+Gradle 9.7의 `help --warning-mode all`은 Kotlin DSL delegate와 BOM 의존성
+constraint에서 Gradle 10 제거 예정 경고를 출력했다. 경고는 빌드를 즉시 실패시키지
+않으므로 전체 빌드가 통과해도 다음 Gradle 메이저 업그레이드에서 구성 단계가 깨질 수
+있었다.
+
+## 결정
+
+- `by project`, `by configurations`, `by sourceSets.creating`, `by
+  configurations.getting`, `by tasks.registering`을 명시적인
+  `providers.gradleProperty`, `getByName`, `create`, `register` 호출로 바꾼다.
+- Java Platform BOM constraint에는 Project 객체를 넘기지 않고
+  `rootProject.dependencies.project(path)`로 project dependency notation을 만든다.
+- CI의 catalog-governance 단계에서 `help --warning-mode all`을 실행하고,
+  `scheduled to be removed in Gradle 10` 또는 `will fail with an error in Gradle 10`
+  문구가 있으면 실패시킨다. 다른 라이브러리의 독립적인 deprecation은 이 gate의
+  범위에 포함하지 않는다.
+- 등록된 task의 이름과 Provider 기반 연결(`artifact`, `dependsOn`)은 기존 이름과
+  동작을 유지한다.
+
+## 결과
+
+- root build script, BOM, Hibernate consumer test source set, Redis consumer test
+  configuration에서 Gradle 10 제거 예정 delegate/Project notation을 제거했다.
+- 경고를 숨기거나 `warning-mode`를 전역으로 억제하지 않고, CI가 새 제거 예정
+  경고를 fail-closed로 차단한다.
+
+## 검증
+
+- 변경 전 `./gradlew help --no-configuration-cache --warning-mode all --no-daemon
+  --console=plain`에서 Gradle 10 제거 예정 경고 23개를 재현했다.
+- 변경 후 같은 명령은 성공했고 Gradle 10 제거 예정 경고는 0개였다. NMCP의
+  별도 Kotlin deprecation warning은 이 이슈의 Gradle 10 제거 경계가 아니므로
+  별도 backlog로 남긴다.
+- `./gradlew :bluetape4k-spring-boot-redis:consumerRuntimeTest
+  :bluetape4k-hibernate:consumerRuntimeTest --no-configuration-cache --no-daemon`
+  이 성공해 두 consumer source set/configuration 경계를 확인했다.
+- `./gradlew :bluetape4k-spring-boot-redis:compileTestKotlin
+  :bluetape4k-hibernate:compileTestKotlin --no-configuration-cache --no-daemon`이
+  성공했다.
+- `.github/workflows/ci.yml`은 `actionlint`와 `scripts/validate-ci-csv-coverage.rb`를
+  통과했다.
+
+## 향후 지침
+
+Gradle 버전을 올리거나 build script delegate를 추가할 때는 먼저
+`help --warning-mode all --no-configuration-cache`를 실행하고, Gradle 메이저 제거
+예정 문구를 별도 분류한다. CI gate의 정규식은 Gradle 메이저 제거 계약만 포함하며,
+독립적인 plugin API deprecation은 해당 plugin migration issue에서 처리한다.

--- a/docs/lessons/2026-08-18-issue-1344-gradle10-warning-cleanup.md
+++ b/docs/lessons/2026-08-18-issue-1344-gradle10-warning-cleanup.md
@@ -15,9 +15,11 @@ constraint에서 Gradle 10 제거 예정 경고를 출력했다. 경고는 빌�
 - Java Platform BOM constraint에는 Project 객체를 넘기지 않고
   `rootProject.dependencies.project(path)`로 project dependency notation을 만든다.
 - CI의 catalog-governance 단계에서 `help --warning-mode all`을 실행하고,
-  `scheduled to be removed in Gradle 10` 또는 `will fail with an error in Gradle 10`
-  문구가 있으면 실패시킨다. 다른 라이브러리의 독립적인 deprecation은 이 gate의
-  범위에 포함하지 않는다.
+  `scheduled to be removed`, `scheduled for removal`, `will be removed`,
+  `will become an error`, `will fail with an error` 중 하나가 `Gradle 10` 또는
+  `Gradle 10.x.y`와 함께 나타나면 실패시킨다. CI 단계는 각 문구의 positive fixture와
+  Gradle 9/non-removal negative fixture를 먼저 검증한다. 다른 라이브러리의 독립적인
+  deprecation은 이 gate의 범위에 포함하지 않는다.
 - 등록된 task의 이름과 Provider 기반 연결(`artifact`, `dependsOn`)은 기존 이름과
   동작을 유지한다.
 
@@ -42,7 +44,7 @@ constraint에서 Gradle 10 제거 예정 경고를 출력했다. 경고는 빌�
   :bluetape4k-hibernate:compileTestKotlin --no-configuration-cache --no-daemon`이
   성공했다.
 - `.github/workflows/ci.yml`은 `actionlint`와 `scripts/validate-ci-csv-coverage.rb`를
-  통과했다.
+  통과했고, Gradle 10 removal 문구 변형의 positive/negative shell fixture도 통과했다.
 
 ## 향후 지침
 

--- a/spring-boot/redis/build.gradle.kts
+++ b/spring-boot/redis/build.gradle.kts
@@ -6,12 +6,12 @@ configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
 
-val consumerRuntimeTest by sourceSets.creating {
+val consumerRuntimeTest = sourceSets.create("consumerRuntimeTest") {
     compileClasspath += sourceSets.main.get().output + configurations.runtimeClasspath.get()
     runtimeClasspath += output + compileClasspath
 }
 
-val consumerRuntimeTestImplementation by configurations.getting
+val consumerRuntimeTestImplementation = configurations.getByName("consumerRuntimeTestImplementation")
 
 tasks.register<Test>("consumerRuntimeTest") {
     description = "Runs Redis serializer smoke tests with the published runtime classpath."


### PR DESCRIPTION
## 변경 요약

Gradle 9.7에서 재현된 Gradle 10 제거 예정 Kotlin DSL delegate와 BOM의 Project-object dependency constraint를 명시 API로 전환하고, 같은 경고가 다시 들어오면 CI가 실패하도록 catalog-governance smoke gate를 추가했습니다.

Epic #1417의 stacked PR train 중 PR1이며, 이번 PR의 진행률은 `1/5`입니다. 선행 PR은 없고, 다음 child #1338은 이 PR이 merge될 때까지 hold합니다.

Closes #1344

## 변경 유형

- [x] `chore` — 빌드/CI/Gradle DSL 유지보수

## 스택 위치

- Repository: `bluetape4k/bluetape4k-projects`
- Base: `develop@344e090da65494c8c53db4d84afbce7dee073073`
- Head: `chore/1344-gradle10-warning-cleanup@74f6f0c4d26869f05f347559c390eff3eed293f3`
- Parent: 없음 (PR1)
- Next: #1338 (현재 hold, PR1 merge 후에만 rebase/생성)

## 변경 내용

- root `build.gradle.kts`의 project/configuration/task delegate를 `providers.gradleProperty`, `getByName`, `register`로 교체했습니다.
- Hibernate와 Spring Boot Redis consumer test source set/configuration을 `create`/`getByName`으로 교체했습니다.
- BOM constraint에서 Project 객체 대신 `rootProject.dependencies.project(path)`를 사용합니다.
- CI catalog-governance가 `help --warning-mode all`의 Gradle 10 removal 문구를 fail-closed로 차단합니다.
- Gradle 10.0.0 및 `scheduled for removal`/`will become an error` 문구 변형을 positive fixture로,
  Gradle 9/non-removal 문구를 negative fixture로 고정했습니다.
- 재현·결정·검증·향후 guard를 [Issue #1344 lesson](https://github.com/bluetape4k/bluetape4k-projects/blob/chore/1344-gradle10-warning-cleanup/docs/lessons/2026-08-18-issue-1344-gradle10-warning-cleanup.md)에 기록했습니다.

## 테스트 및 검증

- 변경 전 baseline: Gradle 10 제거 예정 경고 23개 재현.
- 변경 후 `./gradlew help --no-configuration-cache --warning-mode all --no-daemon --console=plain`: 성공, Gradle 10 removal 문구 0개.
- 기본 configuration-cache `./gradlew help --no-daemon --console=plain`: 성공, cache entry 저장.
- `:bluetape4k-spring-boot-redis:consumerRuntimeTest` + `:bluetape4k-hibernate:consumerRuntimeTest`: 성공.
- `:bluetape4k-spring-boot-redis:compileTestKotlin` + `:bluetape4k-hibernate:compileTestKotlin`: 성공.
- `:bluetape4k-core:generatePomFileForBluetape4kPublication` + metadata task: 성공.
- `actionlint .github/workflows/ci.yml`, `ruby scripts/validate-ci-csv-coverage.rb`, `git diff --check`: 성공.
- Gradle 10 removal pattern positive/negative shell fixture: 성공.

## Code Review

- [x] 독립 exact-head code review — 새 head에서 P0/P1/P2/P3 모두 0, CLEAR
- [x] Hosted CI exact-head — run `32138262121` 및 후속 checks 전부 통과

## 체크리스트

- [x] isolated worktree에서 작업하고 exact base/head를 확인했습니다.
- [x] 변경 build script와 대표 모듈 검증을 실행했습니다.
- [x] CI workflow 문법과 변경 경로 coverage를 확인했습니다.
- [x] lesson에 재현 결과와 향후 guard를 기록했습니다.
- [ ] `docs/testlogs/2026-08.md` 별도 행 — 이번 PR의 명시적 lesson에 동일 결과를 기록했으며, reviewer 지적 시 보강합니다.
- [x] fresh merge approval, merge, canonical sync, worktree cleanup — merge SHA `15e08ee5a0d3200b655c430d9999cbbf324fcb4e`; canonical `develop` 동기화 및 merged PR1 worktree 정리 완료.

## DoD Status

Required checks: 8/8; N/A: 0; Blocked: 0

| 항목 | 상태 | 증거 |
| --- | --- | --- |
| Gradle 10 warning baseline | PASS | 변경 전 `help --warning-mode all`에서 23개 재현 |
| Delegate/constraint migration | PASS | root/BOM/Hibernate/Redis 명시 API 전환 |
| Warning-free help | PASS | exact command 성공, Gradle 10 removal 문구 0개 |
| Representative modules | PASS | 두 consumer task와 두 `compileTestKotlin` 성공 |
| Publish/configuration-cache smoke | PASS | core publication metadata와 기본 cache help 성공 |
| Static/workflow/diff checks | PASS | actionlint, CI CSV, deprecated-pattern search, diff check 성공 |
| Hosted CI exact head | PASS | CI run `32138262121`, Build/전체 테스트 fan-out/Coverage/CI Status 및 정책 checks 통과 |
| Independent exact-head review | PASS | 새 head exact review: P0=0, P1=0, P2=0, P3=0; CLEAR |
| Merge, canonical sync, cleanup | PASS | merge SHA `15e08ee5a0d3200b655c430d9999cbbf324fcb4e`; `develop`와 exact 일치; merged PR1 worktree 제거 |
| Epic #1417 progress | PASS | PR1 of 5 — `1/5`; #1338 remains held |

Final status: DONE — PR #1443이 merge SHA `15e08ee5a0d3200b655c430d9999cbbf324fcb4e`로 병합되었고 canonical `develop` 동기화 및 worktree 정리를 완료했습니다.

Unchecked items: optional separate testlog row만 남았습니다.