### PR TITLE
[build] configuration-cache에서 기본 detekt 명령 실패 수정

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -369,7 +369,7 @@ jobs:
       - name: Detekt static analysis
         run: |
           for attempt in 1 2 3; do
-            ./gradlew detekt --parallel --no-configuration-cache && break
+            ./gradlew detekt --parallel --configuration-cache-problems=fail && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import io.bluetape4k.gradle.applyBluetape4kPomMetadata
 import io.bluetape4k.gradle.centralSnapshotsRepository
 import io.bluetape4k.gradle.configurePublishingSigning
 import io.bluetape4k.gradle.DisabledTestReportTask
+import io.bluetape4k.gradle.DetektSourceCoverageTask
 import io.bluetape4k.gradle.isPublishableLibraryProject
 import io.bluetape4k.gradle.isPublishedProject
 import io.bluetape4k.gradle.resolveCentralPublishingConfig
@@ -1098,72 +1099,27 @@ val detektTargetProjects = subprojects
 
 val detektSourceCoverageReport = layout.buildDirectory.file("reports/detekt/source-coverage.md")
 val detektSourceFilesByProject = detektTargetProjects.associateWith { it.detektKotlinSourceFiles() }
+val detektSourceCoverageProjects = detektTargetProjects.associate { module ->
+    module.path to module.projectDir.absolutePath
+}
+val detektSourceCoverageExclusions = (
+    subprojects
+        .mapNotNull { module -> module.detektExclusionReason()?.let { module.path to it } } +
+        detektExplicitExclusionReasons
+            .filterKeys { moduleName -> subprojects.none { it.name == moduleName } }
+            .map { (moduleName, reason) -> ":$moduleName" to reason }
+    )
+    .toMap()
 
-val detektSourceCoverage = tasks.register("detektSourceCoverage") {
+val detektSourceCoverage = tasks.register<DetektSourceCoverageTask>("detektSourceCoverage") {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     description = "Verifies and reports the Kotlin source scope analyzed by Detekt."
 
-    inputs.files(detektSourceFilesByProject.values)
-    outputs.file(detektSourceCoverageReport)
-
-    doLast {
-        val rows = detektSourceFilesByProject.map { (module, sourceFiles) ->
-            val files = sourceFiles.files
-            val mainRoot = module.projectDir.toPath().resolve("src/main/kotlin")
-            val testRoot = module.projectDir.toPath().resolve("src/test/kotlin")
-            val mainCount = files.count { it.toPath().startsWith(mainRoot) }
-            val testCount = files.count { it.toPath().startsWith(testRoot) }
-            module to Triple(mainCount, testCount, files.size)
-        }
-        val emptyModules = rows.filter { (_, counts) -> counts.third == 0 }
-        val totalMain = rows.sumOf { it.second.first }
-        val totalTest = rows.sumOf { it.second.second }
-        val totalFiles = rows.sumOf { it.second.third }
-        val exclusions = (
-            subprojects
-                .mapNotNull { module -> module.detektExclusionReason()?.let { module.path to it } } +
-                detektExplicitExclusionReasons
-                    .filterKeys { moduleName -> subprojects.none { it.name == moduleName } }
-                    .map { (moduleName, reason) -> ":$moduleName" to reason }
-            )
-            .sortedBy { it.first }
-
-        val report = detektSourceCoverageReport.get().asFile
-        report.parentFile.mkdirs()
-        report.writeText(buildString {
-            appendLine("# Detekt source coverage")
-            appendLine()
-            appendLine("- Included modules: ${rows.size}")
-            appendLine("- Kotlin source files: $totalFiles (main: $totalMain, test: $totalTest)")
-            appendLine("- Empty included modules: ${emptyModules.size}")
-            appendLine()
-            appendLine("## Included modules")
-            appendLine()
-            appendLine("| Project | Main Kotlin | Test Kotlin | Total |")
-            appendLine("| --- | ---: | ---: | ---: |")
-            rows.forEach { (module, counts) ->
-                appendLine("| `${module.path}` | ${counts.first} | ${counts.second} | ${counts.third} |")
-            }
-            appendLine()
-            appendLine("## Explicit exclusions")
-            appendLine()
-            if (exclusions.isEmpty()) {
-                appendLine("No explicit exclusions.")
-            } else {
-                exclusions.forEach { (modulePath, reason) ->
-                    appendLine("- `$modulePath` — $reason")
-                }
-            }
-        })
-
-        check(emptyModules.isEmpty()) {
-            "Detekt source coverage is empty for included modules: ${emptyModules.joinToString { it.first.path }}"
-        }
-        logger.lifecycle(
-            "Detekt source coverage: ${rows.size} modules, $totalFiles Kotlin files " +
-                "(main: $totalMain, test: $totalTest)",
-        )
-    }
+    projectPaths.set(detektTargetProjects.map(Project::getPath))
+    projectRoots.set(detektSourceCoverageProjects)
+    explicitExclusions.set(detektSourceCoverageExclusions)
+    sourceFiles.from(detektSourceFilesByProject.values)
+    reportFile.set(detektSourceCoverageReport)
 }
 
 val detektModuleTasks = detektTargetProjects.map { module ->

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 dependencies {
     testImplementation(kotlin("test"))
+    testImplementation(gradleTestKit())
 }
 
 tasks.test {

--- a/buildSrc/src/main/kotlin/DetektSourceCoverageTask.kt
+++ b/buildSrc/src/main/kotlin/DetektSourceCoverageTask.kt
@@ -1,0 +1,121 @@
+package io.bluetape4k.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Detekt가 분석하는 Kotlin 소스 범위를 검증하고 보고서로 기록합니다.
+ *
+ * 선언된 Gradle property와 file collection만 전달받으며, configuration
+ * cache가 직렬화할 수 없는 [org.gradle.api.Project] 또는 빌드 스크립트
+ * 객체를 task action이 보유하지 않습니다.
+ */
+abstract class DetektSourceCoverageTask : DefaultTask() {
+
+    @get:Input
+    abstract val projectPaths: ListProperty<String>
+
+    @get:Input
+    abstract val projectRoots: MapProperty<String, String>
+
+    @get:Input
+    abstract val explicitExclusions: MapProperty<String, String>
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceFiles: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val reportFile: RegularFileProperty
+
+    @TaskAction
+    fun generateReport() {
+        val files = sourceFiles.files
+        val rows = projectPaths.get().map { projectPath ->
+            val moduleRoot = Paths.get(projectRoots.get().getValue(projectPath)).normalize()
+            val mainRoot = moduleRoot.resolve("src/main/kotlin")
+            val testRoot = moduleRoot.resolve("src/test/kotlin")
+            val mainCount = files.count { it.normalizedPath().isUnder(mainRoot) }
+            val testCount = files.count { it.normalizedPath().isUnder(testRoot) }
+            DetektSourceCoverageRow(
+                projectPath = projectPath,
+                mainCount = mainCount,
+                testCount = testCount,
+            )
+        }
+        val emptyModules = rows.filter { it.totalCount == 0 }
+        val report = reportFile.get().asFile
+        report.parentFile.mkdirs()
+        report.writeText(DetektSourceCoverageReportRenderer.render(rows, explicitExclusions.get()))
+
+        check(emptyModules.isEmpty()) {
+            "Detekt source coverage is empty for included modules: " +
+                emptyModules.joinToString { it.projectPath }
+        }
+        logger.lifecycle(
+            "Detekt source coverage: ${rows.size} modules, ${rows.sumOf { it.totalCount }} Kotlin files " +
+                "(main: ${rows.sumOf { it.mainCount }}, test: ${rows.sumOf { it.testCount }})",
+        )
+    }
+
+    private fun Path.isUnder(root: Path): Boolean = startsWith(root.normalize())
+
+    private fun File.normalizedPath(): Path = Paths.get(toURI()).normalize()
+}
+
+data class DetektSourceCoverageRow(
+    val projectPath: String,
+    val mainCount: Int,
+    val testCount: Int,
+) {
+    val totalCount: Int get() = mainCount + testCount
+}
+
+object DetektSourceCoverageReportRenderer {
+
+    fun render(
+        rows: List<DetektSourceCoverageRow>,
+        exclusions: Map<String, String>,
+    ): String = buildString {
+        val emptyModules = rows.count { it.totalCount == 0 }
+        val totalMain = rows.sumOf { it.mainCount }
+        val totalTest = rows.sumOf { it.testCount }
+        val totalFiles = rows.sumOf { it.totalCount }
+
+        appendLine("# Detekt source coverage")
+        appendLine()
+        appendLine("- Included modules: ${rows.size}")
+        appendLine("- Kotlin source files: $totalFiles (main: $totalMain, test: $totalTest)")
+        appendLine("- Empty included modules: $emptyModules")
+        appendLine()
+        appendLine("## Included modules")
+        appendLine()
+        appendLine("| Project | Main Kotlin | Test Kotlin | Total |")
+        appendLine("| --- | ---: | ---: | ---: |")
+        rows.forEach { row ->
+            appendLine("| `${row.projectPath}` | ${row.mainCount} | ${row.testCount} | ${row.totalCount} |")
+        }
+        appendLine()
+        appendLine("## Explicit exclusions")
+        appendLine()
+        if (exclusions.isEmpty()) {
+            appendLine("No explicit exclusions.")
+        } else {
+            exclusions.toSortedMap().forEach { (modulePath, reason) ->
+                appendLine("- `$modulePath` — $reason")
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/DetektSourceCoverageTestPlugin.kt
+++ b/buildSrc/src/main/kotlin/DetektSourceCoverageTestPlugin.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Gradle TestKit에서 [DetektSourceCoverageTask]의 실제 실행 경계를 검증하는
+ * 최소 fixture plugin입니다.
+ *
+ * 테스트용 project property만 configuration 단계에서 읽고, task action에는
+ * 직렬화 가능한 property와 파일 집합만 전달합니다.
+ */
+class DetektSourceCoverageTestPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        val includeEmptyModule = project.providers.gradleProperty("includeEmptyModule")
+            .map(String::toBoolean)
+            .orElse(false)
+        val fixtureRoot = project.projectDir.absolutePath
+        val emptyRoot = project.layout.projectDirectory.dir("empty").asFile.absolutePath
+        val fixtureSourceFiles = listOf(
+            project.layout.projectDirectory.file("src/main/kotlin/Fixture.kt").asFile,
+            project.layout.projectDirectory.file("src/test/kotlin/FixtureTest.kt").asFile,
+        )
+        val report = project.layout.buildDirectory.file("reports/detekt/source-coverage.md")
+
+        project.tasks.register<DetektSourceCoverageTask>("detektSourceCoverage") {
+            projectPaths.set(
+                includeEmptyModule.map { includeEmpty ->
+                    if (includeEmpty) listOf(":fixture", ":empty") else listOf(":fixture")
+                },
+            )
+            projectRoots.set(
+                includeEmptyModule.map { includeEmpty ->
+                    buildMap {
+                        put(":fixture", fixtureRoot)
+                        if (includeEmpty) {
+                            put(":empty", emptyRoot)
+                        }
+                    }
+                },
+            )
+            explicitExclusions.set(
+                mapOf(
+                    ":zeta" to "Z exclusion",
+                    ":alpha" to "A exclusion",
+                ),
+            )
+            sourceFiles.from(fixtureSourceFiles)
+            reportFile.set(report)
+        }
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/io.bluetape4k.detekt-fixture.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/io.bluetape4k.detekt-fixture.properties
@@ -1,0 +1,1 @@
+implementation-class=io.bluetape4k.gradle.DetektSourceCoverageTestPlugin

--- a/buildSrc/src/test/kotlin/io/bluetape4k/gradle/DetektSourceCoverageTaskIntegrationTest.kt
+++ b/buildSrc/src/test/kotlin/io/bluetape4k/gradle/DetektSourceCoverageTaskIntegrationTest.kt
@@ -1,0 +1,101 @@
+package io.bluetape4k.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import java.io.File
+
+class DetektSourceCoverageTaskIntegrationTest {
+
+    @Test
+    fun `detekt coverage task stores and reuses configuration cache`() {
+        val projectDir = createFixtureProject()
+        try {
+            val arguments = arrayOf(
+                "detekt",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+                "--console=plain",
+            )
+
+            val firstRun = run(projectDir, arguments)
+            assertEquals(TaskOutcome.SUCCESS, firstRun.task(":detekt")?.outcome)
+            assertContains(firstRun.output, "Configuration cache entry stored")
+
+            val secondRun = run(projectDir, arguments)
+            assertContains(secondRun.output, "Configuration cache entry reused")
+
+            val report = File(projectDir, "build/reports/detekt/source-coverage.md").readText()
+            assertContains(report, "- Included modules: 1")
+            assertContains(report, "- Kotlin source files: 2 (main: 1, test: 1)")
+            assertContains(report, "- Empty included modules: 0")
+            assertTrue(report.indexOf("`:alpha`") < report.indexOf("`:zeta`"))
+        } finally {
+            projectDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `detekt coverage task fails closed for an empty included module`() {
+        val projectDir = createFixtureProject(includeEmptyModule = true)
+        try {
+            val result = runAndFail(
+                projectDir,
+                "detekt",
+                "-PincludeEmptyModule=true",
+                "--configuration-cache",
+                "--configuration-cache-problems=fail",
+                "--console=plain",
+            )
+
+            assertContains(result.output, "Detekt source coverage is empty for included modules: :empty")
+        } finally {
+            projectDir.deleteRecursively()
+        }
+    }
+
+    private fun createFixtureProject(includeEmptyModule: Boolean = false): File {
+        val projectDir = createTempDirectory("detekt-source-coverage-fixture").toFile()
+        val mainSource = File(projectDir, "src/main/kotlin/Fixture.kt")
+        val testSource = File(projectDir, "src/test/kotlin/FixtureTest.kt")
+        mainSource.parentFile.mkdirs()
+        testSource.parentFile.mkdirs()
+        mainSource.writeText("class Fixture")
+        testSource.writeText("class FixtureTest")
+        if (includeEmptyModule) {
+            File(projectDir, "empty").mkdirs()
+        }
+
+        File(projectDir, "settings.gradle.kts").writeText("rootProject.name = \"detekt-source-coverage-fixture\"\n")
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                id("io.bluetape4k.detekt-fixture")
+            }
+
+            tasks.register("detekt") {
+                dependsOn("detektSourceCoverage")
+            }
+            """.trimIndent() + "\n",
+        )
+        return projectDir
+    }
+
+    private fun run(projectDir: File, arguments: Array<String>) =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*arguments)
+            .withPluginClasspath()
+            .build()
+
+    private fun runAndFail(projectDir: File, vararg arguments: String) =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*arguments)
+            .withPluginClasspath()
+            .buildAndFail()
+}

--- a/buildSrc/src/test/kotlin/io/bluetape4k/gradle/DetektSourceCoverageTaskTest.kt
+++ b/buildSrc/src/test/kotlin/io/bluetape4k/gradle/DetektSourceCoverageTaskTest.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.gradle
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class DetektSourceCoverageTaskTest {
+
+    @Test
+    fun `report preserves coverage totals and explicit exclusions`() {
+        val report = DetektSourceCoverageReportRenderer.render(
+            rows = listOf(
+                DetektSourceCoverageRow(":alpha", mainCount = 2, testCount = 1),
+                DetektSourceCoverageRow(":beta", mainCount = 0, testCount = 3),
+            ),
+            exclusions = mapOf(":sample" to "Example sources are excluded."),
+        )
+
+        assertContains(report, "- Included modules: 2")
+        assertContains(report, "- Kotlin source files: 6 (main: 2, test: 4)")
+        assertContains(report, "| `:alpha` | 2 | 1 | 3 |")
+        assertContains(report, "- `:sample` — Example sources are excluded.")
+        assertEquals(1, report.lineSequence().count { it == "- Empty included modules: 0" })
+    }
+}

--- a/docs/lessons/2026-08-18-issue-1338-detekt-configuration-cache.md
+++ b/docs/lessons/2026-08-18-issue-1338-detekt-configuration-cache.md
@@ -1,0 +1,54 @@
+# 이슈 #1338 - configuration-cache에서 Detekt source coverage 실행 보장
+
+## 배경
+
+기본 `./gradlew detekt --no-daemon --console=plain` 실행이 configuration-cache
+재사용 시 `:detektSourceCoverage`에서 실패했다. task action이 Kotlin DSL 최상위
+`Project` map을 캡처하고 있었기 때문에 cache entry를 역직렬화한 뒤
+`Build_gradle.getDetektSourceFilesByProject()`가 `null`이 되었다. 같은 작업은
+`--no-configuration-cache`를 사용하면 통과했지만, CI가 cache를 우회하면 이 회귀를
+놓칠 수 있다.
+
+## 결정
+
+`detektSourceCoverage`의 `doLast` 구현을 `buildSrc`의
+`DetektSourceCoverageTask`로 옮겼다. task action에는 `Project`나 build-script
+객체를 전달하지 않고, 프로젝트 경로·소스 루트·명시적 제외 목록을 선언된
+property로 전달한다. 실제 소스는 `@InputFiles` collection에서 실행 시 읽어
+configuration-cache 재사용 뒤에도 module별 main/test 개수와 빈 module 검사를
+현재 파일 상태에 맞게 계산한다. 보고서 형식과 빈 module fail-closed 계약은
+유지하고, renderer 단위 테스트를 추가했다.
+
+야간 Detekt job은 더 이상 `--no-configuration-cache`를 사용하지 않는다.
+`--configuration-cache-problems=fail`을 함께 사용해 첫 시도의 configuration-cache
+문제를 warning으로 넘긴 뒤 재시도에서 우연히 통과하는 loophole을 차단한다.
+
+## 결과
+
+- 기본 Detekt가 configuration-cache 문제 없이 실행된다.
+- 두 번째 실행에서 `Configuration cache entry reused`를 확인하면서도
+  `BUILD SUCCESSFUL`을 유지한다.
+- source coverage 결과는 기존과 동일하게 75개 module, 4,151개 Kotlin 파일
+  (main 1,957, test 2,194), 빈 module 0개를 기록한다.
+- 기존 Detekt rule finding은 `ignoreFailures=true` 계약에 따라 보고서에 남지만,
+  source coverage task와 configuration-cache 검증은 독립적으로 fail-closed 된다.
+
+## 검증
+
+- RED: 기본 configuration-cache 실행이 script-object 직렬화 오류와
+  `Build_gradle.getDetektSourceFilesByProject()` null 오류로 실패했다.
+- RED control: `--no-configuration-cache` 실행은 기존 rule finding을 출력하고
+  `BUILD SUCCESSFUL`로 종료했다.
+- GREEN: `./gradlew :buildSrc:test --no-daemon --console=plain`
+- GREEN: `./gradlew detekt --configuration-cache-problems=fail --no-daemon --console=plain`
+- CACHE HIT: 같은 Detekt 명령을 두 번째 실행해 `Configuration cache entry reused`,
+  `BUILD SUCCESSFUL`, exit 0을 확인했다.
+- 정적 검증: `git diff --check`, `actionlint .github/workflows/nightly-tests.yml`
+
+## 향후 가드
+
+configuration-cache 대상 task action에서는 Kotlin DSL 최상위 `Project`,
+`Task`, script receiver 또는 그 객체를 key로 가진 collection을 캡처하지 않는다.
+새 입력은 `@Input`, `@InputFiles`, `@OutputFile` 같은 task property로 선언하고,
+야간 retry loop를 유지할 때는 `--configuration-cache-problems=fail`을 사용해
+구성 문제를 재시도 사이에 숨기지 않는다.


### PR DESCRIPTION
## Summary

Closes #1338

Epic #1417의 stacked PR train에서 PR2/5로 configuration-cache가 켜진 기본
`detekt` 경로를 복구합니다. `detektSourceCoverage`가 build-script 객체를
캡처하지 않도록 명시적 task property 기반으로 전환하고, 야간 retry가 구성
오류를 숨기지 않도록 fail-closed 검증을 고정했습니다.

## Background

Issue #1338은 기본 `./gradlew detekt`가 configuration-cache 재사용 뒤
`Build_gradle.getDetektSourceFilesByProject()` null 및 script-object 직렬화
오류로 실패하는 문제입니다. CI는 `--no-configuration-cache`로 우회하고 있어
로컬 기본 명령과 CI의 검증 계약이 달랐습니다.

Gradle configuration-cache task action은 `Project` 또는 Kotlin DSL script
object를 보유할 수 없으므로, task 입력을 선언된 property/file collection으로
분리했습니다. 자세한 제약은 [Gradle configuration cache requirements](https://docs.gradle.org/current/userguide/configuration_cache_requirements.html)를
참고합니다.

## What This Solves

- configuration-cache 저장·재사용 양쪽에서 `detektSourceCoverage`가 현재 소스
  범위를 계산하고 빈 module을 fail-closed로 검증합니다.
- nightly Detekt가 `--no-configuration-cache` 우회 없이 구성 문제를 실패로
  표면화하여 retry 사이에 회귀를 숨기지 않습니다.

## Work Done

- `DetektSourceCoverageTask`: buildSrc custom task로 이동하고 `@Input`,
  `@InputFiles`, `@OutputFile`을 통해 project root와 source scope를 전달합니다.
- `DetektSourceCoverageReportRenderer` 및 buildSrc 회귀 테스트를 추가해 기존
  coverage totals와 explicit exclusions를 유지합니다.
- Gradle TestKit fixture plugin으로 실제 task action, configuration-cache 저장·재사용,
  빈 포함 module의 fail-closed 동작을 고정합니다.
- nightly workflow를 `--configuration-cache-problems=fail`로 변경하고,
  재현·결정·검증·향후 guard를 [Issue #1338 lesson](https://github.com/bluetape4k/bluetape4k-projects/blob/fix/1338-detekt-configuration-cache/docs/lessons/2026-08-18-issue-1338-detekt-configuration-cache.md)에
  기록했습니다.

## Validation

- `./gradlew :buildSrc:test --no-daemon --console=plain`: PASS (전체 buildSrc 테스트)
- `./gradlew :buildSrc:test --tests "io.bluetape4k.gradle.DetektSourceCoverageTaskIntegrationTest" --no-daemon --console=plain`: PASS (실제 task action, cache 저장·재사용, empty module)
- `./gradlew detekt --configuration-cache-problems=fail --no-daemon --console=plain`: PASS (75 modules, 4,151 Kotlin files, empty 0)
- 같은 Detekt 명령 두 번째 실행: PASS (`Configuration cache entry reused`, exit 0)
- `./gradlew detekt --no-daemon --console=plain` 두 번: PASS (기본 명령 저장·재사용 모두 exit 0)
- `actionlint .github/workflows/nightly-tests.yml`, `git diff --check`: PASS

## Review Notes

- 이전 exact-head review의 P1/P2(실제 task action·configuration-cache·empty module 검증 부재)를
  Gradle TestKit integration test로 보강했습니다.
- 새 exact-head independent review는 P0/P1/P2/P3 모두 0으로 CLEAR를 확인했습니다.
- Hosted CI exact head의 Build·9개 test fan-out·Coverage·CI Status 및 정책 검증이 19/19 PASS입니다.
- Review evidence: exact head `4c0578630d16bb6dad469417fa1bcd4ab3973360`, local RED/GREEN evidence,
  receipt run `20260818T132330Z-4a03a6f8`

## Metadata

- Issue: #1338, Epic #1417, milestone `1.13.0`, assignee `debop`
- PR: PR2/5, head `4c0578630d16bb6dad469417fa1bcd4ab3973360`, milestone `1.13.0`, assignee `debop`
- Base: `develop@15e08ee5a0d3200b655c430d9999cbbf324fcb4e` (merged PR1 #1443)
- Parent: #1443; Next child: #1334 (hold until this PR merges)
- CI: [run 32148689616](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32148689616) 및
  [Manual Documentation run 32148689627](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32148689627); 19/19 SUCCESS

## DoD Status

Required checks: 9/9; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-12A - Guidance refresh | 현재 AGENTS hierarchy, bluetape workflow/bugfix/Kotlin/writer skill, common gates, PR template, Issue #1338와 Epic #1417를 재확인 | PASS | current workspace/repo paths 및 live issue/parent PR read-back | none |
| Stack base - PR2/5 ancestry | PR1 merge head 위에 branch를 만들고 exact parent ancestry를 확인 | PASS | `git merge-base --is-ancestor 15e08ee5a0d3200b655c430d9999cbbf324fcb4e HEAD`; head `4c0578630d` | none |
| RED - configuration-cache failure | 수정 전 기본 detekt 실패와 `--no-configuration-cache` control을 재현 | PASS | receipt `red-reproduction`; script-object serialization/null root cause | none |
| Fix - cache-safe source coverage task | Project/script capture를 제거하고 declared properties/file collection task로 교체 | PASS | `build.gradle.kts`, `DetektSourceCoverageTask.kt`, renderer regression test | none |
| Test - buildSrc regression | renderer와 실제 task action, configuration-cache 저장·재사용, empty module fail-closed를 검증 | PASS | `./gradlew :buildSrc:test`, `DetektSourceCoverageTaskIntegrationTest` | none |
| GREEN - default detekt/cache reuse | fail-closed configuration-cache와 기본 명령을 저장·재사용 양쪽에서 실행 | PASS | `BUILD SUCCESSFUL`, source coverage 75/4,151/0, `Configuration cache entry reused` | none |
| Static - workflow/docs hygiene | workflow syntax, diff whitespace, lesson/GNO refresh를 검증 | PASS | `actionlint`, `git diff --check`, lesson 및 GNO update/embed 실행 | none |
| Hosted CI exact head | GitHub required checks가 이 exact head에서 green인지 확인 | PASS | [CI run 32148689616](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32148689616), [Manual Documentation run 32148689627](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32148689627), 19/19 SUCCESS | none |
| Independent exact-head review | 독립 reviewer가 새 head의 P0/P1/P2/P3를 판정 | PASS | exact-head review: P0/P1/P2/P3 = 0/0/0/0; TestKit·cache·empty module 경계 확인 | none |

Final status: DONE — PR2/5가 `a3e90aaeed849b4f9c0745d4794250d77cff520e`로 `develop`에 병합되었습니다.

Unchecked required items: none
