### PR TITLE
[release] Java 25 기본 classfile과 2.0.0 SemVer 호환성 계약

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,24 @@ jobs:
       - name: Verify Maven-only release policy
         run: python3 -m unittest scripts/test_release_workflow_policy.py -v
 
+  jvm-release-contract:
+    name: JVM Release Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+      - name: Verify static JVM release contract
+        run: python3 -m unittest scripts/test_jvm_release_contract.py -v
+      - name: Verify compiled classfile contract
+        run: ./scripts/check-jvm-release-contract.sh
+
   codeql-policy:
     name: CodeQL Workflow Policy
     runs-on: ubuntu-latest
@@ -971,7 +989,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [release-policy, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
+    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-io-http, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,16 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
+      - name: Build mock-webflux-server Docker image
+        run: ./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Verify default mock-server image tags
+        run: |
+          docker image inspect bluetape4k/mock-web-server:2.0.0
+          docker image inspect bluetape4k/mock-webflux-server:2.0.0
+
       - name: Test HTTP client modules
         uses: nick-fields/retry@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,11 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Verify JVM release contract
+        run: |
+          python3 -m unittest scripts/test_jvm_release_contract.py -v
+          ./scripts/check-jvm-release-contract.sh
+
       - name: Diagnose signing inputs
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.diagnoseSigning }}
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
   ([#1424](https://github.com/bluetape4k/bluetape4k-projects/issues/1424)).
 - Maven Central에 없는 benchmark 또는 application 전용 모듈이 BOM에 포함되지 않도록 publication과 BOM module classifier를 통일했다. 생성한 BOM inventory와 publication POM inventory가 다르면 publication validation이 실패한다
   ([#1313](https://github.com/bluetape4k/bluetape4k-projects/issues/1313)).
-- Java platform은 library publication 설정 밖에 두되 `Bluetape4k` publication을 NMCP aggregate에 포함했다. 따라서 snapshot과 stable bundle은 74개 publishable library module과 함께 BOM을 포함한다
+- Java platform은 library publication 설정 밖에 두되 `Bluetape4k` publication을 NMCP aggregate에 포함했다. 따라서 `snapshot`과 stable bundle은 74개 publishable library module과 함께 BOM을 포함한다
   ([#1315](https://github.com/bluetape4k/bluetape4k-projects/issues/1315)).
 
 ## [1.12.0] — 2026-08-05
@@ -256,7 +256,7 @@
   client surface after the 1.9.2 design evaluation
   ([#586](https://github.com/bluetape4k/bluetape4k-projects/issues/586)).
 - The default bluetape4k dependency catalog source was pinned to the current
-  release-train catalog ref for repeatable snapshot and release validation.
+  release-train catalog ref for repeatable `snapshot` and release validation.
 
 ### 버그 수정
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ---
 
+<!-- issue-1335-java25-semver:start -->
+## [Unreleased]
+
+### 호환성 변경
+
+- 일반 published artifact의 Java runtime 바닥선을 Java 25로 올릴 준비를
+  하고 `2.0.0` 호환성 계약을 고정했다. Java 21 호환성 섬은
+  `bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-logging`,
+  `bluetape4k-virtualthread-api`, `bluetape4k-virtualthread-jdk21`로
+  유지한다. Java 21–24 소비자는 Java 25로 이동하거나 `1.13.x`를 유지해야
+  한다 ([#1335](https://github.com/bluetape4k/bluetape4k-projects/issues/1335)).
+<!-- issue-1335-java25-semver:end -->
+
 ## [1.12.1] — 2026-08-06
 
 ### 버그 수정

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,6 +69,21 @@ Kotlin 언어를 배우고, 사용하면서, Backend 개발에 자주 사용하�
 - **JetBrains Exposed**: 1.2.x (외부 `bluetape4k-exposed` artifact는 독립 레포에서 별도 릴리즈됨)
 - **데이터베이스**: H2, PostgreSQL, MySQL
 
+<!-- issue-1335-java25-semver:start -->
+### JVM 호환성과 2.0.0
+
+`2.0.0`부터 일반 Bluetape4k artifact는 Java 25 runtime이 필요합니다.
+Java 21 호환성 섬은 `bluetape4k-assertions`, `bluetape4k-junit5`,
+`bluetape4k-logging`, `bluetape4k-virtualthread-api`,
+`bluetape4k-virtualthread-jdk21`의 다섯 모듈로 한정되며, 모든 artifact가
+Java 21과 호환된다는 뜻이 아닙니다.
+
+Java 21–24에서 일반 artifact를 사용 중이면 `2.0.0`을 위해 Java 25로
+이동하거나 `1.13.x`를 유지해야 합니다. Java 21을 유지해야 한다면
+호환성 섬 모듈만 선택하고 Java 25 target artifact를 같은 classpath에
+섞지 않아야 합니다.
+<!-- issue-1335-java25-semver:end -->
+
 ## 모듈 구조
 
 Bluetape4k는 기능별로 분리된 멀티 모듈 Gradle 프로젝트입니다.
@@ -327,7 +342,7 @@ Jib으로 Mock Server Docker 이미지를 다시 빌드할 때는 Gradle configu
 
 ```properties
 projectGroup=io.github.bluetape4k
-baseVersion=1.11.0
+baseVersion=2.0.0
 snapshotVersion=
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ Feel free to open an Issue if you need something that isn't here yet.
 - **JetBrains Exposed**: 1.2.x (external `bluetape4k-exposed` artifacts are released from the standalone repository)
 - **Databases**: H2, PostgreSQL, MySQL
 
+<!-- issue-1335-java25-semver:start -->
+### JVM Compatibility and 2.0.0
+
+Starting with `2.0.0`, general Bluetape4k artifacts require a Java 25 runtime.
+The five-module Java 21 compatibility island is limited to
+`bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-logging`,
+`bluetape4k-virtualthread-api`, and `bluetape4k-virtualthread-jdk21`; it does
+not make every artifact Java 21 compatible.
+
+Consumers on Java 21–24 should move to Java 25 for `2.0.0` or remain on
+`1.13.x`. Consumers that must stay on Java 21 should select only the
+compatibility-island modules and must not mix Java 25-targeted artifacts into
+the same classpath.
+<!-- issue-1335-java25-semver:end -->
+
 ## Module Structure
 
 Bluetape4k is a multi-module Gradle project organized by domain.
@@ -326,7 +341,7 @@ Check `gradle.properties` for the current version:
 
 ```properties
 projectGroup=io.github.bluetape4k
-baseVersion=1.11.0
+baseVersion=2.0.0
 snapshotVersion=
 ```
 

--- a/docs/lessons/2026-08-19-issue-1335-java25-semver.md
+++ b/docs/lessons/2026-08-19-issue-1335-java25-semver.md
@@ -22,11 +22,15 @@ Java 21 classfile을 계속 필요로 하므로, 버전 문자열만 바꾸는 �
 4. mock-web-server와 mock-webflux-server의 Testcontainers 기본 이미지 태그도
    `baseVersion`과 일치해야 한다. Jib가 생성하는 `2.0.0` 태그와 오래된
    `1.13.0` 상수가 어긋나면 Docker 이미지를 찾지 못해 HTTP 테스트가 실패한다.
+5. 사전 배포 workflow가 `project.version=2.0.0-SNAPSHOT`을 만들 때도 기본
+   Testcontainers 경로를 유지해야 한다. 두 Jib 설정은 `baseVersionTag`와
+   `project.version`을 함께 생성하고, CI는 HTTP와 WebFlux 이미지를 모두 직접
+   빌드·inspect한다.
 
 ## 결과와 검증
 
 - `baseVersion=2.0.0`, `snapshotVersion` 빈 값, EN/KO marker parity가 고정됐다.
-- `python3 -m unittest scripts/test_jvm_release_contract.py -v`: 6/6 PASS.
+- `python3 -m unittest scripts/test_jvm_release_contract.py -v`: 9/9 PASS.
 - `python3 -m unittest scripts/test_release_workflow_policy.py -v`: 7/7 PASS.
 - `./scripts/check-jvm-release-contract.sh`: Gradle `BUILD SUCCESSFUL`,
   representative major `69/65/69` PASS.
@@ -36,20 +40,24 @@ Java 21 classfile을 계속 필요로 하므로, 버전 문자열만 바꾸는 �
 
 ## 놓친 점과 보완
 
-초기 문서 초안에는 historical Maven `snapshot` 용어가 일반 문장처럼 남아
+초기 문서 초안에는 historical Maven 사전 배포 용어가 일반 문장처럼 남아
 있어 용어 감사에서 기술 토큰과 독자용 문장을 구분하지 못했다. 의미는 바꾸지
 않고 해당 토큰만 code span으로 고정한 뒤 전체 감사와 read-back을 다시 실행했다.
 또한 첫 hosted CI에서 `BluetapeHttpServer.TAG`와 Jib의 `project.version`이
 각각 `1.13.0`과 `2.0.0`을 가리키는 불일치를 확인했다. 두 기본 태그를
-`2.0.0`으로 맞추고 정적 contract test가 두 소스와 `baseVersion`을 함께
-검증하도록 보완했다.
+`2.0.0`으로 맞춘 뒤, 독립 아키텍처 검토에서 사전 배포의
+`2.0.0-SNAPSHOT` 대 기본 태그 불일치와 WebFlux CI 증거 편중을 추가로
+확인했다. 두 Jib 설정의 `baseVersionTag`·`project.version` 병행 태그,
+두 이미지 직접 build/inspect, `testing/testcontainers` EN/KO 표를 같은
+release 계약으로 보완했다.
 
 ## 향후 지침
 
 - JVM 기본값이나 `baseVersion`을 바꿀 때는 dependency closure로 계산한 Java 21
   island, 실제 classfile major, migration 문서를 함께 갱신한다.
 - Docker 이미지를 Jib로 version tag하는 모듈은 Testcontainers 기본 tag와
-  `baseVersion`의 parity를 함께 검증한다.
+  `baseVersion`의 parity를 함께 검증하고, 사전 배포에서는 full version tag도
+  보존한다.
 - 정적 문서 검증과 `javap` classfile 검증을 CI와 release workflow의 publish 전
   경계에 모두 둔다.
 - Slot 1의 exact head가 merge되고 fresh CI/review 증거가 생기기 전에는

--- a/docs/lessons/2026-08-19-issue-1335-java25-semver.md
+++ b/docs/lessons/2026-08-19-issue-1335-java25-semver.md
@@ -1,0 +1,47 @@
+# 이슈 #1335 Java 25 SemVer 계약 교훈 (2026-08-19)
+
+## 맥락
+
+`baseVersion`을 `1.13.0`에서 `2.0.0`으로 올리면서 기본 JVM 실행 기준을
+Java 25로 전환했다. 그러나 `virtualthread/jdk21`을 사용하는 소비자는
+Java 21 classfile을 계속 필요로 하므로, 버전 문자열만 바꾸는 작업으로는
+호환성 계약을 증명할 수 없었다.
+
+## 결정과 발견
+
+1. 기본 artifact는 Java 25 classfile major `69`를 생성하고, 다음 다섯 모듈만
+   Java 21 compatibility island major `65`를 유지한다: `bluetape4k-assertions`,
+   `bluetape4k-junit5`, `bluetape4k-logging`, `bluetape4k-virtualthread-api`,
+   `bluetape4k-virtualthread-jdk21`.
+2. `gradle.properties`, EN/KO README, `CHANGELOG.md`, 정적 contract test를
+   하나의 계약으로 묶는다. README에는 `2.0.0` 또는 Java 21 island 선택이라는
+   migration 경계를 명시하고, stale한 `1.11.0` publishing 예제는 제거한다.
+3. 문서 검증만으로는 잘못된 target을 놓칠 수 있으므로 `javap -verbose`로
+   representative classfile을 직접 읽는다. `scripts/check-jvm-release-contract.sh`
+   는 publish 전에 이 검사를 수행하고 CI와 release workflow 양쪽에서 호출한다.
+
+## 결과와 검증
+
+- `baseVersion=2.0.0`, `snapshotVersion` 빈 값, EN/KO marker parity가 고정됐다.
+- `python3 -m unittest scripts/test_jvm_release_contract.py -v`: 5/5 PASS.
+- `python3 -m unittest scripts/test_release_workflow_policy.py -v`: 7/7 PASS.
+- `./scripts/check-jvm-release-contract.sh`: Gradle `BUILD SUCCESSFUL`,
+  representative major `69/65/69` PASS.
+- `actionlint`, `git diff --check`, 한국어 용어 감사가 PASS했다. hosted CI와
+  merge는 이 lesson 작성 시점에 아직 완료되지 않았으므로 이 문서는 로컬
+  계약 검증만 증명한다.
+
+## 놓친 점과 보완
+
+초기 문서 초안에는 historical Maven `snapshot` 용어가 일반 문장처럼 남아
+있어 용어 감사에서 기술 토큰과 독자용 문장을 구분하지 못했다. 의미는 바꾸지
+않고 해당 토큰만 code span으로 고정한 뒤 전체 감사와 read-back을 다시 실행했다.
+
+## 향후 지침
+
+- JVM 기본값이나 `baseVersion`을 바꿀 때는 dependency closure로 계산한 Java 21
+  island, 실제 classfile major, migration 문서를 함께 갱신한다.
+- 정적 문서 검증과 `javap` classfile 검증을 CI와 release workflow의 publish 전
+  경계에 모두 둔다.
+- Slot 1의 exact head가 merge되고 fresh CI/review 증거가 생기기 전에는
+  후속 #1339 branch와 PR을 만들지 않는다.

--- a/docs/lessons/2026-08-19-issue-1335-java25-semver.md
+++ b/docs/lessons/2026-08-19-issue-1335-java25-semver.md
@@ -19,11 +19,14 @@ Java 21 classfile을 계속 필요로 하므로, 버전 문자열만 바꾸는 �
 3. 문서 검증만으로는 잘못된 target을 놓칠 수 있으므로 `javap -verbose`로
    representative classfile을 직접 읽는다. `scripts/check-jvm-release-contract.sh`
    는 publish 전에 이 검사를 수행하고 CI와 release workflow 양쪽에서 호출한다.
+4. mock-web-server와 mock-webflux-server의 Testcontainers 기본 이미지 태그도
+   `baseVersion`과 일치해야 한다. Jib가 생성하는 `2.0.0` 태그와 오래된
+   `1.13.0` 상수가 어긋나면 Docker 이미지를 찾지 못해 HTTP 테스트가 실패한다.
 
 ## 결과와 검증
 
 - `baseVersion=2.0.0`, `snapshotVersion` 빈 값, EN/KO marker parity가 고정됐다.
-- `python3 -m unittest scripts/test_jvm_release_contract.py -v`: 5/5 PASS.
+- `python3 -m unittest scripts/test_jvm_release_contract.py -v`: 6/6 PASS.
 - `python3 -m unittest scripts/test_release_workflow_policy.py -v`: 7/7 PASS.
 - `./scripts/check-jvm-release-contract.sh`: Gradle `BUILD SUCCESSFUL`,
   representative major `69/65/69` PASS.
@@ -36,11 +39,17 @@ Java 21 classfile을 계속 필요로 하므로, 버전 문자열만 바꾸는 �
 초기 문서 초안에는 historical Maven `snapshot` 용어가 일반 문장처럼 남아
 있어 용어 감사에서 기술 토큰과 독자용 문장을 구분하지 못했다. 의미는 바꾸지
 않고 해당 토큰만 code span으로 고정한 뒤 전체 감사와 read-back을 다시 실행했다.
+또한 첫 hosted CI에서 `BluetapeHttpServer.TAG`와 Jib의 `project.version`이
+각각 `1.13.0`과 `2.0.0`을 가리키는 불일치를 확인했다. 두 기본 태그를
+`2.0.0`으로 맞추고 정적 contract test가 두 소스와 `baseVersion`을 함께
+검증하도록 보완했다.
 
 ## 향후 지침
 
 - JVM 기본값이나 `baseVersion`을 바꿀 때는 dependency closure로 계산한 Java 21
   island, 실제 classfile major, migration 문서를 함께 갱신한다.
+- Docker 이미지를 Jib로 version tag하는 모듈은 Testcontainers 기본 tag와
+  `baseVersion`의 parity를 함께 검증한다.
 - 정적 문서 검증과 `javap` classfile 검증을 CI와 release workflow의 publish 전
   경계에 모두 둔다.
 - Slot 1의 exact head가 merge되고 fresh CI/review 증거가 생기기 전에는

--- a/docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
+++ b/docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
@@ -29,7 +29,7 @@
 - Create: `scripts/test_jvm_release_contract.py`
 - Test: `scripts/test_jvm_release_contract.py`
 
-- [ ] **Step 1: 현재 상태에서 실패하는 계약 테스트를 작성한다**
+- [x] **Step 1: 현재 상태에서 실패하는 계약 테스트를 작성한다**
 
 `scripts/test_jvm_release_contract.py`는 아래 구현을 사용한다. Marker 추출은 README/CHANGELOG의 계약 범위만 읽고, module set은 `build.gradle.kts`의 중앙 선언만 읽는다.
 
@@ -114,13 +114,13 @@ if __name__ == "__main__":
     unittest.main()
 ```
 
-- [ ] **Step 2: 테스트가 현재 base에서 실패하는지 확인한다**
+- [x] **Step 2: 테스트가 현재 base에서 실패하는지 확인한다**
 
 Run: `python3 -m unittest scripts/test_jvm_release_contract.py -v`
 
 Expected: 현재 `baseVersion=1.13.0`과 marker/workflow 부재 때문에 실패한다. 이 실패는 구현 전 red 상태를 증명한다.
 
-- [ ] **Step 3: 정적 테스트 파일 자체의 문법을 확인한다**
+- [x] **Step 3: 정적 테스트 파일 자체의 문법을 확인한다**
 
 Run: `python3 -m py_compile scripts/test_jvm_release_contract.py`
 
@@ -134,7 +134,7 @@ Expected: exit code `0`; 생성된 `__pycache__`는 커밋하지 않는다.
 - Modify: `README.ko.md` (기술 스택 뒤, 배포 예제)
 - Modify: `CHANGELOG.md` (최상단 release entry 앞)
 
-- [ ] **Step 1: version source를 2.0.0으로 변경한다**
+- [x] **Step 1: version source를 2.0.0으로 변경한다**
 
 `gradle.properties`에서 다음 두 줄을 정확히 유지한다.
 
@@ -145,7 +145,7 @@ snapshotVersion=
 
 `build.gradle.kts`의 publication 계산과 Java target 중앙 설정은 수정하지 않는다.
 
-- [ ] **Step 2: 영어 README에 계약 marker와 migration 문단을 추가한다**
+- [x] **Step 2: 영어 README에 계약 marker와 migration 문단을 추가한다**
 
 Tech Stack 섹션 뒤에 다음 marker block을 추가한다.
 
@@ -168,11 +168,11 @@ the same classpath.
 
 Publishing 예제의 `baseVersion=1.11.0`을 `baseVersion=2.0.0`으로 바꾼다.
 
-- [ ] **Step 3: 한국어 README에 의미가 같은 marker와 migration 문단을 추가한다**
+- [x] **Step 3: 한국어 README에 의미가 같은 marker와 migration 문단을 추가한다**
 
 동일한 marker를 사용하고 한국어로 Java 25 일반 artifact, 다섯 모듈 Java 21 섬, `2.0.0`/`1.13.x` 선택지를 설명한다. Publishing 예제의 `baseVersion=1.11.0`은 `baseVersion=2.0.0`으로 바꾼다.
 
-- [ ] **Step 4: CHANGELOG에 배포 전 호환성 변경을 기록한다**
+- [x] **Step 4: CHANGELOG에 배포 전 호환성 변경을 기록한다**
 
 파일 최상단의 최신 release heading 앞에 실제 날짜가 없는 다음 block을 추가한다.
 
@@ -191,7 +191,7 @@ Publishing 예제의 `baseVersion=1.11.0`을 `baseVersion=2.0.0`으로 바꾼다
 <!-- issue-1335-java25-semver:end -->
 ```
 
-- [ ] **Step 5: 정적 contract test를 다시 실행한다**
+- [x] **Step 5: 정적 contract test를 다시 실행한다**
 
 Run: `python3 -m unittest scripts/test_jvm_release_contract.py -v`
 
@@ -203,7 +203,7 @@ Expected: version/module/document 검사는 통과하고, classfile/workflow 검
 - Create: `scripts/check-jvm-release-contract.sh`
 - Test: `scripts/check-jvm-release-contract.sh`
 
-- [ ] **Step 1: shell checker를 작성한다**
+- [x] **Step 1: shell checker를 작성한다**
 
 아래 구현은 compile task와 representative classfile path를 한 곳에서 고정한다.
 
@@ -245,7 +245,7 @@ assert_major "$JAVA21_CLASS" 65
 assert_major "$JAVA25_CLASS" 69
 ```
 
-- [ ] **Step 2: 실행 권한과 shell 문법을 검증한다**
+- [x] **Step 2: 실행 권한과 shell 문법을 검증한다**
 
 Run:
 
@@ -256,7 +256,7 @@ bash -n scripts/check-jvm-release-contract.sh
 
 Expected: `bash -n` exit code `0`; 실행 권한 변경은 같은 commit에 포함한다.
 
-- [ ] **Step 3: classfile checker를 실행한다**
+- [x] **Step 3: classfile checker를 실행한다**
 
 Run: `./scripts/check-jvm-release-contract.sh`
 
@@ -268,7 +268,7 @@ Expected: 세 대표 classfile이 각각 `major=69`, `major=65`, `major=69`로 �
 - Modify: `.github/workflows/ci.yml` (jobs 아래 `jvm-release-contract` 추가)
 - Modify: `.github/workflows/release.yml` (Java setup/Gradle setup 뒤, publication metadata 앞)
 
-- [ ] **Step 1: CI에 독립 JVM release contract job을 추가한다**
+- [x] **Step 1: CI에 독립 JVM release contract job을 추가한다**
 
 `release-policy` job과 같은 checkout 정책을 사용하고 Java 25와 Gradle wrapper를 준비한 뒤 두 검사를 순서대로 실행한다.
 
@@ -292,7 +292,7 @@ Expected: 세 대표 classfile이 각각 `major=69`, `major=65`, `major=69`로 �
         run: ./scripts/check-jvm-release-contract.sh
 ```
 
-- [ ] **Step 2: release workflow publish 전에 같은 검증을 추가한다**
+- [x] **Step 2: release workflow publish 전에 같은 검증을 추가한다**
 
 기존 `actions/setup-java`와 `gradle/actions/setup-gradle` 직후에 다음 단계를 둔다.
 
@@ -305,7 +305,7 @@ Expected: 세 대표 classfile이 각각 `major=69`, `major=65`, `major=69`로 �
 
 이 단계는 기존 `Verify gradle.properties matches tag`, publication metadata validation, `nmcpPublishAggregationToCentralPortal` 순서를 유지하면서 publish 직전에 추가된다. signing credential이나 GitHub release 생성은 호출하지 않는다.
 
-- [ ] **Step 3: workflow hook 정적 테스트를 실행한다**
+- [x] **Step 3: workflow hook 정적 테스트를 실행한다**
 
 Run: `python3 -m unittest scripts/test_jvm_release_contract.py -v`
 
@@ -319,7 +319,7 @@ Expected: 두 workflow가 두 checker를 모두 호출하므로 전체 정적 �
 - Test: `.github/workflows/ci.yml`, `.github/workflows/release.yml`
 - Test: `README.md`, `README.ko.md`, `CHANGELOG.md`
 
-- [ ] **Step 1: 정적·정책 검증을 실행한다**
+- [x] **Step 1: 정적·정책 검증을 실행한다**
 
 Run:
 
@@ -330,13 +330,13 @@ python3 -m unittest scripts/test_release_workflow_policy.py -v
 
 Expected: 두 unittest suite 모두 실패 없이 종료한다.
 
-- [ ] **Step 2: classfile 및 targeted compile을 실행한다**
+- [x] **Step 2: classfile 및 targeted compile을 실행한다**
 
 Run: `./scripts/check-jvm-release-contract.sh`
 
 Expected: Gradle compile이 성공하고 representative classfile major가 `69/65/69`로 출력된다.
 
-- [ ] **Step 3: 문서·diff 품질 검사를 실행한다**
+- [x] **Step 3: 문서·diff 품질 검사를 실행한다**
 
 Run:
 
@@ -350,21 +350,21 @@ node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
 
 Expected: whitespace 오류와 한국어 용어 감사 finding이 없다.
 
-- [ ] **Step 4: 첫 번째 구현 커밋을 만든다**
+- [x] **Step 4: 첫 번째 구현 커밋을 만든다**
 
 ```bash
 git add scripts/test_jvm_release_contract.py gradle.properties README.md README.ko.md CHANGELOG.md
 git commit -m "2.0.0 Java 호환성 계약을 문서와 테스트에 반영한다" -m "#1335의 runtime floor 상승을 version source와 reader-facing migration contract로 고정한다.\n\nConstraint: 일반 artifact는 Java 25이고 Java 21 호환성은 다섯 모듈로 제한된다\nRejected: published target을 분리해 1.13.0을 유지하는 안은 이번 Slot 범위를 넘어선다\nConfidence: high\nScope-risk: narrow\nDirective: 후속 #1339는 이 커밋의 선행 merge head에서만 시작한다\nTested: scripts/test_jvm_release_contract.py, git diff --check\nNot-tested: classfile checker와 hosted CI는 다음 커밋/검증 단계에서 실행한다"
 ```
 
-- [ ] **Step 5: 두 번째 구현 커밋을 만든다**
+- [x] **Step 5: 두 번째 구현 커밋을 만든다**
 
 ```bash
 git add scripts/check-jvm-release-contract.sh .github/workflows/ci.yml .github/workflows/release.yml
 git commit -m "Java 25 classfile 계약을 CI와 release workflow에 연결한다" -m "publish 전에 version/document contract와 실제 classfile major를 함께 검증한다.\n\nConstraint: release workflow는 기존 tag, credential, Maven-only policy를 보존해야 한다\nRejected: 문서-only 검증은 잘못된 classfile target을 탐지하지 못하므로 제외했다\nConfidence: high\nScope-risk: narrow\nDirective: publish side effect보다 앞에서 계약 검증을 실패시켜야 한다\nTested: JVM release contract, release workflow policy, targeted Gradle compile\nNot-tested: hosted GitHub Actions 실행 결과는 PR CI에서 확인한다"
 ```
 
-- [ ] **Step 6: final local state를 확인한다**
+- [x] **Step 6: final local state를 확인한다**
 
 Run: `git status --short --branch && git log -2 --oneline`
 
@@ -375,7 +375,7 @@ Expected: worktree가 clean이고 두 구현 커밋이 설계·plan 커밋 위�
 **Files:**
 - Modify: PR body only after PR creation, with `## DoD Status` as the final heading.
 
-- [ ] **Step 1: exact base/head와 issue metadata를 재조회한다**
+- [x] **Step 1: exact base/head와 issue metadata를 재조회한다**
 
 Run:
 

--- a/docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
+++ b/docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** 일반 published artifact의 Java 25 runtime 바닥선과 다섯 모듈의 Java 21 호환성 섬을 `2.0.0` release contract로 고정하고, 문서·CI·release workflow가 동일한 계약을 검증하게 한다.
+**Goal:** 일반 published artifact의 Java 25 runtime 바닥선과 다섯 모듈의 Java 21 호환성 섬, mock server release·사전 배포 이미지 태그를 `2.0.0` release contract로 고정하고, 문서·CI·release workflow가 동일한 계약을 검증하게 한다.
 
-**Architecture:** `gradle.properties`를 version source of truth로 유지하고 기존 중앙 JVM target 계산은 변경하지 않는다. 정적 Python contract test는 version/module-set/document/workflow drift를 검증하고, 독립 shell check는 대표 classfile의 실제 major version을 검증한다. CI와 release workflow는 publish 전에 두 검사를 호출한다.
+**Architecture:** `gradle.properties`를 version source of truth로 유지하고 기존 중앙 JVM target 계산은 변경하지 않는다. 정적 Python contract test는 version/module-set/document/workflow와 두 mock server Jib tag drift를 검증하고, 독립 shell check는 대표 classfile의 실제 major version을 검증한다. Jib는 `baseVersionTag`와 `project.version`을 함께 생성해 사전 배포에서도 공개 Testcontainers 기본 태그를 유지한다. CI와 release workflow는 publish 전에 두 검사를 호출하고 PR CI는 두 이미지를 직접 빌드한다.
 
 **Tech Stack:** Kotlin 2.4, Gradle 9.7.0, Java 25 toolchain, Python 3.12 `unittest`, POSIX Bash, GitHub Actions.
 
@@ -21,6 +21,9 @@
 | `scripts/check-jvm-release-contract.sh` | 대표 산출물 compile 및 `javap` classfile major 계약 |
 | `.github/workflows/ci.yml` | pull request/push에서 정적·classfile 계약 실행 |
 | `.github/workflows/release.yml` | Maven Central publish 전에 동일 계약 재실행 |
+| `testing/mock-web-server/build.gradle.kts`, `testing/mock-webflux-server/build.gradle.kts` | release·사전 배포 Jib 태그(`baseVersionTag`, `project.version`) |
+| `testing/testcontainers/.../BluetapeHttpServer.kt`, `BluetapeWebfluxServer.kt` | 공개 기본 이미지 태그와 사전 배포 동작 KDoc |
+| `testing/testcontainers/README.md`, `README.ko.md` | 두 mock server 기본 이미지 태그 표 |
 | `docs/superpowers/specs/2026-08-19-issue-1335-java25-semver-design.md` | 승인된 설계 결정의 기록(이미 커밋됨) |
 
 ### Task 1: 정적 JVM release contract test를 먼저 작성한다
@@ -110,6 +113,31 @@ class JvmReleaseContractTest(unittest.TestCase):
             self.assertIn("scripts/test_jvm_release_contract.py", workflow)
             self.assertIn("scripts/check-jvm-release-contract.sh", workflow)
 
+    def test_mock_server_jib_keeps_snapshot_and_default_tags_available(self) -> None:
+        expected_tag_expression = 'tags = setOf("latest", baseVersionTag, project.version.toString())'
+        for source_path in (
+            "testing/mock-web-server/build.gradle.kts",
+            "testing/mock-webflux-server/build.gradle.kts",
+        ):
+            source = read(source_path)
+            self.assertIn(
+                'val baseVersionTag = providers.gradleProperty("baseVersion").get()',
+                source,
+            )
+            self.assertIn(expected_tag_expression, source)
+
+    def test_ci_builds_and_inspects_both_mock_server_images(self) -> None:
+        workflow = read(".github/workflows/ci.yml")
+        for image in ("mock-web-server", "mock-webflux-server"):
+            self.assertIn(f":bluetape4k-{image}:jibDockerBuild", workflow)
+            self.assertIn(f"bluetape4k/{image}:2.0.0", workflow)
+
+    def test_testcontainers_docs_follow_release_image_tags(self) -> None:
+        for relative in ("testing/testcontainers/README.md", "testing/testcontainers/README.ko.md"):
+            source = read(relative)
+            self.assertIn("`bluetape4k/mock-web-server` | `2.0.0`", source)
+            self.assertIn("`bluetape4k/mock-webflux-server` | `2.0.0`", source)
+
 if __name__ == "__main__":
     unittest.main()
 ```
@@ -197,6 +225,32 @@ Run: `python3 -m unittest scripts/test_jvm_release_contract.py -v`
 
 Expected: version/module/document 검사는 통과하고, classfile/workflow 검사는 Task 3–4 완료 전까지 실패한다.
 
+### Task 2b: mock server release·사전 배포 이미지 태그를 고정한다
+
+**Files:**
+- Modify: `testing/mock-web-server/build.gradle.kts`
+- Modify: `testing/mock-webflux-server/build.gradle.kts`
+- Modify: `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt`
+- Modify: `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt`
+- Modify: `testing/testcontainers/README.md`, `testing/testcontainers/README.ko.md`
+
+- [x] **Step 1: Jib가 baseVersion·project.version을 함께 태그하도록 고정한다**
+
+두 mock server의 Jib `to.tags`는 `latest`, `baseVersionTag`, `project.version`을
+사용한다. release에서는 두 version tag가 같은 값으로 deduplicate되고, 사전 배포에서는
+`2.0.0` 기본 Testcontainers 태그와 `2.0.0-SNAPSHOT` 식별자가 모두 생성된다.
+
+- [x] **Step 2: 공개 TAG KDoc과 EN/KO 표를 같은 계약으로 갱신한다**
+
+`BluetapeHttpServer.TAG`와 `BluetapeWebfluxServer.TAG`는 공개 `const val` API를
+유지한 채 `2.0.0` 기본 태그와 사전 배포의 baseVersion 별칭을 설명한다. 두 locale
+모듈 표에서 오래된 `1.13.0` 태그를 제거한다.
+
+- [x] **Step 3: static contract와 PR CI 직접 gate를 연결한다**
+
+정적 Python test가 두 Jib 설정·두 문서·CI 명령을 모두 읽고, `test-io-http`가 두
+이미지를 순서대로 build한 뒤 `2.0.0` 태그를 `docker image inspect`로 확인한다.
+
 ### Task 3: 실제 classfile major 검증 스크립트를 구현한다
 
 **Files:**
@@ -267,6 +321,7 @@ Expected: 세 대표 classfile이 각각 `major=69`, `major=65`, `major=69`로 �
 **Files:**
 - Modify: `.github/workflows/ci.yml` (jobs 아래 `jvm-release-contract` 추가)
 - Modify: `.github/workflows/release.yml` (Java setup/Gradle setup 뒤, publication metadata 앞)
+- Test: `testing/mock-web-server/build.gradle.kts`, `testing/mock-webflux-server/build.gradle.kts`
 
 - [x] **Step 1: CI에 독립 JVM release contract job을 추가한다**
 
@@ -311,6 +366,9 @@ Run: `python3 -m unittest scripts/test_jvm_release_contract.py -v`
 
 Expected: 두 workflow가 두 checker를 모두 호출하므로 전체 정적 테스트가 통과한다.
 
+PR의 `test-io-http` job은 두 Jib task와 두 `docker image inspect`를 직접 실행해
+WebFlux 이미지가 HTTP 이미지와 같은 release boundary를 지키는지도 고정한다.
+
 ### Task 5: 직접 검증을 수행하고 작업 단위를 커밋한다
 
 **Files:**
@@ -318,6 +376,8 @@ Expected: 두 workflow가 두 checker를 모두 호출하므로 전체 정적 �
 - Test: `scripts/check-jvm-release-contract.sh`
 - Test: `.github/workflows/ci.yml`, `.github/workflows/release.yml`
 - Test: `README.md`, `README.ko.md`, `CHANGELOG.md`
+- Test: `testing/mock-web-server/build.gradle.kts`, `testing/mock-webflux-server/build.gradle.kts`
+- Test: `testing/testcontainers/README.md`, `testing/testcontainers/README.ko.md`
 
 - [x] **Step 1: 정적·정책 검증을 실행한다**
 
@@ -326,6 +386,16 @@ Run:
 ```bash
 python3 -m unittest scripts/test_jvm_release_contract.py -v
 python3 -m unittest scripts/test_release_workflow_policy.py -v
+./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
+./gradlew :bluetape4k-mock-web-server:jibDockerBuild \
+  -PsnapshotVersion=-SNAPSHOT --no-configuration-cache
+./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild \
+  -PsnapshotVersion=-SNAPSHOT --no-configuration-cache
+docker image inspect bluetape4k/mock-web-server:2.0.0 \
+  bluetape4k/mock-web-server:2.0.0-SNAPSHOT
+docker image inspect bluetape4k/mock-webflux-server:2.0.0 \
+  bluetape4k/mock-webflux-server:2.0.0-SNAPSHOT
 ```
 
 Expected: 두 unittest suite 모두 실패 없이 종료한다.
@@ -414,6 +484,6 @@ PR #1의 exact head, required checks, reviews/threads, mergeability, linked issu
 
 ## Plan self-review checklist
 
-- Spec coverage: version/JVM target은 Task 2, 문서는 Task 2, 정적 contract는 Task 1, classfile contract는 Task 3, CI/release hook은 Task 4, migration/DoD/handoff는 Task 5–6에서 다룬다.
+- Spec coverage: version/JVM target은 Task 2, mock server image tag는 Task 2b, 문서는 Task 2, 정적 contract는 Task 1, classfile contract는 Task 3, CI/release hook은 Task 4, migration/DoD/handoff는 Task 5–6에서 다룬다.
 - Placeholder scan: 미해결 placeholder나 모호한 구현 지시를 사용하지 않고 정확한 경로·marker·명령·기대 결과를 고정했다.
 - Type consistency: README/CHANGELOG marker는 `issue-1335-java25-semver`, 대표 classfile은 `PropertyExportingServer`/`Jdk21StructuredTaskScopeProvider`/`Jdk25StructuredTaskScopeProvider`, module set은 설계 문서와 동일하다.

--- a/docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
+++ b/docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
@@ -1,0 +1,419 @@
+# Java 25 기본 classfile과 2.0.0 SemVer 호환성 계약 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 일반 published artifact의 Java 25 runtime 바닥선과 다섯 모듈의 Java 21 호환성 섬을 `2.0.0` release contract로 고정하고, 문서·CI·release workflow가 동일한 계약을 검증하게 한다.
+
+**Architecture:** `gradle.properties`를 version source of truth로 유지하고 기존 중앙 JVM target 계산은 변경하지 않는다. 정적 Python contract test는 version/module-set/document/workflow drift를 검증하고, 독립 shell check는 대표 classfile의 실제 major version을 검증한다. CI와 release workflow는 publish 전에 두 검사를 호출한다.
+
+**Tech Stack:** Kotlin 2.4, Gradle 9.7.0, Java 25 toolchain, Python 3.12 `unittest`, POSIX Bash, GitHub Actions.
+
+---
+
+## 파일 책임 지도
+
+| 파일 | 책임 |
+| --- | --- |
+| `gradle.properties` | `baseVersion=2.0.0` 및 빈 `snapshotVersion`의 source of truth |
+| `README.md`, `README.ko.md` | Java 25 runtime floor, Java 21 compatibility island, 소비자 migration 안내 |
+| `CHANGELOG.md` | 배포 전 `Unreleased` 호환성 변경 기록 |
+| `scripts/test_jvm_release_contract.py` | version, module set, 문서 marker, workflow hook의 정적 계약 |
+| `scripts/check-jvm-release-contract.sh` | 대표 산출물 compile 및 `javap` classfile major 계약 |
+| `.github/workflows/ci.yml` | pull request/push에서 정적·classfile 계약 실행 |
+| `.github/workflows/release.yml` | Maven Central publish 전에 동일 계약 재실행 |
+| `docs/superpowers/specs/2026-08-19-issue-1335-java25-semver-design.md` | 승인된 설계 결정의 기록(이미 커밋됨) |
+
+### Task 1: 정적 JVM release contract test를 먼저 작성한다
+
+**Files:**
+- Create: `scripts/test_jvm_release_contract.py`
+- Test: `scripts/test_jvm_release_contract.py`
+
+- [ ] **Step 1: 현재 상태에서 실패하는 계약 테스트를 작성한다**
+
+`scripts/test_jvm_release_contract.py`는 아래 구현을 사용한다. Marker 추출은 README/CHANGELOG의 계약 범위만 읽고, module set은 `build.gradle.kts`의 중앙 선언만 읽는다.
+
+```python
+#!/usr/bin/env python3
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKER = "issue-1335-java25-semver"
+EXPECTED_ISLAND = {
+    "bluetape4k-assertions",
+    "bluetape4k-junit5",
+    "bluetape4k-logging",
+    "bluetape4k-virtualthread-api",
+    "bluetape4k-virtualthread-jdk21",
+}
+COMMON_TOKENS = ("2.0.0", "1.13.x", "Java 25", "Java 21")
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+def block(text: str, marker: str = MARKER) -> str:
+    pattern = rf"<!-- {re.escape(marker)}:start -->(.*?)<!-- {re.escape(marker)}:end -->"
+    match = re.search(pattern, text, re.DOTALL)
+    if match is None:
+        raise AssertionError(f"missing marker block: {marker}")
+    return match.group(1)
+
+class JvmReleaseContractTest(unittest.TestCase):
+    def test_version_source_is_2_0_0_release_ready(self) -> None:
+        properties = read("gradle.properties")
+        self.assertRegex(properties, r"(?m)^baseVersion=2\.0\.0$")
+        self.assertRegex(properties, r"(?m)^snapshotVersion=$")
+
+    def test_java_21_island_and_default_target_are_explicit(self) -> None:
+        build = read("build.gradle.kts")
+        match = re.search(
+            r"private val java21CompatibilityProjects = setOf\((.*?)\n\)",
+            build,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        modules = set(re.findall(r'"([^"]+)"', match.group(1)))
+        self.assertEqual(EXPECTED_ISLAND, modules)
+        self.assertIn(
+            "val javaCompatibilityVersion = if (project.name in java21CompatibilityProjects) 21 else 25",
+            build,
+        )
+        self.assertIn(
+            "val kotlinJvmTarget = if (javaCompatibilityVersion == 21) JvmTarget.JVM_21 else JvmTarget.JVM_25",
+            build,
+        )
+        self.assertIn("options.release.set(javaCompatibilityVersion)", build)
+
+    def test_readme_locales_share_the_migration_contract(self) -> None:
+        english = block(read("README.md"))
+        korean = block(read("README.ko.md"))
+        for token in COMMON_TOKENS:
+            self.assertIn(token, english)
+            self.assertIn(token, korean)
+        self.assertIn("baseVersion=2.0.0", read("README.md"))
+        self.assertIn("baseVersion=2.0.0", read("README.ko.md"))
+        self.assertNotIn("baseVersion=1.11.0", read("README.md"))
+        self.assertNotIn("baseVersion=1.11.0", read("README.ko.md"))
+
+    def test_changelog_records_unreleased_compatibility_change(self) -> None:
+        changelog = block(read("CHANGELOG.md"))
+        self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("#1335", changelog)
+        for token in COMMON_TOKENS:
+            self.assertIn(token, changelog)
+
+    def test_ci_and_release_workflows_run_both_contract_checks(self) -> None:
+        for workflow in (read(".github/workflows/ci.yml"), read(".github/workflows/release.yml")):
+            self.assertIn("scripts/test_jvm_release_contract.py", workflow)
+            self.assertIn("scripts/check-jvm-release-contract.sh", workflow)
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: 테스트가 현재 base에서 실패하는지 확인한다**
+
+Run: `python3 -m unittest scripts/test_jvm_release_contract.py -v`
+
+Expected: 현재 `baseVersion=1.13.0`과 marker/workflow 부재 때문에 실패한다. 이 실패는 구현 전 red 상태를 증명한다.
+
+- [ ] **Step 3: 정적 테스트 파일 자체의 문법을 확인한다**
+
+Run: `python3 -m py_compile scripts/test_jvm_release_contract.py`
+
+Expected: exit code `0`; 생성된 `__pycache__`는 커밋하지 않는다.
+
+### Task 2: version source와 EN/KO reader-facing contract를 구현한다
+
+**Files:**
+- Modify: `gradle.properties:81`
+- Modify: `README.md` (Tech Stack 뒤, Publishing 예제)
+- Modify: `README.ko.md` (기술 스택 뒤, 배포 예제)
+- Modify: `CHANGELOG.md` (최상단 release entry 앞)
+
+- [ ] **Step 1: version source를 2.0.0으로 변경한다**
+
+`gradle.properties`에서 다음 두 줄을 정확히 유지한다.
+
+```properties
+baseVersion=2.0.0
+snapshotVersion=
+```
+
+`build.gradle.kts`의 publication 계산과 Java target 중앙 설정은 수정하지 않는다.
+
+- [ ] **Step 2: 영어 README에 계약 marker와 migration 문단을 추가한다**
+
+Tech Stack 섹션 뒤에 다음 marker block을 추가한다.
+
+```markdown
+<!-- issue-1335-java25-semver:start -->
+### JVM Compatibility and 2.0.0
+
+Starting with `2.0.0`, general Bluetape4k artifacts require a Java 25 runtime.
+The five-module Java 21 compatibility island is limited to
+`bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-logging`,
+`bluetape4k-virtualthread-api`, and `bluetape4k-virtualthread-jdk21`; it does
+not make every artifact Java 21 compatible.
+
+Consumers on Java 21–24 should move to Java 25 for `2.0.0` or remain on
+`1.13.x`. Consumers that must stay on Java 21 should select only the
+compatibility-island modules and must not mix Java 25-targeted artifacts into
+the same classpath.
+<!-- issue-1335-java25-semver:end -->
+```
+
+Publishing 예제의 `baseVersion=1.11.0`을 `baseVersion=2.0.0`으로 바꾼다.
+
+- [ ] **Step 3: 한국어 README에 의미가 같은 marker와 migration 문단을 추가한다**
+
+동일한 marker를 사용하고 한국어로 Java 25 일반 artifact, 다섯 모듈 Java 21 섬, `2.0.0`/`1.13.x` 선택지를 설명한다. Publishing 예제의 `baseVersion=1.11.0`은 `baseVersion=2.0.0`으로 바꾼다.
+
+- [ ] **Step 4: CHANGELOG에 배포 전 호환성 변경을 기록한다**
+
+파일 최상단의 최신 release heading 앞에 실제 날짜가 없는 다음 block을 추가한다.
+
+```markdown
+<!-- issue-1335-java25-semver:start -->
+## [Unreleased]
+
+### 호환성 변경
+
+- 일반 published artifact의 Java runtime 바닥선을 Java 25로 올릴 준비를
+  하고 `2.0.0` 호환성 계약을 고정했다. Java 21 호환성 섬은
+  `bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-logging`,
+  `bluetape4k-virtualthread-api`, `bluetape4k-virtualthread-jdk21`로
+  유지한다. Java 21–24 소비자는 Java 25로 이동하거나 `1.13.x`를 유지해야
+  한다 ([#1335](https://github.com/bluetape4k/bluetape4k-projects/issues/1335)).
+<!-- issue-1335-java25-semver:end -->
+```
+
+- [ ] **Step 5: 정적 contract test를 다시 실행한다**
+
+Run: `python3 -m unittest scripts/test_jvm_release_contract.py -v`
+
+Expected: version/module/document 검사는 통과하고, classfile/workflow 검사는 Task 3–4 완료 전까지 실패한다.
+
+### Task 3: 실제 classfile major 검증 스크립트를 구현한다
+
+**Files:**
+- Create: `scripts/check-jvm-release-contract.sh`
+- Test: `scripts/check-jvm-release-contract.sh`
+
+- [ ] **Step 1: shell checker를 작성한다**
+
+아래 구현은 compile task와 representative classfile path를 한 곳에서 고정한다.
+
+```bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+readonly GENERAL_CLASS="$ROOT/testing/testcontainers/build/classes/kotlin/main/io/bluetape4k/testcontainers/PropertyExportingServer.class"
+readonly JAVA21_CLASS="$ROOT/virtualthread/jdk21/build/classes/kotlin/main/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.class"
+readonly JAVA25_CLASS="$ROOT/virtualthread/jdk25/build/classes/kotlin/main/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.class"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+assert_major() {
+  local class_file="$1"
+  local expected="$2"
+  [[ -f "$class_file" ]] || fail "missing classfile: $class_file"
+  local actual
+  actual="$(javap -verbose "$class_file" | awk '/major version:/{print $3; exit}')"
+  [[ "$actual" == "$expected" ]] ||
+    fail "classfile major mismatch: file=$class_file expected=$expected actual=$actual"
+  printf 'OK: %s major=%s\n' "${class_file#"$ROOT"/}" "$actual"
+}
+
+"$ROOT/gradlew" \
+  :bluetape4k-testcontainers:compileKotlin \
+  :bluetape4k-virtualthread-jdk21:compileKotlin \
+  :bluetape4k-virtualthread-jdk25:compileKotlin \
+  --no-daemon --no-configuration-cache
+
+assert_major "$GENERAL_CLASS" 69
+assert_major "$JAVA21_CLASS" 65
+assert_major "$JAVA25_CLASS" 69
+```
+
+- [ ] **Step 2: 실행 권한과 shell 문법을 검증한다**
+
+Run:
+
+```bash
+chmod +x scripts/check-jvm-release-contract.sh
+bash -n scripts/check-jvm-release-contract.sh
+```
+
+Expected: `bash -n` exit code `0`; 실행 권한 변경은 같은 commit에 포함한다.
+
+- [ ] **Step 3: classfile checker를 실행한다**
+
+Run: `./scripts/check-jvm-release-contract.sh`
+
+Expected: 세 대표 classfile이 각각 `major=69`, `major=65`, `major=69`로 출력되고 exit code `0`이다.
+
+### Task 4: CI와 release workflow에 계약 검증을 연결한다
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (jobs 아래 `jvm-release-contract` 추가)
+- Modify: `.github/workflows/release.yml` (Java setup/Gradle setup 뒤, publication metadata 앞)
+
+- [ ] **Step 1: CI에 독립 JVM release contract job을 추가한다**
+
+`release-policy` job과 같은 checkout 정책을 사용하고 Java 25와 Gradle wrapper를 준비한 뒤 두 검사를 순서대로 실행한다.
+
+```yaml
+  jvm-release-contract:
+    name: JVM Release Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+      - name: Verify static JVM release contract
+        run: python3 -m unittest scripts/test_jvm_release_contract.py -v
+      - name: Verify compiled classfile contract
+        run: ./scripts/check-jvm-release-contract.sh
+```
+
+- [ ] **Step 2: release workflow publish 전에 같은 검증을 추가한다**
+
+기존 `actions/setup-java`와 `gradle/actions/setup-gradle` 직후에 다음 단계를 둔다.
+
+```yaml
+      - name: Verify JVM release contract
+        run: |
+          python3 -m unittest scripts/test_jvm_release_contract.py -v
+          ./scripts/check-jvm-release-contract.sh
+```
+
+이 단계는 기존 `Verify gradle.properties matches tag`, publication metadata validation, `nmcpPublishAggregationToCentralPortal` 순서를 유지하면서 publish 직전에 추가된다. signing credential이나 GitHub release 생성은 호출하지 않는다.
+
+- [ ] **Step 3: workflow hook 정적 테스트를 실행한다**
+
+Run: `python3 -m unittest scripts/test_jvm_release_contract.py -v`
+
+Expected: 두 workflow가 두 checker를 모두 호출하므로 전체 정적 테스트가 통과한다.
+
+### Task 5: 직접 검증을 수행하고 작업 단위를 커밋한다
+
+**Files:**
+- Test: `scripts/test_jvm_release_contract.py`
+- Test: `scripts/check-jvm-release-contract.sh`
+- Test: `.github/workflows/ci.yml`, `.github/workflows/release.yml`
+- Test: `README.md`, `README.ko.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: 정적·정책 검증을 실행한다**
+
+Run:
+
+```bash
+python3 -m unittest scripts/test_jvm_release_contract.py -v
+python3 -m unittest scripts/test_release_workflow_policy.py -v
+```
+
+Expected: 두 unittest suite 모두 실패 없이 종료한다.
+
+- [ ] **Step 2: classfile 및 targeted compile을 실행한다**
+
+Run: `./scripts/check-jvm-release-contract.sh`
+
+Expected: Gradle compile이 성공하고 representative classfile major가 `69/65/69`로 출력된다.
+
+- [ ] **Step 3: 문서·diff 품질 검사를 실행한다**
+
+Run:
+
+```bash
+git diff --check
+node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  README.md README.ko.md CHANGELOG.md \
+  docs/superpowers/specs/2026-08-19-issue-1335-java25-semver-design.md \
+  docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
+```
+
+Expected: whitespace 오류와 한국어 용어 감사 finding이 없다.
+
+- [ ] **Step 4: 첫 번째 구현 커밋을 만든다**
+
+```bash
+git add scripts/test_jvm_release_contract.py gradle.properties README.md README.ko.md CHANGELOG.md
+git commit -m "2.0.0 Java 호환성 계약을 문서와 테스트에 반영한다" -m "#1335의 runtime floor 상승을 version source와 reader-facing migration contract로 고정한다.\n\nConstraint: 일반 artifact는 Java 25이고 Java 21 호환성은 다섯 모듈로 제한된다\nRejected: published target을 분리해 1.13.0을 유지하는 안은 이번 Slot 범위를 넘어선다\nConfidence: high\nScope-risk: narrow\nDirective: 후속 #1339는 이 커밋의 선행 merge head에서만 시작한다\nTested: scripts/test_jvm_release_contract.py, git diff --check\nNot-tested: classfile checker와 hosted CI는 다음 커밋/검증 단계에서 실행한다"
+```
+
+- [ ] **Step 5: 두 번째 구현 커밋을 만든다**
+
+```bash
+git add scripts/check-jvm-release-contract.sh .github/workflows/ci.yml .github/workflows/release.yml
+git commit -m "Java 25 classfile 계약을 CI와 release workflow에 연결한다" -m "publish 전에 version/document contract와 실제 classfile major를 함께 검증한다.\n\nConstraint: release workflow는 기존 tag, credential, Maven-only policy를 보존해야 한다\nRejected: 문서-only 검증은 잘못된 classfile target을 탐지하지 못하므로 제외했다\nConfidence: high\nScope-risk: narrow\nDirective: publish side effect보다 앞에서 계약 검증을 실패시켜야 한다\nTested: JVM release contract, release workflow policy, targeted Gradle compile\nNot-tested: hosted GitHub Actions 실행 결과는 PR CI에서 확인한다"
+```
+
+- [ ] **Step 6: final local state를 확인한다**
+
+Run: `git status --short --branch && git log -2 --oneline`
+
+Expected: worktree가 clean이고 두 구현 커밋이 설계 커밋 위에 있으며 branch가 `origin/develop`보다 정확히 세 commit 앞선다(설계 1 + 구현 2).
+
+### Task 6: PR train handoff 증거를 준비한다
+
+**Files:**
+- Modify: PR body only after PR creation, with `## DoD Status` as the final heading.
+
+- [ ] **Step 1: exact base/head와 issue metadata를 재조회한다**
+
+Run:
+
+```bash
+git rev-parse HEAD
+git merge-base --is-ancestor origin/develop HEAD
+gh issue view 1335 --repo bluetape4k/bluetape4k-projects --json number,state,milestone,assignees,labels
+```
+
+Expected: branch head가 설계·구현 커밋을 포함하고, #1335가 `OPEN`, milestone `1.13.0`, assignee `debop`인 현재 train metadata와 일치한다.
+
+- [ ] **Step 2: PR #1을 #1335에만 연결한다**
+
+PR base는 `develop`, head는 `chore/1418-01-java25-semver`로 고정한다. PR body의 마지막 섹션은 다음 형식을 사용한다.
+
+```markdown
+## DoD Status
+
+Epic #1418 progress: 1/4
+Required checks: 0/0; N/A: 0; Blocked: 0
+Final status: PENDING
+
+| Item | Evidence |
+| --- | --- |
+| Version | `gradle.properties` `baseVersion=2.0.0`, empty `snapshotVersion` |
+| JVM contract | static test and `major=69/65/69` output |
+| Docs | EN/KO README markers and `CHANGELOG.md` #1335 entry |
+| CI/release hook | both workflows invoke both contract checks |
+
+Unchecked items: hosted CI, fresh review approval, merge, canonical branch sync, and worktree cleanup.
+```
+
+- [ ] **Step 3: successor slot을 hold한다**
+
+PR #1의 exact head, required checks, reviews/threads, mergeability, linked issue, fresh merge approval을 다시 읽기 전에는 #1339 branch/PR을 만들지 않는다. PR #1 merge 후 merge commit SHA를 base로 successor branch를 생성한다.
+
+## Plan self-review checklist
+
+- Spec coverage: version/JVM target은 Task 2, 문서는 Task 2, 정적 contract는 Task 1, classfile contract는 Task 3, CI/release hook은 Task 4, migration/DoD/handoff는 Task 5–6에서 다룬다.
+- Placeholder scan: 미해결 placeholder나 모호한 구현 지시를 사용하지 않고 정확한 경로·marker·명령·기대 결과를 고정했다.
+- Type consistency: README/CHANGELOG marker는 `issue-1335-java25-semver`, 대표 classfile은 `PropertyExportingServer`/`Jdk21StructuredTaskScopeProvider`/`Jdk25StructuredTaskScopeProvider`, module set은 설계 문서와 동일하다.

--- a/docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
+++ b/docs/superpowers/plans/2026-08-19-issue-1335-java25-semver-plan.md
@@ -368,7 +368,7 @@ git commit -m "Java 25 classfile 계약을 CI와 release workflow에 연결한�
 
 Run: `git status --short --branch && git log -2 --oneline`
 
-Expected: worktree가 clean이고 두 구현 커밋이 설계 커밋 위에 있으며 branch가 `origin/develop`보다 정확히 세 commit 앞선다(설계 1 + 구현 2).
+Expected: worktree가 clean이고 두 구현 커밋이 설계·plan 커밋 위에 있으며 branch가 `origin/develop`보다 최소 네 commit 앞선다(설계 1 + plan 1 + 구현 2; writer audit 보정이 있으면 추가 commit을 허용한다).
 
 ### Task 6: PR train handoff 증거를 준비한다
 

--- a/docs/superpowers/specs/2026-08-19-issue-1335-java25-semver-design.md
+++ b/docs/superpowers/specs/2026-08-19-issue-1335-java25-semver-design.md
@@ -18,6 +18,9 @@
 
 - 현재 `gradle.properties`의 `baseVersion`은 `1.13.0`이다.
 - 루트 Gradle 설정은 Java 25를 기본 target으로 사용한다.
+- mock server Jib 설정은 `project.version`을 Docker 태그로 사용하고, 사전 배포 workflow는
+  `snapshotVersion=-SNAPSHOT`을 주입하므로 Testcontainers 기본 태그와 별도의 사전 배포
+  태그가 동시에 필요하다.
 - 다음 다섯 모듈은 Java 21 호환성 섬으로 중앙 설정에 명시되어 있다.
   - `bluetape4k-assertions`
   - `bluetape4k-junit5`
@@ -35,13 +38,13 @@
 2. 일반 artifact와 Java 21 호환성 섬의 런타임 경계를 영어·한국어 문서에 동일하게 설명한다.
 3. version, module target, classfile major, 문서 marker의 drift를 CI에서 조기에 차단한다.
 4. release workflow가 publish 전에 같은 JVM compatibility contract를 재검증하도록 한다.
-5. 다음 stacked slot(#1339)이 이 Slot의 merge head를 정확히 기준으로 작업할 수 있게 변경 범위를 작게 유지한다.
+5. mock server의 release·사전 배포 Jib 태그와 Testcontainers 기본 태그를 같은 계약으로 고정한다.
+6. 다음 stacked slot(#1339)이 이 Slot의 merge head를 정확히 기준으로 작업할 수 있게 변경 범위를 작게 유지한다.
 
 ## 비목표
 
 - 실제 `2.0.0` Git tag 생성 또는 Maven Central release publish
 - 일반 모듈을 Java 21 target으로 되돌리거나 Java 21 섬을 추가·확장하는 작업
-- Testcontainers TAG/KDoc 수정(#1339)
 - `PropertyExportingServer`의 Spring `DynamicPropertyRegistry` 연동(#1321)
 - image family startup/workload gate(#1337)
 - 새 public API, dependency, module 추가
@@ -62,7 +65,26 @@
 
 새로운 모듈이 호환성 섬에 들어가려면 별도 이슈와 compatibility 근거가 필요하며, 이번 Slot에서 암묵적으로 추가하지 않는다.
 
-### 2. 독자-facing 문서
+### 2. mock server image tag 계약
+
+사전 배포 workflow는 `-PsnapshotVersion=-SNAPSHOT`으로 `project.version`을
+`2.0.0-SNAPSHOT`으로 만든다. 반면 `BluetapeHttpServer.TAG`와
+`BluetapeWebfluxServer.TAG`는 공개 `const val` API로서 `baseVersion`인 `2.0.0`을
+기본값으로 사용한다. 두 실행 경계를 맞추기 위해 두 Jib 설정은 다음 태그를 함께
+생성한다.
+
+- `latest`: 기존 로컬 개발 별칭
+- `baseVersionTag`: Testcontainers 기본값이 항상 찾는 안정적인 통합 테스트 별칭
+- `project.version`: release의 `2.0.0` 또는 사전 배포의 `2.0.0-SNAPSHOT` 식별자
+
+release에서는 `baseVersionTag`와 `project.version`이 같은 태그로 deduplicate되고,
+사전 배포에서는 두 버전 태그가 모두 남는다. 따라서 사전 배포 빌드도 기본
+Testcontainers 경로를 깨뜨리지 않으면서 정확한 사전 배포 이미지를 직접 검증할 수
+있다. 이 Slot에서 TAG/KDoc, `testing/testcontainers` EN/KO 표, 두 Jib 설정, PR CI의
+두 이미지 직접 빌드를 함께 고정하며, #1339에는 `DynamicPropertyRegistry` 연동과
+그 이슈의 독립 API 변경만 남긴다.
+
+### 3. 독자-facing 문서
 
 다음 문서를 함께 갱신한다.
 
@@ -82,7 +104,7 @@
 
 `CHANGELOG.md`에는 실제 배포일을 넣지 않는 `Unreleased` 항목을 추가한다. 항목에는 #1335 링크, runtime floor 상승, Java 21 섬 유지, migration 선택지를 기록한다. 실제 release heading/date는 tag 작업에서 별도로 결정한다.
 
-### 3. 정적 release contract test
+### 4. 정적 release contract test
 
 새 `scripts/test_jvm_release_contract.py`는 표준 library test runner 없이 실행할 수 있는 Python `unittest`로 작성한다. 최소 검사는 다음과 같다.
 
@@ -93,10 +115,13 @@
 - `CHANGELOG.md`의 `Unreleased`에 #1335와 Java 25/Java 21 migration contract가 있는지 확인
 - stale `baseVersion=1.11.0` publication 예제가 남아 있지 않은지 확인
 - `.github/workflows/ci.yml`와 `.github/workflows/release.yml`이 이 계약 검증을 호출하는지 확인
+- 두 mock server Jib 설정이 `baseVersionTag`와 `project.version`을 모두 태그하는지 확인
+- PR CI가 두 mock server 이미지를 직접 빌드하고 `2.0.0` 기본 태그를 inspect하는지 확인
+- `testing/testcontainers` EN/KO 표가 두 기본 이미지의 `2.0.0` 태그와 일치하는지 확인
 
 검사는 파일 전체의 문구 수를 임의로 고정하지 않고, 의미가 있는 marker와 정확한 version·module 집합을 검증한다. 따라서 문서 표현을 자연스럽게 다듬어도 계약 검사는 유지된다.
 
-### 4. classfile release contract check
+### 5. classfile release contract check
 
 새 `scripts/check-jvm-release-contract.sh`는 다음을 순서대로 수행한다.
 
@@ -107,9 +132,9 @@
 
 대표 class 선택은 현재 source의 안정적인 public implementation을 사용한다. 검사는 모든 모듈을 중복 compile하지 않고, 중앙 JVM target 경계가 실제 산출물에 반영되는 최소 representative set만 확인한다.
 
-### 5. CI 및 release workflow 연계
+### 6. CI 및 release workflow 연계
 
-`.github/workflows/ci.yml`에는 정적 Python contract test와 classfile check를 실행하는 검증 단계를 추가한다. 기존 release workflow policy, publication inventory, metadata 검사는 그대로 유지한다.
+`.github/workflows/ci.yml`에는 정적 Python contract test와 classfile check를 실행하는 검증 단계를 추가한다. `test-io-http` job은 두 mock server Jib 이미지를 순서대로 빌드하고 `2.0.0` 기본 태그를 직접 inspect한다. 기존 release workflow policy, publication inventory, metadata 검사는 그대로 유지한다.
 
 `.github/workflows/release.yml`의 Java 25 setup과 tag↔`baseVersion` 일치 검사는 유지한다. Maven Central publish task보다 앞에 JVM release contract check를 두어, 버전이 맞더라도 classfile/document contract가 깨진 artifact는 publish하지 않는다.
 
@@ -148,6 +173,16 @@
 python3 -m unittest scripts/test_jvm_release_contract.py -v
 ./scripts/check-jvm-release-contract.sh
 python3 -m unittest scripts/test_release_workflow_policy.py -v
+./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
+./gradlew :bluetape4k-mock-web-server:jibDockerBuild \
+  -PsnapshotVersion=-SNAPSHOT --no-configuration-cache
+./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild \
+  -PsnapshotVersion=-SNAPSHOT --no-configuration-cache
+docker image inspect bluetape4k/mock-web-server:2.0.0 \
+  bluetape4k/mock-web-server:2.0.0-SNAPSHOT
+docker image inspect bluetape4k/mock-webflux-server:2.0.0 \
+  bluetape4k/mock-webflux-server:2.0.0-SNAPSHOT
 ./gradlew :bluetape4k-testcontainers:compileKotlin \
   :bluetape4k-virtualthread-jdk21:compileKotlin \
   :bluetape4k-virtualthread-jdk25:compileKotlin \
@@ -165,6 +200,8 @@ node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
 - [ ] 일반/Java 21 섬 target과 representative classfile major 검증
 - [ ] README EN/KO parity 및 migration 문단
 - [ ] `CHANGELOG.md` Unreleased/#1335 기록
+- [ ] 두 mock server Jib가 release·사전 배포 태그와 Testcontainers 기본 태그를 함께 제공
+- [ ] `testing/testcontainers` EN/KO 표와 PR CI의 두 이미지 직접 검증
 - [ ] CI/release workflow contract hook
 - [ ] 정적 test, classfile check, release policy test, compile, diff check, 한국어 용어 감사 통과
 - [ ] PR body 마지막 섹션이 `## DoD Status`이고 `Required checks: X/Y; N/A: N; Blocked: N`을 포함
@@ -175,6 +212,7 @@ node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
 | 위험 | 탐지 | 대응 |
 | --- | --- | --- |
 | version source와 tag 불일치 | release workflow tag check | publish 중단, tag 작업 전 version 수정 |
+| 사전 배포 Jib tag와 Testcontainers 기본 tag 불일치 | 정적 tag expression test 및 두 이미지 `docker image inspect` | `baseVersionTag`와 `project.version`을 모두 생성하고 두 Jib 경로를 CI에서 빌드 |
 | 일반 모듈이 Java 21로 잘못 생성됨 | representative major check | 중앙 target 설정을 복구하고 재검증 |
 | 호환성 섬이 무심코 확대됨 | 정확한 module-set static test | 섬 외부 target 변경을 revert하거나 별도 이슈로 분리 |
 | EN/KO migration 문구 drift | marker parity test 및 writer audit | 두 locale을 같은 변경에서 수정 |
@@ -196,4 +234,4 @@ tag 단계까지 version·문서·CI contract drift를 발견하지 못하므로
 
 ## 완료 조건
 
-이 설계 문서와 구현 계획이 승인되고, Slot 1의 모든 검증이 fresh exact head에서 통과하며, PR #1335의 최신 review blocker가 없고 merge approval이 새로 확인될 때만 후속 #1339 슬롯으로 이동한다.
+이 설계 문서와 구현 계획이 승인되고, Slot 1의 모든 검증이 fresh exact head에서 통과하며, 두 mock server 이미지의 release·사전 배포 태그 증거와 PR #1335의 최신 review blocker 해소, merge approval이 새로 확인될 때만 후속 #1339 슬롯으로 이동한다.

--- a/docs/superpowers/specs/2026-08-19-issue-1335-java25-semver-design.md
+++ b/docs/superpowers/specs/2026-08-19-issue-1335-java25-semver-design.md
@@ -1,0 +1,199 @@
+# #1335 Java 25 기본 classfile과 2.0.0 SemVer 호환성 계약 설계
+
+- Epic: [#1418](https://github.com/bluetape4k/bluetape4k-projects/issues/1418)
+- Slot: 1/4
+- Issue: [#1335](https://github.com/bluetape4k/bluetape4k-projects/issues/1335)
+- 선행 슬롯: 없음
+- 후속 슬롯: [#1339](https://github.com/bluetape4k/bluetape4k-projects/issues/1339)
+- 기준 브랜치: `develop`
+- 작업 브랜치: `chore/1418-01-java25-semver`
+
+## 결정 요약
+
+현재 일반 모듈은 Java 25 classfile(major 69)을 생성하고, 다섯 개의 명시적인 Java 21 호환성 섬만 Java 21 classfile(major 65)을 생성한다. 이 런타임 바닥선 상승을 호환성 변경으로 분류하고 `baseVersion=2.0.0`으로 전환한다. Java 21 호환성 섬은 유지하지만 일반 모듈 전체의 Java 21 호환성을 약속하지 않는다.
+
+이번 Slot은 실제 release tag, Maven Central 배포, 새 API, 새 모듈을 만들지 않는다. 버전·문서·검증·release workflow 계약을 고정해 후속 stacked slot이 같은 경계를 재해석하지 않도록 하는 것이 목적이다.
+
+## 배경과 근거
+
+- 현재 `gradle.properties`의 `baseVersion`은 `1.13.0`이다.
+- 루트 Gradle 설정은 Java 25를 기본 target으로 사용한다.
+- 다음 다섯 모듈은 Java 21 호환성 섬으로 중앙 설정에 명시되어 있다.
+  - `bluetape4k-assertions`
+  - `bluetape4k-junit5`
+  - `bluetape4k-logging`
+  - `bluetape4k-virtualthread-api`
+  - `bluetape4k-virtualthread-jdk21`
+- 기준 커밋에서 대표 classfile은 일반 모듈 major 69, Java 21 섬 major 65로 확인된다.
+- #1323에서 Java 25 기본 toolchain과 Java 21 호환성 섬의 target 경계를 이미 중앙화했다. 이번 변경은 그 결정을 되돌리거나 섬을 넓히지 않는다.
+
+이 설계에서 SemVer major bump는 source API의 변경만을 의미하지 않는다. 일반 published artifact를 로드할 수 있는 최소 JVM이 Java 21–24에서 Java 25로 올라가므로, 해당 소비자에게 명시적인 migration이 필요한 공개 호환성 경계로 취급한다.
+
+## 목표
+
+1. `2.0.0` 릴리스 계약을 Gradle version source of truth에 반영한다.
+2. 일반 artifact와 Java 21 호환성 섬의 런타임 경계를 영어·한국어 문서에 동일하게 설명한다.
+3. version, module target, classfile major, 문서 marker의 drift를 CI에서 조기에 차단한다.
+4. release workflow가 publish 전에 같은 JVM compatibility contract를 재검증하도록 한다.
+5. 다음 stacked slot(#1339)이 이 Slot의 merge head를 정확히 기준으로 작업할 수 있게 변경 범위를 작게 유지한다.
+
+## 비목표
+
+- 실제 `2.0.0` Git tag 생성 또는 Maven Central release publish
+- 일반 모듈을 Java 21 target으로 되돌리거나 Java 21 섬을 추가·확장하는 작업
+- Testcontainers TAG/KDoc 수정(#1339)
+- `PropertyExportingServer`의 Spring `DynamicPropertyRegistry` 연동(#1321)
+- image family startup/workload gate(#1337)
+- 새 public API, dependency, module 추가
+- 기존 1.13.x artifact의 backport 또는 별도 compatibility variant publish
+
+## 설계
+
+### 1. 버전 및 JVM target 계약
+
+`gradle.properties`의 `baseVersion`을 `2.0.0`으로 설정하고 `snapshotVersion`은 빈 값으로 유지한다. publication 메커니즘은 기존 `baseVersion + snapshotVersion` 계산을 그대로 사용한다.
+
+루트 `build.gradle.kts`의 중앙 target 계산과 Java 21 호환성 섬 목록은 유지한다.
+
+| 대상 | target | 기대 classfile | 공개 의미 |
+| --- | ---: | ---: | --- |
+| 일반 library module | Java 25 | major 69 | `2.0.0`부터 Java 25 runtime 필요 |
+| Java 21 호환성 섬 5개 | Java 21 | major 65 | Java 21 runtime 소비자를 위한 명시적 예외 |
+
+새로운 모듈이 호환성 섬에 들어가려면 별도 이슈와 compatibility 근거가 필요하며, 이번 Slot에서 암묵적으로 추가하지 않는다.
+
+### 2. 독자-facing 문서
+
+다음 문서를 함께 갱신한다.
+
+- `README.md`
+- `README.ko.md`
+- `CHANGELOG.md`
+
+두 README에는 다음 내용을 같은 의미와 marker로 둔다.
+
+- 기본 개발·실행 baseline은 Java 25, Kotlin 2.4, Gradle 9.7이다.
+- 일반 artifact는 Java 25 runtime에서 실행한다.
+- Java 21 호환성 섬은 다섯 모듈로 한정되며 일반 artifact 전체의 Java 21 호환성을 뜻하지 않는다.
+- Java 21–24에서 일반 artifact를 소비하던 사용자는 JDK 25로 이동하거나 1.13.x를 유지한다.
+- Java 21을 유지해야 하는 사용자는 호환성 섬 모듈만 선택하고 Java 25 target artifact를 classpath에 섞지 않는다.
+
+기존 publishing 예제의 stale `baseVersion=1.11.0`은 `2.0.0` 기준으로 바꾼다. README의 실행 명령과 publication 명령은 변경하지 않는다.
+
+`CHANGELOG.md`에는 실제 배포일을 넣지 않는 `Unreleased` 항목을 추가한다. 항목에는 #1335 링크, runtime floor 상승, Java 21 섬 유지, migration 선택지를 기록한다. 실제 release heading/date는 tag 작업에서 별도로 결정한다.
+
+### 3. 정적 release contract test
+
+새 `scripts/test_jvm_release_contract.py`는 표준 library test runner 없이 실행할 수 있는 Python `unittest`로 작성한다. 최소 검사는 다음과 같다.
+
+- `gradle.properties`가 정확히 `baseVersion=2.0.0`이고 `snapshotVersion`이 비어 있는지 확인
+- `build.gradle.kts`의 Java 21 호환성 섬이 정확히 다섯 모듈인지 확인
+- root target 계산이 일반 모듈 Java 25, 섬 Java 21을 선택하는지 확인
+- `README.md`와 `README.ko.md`가 동일한 migration marker와 version contract를 포함하는지 확인
+- `CHANGELOG.md`의 `Unreleased`에 #1335와 Java 25/Java 21 migration contract가 있는지 확인
+- stale `baseVersion=1.11.0` publication 예제가 남아 있지 않은지 확인
+- `.github/workflows/ci.yml`와 `.github/workflows/release.yml`이 이 계약 검증을 호출하는지 확인
+
+검사는 파일 전체의 문구 수를 임의로 고정하지 않고, 의미가 있는 marker와 정확한 version·module 집합을 검증한다. 따라서 문서 표현을 자연스럽게 다듬어도 계약 검사는 유지된다.
+
+### 4. classfile release contract check
+
+새 `scripts/check-jvm-release-contract.sh`는 다음을 순서대로 수행한다.
+
+1. 대표 일반 모듈과 Java 21 섬, `virtualthread-jdk25`의 compile task를 실행한다.
+2. 안정적인 대표 class 파일을 찾는다.
+3. `javap -verbose` 출력의 `major version`을 읽어 일반 모듈/Java 25 구현은 69, Java 21 섬은 65인지 확인한다.
+4. 누락 class, 복수 후보, 예상 외 major는 오류로 종료한다.
+
+대표 class 선택은 현재 source의 안정적인 public implementation을 사용한다. 검사는 모든 모듈을 중복 compile하지 않고, 중앙 JVM target 경계가 실제 산출물에 반영되는 최소 representative set만 확인한다.
+
+### 5. CI 및 release workflow 연계
+
+`.github/workflows/ci.yml`에는 정적 Python contract test와 classfile check를 실행하는 검증 단계를 추가한다. 기존 release workflow policy, publication inventory, metadata 검사는 그대로 유지한다.
+
+`.github/workflows/release.yml`의 Java 25 setup과 tag↔`baseVersion` 일치 검사는 유지한다. Maven Central publish task보다 앞에 JVM release contract check를 두어, 버전이 맞더라도 classfile/document contract가 깨진 artifact는 publish하지 않는다.
+
+검증 단계는 signing credential, GitHub release 생성, tag 생성 등의 side effect를 수행하지 않는다. 실패하면 publish step에 도달하지 않는다.
+
+## 마이그레이션 계약
+
+### 일반 artifact 소비자
+
+- Java 25 runtime으로 이동한 뒤 `2.0.0`을 사용한다.
+- 당장 Java 25로 이동할 수 없으면 `1.13.x`를 유지한다.
+- `2.0.0` 일반 artifact를 Java 21–24 runtime에서 실행할 수 있다고 가정하지 않는다.
+
+### Java 21 유지 소비자
+
+- Java 21 호환성 섬 다섯 모듈만 선택한다.
+- Java 25 target의 일반 artifact를 같은 classpath에 섞지 않는다.
+- 다른 bluetape4k 모듈이 필요하면 해당 모듈의 published classfile baseline을 확인한다.
+
+이 Slot은 dependency resolution을 자동으로 바꾸지 않는다. 소비자의 버전 고정·JDK 전환·모듈 선택은 application migration 작업으로 남긴다.
+
+## Stacked PR train 경계
+
+- PR branch: `chore/1418-01-java25-semver`
+- base: `develop`의 Slot 시작 시점 exact head
+- issue: #1335만 연결
+- PR #1 merge 전에는 #1339 branch/PR을 만들거나 구현하지 않는다.
+- PR #1 merge 후 successor branch는 merge commit exact head에서 생성한다.
+- 각 PR은 자신이 소유한 issue와 DoD만 수정하며 후속 issue의 파일을 선점하지 않는다.
+
+## 검증 계획
+
+구현 후 다음 명령을 순서대로 실행한다.
+
+```bash
+python3 -m unittest scripts/test_jvm_release_contract.py -v
+./scripts/check-jvm-release-contract.sh
+python3 -m unittest scripts/test_release_workflow_policy.py -v
+./gradlew :bluetape4k-testcontainers:compileKotlin \
+  :bluetape4k-virtualthread-jdk21:compileKotlin \
+  :bluetape4k-virtualthread-jdk25:compileKotlin \
+  --no-configuration-cache
+git diff --check
+node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  README.md README.ko.md CHANGELOG.md
+```
+
+실행 환경이 Docker/Testcontainers를 요구하지 않는 Slot이므로, 해당 모듈의 integration test를 성공 증거로 가장하지 않는다. classfile compile과 static contract가 이 변경의 직접적인 검증이다.
+
+## Slot 1 DoD
+
+- [ ] `baseVersion=2.0.0`, empty `snapshotVersion`
+- [ ] 일반/Java 21 섬 target과 representative classfile major 검증
+- [ ] README EN/KO parity 및 migration 문단
+- [ ] `CHANGELOG.md` Unreleased/#1335 기록
+- [ ] CI/release workflow contract hook
+- [ ] 정적 test, classfile check, release policy test, compile, diff check, 한국어 용어 감사 통과
+- [ ] PR body 마지막 섹션이 `## DoD Status`이고 `Required checks: X/Y; N/A: N; Blocked: N`을 포함
+- [ ] Epic #1418 진행률을 1/4로 보고
+
+## 위험과 대응
+
+| 위험 | 탐지 | 대응 |
+| --- | --- | --- |
+| version source와 tag 불일치 | release workflow tag check | publish 중단, tag 작업 전 version 수정 |
+| 일반 모듈이 Java 21로 잘못 생성됨 | representative major check | 중앙 target 설정을 복구하고 재검증 |
+| 호환성 섬이 무심코 확대됨 | 정확한 module-set static test | 섬 외부 target 변경을 revert하거나 별도 이슈로 분리 |
+| EN/KO migration 문구 drift | marker parity test 및 writer audit | 두 locale을 같은 변경에서 수정 |
+| 후속 stacked slot이 미merge base에서 시작됨 | PR base/head live read-back | PR 생성·구현을 hold하고 선행 merge head에서 재생성 |
+
+## 대안과 기각 이유
+
+### `1.13.0` 유지 + published target 분리
+
+Java 21 artifact를 별도 target으로 배포하면 runtime floor를 유지할 수 있지만, 일반 모듈 전체의 target 분리·artifact variant·publication matrix가 새로 필요하다. 현재 #1323이 이미 Java 25 기본 target과 제한된 Java 21 섬을 중앙화했으므로, 이번 Slot에서 이 구조를 뒤집는 것은 범위를 넓히고 소비자 계약을 더 모호하게 만든다.
+
+### 모든 모듈을 Java 21 target으로 회귀
+
+Java 25 API·toolchain을 사용하는 현재 개발 baseline과 충돌하고, 이미 확정된 Java 25 기본 classfile 계약을 훼손한다. 선택하지 않는다.
+
+### release tag에서만 version 변경
+
+tag 단계까지 version·문서·CI contract drift를 발견하지 못하므로, stacked train의 선행 검증 증거가 약해진다. source of truth를 PR에서 먼저 고정한다.
+
+## 완료 조건
+
+이 설계 문서와 구현 계획이 승인되고, Slot 1의 모든 검증이 fresh exact head에서 통과하며, PR #1335의 최신 review blocker가 없고 merge approval이 새로 확인될 때만 후속 #1339 슬롯으로 이동한다.

--- a/gradle.properties
+++ b/gradle.properties
@@ -78,5 +78,5 @@ centralSnapshotsParallelism=8
 # project version
 #
 projectGroup=io.github.bluetape4k
-baseVersion=1.13.0
+baseVersion=2.0.0
 snapshotVersion=

--- a/scripts/check-jvm-release-contract.sh
+++ b/scripts/check-jvm-release-contract.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+readonly GENERAL_CLASS="$ROOT/testing/testcontainers/build/classes/kotlin/main/io/bluetape4k/testcontainers/PropertyExportingServer.class"
+readonly JAVA21_CLASS="$ROOT/virtualthread/jdk21/build/classes/kotlin/main/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.class"
+readonly JAVA25_CLASS="$ROOT/virtualthread/jdk25/build/classes/kotlin/main/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.class"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+assert_major() {
+  local class_file="$1"
+  local expected="$2"
+  [[ -f "$class_file" ]] || fail "missing classfile: $class_file"
+  local actual
+  actual="$(javap -verbose "$class_file" | awk '/major version:/{print $3; exit}')"
+  [[ "$actual" == "$expected" ]] ||
+    fail "classfile major mismatch: file=$class_file expected=$expected actual=$actual"
+  printf 'OK: %s major=%s\n' "${class_file#"$ROOT"/}" "$actual"
+}
+
+"$ROOT/gradlew" \
+  :bluetape4k-testcontainers:compileKotlin \
+  :bluetape4k-virtualthread-jdk21:compileKotlin \
+  :bluetape4k-virtualthread-jdk25:compileKotlin \
+  --no-daemon --no-configuration-cache
+
+assert_major "$GENERAL_CLASS" 69
+assert_major "$JAVA21_CLASS" 65
+assert_major "$JAVA25_CLASS" 69

--- a/scripts/test_jvm_release_contract.py
+++ b/scripts/test_jvm_release_contract.py
@@ -71,6 +71,34 @@ class JvmReleaseContractTest(unittest.TestCase):
                 msg=f"stale mock-server image tag in {source_path}",
             )
 
+    def test_mock_server_jib_keeps_snapshot_and_default_tags_available(self) -> None:
+        expected_tag_expression = 'tags = setOf("latest", baseVersionTag, project.version.toString())'
+        for source_path in (
+            "testing/mock-web-server/build.gradle.kts",
+            "testing/mock-webflux-server/build.gradle.kts",
+        ):
+            source = read(source_path)
+            self.assertIn(
+                'val baseVersionTag = providers.gradleProperty("baseVersion").get()',
+                source,
+                msg=f"missing baseVersion image tag source in {source_path}",
+            )
+            self.assertIn(expected_tag_expression, source, msg=f"snapshot tag drift in {source_path}")
+
+    def test_ci_builds_and_inspects_both_mock_server_images(self) -> None:
+        workflow = read(".github/workflows/ci.yml")
+        for image in ("mock-web-server", "mock-webflux-server"):
+            self.assertIn(f":bluetape4k-{image}:jibDockerBuild", workflow)
+            self.assertIn(f"bluetape4k/{image}:2.0.0", workflow)
+
+    def test_testcontainers_docs_follow_release_image_tags(self) -> None:
+        for relative in ("testing/testcontainers/README.md", "testing/testcontainers/README.ko.md"):
+            source = read(relative)
+            self.assertIn("`bluetape4k/mock-web-server` | `2.0.0`", source)
+            self.assertIn("`bluetape4k/mock-webflux-server` | `2.0.0`", source)
+            self.assertNotIn("`bluetape4k/mock-web-server` | `1.13.0`", source)
+            self.assertNotIn("`bluetape4k/mock-webflux-server` | `1.13.0`", source)
+
     def test_readme_locales_share_the_migration_contract(self) -> None:
         english = block(read("README.md"))
         korean = block(read("README.ko.md"))

--- a/scripts/test_jvm_release_contract.py
+++ b/scripts/test_jvm_release_contract.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKER = "issue-1335-java25-semver"
+EXPECTED_ISLAND = {
+    "bluetape4k-assertions",
+    "bluetape4k-junit5",
+    "bluetape4k-logging",
+    "bluetape4k-virtualthread-api",
+    "bluetape4k-virtualthread-jdk21",
+}
+COMMON_TOKENS = ("2.0.0", "1.13.x", "Java 25", "Java 21")
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def block(text: str, marker: str = MARKER) -> str:
+    pattern = rf"<!-- {re.escape(marker)}:start -->(.*?)<!-- {re.escape(marker)}:end -->"
+    match = re.search(pattern, text, re.DOTALL)
+    if match is None:
+        raise AssertionError(f"missing marker block: {marker}")
+    return match.group(1)
+
+
+class JvmReleaseContractTest(unittest.TestCase):
+    def test_version_source_is_2_0_0_release_ready(self) -> None:
+        properties = read("gradle.properties")
+        self.assertRegex(properties, r"(?m)^baseVersion=2\.0\.0$")
+        self.assertRegex(properties, r"(?m)^snapshotVersion=$")
+
+    def test_java_21_island_and_default_target_are_explicit(self) -> None:
+        build = read("build.gradle.kts")
+        match = re.search(
+            r"private val java21CompatibilityProjects = setOf\((.*?)\n\)",
+            build,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        modules = set(re.findall(r'"([^"]+)"', match.group(1)))
+        self.assertEqual(EXPECTED_ISLAND, modules)
+        self.assertIn(
+            "val javaCompatibilityVersion = if (project.name in java21CompatibilityProjects) 21 else 25",
+            build,
+        )
+        self.assertIn(
+            "val kotlinJvmTarget = if (javaCompatibilityVersion == 21) JvmTarget.JVM_21 else JvmTarget.JVM_25",
+            build,
+        )
+        self.assertIn("options.release.set(javaCompatibilityVersion)", build)
+
+    def test_readme_locales_share_the_migration_contract(self) -> None:
+        english = block(read("README.md"))
+        korean = block(read("README.ko.md"))
+        for token in COMMON_TOKENS:
+            self.assertIn(token, english)
+            self.assertIn(token, korean)
+        self.assertIn("baseVersion=2.0.0", read("README.md"))
+        self.assertIn("baseVersion=2.0.0", read("README.ko.md"))
+        self.assertNotIn("baseVersion=1.11.0", read("README.md"))
+        self.assertNotIn("baseVersion=1.11.0", read("README.ko.md"))
+
+    def test_changelog_records_unreleased_compatibility_change(self) -> None:
+        changelog = block(read("CHANGELOG.md"))
+        self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("#1335", changelog)
+        for token in COMMON_TOKENS:
+            self.assertIn(token, changelog)
+
+    def test_ci_and_release_workflows_run_both_contract_checks(self) -> None:
+        for workflow in (read(".github/workflows/ci.yml"), read(".github/workflows/release.yml")):
+            self.assertIn("scripts/test_jvm_release_contract.py", workflow)
+            self.assertIn("scripts/check-jvm-release-contract.sh", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_jvm_release_contract.py
+++ b/scripts/test_jvm_release_contract.py
@@ -55,6 +55,22 @@ class JvmReleaseContractTest(unittest.TestCase):
         )
         self.assertIn("options.release.set(javaCompatibilityVersion)", build)
 
+    def test_local_mock_server_image_tags_follow_release_version(self) -> None:
+        properties = read("gradle.properties")
+        version = re.search(r"(?m)^baseVersion=([^\n]+)$", properties)
+        self.assertIsNotNone(version)
+        release_version = version.group(1)
+        for source_path in (
+            "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt",
+            "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt",
+        ):
+            source = read(source_path)
+            self.assertRegex(
+                source,
+                rf'(?m)^\s*const val TAG = "{re.escape(release_version)}"$',
+                msg=f"stale mock-server image tag in {source_path}",
+            )
+
     def test_readme_locales_share_the_migration_contract(self) -> None:
         english = block(read("README.md"))
         korean = block(read("README.ko.md"))

--- a/testing/mock-web-server/build.gradle.kts
+++ b/testing/mock-web-server/build.gradle.kts
@@ -62,6 +62,7 @@ tasks.withType<com.google.cloud.tools.jib.gradle.BuildImageTask>().configureEach
 
 // 멀티 플랫폼 여부: -PjibMultiPlatform=true 로 활성화 (CI/CD registry push 전용)
 val jibMultiPlatform = project.hasProperty("jibMultiPlatform")
+val baseVersionTag = providers.gradleProperty("baseVersion").get()
 
 // 호스트 아키텍처 감지: aarch64 = arm64 (Apple Silicon), 그 외 = amd64
 val hostArch = when (System.getProperty("os.arch")) {
@@ -83,7 +84,7 @@ jib {
     }
     to {
         image = "bluetape4k/mock-web-server"
-        tags = setOf("latest", project.version.toString())
+        tags = setOf("latest", baseVersionTag, project.version.toString())
     }
     container {
         ports = listOf("80", "8443")

--- a/testing/mock-webflux-server/build.gradle.kts
+++ b/testing/mock-webflux-server/build.gradle.kts
@@ -80,6 +80,7 @@ tasks.withType<com.google.cloud.tools.jib.gradle.BuildImageTask>().configureEach
 }
 
 val jibMultiPlatform = project.hasProperty("jibMultiPlatform")
+val baseVersionTag = providers.gradleProperty("baseVersion").get()
 val hostArch = when (System.getProperty("os.arch")) {
     "aarch64" -> "arm64"
     else      -> "amd64"
@@ -99,7 +100,7 @@ jib {
     }
     to {
         image = "bluetape4k/mock-webflux-server"
-        tags = setOf("latest", project.version.toString())
+        tags = setOf("latest", baseVersionTag, project.version.toString())
     }
     container {
         ports = listOf("80", "8443")

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -119,8 +119,8 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 | Graph DB | `MemgraphServer` | `memgraph/memgraph` | `3.12.0` |
 | Graph DB | `Neo4jServer` | `neo4j` | `5.26.29` |
 | Graph DB | `PostgreSQLAgeServer` | `apache/age` | `release_PG18_1.7.0` |
-| HTTP | `BluetapeHttpServer` | `bluetape4k/mock-web-server` | `1.13.0` |
-| HTTP | `BluetapeWebfluxServer` | `bluetape4k/mock-webflux-server` | `1.13.0` |
+| HTTP | `BluetapeHttpServer` | `bluetape4k/mock-web-server` | `2.0.0` |
+| HTTP | `BluetapeWebfluxServer` | `bluetape4k/mock-webflux-server` | `2.0.0` |
 | HTTP | `NginxServer` | `nginx` | `1.30.4-alpine` |
 | HTTP | `WireMockServer` | `wiremock/wiremock` | `3.13.2` |
 | Infrastructure | `ConsulServer` | `hashicorp/consul` | `1.22.7` |

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -114,8 +114,8 @@ that Testcontainers runs remain reproducible across local machines and CI.
 | Graph DB | `MemgraphServer` | `memgraph/memgraph` | `3.12.0` |
 | Graph DB | `Neo4jServer` | `neo4j` | `5.26.29` |
 | Graph DB | `PostgreSQLAgeServer` | `apache/age` | `release_PG18_1.7.0` |
-| HTTP | `BluetapeHttpServer` | `bluetape4k/mock-web-server` | `1.13.0` |
-| HTTP | `BluetapeWebfluxServer` | `bluetape4k/mock-webflux-server` | `1.13.0` |
+| HTTP | `BluetapeHttpServer` | `bluetape4k/mock-web-server` | `2.0.0` |
+| HTTP | `BluetapeWebfluxServer` | `bluetape4k/mock-webflux-server` | `2.0.0` |
 | HTTP | `NginxServer` | `nginx` | `1.30.4-alpine` |
 | HTTP | `WireMockServer` | `wiremock/wiremock` | `3.13.2` |
 | Infrastructure | `ConsulServer` | `hashicorp/consul` | `1.22.7` |

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
@@ -43,7 +43,7 @@ class BluetapeHttpServer private constructor(
         /** Docker 이미지 이름 */
         const val IMAGE = "bluetape4k/mock-web-server"
 
-        /** Docker 이미지 태그 */
+        /** Docker 이미지 기본 태그. Jib는 snapshot 빌드에도 이 baseVersion 태그를 함께 생성합니다. */
         const val TAG = "2.0.0"
 
         /** 서버 이름 (시스템 프로퍼티 네임스페이스로 사용됨) */

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt
@@ -44,7 +44,7 @@ class BluetapeHttpServer private constructor(
         const val IMAGE = "bluetape4k/mock-web-server"
 
         /** Docker 이미지 태그 */
-        const val TAG = "1.13.0"
+        const val TAG = "2.0.0"
 
         /** 서버 이름 (시스템 프로퍼티 네임스페이스로 사용됨) */
         const val NAME = "bluetape-http"

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt
@@ -45,7 +45,7 @@ class BluetapeWebfluxServer private constructor(
         /** Docker 이미지 이름 */
         const val IMAGE = "bluetape4k/mock-webflux-server"
 
-        /** Docker 이미지 태그 */
+        /** Docker 이미지 기본 태그. Jib는 snapshot 빌드에도 이 baseVersion 태그를 함께 생성합니다. */
         const val TAG = "2.0.0"
 
         /** 서버 이름 (시스템 프로퍼티 네임스페이스로 사용됨) */

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt
@@ -46,7 +46,7 @@ class BluetapeWebfluxServer private constructor(
         const val IMAGE = "bluetape4k/mock-webflux-server"
 
         /** Docker 이미지 태그 */
-        const val TAG = "1.13.0"
+        const val TAG = "2.0.0"
 
         /** 서버 이름 (시스템 프로퍼티 네임스페이스로 사용됨) */
         const val NAME = "bluetape-webflux"


### PR DESCRIPTION
## Summary

Closes #1335

Epic #1418의 Slot 1로 Java 25 기본 classfile과 `2.0.0` SemVer 호환성 계약을 고정합니다. 기본 artifact는 Java 25를 사용하고, Java 21 소비자용 다섯 모듈 compatibility island는 별도 계약으로 유지합니다.

## Background

저장소의 Java 25 전환과 `1.13.0` 릴리스 기준을 함께 정리하면서, `baseVersion`만 변경해 실제 classfile target과 문서·CI·release workflow가 어긋나는 위험이 확인되었습니다. 후속 #1339는 이 Slot 1이 merge될 때까지 hold합니다.

## What This Solves

- `baseVersion=2.0.0`과 Java 25 classfile major `69`를 기본 계약으로 명시합니다.
- `bluetape4k-assertions`, `bluetape4k-junit5`, `bluetape4k-logging`, `bluetape4k-virtualthread-api`, `bluetape4k-virtualthread-jdk21`의 Java 21 classfile major `65` 예외를 문서와 검사에 고정합니다.
- 잘못된 `1.11.0` publishing 예제와 EN/KO migration 설명의 drift를 제거합니다.
- CI와 release workflow가 publish 전에 정적 계약과 representative classfile을 모두 검사하도록 합니다.
- Jib의 두 mock server가 release에서는 `2.0.0`, 사전 배포에서는 `2.0.0`과 `2.0.0-SNAPSHOT`을 함께 제공하도록 해 Testcontainers 기본 image tag와 full version tag를 모두 보존합니다.
- `BluetapeHttpServer`와 `BluetapeWebfluxServer`의 공개 기본 tag, EN/KO module 표, PR CI의 두 이미지 직접 build/inspect를 같은 계약으로 고정합니다.

## Work Done

- `gradle.properties`, `README.md`, `README.ko.md`, `CHANGELOG.md`에 `2.0.0` runtime floor와 Java 21 island 경계를 반영했습니다.
- `scripts/test_jvm_release_contract.py`와 `scripts/check-jvm-release-contract.sh`를 추가해 version, 문서 parity, Gradle compile, `javap -verbose` major `69/65/69`를 검증합니다.
- 두 mock server Jib 설정에 `baseVersionTag`와 `project.version`을 함께 선언해 사전 배포 이미지도 기본 Testcontainers 경로를 유지합니다.
- `BluetapeHttpServer.TAG`와 `BluetapeWebfluxServer.TAG`, `testing/testcontainers` EN/KO 표를 `2.0.0` 계약에 맞췄습니다.
- `.github/workflows/ci.yml`의 required `jvm-release-contract` job과 `test-io-http`의 WebFlux 이미지 build/inspect, `.github/workflows/release.yml`의 publish 전 검사를 연결했습니다.
- 승인된 설계·계획과 재사용 가능한 lesson을 `docs/superpowers/` 및 `docs/lessons/`에 보존했습니다.

## Validation

- `python3 -m unittest scripts/test_jvm_release_contract.py -v`: PASS (9/9)
- `python3 -m unittest scripts/test_release_workflow_policy.py -v`: PASS (7/7)
- `./scripts/check-jvm-release-contract.sh`: PASS (`BUILD SUCCESSFUL`; major `69/65/69`)
- release Jib build: 두 이미지 `2.0.0` tag 생성 PASS
- 사전 배포 Jib build (`-PsnapshotVersion=-SNAPSHOT`): 두 이미지 `2.0.0` 및 `2.0.0-SNAPSHOT` tag 생성·inspect PASS
- `BluetapeHttpServerTest` 및 `BluetapeWebfluxServerTest`: PASS (22개)
- 기존 HTTP client targeted tests: PASS (`BUILD SUCCESSFUL`, 227 passing)
- `actionlint`, `git diff --check`, 한국어 용어 감사: PASS

## Review Notes

- 이전 hosted run `32254777833`에서 Jib `2.0.0`과 Testcontainers stale `1.13.0` tag mismatch를 확인했고, `a01b71610f`에서 release tag를 맞췄습니다.
- 독립 아키텍처 검토에서 사전 배포 `2.0.0-SNAPSHOT` tag mismatch, WebFlux CI 증거 편중, 설계 scope 불일치를 추가로 확인했습니다.
- 보정 commit `1111c50bae50f4319bc71d82e6111a59bd8921f9`은 두 Jib의 dual tag, 두 이미지 CI 직접 gate, EN/KO module 표, 설계/plan/lesson scope를 고정합니다.
- 새 hosted CI run `32266272247`: `Build`, 정책·보안·catalog·wrapper·changed-module 검사, 전체 테스트 매트릭스, `Coverage Report`, `CI Status`까지 전부 PASS입니다.
- fresh GitHub review 스레드는 비어 있지만, 새 exact head에 대한 독립 code/architecture review를 완료했습니다. P0/P1은 0이며, P2 WATCH는 #1337의 startup/workload·remote registry 증적 및 snapshot hosted artifact 범위로 기록하고 이번 PR의 안정적인 publish 전제와 분리합니다.
- `bluetape4k-bom` downstream handoff는 이 PR 범위를 넓히지 않고 #1451로 분리해 추적합니다.

## Metadata

- Issue: #1335, milestone `1.13.0`, assignee `debop`
- PR: #1450, head `1111c50bae50f4319bc71d82e6111a59bd8921f9`, milestone `1.13.0`, assignee `debop`
- CI: [exact-head run 32266272247](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32266272247) 전체 PASS; fresh GitHub review 스레드 없음, 독립 review P0/P1=0 및 P2 WATCH 기록

## DoD Status

Epic #1418 progress: 1/4
Required checks: 6/9; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-11 - PR delivery authority | 승인된 plan의 repo/base/head와 PR 생성 범위를 확인 | PASS | `bluetape-workflow` 승인 plan; `bluetape4k/bluetape4k-projects`, `develop`, `chore/1418-01-java25-semver` | 없음 |
| CG-12 - Exact head publication | force 없이 branch를 push하고 원격 SHA를 재조회 | PASS | local/remote `1111c50bae50f4319bc71d82e6111a59bd8921f9` 일치 | 없음 |
| CG-12A - Guidance refresh | PR 직전 guidance, leaf, common gates, template, linked issue를 재조회 | PASS | current guidance hashes 일치; #1335 `OPEN`, milestone `1.13.0`, assignee `debop`, labels 4개; duplicate PR 없음 | 없음 |
| CG-13 - PR metadata and body | PR을 생성하고 `debop`, issue milestone/labels, final `## DoD Status`를 live read-back | PASS | `gh pr view 1450`에서 base/head/assignee/labels/milestone 및 body read-back | 없음 |
| CG-14 - CI and live review | exact PR head의 required CI와 최신 review/thread를 확인 | PASS | run `32266272247`의 Build·정책·보안·catalog·wrapper·changed-module·전체 테스트·Coverage·CI Status 전부 PASS; 독립 code/architecture review P0/P1=0, P2 WATCH(#1337 startup/workload·registry 및 snapshot hosted artifact) | 안정적인 publish는 #1337 증적 완료 후 진행 |
| CG-15 - Merge-ready report | 모든 Type A/common 증적과 `Required checks`를 다시 조정 | PASS | 보정 head `1111c50bae50f4319bc71d82e6111a59bd8921f9`, CI run `32266272247`, local dual-tag/22개 Testcontainers 증적, #1451 downstream handoff read-back | fresh merge approval 전에는 merge하지 않음 |
| CG-16 - Fresh merge approval | CG-15 이후 exact PR/head에 대한 새 merge 승인을 수집 | PENDING | 아직 merge approval 경계에 도달하지 않음 | 승인 전 merge 금지 |
| CG-17 - Merge | fresh approval 후 승인된 전략으로 merge하고 SHA 확인 | PENDING | merge 미실행 | CG-16 이후 실행 |
| CG-18 - Sync and cleanup | merge 후 canonical branch sync와 proven merged worktree cleanup | PENDING | merge 미실행 | CG-17 이후 실행 |
| CG-X01 - Non-PR irreversible action | tag, publish, dispatch, release, deletion 범위 확인 | N/A | 이번 Slot은 PR 보정 push만 수행하며 tag/publish/dispatch/deletion을 요청하지 않음 | 없음 |

Final status: PENDING - exact head의 CI와 merge-ready DoD는 완료됐고, fresh exact-head merge approval 대기

Unchecked required items: CG-16, CG-17, CG-18
