### PR TITLE
[test][resilience4j] cancellation 테스트의 Phaser race를 제거한다

### DIFF
--- a/.github/scripts/test-aggregate-kover-coverage.py
+++ b/.github/scripts/test-aggregate-kover-coverage.py
@@ -219,6 +219,15 @@ class AggregateKoverCoverageTest(unittest.TestCase):
         workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
         self.assertNotIn("continue-on-error: true", workflow)
 
+    def test_nightly_spring_demos_skip_coverage_upload_without_kover_tasks(self):
+        workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+        spring_docker_start = workflow.index("  test-spring-docker:")
+        spring_docker_end = workflow.index("\n  # ── Testcontainers", spring_docker_start)
+        spring_docker = workflow[spring_docker_start:spring_docker_end]
+        self.assertIn('kover_tasks: ""', spring_docker)
+        coverage_upload = spring_docker[spring_docker.index("      - name: Upload coverage report") :]
+        self.assertIn("if: ${{ always() && matrix.kover_tasks != '' }}", coverage_upload)
+
     def test_ci_kover_failures_are_not_ignored(self):
         workflow = CI_WORKFLOW.read_text(encoding="utf-8")
         self.assertNotIn("continue-on-error: true", workflow)

--- a/.github/scripts/test-aggregate-kover-coverage.py
+++ b/.github/scripts/test-aggregate-kover-coverage.py
@@ -187,7 +187,15 @@ class AggregateKoverCoverageTest(unittest.TestCase):
     def test_nightly_requires_the_infra_module_inventory(self):
         workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("expected-modules.manifest", workflow)
-        for module in (
+        manifest_start = workflow.index("          if grep -q '^test-infra=success$'")
+        manifest_end = workflow.index("          fi", manifest_start)
+        manifest = workflow[manifest_start:manifest_end]
+        actual_modules = {
+            line.strip().removesuffix("\\").strip().strip("'")
+            for line in manifest.splitlines()
+            if line.strip().startswith("'")
+        }
+        expected_modules = {
             "infra/redisson",
             "infra/lettuce",
             "cache/cache-lettuce",
@@ -200,8 +208,8 @@ class AggregateKoverCoverageTest(unittest.TestCase):
             "cache/cache-hazelcast",
             "infra/elasticsearch",
             "infra/nats",
-        ):
-            self.assertIn(module, workflow)
+        }
+        self.assertSetEqual(actual_modules, expected_modules)
         self.assertIn("expected_module_args+=(--expected-module \"$module\")", workflow)
 
     def test_nightly_excludes_code_free_redis_umbrella_from_coverage(self):

--- a/.github/scripts/test-aggregate-kover-coverage.py
+++ b/.github/scripts/test-aggregate-kover-coverage.py
@@ -188,7 +188,6 @@ class AggregateKoverCoverageTest(unittest.TestCase):
         workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("expected-modules.manifest", workflow)
         for module in (
-            "infra/redis",
             "infra/redisson",
             "infra/lettuce",
             "cache/cache-lettuce",
@@ -204,6 +203,19 @@ class AggregateKoverCoverageTest(unittest.TestCase):
         ):
             self.assertIn(module, workflow)
         self.assertIn("expected_module_args+=(--expected-module \"$module\")", workflow)
+
+    def test_nightly_excludes_code_free_redis_umbrella_from_coverage(self):
+        workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+        redis_start = workflow.index("          - group: redis")
+        redis_end = workflow.index("          - group: kafka-resilience", redis_start)
+        redis_group = workflow[redis_start:redis_end]
+        self.assertNotIn(":bluetape4k-redis:test", redis_group)
+        self.assertNotIn(":bluetape4k-redis:koverXmlReport", redis_group)
+
+        manifest_start = workflow.index("          if grep -q '^test-infra=success$'")
+        manifest_end = workflow.index("          fi", manifest_start)
+        expected_modules = workflow[manifest_start:manifest_end]
+        self.assertNotIn("'infra/redis'", expected_modules)
 
     def test_nightly_keeps_redis_characterization_out_of_coverage(self):
         workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
       io: ${{ steps.filter.outputs.io }}
       io-http: ${{ steps.filter.outputs.io-http }}
       testcontainers-spring: ${{ steps.filter.outputs.testcontainers-spring }}
+      testcontainers-image-gate: ${{ steps.filter.outputs.testcontainers-image-gate }}
       ktor: ${{ steps.filter.outputs.ktor }}
       key-utils: ${{ steps.filter.outputs.key-utils }}
       infra: ${{ steps.filter.outputs.infra }}
@@ -185,6 +186,17 @@ jobs:
             testcontainers-spring:
               - 'testing/testcontainers/**'
               - 'testing/testcontainers-spring/**'
+            testcontainers-image-gate:
+              - 'testing/testcontainers/**'
+              - 'scripts/testcontainers_image_gate_manifest.json'
+              - 'scripts/testcontainers_image_gate.py'
+              - 'scripts/test_testcontainers_contract.py'
+              - 'scripts/test_testcontainers_image_gate.py'
+              - 'scripts/run_testcontainers_image_gate.py'
+              - 'scripts/test_run_testcontainers_image_gate.py'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/nightly-tests.yml'
+              - '.github/workflows/release.yml'
             ktor:
               - 'ktor/**'
             key-utils:
@@ -575,6 +587,81 @@ jobs:
         with:
           name: coverage-testcontainers-spring
           path: '**/build/reports/kover/'
+          if-no-files-found: error
+          retention-days: 30
+
+  # ── 4-d. 변경 Testcontainers image family startup/workload gate ──────────
+  testcontainers-image-gate:
+    name: Test / Testcontainers image startup-workload gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['testcontainers-image-gate'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Collect changed paths
+        id: changed-paths
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          base_sha="$PR_BASE_SHA"
+          if [[ -z "$base_sha" ]]; then
+            base_sha="$BEFORE_SHA"
+          fi
+          if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
+            git diff --name-only HEAD^ HEAD > "$RUNNER_TEMP/testcontainers-changed-paths.txt"
+          else
+            git diff --name-only "$base_sha" "$CURRENT_SHA" > "$RUNNER_TEMP/testcontainers-changed-paths.txt"
+          fi
+          sed -n '1,120p' "$RUNNER_TEMP/testcontainers-changed-paths.txt"
+
+      - name: Run changed image family gate sequentially
+        env:
+          DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
+          TESTCONTAINERS_REGISTRY_MIRROR: ${{ vars.TESTCONTAINERS_REGISTRY_MIRROR || '' }}
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        run: >-
+          python3 scripts/run_testcontainers_image_gate.py
+          --scope changed
+          --changed-path-file "$RUNNER_TEMP/testcontainers-changed-paths.txt"
+          --report-dir build/reports/testcontainers-image-gate
+          --max-attempts 2
+          --timeout-minutes 30
+
+      - name: Publish image gate summary
+        if: always()
+        run: |
+          if [ -f build/reports/testcontainers-image-gate/summary.md ]; then
+            cat build/reports/testcontainers-image-gate/summary.md
+          fi
+
+      - name: Upload image gate evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: testcontainers-image-gate-${{ github.run_id }}
+          path: build/reports/testcontainers-image-gate/
           if-no-files-found: error
           retention-days: 30
 
@@ -1086,7 +1173,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
+    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, testcontainers-image-gate, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1197,6 +1197,65 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  # ── Testcontainers image startup/workload gate — 단일 순차 lane ───────────
+  test-testcontainers-image-gate:
+    name: Test / Testcontainers image startup-workload gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    needs: [build, plan]
+    if: ${{ needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers' }}
+    env:
+      TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'
+      DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
+      TESTCONTAINERS_REGISTRY_MIRROR: ${{ vars.TESTCONTAINERS_REGISTRY_MIRROR || '' }}
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Build mock-web-server Docker image
+        run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+
+      - name: Build mock-webflux-server Docker image
+        run: ./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
+
+      - name: Run full image family gate sequentially
+        run: >-
+          python3 scripts/run_testcontainers_image_gate.py
+          --scope full
+          --report-dir build/reports/testcontainers-image-gate
+          --max-attempts 2
+          --timeout-minutes 30
+
+      - name: Publish image gate summary
+        if: always()
+        run: |
+          if [ -f build/reports/testcontainers-image-gate/summary.md ]; then
+            cat build/reports/testcontainers-image-gate/summary.md
+          fi
+
+      - name: Upload image gate evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-testcontainers-image-gate-${{ github.run_id }}
+          path: build/reports/testcontainers-image-gate/
+          if-no-files-found: error
+          retention-days: 14
+
   # ── Testcontainers Spring bridge (nightly JVM-only contract) ─────────────
   test-testcontainers-spring:
     name: Test / Testcontainers Spring bridge
@@ -1204,7 +1263,7 @@ jobs:
     timeout-minutes: 10
     # Keep the JVM-only bridge after the Docker-backed Testcontainers lane so
     # repository-level Testcontainers verification remains sequential.
-    needs: [test-testcontainers, plan]
+    needs: [test-testcontainers, test-testcontainers-image-gate, plan]
     if: ${{ needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers' }}
     steps:
       - uses: actions/checkout@v7
@@ -1262,6 +1321,7 @@ jobs:
       - test-data
       - test-spring-docker
       - test-testcontainers
+      - test-testcontainers-image-gate
       - test-testcontainers-spring
     if: always()
     steps:
@@ -1362,6 +1422,7 @@ jobs:
       - test-data
       - test-spring-docker
       - test-testcontainers
+      - test-testcontainers-image-gate
       - test-testcontainers-spring
       - coverage-report
     if: always()

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -834,13 +834,11 @@ jobs:
         include:
           - group: redis
             test_tasks: >-
-              :bluetape4k-redis:test
               :bluetape4k-redisson:test
               :bluetape4k-lettuce:test
               :bluetape4k-cache-lettuce:test
               :bluetape4k-cache-redisson:test
             kover_tasks: >-
-              :bluetape4k-redis:koverXmlReport
               :bluetape4k-redisson:koverXmlReport
               :bluetape4k-lettuce:koverXmlReport
               :bluetape4k-cache-lettuce:koverXmlReport
@@ -1348,7 +1346,6 @@ jobs:
           : > coverage-artifacts/expected-modules.manifest
           if grep -q '^test-infra=success$' coverage-artifacts/expected-jobs.manifest; then
             printf '%s\n' \
-              'infra/redis' \
               'infra/redisson' \
               'infra/lettuce' \
               'cache/cache-lettuce' \

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1102,7 +1102,7 @@ jobs:
           retention-days: 14
 
       - name: Upload coverage report
-        if: always()
+        if: ${{ always() && matrix.kover_tasks != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: nightly-coverage-spring-${{ matrix.group }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,81 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "ref=refs/tags/$VERSION" >> "$GITHUB_OUTPUT"
 
+  testcontainers-image-gate:
+    name: Verify Testcontainers image gate
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
+      TESTCONTAINERS_REGISTRY_MIRROR: ${{ vars.TESTCONTAINERS_REGISTRY_MIRROR || '' }}
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-version.outputs.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Build mock-web-server Docker image
+        run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+
+      - name: Build mock-webflux-server Docker image
+        run: ./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
+
+      - name: Run full image family gate
+        run: >-
+          python3 scripts/run_testcontainers_image_gate.py
+          --scope full
+          --report-dir build/reports/testcontainers-image-gate
+          --max-attempts 2
+          --timeout-minutes 30
+
+      - name: Verify stable release gate summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          summary_path = Path("build/reports/testcontainers-image-gate/summary.json")
+          summary = json.loads(summary_path.read_text(encoding="utf-8"))
+          if summary.get("coverage") != "52/52":
+              raise SystemExit(f"stable release requires coverage=52/52, got {summary.get('coverage')!r}")
+          if summary.get("release_gate") is not True:
+              raise SystemExit("stable release image gate is not green")
+          if any(summary.get(key, 0) for key in ("product_failure", "infrastructure_failure", "blocked")):
+              raise SystemExit("stable release image gate contains a failure classification")
+          print(f"coverage={summary['coverage']}")
+          print(f"manifest_digest={summary['manifest_digest']}")
+          PY
+
+      - name: Upload image gate evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-testcontainers-image-gate-${{ github.run_id }}
+          path: build/reports/testcontainers-image-gate/
+          if-no-files-found: error
+          retention-days: 30
+
   publish:
     name: Publish RELEASE to Maven Central Portal
-    needs: resolve-version
+    needs: [resolve-version, testcontainers-image-gate]
     runs-on: ubuntu-latest
     environment: maven-central-release
     steps:

--- a/docs/lessons/2026-08-21-issue-1337-testcontainers-startup-workload-gate.md
+++ b/docs/lessons/2026-08-21-issue-1337-testcontainers-startup-workload-gate.md
@@ -1,0 +1,56 @@
+# Issue #1337 Testcontainers startup·workload gate lesson
+
+## 배경
+
+Issue #1331/#1332에서 52개 Docker image tag를 고정했지만, 기존 CI는
+`testing/testcontainers` 전체 startup/workload를 PR 필수 경로에서 실행하지 않았습니다.
+Nightly matrix는 여러 shard를 병렬 실행해 개별 family의 readiness와 registry 장애를
+stable release 증거로 재사용하기 어려웠습니다. K3s는 API·pod workload 준비와 port open을
+구분해야 했고, Docker Hub pull rate limit도 실제 환경 실패로 재현되었습니다.
+
+## 결정
+
+- 52개 family를 `scripts/testcontainers_image_gate_manifest.json`에 선언하고 source,
+  test class, image/tag, readiness, workload, diagnostics를 하나의 digest로 묶었습니다.
+- Python 표준 라이브러리 runner가 family를 순차 실행하고 `success`, `product_failure`,
+  `infrastructure_failure`, `blocked`를 분리합니다.
+- PR CI는 changed scope, Nightly와 안정 버전 배포는 full scope를 사용합니다.
+- stable publish는 `52/52`, `release_gate=true`, 모든 실패 분류 0을 선행조건으로 합니다.
+- Docker/K3s 진단은 bounded·secret-free artifact로 남기고 rate limit을 면제하지 않습니다.
+- public Kotlin API와 기존 wrapper readiness 구현은 변경하지 않습니다.
+
+## 구현 증거
+
+- manifest 52개와 Kotlin/EN/KO README/test parity 정적 검증: PASS
+- runner 단위 테스트(성공, 제품 실패, 인프라 retry, timeout, redaction, zero-exit 차단): PASS
+- PR CI changed gate, Nightly full sequential lane, release publish dependency: PASS
+- `actionlint` 세 workflow: PASS
+- 실제 Docker/K3s full matrix와 hosted release dispatch `52/52`: PENDING
+
+## 배운 점
+
+1. 고정된 image tag 목록은 pull/start/workload 성공을 증명하지 않습니다. 실행 증거와
+   태그 parity를 같은 manifest digest에 연결해야 release 판단이 재현됩니다.
+2. 병렬 Testcontainers matrix의 green 결과만으로는 family별 readiness와 실패 원인을
+   구분할 수 없습니다. 무거운 Docker lane은 별도 순차 경계와 bounded 진단이 필요합니다.
+3. exit code 0만으로 성공을 선언하면 결과가 누락된 fake/조기 종료를 통과시킬 수 있습니다.
+   runner는 Gradle `BUILD SUCCESSFUL` 증거가 없으면 `blocked`로 닫습니다.
+4. registry rate limit은 제품 실패가 아니지만 release를 허용할 근거도 아닙니다. 인프라
+   실패로 분류하고 인증·mirror·owner/time-bound를 보존해야 합니다.
+
+## 후속 위험
+
+- hosted runner의 Docker Hub 인증·mirror 설정이 실제로 제공되지 않으면 full gate가
+  `infrastructure_failure`가 됩니다. 이 상태를 retry로 덮지 않고 release hold로 유지합니다.
+- K3s privileged runner와 Curator session readiness의 실제 소요 시간이 기존 timeout과
+  맞지 않을 수 있습니다. 첫 Nightly 결과에서 elapsed time과 진단량을 확인합니다.
+- 52개 family를 개별 Gradle invocation으로 실행하므로 Nightly 시간이 길어질 수 있습니다.
+  실행 증거가 안정된 뒤에만 grouping 최적화를 검토하며, 병렬화로 순차 계약을 약화하지 않습니다.
+
+## 문서 SPW 감사
+
+- SPW-01 source/evidence lock: PASS — #1337/#1331/#1332와 현재 52개 source/readme/test를 대조했습니다.
+- SPW-02 contract completeness: PASS — manifest schema, 분류, artifact, release prerequisite를 고정했습니다.
+- SPW-03 Korean technical register/naturalness: PASS — 한국어 문서 terminology audit 결과가 0건입니다.
+- SPW-04 traceability: PASS — issue 요구사항을 manifest, runner, CI/Nightly/release, runbook으로 연결했습니다.
+- SPW-05 final Markdown read-back: PASS — 생성 문서를 마지막 줄까지 읽고 명령·경로·PENDING 범위를 확인했습니다.

--- a/docs/lessons/2026-08-21-issue-1464-nightly-kover-optional-shard.md
+++ b/docs/lessons/2026-08-21-issue-1464-nightly-kover-optional-shard.md
@@ -1,0 +1,41 @@
+# 이슈 #1464 - 선택적 Nightly Kover shard의 artifact 조건 정합성
+
+관련 이슈: #1464 · Epic #1418 Slot 5
+영향 workflow: `.github/workflows/nightly-tests.yml`
+
+## 맥락
+
+Nightly `Test / Spring Boot (demos)` matrix shard는 demo 모듈 테스트만 실행하고
+`kover_tasks`를 비워 coverage 생성을 의도적으로 생략한다. 그러나 coverage
+artifact 업로드가 항상 실행되면서 파일이 없는 정상 경로를 오류로 판정했다.
+
+## 결정 또는 발견
+
+1. `kover_tasks`가 비어 있으면 Kover 생성과 coverage artifact 업로드를 모두
+   생략한다. 테스트 결과 artifact는 계속 업로드해 demo 테스트 결과를 보존한다.
+2. `kover_tasks`를 선언한 shard는 `if-no-files-found: error`를 유지한다. 실제
+   coverage 산출물 누락을 성공으로 숨기지 않는 #1336 fail-closed 계약을 보존한다.
+3. matrix에 선택적 coverage shard를 추가하거나 변경할 때 생성 단계와 업로드
+   단계가 동일한 opt-in 조건을 공유하는 구조 테스트를 함께 갱신한다.
+
+## 결과
+
+테스트가 성공했지만 coverage를 생성하지 않는 shard가 artifact 단계에서 실패하지
+않는다. 따라서 해당 job은 성공으로 남고, Coverage Report의 expected-job manifest와
+Nightly Status가 선택적 shard 때문에 연쇄 실패하지 않는다.
+
+## 검증
+
+- RED: `python3 .github/scripts/test-aggregate-kover-coverage.py`에서 optional
+  `demos` upload 조건 회귀 테스트가 기존 `if: always()`를 탐지해 실패했다.
+- GREEN: 같은 테스트가 workflow 조건을 `always() && matrix.kover_tasks != ''`로
+  고정한 뒤 전체 fixture를 통과했다.
+- 정적 검증: `git diff --check`와 `actionlint`는 child head에서 실행한다.
+- 호스팅 검증: 수정 PR의 Spring Boot demos, Coverage Report, Nightly Status
+  required checks가 모두 성공해야 한다.
+
+## 향후 지침
+
+선택적 matrix shard는 “생성 여부”만 조건화하지 말고 산출물 업로드·집계 manifest·
+성공 판정까지 같은 predicate로 연결한다. 반대로 coverage를 선언한 shard의
+`if-no-files-found: error`는 유지해 실제 회귀를 fail-closed로 드러낸다.

--- a/docs/lessons/2026-08-21-issue-1464-nightly-kover-optional-shard.md
+++ b/docs/lessons/2026-08-21-issue-1464-nightly-kover-optional-shard.md
@@ -17,6 +17,9 @@ artifact 업로드가 항상 실행되면서 파일이 없는 정상 경로를 �
    coverage 산출물 누락을 성공으로 숨기지 않는 #1336 fail-closed 계약을 보존한다.
 3. matrix에 선택적 coverage shard를 추가하거나 변경할 때 생성 단계와 업로드
    단계가 동일한 opt-in 조건을 공유하는 구조 테스트를 함께 갱신한다.
+4. 소스와 테스트가 없는 umbrella 모듈은 `koverXmlReport` task가 성공해도 instruction
+   합계가 `0/0`이다. 이런 모듈은 non-empty expected-module inventory가 아니라 실제
+   구현 모듈의 의존성 집계 경계로 취급한다.
 
 ## 결과
 
@@ -30,6 +33,10 @@ Nightly Status가 선택적 shard 때문에 연쇄 실패하지 않는다.
   `demos` upload 조건 회귀 테스트가 기존 `if: always()`를 탐지해 실패했다.
 - GREEN: 같은 테스트가 workflow 조건을 `always() && matrix.kover_tasks != ''`로
   고정한 뒤 전체 fixture를 통과했다.
+- 호스팅 RED: run `32547775009`에서 `demos` shard는 성공했지만 Coverage Report가
+  `infra/redis`의 빈 Kover report를 거부했다. `infra/redis`는 `lettuce`와
+  `redisson`만 노출하는 code-free umbrella이므로 Nightly Redis test/Kover task와
+  expected-module inventory에서 제외하고 실제 구현 모듈 네 개는 그대로 유지했다.
 - 정적 검증: `git diff --check`와 `actionlint`는 child head에서 실행한다.
 - 호스팅 검증: 수정 PR의 Spring Boot demos, Coverage Report, Nightly Status
   required checks가 모두 성공해야 한다.
@@ -39,3 +46,5 @@ Nightly Status가 선택적 shard 때문에 연쇄 실패하지 않는다.
 선택적 matrix shard는 “생성 여부”만 조건화하지 말고 산출물 업로드·집계 manifest·
 성공 판정까지 같은 predicate로 연결한다. 반대로 coverage를 선언한 shard의
 `if-no-files-found: error`는 유지해 실제 회귀를 fail-closed로 드러낸다.
+또한 umbrella 프로젝트의 Gradle task 성공을 non-empty code coverage와 동일시하지
+않고, main source가 있는 실제 구현 모듈만 expected-module inventory에 등록한다.

--- a/docs/lessons/2026-08-21-issue-1466-image-gate-result-evidence.md
+++ b/docs/lessons/2026-08-21-issue-1466-image-gate-result-evidence.md
@@ -1,0 +1,38 @@
+# Issue #1466 image gate 결과 증거 보존 lesson
+
+## 배경
+
+PR #1463의 hosted CI run `32480088175`에서 Testcontainers image gate가
+`0/52`로 실패했습니다. 52개 family 중 51개는 Gradle `returncode=0`이었지만
+`blocked`로 집계됐고, K3s 한 family만 `exit 137` infrastructure failure였습니다.
+
+## 원인과 결정
+
+runner가 artifact에 저장할 stdout/stderr를 먼저 12,000자로 축약한 뒤,
+축약본에서 `BUILD SUCCESSFUL` marker를 찾았습니다. Jib/Docker 진행 출력이 긴
+family에서는 성공 marker가 축약 경계 뒤에 있어 정상 종료를 `blocked`로
+오판했습니다.
+
+판정은 원문 stdout/stderr에서 수행하고, artifact와 로그에는 기존의
+bounded·redacted 출력을 계속 저장합니다. marker가 없는 `returncode=0`은
+계속 `blocked`로 유지해 조기 종료나 불완전한 결과를 통과시키지 않습니다.
+
+## 검증
+
+- 긴 성공 출력 회귀 테스트: RED에서 `blocked` 재현, 수정 후 GREEN
+- 기존 성공·product failure·infrastructure retry·timeout·redaction 테스트:
+  PASS
+- hosted CI 재실행: PENDING
+
+## 후속 guard
+
+실행 결과의 판정 입력과 보존 입력을 분리합니다. 출력 제한은 저장 경계에만
+적용하고, 성공·실패 marker 검사는 원문을 사용해야 합니다.
+
+## SPW 감사
+
+- SPW-01: PASS — run URL, head, `0/52`, `exit 137`, 원인과 미검증 범위를 고정했습니다.
+- SPW-02: PASS — 배경, 원인, 결정, 검증, 후속 guard를 포함했습니다.
+- SPW-03: PASS — 한국어 기술 문체와 `returncode`, `BUILD SUCCESSFUL` 토큰을 보존했습니다.
+- SPW-04: PASS — artifact JSON과 runner source/test를 대조했습니다.
+- SPW-05: PASS — 최종 Markdown read-back과 `git diff --check`를 수행할 예정입니다.

--- a/docs/lessons/2026-08-22-issue-1468-k3s-image-gate-discovery.md
+++ b/docs/lessons/2026-08-22-issue-1468-k3s-image-gate-discovery.md
@@ -1,0 +1,59 @@
+# Issue #1468 K3s image gate test-discovery lesson
+
+## 배경
+
+PR #1467 exact head `bcdbf1707d8eddce09f1dfd8f30cd22ccaac958c`의 hosted
+image gate run `32488642030`은 정상 family 51개를 통과시켰지만 K3s를
+`infrastructure_failure`로 보고했습니다. K3s attempt의 실제 Gradle 오류는
+`No tests found for given includes: [io.bluetape4k.testcontainers.infra.K3sServerTest](--tests filter)`였습니다.
+
+## 원인과 예상 밖의 점
+
+`K3sServerTest`는 privileged runner 전용 `@Tag("k8s")` 테스트입니다. 기본
+`:bluetape4k-testcontainers:test` task는 이 태그를 제외하고, 저장소는 이미 전용
+`:bluetape4k-testcontainers:k8sTest` task를 제공합니다. image gate manifest는
+test class만 선언하고 실행 task를 표현하지 않아 K3s 테스트를 발견하지 못했습니다.
+
+같은 Gradle stdout에는 선행 Jib task의 정상 진행 문구
+`building image to Docker daemon`가 포함됐습니다. 실패 분류가 전체 출력의
+`docker daemon` substring을 먼저 사용하면서 결정적인 test-discovery 실패를
+인프라 장애로 덮었습니다. 진단 artifact의 Docker event와 종료 코드는 현재 Gradle
+invocation이 K3s 테스트를 실행했다는 증거가 아니었습니다.
+
+## 결정
+
+- family별 예외 task가 필요할 때 manifest의 선택적 `testTask`가 기존 Gradle task
+  path를 지정하게 합니다.
+- K3s entry는 기존 `:bluetape4k-testcontainers:k8sTest`를 재사용합니다.
+- `Execution failed for task`와 `No tests found for given includes`가 함께 나타나는
+  결정적인 Gradle/test-discovery 실패는 일반적인 Docker 출력 marker보다 먼저
+  `product_failure`로 분류합니다.
+- manifest의 선택적 task는 검증된 allowlist에 있는 기존 task만 허용합니다.
+- 실제 K3s container 검증은 privileged hosted runner에서 순차 실행합니다.
+
+## 검증
+
+- 회귀 테스트 3건: task override, test-discovery 분류 우선순위, K3s manifest task를
+  각각 RED로 재현하고 GREEN으로 전환했습니다.
+- 잘못되거나 알려지지 않은 `testTask` manifest 값: RED/GREEN으로 task path와
+  allowlist 검증을 고정했습니다.
+- incidental test-discovery 문구와 Docker 인프라 오류의 충돌 회귀도 고정했습니다.
+- runner/manifest Python 테스트: 19건 PASS
+- `k8sTest --tests K3sServerTest --dry-run`: `BUILD SUCCESSFUL`, 전용 task 선택 확인
+- hosted full image gate `52/52`: PENDING
+
+## 향후 지침
+
+manifest 기반 실행기는 test class만으로 충분하다고 가정하지 않습니다. 테스트가
+JUnit tag, 별도 source set, 전용 Gradle task, profile/property로 격리되면 그 실행
+경계를 manifest와 회귀 테스트에 함께 선언해야 합니다. 실패 분류는 구체적인 현재
+invocation 오류를 먼저 판정하고, 선행 task나 진단 출력에 흔히 나타나는 일반
+substring은 그 뒤에 적용합니다.
+
+## SPW 감사
+
+- SPW-01: PASS — Issue #1468, run `32488642030`, exact head, source/task와 실제 오류를 고정했습니다.
+- SPW-02: PASS — 배경, 원인, 예상 밖의 점, 결정, 검증, 향후 지침을 포함했습니다.
+- SPW-03: PASS — 한국어 기술 문체를 사용하고 Gradle/JUnit 식별자와 exact error를 보존했습니다.
+- SPW-04: PASS — hosted artifact, `build.gradle.kts`, manifest, runner와 회귀 테스트를 대조했습니다.
+- SPW-05: PASS — 최종 Markdown, terminology audit, `git diff --check`를 read-back합니다.

--- a/docs/lessons/2026-08-22-issue-1470-resilience4j-phaser-race.md
+++ b/docs/lessons/2026-08-22-issue-1470-resilience4j-phaser-race.md
@@ -1,0 +1,34 @@
+# Issue #1470: cancellation 테스트의 `Phaser` phase race
+
+## 현상
+
+Nightly run `32550558776`의 `Test / Infra (kafka-resilience)` 첫 시도가
+`FlowCircuitBreakerTest` 출력 도중 멈췄고, workflow retry의 60분 timeout으로
+종료됐다. 두 번째 시도는 동일 명령을 1분 13초에 완료했다.
+
+## 원인
+
+`Phaser(1)`과 `awaitAdvance(1)`은 one-shot 시작 신호가 아니다. child가 먼저
+`arrive()`하면 phase가 `0`에서 `1`로 바뀐다. 이후 parent가
+`awaitAdvance(1)`을 호출하면 다음 phase 전환을 기다리지만, 전환 주체가 없어
+무기한 block된다. parent가 먼저 호출하면 현재 phase가 `0`이므로 즉시
+반환해 실행 순서에 따라 테스트가 통과하거나 멈췄다.
+
+`runSuspendTest`의 `withTimeout`도 blocking `Phaser.awaitAdvance`를 중단할 수
+없어, 테스트 helper의 3분 timeout이 아니라 workflow의 60분 timeout까지
+runner를 점유했다.
+
+## 수정 원칙
+
+- coroutine 테스트의 one-shot 시작 신호는 `CompletableDeferred<Unit>`의
+  `complete(Unit)`과 `await()`를 사용한다.
+- cancellation 테스트는 명시적인 10초 `runSuspendTest` timeout 안에서
+  실행해 이후 동기화 회귀도 fail-fast로 드러나게 한다.
+- 같은 패턴이 있던 `FlowCircuitBreakerTest`와 `BulkheadFlowTest` 네 경로를
+  함께 수정한다.
+
+## 검증
+
+- Hosted RED: run `32550558776`, attempt 1 `Timeout of 3600000ms hit`
+- Retry 비교: attempt 2 `BUILD SUCCESSFUL in 1m 13s`
+- Targeted GREEN: 두 테스트 클래스 11개 테스트 통과

--- a/docs/operations/issue-1337-testcontainers-image-gate.md
+++ b/docs/operations/issue-1337-testcontainers-image-gate.md
@@ -1,0 +1,130 @@
+# Issue #1337 Testcontainers 이미지 family gate 운영 runbook
+
+## 목적
+
+이 runbook은 52개 Docker 기반 Testcontainers 서버 family의 startup,
+애플리케이션 readiness, 대표 workload를 같은 기준으로 실행하고 실패 원인을
+재현 가능한 증거로 남기기 위한 운영 계약입니다. source of truth는
+[`scripts/testcontainers_image_gate_manifest.json`](../../scripts/testcontainers_image_gate_manifest.json)이며,
+Kotlin wrapper·테스트·EN/KO README와 정적 parity 검증을 함께 통과해야 합니다.
+
+대상 workflow는 다음과 같습니다.
+
+| 단계 | scope | 성공 조건 | artifact |
+|---|---|---|---|
+| PR CI | `changed` | 변경 family 모두 `success` 또는 변경 없음 `skipped` | `testcontainers-image-gate-*` |
+| Nightly | `full` 또는 `testcontainers` | 선택 family 전체 `success`, 순차 실행 | `nightly-testcontainers-image-gate-*` |
+| 안정 버전 배포 | `full` | `52/52`, `release_gate=true`, 제품·인프라·차단 0 | `release-testcontainers-image-gate-*` |
+
+## 실행 명령
+
+저장소 루트에서 실행합니다. Docker Hub 인증과 mirror는 환경변수 또는 CI secret으로
+전달하고 명령행에 credential을 넣지 않습니다.
+
+```bash
+# 변경 family 확인
+python3 scripts/run_testcontainers_image_gate.py \
+  --scope changed \
+  --report-dir build/reports/testcontainers-image-gate \
+  --max-attempts 2 \
+  --timeout-minutes 30
+
+# 전체 family 확인
+./gradlew :bluetape4k-mock-web-server:jibDockerBuild \
+  :bluetape4k-mock-webflux-server:jibDockerBuild \
+  --no-configuration-cache
+python3 scripts/run_testcontainers_image_gate.py \
+  --scope full \
+  --report-dir build/reports/testcontainers-image-gate \
+  --max-attempts 2 \
+  --timeout-minutes 30
+```
+
+`--max-attempts`는 runner에서 최대 3회로 제한합니다. 각 family는 하나씩 실행하며,
+`BUILD SUCCESSFUL` 출력이 없거나 Gradle 결과가 누락되면 성공으로 처리하지 않습니다.
+
+## Manifest 변경 절차
+
+1. `testing/testcontainers/src/main/kotlin/**`의 `IMAGE`/`TAG`, 대응 `*Test.kt`, EN/KO README를 함께 확인합니다.
+2. manifest 항목의 `source`, `testSource`, `image`, `tag`, `testPattern`, `readiness`, `workload`, `diagnostics`, `releaseRequired`를 갱신합니다.
+3. 정적 계약과 실행기 단위 테스트를 실행합니다.
+
+```bash
+python3 -m unittest \
+  scripts/test_testcontainers_contract.py \
+  scripts/test_testcontainers_image_gate.py \
+  scripts/test_run_testcontainers_image_gate.py -v
+```
+
+4. `git diff --check`와 workflow `actionlint`를 통과시키고, manifest digest와 변경 family를 PR DoD에 기록합니다.
+5. 이미지 태그를 바꿀 때는 기존 호환성 fixture를 일반 최신 태그로 치환하지 않습니다. 실제 startup/workload 결과와 rollback identity를 함께 남깁니다.
+
+## 결과 artifact 계약
+
+`summary.json`은 다음 필드를 포함합니다.
+
+| 필드 | 의미 |
+|---|---|
+| `manifest_digest` | 실행한 manifest의 SHA-256 |
+| `selected` / `coverage` | 선택 family 수와 성공 수 (`success/selected`) |
+| `success` | startup·readiness·workload 실행이 성공한 family 수 |
+| `product_failure` | 테스트 assertion 또는 제품 동작 실패 수 |
+| `infrastructure_failure` | registry, Docker daemon, timeout, K3s 환경 실패 수 |
+| `blocked` | manifest/결과 누락 또는 prerequisite 미충족 수 |
+| `release_gate` | 안정 버전 배포 허용 여부 |
+| `results` | family별 image/tag, test pattern, 시도 결과, 진단 경로 |
+
+실패 family마다 `<id>.json`이 생성되며 `summary.md`에는 분류별 count와 stable
+release gate가 표시됩니다. stdout/stderr, command, Docker/K3s 진단은 bounded
+redaction을 거치며 password/token/secret/authorization/API key/Bearer 값은
+`<redacted>`로 치환됩니다.
+
+## 실패 분류와 조치
+
+| 분류 | 대표 신호 | 조치 | gate 처리 |
+|---|---|---|---|
+| `product_failure` | JUnit assertion, 예상 응답/연결 계약 불일치 | 해당 wrapper와 대표 workload를 먼저 수정·재검증 | 실패 |
+| `infrastructure_failure` | `TOOMANYREQUESTS`, pull/auth 오류, daemon 연결 거부, timeout | Docker/registry/K3s 진단과 owner/time-bound를 기록하고 bounded retry | 실패 |
+| `blocked` | manifest drift, test 결과 누락, `BUILD SUCCESSFUL` 증거 없음 | source/manifest/runner prerequisite를 복구한 뒤 재실행 | 실패 |
+| `success` | 각 family test가 `BUILD SUCCESSFUL`로 종료 | artifact와 digest를 보존 | 통과 |
+
+rate limit은 면제 사유가 아닙니다. 인증 또는 mirror를 구성할 수 없으면
+`infrastructure_failure`로 남기고 안정 버전 배포를 중단합니다. 재시도 횟수를 늘려
+실패를 숨기지 않습니다.
+
+## K3s 진단
+
+`K3sServer` 실패 시 runner가 Docker inspect/logs/events와 함께 다음 bounded
+진단을 수집합니다.
+
+```bash
+kubectl get pods --all-namespaces -o wide
+kubectl get events --all-namespaces --sort-by=.lastTimestamp
+kubectl logs --all-namespaces --all-containers --tail=200
+```
+
+컨테이너 port open만으로 readiness를 판정하지 않습니다. K3s API와 pod/workload가
+준비되지 않으면 `infrastructure_failure` 또는 `product_failure` 원인을 보존합니다.
+ZooKeeper는 port open이 아니라 Curator session readiness를 사용합니다.
+
+## Rollback과 재실행
+
+- runner/manifest 변경이 문제이면 해당 child commit을 bounded revert하고 기존
+  `scripts/test_testcontainers_contract.py`, Nightly matrix, release workflow를
+  복원한 뒤 static contract를 먼저 통과시킵니다.
+- 이미지 tag 변경 문제이면 이전에 검증된 tag와 manifest digest를 rollback identity로
+  지정하고 full gate를 다시 통과시킵니다. 무제한 retry나 gate skip은 정상 rollback이
+  아닙니다.
+- release gate 실패 시 `publish`는 실행되지 않습니다. 새 배포를 시도하기 전에
+  실패 artifact, exact tag SHA, owner, 종료 시각, forward-fix를 기록합니다.
+- 이미 Maven Central publish가 시작됐다면 추가 publish를 중단하고 release owner가
+  tag와 artifact identity를 확인합니다. 이 runbook은 외부 artifact 삭제를 수행하지
+  않습니다.
+
+## 현재 검증 상태
+
+이 문서 작성 시점에는 manifest/source/README/test parity, runner 단위 테스트,
+workflow 정적 검증은 통과했습니다. 실제 Docker Hub pull, K3s workload, hosted
+Nightly, release dispatch의 `52/52` 결과는 아직 실행 전이므로 `PENDING`입니다.
+그 결과가 확보되기 전에는 PR을 merge-ready 또는 stable publish-ready로 표시하지
+않습니다.

--- a/docs/superpowers/plans/2026-08-21-issue-1337-testcontainers-startup-workload-gate-plan.md
+++ b/docs/superpowers/plans/2026-08-21-issue-1337-testcontainers-startup-workload-gate-plan.md
@@ -1,0 +1,127 @@
+# Testcontainers 이미지 family startup·workload gate 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Issue #1337의 변경 Docker image family에 대해 startup, 애플리케이션 readiness, 대표 workload를 동일한 manifest와 실행기로 검증하고, PR·Nightly·stable release가 `52/52` 성공 증거 없이는 통과하지 않도록 고정한다.
+
+**Architecture:** 현재 `testing/testcontainers`의 52개 `*Server.kt`/`*Test.kt` 계약을 단일 JSON manifest로 선언한다. Python 표준 라이브러리 기반 정적 검증기는 manifest와 Kotlin source, EN/KO README, 테스트 클래스의 parity를 검증한다. 별도 실행기는 manifest 항목을 `max-parallel: 1`로 순차 실행하고, JUnit/Gradle 결과와 Docker·K3s 진단을 secret-free JSON/Markdown artifact로 남긴다. CI와 Nightly는 changed/full scope를 각각 호출하고, release workflow는 tag checkout 뒤 full scope의 성공 요약을 `publish`의 선행 조건으로 사용한다. public Kotlin API와 기존 readiness 구현은 변경하지 않는다.
+
+**Tech Stack:** Python 3.12 표준 라이브러리, GitHub Actions, Gradle Wrapper 9.7, JDK 25, Docker CLI, 기존 JUnit 5/Testcontainers/Kover 실행 경로
+
+---
+
+## 사전 조건과 불변 계약
+
+- [ ] 작업 대상은 `.worktrees/feat/1418-04-testcontainers-startup-workload-gate`의 `feat/1418-04-testcontainers-startup-workload-gate`이며 base는 `origin/develop`의 착수 SHA로 고정한다. canonical worktree와 다른 stacked worktree를 수정하지 않는다.
+- [ ] 현재 52개 `IMAGE/TAG` 선언, EN/KO README 52행, 대응 `*Test.kt` 52개를 baseline으로 기록한다. 기존 `scripts/test_testcontainers_contract.py`의 성공을 보존하고, `git diff --check`를 모든 커밋 전후에 실행한다.
+- [ ] 실행기는 Docker Hub 인증·mirror·retry를 환경변수/Actions secret으로만 받고 값 자체를 log/artifact에 기록하지 않는다. rate-limit은 `infrastructure_failure`로 분류하며 성공으로 재분류하지 않는다.
+- [ ] 테스트containers 계열 실행은 shared Docker daemon 경합을 피하도록 하나의 gate job 내부에서 순차 실행한다. 재시도는 횟수와 원인을 artifact에 남기되 제품 실패를 숨기지 않는다.
+- [ ] stable publish는 gate summary의 모든 `releaseRequired=true` 항목이 `success`이고 `coverage`가 `52/52`일 때만 진행한다. `product_failure`, 미분류, timeout, missing result, blocked는 fail-closed다.
+
+## Task 1: 이미지 family manifest와 정적 계약 검증
+
+**Files:**
+- Create: `scripts/testcontainers_image_gate_manifest.json`
+- Create: `scripts/test_testcontainers_image_gate.py`
+- Modify: `scripts/test_testcontainers_contract.py`
+
+- [ ] `testcontainers_image_gate_manifest.json`에 52개 family를 정확히 한 번씩 선언한다. 각 항목은 `id`, `server`, `source`, `image`, `tag`, `testPattern`, `readiness`, `workload`, `diagnostics`, `releaseRequired`를 갖고 source 경로와 기존 테스트 클래스명을 그대로 가리킨다.
+- [ ] `readiness`는 HTTP endpoint, TCP/Curator/API, 기존 Testcontainers wait strategy 등 현재 구현의 observable contract를 사용한다. readiness를 새로 구현하거나 포트 open만으로 애플리케이션 준비를 주장하지 않는다.
+- [ ] `workload`는 해당 `*Test.kt`의 최소 대표 성공 경로를 식별하고, K3s는 API readiness 뒤 pod/event/log 수집과 대표 workload를 포함한다. K3s가 없는 로컬 환경에서 임의의 성공값을 만들지 않는다.
+- [ ] 정적 테스트로 schema/type/중복, 52개 수, Kotlin `IMAGE/TAG`와 manifest image/tag, EN/KO README parity, source/testPattern 존재, 빈 readiness/workload 금지, `releaseRequired` boolean, changed-only selection 키를 검증한다.
+- [ ] 기존 `test_testcontainers_contract.py`에 manifest와의 source/tag count/parity assertion을 추가하되 기존 4개 contract test의 의미와 출력은 유지한다.
+- [ ] 먼저 `python3 -m unittest scripts/test_testcontainers_image_gate.py scripts/test_testcontainers_contract.py -v`를 실행해 검증기가 의도한 drift를 red/green으로 확인하고, 테스트 파일 자체에 Docker 호출을 넣지 않는다.
+
+## Task 2: 순차 실행기와 실패 진단 artifact
+
+**Files:**
+- Create: `scripts/run_testcontainers_image_gate.py`
+- Create: `scripts/test_run_testcontainers_image_gate.py`
+- Create: `scripts/testcontainers_image_gate_lib.py` (실행·분류·redaction이 재사용될 때만)
+
+- [ ] CLI를 `--manifest`, `--scope {changed,full}`, `--report-dir`, `--gradle-task`, `--max-attempts`, `--timeout-minutes`로 고정하고 기본 task는 `:bluetape4k-testcontainers:test`로 둔다. 변경 scope는 base/head diff의 실제 `testing/testcontainers` 및 manifest 관련 변경 family만 선택하고, release는 항상 `full`을 사용한다.
+- [ ] family를 manifest 순서대로 하나씩 실행한다. 각 호출은 `--tests <testPattern>`을 사용하며 exit code, elapsed time, attempts, JUnit result 경로, image/tag, commit SHA를 기록한다. 프로세스 환경과 command line에서 secret-looking 값은 `<redacted>`로 치환한다.
+- [ ] 성공은 startup/readiness/workload와 JUnit 결과가 모두 확인된 경우에만 `success`로 기록한다. non-zero Gradle/JUnit assertion은 `product_failure`, Docker pull/auth/daemon/timeout/rate-limit은 `infrastructure_failure`, prerequisite 누락·manifest 오류·결과 누락은 `blocked`로 기록한다.
+- [ ] 실패 시 `docker inspect`, container logs, bounded `docker events`를 수집하고, K3s family는 bounded `kubectl get pods`, `describe`, events, logs를 수집한다. 진단 실패가 원래 제품 실패를 덮어쓰지 않으며 artifact 크기와 시간 제한을 둔다.
+- [ ] `summary.json`, `summary.md`, family별 JSON, raw Gradle/JUnit 경로 목록을 생성한다. summary는 `selected`, `success`, `product_failure`, `infrastructure_failure`, `blocked`, `coverage`, `release_gate`를 포함하고, 항목이 하나라도 누락되면 `release_gate=false`다.
+- [ ] subprocess를 fake runner로 주입해 success/product/infrastructure/timeout/secret-redaction/diagnostic-failure을 단위 테스트한다. 실제 Docker daemon은 이 테스트에서 요구하지 않는다.
+- [ ] 실행기는 `max-parallel=1`을 내부 불변값으로 유지하고, `--max-attempts`를 무제한으로 허용하지 않는다. 재시도 후에도 원인이 달라지지 않으면 원래 분류와 모든 시도 결과를 보존한다.
+
+## Task 3: Pull Request CI gate 연결
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `scripts/test_release_workflow_policy.py` (release job set 검증은 Task 5와 함께 갱신)
+
+- [ ] `testing/testcontainers/**`, manifest/runner/관련 workflow 변경을 감지하는 filter를 추가하고, 변경 family를 계산해 `run_testcontainers_image_gate.py --scope changed`에 전달한다.
+- [ ] `testcontainers-image-gate` job은 JDK 25, Python 3.12, Gradle wrapper를 설정하고 registry auth/mirror는 secret/vars에서만 주입한다. 하나의 job에서 gate를 순차 실행하고 `if: always()` artifact upload를 보장한다.
+- [ ] summary가 `releaseRequired` family 전부 성공했을 때만 job을 성공시킨다. 변경 범위가 없을 때는 `skipped`를 명시하고 stable release의 full gate와 혼동하지 않는다.
+- [ ] 기존 `testcontainers-spring`, release-policy, required check의 dependency를 점검해 image gate 실패가 green CI로 우회되지 않게 한다. 기존 일반 Testcontainers 테스트와 중복되는 Docker 실행은 제외 플래그로 명시한다.
+- [ ] PR 경로에서 `python3 -m unittest scripts/test_testcontainers_image_gate.py scripts/test_run_testcontainers_image_gate.py scripts/test_testcontainers_contract.py scripts/test_release_workflow_policy.py -v`와 `actionlint .github/workflows/ci.yml`을 실행한다.
+
+## Task 4: Nightly full gate와 진단 보존
+
+**Files:**
+- Modify: `.github/workflows/nightly-tests.yml`
+
+- [ ] 기존 broad Testcontainers matrix는 유지하되, 새 `test-testcontainers-image-gate` job을 별도 `max-parallel: 1` lane으로 추가해 동일 runner의 `--scope full`을 호출한다. 기존 matrix의 8-way 병렬이 새 gate를 병렬화하지 않도록 dependency와 job 이름을 분리한다.
+- [ ] mock-web-server/mock-webflux-server image build와 K3s prerequisite를 gate가 재사용하되, 실패 시 어떤 prerequisite가 막혔는지 summary에 남긴다. ZooKeeper readiness는 현재 `ZookeeperServerSupport.kt`의 Curator session contract를 그대로 사용한다.
+- [ ] Nightly artifact에는 summary, family 진단, JUnit XML, Kover 결과를 retention 14일 이상으로 업로드하고, `52/52`와 분류별 count를 job summary에 출력한다.
+- [ ] `test-testcontainers-spring`와 downstream nightly 집계가 image gate 결과를 읽도록 연결하되, 기존 nightly 전용 테스트 범위와 coverage 계산을 임의로 확장하지 않는다.
+- [ ] YAML syntax/actionlint와 fake runner unit test를 먼저 실행한 뒤, Docker-backed full gate는 하나의 sequential lane에서만 실행한다. rate-limit 또는 daemon 장애가 발생하면 artifact를 남기고 성공으로 강제하지 않는다.
+
+## Task 5: Stable release fail-closed gate
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+- Modify: `scripts/test_release_workflow_policy.py`
+- Modify: `scripts/test_testcontainers_image_gate.py`
+
+- [ ] `resolve-version` 뒤 `testcontainers-image-gate` job을 추가한다. tag ref를 checkout하고 JDK 25/Python 3.12/Gradle을 설정한 뒤 동일 runner로 `--scope full`을 호출한다. `summary.json`에서 `release_gate=true`, `coverage=52/52`, 모든 `releaseRequired=true` 성공을 재검증한다.
+- [ ] `publish.needs`에 `testcontainers-image-gate`를 포함시켜 gate가 실패·누락·취소되면 Maven Central publish가 시작되지 않도록 한다. publish job의 기존 Maven-only 권한과 release machinery 금지 계약은 보존한다.
+- [ ] release artifact에는 tag, exact commit SHA, manifest digest, runner version, per-family result, failure classification, rollback identity를 기록한다. signing secret과 registry credential은 진단에 포함하지 않는다.
+- [ ] `scripts/test_release_workflow_policy.py`의 release job set을 `resolve-version`, `testcontainers-image-gate`, `publish`로 갱신하고 개발 버전 배포 workflow는 여전히 `publish` 하나만 허용한다. 정확한 Maven release task가 한 번만 호출되는 검증을 보존한다.
+- [ ] semantic negative test로 gate dependency 제거, `coverage != 52/52`, 개발 버전 배포 task 삽입, GitHub Release machinery, `contents: write`를 각각 거부하는지 검증한다.
+- [ ] 정상 rollback은 이전에 검증된 bounded manifest/tag로 gate를 다시 통과한 뒤 publish를 재시도하는 경로로 한정한다. rate-limit 우회를 위한 무제한 retry나 gate skip을 정상 rollback으로 문서화하지 않는다.
+
+## Task 6: 운영 문서와 README 계약
+
+**Files:**
+- Create: `docs/operations/issue-1337-testcontainers-image-gate.md`
+- Modify: `testing/testcontainers/README.md`
+- Modify: `testing/testcontainers/README.ko.md`
+- Create: `docs/lessons/2026-08-21-issue-1337-testcontainers-startup-workload-gate.md`
+
+- [ ] 운영 문서에 local/PR/Nightly/release 명령, manifest 갱신 절차, auth/mirror/retry 설정, artifact schema, 분류별 triage, rate-limit 대응, K3s timeout·pod/event/log 확인, rollback/forward-fix를 한국어로 기록한다.
+- [ ] EN/KO README에 “52개 image family gate”의 목적, startup/readiness/workload 의미, stable publish prerequisite, 로컬 실행 예를 추가하고 현재 52행 default-tag 표와 모순되지 않게 한다. copyable command marker와 EN/KO marker parity를 고정한다.
+- [ ] lesson에는 원인-결정-검증-잔여 위험을 기록하고 실제 실행 결과가 없는 항목은 `PENDING`으로 명시한다. benchmark나 chart를 만들지 않으며 이번 slot의 증거 범위를 image gate로 한정한다.
+- [ ] 문서 산출물에 대해 SPW-01 source/evidence lock, SPW-02 contract completeness, SPW-03 Korean technical register/naturalness, SPW-04 traceability, SPW-05 final Markdown read-back을 각각 기록한다. `audit-korean-terms.mjs`, placeholder scan, `git diff --check`가 모두 통과해야 한다.
+
+## Task 7: 검증 순서와 DoD 증거 수집
+
+- [ ] 정적/단위 검증: `python3 -m unittest scripts/testcontainers_image_gate.py scripts/test_run_testcontainers_image_gate.py scripts/test_testcontainers_contract.py scripts/test_release_workflow_policy.py -v`, `python3 -m py_compile scripts/run_testcontainers_image_gate.py`, `git diff --check`.
+- [ ] workflow 검증: `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml .github/workflows/release.yml`, release policy 재실행, 변경된 workflow의 job dependency와 artifact path read-back.
+- [ ] Gradle 검증: `./gradlew projects --no-daemon --no-configuration-cache`, `./gradlew :bluetape4k-testcontainers:compileKotlin :bluetape4k-testcontainers:compileTestKotlin --no-daemon --no-configuration-cache`, 이후 `./gradlew :bluetape4k-testcontainers:test --rerun-tasks --no-configuration-cache`를 순차 실행한다.
+- [ ] Docker-backed 검증은 CI/Nightly의 하나의 sequential lane에서 실행하고, 변경 범위와 full scope를 각각 `52/52` 선택/실행/결과 count로 read-back한다. Docker daemon, registry, K3s 장애는 통과가 아닌 `infrastructure_failure` evidence로 보고한다.
+- [ ] 실패 시 `git diff --check`, static tests, targeted Gradle compile을 유지한 채 원인별 최소 수정 후 해당 단계부터 재검증한다. 전체 테스트가 장시간/환경 장애로 실행되지 않으면 정확한 command, elapsed time, 로그 경로, 미검증 범위를 DoD에 남긴다.
+- [ ] 최종 DoD는 public API 변경 없음, manifest/source/README/test parity, sequential gate, secret-free diagnostics, PR/Nightly/release dependency, `52/52`, P/I/blocked 0, stable publish fail-closed, docs EN/KO parity를 각각 증거와 함께 보고한다.
+
+## Task 8: stacked PR 생성과 다음 승인 경계
+
+- [ ] 모든 구현·문서·workflow 변경을 이 branch에 하나의 reviewable child commit train으로 정리하고 commit마다 Lore 형식(`Constraint`, `Rejected`, `Confidence`, `Scope-risk`, `Directive`, `Tested`, `Not-tested`)을 사용한다. plan/spec 커밋은 이미 `a7e0ac7f6`로 보존한다.
+- [ ] child PR은 base `develop`, head `feat/1418-04-testcontainers-startup-workload-gate`, linked Issue `#1337`, Epic `#1418`로 생성한다. 본문과 `## DoD Status`는 한국어로 작성하고 exact base/head, checks, artifacts, `52/52` 결과, one-person review N/A 사유, 남은 위험을 명시한다.
+- [ ] PR 생성 후 live read-back으로 exact head/base, mergeability, checks/reviews/comments, changed files, linked issue, labels/milestone을 확인한다. CI가 green이어도 path-filtered/skipped 또는 infrastructure failure가 있으면 merge-ready로 표시하지 않는다.
+- [ ] PR이 열려 있는 동안 Epic #1418은 `3/4`로 유지하고 #1337 PR 링크와 `PENDING` gate를 기록한다. merge 승인 전에는 branch 삭제, worktree cleanup, Epic close, default-branch sync를 수행하지 않는다.
+- [ ] fresh exact-head CI/review/DoD 증거가 모두 확보된 뒤에만 사용자에게 merge 승인 경계를 보고한다. 이번 계획의 종료 상태는 구현 완료가 아니라 계획 승인 대기(`PENDING`)다.
+
+## Rollback Plan
+
+- [ ] 코드/문서 변경이 문제를 일으키면 해당 child commit을 되돌리고 기존 `test_testcontainers_contract.py`, 기존 Nightly matrix, 기존 release workflow를 복원한다. gate skip을 추가해 green으로 위장하지 않는다.
+- [ ] workflow만 실패하면 이전 workflow commit으로 bounded revert한 뒤, 정적 contract와 release policy를 먼저 통과시키고 재작업한다. publish가 이미 시작된 경우에는 신규 publish를 중단하고 release owner가 tag/artifact identity를 확인한다.
+- [ ] registry/K3s/Docker 장애는 retry 횟수 증가 대신 진단 artifact와 owner/time-bound를 남긴다. 정상 경로는 bounded manifest를 수정·검증하고 full gate를 다시 통과하는 것이며, break-glass는 별도 명시적 승인 없이는 사용하지 않는다.
+
+## 완료 기준
+
+- [ ] Issue #1337 요구사항 4개와 설계 acceptance criteria 8개가 코드·workflow·문서·테스트 증거로 연결된다.
+- [ ] changed scope와 full scope 모두 선택/실행/분류 결과가 재현 가능하고, stable release는 `52/52` 성공이 아니면 publish하지 않는다.
+- [ ] fresh CI/targeted tests/full module tests/actionlint/read-back이 확보되고, unchecked item·known failure·blocked gate가 DoD에 숨김없이 남는다.

--- a/docs/superpowers/specs/2026-08-21-issue-1337-testcontainers-startup-workload-gate-design.md
+++ b/docs/superpowers/specs/2026-08-21-issue-1337-testcontainers-startup-workload-gate-design.md
@@ -1,0 +1,202 @@
+# #1337 Testcontainers startup/workload gate 설계
+
+## 결정 요약
+
+Epic #1418 Slot 4는 #1331에서 갱신한 Testcontainers 이미지 family가 실제로
+기동되고 대표 workload를 처리하는지 stable publish 전에 검증한다. 검증 대상은
+현재 태그 갱신 PR #1332가 기록한 52개 변경 family로 고정하되, 각 wrapper의
+기존 테스트와 property/endpoint 계약을 재사용한다.
+
+검증 목록을 workflow YAML에 직접 복제하지 않고, source symbol·image·tag·기존
+테스트·workload probe를 한 manifest에서 관리한다. CI와 Nightly는 manifest를
+읽어 변경 family만 선택하고, Testcontainers 자원을 공유하는 단계는
+`max-parallel: 1`로 순차 실행한다. 모든 family의 결과와 진단 artifact가
+완료되어야 stable release job이 진행된다.
+
+## 문제와 현재 근거
+
+- Issue #1331은 `TAG/DEFAULT_TAG` 55개를 검토했고, PR #1332는 52개 기본 태그를
+  변경했다. PR #1332의 Full DB startup은 Docker Hub unauthenticated pull-rate
+  limit으로 `PENDING`이었다.
+- 현재 `.github/workflows/ci.yml`은 `testing/testcontainers/**`를
+  `io-http` 또는 shared 경계로만 분류하며, 일반 PR에서 전체 Testcontainers
+  startup matrix를 요구하지 않는다.
+- `.github/workflows/nightly-tests.yml`은 Testcontainers 그룹을 실행하지만,
+  기존 그룹 결과를 image family별 stable publish 증거로 연결하지 않는다.
+- `BluetapeHttpServer`와 `BluetapeWebfluxServer`는 `/httpbin/get` HTTP 200을
+  wait strategy로 사용한다. 이는 해당 family의 최소 workload probe로 재사용할
+  수 있다.
+- K3s는 privileged Docker runner가 필요하고, ZooKeeper는 listening port가 아닌
+  Curator session readiness가 필요하다는 선행 이슈 증거가 있다. 각 provider의
+  application-level readiness를 manifest에 명시해야 한다.
+- release workflow는 현재 static Testcontainers tag contract를 검사하지만,
+  실제 image startup/workload 결과를 publish prerequisite로 요구하지 않는다.
+
+## 목표와 범위
+
+### 목표
+
+1. `#1331` 변경 family 52개가 manifest에 빠짐없이 표현되는지 검증한다.
+2. 각 family에 대해 container startup, application readiness, 대표 workload를
+   순서대로 실행한다.
+3. 성공·실패·인프라 원인을 구분할 수 있는 immutable artifact를 남긴다.
+4. PR/Nightly/release 경로가 같은 gate와 결과 계약을 사용하게 한다.
+5. required family가 하나라도 미완료이면 stable publish를 차단한다.
+
+### 범위 제외
+
+- 기존 wrapper의 public API, endpoint 이름, credential/property key를 변경하지
+  않는다.
+- 모든 provider를 새 generic Kotlin abstraction으로 통합하지 않는다.
+- Docker Hub rate limit을 성공 또는 검증 면제 상태로 처리하지 않는다.
+- 이 Slot에서 이미지 태그 자체를 다시 선택하지 않는다. 태그 변경은 #1331의
+  source와 문서 계약을 기준으로 한다.
+- #1337의 선행 ZooKeeper readiness 수정은 재구현하지 않고 현재 계약을
+  manifest adapter로 연결한다.
+
+## 대안과 선택
+
+### A. Manifest-driven 기존 테스트 재사용 — 선택
+
+family별로 source symbol, image/tag, 기존 test class, readiness 방식, workload
+probe를 명시한다. 실행기는 manifest를 검증한 뒤 기존 Gradle test pattern을
+순차 호출하고, provider별 진단 collector를 실행한다.
+
+- 장점: 현재 wrapper 계약을 그대로 검증하고, 52개 목록과 CI/release 경계를
+  한 원본에서 추적할 수 있다.
+- 단점: 신규 family가 추가될 때 manifest 항목과 probe를 함께 작성해야 한다.
+- 선택 이유: public API 변경 없이 #1331 변경 집합과 stable publish gate를
+  연결한다.
+
+### B. 모든 wrapper를 위한 generic Kotlin smoke harness
+
+공통 인터페이스로 모든 server를 감싸고 generic startup/workload를 실행한다.
+
+- 장점: 실행 진입점이 하나다.
+- 단점: provider별 readiness, credential, workload가 달라 abstraction이
+  실제 계약을 숨기거나 가장 약한 공통분모로 축소될 위험이 크다.
+- 거부 이유: source의 application-level readiness를 보존하지 못한다.
+
+### C. HTTP와 K3s만 우선 검증
+
+실패 증거가 이미 있는 HTTP/K3s family만 required로 고정한다.
+
+- 장점: 구현과 CI 시간이 짧다.
+- 단점: 52개 변경 family 전체를 stable publish 전에 검증하라는 #1337 요구를
+  만족하지 못한다.
+- 거부 이유: 일부 provider 성공을 전체 image family 성공으로 오인하게 된다.
+
+## 구성 요소와 데이터 흐름
+
+```text
+TAG source + existing test inventory
+        │ static contract
+        ▼
+image-family-gate.json
+        │ select changed families
+        ▼
+CI/Nightly sequential runner (max-parallel=1)
+        │
+        ├─ pull/auth/mirror setup (secret-free logs)
+        ├─ container startup
+        ├─ application readiness
+        ├─ representative workload
+        └─ inspect/log/events + JUnit result artifact
+        ▼
+gate-summary.json (all required families)
+        │
+        ├─ PR required check
+        ├─ Nightly summary/artifact
+        └─ release publish prerequisite
+```
+
+### Manifest 계약
+
+각 항목은 다음 정보를 가진다.
+
+- `id`: 안정적인 family 식별자
+- `source`: `TAG`/`DEFAULT_TAG` 선언의 실제 파일과 symbol
+- `image`와 `tag`: 실행할 Docker image와 source tag
+- `testPattern`: 기존 Testcontainers test class 또는 method
+- `readiness`: `http`, `log`, `client-session`, `k3s-api` 중 하나와 세부 조건
+- `workload`: 성공을 판정하는 실제 요청/명령과 기대 결과
+- `diagnostics`: 실패 시 수집할 Docker/Kubernetes 정보
+- `releaseRequired`: stable publish 차단 대상 여부
+
+manifest 검증기는 source tag, README tag 표, Nightly pre-pull, test pattern이
+서로 일치하는지 확인한다. 누락·중복·미존재 symbol·빈 workload는 즉시 실패한다.
+
+### 실행 및 결과 계약
+
+runner는 항목을 한 번에 하나씩 실행한다. 각 항목의 결과에는 image/tag,
+resolved digest, runner/Java/Docker metadata, startup/readiness/workload
+duration, outcome, failure category, artifact paths를 기록한다. 결과 파일은
+`success`, `product_failure`, `infrastructure_failure`, `blocked` 중 하나를
+사용하며, `infrastructure_failure`도 gate 결과는 실패로 남긴다.
+
+Docker 실패에는 `docker inspect`, `docker logs`, container events를 남긴다.
+K3s 항목은 pod status, events, logs, readiness timeout을 남긴다. 인증 정보,
+registry token, 전체 환경변수는 artifact와 로그에 기록하지 않는다.
+
+## 실패와 rollback
+
+- 포트가 열렸지만 application workload가 실패하면 readiness 성공으로 간주하지
+  않고 `product_failure`로 중단한다.
+- pull rate limit, registry 인증, mirror 연결 실패는 `infrastructure_failure`로
+  분류하고 재시도 횟수와 최종 원인을 남긴다. 실패한 family가 있으면 publish는
+  진행하지 않는다.
+- timeout은 항목별 bounded timeout을 사용하고, 진단 수집 후 다음 family로
+  넘어가지 않는다. 전체 gate를 fail-closed로 종료한다.
+- manifest/source drift가 발견되면 실행보다 먼저 static contract가 실패한다.
+- release rollback은 이전 artifact를 성공으로 재사용하지 않는다. 새 commit에서
+  gate를 다시 통과해야 하며, 이전 결과는 traceability artifact로만 보존한다.
+
+## 호환성 및 운영 경계
+
+- 기존 `PropertyExportingServer` property namespace, endpoint, credential,
+  lifecycle을 그대로 사용한다.
+- HTTP family는 `/httpbin/get` 200을 workload로 사용하고, provider별 추가
+  endpoint는 manifest에 명시한다.
+- K3s는 privileged runner와 별도 nightly/release preflight lane으로 유지한다.
+- CI PR gate는 변경 family만 실행하지만, release gate는 release manifest에
+  포함된 모든 required family를 실행한다.
+- 개발 버전 배포는 이 Slot의 stable publish 차단 규칙을 우회하지 않으며,
+  release workflow가 사용하는 동일한 summary schema를 소비한다.
+
+## 수용 기준
+
+- [ ] 52개 변경 family가 manifest에 1:1로 등록되고 source/README/Nightly
+      pre-pull과 일치한다.
+- [ ] 변경된 family를 선택하는 PR required job이 추가되고 `max-parallel: 1`
+      순차 실행을 보장한다.
+- [ ] 모든 항목이 startup과 application-level workload를 별도로 판정한다.
+- [ ] Docker/K3s 실패 진단 artifact와 failure category가 summary에 기록된다.
+- [ ] registry auth/mirror/retry 설정이 로그에 secret을 남기지 않고 rate limit을
+      검증 면제 사유로 허용하지 않는다.
+- [ ] stable release workflow가 required summary 성공 없이는 publish하지 않는다.
+- [ ] static manifest contract, `actionlint`, 대상 Gradle compile/test,
+      Testcontainers 순차 검증, `git diff --check`가 통과한다.
+- [ ] 기존 public API와 property/endpoint/credential/lifecycle 테스트가
+      회귀 없이 통과한다.
+
+## DoD와 중단 조건
+
+Slot 4 DoD는 PR exact head에서 required checks가 모두 성공하고, manifest
+coverage가 `52/52`, product/infrastructure failure가 `0`, stable publish
+prerequisite가 live read-back된 상태다. 하나라도 누락되거나 Docker/K3s
+증거가 `PENDING`이면 merge-ready로 보고하지 않고 해당 family를 복구한다.
+
+현재 Epic #1418은 Slot 3 완료 후 `3/4`이며, 이 설계가 완료되어도 #1337의
+구현·CI·release 검증이 끝날 때까지 Epic은 `PENDING`이다.
+
+## 근거 원본
+
+- GitHub Issue #1337, #1331, merged PR #1332
+- `.github/workflows/ci.yml`
+- `.github/workflows/nightly-tests.yml`
+- `.github/workflows/release.yml`
+- `scripts/test_testcontainers_contract.py`
+- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt`
+- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt`
+- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt`
+- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZookeeperServerSupport.kt`

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/bulkhead/BulkheadFlowTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/bulkhead/BulkheadFlowTest.kt
@@ -148,58 +148,18 @@ class BulkheadFlowTest {
     }
 
     @Test
-    fun `실행이 취소되었을 경우 bulkhead는 완료로 기록되지 않습니다`() = runSuspendTest(
-        timeout = 10.seconds,
-    ) {
-        val started = CompletableDeferred<Unit>()
-        var flowCompleted = false
-        val bulkhead = Bulkhead.of("testName") {
-            BulkheadConfig.custom()
-                .maxConcurrentCalls(1)
-                .maxWaitDuration(Duration.ZERO)
-                .build()
-        }.registerEventListener()
-
-        val job = launch(start = CoroutineStart.ATOMIC) {
-            flow {
-                started.complete(Unit)
-                delay(5000L.milliseconds)
-                emit(1)
-                flowCompleted = true
-            }
-                .bulkhead(bulkhead)
-                .first()
-        }
-
-        started.await()
-        job.cancelAndJoin()
-
-        job.isCompleted.shouldBeTrue()
-        job.isCancelled.shouldBeTrue()
-        flowCompleted.shouldBeFalse()
-
-        permittedEvents shouldBeEqualTo 1
-        rejectedEvents shouldBeEqualTo 0
-        finishedEvents shouldBeEqualTo 0
-    }
-
-    @Test
-    fun `작업이 예외로 인한 취소가 되었을 경우 bulkhead는 완료로 기록되지 않습니다`() =
+    fun `실행이 취소되었을 경우 bulkhead는 완료로 기록되지 않습니다`() =
         runSuspendTest(timeout = 10.seconds) {
-        val started = CompletableDeferred<Unit>()
-        val parentJob = Job()
-        var flowCompleted = false
+            val started = CompletableDeferred<Unit>()
+            var flowCompleted = false
+            val bulkhead = Bulkhead.of("testName") {
+                BulkheadConfig.custom()
+                    .maxConcurrentCalls(1)
+                    .maxWaitDuration(Duration.ZERO)
+                    .build()
+            }.registerEventListener()
 
-        val bulkhead = Bulkhead.of("testName") {
-            BulkheadConfig.custom()
-                .maxConcurrentCalls(1)
-                .maxWaitDuration(Duration.ZERO)
-                .build()
-        }.registerEventListener()
-
-        val parentScope = CoroutineScope(parentJob)
-        val job = parentScope.launch {
-            launch(start = CoroutineStart.ATOMIC) {
+            val job = launch(start = CoroutineStart.ATOMIC) {
                 flow {
                     started.complete(Unit)
                     delay(5000L.milliseconds)
@@ -209,18 +169,57 @@ class BulkheadFlowTest {
                     .bulkhead(bulkhead)
                     .first()
             }
-            error("exceptional cancellation")
+
+            started.await()
+            job.cancelAndJoin()
+
+            job.isCompleted.shouldBeTrue()
+            job.isCancelled.shouldBeTrue()
+            flowCompleted.shouldBeFalse()
+
+            permittedEvents shouldBeEqualTo 1
+            rejectedEvents shouldBeEqualTo 0
+            finishedEvents shouldBeEqualTo 0
         }
 
-        started.await()
-        parentJob.runCatching { join() }
+    @Test
+    fun `작업이 예외로 인한 취소가 되었을 경우 bulkhead는 완료로 기록되지 않습니다`() =
+        runSuspendTest(timeout = 10.seconds) {
+            val started = CompletableDeferred<Unit>()
+            val parentJob = Job()
+            var flowCompleted = false
 
-        job.isCompleted.shouldBeTrue()
-        job.isCancelled.shouldBeTrue()
-        flowCompleted.shouldBeFalse()
+            val bulkhead = Bulkhead.of("testName") {
+                BulkheadConfig.custom()
+                    .maxConcurrentCalls(1)
+                    .maxWaitDuration(Duration.ZERO)
+                    .build()
+            }.registerEventListener()
 
-        permittedEvents shouldBeEqualTo 1
-        rejectedEvents shouldBeEqualTo 0
-        finishedEvents shouldBeEqualTo 0
-    }
+            val parentScope = CoroutineScope(parentJob)
+            val job = parentScope.launch {
+                launch(start = CoroutineStart.ATOMIC) {
+                    flow {
+                        started.complete(Unit)
+                        delay(5000L.milliseconds)
+                        emit(1)
+                        flowCompleted = true
+                    }
+                        .bulkhead(bulkhead)
+                        .first()
+                }
+                error("exceptional cancellation")
+            }
+
+            started.await()
+            parentJob.runCatching { join() }
+
+            job.isCompleted.shouldBeTrue()
+            job.isCancelled.shouldBeTrue()
+            flowCompleted.shouldBeFalse()
+
+            permittedEvents shouldBeEqualTo 1
+            rejectedEvents shouldBeEqualTo 0
+            finishedEvents shouldBeEqualTo 0
+        }
 }

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/bulkhead/BulkheadFlowTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/bulkhead/BulkheadFlowTest.kt
@@ -148,7 +148,9 @@ class BulkheadFlowTest {
     }
 
     @Test
-    fun `실행이 취소되었을 경우 bulkhead는 완료로 기록되지 않습니다`() = runSuspendTest(timeout = 10.seconds) {
+    fun `실행이 취소되었을 경우 bulkhead는 완료로 기록되지 않습니다`() = runSuspendTest(
+        timeout = 10.seconds,
+    ) {
         val started = CompletableDeferred<Unit>()
         var flowCompleted = false
         val bulkhead = Bulkhead.of("testName") {
@@ -182,7 +184,8 @@ class BulkheadFlowTest {
     }
 
     @Test
-    fun `작업이 예외로 인한 취소가 되었을 경우 bulkhead는 완료로 기록되지 않습니다`() = runSuspendTest(timeout = 10.seconds) {
+    fun `작업이 예외로 인한 취소가 되었을 경우 bulkhead는 완료로 기록되지 않습니다`() =
+        runSuspendTest(timeout = 10.seconds) {
         val started = CompletableDeferred<Unit>()
         val parentJob = Job()
         var flowCompleted = false

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/bulkhead/BulkheadFlowTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/bulkhead/BulkheadFlowTest.kt
@@ -12,6 +12,7 @@ import io.github.resilience4j.bulkhead.Bulkhead
 import io.github.resilience4j.bulkhead.BulkheadConfig
 import io.github.resilience4j.bulkhead.BulkheadFullException
 import io.github.resilience4j.kotlin.bulkhead.bulkhead
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -26,8 +27,8 @@ import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
-import java.util.concurrent.Phaser
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class BulkheadFlowTest {
 
@@ -147,8 +148,8 @@ class BulkheadFlowTest {
     }
 
     @Test
-    fun `실행이 취소되었을 경우 bulkhead는 완료로 기록되지 않습니다`() = runSuspendTest {
-        val phaser = Phaser(1)
+    fun `실행이 취소되었을 경우 bulkhead는 완료로 기록되지 않습니다`() = runSuspendTest(timeout = 10.seconds) {
+        val started = CompletableDeferred<Unit>()
         var flowCompleted = false
         val bulkhead = Bulkhead.of("testName") {
             BulkheadConfig.custom()
@@ -159,7 +160,7 @@ class BulkheadFlowTest {
 
         val job = launch(start = CoroutineStart.ATOMIC) {
             flow {
-                phaser.arrive()
+                started.complete(Unit)
                 delay(5000L.milliseconds)
                 emit(1)
                 flowCompleted = true
@@ -168,7 +169,7 @@ class BulkheadFlowTest {
                 .first()
         }
 
-        phaser.awaitAdvance(1)
+        started.await()
         job.cancelAndJoin()
 
         job.isCompleted.shouldBeTrue()
@@ -181,8 +182,8 @@ class BulkheadFlowTest {
     }
 
     @Test
-    fun `작업이 예외로 인한 취소가 되었을 경우 bulkhead는 완료로 기록되지 않습니다`() = runSuspendTest {
-        val phaser = Phaser(1)
+    fun `작업이 예외로 인한 취소가 되었을 경우 bulkhead는 완료로 기록되지 않습니다`() = runSuspendTest(timeout = 10.seconds) {
+        val started = CompletableDeferred<Unit>()
         val parentJob = Job()
         var flowCompleted = false
 
@@ -197,7 +198,7 @@ class BulkheadFlowTest {
         val job = parentScope.launch {
             launch(start = CoroutineStart.ATOMIC) {
                 flow {
-                    phaser.arrive()
+                    started.complete(Unit)
                     delay(5000L.milliseconds)
                     emit(1)
                     flowCompleted = true
@@ -208,7 +209,7 @@ class BulkheadFlowTest {
             error("exceptional cancellation")
         }
 
-        phaser.awaitAdvance(1)
+        started.await()
         parentJob.runCatching { join() }
 
         job.isCompleted.shouldBeTrue()

--- a/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/circuitbreaker/FlowCircuitBreakerTest.kt
+++ b/infra/resilience4j/src/test/kotlin/io/bluetape4k/resilience4j/circuitbreaker/FlowCircuitBreakerTest.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import io.github.resilience4j.kotlin.circuitbreaker.circuitBreaker
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -20,8 +21,8 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import org.junit.jupiter.api.Test
-import java.util.concurrent.Phaser
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class FlowCircuitBreakerTest {
 
@@ -138,8 +139,8 @@ class FlowCircuitBreakerTest {
     }
 
     @Test
-    fun `Job 취소 시에는 fail로 기록하지 않습니다`() = runSuspendTest {
-        val phaser = Phaser(1)
+    fun `Job 취소 시에는 fail로 기록하지 않습니다`() = runSuspendTest(timeout = 10.seconds) {
+        val started = CompletableDeferred<Unit>()
         var flowCompleted = false
         val circuitBreaker = CircuitBreaker.ofDefaults("testName")
         val metrics = circuitBreaker.metrics
@@ -147,7 +148,7 @@ class FlowCircuitBreakerTest {
 
         val job = launch(start = CoroutineStart.ATOMIC) {
             flow {
-                phaser.arrive()
+                started.complete(Unit)
                 delay(5000L.milliseconds)
                 emit(1)
                 flowCompleted = true
@@ -156,7 +157,7 @@ class FlowCircuitBreakerTest {
                 .first()
         }
 
-        phaser.awaitAdvance(1)
+        started.await()
         job.cancelAndJoin()
 
         job.isCompleted.shouldBeTrue()
@@ -170,9 +171,9 @@ class FlowCircuitBreakerTest {
     }
 
     @Test
-    fun `Job 예외 취소 시에는 fail로 기록하지 않습니다`() = runSuspendTest {
+    fun `Job 예외 취소 시에는 fail로 기록하지 않습니다`() = runSuspendTest(timeout = 10.seconds) {
         val parentJob = Job()
-        val phaser = Phaser(1)
+        val started = CompletableDeferred<Unit>()
         var flowCompleted = false
         val circuitBreaker = CircuitBreaker.ofDefaults("testName")
         val metrics = circuitBreaker.metrics
@@ -182,7 +183,7 @@ class FlowCircuitBreakerTest {
         val job = parentScope.launch {
             launch(start = CoroutineStart.ATOMIC) {
                 flow {
-                    phaser.arrive()
+                    started.complete(Unit)
                     delay(5000L.milliseconds)
                     emit(1)
                     flowCompleted = true
@@ -193,7 +194,7 @@ class FlowCircuitBreakerTest {
             error("exceptional cancellation")
         }
 
-        phaser.awaitAdvance(1)
+        started.await()
         parentJob.runCatching { join() }
 
         job.isCompleted.shouldBeTrue()

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -177,10 +177,12 @@ class GateRunner:
             started = time.monotonic()
             result = self.command_runner(command, self.timeout_seconds)
             elapsed = round(time.monotonic() - started, 3)
-            stdout = _bounded(getattr(result, "stdout", ""))
-            stderr = _bounded(getattr(result, "stderr", ""))
+            raw_stdout = getattr(result, "stdout", "")
+            raw_stderr = getattr(result, "stderr", "")
+            stdout = _bounded(raw_stdout)
+            stderr = _bounded(raw_stderr)
             returncode = getattr(result, "returncode", None)
-            status = _classify_command_result(returncode, stdout, stderr)
+            status = _classify_command_result(returncode, raw_stdout, raw_stderr)
             attempts.append(
                 {
                     "attempt": attempt,

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -40,6 +40,11 @@ INFRASTRUCTURE_MARKERS = (
     "connection reset",
     "eof",
 )
+TEST_DISCOVERY_FAILURE_PATTERN = re.compile(
+    r"execution failed for task ['\"][^'\"]+['\"].*"
+    r"no tests found for given includes",
+    re.IGNORECASE | re.DOTALL,
+)
 SECRET_PATTERN = re.compile(
     r"(?i)(password|passwd|token|secret|authorization|api[_-]?key)\s*[:=]\s*([^\s,;]+)"
 )
@@ -67,7 +72,11 @@ def classify_failure(returncode: int | None, stdout: str, stderr: str) -> str:
     if returncode == 0:
         return "success"
     haystack = f"{stdout}\n{stderr}".lower()
-    if returncode is None or any(marker in haystack for marker in INFRASTRUCTURE_MARKERS):
+    if returncode is None:
+        return "infrastructure_failure"
+    if TEST_DISCOVERY_FAILURE_PATTERN.search(haystack):
+        return "product_failure"
+    if any(marker in haystack for marker in INFRASTRUCTURE_MARKERS):
         return "infrastructure_failure"
     return "product_failure"
 
@@ -132,6 +141,11 @@ class GateRunner:
 
     def _command(self, entry: dict[str, Any]) -> list[str]:
         command = shlex.split(self.gradle_task)
+        if test_task := entry.get("testTask"):
+            task_positions = [index for index, part in enumerate(command) if part.startswith(":")]
+            if len(task_positions) != 1:
+                raise ValueError(f"expected one Gradle task in command: {self.gradle_task}")
+            command[task_positions[0]] = str(test_task)
         command.extend(("--tests", str(entry["testPattern"]), "--no-configuration-cache"))
         return command
 

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Run the manifest-driven Testcontainers image gate sequentially."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shlex
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from scripts.testcontainers_image_gate import MANIFEST, load_manifest, select_entries, validate_manifest
+
+
+CommandRunner = Callable[[list[str], int], Any]
+DiagnosticRunner = Callable[[dict[str, Any]], dict[str, str]]
+MAX_ATTEMPTS = 3
+MAX_OUTPUT_CHARS = 12_000
+INFRASTRUCTURE_MARKERS = (
+    "toomanyrequests",
+    "rate limit",
+    "pull access denied",
+    "manifest unknown",
+    "connection refused",
+    "cannot connect to the docker daemon",
+    "docker daemon",
+    "no space left on device",
+    "timed out",
+    "timeout",
+    "connection reset",
+    "eof",
+)
+SECRET_PATTERN = re.compile(
+    r"(?i)(password|passwd|token|secret|authorization|api[_-]?key)\s*[:=]\s*([^\s,;]+)"
+)
+BEARER_PATTERN = re.compile(r"(?i)(bearer\s+)[^\s,;]+")
+
+
+def redact(value: str) -> str:
+    """Remove common credential values before text enters logs or artifacts."""
+
+    redacted = BEARER_PATTERN.sub(r"\1<redacted>", value)
+    redacted = SECRET_PATTERN.sub(r"\1=<redacted>", redacted)
+    return redacted
+
+
+def _bounded(value: object) -> str:
+    text = redact(str(value or ""))
+    if len(text) <= MAX_OUTPUT_CHARS:
+        return text
+    return text[:MAX_OUTPUT_CHARS] + "\n...[truncated]"
+
+
+def classify_failure(returncode: int | None, stdout: str, stderr: str) -> str:
+    """Classify a command result without conflating registry/daemon failures with product bugs."""
+
+    if returncode == 0:
+        return "success"
+    haystack = f"{stdout}\n{stderr}".lower()
+    if returncode is None or any(marker in haystack for marker in INFRASTRUCTURE_MARKERS):
+        return "infrastructure_failure"
+    return "product_failure"
+
+
+def _classify_command_result(returncode: int | None, stdout: str, stderr: str) -> str:
+    status = classify_failure(returncode, stdout, stderr)
+    if status == "success" and not re.search(r"\bBUILD SUCCESSFUL\b", f"{stdout}\n{stderr}"):
+        return "blocked"
+    return status
+
+
+def _subprocess_runner(command: list[str], timeout_seconds: int) -> Any:
+    try:
+        return subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as error:
+        return type(
+            "TimeoutResult",
+            (),
+            {
+                "returncode": None,
+                "stdout": error.stdout or "",
+                "stderr": (error.stderr or "") + " timeout",
+            },
+        )()
+
+
+class GateRunner:
+    """Execute selected families one by one and persist fail-closed evidence."""
+
+    def __init__(
+        self,
+        entries: Iterable[dict[str, Any]],
+        report_dir: Path,
+        *,
+        command_runner: CommandRunner = _subprocess_runner,
+        diagnostic_runner: DiagnosticRunner | None = None,
+        gradle_task: str = "./gradlew :bluetape4k-testcontainers:test",
+        max_attempts: int = 1,
+        timeout_minutes: int = 30,
+        manifest_path: Path | None = None,
+    ) -> None:
+        self.entries = [dict(entry) for entry in entries]
+        self.report_dir = report_dir
+        self.command_runner = command_runner
+        self.diagnostic_runner = diagnostic_runner or self._collect_diagnostics
+        self.gradle_task = gradle_task
+        self.max_attempts = max(1, min(max_attempts, MAX_ATTEMPTS))
+        self.timeout_seconds = max(60, timeout_minutes * 60)
+        self.manifest_digest = self._digest(manifest_path)
+
+    def _digest(self, manifest_path: Path | None) -> str:
+        if manifest_path and manifest_path.is_file():
+            return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+        canonical = json.dumps(self.entries, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
+
+    def _command(self, entry: dict[str, Any]) -> list[str]:
+        command = shlex.split(self.gradle_task)
+        command.extend(("--tests", str(entry["testPattern"]), "--no-configuration-cache"))
+        return command
+
+    def _collect_diagnostics(self, entry: dict[str, Any]) -> dict[str, str]:
+        image_ref = f"{entry['image']}:{entry['tag']}"
+        commands: list[tuple[str, list[str]]] = [
+            (
+                "docker_ps",
+                ["docker", "ps", "-a", "--no-trunc", "--filter", f"ancestor={image_ref}"],
+            ),
+            ("docker_inspect", ["docker", "inspect", image_ref]),
+            ("docker_events", ["timeout", "10s", "docker", "events", "--since", "5m"]),
+        ]
+        if entry["server"] == "K3sServer":
+            commands.extend(
+                (
+                    ("kubectl_pods", ["kubectl", "get", "pods", "--all-namespaces", "-o", "wide"]),
+                    (
+                        "kubectl_events",
+                        ["kubectl", "get", "events", "--all-namespaces", "--sort-by=.lastTimestamp"],
+                    ),
+                    (
+                        "kubectl_logs",
+                        ["kubectl", "logs", "--all-namespaces", "--all-containers", "--tail=200"],
+                    ),
+                )
+            )
+        diagnostics: dict[str, str] = {}
+        for label, command in commands:
+            result = self.command_runner(command, min(self.timeout_seconds, 60))
+            diagnostics[label] = _bounded(
+                f"exit={getattr(result, 'returncode', None)}\n"
+                f"stdout={getattr(result, 'stdout', '')}\n"
+                f"stderr={getattr(result, 'stderr', '')}"
+            )
+        return diagnostics
+
+    def _run_family(self, entry: dict[str, Any]) -> dict[str, Any]:
+        attempts: list[dict[str, Any]] = []
+        command = self._command(entry)
+        final_status = "blocked"
+        for attempt in range(1, self.max_attempts + 1):
+            started = time.monotonic()
+            result = self.command_runner(command, self.timeout_seconds)
+            elapsed = round(time.monotonic() - started, 3)
+            stdout = _bounded(getattr(result, "stdout", ""))
+            stderr = _bounded(getattr(result, "stderr", ""))
+            returncode = getattr(result, "returncode", None)
+            status = _classify_command_result(returncode, stdout, stderr)
+            attempts.append(
+                {
+                    "attempt": attempt,
+                    "command": redact(" ".join(command)),
+                    "returncode": returncode,
+                    "elapsed_seconds": elapsed,
+                    "status": status,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                }
+            )
+            final_status = status
+            if status == "success":
+                break
+
+        result: dict[str, Any] = {
+            "id": entry["id"],
+            "server": entry["server"],
+            "image": entry["image"],
+            "tag": entry["tag"],
+            "test_pattern": entry["testPattern"],
+            "release_required": bool(entry["releaseRequired"]),
+            "status": final_status,
+            "attempts": attempts,
+        }
+        if final_status != "success":
+            try:
+                result["diagnostics"] = self.diagnostic_runner(entry)
+            except Exception as error:  # diagnostics must not hide the original failure
+                result["diagnostics"] = {"diagnostic_error": _bounded(error)}
+        return result
+
+    def run(self) -> dict[str, Any]:
+        self.report_dir.mkdir(parents=True, exist_ok=True)
+        results = []
+        for entry in self.entries:
+            result = self._run_family(entry)
+            results.append(result)
+            (self.report_dir / f"{entry['id']}.json").write_text(
+                json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+
+        counts = {status: sum(result["status"] == status for result in results) for status in (
+            "success",
+            "product_failure",
+            "infrastructure_failure",
+            "blocked",
+        )}
+        selected = len(results)
+        release_gate = selected > 0 and counts["success"] == selected and all(
+            result["release_required"] for result in results
+        )
+        summary: dict[str, Any] = {
+            "schema_version": 1,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "manifest_digest": self.manifest_digest,
+            "selected": selected,
+            "success": counts["success"],
+            "product_failure": counts["product_failure"],
+            "infrastructure_failure": counts["infrastructure_failure"],
+            "blocked": counts["blocked"],
+            "coverage": f"{counts['success']}/{selected}",
+            "release_gate": release_gate,
+            "status": "success" if release_gate else ("skipped" if selected == 0 else "failed"),
+            "results": results,
+        }
+        (self.report_dir / "summary.json").write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+        self._write_markdown(summary)
+        return summary
+
+    def _write_markdown(self, summary: dict[str, Any]) -> None:
+        lines = [
+            "# Testcontainers image gate",
+            "",
+            f"- 상태: `{summary['status']}`",
+            f"- 선택/성공: `{summary['coverage']}`",
+            f"- 제품 실패: `{summary['product_failure']}`",
+            f"- 인프라 실패: `{summary['infrastructure_failure']}`",
+            f"- 차단: `{summary['blocked']}`",
+            f"- stable release gate: `{str(summary['release_gate']).lower()}`",
+            f"- manifest digest: `{summary['manifest_digest']}`",
+            "",
+            "| family | image | tag | status | attempts |",
+            "|---|---|---|---|---:|",
+        ]
+        lines.extend(
+            f"| `{result['server']}` | `{result['image']}` | `{result['tag']}` | "
+            f"`{result['status']}` | {len(result['attempts'])} |"
+            for result in summary["results"]
+        )
+        (self.report_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _blocked_summary(report_dir: Path, errors: Sequence[str], manifest_path: Path) -> dict[str, Any]:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "manifest_digest": hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+        if manifest_path.is_file()
+        else "",
+        "selected": 0,
+        "success": 0,
+        "product_failure": 0,
+        "infrastructure_failure": 0,
+        "blocked": 1,
+        "coverage": "0/0",
+        "release_gate": False,
+        "status": "blocked",
+        "errors": list(errors),
+        "results": [],
+    }
+    (report_dir / "summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return summary
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=MANIFEST)
+    parser.add_argument("--scope", choices=("changed", "full"), default="changed")
+    parser.add_argument("--changed-path", action="append", default=[])
+    parser.add_argument("--changed-path-file", type=Path)
+    parser.add_argument("--report-dir", type=Path, default=Path("build/reports/testcontainers-image-gate"))
+    parser.add_argument("--gradle-task", default="./gradlew :bluetape4k-testcontainers:test")
+    parser.add_argument("--max-attempts", type=int, default=1)
+    parser.add_argument("--timeout-minutes", type=int, default=30)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        entries = load_manifest(args.manifest)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        _blocked_summary(args.report_dir, [str(error)], args.manifest)
+        print(f"BLOCKED: {error}", file=sys.stderr)
+        return 2
+    errors = validate_manifest(entries)
+    if errors:
+        _blocked_summary(args.report_dir, errors, args.manifest)
+        print("BLOCKED: manifest contract drift", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
+    changed_paths = set(args.changed_path)
+    if args.changed_path_file and args.changed_path_file.is_file():
+        changed_paths.update(
+            line.strip() for line in args.changed_path_file.read_text(encoding="utf-8").splitlines() if line.strip()
+        )
+    selected = select_entries(entries, changed_paths, scope=args.scope)
+    summary = GateRunner(
+        selected,
+        args.report_dir,
+        gradle_task=args.gradle_task,
+        max_attempts=args.max_attempts,
+        timeout_minutes=args.timeout_minutes,
+        manifest_path=args.manifest,
+    ).run()
+    print(json.dumps({key: summary[key] for key in (
+        "status", "coverage", "product_failure", "infrastructure_failure", "blocked", "release_gate"
+    )}, ensure_ascii=False))
+    return 0 if summary["status"] in {"success", "skipped"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -45,8 +45,12 @@ def release_policy_errors(workflow: str) -> list[str]:
         errors.append("release workflow must not request write access to repository contents")
     if ISSUE_RELEASE_MACHINERY.search(workflow):
         errors.append("release workflow must not contain issue-specific release machinery")
-    if job_ids(workflow) != {"resolve-version", "publish"}:
-        errors.append("release workflow must contain only resolve-version and publish jobs")
+    if job_ids(workflow) != {"resolve-version", "testcontainers-image-gate", "publish"}:
+        errors.append("release workflow must contain resolve-version, testcontainers-image-gate, and publish jobs")
+    if "needs: [resolve-version, testcontainers-image-gate]" not in workflow:
+        errors.append("publish must depend on the full Testcontainers image gate")
+    if "--scope full" not in workflow or "coverage=52/52" not in workflow:
+        errors.append("release workflow must verify the full 52/52 image gate")
     return errors
 
 
@@ -102,6 +106,12 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
 
         self.assertIn("Publish RELEASE to Maven Central Portal", workflow)
         self.assertEqual([], release_policy_errors(workflow))
+
+    def test_release_workflow_blocks_publish_without_full_image_gate(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace("needs: [resolve-version, testcontainers-image-gate]", "needs: resolve-version")
+        errors = release_policy_errors(mutated)
+        self.assertIn("publish must depend on the full Testcontainers image gate", errors)
 
     def test_snapshot_workflow_is_not_coupled_to_issue_754_release_state(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Unit tests for the Docker-backed image gate runner."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.run_testcontainers_image_gate import (
+    GateRunner,
+    classify_failure,
+    redact,
+)
+
+
+def entry(server: str = "FlociServer") -> dict[str, object]:
+    return {
+        "id": server.lower(),
+        "server": server,
+        "source": "testing/testcontainers/src/main/kotlin/example/Server.kt",
+        "testSource": "testing/testcontainers/src/test/kotlin/example/ServerTest.kt",
+        "image": "example/image",
+        "tag": "1.0",
+        "testPattern": f"example.{server}Test",
+        "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+        "workload": f"example.{server}Test:representative_test",
+        "diagnostics": ["docker_inspect", "docker_logs", "docker_events"],
+        "releaseRequired": True,
+    }
+
+
+class TestRunTestcontainersImageGate(unittest.TestCase):
+    def test_successful_family_records_command_and_coverage(self) -> None:
+        calls: list[list[str]] = []
+
+        def command_runner(command: list[str], timeout_seconds: int) -> SimpleNamespace:
+            calls.append(command)
+            return SimpleNamespace(returncode=0, stdout="BUILD SUCCESSFUL", stderr="")
+
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [entry()],
+                Path(directory),
+                command_runner=command_runner,
+                max_attempts=1,
+            ).run()
+            self.assertEqual("success", summary["results"][0]["status"])
+            self.assertEqual("1/1", summary["coverage"])
+            self.assertTrue(summary["release_gate"])
+            self.assertIn("--tests", calls[0])
+            self.assertTrue((Path(directory) / "summary.json").is_file())
+
+    def test_infrastructure_failure_retries_and_collects_diagnostics(self) -> None:
+        calls: list[list[str]] = []
+        diagnostics: list[str] = []
+
+        def command_runner(command: list[str], timeout_seconds: int) -> SimpleNamespace:
+            calls.append(command)
+            return SimpleNamespace(returncode=1, stdout="toomanyrequests: rate limit", stderr="")
+
+        def diagnostic_runner(family: dict[str, object]) -> dict[str, str]:
+            diagnostics.append(str(family["server"]))
+            return {"docker_logs": "<redacted>"}
+
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [entry()],
+                Path(directory),
+                command_runner=command_runner,
+                diagnostic_runner=diagnostic_runner,
+                max_attempts=2,
+            ).run()
+            result = summary["results"][0]
+            self.assertEqual("infrastructure_failure", result["status"])
+            self.assertEqual(2, len(result["attempts"]))
+            self.assertEqual(["FlociServer"], diagnostics)
+            self.assertFalse(summary["release_gate"])
+
+    def test_product_failure_and_timeout_are_distinct(self) -> None:
+        self.assertEqual("product_failure", classify_failure(1, "AssertionError: expected 200", ""))
+        self.assertEqual("infrastructure_failure", classify_failure(1, "connection refused", ""))
+        self.assertEqual("infrastructure_failure", classify_failure(None, "", "timeout"))
+
+    def test_zero_exit_without_gradle_success_evidence_is_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [entry()],
+                Path(directory),
+                command_runner=lambda command, timeout_seconds: SimpleNamespace(
+                    returncode=0, stdout="completed without the Gradle result", stderr=""
+                ),
+                max_attempts=1,
+            ).run()
+            self.assertEqual("blocked", summary["results"][0]["status"])
+            self.assertFalse(summary["release_gate"])
+
+    def test_secret_redaction_applies_to_artifact_text(self) -> None:
+        safe = redact("TOKEN=super-secret password=hunter2 Authorization: Bearer abc123")
+        self.assertNotIn("super-secret", safe)
+        self.assertNotIn("hunter2", safe)
+        self.assertNotIn("abc123", safe)
+        self.assertIn("<redacted>", safe)
+
+    def test_summary_json_is_machine_readable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [entry()],
+                Path(directory),
+                command_runner=lambda command, timeout_seconds: SimpleNamespace(
+                    returncode=0, stdout="BUILD SUCCESSFUL", stderr=""
+                ),
+                max_attempts=1,
+            ).run()
+            read_back = json.loads((Path(directory) / "summary.json").read_text())
+            self.assertEqual(summary["manifest_digest"], read_back["manifest_digest"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -84,6 +84,44 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
         self.assertEqual("infrastructure_failure", classify_failure(1, "connection refused", ""))
         self.assertEqual("infrastructure_failure", classify_failure(None, "", "timeout"))
 
+    def test_test_discovery_failure_wins_over_unrelated_docker_output(self) -> None:
+        stdout = "building image to Docker daemon\ntimeout while preparing unrelated diagnostics\n"
+        stderr = (
+            "Execution failed for task ':bluetape4k-testcontainers:test'.\n"
+            "> No tests found for given includes: "
+            "[io.bluetape4k.testcontainers.infra.K3sServerTest](--tests filter)"
+        )
+
+        self.assertEqual("product_failure", classify_failure(1, stdout, stderr))
+
+    def test_test_discovery_words_without_gradle_failure_context_do_not_override_infrastructure(self) -> None:
+        stdout = "building image to Docker daemon\n"
+        stderr = "diagnostic note: No tests found for given includes may be reported later"
+
+        self.assertEqual("infrastructure_failure", classify_failure(1, stdout, stderr))
+
+    def test_family_specific_test_task_overrides_the_default_task(self) -> None:
+        calls: list[list[str]] = []
+        k3s = entry("K3sServer")
+        k3s["testTask"] = ":bluetape4k-testcontainers:k8sTest"
+
+        def command_runner(command: list[str], timeout_seconds: int) -> SimpleNamespace:
+            calls.append(command)
+            return SimpleNamespace(returncode=0, stdout="BUILD SUCCESSFUL", stderr="")
+
+        with tempfile.TemporaryDirectory() as directory:
+            GateRunner(
+                [k3s],
+                Path(directory),
+                command_runner=command_runner,
+                max_attempts=1,
+            ).run()
+
+        self.assertEqual(
+            ["./gradlew", ":bluetape4k-testcontainers:k8sTest"],
+            calls[0][:2],
+        )
+
     def test_zero_exit_without_gradle_success_evidence_is_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             summary = GateRunner(

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -97,6 +97,20 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             self.assertEqual("blocked", summary["results"][0]["status"])
             self.assertFalse(summary["release_gate"])
 
+    def test_success_after_long_gradle_output_is_not_blocked(self) -> None:
+        long_success = ("progress\n" * 4000) + "BUILD SUCCESSFUL\n"
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [entry()],
+                Path(directory),
+                command_runner=lambda command, timeout_seconds: SimpleNamespace(
+                    returncode=0, stdout=long_success, stderr=""
+                ),
+                max_attempts=1,
+            ).run()
+            self.assertEqual("success", summary["results"][0]["status"])
+            self.assertTrue(summary["release_gate"])
+
     def test_secret_redaction_applies_to_artifact_text(self) -> None:
         safe = redact("TOKEN=super-secret password=hunter2 Authorization: Bearer abc123")
         self.assertNotIn("super-secret", safe)

--- a/scripts/test_testcontainers_contract.py
+++ b/scripts/test_testcontainers_contract.py
@@ -7,6 +7,8 @@ import re
 import unittest
 from pathlib import Path
 
+from scripts.testcontainers_image_gate import load_manifest, validate_manifest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 KOTLIN_ROOT = ROOT / "testing/testcontainers/src/main/kotlin"
@@ -136,6 +138,10 @@ class TestTestcontainersContract(unittest.TestCase):
                 self.assertIn("not supported", content)
             else:
                 self.assertIn("지원하지 않", content)
+
+    def test_image_gate_manifest_matches_this_contract(self) -> None:
+        manifest = load_manifest(ROOT / "scripts/testcontainers_image_gate_manifest.json")
+        self.assertEqual([], validate_manifest(manifest, ROOT))
 
 
 if __name__ == "__main__":

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -25,6 +25,14 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertEqual(EXPECTED_FAMILY_COUNT, len(self.entries))
         self.assertEqual([], validate_manifest(self.entries, self.root))
 
+    def test_k3s_family_uses_the_existing_tagged_test_task(self) -> None:
+        k3s = next(entry for entry in self.entries if entry["server"] == "K3sServer")
+        self.assertEqual(":bluetape4k-testcontainers:k8sTest", k3s["testTask"])
+        build_script = (
+            self.root / "testing/testcontainers/build.gradle.kts"
+        ).read_text(encoding="utf-8")
+        self.assertIn('tasks.register<Test>("k8sTest")', build_script)
+
     def test_changed_scope_is_deterministic_and_full_scope_is_complete(self) -> None:
         changed = select_entries(self.entries, {"testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt"})
         self.assertEqual(["FlociServer"], [entry["server"] for entry in changed])
@@ -36,6 +44,20 @@ class TestTestcontainersImageGate(unittest.TestCase):
     def test_invalid_manifest_reports_drift_without_running_docker(self) -> None:
         invalid = [dict(self.entries[0], image="wrong/image")]
         self.assertIn("image drift", " ".join(validate_manifest(invalid, self.root)))
+
+    def test_invalid_family_specific_test_task_reports_drift(self) -> None:
+        invalid = [dict(self.entries[0], testTask="test")]
+        self.assertIn(
+            "testTask must be a Gradle task path",
+            " ".join(validate_manifest(invalid, self.root)),
+        )
+
+    def test_unknown_family_specific_test_task_reports_drift(self) -> None:
+        invalid = [dict(self.entries[0], testTask=":not-existing-task")]
+        self.assertIn(
+            "unknown testTask",
+            " ".join(validate_manifest(invalid, self.root)),
+        )
 
     def test_ci_workflow_runs_changed_gate_and_uploads_evidence(self) -> None:
         workflow = (self.root / ".github/workflows/ci.yml").read_text(encoding="utf-8")

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -30,9 +30,20 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertEqual(["FlociServer"], [entry["server"] for entry in changed])
         self.assertEqual(self.entries, select_entries(self.entries, set(), scope="full"))
 
+        shared = select_entries(self.entries, {"scripts/run_testcontainers_image_gate.py"})
+        self.assertEqual(EXPECTED_FAMILY_COUNT, len(shared))
+
     def test_invalid_manifest_reports_drift_without_running_docker(self) -> None:
         invalid = [dict(self.entries[0], image="wrong/image")]
         self.assertIn("image drift", " ".join(validate_manifest(invalid, self.root)))
+
+    def test_ci_workflow_runs_changed_gate_and_uploads_evidence(self) -> None:
+        workflow = (self.root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertIn("testcontainers-image-gate:", workflow)
+        self.assertIn("--scope changed", workflow)
+        self.assertIn("--changed-path-file", workflow)
+        self.assertIn("build/reports/testcontainers-image-gate/", workflow)
+        self.assertIn("testcontainers-image-gate, test-ktor", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -53,6 +53,13 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertIn("needs: [test-testcontainers, test-testcontainers-image-gate, plan]", workflow)
         self.assertIn("- test-testcontainers-image-gate", workflow)
 
+    def test_release_publish_depends_on_full_gate_summary(self) -> None:
+        workflow = (self.root / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        self.assertIn("testcontainers-image-gate:", workflow)
+        self.assertIn("needs: [resolve-version, testcontainers-image-gate]", workflow)
+        self.assertIn("--scope full", workflow)
+        self.assertIn("coverage=52/52", workflow)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Test the manifest-driven Testcontainers image gate contract."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.testcontainers_image_gate import (
+    EXPECTED_FAMILY_COUNT,
+    load_manifest,
+    select_entries,
+    validate_manifest,
+)
+
+
+class TestTestcontainersImageGate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root = Path(__file__).resolve().parents[1]
+        cls.manifest_path = cls.root / "scripts/testcontainers_image_gate_manifest.json"
+        cls.entries = load_manifest(cls.manifest_path)
+
+    def test_manifest_covers_every_image_family_and_has_required_fields(self) -> None:
+        self.assertEqual(EXPECTED_FAMILY_COUNT, len(self.entries))
+        self.assertEqual([], validate_manifest(self.entries, self.root))
+
+    def test_changed_scope_is_deterministic_and_full_scope_is_complete(self) -> None:
+        changed = select_entries(self.entries, {"testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt"})
+        self.assertEqual(["FlociServer"], [entry["server"] for entry in changed])
+        self.assertEqual(self.entries, select_entries(self.entries, set(), scope="full"))
+
+    def test_invalid_manifest_reports_drift_without_running_docker(self) -> None:
+        invalid = [dict(self.entries[0], image="wrong/image")]
+        self.assertIn("image drift", " ".join(validate_manifest(invalid, self.root)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -45,6 +45,14 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertIn("build/reports/testcontainers-image-gate/", workflow)
         self.assertIn("testcontainers-image-gate, test-ktor", workflow)
 
+    def test_nightly_runs_full_gate_sequentially_before_spring_bridge(self) -> None:
+        workflow = (self.root / ".github/workflows/nightly-tests.yml").read_text(encoding="utf-8")
+        self.assertIn("test-testcontainers-image-gate:", workflow)
+        self.assertIn("--scope full", workflow)
+        self.assertIn("TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'", workflow)
+        self.assertIn("needs: [test-testcontainers, test-testcontainers-image-gate, plan]", workflow)
+        self.assertIn("- test-testcontainers-image-gate", workflow)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -25,6 +25,7 @@ REQUIRED_FIELDS = {
     "diagnostics",
     "releaseRequired",
 }
+KNOWN_TEST_TASKS = {":bluetape4k-testcontainers:k8sTest"}
 
 
 def _contract_module() -> Any:
@@ -132,6 +133,13 @@ def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[
             errors.append(f"diagnostics is empty for {server}")
         if not isinstance(entry["releaseRequired"], bool):
             errors.append(f"releaseRequired must be boolean for {server}")
+        test_task = entry.get("testTask")
+        if test_task is not None and (
+            not isinstance(test_task, str) or not test_task.startswith(":")
+        ):
+            errors.append(f"testTask must be a Gradle task path for {server}")
+        elif test_task is not None and test_task not in KNOWN_TEST_TASKS:
+            errors.append(f"unknown testTask for {server}: {test_task}")
 
     missing_servers = expected_servers - names
     extra_servers = names - expected_servers

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -150,4 +150,13 @@ def select_entries(
     if scope == "full":
         return list(entries)
     normalized = {path.replace("\\", "/") for path in changed_paths}
+    shared_prefixes = (
+        "scripts/testcontainers_image_gate",
+        "scripts/run_testcontainers_image_gate.py",
+        ".github/workflows/ci.yml",
+        ".github/workflows/nightly-tests.yml",
+        ".github/workflows/release.yml",
+    )
+    if any(path.startswith(prefix) for path in normalized for prefix in shared_prefixes):
+        return list(entries)
     return [entry for entry in entries if str(entry["source"]) in normalized]

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Shared manifest validation and selection for the Testcontainers image gate."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "scripts/testcontainers_image_gate_manifest.json"
+EXPECTED_FAMILY_COUNT = 52
+REQUIRED_FIELDS = {
+    "id",
+    "server",
+    "source",
+    "testSource",
+    "image",
+    "tag",
+    "testPattern",
+    "readiness",
+    "workload",
+    "diagnostics",
+    "releaseRequired",
+}
+
+
+def _contract_module() -> Any:
+    """Load the existing source/README contract without depending on cwd."""
+
+    root_string = str(ROOT)
+    if root_string not in sys.path:
+        sys.path.insert(0, root_string)
+    from scripts.test_testcontainers_contract import kotlin_servers, readme_tag_table
+
+    return kotlin_servers, readme_tag_table
+
+
+def load_manifest(path: Path = MANIFEST) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("version") != 1:
+        raise ValueError(f"unsupported manifest format: {path}")
+    entries = payload.get("families")
+    if not isinstance(entries, list):
+        raise ValueError(f"manifest families must be a list: {path}")
+    return [dict(entry) for entry in entries]
+
+
+def _test_pattern_for(server: str, source: Path) -> str:
+    package_path = source.parent.relative_to(ROOT / "testing/testcontainers/src/main/kotlin")
+    package = ".".join(package_path.parts)
+    return f"{package}.{server}Test"
+
+
+def _test_source_for(server: str, source: Path) -> Path:
+    test_root = ROOT / "testing/testcontainers/src/test/kotlin"
+    package_path = source.parent.relative_to(ROOT / "testing/testcontainers/src/main/kotlin")
+    return test_root / package_path / f"{server}Test.kt"
+
+
+def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[str]:
+    """Return all source, test, documentation, and schema drift findings."""
+
+    kotlin_servers, readme_tag_table = _contract_module()
+    source_servers = kotlin_servers()
+    errors: list[str] = []
+    if len(entries) != EXPECTED_FAMILY_COUNT:
+        errors.append(f"family count {len(entries)} != {EXPECTED_FAMILY_COUNT}")
+
+    names: set[str] = set()
+    ids: set[str] = set()
+    expected_readme = readme_tag_table(root / "testing/testcontainers/README.md")
+    expected_servers = set(source_servers)
+
+    for index, entry in enumerate(entries):
+        prefix = f"families[{index}]"
+        missing = REQUIRED_FIELDS - set(entry)
+        if missing:
+            errors.append(f"{prefix} missing fields: {', '.join(sorted(missing))}")
+            continue
+
+        server = entry["server"]
+        family_id = entry["id"]
+        if not isinstance(server, str) or not server:
+            errors.append(f"{prefix} server must be a non-empty string")
+            continue
+        if server in names:
+            errors.append(f"duplicate server: {server}")
+        names.add(server)
+        if not isinstance(family_id, str) or not family_id:
+            errors.append(f"{prefix} id must be a non-empty string")
+        elif family_id in ids:
+            errors.append(f"duplicate id: {family_id}")
+        else:
+            ids.add(family_id)
+
+        source = root / str(entry["source"])
+        details = source_servers.get(server)
+        if details is None:
+            errors.append(f"unknown server: {server}")
+            continue
+        if not source.is_file():
+            errors.append(f"missing source: {entry['source']}")
+        expected_source = Path(details["path"])
+        if source.resolve() != expected_source.resolve():
+            errors.append(f"source drift for {server}: {entry['source']} != {expected_source}")
+        if entry["image"] != details["image"]:
+            errors.append(f"image drift for {server}: {entry['image']} != {details['image']}")
+        if entry["tag"] != details["tag"]:
+            errors.append(f"tag drift for {server}: {entry['tag']} != {details['tag']}")
+        if server not in expected_readme:
+            errors.append(f"README row missing for {server}")
+        elif tuple(expected_readme[server]) != (entry["image"], entry["tag"]):
+            errors.append(f"README drift for {server}")
+
+        test_source = root / str(entry["testSource"])
+        if not test_source.is_file():
+            errors.append(f"missing test source for {server}: {entry['testSource']}")
+        expected_pattern = _test_pattern_for(server, source)
+        if entry["testPattern"] != expected_pattern:
+            errors.append(f"test pattern drift for {server}: {entry['testPattern']} != {expected_pattern}")
+        expected_test_source = _test_source_for(server, source)
+        if test_source.resolve() != expected_test_source.resolve():
+            errors.append(f"test source drift for {server}: {entry['testSource']} != {expected_test_source}")
+        if not isinstance(entry["readiness"], str) or not entry["readiness"].strip():
+            errors.append(f"readiness is empty for {server}")
+        if not isinstance(entry["workload"], str) or not entry["workload"].strip():
+            errors.append(f"workload is empty for {server}")
+        if not isinstance(entry["diagnostics"], list) or not entry["diagnostics"]:
+            errors.append(f"diagnostics is empty for {server}")
+        if not isinstance(entry["releaseRequired"], bool):
+            errors.append(f"releaseRequired must be boolean for {server}")
+
+    missing_servers = expected_servers - names
+    extra_servers = names - expected_servers
+    errors.extend(f"manifest missing server: {name}" for name in sorted(missing_servers))
+    errors.extend(f"manifest has unknown server: {name}" for name in sorted(extra_servers))
+    return errors
+
+
+def select_entries(
+    entries: list[dict[str, Any]], changed_paths: set[str], scope: str = "changed"
+) -> list[dict[str, Any]]:
+    """Select changed families deterministically, or all families for a full gate."""
+
+    if scope not in {"changed", "full"}:
+        raise ValueError(f"unsupported scope: {scope}")
+    if scope == "full":
+        return list(entries)
+    normalized = {path.replace("\\", "/") for path in changed_paths}
+    return [entry for entry in entries if str(entry["source"]) in normalized]

--- a/scripts/testcontainers_image_gate_manifest.json
+++ b/scripts/testcontainers_image_gate_manifest.json
@@ -434,6 +434,7 @@
       "image": "rancher/k3s",
       "tag": "v1.36.3-k3s1",
       "testPattern": "io.bluetape4k.testcontainers.infra.K3sServerTest",
+      "testTask": ":bluetape4k-testcontainers:k8sTest",
       "readiness": "k3s_api_and_pod_readiness",
       "workload": "io.bluetape4k.testcontainers.infra.K3sServerTest:representative_test",
       "diagnostics": [

--- a/scripts/testcontainers_image_gate_manifest.json
+++ b/scripts/testcontainers_image_gate_manifest.json
@@ -1,0 +1,892 @@
+{
+  "version": 1,
+  "families": [
+    {
+      "id": "dynamo-db-local",
+      "server": "DynamoDbLocalServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/DynamoDbLocalServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/DynamoDbLocalServerTest.kt",
+      "image": "amazon/dynamodb-local",
+      "tag": "3.3.1",
+      "testPattern": "io.bluetape4k.testcontainers.aws.DynamoDbLocalServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.aws.DynamoDbLocalServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "floci",
+      "server": "FlociServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/FlociServerTest.kt",
+      "image": "floci/floci",
+      "tag": "1.6.0",
+      "testPattern": "io.bluetape4k.testcontainers.aws.FlociServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.aws.FlociServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "local-stack",
+      "server": "LocalStackServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/LocalStackServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/LocalStackServerTest.kt",
+      "image": "localstack/localstack",
+      "tag": "4",
+      "testPattern": "io.bluetape4k.testcontainers.aws.LocalStackServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.aws.LocalStackServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "mini-stack",
+      "server": "MiniStackServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/MiniStackServerTest.kt",
+      "image": "ministackorg/ministack",
+      "tag": "1.4.14",
+      "testPattern": "io.bluetape4k.testcontainers.aws.MiniStackServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.aws.MiniStackServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "click-house",
+      "server": "ClickHouseServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/ClickHouseServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/ClickHouseServerTest.kt",
+      "image": "clickhouse/clickhouse-server",
+      "tag": "26.7.3.19",
+      "testPattern": "io.bluetape4k.testcontainers.database.ClickHouseServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.ClickHouseServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "cockroach",
+      "server": "CockroachServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/CockroachServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/CockroachServerTest.kt",
+      "image": "cockroachdb/cockroach",
+      "tag": "v25.4.14",
+      "testPattern": "io.bluetape4k.testcontainers.database.CockroachServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.CockroachServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "maria-d-b",
+      "server": "MariaDBServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MariaDBServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/MariaDBServerTest.kt",
+      "image": "mariadb",
+      "tag": "12.3.2",
+      "testPattern": "io.bluetape4k.testcontainers.database.MariaDBServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.MariaDBServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "my-s-q-l5",
+      "server": "MySQL5Server",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL5Server.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/MySQL5ServerTest.kt",
+      "image": "biarms/mysql",
+      "tag": "5",
+      "testPattern": "io.bluetape4k.testcontainers.database.MySQL5ServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.MySQL5ServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "my-s-q-l8",
+      "server": "MySQL8Server",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL8Server.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/MySQL8ServerTest.kt",
+      "image": "mysql",
+      "tag": "8.4.11",
+      "testPattern": "io.bluetape4k.testcontainers.database.MySQL8ServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.MySQL8ServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "pgvector",
+      "server": "PgvectorServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PgvectorServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/PgvectorServerTest.kt",
+      "image": "pgvector/pgvector",
+      "tag": "0.8.6-pg16",
+      "testPattern": "io.bluetape4k.testcontainers.database.PgvectorServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.PgvectorServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "postgis",
+      "server": "PostgisServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PostgisServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/PostgisServerTest.kt",
+      "image": "postgis/postgis",
+      "tag": "16-3.5",
+      "testPattern": "io.bluetape4k.testcontainers.database.PostgisServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.PostgisServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "postgre-s-q-l",
+      "server": "PostgreSQLServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/PostgreSQLServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/PostgreSQLServerTest.kt",
+      "image": "postgres",
+      "tag": "18.4-alpine",
+      "testPattern": "io.bluetape4k.testcontainers.database.PostgreSQLServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.PostgreSQLServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "trino",
+      "server": "TrinoServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/TrinoServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/database/TrinoServerTest.kt",
+      "image": "trinodb/trino",
+      "tag": "483",
+      "testPattern": "io.bluetape4k.testcontainers.database.TrinoServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.database.TrinoServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "falkor-d-b",
+      "server": "FalkorDBServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/FalkorDBServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/FalkorDBServerTest.kt",
+      "image": "falkordb/falkordb",
+      "tag": "v4.20.2",
+      "testPattern": "io.bluetape4k.testcontainers.graphdb.FalkorDBServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.graphdb.FalkorDBServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "memgraph",
+      "server": "MemgraphServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/MemgraphServerTest.kt",
+      "image": "memgraph/memgraph",
+      "tag": "3.12.0",
+      "testPattern": "io.bluetape4k.testcontainers.graphdb.MemgraphServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.graphdb.MemgraphServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "neo4j",
+      "server": "Neo4jServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/Neo4jServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/Neo4jServerTest.kt",
+      "image": "neo4j",
+      "tag": "5.26.29",
+      "testPattern": "io.bluetape4k.testcontainers.graphdb.Neo4jServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.graphdb.Neo4jServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "postgre-s-q-l-age",
+      "server": "PostgreSQLAgeServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/graphdb/PostgreSQLAgeServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/graphdb/PostgreSQLAgeServerTest.kt",
+      "image": "apache/age",
+      "tag": "release_PG18_1.7.0",
+      "testPattern": "io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "bluetape-http",
+      "server": "BluetapeHttpServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/http/BluetapeHttpServerTest.kt",
+      "image": "bluetape4k/mock-web-server",
+      "tag": "2.0.0",
+      "testPattern": "io.bluetape4k.testcontainers.http.BluetapeHttpServerTest",
+      "readiness": "http_endpoint_readiness",
+      "workload": "io.bluetape4k.testcontainers.http.BluetapeHttpServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "bluetape-webflux",
+      "server": "BluetapeWebfluxServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/http/BluetapeWebfluxServerTest.kt",
+      "image": "bluetape4k/mock-webflux-server",
+      "tag": "2.0.0",
+      "testPattern": "io.bluetape4k.testcontainers.http.BluetapeWebfluxServerTest",
+      "readiness": "http_endpoint_readiness",
+      "workload": "io.bluetape4k.testcontainers.http.BluetapeWebfluxServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "nginx",
+      "server": "NginxServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/NginxServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/http/NginxServerTest.kt",
+      "image": "nginx",
+      "tag": "1.30.4-alpine",
+      "testPattern": "io.bluetape4k.testcontainers.http.NginxServerTest",
+      "readiness": "http_endpoint_readiness",
+      "workload": "io.bluetape4k.testcontainers.http.NginxServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "wire-mock",
+      "server": "WireMockServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/WireMockServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/http/WireMockServerTest.kt",
+      "image": "wiremock/wiremock",
+      "tag": "3.13.2",
+      "testPattern": "io.bluetape4k.testcontainers.http.WireMockServerTest",
+      "readiness": "http_endpoint_readiness",
+      "workload": "io.bluetape4k.testcontainers.http.WireMockServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "consul",
+      "server": "ConsulServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ConsulServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ConsulServerTest.kt",
+      "image": "hashicorp/consul",
+      "tag": "1.22.7",
+      "testPattern": "io.bluetape4k.testcontainers.infra.ConsulServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.ConsulServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "etcd",
+      "server": "EtcdServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/EtcdServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/EtcdServerTest.kt",
+      "image": "gcr.io/etcd-development/etcd",
+      "tag": "v3.6.14",
+      "testPattern": "io.bluetape4k.testcontainers.infra.EtcdServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.EtcdServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "grafana",
+      "server": "GrafanaServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/GrafanaServerTest.kt",
+      "image": "grafana/grafana",
+      "tag": "13.1.3",
+      "testPattern": "io.bluetape4k.testcontainers.infra.GrafanaServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.GrafanaServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "jaeger",
+      "server": "JaegerServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/JaegerServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/JaegerServerTest.kt",
+      "image": "jaegertracing/all-in-one",
+      "tag": "1.76.0",
+      "testPattern": "io.bluetape4k.testcontainers.infra.JaegerServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.JaegerServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "k3s",
+      "server": "K3sServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/K3sServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/K3sServerTest.kt",
+      "image": "rancher/k3s",
+      "tag": "v1.36.3-k3s1",
+      "testPattern": "io.bluetape4k.testcontainers.infra.K3sServerTest",
+      "readiness": "k3s_api_and_pod_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.K3sServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events",
+        "kubectl_pods",
+        "kubectl_events",
+        "kubectl_logs"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "keycloak",
+      "server": "KeycloakServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/KeycloakServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/KeycloakServerTest.kt",
+      "image": "quay.io/keycloak/keycloak",
+      "tag": "26.7.1",
+      "testPattern": "io.bluetape4k.testcontainers.infra.KeycloakServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.KeycloakServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "prometheus",
+      "server": "PrometheusServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/PrometheusServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/PrometheusServerTest.kt",
+      "image": "prom/prometheus",
+      "tag": "v3.13.2",
+      "testPattern": "io.bluetape4k.testcontainers.infra.PrometheusServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.PrometheusServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "toxiproxy",
+      "server": "ToxiproxyServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ToxiproxyServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ToxiproxyServerTest.kt",
+      "image": "ghcr.io/shopify/toxiproxy",
+      "tag": "2.9.0",
+      "testPattern": "io.bluetape4k.testcontainers.infra.ToxiproxyServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.ToxiproxyServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "vault",
+      "server": "VaultServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/VaultServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/VaultServerTest.kt",
+      "image": "hashicorp/vault",
+      "tag": "1.20.4",
+      "testPattern": "io.bluetape4k.testcontainers.infra.VaultServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.VaultServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "zipkin",
+      "server": "ZipkinServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZipkinServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ZipkinServerTest.kt",
+      "image": "openzipkin/zipkin-slim",
+      "tag": "2.23",
+      "testPattern": "io.bluetape4k.testcontainers.infra.ZipkinServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.ZipkinServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "zoo-keeper",
+      "server": "ZooKeeperServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServerTest.kt",
+      "image": "zookeeper",
+      "tag": "3.9.5",
+      "testPattern": "io.bluetape4k.testcontainers.infra.ZooKeeperServerTest",
+      "readiness": "curator_session_readiness",
+      "workload": "io.bluetape4k.testcontainers.infra.ZooKeeperServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "chroma-d-b",
+      "server": "ChromaDBServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/llm/ChromaDBServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/llm/ChromaDBServerTest.kt",
+      "image": "chromadb/chroma",
+      "tag": "0.5.23",
+      "testPattern": "io.bluetape4k.testcontainers.llm.ChromaDBServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.llm.ChromaDBServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "ollama",
+      "server": "OllamaServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/llm/OllamaServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/llm/OllamaServerTest.kt",
+      "image": "ollama/ollama",
+      "tag": "0.32.6",
+      "testPattern": "io.bluetape4k.testcontainers.llm.OllamaServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.llm.OllamaServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "mailpit",
+      "server": "MailpitServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mail/MailpitServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mail/MailpitServerTest.kt",
+      "image": "axllent/mailpit",
+      "tag": "v1.30.7",
+      "testPattern": "io.bluetape4k.testcontainers.mail.MailpitServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.mail.MailpitServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "kafka",
+      "server": "KafkaServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/KafkaServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/KafkaServerTest.kt",
+      "image": "confluentinc/cp-kafka",
+      "tag": "7.5.16",
+      "testPattern": "io.bluetape4k.testcontainers.mq.KafkaServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.mq.KafkaServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "nats",
+      "server": "NatsServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/NatsServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/NatsServerTest.kt",
+      "image": "nats",
+      "tag": "2.14.4",
+      "testPattern": "io.bluetape4k.testcontainers.mq.NatsServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.mq.NatsServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "pulsar",
+      "server": "PulsarServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/PulsarServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/PulsarServerTest.kt",
+      "image": "apachepulsar/pulsar",
+      "tag": "3.3.9",
+      "testPattern": "io.bluetape4k.testcontainers.mq.PulsarServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.mq.PulsarServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "rabbit-m-q",
+      "server": "RabbitMQServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/RabbitMQServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/RabbitMQServerTest.kt",
+      "image": "rabbitmq",
+      "tag": "3.13",
+      "testPattern": "io.bluetape4k.testcontainers.mq.RabbitMQServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.mq.RabbitMQServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "redpanda",
+      "server": "RedpandaServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/RedpandaServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/RedpandaServerTest.kt",
+      "image": "docker.redpanda.com/redpandadata/redpanda",
+      "tag": "v26.2.1",
+      "testPattern": "io.bluetape4k.testcontainers.mq.RedpandaServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.mq.RedpandaServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "cassandra",
+      "server": "CassandraServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/CassandraServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/CassandraServerTest.kt",
+      "image": "cassandra",
+      "tag": "5.0.8",
+      "testPattern": "io.bluetape4k.testcontainers.storage.CassandraServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.CassandraServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "elasticsearch-oss",
+      "server": "ElasticsearchOssServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchOssServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchOssServerTest.kt",
+      "image": "docker.elastic.co/elasticsearch/elasticsearch-oss",
+      "tag": "7.10.2",
+      "testPattern": "io.bluetape4k.testcontainers.storage.ElasticsearchOssServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.ElasticsearchOssServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "elasticsearch",
+      "server": "ElasticsearchServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/ElasticsearchServerTest.kt",
+      "image": "docker.elastic.co/elasticsearch/elasticsearch",
+      "tag": "9.5.0",
+      "testPattern": "io.bluetape4k.testcontainers.storage.ElasticsearchServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.ElasticsearchServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "hazelcast",
+      "server": "HazelcastServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/HazelcastServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/HazelcastServerTest.kt",
+      "image": "hazelcast/hazelcast",
+      "tag": "5.7.0-slim-jdk25",
+      "testPattern": "io.bluetape4k.testcontainers.storage.HazelcastServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.HazelcastServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "ignite2",
+      "server": "Ignite2Server",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt",
+      "image": "apacheignite/ignite",
+      "tag": "2.18.0",
+      "testPattern": "io.bluetape4k.testcontainers.storage.Ignite2ServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.Ignite2ServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "ignite3",
+      "server": "Ignite3Server",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite3Server.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite3ServerTest.kt",
+      "image": "apacheignite/ignite",
+      "tag": "3.1.0",
+      "testPattern": "io.bluetape4k.testcontainers.storage.Ignite3ServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.Ignite3ServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "influx-d-b",
+      "server": "InfluxDBServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/InfluxDBServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/InfluxDBServerTest.kt",
+      "image": "influxdb",
+      "tag": "2.9.1",
+      "testPattern": "io.bluetape4k.testcontainers.storage.InfluxDBServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.InfluxDBServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "min-i-o",
+      "server": "MinIOServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/MinIOServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/MinIOServerTest.kt",
+      "image": "minio/minio",
+      "tag": "RELEASE.2025-07-23T15-54-02Z",
+      "testPattern": "io.bluetape4k.testcontainers.storage.MinIOServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.MinIOServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "mongo-d-b",
+      "server": "MongoDBServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/MongoDBServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/MongoDBServerTest.kt",
+      "image": "mongo",
+      "tag": "8.0.28",
+      "testPattern": "io.bluetape4k.testcontainers.storage.MongoDBServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.MongoDBServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "open-search",
+      "server": "OpenSearchServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/OpenSearchServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/OpenSearchServerTest.kt",
+      "image": "opensearchproject/opensearch",
+      "tag": "3.8.0",
+      "testPattern": "io.bluetape4k.testcontainers.storage.OpenSearchServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.OpenSearchServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "redis-cluster",
+      "server": "RedisClusterServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedisClusterServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/RedisClusterServerTest.kt",
+      "image": "tommy351/redis-cluster",
+      "tag": "6.2",
+      "testPattern": "io.bluetape4k.testcontainers.storage.RedisClusterServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.RedisClusterServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    },
+    {
+      "id": "redis",
+      "server": "RedisServer",
+      "source": "testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/RedisServer.kt",
+      "testSource": "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/RedisServerTest.kt",
+      "image": "redis",
+      "tag": "8.8.1",
+      "testPattern": "io.bluetape4k.testcontainers.storage.RedisServerTest",
+      "readiness": "testcontainers_wait_strategy_and_workload_readiness",
+      "workload": "io.bluetape4k.testcontainers.storage.RedisServerTest:representative_test",
+      "diagnostics": [
+        "docker_inspect",
+        "docker_logs",
+        "docker_events"
+      ],
+      "releaseRequired": true
+    }
+  ]
+}

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -164,6 +164,49 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 `LocalStackServer`는 deprecated이므로 새 AWS 테스트에는 `FlociServer` 또는
 `MiniStackServer`를 사용하세요.
 
+## 이미지 family startup·workload gate
+
+52개 Docker 기반 서버 family는
+[`scripts/testcontainers_image_gate_manifest.json`](../../scripts/testcontainers_image_gate_manifest.json)에 선언합니다.
+manifest는 고정 image/tag와 Kotlin wrapper, 대표 테스트 클래스, readiness 계약,
+workload 증거, 진단 명령을 연결합니다.
+
+동일한 실행기를 PR CI, Nightly, 안정 버전 배포 workflow에서 사용합니다. 선택된
+family는 `max-parallel: 1`로 순차 실행하고 `success`, `product_failure`,
+`infrastructure_failure`, `blocked`로 분류하며 `summary.json`, `summary.md`,
+family별 JSON을 남깁니다. 안정 버전 배포는 `52/52`, `release_gate=true`,
+모든 실패 분류 0을 요구합니다. Docker Hub 인증과 mirror 설정은 환경변수 또는
+CI secret으로만 전달하며, 증거에는 credential을 기록하지 않습니다.
+
+<!-- TESTCONTAINERS_IMAGE_GATE_COMMAND_START -->
+저장소 루트에서 변경 family gate를 실행합니다.
+
+```bash
+python3 scripts/run_testcontainers_image_gate.py \
+  --scope changed \
+  --report-dir build/reports/testcontainers-image-gate \
+  --max-attempts 2 \
+  --timeout-minutes 30
+```
+
+안정 버전 배포와 같은 전체 gate를 실행합니다.
+
+```bash
+./gradlew :bluetape4k-mock-web-server:jibDockerBuild \
+  :bluetape4k-mock-webflux-server:jibDockerBuild \
+  --no-configuration-cache
+python3 scripts/run_testcontainers_image_gate.py \
+  --scope full \
+  --report-dir build/reports/testcontainers-image-gate \
+  --max-attempts 2 \
+  --timeout-minutes 30
+```
+<!-- TESTCONTAINERS_IMAGE_GATE_COMMAND_END -->
+
+family 실패 시 JSON artifact와 제한된 Docker/K3s 진단을 먼저 확인한 뒤 재시도합니다.
+registry rate limit, daemon 장애, readiness timeout은 인프라 증거로 남기며 gate를
+건너뛰거나 배포를 진행하는 근거로 사용하지 않습니다.
+
 ## 사용 예
 
 ### 데이터베이스

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -160,6 +160,51 @@ and `PostgreSQLAgeServer` stays on the latest stable PG18 image rather than the
 `1.8.0-rc0` release candidate. `LocalStackServer` is deprecated; new AWS tests
 should use `FlociServer` or `MiniStackServer`.
 
+## Image Family Startup and Workload Gate
+
+The 52 Docker-backed server families are declared in
+[`scripts/testcontainers_image_gate_manifest.json`](../../scripts/testcontainers_image_gate_manifest.json).
+The manifest links each pinned image/tag to its Kotlin wrapper, representative
+test class, readiness contract, workload evidence, and diagnostic commands.
+
+The same runner is used by pull-request CI, Nightly, and the stable release
+workflow. It executes the selected families sequentially (`max-parallel: 1`),
+records `success`, `product_failure`, `infrastructure_failure`, or `blocked`,
+and writes `summary.json`, `summary.md`, and one JSON file per family. Stable
+publication requires `52/52`, `release_gate=true`, and zero failure-classification
+counts. Docker Hub authentication and mirror settings are supplied through
+environment variables or CI secrets; credentials are redacted from evidence.
+
+<!-- TESTCONTAINERS_IMAGE_GATE_COMMAND_START -->
+Run the changed-family gate from the repository root:
+
+```bash
+python3 scripts/run_testcontainers_image_gate.py \
+  --scope changed \
+  --report-dir build/reports/testcontainers-image-gate \
+  --max-attempts 2 \
+  --timeout-minutes 30
+```
+
+Run the complete release-equivalent gate:
+
+```bash
+./gradlew :bluetape4k-mock-web-server:jibDockerBuild \
+  :bluetape4k-mock-webflux-server:jibDockerBuild \
+  --no-configuration-cache
+python3 scripts/run_testcontainers_image_gate.py \
+  --scope full \
+  --report-dir build/reports/testcontainers-image-gate \
+  --max-attempts 2 \
+  --timeout-minutes 30
+```
+<!-- TESTCONTAINERS_IMAGE_GATE_COMMAND_END -->
+
+When a family fails, inspect its JSON artifact and the bounded Docker/K3s
+diagnostics before retrying. Registry rate limits, daemon failures, and
+readiness timeouts remain infrastructure evidence; they are not a reason to
+skip the gate or publish a release.
+
 ## Usage Examples
 
 ### Database


### PR DESCRIPTION
## Summary

Closes #1470

Nightly `kafka-resilience` shard를 60분 동안 멈추게 한 Resilience4j cancellation 테스트의 `Phaser` phase race를 제거합니다. coroutine-native one-shot gate와 명시적 timeout으로 같은 실행 순서에서도 결정적으로 완료하거나 빠르게 실패하게 합니다.

## Background

Nightly run [32550558776](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32550558776)의 [kafka-resilience job](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32550558776/job/96976945158) attempt 1은 `FlowCircuitBreakerTest`의 첫 cancellation 테스트 뒤 56분간 출력을 내지 못하고 `Timeout of 3600000ms hit`으로 종료됐습니다. attempt 2는 동일 Gradle 명령을 1분 13초에 완료했습니다.

`Phaser(1)`의 child가 먼저 `arrive()`해 phase를 `0→1`로 바꾼 뒤 parent가 `awaitAdvance(1)`을 호출하면 다음 phase를 영구 대기합니다. parent가 먼저 호출하면 즉시 반환하므로 scheduling에 따라 통과와 hang이 갈렸습니다. 같은 패턴은 `FlowCircuitBreakerTest`와 `BulkheadFlowTest`의 cancellation 테스트 네 곳에 있었습니다.

## Work Done

- 네 `Phaser` one-shot gate를 `CompletableDeferred<Unit>`의 `complete/await`로 교체했습니다.
- 네 cancellation 테스트에 10초 `runSuspendTest` timeout을 명시했습니다.
- `docs/lessons/2026-08-22-issue-1470-resilience4j-phaser-race.md`에 원인과 재사용 규칙을 기록했습니다.
- Stack: PR #1465 (`ad67d00fff8e0da63ebcefb790f05674343044d5`) 위의 child입니다.

## Validation

- Hosted RED: run `32550558776` attempt 1, `Timeout of 3600000ms hit`
- Retry comparison: attempt 2, `BUILD SUCCESSFUL in 1m 13s`
- Targeted: `FlowCircuitBreakerTest`, `BulkheadFlowTest` — 11/11 PASS
- Module: `:bluetape4k-resilience4j:test` — 292/292 PASS
- `:bluetape4k-resilience4j:detekt`: PASS
- changed-source max-line scan: PASS, 120자 초과 0
- `git diff --check`: PASS
- Korean terminology audit: PASS, findings 0
- Hosted Nightly `kafka-resilience`: 5분 10초 내 성공, `BUILD SUCCESSFUL in 4m 11s`, `Command completed after 1 attempt(s)`
- Hosted CI `32555282810`: exact head, 21/21 jobs PASS
- Hosted full Nightly `32555284106`: exact head, 42/42 jobs PASS
- Coveralls build `81306209`: SUCCESS
- Nightly image gate artifact: 52/52 success, product/infrastructure failure 0, blocked 0
- Nightly aggregate: Kover XML 91개, total coverage 90.61%, expected manifest 검증 PASS

## Review Notes

- Exact base: `ad67d00fff8e0da63ebcefb790f05674343044d5`
- Exact head: `838628c06d41b5814388777b3a5a642b1aa05368`
- 초기 독립 review: P0/P1/P2=0, line-length P3와 후속 Kotlin 들여쓰기 P3를 별도 커밋으로 해소
- 최종 exact-delta review: P0/P1/P2/P3=0, 코드 `CLEAR`
- Hosted: CI run `32555282810`, Nightly run `32555284106`

## Metadata

- Issue: #1470, milestone `2.0.0`, assignee `debop`
- Parent PR: #1465, base `fix/1418-05-nightly-kover-demos`
- Head: `fix/1418-08-flow-circuitbreaker-phaser-race`
- Epic #1418: native sub-issues `3/8`, primary release slots `3/4`

## DoD Status

Required checks: 9/10; Blocked: 0

| Check | Status | Evidence / Next Action |
|---|---|---|
| Root cause | PASS | hosted attempt 1 timeout과 `Phaser` child-first phase race 일치 |
| Scope/stack | PASS | exact base `ad67d00…`, 별도 child branch |
| RED | PASS | run `32550558776`, attempt 1 60분 timeout |
| Minimal fix | PASS | 테스트 네 곳의 gate와 timeout만 수정 |
| Targeted GREEN | PASS | 11/11 |
| Module/static | PASS | 292/292, detekt, diff check |
| Durable lesson | PASS | issue #1470 lesson, terminology audit 0 |
| Independent review | PASS | exact base/head, P0/P1/P2/P3=0, ktlint base 대비 무회귀 |
| Hosted CI | PASS | CI 21/21, full Nightly 42/42, Coveralls SUCCESS, `kafka-resilience` 첫 시도, image gate 52/52, aggregate 90.61% |
| Merge/cleanup | PENDING | fresh approval 전 merge 금지 |

Final status: PENDING — 검증은 완료됐고 fresh merge approval만 남았습니다.
