### PR TITLE
[CI] Kafka4 테스트와 Kover를 변경 경로에 포함

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Validate CSV CI coverage
         run: ruby scripts/validate-ci-csv-coverage.rb
+      - name: Validate Kafka4 CI coverage
+        run: ruby scripts/validate-ci-kafka4-coverage.rb
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -167,6 +169,7 @@ jobs:
               - 'cache/cache-redisson/**'
             kafka-infra:
               - 'infra/kafka/**'
+              - 'infra/kafka4/**'
             telemetry-infra:
               - 'infra/opentelemetry/**'
               - 'infra/kafka-logback/**'
@@ -706,6 +709,7 @@ jobs:
           command: |
             ./gradlew \
               :bluetape4k-kafka:test \
+              :bluetape4k-kafka4:test \
               --max-workers=2 \
               --no-configuration-cache
         env:
@@ -716,6 +720,7 @@ jobs:
         run: |
           ./gradlew \
             :bluetape4k-kafka:koverXmlReport \
+            :bluetape4k-kafka4:koverXmlReport \
             --max-workers=2 \
             --no-configuration-cache
         continue-on-error: true

--- a/docs/lessons/2026-08-19-issue-1334-kafka4-ci-coverage.md
+++ b/docs/lessons/2026-08-19-issue-1334-kafka4-ci-coverage.md
@@ -11,6 +11,7 @@
 - `scripts/validate-ci-kafka4-coverage.rb`를 `changes` 작업에서 실행해 다음 계약을 fail-closed로 검사한다.
   - `settings.gradle.kts`의 `infra` 자동 등록과 `infra/kafka4/build.gradle.kts` 존재
   - 경로 필터와 `test-kafka-infra` 스케줄링 조건
+  - test step의 무조건 실행과 Kover step의 `if: always()` 조건
   - Kafka3/Kafka4 테스트·Kover task 및 테스트 실패 전파
   - 테스트 결과 XML과 Kover 보고서 artifact 경로
 - validator 회귀 스크립트에서 경로, task, 조건, artifact, 자동 등록 누락을 각각 실패 fixture로 고정한다.

--- a/docs/lessons/2026-08-19-issue-1334-kafka4-ci-coverage.md
+++ b/docs/lessons/2026-08-19-issue-1334-kafka4-ci-coverage.md
@@ -1,0 +1,32 @@
+# Issue #1334: Kafka4 CI 경로와 Kover 커버리지 계약
+
+## 배경
+
+일일 CI의 `kafka-infra` 경로 필터가 `infra/kafka/**`만 선택해 `infra/kafka4/**` 변경을 놓치고 있었다. Kafka4 모듈은 Gradle 설정에서 자동 등록되지만, 해당 모듈의 테스트와 Kover 보고서가 Kafka CI 작업과 산출물 계약에 포함되어 있는지 검증하는 장치도 없었다.
+
+## 결정
+
+- `kafka-infra` 필터에 `infra/kafka4/**`를 추가한다.
+- Kafka CI 작업에서 `:bluetape4k-kafka4:test`와 `:bluetape4k-kafka4:koverXmlReport`를 Kafka3 작업과 함께 실행한다.
+- `scripts/validate-ci-kafka4-coverage.rb`를 `changes` 작업에서 실행해 다음 계약을 fail-closed로 검사한다.
+  - `settings.gradle.kts`의 `infra` 자동 등록과 `infra/kafka4/build.gradle.kts` 존재
+  - 경로 필터와 `test-kafka-infra` 스케줄링 조건
+  - Kafka3/Kafka4 테스트·Kover task 및 테스트 실패 전파
+  - 테스트 결과 XML과 Kover 보고서 artifact 경로
+- validator 회귀 스크립트에서 경로, task, 조건, artifact, 자동 등록 누락을 각각 실패 fixture로 고정한다.
+
+## 검증 결과
+
+- `ruby scripts/validate-ci-kafka4-coverage_test.rb` — 통과
+- `ruby scripts/validate-ci-kafka4-coverage.rb` — `CI Kafka4 coverage is valid`
+- `ruby scripts/validate-ci-csv-coverage.rb` — `CI CSV coverage is valid`
+- `actionlint .github/workflows/ci.yml` — 통과
+- `./gradlew :bluetape4k-kafka4:test --no-daemon --no-configuration-cache --console=plain` — 297개 테스트 통과
+- `./gradlew :bluetape4k-kafka4:koverXmlReport --no-daemon --no-configuration-cache --console=plain` — `build/reports/kover/report.xml` 생성
+- `./gradlew projects --no-daemon --no-configuration-cache --console=plain` — `:bluetape4k-kafka4`가 `/infra/kafka4`로 자동 등록됨
+
+첫 전체 실행에서는 Embedded Kafka의 `createTopics` node-assignment timeout으로 1개 테스트가 실패했다. 해당 테스트를 단독 실행해 통과한 뒤 전체 297개 테스트를 재실행해 통과했으므로, 이번 변경의 회귀가 아닌 일시적 테스트 환경 변동으로 기록한다. CI에서는 기존 retry step이 이 경계를 처리한다.
+
+## 재발 방지
+
+CI 경로 필터, Gradle 자동 등록, 실제 test/Kover task, artifact 업로드 경로를 하나의 validator와 회귀 fixture로 함께 검사한다. 새 infra 모듈을 추가하거나 CI 작업을 분리할 때는 자동 등록 목록과 변경 경로·task manifest를 함께 갱신하고 validator를 먼저 실행한다.

--- a/scripts/validate-ci-kafka4-coverage.rb
+++ b/scripts/validate-ci-kafka4-coverage.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "optparse"
+require "shellwords"
+require "yaml"
+
+KAFKA4_PATH = "infra/kafka4/**"
+KAFKA4_TEST_TASK = ":bluetape4k-kafka4:test"
+KAFKA4_KOVER_TASK = ":bluetape4k-kafka4:koverXmlReport"
+KAFKA_PATH_FILTER = "kafka-infra"
+KAFKA_JOB = "test-kafka-infra"
+KAFKA_JOB_CONDITION = "${{ needs.changes.outputs['kafka-infra'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}"
+FORBIDDEN_GRADLE_OPTIONS = ["-x", "--exclude-task", "-m", "--dry-run"].freeze
+
+def fail_validation(message)
+  warn message
+  exit 1
+end
+
+def require_once(values, expected, label)
+  count = values.count(expected)
+  fail_validation("expected #{expected} exactly once in #{label}, found #{count}") unless count == 1
+end
+
+def gradle_tokens(command, label)
+  normalized = command.gsub(/\\\r?\n/, " ").strip
+  fail_validation("#{label} must use one simple Gradle invocation") if normalized.match?(/[\r\n#;&|<>$`]/)
+
+  tokens = Shellwords.shellsplit(normalized)
+  fail_validation("#{label} must run through ./gradlew") unless tokens.first == "./gradlew"
+
+  forbidden = tokens.find do |token|
+    FORBIDDEN_GRADLE_OPTIONS.include?(token) ||
+      token.start_with?("-x=", "-x:", "--exclude-task=", "--dry-run=")
+  end
+  fail_validation("#{label} must execute its tasks; forbidden option #{forbidden}") if forbidden
+  tokens
+rescue ArgumentError => error
+  fail_validation("invalid #{label}: #{error.message}")
+end
+
+def command_tokens(step, label)
+  command = step["run"] || step.dig("with", "command")
+  fail_validation("#{label} must define a command") unless command
+
+  gradle_tokens(command, label)
+end
+
+options = {
+  workflow: ".github/workflows/ci.yml",
+  settings: "settings.gradle.kts",
+  repo_root: ".",
+}
+OptionParser.new do |parser|
+  parser.on("--workflow PATH", "CI workflow path") { |value| options[:workflow] = value }
+  parser.on("--settings PATH", "Gradle settings path") { |value| options[:settings] = value }
+  parser.on("--repo-root PATH", "repository root") { |value| options[:repo_root] = value }
+end.parse!
+
+repo_root = File.expand_path(options[:repo_root])
+workflow_path = File.expand_path(options[:workflow], repo_root)
+settings_path = File.expand_path(options[:settings], repo_root)
+
+workflow = YAML.safe_load(File.read(workflow_path), aliases: true)
+jobs = workflow.fetch("jobs")
+
+module_path = File.join(repo_root, "infra", "kafka4")
+fail_validation("Kafka4 module directory is missing: #{module_path}") unless Dir.exist?(module_path)
+fail_validation("Kafka4 module build file is missing: #{module_path}/build.gradle.kts") unless File.file?(File.join(module_path, "build.gradle.kts"))
+
+settings = File.read(settings_path)
+unless settings.match?(/includeModules\(\s*[\"']infra[\"']\s*,\s*withBaseDir\s*=\s*false\s*\)/)
+  fail_validation("settings.gradle.kts does not auto-register infra modules: #{settings_path}")
+end
+
+changes_job = jobs.fetch("changes")
+changes_outputs = changes_job.fetch("outputs")
+expected_output = "${{ steps.filter.outputs.#{KAFKA_PATH_FILTER} }}"
+fail_validation("changes.#{KAFKA_PATH_FILTER} output must use #{expected_output}") unless changes_outputs.fetch(KAFKA_PATH_FILTER) == expected_output
+
+filter_step = changes_job.fetch("steps").find { |step| step["id"] == "filter" }
+fail_validation("changes job must define the paths-filter step") unless filter_step
+
+filters = YAML.safe_load(filter_step.fetch("with").fetch("filters"), aliases: true)
+kafka_paths = filters.fetch(KAFKA_PATH_FILTER)
+require_once(kafka_paths, "infra/kafka/**", "#{KAFKA_PATH_FILTER} paths")
+require_once(kafka_paths, KAFKA4_PATH, "#{KAFKA_PATH_FILTER} paths")
+
+kafka_job = jobs.fetch(KAFKA_JOB)
+needs = Array(kafka_job.fetch("needs"))
+fail_validation("#{KAFKA_JOB} job must depend on changes") unless needs.include?("changes")
+unless kafka_job.fetch("if") == KAFKA_JOB_CONDITION
+  fail_validation("#{KAFKA_JOB} job condition must select the kafka-infra output")
+end
+
+steps = kafka_job.fetch("steps")
+test_step = steps.find { |step| step["name"] == "Test Kafka infra modules" }
+kover_step = steps.find { |step| step["name"] == "Generate Kover XML report" }
+fail_validation("#{KAFKA_JOB} job must define Test Kafka infra modules") unless test_step
+fail_validation("#{KAFKA_JOB} job must define Generate Kover XML report") unless kover_step
+fail_validation("Test Kafka infra modules must fail the #{KAFKA_JOB} job") if test_step.key?("continue-on-error")
+
+test_tokens = command_tokens(test_step, "Kafka test command")
+kover_tokens = command_tokens(kover_step, "Kafka Kover command")
+require_once(test_tokens, ":bluetape4k-kafka:test", "Kafka test command")
+require_once(test_tokens, KAFKA4_TEST_TASK, "Kafka test command")
+require_once(kover_tokens, ":bluetape4k-kafka:koverXmlReport", "Kafka Kover command")
+require_once(kover_tokens, KAFKA4_KOVER_TASK, "Kafka Kover command")
+
+all_task_tokens = steps.flat_map do |step|
+  [step["run"], step.dig("with", "command")].compact.flat_map do |command|
+    command_tokens({ "run" => command }, "Kafka CI command")
+  end
+end
+require_once(all_task_tokens, KAFKA4_TEST_TASK, "all Kafka CI commands")
+require_once(all_task_tokens, KAFKA4_KOVER_TASK, "all Kafka CI commands")
+
+test_results_step = steps.find { |step| step["name"] == "Upload test results" }
+coverage_step = steps.find { |step| step["name"] == "Upload coverage report" }
+fail_validation("#{KAFKA_JOB} job must upload test results") unless test_results_step
+fail_validation("#{KAFKA_JOB} job must upload Kover coverage") unless coverage_step
+
+test_results_path = test_results_step.dig("with", "path").to_s
+fail_validation("Kafka test results artifact must include XML test results") unless test_results_path.include?("**/build/test-results/test/*.xml")
+
+coverage_path = coverage_step.dig("with", "path").to_s
+fail_validation("Kafka coverage artifact must include Kover reports") unless coverage_path.include?("**/build/reports/kover/")
+
+puts "CI Kafka4 coverage is valid"

--- a/scripts/validate-ci-kafka4-coverage.rb
+++ b/scripts/validate-ci-kafka4-coverage.rb
@@ -98,7 +98,9 @@ test_step = steps.find { |step| step["name"] == "Test Kafka infra modules" }
 kover_step = steps.find { |step| step["name"] == "Generate Kover XML report" }
 fail_validation("#{KAFKA_JOB} job must define Test Kafka infra modules") unless test_step
 fail_validation("#{KAFKA_JOB} job must define Generate Kover XML report") unless kover_step
+fail_validation("Test Kafka infra modules must not be conditional") if test_step.key?("if")
 fail_validation("Test Kafka infra modules must fail the #{KAFKA_JOB} job") if test_step.key?("continue-on-error")
+fail_validation("Generate Kover XML report must always run") unless kover_step["if"] == "always()"
 
 test_tokens = command_tokens(test_step, "Kafka test command")
 kover_tokens = command_tokens(kover_step, "Kafka Kover command")

--- a/scripts/validate-ci-kafka4-coverage_test.rb
+++ b/scripts/validate-ci-kafka4-coverage_test.rb
@@ -75,6 +75,24 @@ with_workflow_variant(nil, ->(out, err, result) {
 end
 
 with_workflow_variant(nil, ->(out, err, result) {
+  assert_failure(out, err, result, "Kafka4 test condition", "must not be conditional")
+}) do |content|
+  content.sub(
+    "      - name: Test Kafka infra modules\n        uses: nick-fields/retry@v4",
+    "      - name: Test Kafka infra modules\n        if: ${{ false }}\n        uses: nick-fields/retry@v4",
+  )
+end
+
+with_workflow_variant(nil, ->(out, err, result) {
+  assert_failure(out, err, result, "Kafka4 Kover condition", "must always run")
+}) do |content|
+  content.sub(
+    "      - name: Generate Kover XML report\n        if: always()\n        run: |\n          ./gradlew \\\n            :bluetape4k-kafka:koverXmlReport",
+    "      - name: Generate Kover XML report\n        if: failure()\n        run: |\n          ./gradlew \\\n            :bluetape4k-kafka:koverXmlReport",
+  )
+end
+
+with_workflow_variant(nil, ->(out, err, result) {
   assert_failure(out, err, result, "Kafka4 test-results artifact", "XML test results")
 }) do |content|
   content.sub(

--- a/scripts/validate-ci-kafka4-coverage_test.rb
+++ b/scripts/validate-ci-kafka4-coverage_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "rbconfig"
+require "tempfile"
+
+ROOT = File.expand_path("..", __dir__)
+VALIDATOR = File.join(__dir__, "validate-ci-kafka4-coverage.rb")
+WORKFLOW = File.join(ROOT, ".github", "workflows", "ci.yml")
+SETTINGS = File.join(ROOT, "settings.gradle.kts")
+
+def run_validator(workflow: WORKFLOW, settings: SETTINGS, repo_root: ROOT)
+  Open3.capture3(
+    RbConfig.ruby,
+    VALIDATOR,
+    "--workflow", workflow,
+    "--settings", settings,
+    "--repo-root", repo_root,
+  )
+end
+
+def assert_success(stdout, stderr, status, label)
+  return if status.success?
+
+  warn "#{label} failed: #{stdout}\n#{stderr}"
+  exit 1
+end
+
+def assert_failure(stdout, stderr, status, label, expected_message)
+  if status.success? || ![stdout, stderr].any? { |output| output.include?(expected_message) }
+    warn "#{label} unexpectedly passed or emitted the wrong error: #{stdout}\n#{stderr}"
+    exit 1
+  end
+end
+
+def with_workflow_variant(source, replacement)
+  Tempfile.create(["ci-kafka4-", ".yml"]) do |file|
+    content = File.read(WORKFLOW)
+    updated = yield(content)
+    raise "workflow fixture was not changed" if updated == content
+
+    file.write(updated)
+    file.flush
+    stdout, stderr, status = run_validator(workflow: file.path)
+    replacement.call(stdout, stderr, status)
+  end
+end
+
+stdout, stderr, status = run_validator
+assert_success(stdout, stderr, status, "live CI manifest")
+
+with_workflow_variant(nil, ->(out, err, result) {
+  assert_failure(out, err, result, "Kafka4 path filter", "infra/kafka4/**")
+}) do |content|
+  content.sub("              - 'infra/kafka4/**'", "              - 'infra/kafka4-missing/**'")
+end
+
+with_workflow_variant(nil, ->(out, err, result) {
+  assert_failure(out, err, result, "Kafka4 test task", ":bluetape4k-kafka4:test")
+}) do |content|
+  content.sub(":bluetape4k-kafka4:test", ":bluetape4k-kafka4:compileTestKotlin")
+end
+
+with_workflow_variant(nil, ->(out, err, result) {
+  assert_failure(out, err, result, "Kafka4 Kover task", ":bluetape4k-kafka4:koverXmlReport")
+}) do |content|
+  content.sub(":bluetape4k-kafka4:koverXmlReport", ":bluetape4k-kafka4:tasks")
+end
+
+with_workflow_variant(nil, ->(out, err, result) {
+  assert_failure(out, err, result, "Kafka4 job condition", "kafka-infra output")
+}) do |content|
+  content.sub("needs.changes.outputs['kafka-infra'] == 'true'", "needs.changes.outputs['wrong-filter'] == 'true'")
+end
+
+with_workflow_variant(nil, ->(out, err, result) {
+  assert_failure(out, err, result, "Kafka4 test-results artifact", "XML test results")
+}) do |content|
+  content.sub(
+    "name: test-results-kafka-infra\n          path: '**/build/test-results/test/*.xml'",
+    "name: test-results-kafka-infra\n          path: '**/build/test-results/test/*.txt'",
+  )
+end
+
+with_workflow_variant(nil, ->(out, err, result) {
+  assert_failure(out, err, result, "Kafka4 coverage artifact", "Kover reports")
+}) do |content|
+  content.sub(
+    "name: coverage-kafka-infra\n          path: '**/build/reports/kover/'",
+    "name: coverage-kafka-infra\n          path: '**/build/reports/jacoco/'",
+  )
+end
+
+Dir.mktmpdir("ci-kafka4-registration-") do |directory|
+  module_path = File.join(directory, "infra", "kafka4")
+  FileUtils.mkdir_p(module_path)
+  File.write(File.join(module_path, "build.gradle.kts"), "")
+  workflow = File.join(directory, "ci.yml")
+  settings = File.join(directory, "settings.gradle.kts")
+  FileUtils.cp(WORKFLOW, workflow)
+  FileUtils.cp(SETTINGS, settings)
+  File.write(settings, "rootProject.name = \"fixture\"\n")
+
+  stdout, stderr, status = run_validator(workflow: workflow, settings: settings, repo_root: directory)
+  assert_failure(stdout, stderr, status, "Gradle module registration", "settings.gradle.kts")
+end
+
+puts "Kafka4 CI coverage validator regression tests passed"


### PR DESCRIPTION
## Summary

Closes #1334

Kafka4 소스 변경이 일일 CI에서 선택되고 테스트·Kover artifact까지 남도록 `kafka-infra` 경로와 task manifest를 보강합니다.

## Background

Epic #1417의 PR3/5 작업입니다. `infra/kafka4/**`가 기존 path filter에 없어 Kafka4 테스트 변경이 `Test / Kafka Infra` 작업을 건너뛸 수 있었고, CI job은 Kafka3 task만 실행했습니다.

## What This Solves

- Kafka4 변경이 Kafka CI job을 skip하지 않도록 path filter와 scheduling condition을 고정합니다.
- Kafka4 테스트·Kover task와 결과 artifact가 Kafka3 경로와 함께 실행되는지 fail-closed로 검사합니다.
- Gradle 자동 등록과 CI manifest가 어긋나는 회귀를 negative fixture로 표면화합니다.

## Work Done

- `.github/workflows/ci.yml`: `infra/kafka4/**`, `:bluetape4k-kafka4:test`, `:bluetape4k-kafka4:koverXmlReport`, Kafka4 coverage validator를 추가했습니다.
- `scripts/validate-ci-kafka4-coverage.rb`: 자동 등록·path filter·job condition·test/Kover task·artifact 경로를 검증합니다.
- `scripts/validate-ci-kafka4-coverage_test.rb`: path/task/step condition/artifact/자동 등록 누락을 실패 fixture로 고정합니다.
- `docs/lessons/2026-08-19-issue-1334-kafka4-ci-coverage.md`: fail-closed CI 계약과 Embedded Kafka 일시 timeout 대응을 기록했습니다.

## Validation

- `ruby scripts/validate-ci-kafka4-coverage_test.rb`: PASS (live + negative fixtures)
- `ruby scripts/validate-ci-kafka4-coverage.rb`: PASS (`CI Kafka4 coverage is valid`)
- `ruby scripts/validate-ci-csv-coverage.rb`: PASS (`CI CSV coverage is valid`)
- `actionlint .github/workflows/ci.yml`: PASS
- `./gradlew :bluetape4k-kafka4:test --no-daemon --no-configuration-cache --console=plain`: PASS (297 tests)
- `./gradlew :bluetape4k-kafka4:koverXmlReport --no-daemon --no-configuration-cache --console=plain`: PASS (`infra/kafka4/build/reports/kover/report.xml`)
- `./gradlew projects --no-daemon --no-configuration-cache --console=plain`: PASS (`:bluetape4k-kafka4` → `/infra/kafka4`)

## Review Notes

- P0/P1: 0
- P2/P3: 0 (독립 exact-head 리뷰에서 추가 findings 없음)
- Review evidence: `3e3c3da060d768eaf4b323fd3eae9baee282f0b4` 기준 독립 리뷰 완료; test step 무조건 실행과 Kover `if: always()` 계약을 validator/negative fixture에 고정

## Metadata

- Issue: #1334, milestone `1.13.0`, assignee `debop`
- PR: #1445, milestone `1.13.0`, assignee `debop`
- Base: `develop@a3e90aaeed849b4f9c0745d4794250d77cff520e`
- Head: `fix/1334-kafka4-ci-coverage@3e3c3da060d768eaf4b323fd3eae9baee282f0b4`
- CI: [run 32159499494](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32159499494), exact head `3e3c3da060d768eaf4b323fd3eae9baee282f0b4`, all required jobs PASS
- Merge: `28e39ac66ef17863bb18f604b9935074e206cda2`; `develop` fast-forward 동기화 완료

## DoD Status

Required checks: 22/24; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 - Guidance | 현재 AGENTS/skill/plan을 재확인 | PASS | `/Users/debop/.codex/AGENTS.md`, workspace/repo AGENTS, workflow/maintenance/Kotlin/writer skill | 없음 |
| CG-02 - Evidence | GNO와 live Issue/Epic/PR/base를 확인 | PASS | Issue #1334, Epic #1417, `git ls-remote` | 없음 |
| CG-03 - Worktree | isolated `fix/1334-kafka4-ci-coverage`에서 작업 | PASS | exact base `a3e90aa…`, scoped diff | 없음 |
| CG-04 - Policy | Type-E·Korean docs·production behavior 경계를 적용 | PASS | CI/scripts/docs만 변경 | 없음 |
| CG-05 - Patterns | 기존 CSV validator와 workflow 패턴 재사용 | PASS | `scripts/validate-ci-csv-coverage.rb` 비교 | 없음 |
| CG-06 - Contracts | path/task/artifact/registration 계약을 문서·validator에 반영 | PASS | `ci.yml`, validator, lesson | 없음 |
| CG-07 - Targeted proof | RED/GREEN validator 및 targeted Gradle 증거 확보 | PASS | Ruby regression, Kafka4 test/Kover | 없음 |
| CG-08 - Sequential checks | Testcontainers/Gradle 상태 검사를 순차 실행 | PASS | Kafka4 test → Kover 순서 | 없음 |
| CG-09 - Lesson | 재사용 가능한 CI fail-closed lesson 작성 | PASS | `docs/lessons/2026-08-19-issue-1334-kafka4-ci-coverage.md` | 없음 |
| CG-10 - Pre-PR proof | diff/validator/actionlint/Gradle proof와 Lore commit 수렴 | PASS | fix commits `5c062848…`, `207432c…`, `3e3c3da…` | 없음 |
| CG-11 - Delivery authority | 승인된 PR3/5 repo/base/head 확인 | PASS | `develop` ← `fix/1334-kafka4-ci-coverage` | 없음 |
| CG-12 - Exact push | exact head를 origin에 게시 | PASS | local/remote `3e3c3da…` 일치 | 없음 |
| CG-12A - Guidance refresh | PR 직전 AGENTS/skill/common gates/template/Issue 재확인 | PASS | current read-back snapshot, no drift | 없음 |
| CG-13 - PR | PR 생성·metadata·DoD live read-back | PASS | 생성 후 URL/metadata로 갱신 | 없음 |
| CG-14 - CI/review | exact-head hosted CI와 독립 review | PASS | [run 32159499494](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32159499494)에서 18개 check PASS; head `3e3c3da060d768eaf4b323fd3eae9baee282f0b4`; 독립 review P0/P1/P2/P3=0 | 없음 |
| CG-15 - Merge-ready | CI/review/DoD를 다시 읽고 report | PASS | exact head/base/metadata/body/checks/mergeability live read-back 및 사용자 merge-ready handoff | 없음 |
| CG-16 - Fresh approval | merge-ready 이후 승인 | PASS | merge-ready 보고 후 사용자 승인 확인 | 없음 |
| CG-17 - Merge | 승인 후 merge 및 SHA 검증 | PASS | PR #1445 MERGED, merge SHA `28e39ac66ef17863bb18f604b9935074e206cda2`; Issue #1334 CLOSED | 없음 |
| CG-18 - Sync/cleanup | canonical sync와 proven worktree cleanup | PASS | `develop`/`origin/develop` `28e39ac…` 일치; merged PR3 worktree/local branch 정리; PR #1414 worktree 보존 | 없음 |
| E-01 - Route skills | maintenance/writer/Kotlin support skill 적용 | PASS | loaded skills 및 diagram N/A | 없음 |
| E-02 - Discover | current source/live/GNO/lesson 확인 | PASS | Issue #1334, CSV validator, CI manifest | 없음 |
| E-03 - Preserve | production behavior·managed surface 보존 | PASS | workflow/scripts/docs scope | 없음 |
| E-04 - Chezmoi parity | managed user-scope surface apply/parity | N/A | Codex/dotfiles surface를 변경하지 않음 | 해당 없음 |
| E-05 - Maintenance verify | actionlint, diff check, references, lesson audit | PASS | fresh command evidence | 없음 |
| E-06 - Durable pre-PR | duplicate/locale/capability/pruning pass | PASS | final scoped diff, Korean lesson audit | 없음 |

Final status: DONE

Unchecked required items: 없음
