### PR TITLE
[docs] Testcontainers TAG·KDoc·JDK baseline 계약 동기화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
       - uses: actions/setup-java@v5.7.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
@@ -73,6 +76,8 @@ jobs:
           gradle-version: wrapper
       - name: Verify static JVM release contract
         run: python3 -m unittest scripts/test_jvm_release_contract.py -v
+      - name: Verify Testcontainers image-tag and documentation contract
+        run: python3 -m unittest scripts/test_testcontainers_contract.py -v
       - name: Verify compiled classfile contract
         run: ./scripts/check-jvm-release-contract.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,10 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
       - uses: gradle/actions/setup-gradle@v6.3.0
         with:
           gradle-version: wrapper
@@ -147,6 +151,7 @@ jobs:
       - name: Verify JVM release contract
         run: |
           python3 -m unittest scripts/test_jvm_release_contract.py -v
+          python3 -m unittest scripts/test_testcontainers_contract.py -v
           ./scripts/check-jvm-release-contract.sh
 
       - name: Diagnose signing inputs

--- a/docs/lessons/2026-08-20-issue-1339-testcontainers-contract.md
+++ b/docs/lessons/2026-08-20-issue-1339-testcontainers-contract.md
@@ -26,7 +26,8 @@ JDK 21을 기준으로 안내하고 있었다.
 ## 결과
 
 문서와 KDoc은 현재 이미지 태그 및 MiniStack capability를 설명하고, README
-두 locale은 같은 기본 태그와 제한 문구를 제공한다. 생산 코드의 실행 동작과
+두 locale은 같은 기본 태그와 제한 문구를 제공한다. 계약 검사는 PR CI와 release
+preflight에서 함께 실행되어 이후 drift를 차단한다. 생산 코드의 실행 동작과
 컨테이너 이미지는 변경하지 않는다.
 
 ## 검증

--- a/docs/lessons/2026-08-20-issue-1339-testcontainers-contract.md
+++ b/docs/lessons/2026-08-20-issue-1339-testcontainers-contract.md
@@ -1,0 +1,45 @@
+# 이슈 #1339 Testcontainers 태그·문서 계약 교훈 (2026-08-20)
+
+관련 이슈: #1339 · Epic #1418 Slot 2
+영향 module: `:bluetape4k-testcontainers`, `:bluetape4k-http`
+
+## 맥락
+
+Testcontainers 서버의 `IMAGE`·`TAG` 상수와 EN/KO README 기본 태그 표는 같은
+기본 이미지를 설명하지만, KDoc 예제에는 이전 태그가 남아 있었다. MiniStack
+`1.4.14`의 KMS Grant API 제한도 실제 `@Disabled` 테스트와 공개 KDoc/README의
+지원 주장 사이에 불일치를 만들었다. HTTP 프로파일러 문서는 Java 25 전환 뒤에도
+JDK 21을 기준으로 안내하고 있었다.
+
+## 결정 또는 발견
+
+1. 기본 태그 예제는 하드코딩하지 않고 각 서버 companion object의 `TAG`를
+   참조한다. `@param tag` 기본값도 `[TAG]`로 연결해 태그 갱신 시 KDoc이 함께
+   검토되도록 한다.
+2. `scripts/test_testcontainers_contract.py`가 `*Server.kt`의 `IMAGE`·`TAG`와
+   EN/KO README 표를 직접 비교하고, KDoc의 stale literal을 차단한다.
+3. 고정된 MiniStack 태그는 KMS 핵심 기능만 지원하며 `CreateGrant`,
+   `ListGrants`, `RevokeGrant`는 지원하지 않는다. 이 경계를 KDoc, EN/KO
+   README, 비활성화 테스트의 설명과 동일하게 유지한다.
+4. `io/http` 프로파일러 요구 사항은 프로젝트 기본 툴체인인 JDK 25로 맞춘다.
+
+## 결과
+
+문서와 KDoc은 현재 이미지 태그 및 MiniStack capability를 설명하고, README
+두 locale은 같은 기본 태그와 제한 문구를 제공한다. 생산 코드의 실행 동작과
+컨테이너 이미지는 변경하지 않는다.
+
+## 검증
+
+`python3 -m unittest scripts/test_testcontainers_contract.py -v`로 Kotlin
+상수·README 표·KDoc·JDK baseline·MiniStack 제한을 검증한다. `git diff --check`,
+Kotlin 컴파일, 한국어 용어 감사를 추가로 실행하고 결과를 PR DoD에 기록한다.
+
+## 향후 지침
+
+- 새 `*Server`를 추가하거나 `TAG`를 변경할 때 Kotlin 상수, EN/KO 표, KDoc
+  예제를 함께 갱신하고 계약 검사를 실행한다.
+- 에뮬레이터 capability를 “전체 지원”으로 확대해 쓰기 전에 고정 이미지에서
+  실제 API 테스트가 활성화되는지 확인한다.
+- Java toolchain을 올릴 때 모듈 README의 실행 요구 사항과 예제도 같은
+  stacked slot에서 갱신한다.

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -356,7 +356,7 @@ JMH(Java Microbenchmark Harness) 기반 벤치마크 3종으로 클라이언트�
 > 다운로드 후 `-PasyncProfilerLib` 에 네이티브 `libasyncProfiler.so` / `libasyncProfiler.dylib` 경로를 지정하세요.
 > kotlinx-benchmark 런타임이 에이전트를 자동 감지하여 JMH forks를 0으로 설정합니다.
 
-> **요구 사항**: 모든 프로파일러는 프로젝트 툴체인인 JDK 21에서 동작합니다. 추가 Gradle 의존성 불필요.
+> **요구 사항**: 모든 프로파일러는 프로젝트 툴체인인 JDK 25에서 동작합니다. 추가 Gradle 의존성 불필요.
 
 ![Profiling workflow](../../docs/images/readme-diagrams/io-http-diagram-05.png)
 

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -355,7 +355,7 @@ Output files are written to `build/benchmark-profiling/`.
 > and point `-PasyncProfilerLib` at the native `libasyncProfiler.so` / `libasyncProfiler.dylib`.
 > The kotlinx-benchmark runtime detects the agent and automatically sets JMH forks to 0.
 
-> **Requirements**: All profilers run on JDK 21 (the project toolchain). No extra Gradle dependencies needed.
+> **Requirements**: All profilers run on JDK 25 (the project toolchain). No extra Gradle dependencies needed.
 
 ![Profiling workflow](../../docs/images/readme-diagrams/io-http-diagram-05.png)
 

--- a/scripts/test_testcontainers_contract.py
+++ b/scripts/test_testcontainers_contract.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Validate the Testcontainers image-tag and documentation contract."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+KOTLIN_ROOT = ROOT / "testing/testcontainers/src/main/kotlin"
+README_EN = ROOT / "testing/testcontainers/README.md"
+README_KO = ROOT / "testing/testcontainers/README.ko.md"
+MINISTACK_SOURCE = KOTLIN_ROOT / "io/bluetape4k/testcontainers/aws/MiniStackServer.kt"
+HTTP_READMES = (ROOT / "io/http/README.md", ROOT / "io/http/README.ko.md")
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def kotlin_servers() -> dict[str, dict[str, str | Path]]:
+    servers: dict[str, dict[str, str | Path]] = {}
+    image_pattern = re.compile(r"\bconst\s+val\s+IMAGE\s*(?::\s*String)?\s*=\s*\"([^\"]+)\"")
+    tag_pattern = re.compile(r"\bconst\s+val\s+TAG\s*(?::\s*String)?\s*=\s*\"([^\"]+)\"")
+    class_pattern = re.compile(r"\bclass\s+([A-Za-z_]\w*Server)\b")
+
+    for path in sorted(KOTLIN_ROOT.rglob("*Server.kt")):
+        source = read(path)
+        class_match = class_pattern.search(source)
+        image_match = image_pattern.search(source)
+        tag_match = tag_pattern.search(source)
+        if not class_match:
+            continue
+        if bool(image_match) != bool(tag_match):
+            raise AssertionError(f"IMAGE/TAG must be declared together: {path}")
+        if not image_match:
+            continue
+
+        name = class_match.group(1)
+        if name in servers:
+            raise AssertionError(f"duplicate server declaration: {name}")
+        servers[name] = {
+            "image": image_match.group(1),
+            "tag": tag_match.group(1),
+            "path": path,
+            "source": source,
+        }
+    return servers
+
+
+def readme_tag_table(path: Path) -> dict[str, tuple[str, str]]:
+    lines = read(path).splitlines()
+    heading = "## Default Docker Image Tags" if path == README_EN else "## 기본 Docker 이미지 태그"
+    try:
+        start = next(index for index, line in enumerate(lines) if line.strip() == heading)
+    except StopIteration as error:
+        raise AssertionError(f"missing tag table heading in {path}") from error
+
+    row_pattern = re.compile(
+        r"^\|\s*[^|]+\|\s*`(?P<server>[^`]+)`\s*\|\s*`(?P<image>[^`]+)`\s*\|\s*`(?P<tag>[^`]+)`"
+    )
+    rows: dict[str, tuple[str, str]] = {}
+    for line in lines[start + 1 :]:
+        if line.startswith("## "):
+            break
+        match = row_pattern.match(line)
+        if not match:
+            continue
+        server = match.group("server")
+        if server in rows:
+            raise AssertionError(f"duplicate README row for {server}: {path}")
+        rows[server] = (match.group("image"), match.group("tag"))
+    if not rows:
+        raise AssertionError(f"empty tag table in {path}")
+    return rows
+
+
+class TestTestcontainersContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.sources = kotlin_servers()
+        cls.en_rows = readme_tag_table(README_EN)
+        cls.ko_rows = readme_tag_table(README_KO)
+
+    def test_readme_tables_match_each_other_and_kotlin_constants(self) -> None:
+        self.assertEqual(self.en_rows, self.ko_rows, "EN/KO default-tag tables drifted")
+        expected = {
+            name: (str(details["image"]), str(details["tag"]))
+            for name, details in self.sources.items()
+        }
+        self.assertEqual(expected, self.en_rows, "README defaults drifted from Kotlin IMAGE/TAG")
+
+    def test_kdoc_defaults_do_not_pin_stale_tags(self) -> None:
+        default_pattern = re.compile(
+            r"@param\s+tag[^\n]*\(기본:\s*(?:`([^`]+)`|\[([^\]]+)\])\)"
+        )
+        literal_patterns = (
+            re.compile(r'withTag\("([^"]+)"\)'),
+            re.compile(r'\btag\s*=\s*"([^"]+)"'),
+        )
+        stale: list[str] = []
+        for name, details in self.sources.items():
+            source = str(details["source"])
+            expected_tag = str(details["tag"])
+            for match in default_pattern.finditer(source):
+                value = match.group(1) or match.group(2)
+                if value not in {"TAG", expected_tag}:
+                    stale.append(f"{name}: @param tag default {value!r}")
+            for pattern in literal_patterns:
+                for match in pattern.finditer(source):
+                    value = match.group(1)
+                    if value != expected_tag:
+                        stale.append(f"{name}: literal tag {value!r}")
+        self.assertEqual([], stale, "stale KDoc tag literals: " + "; ".join(stale))
+
+    def test_jdk_baseline_is_25_in_both_http_readmes(self) -> None:
+        for path in HTTP_READMES:
+            content = read(path)
+            self.assertIn("JDK 25", content, path.as_posix())
+            self.assertNotIn("JDK 21", content, path.as_posix())
+
+    def test_ministack_grant_limitation_is_explicit(self) -> None:
+        source = read(MINISTACK_SOURCE)
+        for action in ("CreateGrant", "ListGrants", "RevokeGrant"):
+            self.assertIn(action, source)
+        self.assertIn("미지원", source)
+        self.assertNotIn("KMS 전 기능 지원", source)
+
+        for path in (README_EN, README_KO):
+            content = read(path)
+            for action in ("CreateGrant", "ListGrants", "RevokeGrant"):
+                self.assertIn(action, content, path.as_posix())
+            if path == README_EN:
+                self.assertIn("not supported", content)
+            else:
+                self.assertIn("지원하지 않", content)
+
+
+if __name__ == "__main__":
+    result = unittest.main(verbosity=2, exit=False)
+    if result.result.wasSuccessful():
+        print(f"PASS: {len(kotlin_servers())} Kotlin server TAG contracts match EN/KO README tables")
+    raise SystemExit(not result.result.wasSuccessful())

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -448,6 +448,9 @@ val kmsClient = KmsClient.builder()
     .region(Region.of(miniStack.regionName))
     .build()
 
+// 고정된 ministackorg/ministack:1.4.14 이미지는 위 예제에서 사용하는 KMS 핵심 기능을 지원합니다.
+// CreateGrant, ListGrants, RevokeGrant는 이 태그에서 지원하지 않으므로 해당 테스트는 비활성화되어 있습니다.
+
 // FlociServer — GraalVM Native 기반 LocalStack 대체 OSS 경로
 val floci = FlociServer.Launcher.floci
 val sqsClient = SqsClient.builder()

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -402,6 +402,9 @@ val kmsClient = KmsClient.builder()
     .region(Region.of(miniStack.regionName))
     .build()
 
+// The pinned ministackorg/ministack:1.4.14 image supports the core KMS operations used above.
+// CreateGrant, ListGrants, and RevokeGrant are not supported by this tag, so those tests remain disabled.
+
 // FlociServer — GraalVM Native image and open-source LocalStack replacement
 val floci = FlociServer.Launcher.floci
 val sqsClient = SqsClient.builder()

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt
@@ -22,7 +22,8 @@ import java.time.Duration
  *
  * - Docker 이미지: `ministackorg/ministack:1.4.14` (~270MB, ~30MB RAM, ~2초 기동)
  * - 헬스 엔드포인트: `/_ministack/health`
- * - KMS 전 기능 지원 (DisableKey/EnableKey/Grant 포함)
+ * - KMS 핵심 기능 지원 (DisableKey/EnableKey 등)
+ * - KMS Grant API(`CreateGrant`, `ListGrants`, `RevokeGrant`)는 고정 태그에서 미지원
  * - DynamoDB GSI Pagination 지원
  *
  * MiniStack은 모든 AWS 서비스를 항상 활성화합니다.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/CockroachServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/CockroachServer.kt
@@ -44,7 +44,7 @@ class CockroachServer private constructor(
          * ```
          *
          * @param image docker image (기본: `cockroachdb/cockroach`)
-         * @param tag docker image tag (기본: `v22.2.8`)
+         * @param tag docker image tag (기본: [TAG])
          * @param username 사용자 이름 (기본: `test`)
          * @param password 비밀번호 (기본: `test`)
          * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)
@@ -75,7 +75,7 @@ class CockroachServer private constructor(
          * // server.isRunning == false
          * ```
          *
-         * @param imageName docker image name (eg: `cockroachdb/cockroach:v22.2.8`)
+         * @param imageName docker image name (예: `cockroachdb/cockroach:TAG`)
          * @param username 사용자 이름 (기본: `test`)
          * @param password 비밀번호 (기본: `test`)
          * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MariaDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MariaDBServer.kt
@@ -48,7 +48,7 @@ class MariaDBServer private constructor(
          * ```
          *
          * @param image             docker image (기본: `mariadb`)
-         * @param tag               docker image tag (기본: `12`)
+         * @param tag               docker image tag (기본: [TAG])
          * @param useDefaultPort    기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse             재사용 여부 (기본: `false`)
          * @param username          사용자 이름 (기본: `test`)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL5Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL5Server.kt
@@ -46,12 +46,12 @@ class MySQL5Server private constructor(
          * [MySQL5Server]를 생성합니다.
          *
          * ```kotlin
-         * val server = MySQL5Server(image = "biarms/mysql", tag = "5")
+         * val server = MySQL5Server(image = "biarms/mysql", tag = TAG)
          * // server.url.startsWith("jdbc:mysql://") == true (시작 후)
          * ```
          *
          * @param image             docker image (기본: `mysql`)
-         * @param tag               docker image tag (기본: `5.7`)
+         * @param tag               docker image tag (기본: [TAG])
          * @param useDefaultPort    기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse             재사용 여부 (기본: `false`)
          * @param username          사용자 이름 (기본: `test`)
@@ -82,7 +82,7 @@ class MySQL5Server private constructor(
          * [MySQL5Server]를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("biarms/mysql").withTag("5").asCompatibleSubstituteFor("mysql")
+         * val image = DockerImageName.parse("biarms/mysql").withTag(TAG).asCompatibleSubstituteFor("mysql")
          * val server = MySQL5Server(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL8Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL8Server.kt
@@ -48,7 +48,7 @@ class MySQL8Server private constructor(
          * ```
          *
          * @param image             docker image (기본: `mysql`)
-         * @param tag               docker image tag (기본: `8.4`)
+         * @param tag               docker image tag (기본: [TAG])
          * @param useDefaultPort    기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse             재사용 여부 (기본: `false`)
          * @param username          사용자 이름 (기본: `test`)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PostgreSQLServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PostgreSQLServer.kt
@@ -51,7 +51,7 @@ class PostgreSQLServer private constructor(
          * [PostgreSQLServer]를 생성합니다.
          *
          * @param image docker image (기본: `postgres`)
-         * @param tag docker image tag (기본: `9.6`)
+         * @param tag docker image tag (기본: [TAG])
          * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse 재사용 여부 (기본: `false`)
          * @param username 사용자 이름 (기본: `test`)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/PostgreSQLAgeServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/PostgreSQLAgeServer.kt
@@ -75,7 +75,7 @@ class PostgreSQLAgeServer private constructor(
          * [PostgreSQLAgeServer]를 생성합니다.
          *
          * @param image Docker 이미지 (기본: `apache/age`)
-         * @param tag Docker 이미지 태그 (기본: `release_PG17_1.6.0`)
+         * @param tag Docker 이미지 태그 (기본: [TAG])
          * @param useDefaultPort 기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse 재사용 여부 (기본: `false`)
          */

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/WireMockServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/WireMockServer.kt
@@ -53,7 +53,7 @@ class WireMockServer private constructor(
          * [WireMockServer]를 생성합니다.
          *
          * @param image         Docker 이미지 이름 (기본: `wiremock/wiremock`)
-         * @param tag           Docker 이미지 태그 (기본: `3.13.2`)
+         * @param tag           Docker 이미지 태그 (기본: [TAG])
          * @param useDefaultPort 기본 HTTP 포트를 사용할지 여부 (기본: `false`)
          * @param reuse         컨테이너 재사용 여부 (기본: `false`)
          */

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/JaegerServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/JaegerServer.kt
@@ -41,7 +41,7 @@ class JaegerServer private constructor(
          * [DockerImageName]으로 [JaegerServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("jaegertracing/all-in-one").withTag("1")
+         * val image = DockerImageName.parse("jaegertracing/all-in-one").withTag(TAG)
          * val server = JaegerServer(image)
          * // server.isRunning == false
          * ```
@@ -63,7 +63,7 @@ class JaegerServer private constructor(
          * 이미지 이름/태그로 [JaegerServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = JaegerServer(image = "jaegertracing/all-in-one", tag = "1")
+         * val server = JaegerServer(image = "jaegertracing/all-in-one", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ToxiproxyServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ToxiproxyServer.kt
@@ -82,7 +82,7 @@ class ToxiproxyServer private constructor(
          * - 컨테이너를 시작하지 않으며 호출자가 `start()`를 직접 호출해야 합니다.
          *
          * ```kotlin
-         * val server = ToxiproxyServer(image = "ghcr.io/shopify/toxiproxy", tag = "2.9.0")
+         * val server = ToxiproxyServer(image = "ghcr.io/shopify/toxiproxy", tag = TAG)
          * server.start()
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZipkinServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZipkinServer.kt
@@ -35,7 +35,7 @@ class ZipkinServer private constructor(
          * [DockerImageName]으로 [ZipkinServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("openzipkin/zipkin-slim").withTag("2.23")
+         * val image = DockerImageName.parse("openzipkin/zipkin-slim").withTag(TAG)
          * val server = ZipkinServer(image)
          * // server.isRunning == false
          * ```
@@ -57,7 +57,7 @@ class ZipkinServer private constructor(
          * 이미지 이름/태그로 [ZipkinServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = ZipkinServer(image = "openzipkin/zipkin-slim", tag = "2.23")
+         * val server = ZipkinServer(image = "openzipkin/zipkin-slim", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/llm/ChromaDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/llm/ChromaDBServer.kt
@@ -38,7 +38,7 @@ class ChromaDBServer private constructor(
          * [DockerImageName]으로 [ChromaDBServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("chromadb/chroma").withTag("0.5.23")
+         * val image = DockerImageName.parse("chromadb/chroma").withTag(TAG)
          * val server = ChromaDBServer(image)
          * // server.isRunning == false
          * ```
@@ -60,7 +60,7 @@ class ChromaDBServer private constructor(
          * 이미지 이름/태그로 [ChromaDBServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = ChromaDBServer(image = "chromadb/chroma", tag = "0.5.23")
+         * val server = ChromaDBServer(image = "chromadb/chroma", tag = TAG)
          * // server.url.startsWith("http://") == true (시작 후)
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/NatsServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/NatsServer.kt
@@ -67,7 +67,7 @@ class NatsServer private constructor(
          * - 컨테이너 시작은 호출자가 `start()`로 수행해야 합니다.
          *
          * ```kotlin
-         * val server = NatsServer(image = "nats", tag = "2.10")
+         * val server = NatsServer(image = "nats", tag = TAG)
          * // server.url.startsWith("nats://") == true
          * ```
          */

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/PulsarServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/PulsarServer.kt
@@ -66,7 +66,7 @@ class PulsarServer private constructor(
          * - 컨테이너 시작은 호출자가 `start()`로 수행해야 합니다.
          *
          * ```kotlin
-         * val server = PulsarServer(image = "apachepulsar/pulsar", tag = "3.3.5")
+         * val server = PulsarServer(image = "apachepulsar/pulsar", tag = TAG)
          * // server.brokerPort > 0
          * ```
          */

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/CassandraServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/CassandraServer.kt
@@ -59,7 +59,7 @@ class CassandraServer private constructor(
          * 이미지 이름/태그로 [CassandraServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val server = CassandraServer(image = "cassandra", tag = "5")
+         * val server = CassandraServer(image = "cassandra", tag = TAG)
          * // server.cqlPort > 0 (시작 후)
          * ```
          *
@@ -86,7 +86,7 @@ class CassandraServer private constructor(
          * [DockerImageName]으로 [CassandraServer] 인스턴스를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("cassandra").withTag("5")
+         * val image = DockerImageName.parse("cassandra").withTag(TAG)
          * val server = CassandraServer(image)
          * // server.isRunning == false
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchOssServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchOssServer.kt
@@ -49,7 +49,7 @@ class ElasticsearchOssServer private constructor(
          * - 이 함수는 컨테이너를 시작하지 않습니다.
          *
          * ```kotlin
-         * val server = ElasticsearchOssServer(image = ElasticsearchOssServer.IMAGE, tag = "7.10.2")
+         * val server = ElasticsearchOssServer(image = ElasticsearchOssServer.IMAGE, tag = TAG)
          * // server.isRunning == false
          * ```
          *
@@ -80,7 +80,7 @@ class ElasticsearchOssServer private constructor(
          * - 컨테이너 시작은 호출자가 `start()`를 직접 호출해야 합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse(ElasticsearchOssServer.IMAGE).withTag("7.10.2")
+         * val image = DockerImageName.parse(ElasticsearchOssServer.IMAGE).withTag(TAG)
          * val server = ElasticsearchOssServer(image)
          * // server.port > 0
          * ```

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/MongoDBServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/MongoDBServer.kt
@@ -52,7 +52,7 @@ class MongoDBServer private constructor(
          * - 컨테이너 시작은 수행하지 않고 새 인스턴스만 반환합니다.
          *
          * ```kotlin
-         * val server = MongoDBServer(image = "mongo", tag = "8", databaseName = "app")
+         * val server = MongoDBServer(image = "mongo", tag = TAG, databaseName = "app")
          * // server.url.contains("/app") == true
          * ```
          *

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedisServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedisServer.kt
@@ -67,7 +67,7 @@ class RedisServer private constructor(
          * - 컨테이너 시작은 수행하지 않습니다.
          *
          * ```kotlin
-         * val server = RedisServer(image = "redis", tag = "8")
+         * val server = RedisServer(image = "redis", tag = TAG)
          * // server.port > 0
          * ```
          */
@@ -155,7 +155,7 @@ class RedisServer private constructor(
                     start()
                     ShutdownQueue.register(this)
 
-                    // Redisson 을 사용하는 경우에만 warm up 을 수행한다 
+                    // Redisson 을 사용하는 경우에만 warm up 을 수행한다
                     if (classIsPresent("org.redisson.Redisson")) {
                         // Testcontainers 첫 실행 시 Docker 포트 프록시가 완전히 준비되기 전에
                         // Redisson pub/sub 채널을 열면 StacklessClosedChannelException이 발생합니다.


### PR DESCRIPTION
## 변경 요약

Epic #1418의 두 번째 stacked slot으로 이슈 #1339의 Testcontainers 문서 계약을
동기화했습니다. 현재 `IMAGE`·`TAG` 상수와 EN/KO README 표를 자동 대조하고,
KDoc의 stale tag 예제를 `TAG` 참조로 바꿨습니다. MiniStack `1.4.14`의 KMS
Grant 미지원 범위와 IO HTTP JDK 25 baseline도 두 locale에 반영했습니다. 계약
검사는 PR CI와 release preflight에서도 실행하도록 연결했습니다.

Closes #1339

## 변경 유형

- [x] `docs` — 문서/KDoc 및 계약 검사 유지보수
- [x] `test` — 정적 계약 검사 추가

## 테스트

- [x] `python3 -m unittest scripts/test_testcontainers_contract.py -v` → 4/4 PASS, 52개 서버 TAG 매핑
- [x] `python3 -m unittest scripts/test_release_workflow_policy.py -v` → 7/7 PASS
- [x] `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-configuration-cache` → `BUILD SUCCESSFUL`
- [x] `git diff --check`, trailing whitespace 감사, scoped 한국어 용어 감사 → PASS
- [ ] `docs/testlogs/2026-08.md` 기록 — docs-only 변경이므로 N/A

## Code Review

- [x] hosted PR CI → run `32274623616`, exact head `ce0da603` 기준 19/19 PASS
- [x] Coveralls status → `+2.1%`로 81.54% 상승, status PASS (`81252781`)
- [x] 독립 read-only 리뷰 → exact head 기준 P0/P1/P2/P3=0; 계약 검사 CI/release wiring 해소 확인

## 체크리스트

- [x] 변경된 `testing/testcontainers` 및 `io/http` README EN/KO 동기화
- [x] 기존 공개 KDoc 예제의 기본 태그를 현재 `TAG` 계약으로 연결
- [x] 계약 검사를 PR CI와 release preflight에 연결
- [x] `worktree`에서 작업 후 PR 생성
- [x] MiniStack KMS Grant 지원 범위를 실제 비활성화 테스트와 일치시킴

## DoD Status

Epic #1418 progress: 1/4 (Slot 2 PR 생성, #1335 merged; #1339 CI/review 대기)
Required checks: 6/9; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-11 - PR delivery authority | 승인된 Epic plan의 repo/base/head 범위 확인 | PASS | `bluetape4k/bluetape4k-projects`, `develop`, `docs/1418-02-testcontainers-contract` | 없음 |
| CG-12 - Exact head publication | force 없이 branch push 후 원격 SHA 재조회 | PASS | local/remote `ce0da603c67a1e77f7ba22191e994c3314ca62a6` 일치 | 없음 |
| CG-12A - Guidance refresh | PR 직전 guidance, leaf, common gates, template, #1339 metadata 재조회 | PASS | current guidance hash/read-back; #1339 OPEN, milestone `1.13.0`, assignee `debop`, labels `documentation`, `test`, `tech-debt`; duplicate PR 없음 | 없음 |
| CG-13 - PR metadata and body | PR 생성 후 assignee·milestone·labels·final heading read-back | PASS | [PR #1452](https://github.com/bluetape4k/bluetape4k-projects/pull/1452)에서 base/head/assignee/milestone/labels와 final `## DoD Status`를 live read-back | 없음 |
| CG-14 - CI and live review | exact PR head hosted CI와 review/thread 확인 | PASS | run `32274623616` 19/19 PASS, Coveralls `81252781` PASS; independent review P0/P1/P2/P3=0; GitHub review/thread 없음 | 없음 |
| CG-15 - Merge-ready report | 최종 DoD와 `Required checks` 재조정 | PASS | current head `ce0da603c67a1e77f7ba22191e994c3314ca62a6`, `Required checks: 6/9; N/A: 1; Blocked: 0`, final heading live read-back | fresh merge approval 요청 |
| CG-16 - Fresh merge approval | CG-15 이후 exact PR/head 새 merge 승인 수집 | PENDING | 아직 merge-ready 경계 전 | 승인 전 merge 금지 |
| CG-17 - Merge | fresh approval 후 승인 전략으로 merge 및 SHA 확인 | PENDING | merge 미실행 | CG-16 이후 실행 |
| CG-18 - Sync and cleanup | merge 후 canonical branch sync와 proven merged worktree 정리 | PENDING | merge 미실행 | CG-17 이후 실행 |
| CG-X01 - Non-PR irreversible action | tag·publish·dispatch·release·deletion 범위 확인 | N/A | 이번 slot은 PR push만 수행하며 해당 side effect를 요청하지 않음 | 없음 |

Final status: READY FOR FRESH MERGE APPROVAL - exact head, hosted CI, Coveralls, 독립 리뷰, DoD read-back 완료

Unchecked required items: CG-16, CG-17, CG-18
