### PR TITLE
[ci][testcontainers] 긴 image gate 출력의 정상 종료 판정을 보존한다

### DIFF
--- a/docs/lessons/2026-08-21-issue-1466-image-gate-result-evidence.md
+++ b/docs/lessons/2026-08-21-issue-1466-image-gate-result-evidence.md
@@ -1,0 +1,38 @@
+# Issue #1466 image gate 결과 증거 보존 lesson
+
+## 배경
+
+PR #1463의 hosted CI run `32480088175`에서 Testcontainers image gate가
+`0/52`로 실패했습니다. 52개 family 중 51개는 Gradle `returncode=0`이었지만
+`blocked`로 집계됐고, K3s 한 family만 `exit 137` infrastructure failure였습니다.
+
+## 원인과 결정
+
+runner가 artifact에 저장할 stdout/stderr를 먼저 12,000자로 축약한 뒤,
+축약본에서 `BUILD SUCCESSFUL` marker를 찾았습니다. Jib/Docker 진행 출력이 긴
+family에서는 성공 marker가 축약 경계 뒤에 있어 정상 종료를 `blocked`로
+오판했습니다.
+
+판정은 원문 stdout/stderr에서 수행하고, artifact와 로그에는 기존의
+bounded·redacted 출력을 계속 저장합니다. marker가 없는 `returncode=0`은
+계속 `blocked`로 유지해 조기 종료나 불완전한 결과를 통과시키지 않습니다.
+
+## 검증
+
+- 긴 성공 출력 회귀 테스트: RED에서 `blocked` 재현, 수정 후 GREEN
+- 기존 성공·product failure·infrastructure retry·timeout·redaction 테스트:
+  PASS
+- hosted CI 재실행: PENDING
+
+## 후속 guard
+
+실행 결과의 판정 입력과 보존 입력을 분리합니다. 출력 제한은 저장 경계에만
+적용하고, 성공·실패 marker 검사는 원문을 사용해야 합니다.
+
+## SPW 감사
+
+- SPW-01: PASS — run URL, head, `0/52`, `exit 137`, 원인과 미검증 범위를 고정했습니다.
+- SPW-02: PASS — 배경, 원인, 결정, 검증, 후속 guard를 포함했습니다.
+- SPW-03: PASS — 한국어 기술 문체와 `returncode`, `BUILD SUCCESSFUL` 토큰을 보존했습니다.
+- SPW-04: PASS — artifact JSON과 runner source/test를 대조했습니다.
+- SPW-05: PASS — 최종 Markdown read-back과 `git diff --check`를 수행할 예정입니다.

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -177,10 +177,12 @@ class GateRunner:
             started = time.monotonic()
             result = self.command_runner(command, self.timeout_seconds)
             elapsed = round(time.monotonic() - started, 3)
-            stdout = _bounded(getattr(result, "stdout", ""))
-            stderr = _bounded(getattr(result, "stderr", ""))
+            raw_stdout = getattr(result, "stdout", "")
+            raw_stderr = getattr(result, "stderr", "")
+            stdout = _bounded(raw_stdout)
+            stderr = _bounded(raw_stderr)
             returncode = getattr(result, "returncode", None)
-            status = _classify_command_result(returncode, stdout, stderr)
+            status = _classify_command_result(returncode, raw_stdout, raw_stderr)
             attempts.append(
                 {
                     "attempt": attempt,

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -97,6 +97,20 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             self.assertEqual("blocked", summary["results"][0]["status"])
             self.assertFalse(summary["release_gate"])
 
+    def test_success_after_long_gradle_output_is_not_blocked(self) -> None:
+        long_success = ("progress\n" * 4000) + "BUILD SUCCESSFUL\n"
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [entry()],
+                Path(directory),
+                command_runner=lambda command, timeout_seconds: SimpleNamespace(
+                    returncode=0, stdout=long_success, stderr=""
+                ),
+                max_attempts=1,
+            ).run()
+            self.assertEqual("success", summary["results"][0]["status"])
+            self.assertTrue(summary["release_gate"])
+
     def test_secret_redaction_applies_to_artifact_text(self) -> None:
         safe = redact("TOKEN=super-secret password=hunter2 Authorization: Bearer abc123")
         self.assertNotIn("super-secret", safe)


### PR DESCRIPTION
## 변경 요약

Closes #1466

PR #1463의 hosted CI `32480088175`에서 정상 종료한 Testcontainers image family가
artifact 출력 축약 때문에 `blocked`로 오판된 결과 판정 결함을 수정합니다.

## 변경 유형

- [x] `fix` — 버그 수정
- [x] `test` — 회귀 테스트 추가
- [x] `docs` — lesson 기록

## 원인

`GateRunner`가 stdout/stderr를 12,000자로 축약한 뒤 `BUILD SUCCESSFUL` marker를
검사했습니다. Jib/Docker 진행 출력이 긴 family에서는 marker가 축약 경계 뒤에
있어 `returncode=0`인 결과가 `blocked`가 됐습니다. 부모 run의 결과는 `0/52`,
`infrastructure_failure=1`, `blocked=51`이었고, K3s의 `exit 137`은 별도 인프라
실패입니다.

## 변경 내용

- 성공·실패 분류는 원문 stdout/stderr를 사용합니다.
- artifact와 로그의 bounded·redacted 보존 출력은 유지합니다.
- 긴 성공 출력이 `success`가 되는 회귀 테스트를 추가했습니다.
- 결과 판정 경계와 운영 교훈을 [lesson](https://github.com/bluetape4k/bluetape4k-projects/blob/fix/1418-06-image-gate-result-evidence/docs/lessons/2026-08-21-issue-1466-image-gate-result-evidence.md)에 기록했습니다.

## 검증

- RED: 긴 출력 회귀 테스트가 기존 구현에서 `blocked`로 실패
- GREEN: `python3 -m unittest scripts.test_run_testcontainers_image_gate scripts.test_testcontainers_image_gate -v` → 13 passing
- `python3 -m py_compile scripts/run_testcontainers_image_gate.py scripts/test_run_testcontainers_image_gate.py` → PASS
- Korean terminology audit → PASS, findings=0
- `git diff --check HEAD^ HEAD` → PASS
- 부모 실패 evidence: [run 32480044880](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32480044880) 및 [PR #1463 gate job](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32480088175/job/96766071327)
- hosted CI 재실행 → PENDING

## Stacked PR train

- 부모 PR: #1463, exact base `develop`, 부모 head `195cc36019c41b5f454721293969efd65e56cbfe`
- 이 PR base: `feat/1418-04-testcontainers-startup-workload-gate`
- 이 PR head: `bcdbf1707d8eddce09f1dfd8f30cd22ccaac958c`
- 후속 child #1465는 이 수정이 부모에 반영된 뒤 base를 갱신해야 합니다.
- Epic #1418 진행률: **3/4** (부모 Slot 4와 후속 slots가 merge 대기 중)

## 메타데이터

- assignee: `debop`
- labels: `test`, `ci`, `tech-debt`
- milestone: `2.0.0`

## DoD Status

Required checks: 13/15; N/A: 2; Blocked: 0

| ID | 상태 | 증거 |
|---|---|---|
| CG-01 | PASS | 부모 exact head 및 실패 로그 확인 |
| CG-02 | PASS | TDD RED 재현 |
| CG-03 | PASS | 원문 판정 + bounded 보존 최소 수정 |
| CG-04 | PASS | 긴 출력 회귀 테스트 GREEN |
| CG-05 | PASS | 기존 13 Python tests PASS |
| CG-06 | PASS | Python compile PASS |
| CG-07 | PASS | Korean terminology audit PASS |
| CG-08 | PASS | `git diff --check` PASS |
| CG-09 | PASS | issue/label/milestone/assignee 확인 |
| CG-10 | PASS | Korean lesson read-back 및 SPW-01~05 기록 |
| CG-11 | PASS | parent/head/merge-base exact 확인 |
| CG-12 | PASS | child branch push 및 SHA read-back |
| CG-13 | PASS | PR body 마지막 섹션을 DoD로 고정 |
| CG-14 | N/A | production API·Kotlin runtime/Testcontainers contract 변경 없음 |
| CG-15 | N/A | 1인 개발 저장소로 독립 human review 없음; automated gate 유지 |
| CG-16 | PASS | cumulative head `838628c06d41b5814388777b3a5a642b1aa05368`: CI 21/21, Nightly 42/42, image gate 52/52 |
| CG-17 | PASS | aggregate 90.61%, Coveralls `81306209` SUCCESS, failures 0 |
| CG-18 | PENDING | fresh merge approval, merge, sync/cleanup |

최종 상태: `PENDING` — 누적 검증 PASS, fresh train merge 승인 대기

Unchecked: `CG-18`
