### PR TITLE
[test][coverage] Lettuce lock·map 잔여 경계를 보강한다

### DIFF
--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceResidualLockCoverageTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/lock/LettuceResidualLockCoverageTest.kt
@@ -1,0 +1,180 @@
+package io.bluetape4k.redis.lettuce.lock
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.bluetape4k.redis.lettuce.lock.internal.deriveFencedLockKeys
+import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.future.await
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+/** 잔여 lock client 경계를 실제 Redis 상태 전이로 고정합니다. */
+internal class LettuceResidualLockCoverageTest {
+
+    @Test
+    fun `blocking future read write surfaces cover mutation and downgrade`() = runSuspendIO {
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
+            val lock = LettuceReadWriteLock.create(connection, "residual-rw-${System.nanoTime()}")
+            try {
+                val read = lock.readLock().tryAcquire(OWNER_1, REQUEST_1, LEASE)
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<ReadLockHandle>>()
+                    .handle
+                lock.readLock().inspectAsync(read).await()
+                    .shouldBeInstanceOf<LockInspectResult.Owned<ReadLockHandle>>()
+                lock.readLock().reconcileAsync(OWNER_1, REQUEST_1).await()
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<ReadLockHandle>>()
+                lock.readLock().renewAsync(read, Duration.ofSeconds(1)).await()
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<ReadLockHandle>>()
+                lock.readLock().releaseAsync(read).await() shouldBeEqualTo LockMutationResult.Released(0)
+
+                val write = lock.writeLock().tryAcquireAsync(OWNER_2, REQUEST_2, LEASE).await()
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<WriteLockHandle>>()
+                    .handle
+                lock.writeLock().inspectAsync(write).await()
+                    .shouldBeInstanceOf<LockInspectResult.Owned<WriteLockHandle>>()
+                lock.writeLock().reconcileAsync(OWNER_2, REQUEST_2).await()
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<WriteLockHandle>>()
+                lock.writeLock().renewAsync(write, Duration.ofSeconds(1)).await()
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<WriteLockHandle>>()
+                val downgraded = lock.downgradeAsync(write).await()
+                    .shouldBeInstanceOf<DowngradeResult.Downgraded>()
+                    .handle
+                lock.readLock().releaseAsync(downgraded).await() shouldBeEqualTo LockMutationResult.Released(0)
+            } finally {
+                lock.close()
+            }
+        }
+    }
+
+    @Test
+    fun `suspending read write acquire paths preserve ownership and phase conversion`() = runSuspendIO {
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
+            val lock = LettuceSuspendReadWriteLock.create(connection, "residual-suspend-rw-${System.nanoTime()}")
+            try {
+                val read = lock.readLock().acquire(OWNER_1, REQUEST_1, Duration.ofMillis(200), LEASE)
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<ReadLockHandle>>()
+                    .handle
+                lock.readLock().inspect(read)
+                    .shouldBeInstanceOf<LockInspectResult.Owned<ReadLockHandle>>()
+                lock.readLock().reconcile(OWNER_1, REQUEST_1)
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<ReadLockHandle>>()
+                lock.readLock().renew(read, Duration.ofSeconds(1))
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<ReadLockHandle>>()
+                lock.readLock().release(read) shouldBeEqualTo LockMutationResult.Released(0)
+
+                val write = lock.writeLock().acquire(OWNER_2, REQUEST_2, Duration.ofMillis(200), LEASE)
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<WriteLockHandle>>()
+                    .handle
+                lock.writeLock().inspect(write)
+                    .shouldBeInstanceOf<LockInspectResult.Owned<WriteLockHandle>>()
+                lock.writeLock().reconcile(OWNER_2, REQUEST_2)
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<WriteLockHandle>>()
+                lock.writeLock().renew(write, Duration.ofSeconds(1))
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<WriteLockHandle>>()
+                val downgraded = lock.downgrade(write)
+                    .shouldBeInstanceOf<DowngradeResult.Downgraded>()
+                    .handle
+                lock.readLock().release(downgraded) shouldBeEqualTo LockMutationResult.Released(0)
+            } finally {
+                lock.close()
+            }
+        }
+    }
+
+    @Test
+    fun `multi adapters retain request identity`() = runSuspendIO {
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
+            val multiConfig = MultiLockConfig(lock = LockConfig(hashTag = "residual-multi-${System.nanoTime()}"))
+            val multi = LettuceMultiLock.create(connection, listOf("account", "inventory"), multiConfig)
+            val suspendingMulti = LettuceSuspendMultiLock.create(
+                connection,
+                listOf("account", "inventory"),
+                multiConfig,
+            )
+            try {
+                val multiHandle = multi.acquireAsync(OWNER_1, REQUEST_1, Duration.ofMillis(200), LEASE).await()
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<MultiLockHandle>>()
+                    .handle
+                multi.inspectAsync(multiHandle).await()
+                    .shouldBeInstanceOf<LockInspectResult.Owned<MultiLockHandle>>()
+                multi.reconcileAsync(OWNER_1, REQUEST_1).await()
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<MultiLockHandle>>()
+                multi.renewAsync(multiHandle, Duration.ofSeconds(1)).await()
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<MultiLockHandle>>()
+                multi.releaseAsync(multiHandle).await() shouldBeEqualTo LockMutationResult.Released(0)
+
+                val suspendingHandle = suspendingMulti.acquire(OWNER_2, REQUEST_2, Duration.ofMillis(200), LEASE)
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<MultiLockHandle>>()
+                    .handle
+                suspendingMulti.inspect(suspendingHandle)
+                    .shouldBeInstanceOf<LockInspectResult.Owned<MultiLockHandle>>()
+                suspendingMulti.reconcile(OWNER_2, REQUEST_2)
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<MultiLockHandle>>()
+                suspendingMulti.renew(suspendingHandle, Duration.ofSeconds(1))
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<MultiLockHandle>>()
+                suspendingMulti.release(suspendingHandle) shouldBeEqualTo LockMutationResult.Released(0)
+            } finally {
+                multi.close()
+                suspendingMulti.close()
+            }
+        }
+    }
+
+    @Test
+    fun `fenced adapters retain request identity`() = runSuspendIO {
+        LettuceTestUtils.client.connect(StringCodec.UTF8).use { connection ->
+            val fencedConfig = FencedLockConfig(epoch = 61)
+            val fencedName = "residual-fenced-${System.nanoTime()}"
+            val fenced = LettuceFencedLock.create(connection, fencedName, fencedConfig)
+            val suspendingFenced = LettuceSuspendFencedLock.create(connection, fencedName, fencedConfig)
+            val keys = deriveFencedLockKeys(fencedName, fencedConfig, connection.codec)
+            try {
+                fenced.bootstrapFencing() shouldBeEqualTo FencedBootstrapResult.Initialized
+                val holder = fenced.tryAcquire(OWNER_1, REQUEST_1, LEASE)
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
+                    .handle
+                val pending = fenced.acquireAsync(OWNER_2, REQUEST_2, Duration.ofSeconds(1), LEASE)
+                fenced.release(holder) shouldBeEqualTo LockMutationResult.Released(0)
+
+                val acquired = pending.await()
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
+                    .handle
+                fenced.inspectAsync(acquired).await()
+                    .shouldBeInstanceOf<LockInspectResult.Owned<FencedLockHandle>>()
+                fenced.reconcileAsync(OWNER_2, REQUEST_2).await()
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<FencedLockHandle>>()
+                fenced.renewAsync(acquired, Duration.ofSeconds(1)).await()
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<FencedLockHandle>>()
+                fenced.releaseAsync(acquired).await() shouldBeEqualTo LockMutationResult.Released(0)
+
+                suspendingFenced.bootstrapFencing() shouldBeEqualTo FencedBootstrapResult.AlreadyInitialized
+                val suspendHandle = suspendingFenced.acquire(OWNER_3, REQUEST_3, Duration.ofMillis(200), LEASE)
+                    .shouldBeInstanceOf<LockAcquireResult.Acquired<FencedLockHandle>>()
+                    .handle
+                suspendingFenced.inspect(suspendHandle)
+                    .shouldBeInstanceOf<LockInspectResult.Owned<FencedLockHandle>>()
+                suspendingFenced.reconcile(OWNER_3, REQUEST_3)
+                    .shouldBeInstanceOf<LockReconcileResult.Owned<FencedLockHandle>>()
+                suspendingFenced.renew(suspendHandle, Duration.ofSeconds(1))
+                    .shouldBeInstanceOf<LockMutationResult.Renewed<FencedLockHandle>>()
+                suspendingFenced.release(suspendHandle) shouldBeEqualTo LockMutationResult.Released(0)
+            } finally {
+                fenced.close()
+                suspendingFenced.close()
+                connection.sync().del(*keys.all)
+            }
+        }
+    }
+
+    private companion object {
+        val OWNER_1 = LockOwnerId.from("residual-owner-1")
+        val OWNER_2 = LockOwnerId.from("residual-owner-2")
+        val OWNER_3 = LockOwnerId.from("residual-owner-3")
+        val REQUEST_1 = LockRequestId.from("residual-request-1")
+        val REQUEST_2 = LockRequestId.from("residual-request-2")
+        val REQUEST_3 = LockRequestId.from("residual-request-3")
+        val LEASE = LeasePolicy.Fixed(Duration.ofSeconds(3))
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceResidualMapCoverageTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceResidualMapCoverageTest.kt
@@ -1,0 +1,75 @@
+package io.bluetape4k.redis.lettuce.map
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.lettuce.core.codec.StringCodec
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Loaded map의 write-behind 재시도와 일괄 삭제 경계를 실제 Redis로 검증합니다. */
+internal class LettuceResidualMapCoverageTest: AbstractLettuceTest() {
+
+    @Test
+    fun `blocking write-behind exhaustion persists failed keys in dead-letter`() {
+        val prefix = "residual-loaded-map:${randomName()}"
+        val attempts = AtomicInteger(0)
+        val writer = object: MapWriter<String, String> {
+            override fun write(map: Map<String, String>) {
+                attempts.incrementAndGet()
+                error("residual write failure")
+            }
+
+            override fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofMillis(20),
+            writeBehindBatchSize = 1,
+        )
+
+        LettuceLoadedMap(client = client, writer = writer, config = config).use { map ->
+            map["dead-key"] = "dead-value"
+
+            val connection = client.connect(StringCodec.UTF8)
+            try {
+                val deadline = System.currentTimeMillis() + 2_000L
+                var keys = emptyList<String>()
+                while (System.currentTimeMillis() < deadline && keys.none { it == "dead-key" }) {
+                    keys = connection.sync().lrange("$prefix:dead-letter", 0L, -1L)
+                    if (keys.none { it == "dead-key" }) Thread.sleep(25L)
+                }
+                keys.contains("dead-key").shouldBeTrue()
+                attempts.get() shouldBeEqualTo 3
+            } finally {
+                connection.close()
+            }
+        }
+    }
+
+    @Test
+    fun `suspending write-through deleteAll invokes writer and removes every cache key`() = runSuspendIO {
+        val deleted = mutableListOf<String>()
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) = Unit
+
+            override suspend fun delete(keys: Collection<String>) {
+                deleted.addAll(keys)
+            }
+        }
+        val config = LettuceCacheConfig.READ_WRITE_THROUGH.copy(keyPrefix = "residual-suspend-map:${randomName()}")
+
+        LettuceSuspendedLoadedMap(client = client, writer = writer, config = config).use { map ->
+            map.set("k1", "v1")
+            map.set("k2", "v2")
+            map.deleteAll(listOf("k1", "k2"))
+
+            deleted shouldBeEqualTo listOf("k1", "k2")
+            map.get("k1").shouldBeNull()
+            map.get("k2").shouldBeNull()
+        }
+    }
+}


### PR DESCRIPTION
## 목적

부모 PR #1454의 Coveralls 기준선 회귀를 threshold 완화 없이 보강하기 위해
Lettuce lock/map의 실제 Redis 잔여 경계를 test-only child로 고정한다.

## stacked PR train

- Epic: #1418 Slot 3 보정
- Parent/base: #1454 / `feat/1418-03-dynamic-property-registry`
- Parent exact base: `66e4523e70f7906c36a33ed4e65c2eae6defb32f`
- Head: `f86a92b50ec2175f5d0e49cb479df3df52b20941`
- 선행 child: #1455 CLOSED, PR #1456 MERGED
- Linked issue: #1457

## 변경 범위

- `LettuceResidualLockCoverageTest`: read/write blocking·future·suspend acquire,
  inspect/reconcile/renew/release, downgrade, MultiLock/FencedLock request identity
  경계를 실제 Redis로 검증한다.
- `LettuceResidualMapCoverageTest`: blocking write-behind 재시도 dead-letter와
  suspended write-through `deleteAll` 경계를 검증한다.
- production/API/config/dependency/workflow/threshold 변경 없음.

## 검증

- 신규 residual tests: **6 passing** (lock 4, map 2)
- `:bluetape4k-lettuce:koverLog`: application line coverage `86.5125%`
- `:bluetape4k-lettuce:detekt`: PASS
- 전체 Lettuce test: `902 passing / 1 failing`; 기존 `LettuceFairLockTest`의
  `waiter was not removed` 일회성 실패는 해당 클래스 재실행에서 PASS
- `detektTest`: 기존 baseline 76건으로 실패; 신규 파일 findings 없음
- `git diff --check`: PASS

### child CI 재확인

- workflow_dispatch run `32363605246`가 child head `f86a92b50ec2175f5d0e49cb479df3df52b20941`에서 **20/20 jobs success**로 종료했다.
- Coverage Report aggregate: **92.41%** (`239568` instruction covered / `19678` missed); `infra/lettuce` **94.42%**.
- Coveralls child exact-head: **81.15%**, [job #186510820](https://coveralls.io/jobs/186510820) API upload success.
- 최신 PR 상태 컨텍스트 `coverage/coveralls`와 `coverage/coveralls (push)`가 모두 **PASS**로 live read-back되었다. Coveralls는 child에 base build 비교를 제공하지 않아 develop `81.507%` 대비 `-0.357pp`는 참고값이며, parent 직전 `81.054%` vs develop `81.507%` 회귀와는 별도로 기록한다.

## 운영/회귀 경계

- Docker/Redis failure는 raw log 없이 재시도로 숨기지 않는다.
- 부모 exact-head aggregate/Coveralls가 develop `81.507%` 이상으로 회복되는지
  child merge 후 다시 확인한다. 회복되지 않으면 residual 수치와 다음 child 범위를
  parent DoD에 기록하고 merge를 보류한다.

Closes #1457

## DoD Status

- 상태: **PENDING — fresh exact-head merge approval 및 parent 재검증 대기**
- Required checks: workflow_dispatch `32363605246` 20/20 jobs success; 최신 `coverage/coveralls` 및 `coverage/coveralls (push)` PR 상태 컨텍스트 PASS
- Coveralls: child exact-head **81.15%**, [job #186510820](https://coveralls.io/jobs/186510820) API upload success; parent 직전 `81.054%` vs develop `81.507%`는 여전히 실패
- Review: fresh exact-head read-back **CLEAR (P0/P1/P2/P3=0)**; formal GitHub approval 없음
- Merge recommendation: **WATCH** — child merge 후 parent exact-head aggregate/Coveralls 재실행 필요
- Unchecked: fresh merge approval, child merge, parent exact-head rerun, parent
  merge, #1321 closeout
