### PR TITLE
[ci][testcontainers] K3s image gate가 전용 k8s task를 실행하게 한다

### DIFF
--- a/docs/lessons/2026-08-22-issue-1468-k3s-image-gate-discovery.md
+++ b/docs/lessons/2026-08-22-issue-1468-k3s-image-gate-discovery.md
@@ -1,0 +1,59 @@
+# Issue #1468 K3s image gate test-discovery lesson
+
+## 배경
+
+PR #1467 exact head `bcdbf1707d8eddce09f1dfd8f30cd22ccaac958c`의 hosted
+image gate run `32488642030`은 정상 family 51개를 통과시켰지만 K3s를
+`infrastructure_failure`로 보고했습니다. K3s attempt의 실제 Gradle 오류는
+`No tests found for given includes: [io.bluetape4k.testcontainers.infra.K3sServerTest](--tests filter)`였습니다.
+
+## 원인과 예상 밖의 점
+
+`K3sServerTest`는 privileged runner 전용 `@Tag("k8s")` 테스트입니다. 기본
+`:bluetape4k-testcontainers:test` task는 이 태그를 제외하고, 저장소는 이미 전용
+`:bluetape4k-testcontainers:k8sTest` task를 제공합니다. image gate manifest는
+test class만 선언하고 실행 task를 표현하지 않아 K3s 테스트를 발견하지 못했습니다.
+
+같은 Gradle stdout에는 선행 Jib task의 정상 진행 문구
+`building image to Docker daemon`가 포함됐습니다. 실패 분류가 전체 출력의
+`docker daemon` substring을 먼저 사용하면서 결정적인 test-discovery 실패를
+인프라 장애로 덮었습니다. 진단 artifact의 Docker event와 종료 코드는 현재 Gradle
+invocation이 K3s 테스트를 실행했다는 증거가 아니었습니다.
+
+## 결정
+
+- family별 예외 task가 필요할 때 manifest의 선택적 `testTask`가 기존 Gradle task
+  path를 지정하게 합니다.
+- K3s entry는 기존 `:bluetape4k-testcontainers:k8sTest`를 재사용합니다.
+- `Execution failed for task`와 `No tests found for given includes`가 함께 나타나는
+  결정적인 Gradle/test-discovery 실패는 일반적인 Docker 출력 marker보다 먼저
+  `product_failure`로 분류합니다.
+- manifest의 선택적 task는 검증된 allowlist에 있는 기존 task만 허용합니다.
+- 실제 K3s container 검증은 privileged hosted runner에서 순차 실행합니다.
+
+## 검증
+
+- 회귀 테스트 3건: task override, test-discovery 분류 우선순위, K3s manifest task를
+  각각 RED로 재현하고 GREEN으로 전환했습니다.
+- 잘못되거나 알려지지 않은 `testTask` manifest 값: RED/GREEN으로 task path와
+  allowlist 검증을 고정했습니다.
+- incidental test-discovery 문구와 Docker 인프라 오류의 충돌 회귀도 고정했습니다.
+- runner/manifest Python 테스트: 19건 PASS
+- `k8sTest --tests K3sServerTest --dry-run`: `BUILD SUCCESSFUL`, 전용 task 선택 확인
+- hosted full image gate `52/52`: PENDING
+
+## 향후 지침
+
+manifest 기반 실행기는 test class만으로 충분하다고 가정하지 않습니다. 테스트가
+JUnit tag, 별도 source set, 전용 Gradle task, profile/property로 격리되면 그 실행
+경계를 manifest와 회귀 테스트에 함께 선언해야 합니다. 실패 분류는 구체적인 현재
+invocation 오류를 먼저 판정하고, 선행 task나 진단 출력에 흔히 나타나는 일반
+substring은 그 뒤에 적용합니다.
+
+## SPW 감사
+
+- SPW-01: PASS — Issue #1468, run `32488642030`, exact head, source/task와 실제 오류를 고정했습니다.
+- SPW-02: PASS — 배경, 원인, 예상 밖의 점, 결정, 검증, 향후 지침을 포함했습니다.
+- SPW-03: PASS — 한국어 기술 문체를 사용하고 Gradle/JUnit 식별자와 exact error를 보존했습니다.
+- SPW-04: PASS — hosted artifact, `build.gradle.kts`, manifest, runner와 회귀 테스트를 대조했습니다.
+- SPW-05: PASS — 최종 Markdown, terminology audit, `git diff --check`를 read-back합니다.

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -40,6 +40,11 @@ INFRASTRUCTURE_MARKERS = (
     "connection reset",
     "eof",
 )
+TEST_DISCOVERY_FAILURE_PATTERN = re.compile(
+    r"execution failed for task ['\"][^'\"]+['\"].*"
+    r"no tests found for given includes",
+    re.IGNORECASE | re.DOTALL,
+)
 SECRET_PATTERN = re.compile(
     r"(?i)(password|passwd|token|secret|authorization|api[_-]?key)\s*[:=]\s*([^\s,;]+)"
 )
@@ -67,7 +72,11 @@ def classify_failure(returncode: int | None, stdout: str, stderr: str) -> str:
     if returncode == 0:
         return "success"
     haystack = f"{stdout}\n{stderr}".lower()
-    if returncode is None or any(marker in haystack for marker in INFRASTRUCTURE_MARKERS):
+    if returncode is None:
+        return "infrastructure_failure"
+    if TEST_DISCOVERY_FAILURE_PATTERN.search(haystack):
+        return "product_failure"
+    if any(marker in haystack for marker in INFRASTRUCTURE_MARKERS):
         return "infrastructure_failure"
     return "product_failure"
 
@@ -132,6 +141,11 @@ class GateRunner:
 
     def _command(self, entry: dict[str, Any]) -> list[str]:
         command = shlex.split(self.gradle_task)
+        if test_task := entry.get("testTask"):
+            task_positions = [index for index, part in enumerate(command) if part.startswith(":")]
+            if len(task_positions) != 1:
+                raise ValueError(f"expected one Gradle task in command: {self.gradle_task}")
+            command[task_positions[0]] = str(test_task)
         command.extend(("--tests", str(entry["testPattern"]), "--no-configuration-cache"))
         return command
 

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -84,6 +84,44 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
         self.assertEqual("infrastructure_failure", classify_failure(1, "connection refused", ""))
         self.assertEqual("infrastructure_failure", classify_failure(None, "", "timeout"))
 
+    def test_test_discovery_failure_wins_over_unrelated_docker_output(self) -> None:
+        stdout = "building image to Docker daemon\ntimeout while preparing unrelated diagnostics\n"
+        stderr = (
+            "Execution failed for task ':bluetape4k-testcontainers:test'.\n"
+            "> No tests found for given includes: "
+            "[io.bluetape4k.testcontainers.infra.K3sServerTest](--tests filter)"
+        )
+
+        self.assertEqual("product_failure", classify_failure(1, stdout, stderr))
+
+    def test_test_discovery_words_without_gradle_failure_context_do_not_override_infrastructure(self) -> None:
+        stdout = "building image to Docker daemon\n"
+        stderr = "diagnostic note: No tests found for given includes may be reported later"
+
+        self.assertEqual("infrastructure_failure", classify_failure(1, stdout, stderr))
+
+    def test_family_specific_test_task_overrides_the_default_task(self) -> None:
+        calls: list[list[str]] = []
+        k3s = entry("K3sServer")
+        k3s["testTask"] = ":bluetape4k-testcontainers:k8sTest"
+
+        def command_runner(command: list[str], timeout_seconds: int) -> SimpleNamespace:
+            calls.append(command)
+            return SimpleNamespace(returncode=0, stdout="BUILD SUCCESSFUL", stderr="")
+
+        with tempfile.TemporaryDirectory() as directory:
+            GateRunner(
+                [k3s],
+                Path(directory),
+                command_runner=command_runner,
+                max_attempts=1,
+            ).run()
+
+        self.assertEqual(
+            ["./gradlew", ":bluetape4k-testcontainers:k8sTest"],
+            calls[0][:2],
+        )
+
     def test_zero_exit_without_gradle_success_evidence_is_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             summary = GateRunner(

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -25,6 +25,14 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertEqual(EXPECTED_FAMILY_COUNT, len(self.entries))
         self.assertEqual([], validate_manifest(self.entries, self.root))
 
+    def test_k3s_family_uses_the_existing_tagged_test_task(self) -> None:
+        k3s = next(entry for entry in self.entries if entry["server"] == "K3sServer")
+        self.assertEqual(":bluetape4k-testcontainers:k8sTest", k3s["testTask"])
+        build_script = (
+            self.root / "testing/testcontainers/build.gradle.kts"
+        ).read_text(encoding="utf-8")
+        self.assertIn('tasks.register<Test>("k8sTest")', build_script)
+
     def test_changed_scope_is_deterministic_and_full_scope_is_complete(self) -> None:
         changed = select_entries(self.entries, {"testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt"})
         self.assertEqual(["FlociServer"], [entry["server"] for entry in changed])
@@ -36,6 +44,20 @@ class TestTestcontainersImageGate(unittest.TestCase):
     def test_invalid_manifest_reports_drift_without_running_docker(self) -> None:
         invalid = [dict(self.entries[0], image="wrong/image")]
         self.assertIn("image drift", " ".join(validate_manifest(invalid, self.root)))
+
+    def test_invalid_family_specific_test_task_reports_drift(self) -> None:
+        invalid = [dict(self.entries[0], testTask="test")]
+        self.assertIn(
+            "testTask must be a Gradle task path",
+            " ".join(validate_manifest(invalid, self.root)),
+        )
+
+    def test_unknown_family_specific_test_task_reports_drift(self) -> None:
+        invalid = [dict(self.entries[0], testTask=":not-existing-task")]
+        self.assertIn(
+            "unknown testTask",
+            " ".join(validate_manifest(invalid, self.root)),
+        )
 
     def test_ci_workflow_runs_changed_gate_and_uploads_evidence(self) -> None:
         workflow = (self.root / ".github/workflows/ci.yml").read_text(encoding="utf-8")

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -25,6 +25,7 @@ REQUIRED_FIELDS = {
     "diagnostics",
     "releaseRequired",
 }
+KNOWN_TEST_TASKS = {":bluetape4k-testcontainers:k8sTest"}
 
 
 def _contract_module() -> Any:
@@ -132,6 +133,13 @@ def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[
             errors.append(f"diagnostics is empty for {server}")
         if not isinstance(entry["releaseRequired"], bool):
             errors.append(f"releaseRequired must be boolean for {server}")
+        test_task = entry.get("testTask")
+        if test_task is not None and (
+            not isinstance(test_task, str) or not test_task.startswith(":")
+        ):
+            errors.append(f"testTask must be a Gradle task path for {server}")
+        elif test_task is not None and test_task not in KNOWN_TEST_TASKS:
+            errors.append(f"unknown testTask for {server}: {test_task}")
 
     missing_servers = expected_servers - names
     extra_servers = names - expected_servers

--- a/scripts/testcontainers_image_gate_manifest.json
+++ b/scripts/testcontainers_image_gate_manifest.json
@@ -434,6 +434,7 @@
       "image": "rancher/k3s",
       "tag": "v1.36.3-k3s1",
       "testPattern": "io.bluetape4k.testcontainers.infra.K3sServerTest",
+      "testTask": ":bluetape4k-testcontainers:k8sTest",
       "readiness": "k3s_api_and_pod_readiness",
       "workload": "io.bluetape4k.testcontainers.infra.K3sServerTest:representative_test",
       "diagnostics": [


### PR DESCRIPTION
## Summary

Closes #1468

K3s family가 기본 `test` task에서 제외돼 실제 테스트를 찾지 못한 문제를 수정합니다. 기존 전용 `k8sTest` task를 manifest에서 선택하고, Gradle test-discovery 실패를 Docker 인프라 문구보다 정확히 우선 판정합니다.

## Background

PR #1467 exact head `bcdbf1707d8eddce09f1dfd8f30cd22ccaac958c`의 hosted image gate는 51/52를 통과했지만 K3s에서 `No tests found for given includes`로 실패했습니다. `K3sServerTest`는 `@Tag("k8s")`이고 기본 test task가 이 태그를 제외하므로, 전용 task를 선택하지 않은 runner 계약이 원인이었습니다.

## What This Solves

- K3s gate가 `:bluetape4k-testcontainers:k8sTest`를 실행해 tagged test를 실제로 발견합니다.
- 선행 Jib 출력의 `docker daemon`이나 무관한 timeout 문구가 test-discovery product failure를 덮지 않습니다.
- 존재하지 않는 family별 Gradle task가 manifest validation을 통과하지 않습니다.

## Work Done

- Manifest/runner: 선택적 `testTask` 계약과 K3s 전용 task를 추가했습니다.
- Failure classification: 실제 Gradle task failure 문맥이 있을 때만 test-discovery failure로 판정합니다.
- Regression tests: task override, 분류 충돌, task path와 allowlist, Gradle task 선언을 RED/GREEN으로 고정했습니다.
- Lesson: `docs/lessons/2026-08-22-issue-1468-k3s-image-gate-discovery.md`에 원인과 재발 방지 규칙을 기록했습니다.

## Validation

- `python3 -m unittest scripts.test_run_testcontainers_image_gate scripts.test_testcontainers_image_gate`: PASS (19 tests)
- `python3 -m py_compile ...`: PASS
- `./gradlew :bluetape4k-testcontainers:k8sTest --tests io.bluetape4k.testcontainers.infra.K3sServerTest --no-configuration-cache --dry-run`: PASS (`k8sTest` 선택)
- `node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs docs/lessons/2026-08-22-issue-1468-k3s-image-gate-discovery.md`: PASS (findings=0)
- `git diff HEAD^ HEAD --check`: PASS

## Review Notes

- P0/P1/P2: 0
- P3: hosted full image gate `52/52` 증거가 필요합니다.
- Review evidence: 독립 code-reviewer 재검토 `CLEAR`; Python 19 tests, AST/JSON parse, diff check 통과

## Metadata

- Issue: #1468, milestone `2.0.0`, assignee `debop`
- Stack base: `fix/1418-06-image-gate-result-evidence` @ `bcdbf1707d8eddce09f1dfd8f30cd22ccaac958c`
- PR head: `fix/1418-07-k3s-gate-discovery` @ `9db9a18fe48b179ab7c30321263798dba31d7a92`
- Follow-up: PR #1465를 이 branch 위로 재적층하고 Nightly Kover skip 계약을 검증합니다.

## DoD Status

Required checks: 8/9; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - Defect/root cause | Hosted artifact와 Gradle tag/task 경계를 대조 | PASS | run `32488642030`, `No tests found for given includes`, `@Tag("k8s")`, `k8sTest` | none |
| C-02 - Scope/issue | Focused issue와 stack boundary 고정 | PASS | Issue #1468, base/head, milestone/labels/assignee | none |
| C-03/C-04 - RED/surgical fix | 네 실패 경로를 RED로 재현 후 최소 구현 | PASS | 분류 충돌, task override/path/allowlist tests | none |
| C-05 - GREEN/blast radius | 전체 Python tests, compile, Gradle dry-run | PASS | 19/19, py_compile, k8sTest dry-run | none |
| C-06/CG-09 - Lesson | 재사용 가능한 원인과 guard 기록 | PASS | lesson commit, terminology audit 0 | default checkout 반영 후 GNO exact lesson 검색 재확인 |
| CG-10 - Pre-PR review | Exact diff 독립 재검토 | PASS | P0=0, P1=0, P2=0, verdict CLEAR | none |
| CG-12 - Exact head publish | 원격 branch read-back | PASS | local/origin `9db9a18fe48b179ab7c30321263798dba31d7a92` | none |
| CG-12A - Guidance refresh | AGENTS/leaf/common/template/issue 재확인 | PASS | 2026-08-22 current hashes와 live Issue #1468 | none |
| CG-14 - Hosted full gate | Privileged runner에서 52 families 실행 | PASS | run `32545193586`, exact head `9db9a18…`, `52/52`, K3s `k8sTest`, failures=0 | none |

Final status: PENDING — 구현·review·hosted full gate는 PASS이며, stacked train의 fresh merge 승인과 merge/cleanup이 남았습니다.

Unchecked required items: CG-15, CG-16, CG-17, CG-18, C-08, C-09