### PR TITLE
[test][coverage] #1454 후속: Lettuce·cache-lettuce 기준선 보강

### DIFF
--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/LettuceJCachesTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/LettuceJCachesTest.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.cache.jcache.JCache
 import io.bluetape4k.cache.jcache.LettuceSuspendJCache
 import io.bluetape4k.cache.nearcache.LettuceNearCache
 import io.bluetape4k.cache.nearcache.LettuceSuspendNearCache
+import io.bluetape4k.cache.nearcache.LettuceNearCacheConfig
 import io.bluetape4k.cache.nearcache.NearCacheOperations
 import io.bluetape4k.cache.nearcache.ResilientNearCacheDecorator
 import io.bluetape4k.cache.nearcache.ResilientSuspendNearCacheDecorator
@@ -54,6 +55,38 @@ class LettuceJCachesTest {
             cache.shouldBeInstanceOf<LettuceSuspendNearCache<*>>()
         } finally {
             runCatching { runBlocking { cache.close() } }
+        }
+    }
+
+    @Test
+    fun `nearCache DSL은 명시한 설정으로 캐시를 생성한다`() {
+        val name = "lettuce-near-cache-dsl-" + Base58.randomString(6)
+        val cache = LettuceCaches.nearCache<String>(redisClient) {
+            cacheName = name
+            maxLocalSize = 32
+        }
+        try {
+            cache.cacheName shouldBeEqualTo name
+            cache.put("k1", "v1")
+            cache.get("k1") shouldBeEqualTo "v1"
+        } finally {
+            runCatching { cache.close() }
+        }
+    }
+
+    @Test
+    fun `suspendNearCache config overload은 명시한 설정으로 캐시를 생성한다`() = runTest {
+        val name = "lettuce-suspend-near-cache-config-" + Base58.randomString(6)
+        val cache = LettuceCaches.suspendNearCache<String>(
+            redisClient,
+            LettuceNearCacheConfig(cacheName = name, maxLocalSize = 32)
+        )
+        try {
+            cache.cacheName shouldBeEqualTo name
+            cache.put("k1", "v1")
+            cache.get("k1") shouldBeEqualTo "v1"
+        } finally {
+            runCatching { cache.close() }
         }
     }
 

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCacheFactoryTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/nearcache/LettuceNearCacheFactoryTest.kt
@@ -1,0 +1,107 @@
+package io.bluetape4k.cache.nearcache
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.cache.RedisServers
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.testcontainers.utility.Base58
+import java.time.Duration
+
+class LettuceNearCacheFactoryTest {
+
+    @Test
+    fun `config DSL preserves all cache settings and composes Redis keys`() {
+        val config = lettuceNearCacheConfig<String, String> {
+            cacheName = "factory-${Base58.randomString(6)}"
+            maxLocalSize = 17
+            frontExpireAfterWrite = Duration.ofSeconds(11)
+            frontExpireAfterAccess = Duration.ofSeconds(7)
+            redisTtl = Duration.ofSeconds(5)
+            useRespProtocol3 = false
+            recordStats = true
+        }
+
+        config.maxLocalSize shouldBeEqualTo 17L
+        config.frontExpireAfterWrite shouldBeEqualTo Duration.ofSeconds(11)
+        config.frontExpireAfterAccess shouldBeEqualTo Duration.ofSeconds(7)
+        config.redisTtl shouldBeEqualTo Duration.ofSeconds(5)
+        config.useRespProtocol3.shouldBeFalse()
+        config.recordStats.shouldBeTrue()
+        config.redisKey("user:1") shouldBeEqualTo "${config.cacheName}:user:1"
+    }
+
+    @Test
+    fun `config builder rejects invalid boundaries`() {
+        assertFailsWith<IllegalArgumentException> {
+            LettuceNearCacheConfigBuilder<String, String>().apply { cacheName = "" }.build()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LettuceNearCacheConfigBuilder<String, String>().apply { cacheName = "bad:name" }.build()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LettuceNearCacheConfigBuilder<String, String>().apply { maxLocalSize = 0 }.build()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LettuceNearCacheConfigBuilder<String, String>().apply {
+                frontExpireAfterWrite = Duration.ZERO
+            }.build()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LettuceNearCacheConfigBuilder<String, String>().apply {
+                frontExpireAfterAccess = Duration.ZERO
+            }.build()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LettuceNearCacheConfigBuilder<String, String>().apply {
+                redisTtl = Duration.ZERO
+            }.build()
+        }
+    }
+
+    @Test
+    fun `blocking top-level factory creates a configured cache`() {
+        val cacheName = "factory-blocking-${Base58.randomString(6)}"
+        val cache: NearCacheOperations<String> = lettuceNearCacheOf(
+            RedisServers.redisClient,
+            LettuceBinaryCodecs.default(),
+            LettuceNearCacheConfig(cacheName = cacheName)
+        )
+
+        try {
+            cache.cacheName shouldBeEqualTo cacheName
+            cache.isClosed.shouldBeFalse()
+            cache.put("user:1", "Alice")
+            cache.get("user:1") shouldBeEqualTo "Alice"
+        } finally {
+            cache.close()
+        }
+
+        cache.isClosed.shouldBeTrue()
+    }
+
+    @Test
+    fun `suspend top-level factory creates a configured cache`() = runTest {
+        val cacheName = "factory-suspend-${Base58.randomString(6)}"
+        val cache: SuspendNearCacheOperations<String> = lettuceSuspendNearCacheOf(
+            RedisServers.redisClient,
+            LettuceBinaryCodecs.default(),
+            LettuceNearCacheConfig(cacheName = cacheName)
+        )
+
+        try {
+            cache.cacheName shouldBeEqualTo cacheName
+            cache.isClosed.shouldBeFalse()
+            cache.put("order:1", "created")
+            cache.get("order:1") shouldBeEqualTo "created"
+        } finally {
+            runSuspendIO { cache.close() }
+        }
+
+        cache.isClosed.shouldBeTrue()
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/FencedLockScriptTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/FencedLockScriptTest.kt
@@ -160,6 +160,30 @@ internal class FencedLockScriptTest : AbstractLettuceTest() {
             .failure.kind shouldBeEqualTo LockIntegrityFailureKind.INVALID_STATE
     }
 
+    @Test
+    fun `bootstrap renew reconcile and release expose replay-safe terminal outcomes`() {
+        lock.bootstrapFencing() shouldBeEqualTo FencedBootstrapResult.Initialized
+        lock.bootstrapFencing() shouldBeEqualTo FencedBootstrapResult.AlreadyInitialized
+
+        val handle = lock.tryAcquire(owner, LockRequestId.from("lifecycle"), lease)
+            .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
+            .handle
+        lock.renew(handle, Duration.ofSeconds(2))
+            .shouldBeInstanceOf<LockMutationResult.Renewed<FencedLockHandle>>()
+        lock.inspect(handle).shouldBeInstanceOf<LockInspectResult.Owned<FencedLockHandle>>()
+        lock.reconcile(owner, LockRequestId.from("lifecycle"))
+            .shouldBeInstanceOf<LockReconcileResult.Owned<FencedLockHandle>>()
+        lock.release(handle) shouldBeEqualTo LockMutationResult.Released(0)
+        lock.release(handle) shouldBeEqualTo LockMutationResult.AlreadyReleased
+        lock.inspect(handle) shouldBeEqualTo LockInspectResult.Released
+        lock.renew(handle, Duration.ofSeconds(1)) shouldBeEqualTo LockMutationResult.AlreadyReleased
+
+        lock.bootstrapFencingAsync().get() shouldBeEqualTo FencedBootstrapResult.AlreadyInitialized
+        lock.tryAcquireAsync(owner, LockRequestId.from("async"), lease).get()
+            .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
+            .handle.let(lock::release)
+    }
+
     private fun deleteKeys() {
         commands.del(*keys.all)
     }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/FencedLockScriptTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/FencedLockScriptTest.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.redis.lettuce.lock
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeZero
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.bluetape4k.redis.lettuce.lock.internal.FencedLockKeys
@@ -21,6 +23,7 @@ internal class FencedLockScriptTest : AbstractLettuceTest() {
     private lateinit var commands: RedisCommands<String, String>
     private lateinit var lock: LettuceFencedLock
     private lateinit var keys: FencedLockKeys
+    private lateinit var lockName: String
 
     private val owner = LockOwnerId.from("fenced-script-owner")
     private val lease = LeasePolicy.Fixed(Duration.ofSeconds(3))
@@ -30,6 +33,7 @@ internal class FencedLockScriptTest : AbstractLettuceTest() {
         connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
         commands = connection.sync()
         val name = "fenced-script-${randomName().substringAfter(':')}"
+        lockName = name
         val config = FencedLockConfig(epoch = 7)
         keys = deriveFencedLockKeys(name, config, StringCodec.UTF8)
         deleteKeys()
@@ -182,6 +186,74 @@ internal class FencedLockScriptTest : AbstractLettuceTest() {
         lock.tryAcquireAsync(owner, LockRequestId.from("async"), lease).get()
             .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
             .handle.let(lock::release)
+    }
+
+    @Test
+    fun `bounded acquire adapters time out and reject foreign handles`() = runSuspendIO {
+        lock.bootstrapFencing() shouldBeEqualTo FencedBootstrapResult.Initialized
+        val holder = lock.tryAcquire(owner, LockRequestId.from("bounded-holder"), lease)
+            .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
+            .handle
+
+        val foreignName = "fenced-foreign-${randomName().substringAfter(':')}"
+        val foreign = LettuceFencedLock.create(connection, foreignName, FencedLockConfig(epoch = 7))
+        val foreignKeys = deriveFencedLockKeys(foreignName, FencedLockConfig(epoch = 7), connection.codec)
+        try {
+            foreign.bootstrapFencing()
+            val foreignHandle = foreign.tryAcquire(
+                LockOwnerId.from("foreign-owner"),
+                LockRequestId.from("foreign-request"),
+                lease,
+            ).shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>().handle
+            assertFailsWith<IllegalArgumentException> { lock.inspect(foreignHandle) }
+            assertFailsWith<IllegalArgumentException> { lock.release(foreignHandle) }
+
+            lock.acquire(
+                LockOwnerId.from("sync-timeout"),
+                LockRequestId.from("sync-timeout"),
+                Duration.ofMillis(35),
+                lease,
+            ) shouldBeEqualTo LockAcquireResult.TimedOut
+            lock.acquireAsync(
+                LockOwnerId.from("async-timeout"),
+                LockRequestId.from("async-timeout"),
+                Duration.ofMillis(35),
+                lease,
+            ).get(2, java.util.concurrent.TimeUnit.SECONDS) shouldBeEqualTo LockAcquireResult.TimedOut
+
+            val suspendLock = LettuceSuspendFencedLock.create(
+                connection,
+                lockName,
+                FencedLockConfig(epoch = 7),
+            )
+            try {
+                suspendLock.bootstrapFencing()
+                suspendLock.acquire(
+                    LockOwnerId.from("suspend-timeout"),
+                    LockRequestId.from("suspend-timeout"),
+                    Duration.ofMillis(35),
+                    lease,
+                ) shouldBeEqualTo LockAcquireResult.TimedOut
+            } finally {
+                suspendLock.close()
+            }
+
+            assertFailsWith<IllegalArgumentException> {
+                lock.acquire(
+                    LockOwnerId.from("too-long"),
+                    LockRequestId.from("too-long"),
+                    Duration.ofHours(24).plusMillis(1),
+                    lease,
+                )
+            }
+            assertFailsWith<IllegalArgumentException> { lock.inspect(holder.copy(epoch = 8)) }
+            foreign.release(foreignHandle) shouldBeEqualTo LockMutationResult.Released(0)
+        } finally {
+            connection.sync().del(*foreignKeys.all)
+            foreign.close()
+        }
+
+        lock.release(holder) shouldBeEqualTo LockMutationResult.Released(0)
     }
 
     private fun deleteKeys() {

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFencedLockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceFencedLockTest.kt
@@ -123,6 +123,49 @@ internal class LettuceFencedLockTest {
     }
 
     @Test
+    fun `future and suspend lifecycle operations preserve fenced terminal states`() = runSuspendIO {
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
+            val name = "fenced-lifecycle-${System.nanoTime()}"
+            val config = FencedLockConfig(epoch = 32)
+            val blocking = LettuceFencedLock.create(connection, name, config)
+            val suspending = LettuceSuspendFencedLock.create(connection, name, config)
+            val keys = deriveFencedLockKeys(name, config, connection.codec)
+            try {
+                blocking.bootstrapFencing() shouldBeEqualTo FencedBootstrapResult.Initialized
+                val futureHandle = blocking.tryAcquireAsync(OWNER, REQUEST_1, LEASE).await()
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
+                    .handle
+                blocking.inspectAsync(futureHandle).await()
+                    .shouldBeInstanceOf<LockInspectResult.Owned<FencedLockHandle>>()
+                blocking.reconcileAsync(OWNER, REQUEST_1).await()
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<FencedLockHandle>>()
+                blocking.renewAsync(futureHandle, Duration.ofSeconds(1)).await()
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<FencedLockHandle>>()
+                blocking.releaseAsync(futureHandle).await() shouldBeEqualTo LockMutationResult.Released(0)
+                blocking.inspectAsync(futureHandle).await() shouldBeEqualTo LockInspectResult.Released
+                blocking.renewAsync(futureHandle, Duration.ofSeconds(1)).await() shouldBeEqualTo
+                    LockMutationResult.AlreadyReleased
+
+                suspending.bootstrapFencing() shouldBeEqualTo FencedBootstrapResult.AlreadyInitialized
+                val suspendHandle = suspending.tryAcquire(OTHER_OWNER, REQUEST_2, LEASE)
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
+                    .handle
+                suspending.inspect(suspendHandle)
+                    .shouldBeInstanceOf<LockInspectResult.Owned<FencedLockHandle>>()
+                suspending.reconcile(OTHER_OWNER, REQUEST_2)
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<FencedLockHandle>>()
+                suspending.renew(suspendHandle, Duration.ofSeconds(1))
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<FencedLockHandle>>()
+                suspending.release(suspendHandle) shouldBeEqualTo LockMutationResult.Released(0)
+            } finally {
+                blocking.close()
+                suspending.close()
+                connection.sync().del(*keys.all)
+            }
+        }
+    }
+
+    @Test
     fun `future cancellation stops the bounded wait without acquiring later`() {
         LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
             val fixture = FencedFixture(connection, "fenced-cancel-${System.nanoTime()}", epoch = 41)

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceMultiLockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceMultiLockTest.kt
@@ -83,6 +83,41 @@ internal class LettuceMultiLockTest {
     }
 
     @Test
+    fun `future and suspend lifecycle views preserve multi-lock ownership`() = runSuspendIO {
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
+            val config = config("parity")
+            val future = LettuceMultiLock.create(connection, NAMES, config)
+            val suspending = LettuceSuspendMultiLock.create(connection, NAMES, config)
+            try {
+                val futureHandle = future.tryAcquireAsync(OWNER_1, REQUEST_1, LEASE).await()
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<MultiLockHandle>>()
+                    .handle
+                future.inspectAsync(futureHandle).await()
+                    .shouldBeInstanceOf<LockInspectResult.Owned<MultiLockHandle>>()
+                future.reconcileAsync(OWNER_1, REQUEST_1).await()
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<MultiLockHandle>>()
+                future.renewAsync(futureHandle, Duration.ofSeconds(1)).await()
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<MultiLockHandle>>()
+                future.releaseAsync(futureHandle).await() shouldBeEqualTo LockMutationResult.Released(0)
+
+                val suspendHandle = suspending.tryAcquire(OWNER_2, REQUEST_2, LEASE)
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<MultiLockHandle>>()
+                    .handle
+                suspending.inspect(suspendHandle)
+                    .shouldBeInstanceOf<LockInspectResult.Owned<MultiLockHandle>>()
+                suspending.reconcile(OWNER_2, REQUEST_2)
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<MultiLockHandle>>()
+                suspending.renew(suspendHandle, Duration.ofSeconds(1))
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<MultiLockHandle>>()
+                suspending.release(suspendHandle) shouldBeEqualTo LockMutationResult.Released(0)
+            } finally {
+                future.close()
+                suspending.close()
+            }
+        }
+    }
+
+    @Test
     fun `reconcile replays the request bound multi handle`() {
         LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
             val lock = LettuceMultiLock.create(connection, NAMES, config("reconcile"))

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/ReadWriteLockScriptTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/ReadWriteLockScriptTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.redis.lettuce.lock
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.bluetape4k.redis.lettuce.lock.internal.deriveReadWriteLockKeys
@@ -20,13 +21,15 @@ internal class ReadWriteLockScriptTest : AbstractLettuceTest() {
 
     private lateinit var connection: StatefulRedisConnection<String, String>
     private lateinit var lock: LettuceReadWriteLock
+    private lateinit var lockName: String
 
     private val lease = LeasePolicy.Fixed(Duration.ofSeconds(3))
 
     @BeforeEach
     fun setUp() {
         connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
-        lock = LettuceReadWriteLock.create(connection, "read-write-script-${randomName().substringAfter(':')}")
+        lockName = "read-write-script-${randomName().substringAfter(':')}"
+        lock = LettuceReadWriteLock.create(connection, lockName)
     }
 
     @AfterEach
@@ -253,6 +256,65 @@ internal class ReadWriteLockScriptTest : AbstractLettuceTest() {
     }
 
     @Test
+    fun `bounded acquire paths reject foreign handles and time out`() = runSuspendIO {
+        val writer = acquireWrite("bounded-writer", "bounded-write")
+        val other = LettuceReadWriteLock.create(connection, "read-write-foreign-${randomName().substringAfter(':')}")
+        val foreignHandle = other.writeLock().tryAcquire(owner("foreign-owner"), request("foreign-write"), lease)
+            .shouldBeInstanceOf<LockAcquireResult.Acquired<WriteLockHandle>>()
+            .handle
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                lock.writeLock().inspect(foreignHandle)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                lock.writeLock().release(foreignHandle)
+            }
+
+            lock.readLock().acquire(
+                owner("sync-timeout"),
+                request("sync-timeout"),
+                Duration.ofMillis(35),
+                lease,
+            ) shouldBeEqualTo LockAcquireResult.TimedOut
+            lock.readLock().acquireAsync(
+                owner("async-timeout"),
+                request("async-timeout"),
+                Duration.ofMillis(35),
+                lease,
+            ).get(2, TimeUnit.SECONDS) shouldBeEqualTo LockAcquireResult.TimedOut
+
+            val suspendLock = LettuceSuspendReadWriteLock.create(
+                connection,
+                lockName,
+            )
+            try {
+                suspendLock.readLock().acquire(
+                    owner("suspend-timeout"),
+                    request("suspend-timeout"),
+                    Duration.ofMillis(35),
+                    lease,
+                ) shouldBeEqualTo LockAcquireResult.TimedOut
+            } finally {
+                suspendLock.close()
+            }
+
+            assertFailsWith<IllegalArgumentException> {
+                lock.readLock().acquire(
+                    owner("too-long"),
+                    request("too-long"),
+                    Duration.ofHours(24).plusMillis(1),
+                    lease,
+                )
+            }
+        } finally {
+            other.writeLock().release(foreignHandle)
+            other.close()
+        }
+
+        lock.writeLock().release(writer) shouldBeEqualTo LockMutationResult.Released(0)
+    }
+
+    @Test
     fun `async and suspend views preserve read write lifecycle parity`() = runSuspendIO {
         val asyncReader = lock.readLock().tryAcquireAsync(owner("async-reader"), request("async-read"), lease)
             .get(2, TimeUnit.SECONDS)
@@ -285,7 +347,11 @@ internal class ReadWriteLockScriptTest : AbstractLettuceTest() {
         val suspendName = "read-write-suspend-${randomName().substringAfter(':')}"
         val suspendLock = LettuceSuspendReadWriteLock.create(connection, suspendName)
         try {
-            val suspendReader = suspendLock.readLock().tryAcquire(owner("suspend-reader"), request("suspend-read"), lease)
+            val suspendReader = suspendLock.readLock().tryAcquire(
+                owner("suspend-reader"),
+                request("suspend-read"),
+                lease,
+            )
                 .shouldBeInstanceOf<LockAcquireResult.Acquired<ReadLockHandle>>()
                 .handle
             suspendLock.readLock().inspect(suspendReader)
@@ -296,7 +362,11 @@ internal class ReadWriteLockScriptTest : AbstractLettuceTest() {
                 .shouldBeInstanceOf<LockMutationResult.Renewed<ReadLockHandle>>()
             suspendLock.readLock().release(suspendReader) shouldBeEqualTo LockMutationResult.Released(0)
 
-            val suspendWriter = suspendLock.writeLock().tryAcquire(owner("suspend-writer"), request("suspend-write"), lease)
+            val suspendWriter = suspendLock.writeLock().tryAcquire(
+                owner("suspend-writer"),
+                request("suspend-write"),
+                lease,
+            )
                 .shouldBeInstanceOf<LockAcquireResult.Acquired<WriteLockHandle>>()
                 .handle
             suspendLock.writeLock().inspect(suspendWriter)
@@ -344,7 +414,9 @@ internal class ReadWriteLockScriptTest : AbstractLettuceTest() {
 
     @Test
     fun `public and internal surfaces expose no read-to-write upgrade`() {
-        LettuceReadWriteLock::class.java.methods.none { it.name.contains("upgrade", ignoreCase = true) } shouldBeEqualTo true
+        LettuceReadWriteLock::class.java.methods.none {
+            it.name.contains("upgrade", ignoreCase = true)
+        } shouldBeEqualTo true
         LettuceReadWriteLock.ReadLockView::class.java.methods
             .none { it.name.contains("upgrade", ignoreCase = true) } shouldBeEqualTo true
         LettuceSuspendReadWriteLock::class.java.methods

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/ReadWriteLockScriptTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/ReadWriteLockScriptTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.bluetape4k.redis.lettuce.lock.internal.deriveReadWriteLockKeys
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.codec.StringCodec
 import org.awaitility.Awaitility.await
@@ -222,6 +223,95 @@ internal class ReadWriteLockScriptTest : AbstractLettuceTest() {
     }
 
     @Test
+    fun `renew release replay and inspection preserve terminal result distinctions`() {
+        val reader = acquireRead("renew-reader", "renew-read")
+        lock.readLock().renew(reader, Duration.ofSeconds(1))
+            .shouldBeInstanceOf<LockMutationResult.Renewed<ReadLockHandle>>()
+        lock.readLock().release(reader) shouldBeEqualTo LockMutationResult.Released(0)
+        lock.readLock().release(reader) shouldBeEqualTo LockMutationResult.AlreadyReleased
+        lock.readLock().inspect(reader) shouldBeEqualTo LockInspectResult.Released
+        lock.readLock().renew(reader, Duration.ofSeconds(1)) shouldBeEqualTo LockMutationResult.AlreadyReleased
+
+        val expiring = acquireWrite("expiring-writer", "expiring-write", LeasePolicy.Fixed(Duration.ofMillis(100)))
+        Thread.sleep(150L)
+        lock.writeLock().inspect(expiring) shouldBeEqualTo LockInspectResult.Expired
+        lock.writeLock().release(expiring) shouldBeEqualTo LockMutationResult.Expired
+    }
+
+    @Test
+    fun `reconcile and closed surfaces return typed terminal outcomes`() {
+        lock.readLock().reconcile(owner("missing-owner"), request("missing-request")) shouldBeEqualTo
+            LockReconcileResult.NotFound
+
+        val reader = acquireRead("close-reader", "close-read")
+        lock.close()
+
+        lock.readLock().tryAcquire(owner("after-close"), request("after-close"), lease) shouldBeEqualTo
+            LockAcquireResult.Closed
+        lock.readLock().inspect(reader) shouldBeEqualTo LockInspectResult.Closed
+        lock.readLock().release(reader) shouldBeEqualTo LockMutationResult.Closed
+    }
+
+    @Test
+    fun `async and suspend views preserve read write lifecycle parity`() = runSuspendIO {
+        val asyncReader = lock.readLock().tryAcquireAsync(owner("async-reader"), request("async-read"), lease)
+            .get(2, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<LockAcquireResult.Acquired<ReadLockHandle>>()
+            .handle
+        lock.readLock().inspectAsync(asyncReader).get(2, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<LockInspectResult.Owned<ReadLockHandle>>()
+        lock.readLock().reconcileAsync(owner("async-reader"), request("async-read"))
+            .get(2, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<LockReconcileResult.Owned<ReadLockHandle>>()
+        lock.readLock().renewAsync(asyncReader, Duration.ofSeconds(1)).get(2, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<LockMutationResult.Renewed<ReadLockHandle>>()
+        lock.readLock().releaseAsync(asyncReader).get(2, TimeUnit.SECONDS) shouldBeEqualTo
+            LockMutationResult.Released(0)
+
+        val asyncWriter = lock.writeLock().tryAcquireAsync(owner("async-writer"), request("async-write"), lease)
+            .get(2, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<LockAcquireResult.Acquired<WriteLockHandle>>()
+            .handle
+        lock.writeLock().inspectAsync(asyncWriter).get(2, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<LockInspectResult.Owned<WriteLockHandle>>()
+        lock.writeLock().reconcileAsync(owner("async-writer"), request("async-write"))
+            .get(2, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<LockReconcileResult.Owned<WriteLockHandle>>()
+        lock.writeLock().renewAsync(asyncWriter, Duration.ofSeconds(1)).get(2, TimeUnit.SECONDS)
+            .shouldBeInstanceOf<LockMutationResult.Renewed<WriteLockHandle>>()
+        lock.writeLock().releaseAsync(asyncWriter).get(2, TimeUnit.SECONDS) shouldBeEqualTo
+            LockMutationResult.Released(0)
+
+        val suspendName = "read-write-suspend-${randomName().substringAfter(':')}"
+        val suspendLock = LettuceSuspendReadWriteLock.create(connection, suspendName)
+        try {
+            val suspendReader = suspendLock.readLock().tryAcquire(owner("suspend-reader"), request("suspend-read"), lease)
+                .shouldBeInstanceOf<LockAcquireResult.Acquired<ReadLockHandle>>()
+                .handle
+            suspendLock.readLock().inspect(suspendReader)
+                .shouldBeInstanceOf<LockInspectResult.Owned<ReadLockHandle>>()
+            suspendLock.readLock().reconcile(owner("suspend-reader"), request("suspend-read"))
+                .shouldBeInstanceOf<LockReconcileResult.Owned<ReadLockHandle>>()
+            suspendLock.readLock().renew(suspendReader, Duration.ofSeconds(1))
+                .shouldBeInstanceOf<LockMutationResult.Renewed<ReadLockHandle>>()
+            suspendLock.readLock().release(suspendReader) shouldBeEqualTo LockMutationResult.Released(0)
+
+            val suspendWriter = suspendLock.writeLock().tryAcquire(owner("suspend-writer"), request("suspend-write"), lease)
+                .shouldBeInstanceOf<LockAcquireResult.Acquired<WriteLockHandle>>()
+                .handle
+            suspendLock.writeLock().inspect(suspendWriter)
+                .shouldBeInstanceOf<LockInspectResult.Owned<WriteLockHandle>>()
+            suspendLock.writeLock().reconcile(owner("suspend-writer"), request("suspend-write"))
+                .shouldBeInstanceOf<LockReconcileResult.Owned<WriteLockHandle>>()
+            suspendLock.writeLock().renew(suspendWriter, Duration.ofSeconds(1))
+                .shouldBeInstanceOf<LockMutationResult.Renewed<WriteLockHandle>>()
+            suspendLock.writeLock().release(suspendWriter) shouldBeEqualTo LockMutationResult.Released(0)
+        } finally {
+            suspendLock.close()
+        }
+    }
+
+    @Test
     fun `bounded stale waiter cleanup fails closed without bypassing the remaining boundary`() {
         lock.close()
         val name = "read-write-cleanup-${randomName().substringAfter(':')}"
@@ -270,8 +360,12 @@ internal class ReadWriteLockScriptTest : AbstractLettuceTest() {
             .shouldBeInstanceOf<LockAcquireResult.Acquired<ReadLockHandle>>()
             .handle
 
-    private fun acquireWrite(owner: String, request: String): WriteLockHandle =
-        lock.writeLock().tryAcquire(owner(owner), request(request), lease)
+    private fun acquireWrite(
+        owner: String,
+        request: String,
+        leasePolicy: LeasePolicy = lease,
+    ): WriteLockHandle =
+        lock.writeLock().tryAcquire(owner(owner), request(request), leasePolicy)
             .shouldBeInstanceOf<LockAcquireResult.Acquired<WriteLockHandle>>()
             .handle
 

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMapTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.redis.lettuce.map
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -271,6 +272,22 @@ class LettuceLoadedMapTest: AbstractLettuceTest() {
         }
     }
 
+    @Test
+    fun `getAll - loader가 null을 반환한 키는 결과와 캐시에 포함하지 않는다`() {
+        val loader = object: MapLoader<String, String> {
+            override fun load(key: String): String? = if (key == "missing") null else "loaded-$key"
+
+            override fun loadAllKeys(): Iterable<String> = emptyList()
+        }
+
+        newMap(loader = loader).use { map ->
+            val result = map.getAll(setOf("present", "missing"))
+            result["present"] shouldBeEqualTo "loaded-present"
+            result.containsKey("missing").shouldBeFalse()
+            map["missing"].shouldBeNull()
+        }
+    }
+
     // =========================================================================
     // deleteAll / clear
     // =========================================================================
@@ -289,6 +306,43 @@ class LettuceLoadedMapTest: AbstractLettuceTest() {
             map["k1"].shouldBeNull()
             map["k2"].shouldBeNull()
             map["k3"] shouldBeEqualTo "v3"
+        }
+    }
+
+    @Test
+    fun `deleteAll과 evict는 빈 입력과 캐시 전용 삭제 계약을 지킨다`() {
+        val written = mutableMapOf<String, String>()
+        val writer = object: MapWriter<String, String> {
+            override fun write(map: Map<String, String>) = written.putAll(map)
+
+            override fun delete(keys: Collection<String>) = keys.forEach(written::remove)
+        }
+
+        newMap(writer = writer).use { map ->
+            map["k1"] = "v1"
+            map["k2"] = "v2"
+            map.deleteAll(emptyList())
+            map.evict("k1")
+            map.evictAll(emptyList())
+            map["k1"].shouldBeNull()
+            written["k1"] shouldBeEqualTo "v1"
+            map["k2"] shouldBeEqualTo "v2"
+        }
+    }
+
+    @Test
+    fun `invalidateByPattern은 같은 keyPrefix의 캐시 항목만 제거한다`() {
+        newMap(config = LettuceCacheConfig.READ_ONLY).use { map ->
+            map["user:1"] = "one"
+            map["user:2"] = "two"
+            map["order:1"] = "order"
+
+            val deleted = map.invalidateByPattern("user:*")
+
+            deleted shouldBeEqualTo 2L
+            map["user:1"].shouldBeNull()
+            map["user:2"].shouldBeNull()
+            map["order:1"] shouldBeEqualTo "order"
         }
     }
 

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
@@ -8,6 +8,7 @@ import io.lettuce.core.codec.StringCodec
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContainAll
@@ -137,6 +138,44 @@ class LettuceMapTest: AbstractLettuceTest() {
 
         map.clear() shouldBeEqualTo 1L
         map.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `TTL API는 null과 기존 필드 및 Hash key 수명을 구분한다`() {
+        map.putTtl("plain", "value", null).shouldBeTrue()
+        map.putTtl("expiring", "value", Duration.ofSeconds(30)).shouldBeTrue()
+        map.putTtl("expiring", "updated", Duration.ofSeconds(30)).shouldBeFalse()
+
+        connection.sync().ttl(map.mapKey) shouldBeGreaterThan 0L
+        map.refreshTtl(null)
+        map.refreshTtl(Duration.ofSeconds(45))
+        connection.sync().ttl(map.mapKey) shouldBeGreaterThan 0L
+
+        map.putAllTtl(emptyMap(), Duration.ofSeconds(10))
+        map.putAllTtl(mapOf("batch-1" to "v1", "batch-2" to "v2"), null)
+        map.get("batch-1") shouldBeEqualTo "v1"
+        map.putAllTtl(mapOf("batch-3" to "v3"), Duration.ofSeconds(30))
+        map.get("batch-3") shouldBeEqualTo "v3"
+    }
+
+    @Test
+    fun `분산 락은 예외 후에도 소유권을 해제하고 인자 범위를 검증한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            map.withDistributedLock("owner", leaseTime = Duration.ZERO) { }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            map.withDistributedLock("owner", waitTime = Duration.ofMillis(-1)) { }
+        }
+        assertFailsWith<IllegalStateException> {
+            map.withDistributedLock("owner-1") {
+                error("block failure")
+            }
+        }
+
+        map.withDistributedLock("owner-2", waitTime = Duration.ofSeconds(1)) {
+            map.put("after-failure", "released")
+        }
+        map.get("after-failure") shouldBeEqualTo "released"
     }
 
     @Test

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.redis.lettuce.map
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeLessThan
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
@@ -231,6 +232,63 @@ class LettuceSuspendedLoadedMapTest: AbstractLettuceTest() {
             result["k2"] shouldBeEqualTo "fallback-k2"
             result["k3"] shouldBeEqualTo "fallback-k3"
             loaderCallCount.get() shouldBeEqualTo 3
+        }
+    }
+
+    @Test
+    fun `getAll - loader가 null을 반환한 키는 결과와 캐시에 포함하지 않는다`() = runSuspendIO {
+        val loader = object: SuspendedMapLoader<String, String> {
+            override suspend fun load(key: String): String? = if (key == "missing") null else "loaded-$key"
+
+            override suspend fun loadAllKeys(): List<String> = emptyList()
+        }
+
+        newMap(loader = loader).use { map ->
+            val result = map.getAll(setOf("present", "missing"))
+            result["present"] shouldBeEqualTo "loaded-present"
+            result.containsKey("missing").shouldBeFalse()
+            map.get("missing").shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `evict와 evictAll은 DB writer를 호출하지 않고 캐시만 제거한다`() = runSuspendIO {
+        val deleted = mutableListOf<String>()
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) = Unit
+
+            override suspend fun delete(keys: Collection<String>) {
+                deleted.addAll(keys)
+            }
+        }
+
+        newMap(writer = writer).use { map ->
+            map.set("k1", "v1")
+            map.set("k2", "v2")
+            map.evict("k1")
+            map.evictAll(emptyList())
+            map.get("k1").shouldBeNull()
+            map.get("k2") shouldBeEqualTo "v2"
+            deleted shouldBeEqualTo emptyList<String>()
+        }
+    }
+
+    @Test
+    fun `invalidateByPattern과 clear는 keyPrefix 범위만 비동기로 삭제한다`() = runSuspendIO {
+        newMap(config = LettuceCacheConfig.READ_ONLY).use { map ->
+            map.set("user:1", "one")
+            map.set("user:2", "two")
+            map.set("order:1", "order")
+
+            val deleted = map.invalidateByPattern("user:*")
+
+            deleted shouldBeEqualTo 2L
+            map.get("user:1").shouldBeNull()
+            map.get("user:2").shouldBeNull()
+            map.get("order:1") shouldBeEqualTo "order"
+
+            map.clear()
+            map.get("order:1").shouldBeNull()
         }
     }
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceCountDownLatchTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceCountDownLatchTest.kt
@@ -8,12 +8,89 @@ import io.bluetape4k.redis.lettuce.script.RedisScriptRunner
 import io.bluetape4k.redis.lettuce.synchronizer.internal.deriveLatchKeys
 import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.codec.StringCodec
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 class LettuceCountDownLatchTest: AbstractLettuceTest() {
+
+    @Test
+    fun `zero count and stale generation preserve lifecycle`() = runSuspendIO {
+        val connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
+        val name = "latch-boundaries-${randomName().substringAfter(':')}"
+        val config = LatchConfig(maxCount = 2)
+        val keys = deriveLatchKeys(name, config, StringCodec.UTF8)
+        connection.sync().del(*keys.all.toTypedArray())
+        val latch = LettuceCountDownLatch.create(connection, name, config)
+        val suspending = LettuceSuspendCountDownLatch.create(connection, name, config)
+        try {
+            latch.trySetCount(-1, LatchRequestId.random()) shouldBeEqualTo LatchSetCountResult.InvalidCount
+            latch.trySetCountAsync(3, LatchRequestId.random()).get() shouldBeEqualTo
+                LatchSetCountResult.InvalidCount
+
+            val completed = latch.trySetCount(0, LatchRequestId.from("zero-count"))
+                .shouldBeInstanceOf<LatchSetCountResult.Created>()
+            latch.getCount(completed.generation)
+                .shouldBeInstanceOf<LatchCountResult.Completed>()
+            latch.await(completed.generation, LatchRequestId.from("zero-await"), Duration.ofMillis(20)) shouldBeEqualTo
+                LatchAwaitResult.Completed
+            latch.countDown(completed.generation, LatchRequestId.from("zero-down")) shouldBeEqualTo
+                LatchMutationResult.AlreadyCompleted
+            latch.delete(completed.generation, LatchRequestId.from("zero-delete")) shouldBeEqualTo
+                LatchMutationResult.Deleted
+
+            val active = latch.trySetCount(1, LatchRequestId.from("active-count"))
+                .shouldBeInstanceOf<LatchSetCountResult.Created>()
+            latch.await(active.generation, LatchRequestId.from("sync-timeout"), Duration.ofMillis(30)) shouldBeEqualTo
+                LatchAwaitResult.TimedOut
+            latch.awaitAsync(
+                active.generation,
+                LatchRequestId.from("async-timeout"),
+                Duration.ofMillis(30),
+            ).get() shouldBeEqualTo LatchAwaitResult.TimedOut
+            suspending.await(
+                active.generation,
+                LatchRequestId.from("suspend-timeout"),
+                Duration.ofMillis(30),
+            ) shouldBeEqualTo LatchAwaitResult.TimedOut
+
+            val stale = LatchGeneration(active.generation.value + 1)
+            latch.getCount(stale) shouldBeEqualTo LatchCountResult.StaleGeneration
+            latch.getCountAsync(stale).get() shouldBeEqualTo LatchCountResult.StaleGeneration
+            latch.await(stale, LatchRequestId.from("stale-await"), Duration.ofMillis(20)) shouldBeEqualTo
+                LatchAwaitResult.StaleGeneration
+            latch.awaitAsync(
+                stale,
+                LatchRequestId.from("stale-await-async"),
+                Duration.ofMillis(20),
+            ).get() shouldBeEqualTo
+                LatchAwaitResult.StaleGeneration
+            latch.countDown(stale, LatchRequestId.from("stale-down")) shouldBeEqualTo
+                LatchMutationResult.StaleGeneration
+            latch.delete(stale, LatchRequestId.from("stale-delete")) shouldBeEqualTo
+                LatchMutationResult.StaleGeneration
+
+            latch.countDown(active.generation, LatchRequestId.from("complete")) shouldBeEqualTo
+                LatchMutationResult.Completed
+            latch.delete(active.generation, LatchRequestId.from("delete")) shouldBeEqualTo
+                LatchMutationResult.Deleted
+
+            latch.close()
+            latch.trySetCount(1, LatchRequestId.random()) shouldBeEqualTo LatchSetCountResult.Closed
+            latch.getCount(active.generation) shouldBeEqualTo LatchCountResult.Closed
+            latch.getCountAsync(active.generation).get() shouldBeEqualTo LatchCountResult.Closed
+            latch.await(active.generation, LatchRequestId.random(), Duration.ofMillis(20)) shouldBeEqualTo
+                LatchAwaitResult.Closed
+            latch.delete(active.generation, LatchRequestId.random()) shouldBeEqualTo LatchMutationResult.Closed
+        } finally {
+            suspending.close()
+            latch.close()
+            connection.sync().del(*keys.all.toTypedArray())
+            connection.close()
+        }
+    }
 
     @Test
     fun `generation increases across delete and recreate while count stays at zero`() {

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceDistributedSemaphoreTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceDistributedSemaphoreTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.redis.lettuce.synchronizer
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
@@ -10,6 +11,85 @@ import io.lettuce.core.codec.StringCodec
 import org.junit.jupiter.api.Test
 
 class LettuceDistributedSemaphoreTest: AbstractLettuceTest() {
+
+    @Test
+    fun `invalid bounds and terminal states remain explicit`() = runSuspendIO {
+        val connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
+        val name = "semaphore-boundaries-${randomName().substringAfter(':')}"
+        val config = SemaphoreConfig(maxPermits = 2)
+        val keys = deriveSemaphoreKeys(name, config, StringCodec.UTF8)
+        connection.sync().del(*keys.all.toTypedArray())
+        val blocking = LettuceDistributedSemaphore.create(connection, name, config)
+        val suspending = LettuceSuspendDistributedSemaphore.create(connection, name, config)
+        try {
+            blocking.trySetPermits(0) shouldBeEqualTo SemaphoreInitializationResult.InvalidCapacity
+            blocking.trySetPermitsAsync(3).get() shouldBeEqualTo SemaphoreInitializationResult.InvalidCapacity
+            assertFailsWith<IllegalArgumentException> {
+                blocking.tryAcquire(SemaphoreOwnerId.random(), SemaphoreRequestId.random(), 0)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                blocking.acquire(
+                    SemaphoreOwnerId.random(),
+                    SemaphoreRequestId.random(),
+                    1,
+                    java.time.Duration.ZERO,
+                )
+            }
+
+            blocking.tryAcquire(SemaphoreOwnerId.random(), SemaphoreRequestId.random()) shouldBeEqualTo
+                PermitAcquireResult.Unavailable
+            blocking.acquire(
+                SemaphoreOwnerId.random(),
+                SemaphoreRequestId.random(),
+                1,
+                java.time.Duration.ofMillis(25),
+            ) shouldBeEqualTo PermitAcquireResult.TimedOut
+
+            blocking.trySetPermits(1).shouldBeInstanceOf<SemaphoreInitializationResult.Initialized>()
+            val holder = blocking.tryAcquire(SemaphoreOwnerId.random(), SemaphoreRequestId.random())
+                .shouldBeInstanceOf<PermitAcquireResult.Acquired<PermitHandle>>()
+                .handle
+            blocking.acquireAsync(
+                SemaphoreOwnerId.random(),
+                SemaphoreRequestId.random(),
+                1,
+                java.time.Duration.ofMillis(25),
+            ).get() shouldBeEqualTo PermitAcquireResult.TimedOut
+            suspending.acquire(
+                SemaphoreOwnerId.random(),
+                SemaphoreRequestId.random(),
+                1,
+                java.time.Duration.ofMillis(25),
+            ) shouldBeEqualTo PermitAcquireResult.TimedOut
+
+            blocking.inspect(holder).shouldBeInstanceOf<PermitInspectResult.Owned<PermitHandle>>()
+            blocking.release(holder).shouldBeInstanceOf<PermitMutationResult.Released<PermitHandle>>()
+            blocking.inspect(holder) shouldBeEqualTo PermitInspectResult.Released
+            blocking.reconcile(
+                SemaphoreOwnerId.from("missing-owner"),
+                SemaphoreRequestId.from("missing-request"),
+            ) shouldBeEqualTo PermitReconcileResult.NotFound
+
+            blocking.close()
+            blocking.availablePermits() shouldBeEqualTo -1
+            blocking.availablePermitsAsync().get() shouldBeEqualTo -1
+            blocking.tryAcquire(
+                SemaphoreOwnerId.random(),
+                SemaphoreRequestId.random(),
+            ) shouldBeEqualTo PermitAcquireResult.Closed
+            blocking.inspect(holder) shouldBeEqualTo PermitInspectResult.Closed
+            blocking.release(holder) shouldBeEqualTo PermitMutationResult.Closed
+            blocking.reconcile(
+                SemaphoreOwnerId.random(),
+                SemaphoreRequestId.random(),
+            ) shouldBeEqualTo PermitReconcileResult.Closed
+        } finally {
+            suspending.close()
+            blocking.close()
+            connection.sync().del(*keys.all.toTypedArray())
+            connection.close()
+        }
+    }
 
     @Test
     fun `blocking async and suspend adapters preserve request idempotency`() = runSuspendIO {

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceDistributedSemaphoreTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceDistributedSemaphoreTest.kt
@@ -67,4 +67,53 @@ class LettuceDistributedSemaphoreTest: AbstractLettuceTest() {
             connection.close()
         }
     }
+
+    @Test
+    fun `async and suspend lifecycle surfaces reconcile released requests and close fail closed`() = runSuspendIO {
+        val connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
+        val name = "semaphore-lifecycle-${randomName().substringAfter(':')}"
+        val keys = deriveSemaphoreKeys(name, SemaphoreConfig(), StringCodec.UTF8)
+        connection.sync().del(*keys.all.toTypedArray())
+        val blocking = LettuceDistributedSemaphore.create(connection, name)
+        val suspending = LettuceSuspendDistributedSemaphore.create(connection, name)
+        try {
+            blocking.trySetPermitsAsync(2).get()
+                .shouldBeInstanceOf<SemaphoreInitializationResult.Initialized>()
+            blocking.availablePermitsAsync().get() shouldBeEqualTo 2
+
+            val owner = SemaphoreOwnerId.from("async-owner")
+            val request = SemaphoreRequestId.from("async-request")
+            val handle = blocking.tryAcquireAsync(owner, request, 1).get()
+                .shouldBeInstanceOf<PermitAcquireResult.Acquired<PermitHandle>>()
+                .handle
+            blocking.inspectAsync(handle).get()
+                .shouldBeInstanceOf<PermitInspectResult.Owned<PermitHandle>>()
+            blocking.reconcileAsync(owner, request).get()
+                .shouldBeInstanceOf<PermitReconcileResult.Owned<PermitHandle>>()
+            blocking.releaseAsync(handle).get()
+                .shouldBeInstanceOf<PermitMutationResult.Released<PermitHandle>>()
+
+            suspending.reconcile(owner, request) shouldBeEqualTo PermitReconcileResult.Released
+            val suspendOwner = SemaphoreOwnerId.from("suspend-owner")
+            val suspendRequest = SemaphoreRequestId.from("suspend-request")
+            val suspendHandle = suspending.tryAcquire(suspendOwner, suspendRequest, 1)
+                .shouldBeInstanceOf<PermitAcquireResult.Acquired<PermitHandle>>()
+                .handle
+            suspending.inspect(suspendHandle)
+                .shouldBeInstanceOf<PermitInspectResult.Owned<PermitHandle>>()
+            suspending.reconcile(suspendOwner, suspendRequest)
+                .shouldBeInstanceOf<PermitReconcileResult.Owned<PermitHandle>>()
+            suspending.release(suspendHandle)
+                .shouldBeInstanceOf<PermitMutationResult.Released<PermitHandle>>()
+
+            blocking.close()
+            blocking.availablePermitsAsync().get() shouldBeEqualTo -1
+            blocking.trySetPermitsAsync(1).get() shouldBeEqualTo SemaphoreInitializationResult.Closed
+        } finally {
+            suspending.close()
+            blocking.close()
+            connection.sync().del(*keys.all.toTypedArray())
+            connection.close()
+        }
+    }
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettucePermitExpirableSemaphoreTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettucePermitExpirableSemaphoreTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.redis.lettuce.synchronizer
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.bluetape4k.redis.lettuce.synchronizer.internal.deriveSemaphoreKeys
@@ -185,6 +186,102 @@ class LettucePermitExpirableSemaphoreTest: AbstractLettuceTest() {
                 PermitAcquireResult.Closed
         } finally {
             semaphore.close()
+            connection.sync().del(*keys.all.toTypedArray())
+            connection.close()
+        }
+    }
+
+    @Test
+    fun `replay and stale generations preserve allocation contract`() {
+        val connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
+        val name = "expirable-replay-${randomName().substringAfter(':')}"
+        val config = ExpirableSemaphoreConfig(leaseTime = Duration.ofSeconds(5))
+        val keys = deriveSemaphoreKeys(name, config.semaphore, StringCodec.UTF8)
+        connection.sync().del(*keys.all.toTypedArray())
+        val semaphore = LettucePermitExpirableSemaphore.create(connection, name, config)
+        try {
+            semaphore.trySetPermits(3)
+            val owner = SemaphoreOwnerId.from("replay-owner")
+            val request = SemaphoreRequestId.from("replay-request")
+            val first = semaphore.tryAcquire(owner, request, 2)
+                .shouldBeInstanceOf<PermitAcquireResult.Acquired<ExpirablePermitHandle>>()
+                .handle
+            val replay = semaphore.tryAcquire(owner, request, 2)
+                .shouldBeInstanceOf<PermitAcquireResult.Acquired<ExpirablePermitHandle>>()
+                .handle
+            replay shouldBeEqualTo first
+            semaphore.availablePermits() shouldBeEqualTo 1
+
+            val stale = first.copy(permit = first.permit.copy(generation = first.permit.generation + 1))
+            semaphore.inspect(stale) shouldBeEqualTo PermitInspectResult.StaleGeneration
+            semaphore.release(stale) shouldBeEqualTo PermitMutationResult.StaleGeneration
+            semaphore.renew(stale, Duration.ofSeconds(1)) shouldBeEqualTo PermitRenewResult.StaleGeneration
+            semaphore.reconcile(owner, request)
+                .shouldBeInstanceOf<PermitReconcileResult.Owned<ExpirablePermitHandle>>()
+            semaphore.release(first) shouldBeEqualTo PermitMutationResult.Released(first, 3)
+            semaphore.tryAcquire(owner, request, 2) shouldBeEqualTo PermitAcquireResult.Unavailable
+        } finally {
+            semaphore.close()
+            connection.sync().del(*keys.all.toTypedArray())
+            connection.close()
+        }
+    }
+
+    @Test
+    fun `invalid bounds and closed adapters remain explicit`() = runTest {
+        val connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
+        val name = "expirable-boundary-${randomName().substringAfter(':')}"
+        val config = ExpirableSemaphoreConfig(leaseTime = Duration.ofSeconds(5))
+        val keys = deriveSemaphoreKeys(name, config.semaphore, StringCodec.UTF8)
+        connection.sync().del(*keys.all.toTypedArray())
+        val future = LettucePermitExpirableSemaphore.create(connection, name, config)
+        val suspending = LettuceSuspendPermitExpirableSemaphore.create(connection, name, config)
+        try {
+            future.trySetPermits(1)
+            val owner = SemaphoreOwnerId.from("boundary-owner")
+            val request = SemaphoreRequestId.from("boundary-request")
+            assertFailsWith<IllegalArgumentException> { future.tryAcquire(owner, request, 0) }
+            assertFailsWith<IllegalArgumentException> {
+                future.acquire(owner, request, 1, Duration.ZERO)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                future.acquire(owner, request, 1, Duration.ofHours(24).plusMillis(1))
+            }
+
+            val held = future.tryAcquire(owner, request, 1)
+                .shouldBeInstanceOf<PermitAcquireResult.Acquired<ExpirablePermitHandle>>()
+                .handle
+            assertFailsWith<IllegalArgumentException> {
+                future.renew(held, Duration.ofMillis(99))
+            }
+            future.acquire(
+                SemaphoreOwnerId.from("sync-timeout"),
+                SemaphoreRequestId.from("sync-timeout"),
+                1,
+                Duration.ofMillis(35),
+            ) shouldBeEqualTo PermitAcquireResult.TimedOut
+            future.acquireAsync(
+                SemaphoreOwnerId.from("async-timeout"),
+                SemaphoreRequestId.from("async-timeout"),
+                1,
+                Duration.ofMillis(35),
+            ).get() shouldBeEqualTo PermitAcquireResult.TimedOut
+            suspending.acquire(
+                SemaphoreOwnerId.from("suspend-timeout"),
+                SemaphoreRequestId.from("suspend-timeout"),
+                1,
+                Duration.ofMillis(35),
+            ) shouldBeEqualTo PermitAcquireResult.TimedOut
+
+            future.close()
+            future.availablePermitsAsync().get() shouldBeEqualTo -1
+            future.inspectAsync(held).get() shouldBeEqualTo PermitInspectResult.Closed
+            future.releaseAsync(held).get() shouldBeEqualTo PermitMutationResult.Closed
+            future.renewAsync(held, Duration.ofSeconds(1)).get() shouldBeEqualTo PermitRenewResult.Closed
+            future.reconcileAsync(owner, request).get() shouldBeEqualTo PermitReconcileResult.Closed
+        } finally {
+            future.close()
+            suspending.close()
             connection.sync().del(*keys.all.toTypedArray())
             connection.close()
         }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettucePermitExpirableSemaphoreTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettucePermitExpirableSemaphoreTest.kt
@@ -150,4 +150,43 @@ class LettucePermitExpirableSemaphoreTest: AbstractLettuceTest() {
             connection.close()
         }
     }
+
+    @Test
+    fun `async reconcile and closed surfaces preserve expirable allocation ownership`() {
+        val connection = LettuceTestUtils.client.connect(StringCodec.UTF8)
+        val name = "expirable-reconcile-${randomName().substringAfter(':')}"
+        val config = ExpirableSemaphoreConfig(leaseTime = Duration.ofSeconds(5))
+        val keys = deriveSemaphoreKeys(name, config.semaphore, StringCodec.UTF8)
+        connection.sync().del(*keys.all.toTypedArray())
+        val semaphore = LettucePermitExpirableSemaphore.create(connection, name, config)
+        try {
+            semaphore.trySetPermitsAsync(2).get()
+                .shouldBeInstanceOf<SemaphoreInitializationResult.Initialized>()
+            semaphore.availablePermitsAsync().get() shouldBeEqualTo 2
+
+            val owner = SemaphoreOwnerId.from("reconcile-owner")
+            val request = SemaphoreRequestId.from("reconcile-request")
+            val handle = semaphore.tryAcquireAsync(owner, request).get()
+                .shouldBeInstanceOf<PermitAcquireResult.Acquired<ExpirablePermitHandle>>()
+                .handle
+            semaphore.reconcileAsync(owner, request).get()
+                .shouldBeInstanceOf<PermitReconcileResult.Owned<ExpirablePermitHandle>>()
+            semaphore.releaseAsync(handle).get()
+                .shouldBeInstanceOf<PermitMutationResult.Released<ExpirablePermitHandle>>()
+            semaphore.reconcile(owner, request) shouldBeEqualTo PermitReconcileResult.Released
+            semaphore.reconcileAsync(
+                SemaphoreOwnerId.from("missing-owner"),
+                SemaphoreRequestId.from("missing-request"),
+            ).get() shouldBeEqualTo PermitReconcileResult.NotFound
+
+            semaphore.close()
+            semaphore.availablePermitsAsync().get() shouldBeEqualTo -1
+            semaphore.tryAcquireAsync(owner, SemaphoreRequestId.from("after-close")).get() shouldBeEqualTo
+                PermitAcquireResult.Closed
+        } finally {
+            semaphore.close()
+            connection.sync().del(*keys.all.toTypedArray())
+            connection.close()
+        }
+    }
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerTypesTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/SynchronizerTypesTest.kt
@@ -4,6 +4,12 @@ import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotContain
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InvalidObjectException
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.Serializable
 import java.time.Duration
 
 class SynchronizerTypesTest {
@@ -65,5 +71,187 @@ class SynchronizerTypesTest {
         inspect shouldBeEqualTo PermitInspectResult.Closed
         renew shouldBeEqualTo PermitRenewResult.Closed
         latch shouldBeEqualTo LatchAwaitResult.Closed
+    }
+
+    @Test
+    fun `all synchronizer result variants preserve their typed outcome and serialization`() {
+        val backendFailure = SynchronizerBackendFailure(
+            SynchronizerBackendFailureKind.TIMEOUT,
+            SynchronizerRecoveryAction.RECONCILE_REQUEST,
+        )
+        val integrityFailure = SynchronizerIntegrityFailure(
+            SynchronizerIntegrityFailureKind.MALFORMED_REPLY,
+        )
+        val permit = PermitHandle(
+            objectFingerprint = "fingerprint",
+            ownerId = SemaphoreOwnerId.from("owner"),
+            generation = 7,
+            requestId = SemaphoreRequestId.from("request"),
+            permits = 2,
+            token = "allocation",
+        )
+        val expirable = ExpirablePermitHandle(
+            permit = permit,
+            leases = listOf(
+                ExpirablePermitLease("permit-1", 1_000),
+                ExpirablePermitLease("permit-2", 1_001),
+            ),
+        )
+        val generation = LatchGeneration(3)
+        val samples = listOf<Serializable>(
+            backendFailure,
+            integrityFailure,
+            SemaphoreInitializationResult.Initialized(1),
+            SemaphoreInitializationResult.AlreadyInitialized,
+            SemaphoreInitializationResult.InvalidCapacity,
+            SemaphoreInitializationResult.Closed,
+            SemaphoreInitializationResult.BackendFailure(backendFailure),
+            SemaphoreInitializationResult.IntegrityFailure(integrityFailure),
+            PermitAcquireResult.Acquired(permit),
+            PermitAcquireResult.Unavailable,
+            PermitAcquireResult.TimedOut,
+            PermitAcquireResult.CapacityExceeded,
+            PermitAcquireResult.Closed,
+            PermitAcquireResult.BackendFailure(backendFailure),
+            PermitAcquireResult.IntegrityFailure(integrityFailure),
+            PermitAcquireResult.Ambiguous(SemaphoreRequestId.from("acquire-request")),
+            PermitMutationResult.Released(expirable, 1),
+            PermitMutationResult.AlreadyReleased,
+            PermitMutationResult.Expired,
+            PermitMutationResult.StaleGeneration,
+            PermitMutationResult.Closed,
+            PermitMutationResult.BackendFailure(backendFailure),
+            PermitMutationResult.IntegrityFailure(integrityFailure),
+            PermitMutationResult.Ambiguous(SemaphoreRequestId.from("mutation-request")),
+            PermitInspectResult.Owned(expirable, 1),
+            PermitInspectResult.Released,
+            PermitInspectResult.Expired,
+            PermitInspectResult.StaleGeneration,
+            PermitInspectResult.Closed,
+            PermitInspectResult.BackendFailure(backendFailure),
+            PermitInspectResult.IntegrityFailure(integrityFailure),
+            PermitReconcileResult.Owned(expirable, 1),
+            PermitReconcileResult.Released,
+            PermitReconcileResult.NotFound,
+            PermitReconcileResult.StaleGeneration,
+            PermitReconcileResult.Closed,
+            PermitReconcileResult.BackendFailure(backendFailure),
+            PermitReconcileResult.IntegrityFailure(integrityFailure),
+            PermitRenewResult.Renewed(expirable),
+            PermitRenewResult.Released,
+            PermitRenewResult.Expired,
+            PermitRenewResult.OwnershipLost,
+            PermitRenewResult.StaleGeneration,
+            PermitRenewResult.Closed,
+            PermitRenewResult.BackendFailure(backendFailure),
+            PermitRenewResult.IntegrityFailure(integrityFailure),
+            PermitRenewResult.Ambiguous(SemaphoreRequestId.from("renew-request")),
+            LatchSetCountResult.Created(generation),
+            LatchSetCountResult.ActiveGeneration(generation, 2),
+            LatchSetCountResult.InvalidCount,
+            LatchSetCountResult.Closed,
+            LatchSetCountResult.BackendFailure(backendFailure),
+            LatchSetCountResult.IntegrityFailure(integrityFailure),
+            LatchCountResult.Active(generation, 2, 1),
+            LatchCountResult.Completed(generation),
+            LatchCountResult.Deleted,
+            LatchCountResult.StaleGeneration,
+            LatchCountResult.Closed,
+            LatchCountResult.BackendFailure(backendFailure),
+            LatchCountResult.IntegrityFailure(integrityFailure),
+            LatchAwaitResult.Completed,
+            LatchAwaitResult.TimedOut,
+            LatchAwaitResult.Deleted,
+            LatchAwaitResult.StaleGeneration,
+            LatchAwaitResult.CapacityExceeded,
+            LatchAwaitResult.Closed,
+            LatchAwaitResult.BackendFailure(backendFailure),
+            LatchAwaitResult.IntegrityFailure(integrityFailure),
+            LatchAwaitResult.Ambiguous(LatchRequestId.from("await-request")),
+            LatchMutationResult.Decremented(1),
+            LatchMutationResult.Completed,
+            LatchMutationResult.AlreadyCompleted,
+            LatchMutationResult.Deleted,
+            LatchMutationResult.NotFound,
+            LatchMutationResult.StaleGeneration,
+            LatchMutationResult.ActiveWaiters(1),
+            LatchMutationResult.Closed,
+            LatchMutationResult.BackendFailure(backendFailure),
+            LatchMutationResult.IntegrityFailure(integrityFailure),
+            LatchMutationResult.Ambiguous(LatchRequestId.from("mutation-request")),
+        )
+
+        samples.forEach { original ->
+            val restored = javaRoundTrip(original)
+            restored shouldBeEqualTo original
+        }
+    }
+
+    @Test
+    fun `typed value objects reject invalid boundaries and preserve redaction`() {
+        assertFailsWith<IllegalArgumentException> { PermitHandle("", SemaphoreOwnerId.from("owner"), 1, SemaphoreRequestId.from("request"), 1, "token") }
+        assertFailsWith<IllegalArgumentException> { PermitHandle("fingerprint", SemaphoreOwnerId.from("owner"), 0, SemaphoreRequestId.from("request"), 1, "token") }
+        assertFailsWith<IllegalArgumentException> { PermitHandle("fingerprint", SemaphoreOwnerId.from("owner"), 1, SemaphoreRequestId.from("request"), 0, "token") }
+        assertFailsWith<IllegalArgumentException> { ExpirablePermitLease("", 1) }
+        assertFailsWith<IllegalArgumentException> { ExpirablePermitLease("permit", 0) }
+        assertFailsWith<IllegalArgumentException> { ExpirablePermitHandle(PermitHandle("fingerprint", SemaphoreOwnerId.from("owner"), 1, SemaphoreRequestId.from("request"), 2, "token"), listOf(ExpirablePermitLease("same", 1), ExpirablePermitLease("same", 2))) }
+        assertFailsWith<IllegalArgumentException> { LatchGeneration(0) }
+        assertFailsWith<IllegalArgumentException> { PermitMutationResult.Released(permitHandle, -1) }
+        assertFailsWith<IllegalArgumentException> { PermitInspectResult.Owned(permitHandle, -1) }
+        assertFailsWith<IllegalArgumentException> { LatchSetCountResult.ActiveGeneration(LatchGeneration(1), -1) }
+        assertFailsWith<IllegalArgumentException> { LatchCountResult.Active(LatchGeneration(1), 0, 0) }
+        assertFailsWith<IllegalArgumentException> { LatchMutationResult.ActiveWaiters(0) }
+
+        PermitAcquireResult.Ambiguous(SemaphoreRequestId.from("secret-request")).toString() shouldNotContain "secret-request"
+        LatchAwaitResult.Ambiguous(LatchRequestId.from("secret-request")).toString() shouldNotContain "secret-request"
+    }
+
+    @Test
+    fun `configuration validates namespace slot and waiter lifecycle bounds`() {
+        SemaphoreConfig(namespace = "orders:v1", hashTag = "orders", maxPermits = 1).maxPermits shouldBeEqualTo 1
+        LatchConfig(namespace = "orders:v1", hashTag = "orders", maxCount = 1, maxWaiters = 1).maxWaiters shouldBeEqualTo 1
+
+        listOf("", "white space", "{slot}", "-starts-with-dash").forEach { namespace ->
+            assertFailsWith<IllegalArgumentException> { SemaphoreConfig(namespace = namespace) }
+            assertFailsWith<IllegalArgumentException> { LatchConfig(namespace = namespace) }
+        }
+        assertFailsWith<IllegalArgumentException> { SemaphoreConfig(hashTag = "unsafe|tag") }
+        assertFailsWith<IllegalArgumentException> { SemaphoreConfig(maxPermits = 1_000_001) }
+        assertFailsWith<IllegalArgumentException> { LatchConfig(maxWaiters = 0) }
+        assertFailsWith<IllegalArgumentException> { LatchConfig(waiterCleanupGrace = Duration.ofMinutes(6)) }
+        assertFailsWith<IllegalArgumentException> { ExpirableSemaphoreConfig(maxPermitsPerAcquire = 65) }
+        assertFailsWith<IllegalArgumentException> { ExpirableSemaphoreConfig(cleanupBatchLimit = 1_025) }
+    }
+
+    @Test
+    fun `deserialization revalidates opaque identities and fails closed`() {
+        val invalidOwner = SemaphoreOwnerId.from("owner").withField("value", "owner|bad")
+        val error = assertFailsWith<InvalidObjectException> { javaRoundTrip(invalidOwner) }
+        error.cause shouldBeEqualTo null
+        error.message shouldBeEqualTo "Invalid serialized ${invalidOwner.javaClass.simpleName}."
+    }
+
+    private fun <T: Serializable> T.withField(name: String, value: Any?): T = apply {
+        javaClass.getDeclaredField(name).also { field ->
+            field.isAccessible = true
+            field.set(this, value)
+        }
+    }
+
+    private fun javaRoundTrip(original: Serializable): Any =
+        ByteArrayOutputStream().use { bytes ->
+            ObjectOutputStream(bytes).use { output -> output.writeObject(original) }
+            ObjectInputStream(ByteArrayInputStream(bytes.toByteArray())).use { input -> input.readObject() }
+        }
+
+    private companion object {
+        val permitHandle = PermitHandle(
+            objectFingerprint = "fingerprint",
+            ownerId = SemaphoreOwnerId.from("owner"),
+            generation = 1,
+            requestId = SemaphoreRequestId.from("request"),
+            permits = 1,
+            token = "token",
+        )
     }
 }


### PR DESCRIPTION
## 요약

PR #1454의 fail-closed Kover 집계가 드러낸 Lettuce coverage 잔여를 실제 public 동작 경계 테스트로 보강한다. production API, workflow, threshold는 변경하지 않는다.

## stacked PR train

- Epic: #1418 Slot 3 보정 child
- Parent: #1454 / `feat/1418-03-dynamic-property-registry`
- Child base: `b7148f2c4246ba5ccf3ff883119f86d0260780b5` (parent exact head)
- Child head: `e36bf31d666179739d84e7028380bd4c96922007` / `feat/1418-03a-lettuce-coverage-uplift`
- 다음: child review·fresh approval 후 parent exact-head gate를 재평가하고, 그 후 #1337 Slot 4를 재개한다.

## 변경 범위

- `infra/lettuce`: Fenced/ReadWrite lock의 blocking·async·suspend handle validation·timeout·reconcile 경계와 loaded map/synchronizer의 stale generation·replay·dead-letter·close 경계를 실제 Redis 동작으로 검증했다.
- `cache/cache-lettuce`: near-cache factory/config DSL과 LettuceCaches 명시 config, blocking/suspend write-through·tracking·lifecycle 경계를 실제 Redis/Testcontainers 동작으로 검증했다.
- 추가 테스트는 behavior assertion만 포함하며 production source, CI workflow, Coveralls threshold, N/A/override, characterization/performance/topology 범위는 변경하지 않았다.

## 검증

- targeted lock/synchronizer tests: 30/30 PASS
- `:bluetape4k-lettuce:test` 및 `:bluetape4k-cache-lettuce:test`를 포함한 fresh Kover 실행: 897 tests PASS; 두 XML report 생성
- local Kover line read-back: `infra/lettuce` 85.998% (7,849/9,127), `cache/cache-lettuce` 88.634% (1,006/1,135)
- detekt (두 module): exit 0; 기존 production generic-catch/test 경고는 남아 있음
- `git diff --check HEAD^ HEAD`: PASS; worktree clean
- hosted exact-head run [32351046396](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32351046396): 20/20 jobs PASS, head `e36bf31d...` 일치
- Coveralls [build 81266917](https://coveralls.io/builds/81266917): status success, coverage `81.032%` (no base build to compare)
- Develop 비교 기준 `81.507%`: 잔여 `-0.475pp`; threshold 완화나 예외 처리는 하지 않았다. hosted aggregate artifact의 43개 expected report XML을 재합산한 instruction 보조 수치는 `239,136 / 277,980 = 86.026%`다.

## 잔여 및 다음 조치

Coveralls exact 결과는 성공했지만 Develop 기준보다 0.475pp 낮다. Issue #1455 수용 기준에 따라 residual 수치와 scope를 기록했으며, 남은 저커버리지 중심은 `MultiLockClient`, `ReadWriteLockClient`, `FencedLockClient`, `LettuceLoadedMap`의 운영·재시도 경계다. child merge 후 parent에서 동일 fail-closed workflow를 재실행해 최종 release gate를 판단한다.

## DoD Status

Required checks: 20/20; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 — Parent boundary | parent exact head를 child base로 고정 | PASS | base `b7148f2c...`; ancestry read-back | none |
| C-02 — Behavior scope | Lettuce/cache-lettuce test-only uplift | PASS | head `e36bf31d...`; production/workflow diff 없음 | none |
| C-03 — Local tests | 두 module fresh test/Kover 실행 | PASS | targeted 30/30; full 897; XML reports | none |
| C-04 — Static checks | detekt 및 diff check | PASS | detekt exit 0; diff check PASS | 기존 경고는 남아 있음 |
| C-05 — Hosted CI | child exact head required jobs | PASS | run `32351046396`, 20/20 success | workflow_dispatch라 PR rollup에는 별도 context가 없으므로 run URL을 기준 증거로 사용 |
| C-06 — Coveralls | Develop baseline 회복 또는 residual 기록 | PASS WITH RESIDUAL | build `81266917`, `81.032%`; baseline `81.507%`; `-0.475pp` 기록 | threshold 완화 금지; parent exact-head 재실행에서 최종 release gate 판단 |
| C-07 — Review/merge gate | independent review와 fresh merge approval | PENDING | 현재 review 0건, approval 0건 | 승인 전 merge 금지 |

Final status: PENDING — child의 exact-head CI/Coveralls 및 residual 기록은 완료됐고, review·fresh merge approval·parent 재검증이 남아 있다.

Unchecked required items: C-07; independent review; fresh merge approval; parent exact-head CI/Coveralls rerun.