### PR TITLE
[coroutines] BufferedResumableCollector 종료 경합을 선형화한다

### DIFF
--- a/.github/scripts/test-aggregate-kover-coverage.py
+++ b/.github/scripts/test-aggregate-kover-coverage.py
@@ -166,6 +166,21 @@ class AggregateKoverCoverageTest(unittest.TestCase):
             self.assertIn(module, workflow)
         self.assertIn("--expected-module", workflow)
 
+    def test_ci_routes_search_messaging_changes_to_nats_and_elasticsearch(self):
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("search-messaging: ${{ steps.filter.outputs.search-messaging }}", workflow)
+        self.assertIn("'infra/elasticsearch/**'", workflow)
+        self.assertIn("'infra/nats/**'", workflow)
+        self.assertIn("test-search-messaging:", workflow)
+        self.assertIn(":bluetape4k-elasticsearch:test --max-workers=1", workflow)
+        self.assertIn(":bluetape4k-nats:test --max-workers=1", workflow)
+        self.assertIn(":bluetape4k-elasticsearch:koverXmlReport --max-workers=1", workflow)
+        self.assertIn(":bluetape4k-nats:koverXmlReport --max-workers=1", workflow)
+        self.assertIn("test-search-messaging=${{ needs.test-search-messaging.result }}", workflow)
+        self.assertIn("'infra/elasticsearch'", workflow)
+        self.assertIn("'infra/nats'", workflow)
+        self.assertIn("test-search-messaging, test-kafka-infra", workflow)
+
     def test_ci_only_uploads_coveralls_after_successful_aggregation(self):
         workflow = CI_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("id: aggregate-coverage", workflow)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
       ktor: ${{ steps.filter.outputs.ktor }}
       key-utils: ${{ steps.filter.outputs.key-utils }}
       infra: ${{ steps.filter.outputs.infra }}
+      search-messaging: ${{ steps.filter.outputs.search-messaging }}
       kafka-infra: ${{ steps.filter.outputs.kafka-infra }}
       telemetry-infra: ${{ steps.filter.outputs.telemetry-infra }}
       data: ${{ steps.filter.outputs.data }}
@@ -207,6 +208,9 @@ jobs:
               - 'infra/lettuce/**'
               - 'cache/cache-lettuce/**'
               - 'cache/cache-redisson/**'
+            search-messaging:
+              - 'infra/elasticsearch/**'
+              - 'infra/nats/**'
             kafka-infra:
               - 'infra/kafka/**'
               - 'infra/kafka4/**'
@@ -872,7 +876,62 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  # ── 7-a. Kafka Infra 테스트 (Testcontainers) ────────────────────────────
+  # ── 7-a. Search & Messaging 테스트 (Testcontainers) ─────────────────────
+  test-search-messaging:
+    name: Test / Search & Messaging
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['search-messaging'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test search and messaging modules
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: bash
+          command: |
+            ./gradlew :bluetape4k-elasticsearch:test --max-workers=1 --no-configuration-cache
+            ./gradlew :bluetape4k-nats:test --max-workers=1 --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew :bluetape4k-elasticsearch:koverXmlReport --max-workers=1 --no-configuration-cache
+          ./gradlew :bluetape4k-nats:koverXmlReport --max-workers=1 --no-configuration-cache
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-search-messaging
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-search-messaging
+          path: '**/build/reports/kover/'
+          if-no-files-found: error
+          retention-days: 30
+
+  # ── 7-b. Kafka Infra 테스트 (Testcontainers) ────────────────────────────
   test-kafka-infra:
     name: Test / Kafka Infra
     runs-on: ubuntu-latest
@@ -1075,7 +1134,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test-core, test-io, test-io-http, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data]
+    needs: [test-core, test-io, test-io-http, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data]
     if: always()
     steps:
       - uses: actions/checkout@v7
@@ -1091,6 +1150,7 @@ jobs:
             test-ktor=${{ needs.test-ktor.result }}
             test-key-utils=${{ needs.test-key-utils.result }}
             test-infra=${{ needs.test-infra.result }}
+            test-search-messaging=${{ needs.test-search-messaging.result }}
             test-kafka-infra=${{ needs.test-kafka-infra.result }}
             test-telemetry-infra=${{ needs.test-telemetry-infra.result }}
             test-data=${{ needs.test-data.result }}
@@ -1105,6 +1165,12 @@ jobs:
               'infra/redisson' \
               'cache/cache-redisson' \
               > coverage-artifacts/expected-modules.manifest
+          fi
+          if grep -q '^test-search-messaging=success$' coverage-artifacts/expected-jobs.manifest; then
+            printf '%s\n' \
+              'infra/elasticsearch' \
+              'infra/nats' \
+              >> coverage-artifacts/expected-modules.manifest
           fi
           if grep -q '=success$' coverage-artifacts/expected-jobs.manifest; then
             echo 'has_expected=true' >> "$GITHUB_OUTPUT"
@@ -1173,7 +1239,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, testcontainers-image-gate, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
+    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, testcontainers-image-gate, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   바이트열과 `flush()`/`close()`의 하위 sink 위임 횟수 및 데이터 전달 경계를
   검증하도록 강화됐다
   ([#1341](https://github.com/bluetape4k/bluetape4k-projects/issues/1341)).
+- `BufferedResumableCollector`가 producer admission과 첫 terminal 상태를 하나의
+  atomic 상태로 조정한다. `complete`/`error`와 producer가 경합해도 이미 수락된 값은
+  모두 drain되고 첫 terminal cause가 유지되며, terminal 전에 enqueue하지 못한
+  producer는 `IllegalStateException`으로 명시적으로 거부된다
+  ([#1349](https://github.com/bluetape4k/bluetape4k-projects/issues/1349)).
 
 ## [1.12.1] — 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `SuspendJCacheEntryEventListener`와 `SuspendNearJCache`가
   `CancellationException`을 일반 실패로 소실하지 않고 호출자와 listener child job에
   재전파한다. listener callback은 immutable event snapshot과 close gate를 사용하며,
+  제거·만료 이벤트의 nullable value는 읽지 않고 key-only snapshot으로 전파한다.
   비결정적인 `Thread.sleep` 검증을 `runTest` 기반 수명주기·비동기 회귀 검증으로
   교체했다. 1,000개 cooperative callback burst의 close 취소와 raw event metadata
   비노출도 검증했으며, callback fan-out bounded admission/coalescing은 별도 후속

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@
   모두 drain되고 첫 terminal cause가 유지되며, terminal 전에 enqueue하지 못한
   producer는 `IllegalStateException`으로 명시적으로 거부된다
   ([#1349](https://github.com/bluetape4k/bluetape4k-projects/issues/1349)).
+- `SuspendJCacheEntryEventListener`와 `SuspendNearJCache`가
+  `CancellationException`을 일반 실패로 소실하지 않고 호출자와 listener child job에
+  재전파한다. listener callback은 immutable event snapshot과 close gate를 사용하며,
+  비결정적인 `Thread.sleep` 검증을 `runTest` 기반 수명주기·비동기 회귀 검증으로
+  교체했다. 1,000개 cooperative callback burst의 close 취소와 raw event metadata
+  비노출도 검증했으며, callback fan-out bounded admission/coalescing은 별도 후속
+  이슈로 분리했다
+  ([#1360](https://github.com/bluetape4k/bluetape4k-projects/issues/1360),
+  [#1474](https://github.com/bluetape4k/bluetape4k-projects/issues/1474)).
 
 ## [1.12.1] — 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@
   한다 ([#1335](https://github.com/bluetape4k/bluetape4k-projects/issues/1335)).
 <!-- issue-1335-java25-semver:end -->
 
+### 추가
+
+- NATS JetStream `ConsumerContext` pull consumer와 `JetStream` push
+  subscription을 수집마다 생성·정리하는 cold `Flow<Message>` API를 추가했다.
+  유한한 Flow 용량과 NATS pending limit을 검증하고, 취소 시 adapter 소유
+  handle만 닫으며 pending queue drop은 `NatsConsumerFlowException`으로
+  보고한다. adapter는 manual ack만 제공해 업무 처리 성공 뒤 caller가
+  `ack()`/`nak()`/`term()`을 선택하도록 한다
+  ([#1350](https://github.com/bluetape4k/bluetape4k-projects/issues/1350)).
+
 ### 버그 수정
 
 - `BufferedSuspendedSink` 회귀 테스트가 모든 `write`/`writeAll` 오버로드의 정확한

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollector.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollector.kt
@@ -4,21 +4,24 @@ import io.bluetape4k.coroutines.flow.extensions.Resumable
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /**
- * A resumable collector that transfers values asynchronously through a multi-producer, single-consumer buffer.
+ * 다중 producer의 값을 단일 consumer에게 비동기로 전달하는 resumable collector입니다.
  *
- * ## Contract
- * - Producer admission is serialized so the internal `SpscArrayQueue` remains single-producer.
- * - A producer suspends while the consumer cannot free buffer capacity.
- * - All producer calls must finish before `error` or `complete` is invoked; concurrent termination is unsupported.
- * - A collector failure during `drain` marks the collector as cancelled, and later `next` calls fail with
- *   `CancellationException`.
- * - After `error` or `complete`, the drain loop terminates when the buffer is empty and propagates a stored error.
- * - The fixed-size buffer reuses its slots without allocating an additional collection.
+ * ## 동작/계약
+ * - producer admission 수와 terminal 종류를 하나의 atomic 상태로 관리합니다.
+ * - 첫 `complete` 또는 `error`만 terminal 상태를 결정하며 이후 signal은 no-op입니다.
+ * - terminal보다 먼저 offer commit에 성공한 값은 수락된 값으로 간주하고 enqueue 순서대로 모두 전달합니다.
+ * - offer commit 전에 terminal을 관찰한 producer는 값을 enqueue하지 않고 `IllegalStateException`으로 종료합니다.
+ * - producer가 mutex 또는 capacity를 기다리는 동안 취소되면 `CancellationException`을 그대로 전파합니다.
+ * - collector 실패나 취소는 대기 중 producer를 깨우며, producer에는 cause를 보존한
+ *   `CancellationException`을 전파합니다.
+ * - `error`가 승리하면 수락된 값을 모두 전달한 뒤 같은 예외를 drain 호출자에게 전파합니다.
  *
  * ```kotlin
  * val rc = BufferedResumableCollector<Int>(4)
@@ -28,7 +31,31 @@ import kotlinx.coroutines.sync.withLock
  * // result == [1, 2]
  * ```
  */
-class BufferedResumableCollector<T> private constructor(capacity: Int): Resumable() {
+class BufferedResumableCollector<T> private constructor(
+    capacity: Int,
+    private val beforeOfferCommit: (suspend () -> Unit)? = null,
+    private val afterOffer: (() -> Unit)? = null,
+): Resumable() {
+
+    private enum class OfferPhase {
+        Idle,
+        Preparing,
+        Committed,
+    }
+
+    private sealed interface Terminal {
+        data object Open: Terminal
+        data object Complete: Terminal
+        data class Error(val cause: Throwable?): Terminal
+        data class Cancelled(val cause: Throwable): Terminal
+    }
+
+    private data class State(
+        val terminal: Terminal,
+        val activeAdmissions: Int,
+        val offerPhase: OfferPhase = OfferPhase.Idle,
+        val pendingTerminal: Terminal? = null,
+    )
 
     companion object: KLoggingChannel() {
         /**
@@ -44,15 +71,21 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
         operator fun <T> invoke(capacity: Int): BufferedResumableCollector<T> {
             return BufferedResumableCollector(capacity.coerceAtLeast(1))
         }
+
+        internal fun <T> forTest(
+            capacity: Int,
+            beforeOfferCommit: (suspend () -> Unit)? = null,
+            afterOffer: (() -> Unit)? = null,
+        ): BufferedResumableCollector<T> = BufferedResumableCollector(
+            capacity = capacity.coerceAtLeast(1),
+            beforeOfferCommit = beforeOfferCommit,
+            afterOffer = afterOffer,
+        )
     }
 
     private val queue: SpscArrayQueue<T> = SpscArrayQueue(capacity)
 
-    private val done = atomic(false)
-    private val cancelled = atomic(false)
-
-    @Volatile
-    private var error: Throwable? = null
+    private val state = atomic(State(Terminal.Open, 0))
 
     private val available = atomic(0L)
 
@@ -68,22 +101,48 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
      * ## 동작/계약
      * - 버퍼가 가득 찬 동안 소비자가 비울 때까지 suspend 대기합니다.
      * - 성공적으로 적재되면 대기 중 소비자를 깨웁니다.
-     * - drain 측 취소가 이미 반영된 경우 `CancellationException`을 던집니다.
+     * - terminal이 producer보다 먼저 선형화되면 `IllegalStateException`을 던집니다.
+     * - mutex 또는 capacity 대기 중 취소되면 `CancellationException`을 그대로 전파합니다.
+     * - `Preparing -> Committed` 전이를 값 수락 시점으로 삼으며 이후에는 cancellation을 다시 검사하지 않습니다.
      *
      * @param value 버퍼에 추가할 값입니다.
      */
-    suspend fun next(value: T) = producerMutex.withLock {
-        while (!cancelled.value) {
-            if (queue.offer(value)) {
-                if (available.getAndIncrement() == 0L) {
-                    valueReady.resume()
+    suspend fun next(value: T) {
+        acquireAdmission()
+        try {
+            producerMutex.withLock {
+                while (true) {
+                    currentCoroutineContext().ensureActive()
+                    rejectTerminatedProducer()
+                    if (!queue.canOffer) {
+                        await()
+                        continue
+                    }
+
+                    beginOfferPreparation()
+                    try {
+                        beforeOfferCommit?.invoke()
+                    } catch (ex: Throwable) {
+                        abortOfferPreparation()
+                        throw ex
+                    }
+                    commitOffer()
+
+                    val shouldSignalValue = available.getAndIncrement() == 0L
+                    try {
+                        check(queue.offer(value)) { "Committed producer offer must have capacity" }
+                        afterOffer?.invoke()
+                    } finally {
+                        finishCommittedOffer()
+                        if (shouldSignalValue) {
+                            valueReady.resume()
+                        }
+                    }
+                    return@withLock
                 }
-                break
             }
-            await()
-        }
-        if (cancelled.value) {
-            throw CancellationException("Cancel in next.")
+        } finally {
+            releaseAdmission()
         }
     }
 
@@ -91,27 +150,26 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
      * 오류 종료를 기록하고 drain 루프를 깨웁니다.
      *
      * ## 동작/계약
-     * - 전달받은 예외를 저장하고 `done = true`로 전환합니다.
+     * - 첫 terminal signal인 경우에만 전달받은 예외를 저장합니다.
      * - 버퍼가 모두 비워진 뒤 `drain`에서 저장된 예외가 전파됩니다.
+     * - value waiter와 capacity waiter를 모두 깨웁니다.
      *
      * @param ex 종료 시 전파할 예외입니다.
      */
     fun error(ex: Throwable?) {
-        error = ex
-        done.value = true
-        valueReady.resume()
+        terminate(Terminal.Error(ex))
     }
 
     /**
      * 정상 종료를 기록하고 drain 루프를 깨웁니다.
      *
      * ## 동작/계약
-     * - `done = true`로 전환합니다.
+     * - 첫 terminal signal인 경우에만 정상 종료 상태로 전환합니다.
      * - 버퍼에 남은 값을 모두 전달한 뒤 `drain`이 정상 종료됩니다.
+     * - value waiter와 capacity waiter를 모두 깨웁니다.
      */
     fun complete() {
-        done.value = true
-        valueReady.resume()
+        terminate(Terminal.Complete)
     }
 
     /**
@@ -120,7 +178,8 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
      * ## 동작/계약
      * - 버퍼에 값이 있으면 즉시 `collector.emit`을 호출하고, 없으면 `valueReady.await()`로 대기합니다.
      * - `collector.emit`이 예외를 던지면 `onCrash`를 호출하고 취소 상태로 전환한 뒤 예외를 다시 던집니다.
-     * - `done == true`이고 버퍼가 비었을 때 종료하며, 저장된 `error`가 있으면 종료 시점에 전파합니다.
+     * - terminal 상태이고 버퍼가 비었으며 active admission이 0일 때만 종료합니다.
+     * - terminal error가 있으면 buffered 값을 모두 전달한 뒤 같은 예외를 전파합니다.
      *
      * ```kotlin
      * val rc = BufferedResumableCollector<Int>(2)
@@ -141,11 +200,17 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
         val limit = this.limit.toLong()
 
         while (true) {
+            ensureDrainActive()
             val ne = !queue.poll(output)
+            val currentState = state.value
 
-            if (done.value && ne) {
-                error?.let { throw it }
-                break
+            if (ne && currentState.terminal !== Terminal.Open && currentState.activeAdmissions == 0) {
+                when (val terminal = currentState.terminal) {
+                    Terminal.Open -> kotlin.error("Open state cannot terminate drain")
+                    Terminal.Complete -> break
+                    is Terminal.Error -> terminal.cause?.let { throw it } ?: break
+                    is Terminal.Cancelled -> throw terminal.cause
+                }
             }
 
             if (!ne) {
@@ -154,9 +219,7 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
                     collector.emit(output[0] as T)
                 } catch (ex: Throwable) {
                     onCrash?.invoke(this)
-                    cancelled.value = true
-                    resume()
-
+                    cancelDrain(ex)
                     throw ex
                 }
 
@@ -171,9 +234,165 @@ class BufferedResumableCollector<T> private constructor(capacity: Int): Resumabl
 
             if (available.addAndGet(-consumed) == 0L) {
                 resume()
-                valueReady.await()
+                try {
+                    valueReady.await()
+                } catch (ex: Throwable) {
+                    cancelDrain(ex)
+                    throw ex
+                }
             }
             consumed = 0L
         }
+    }
+
+    private suspend fun acquireAdmission() {
+        while (true) {
+            currentCoroutineContext().ensureActive()
+            val current = state.value
+            val terminal = current.pendingTerminal ?: current.terminal
+            if (terminal !== Terminal.Open) {
+                throw producerFailure(terminal)
+            }
+            val updated = current.copy(activeAdmissions = current.activeAdmissions + 1)
+            if (state.compareAndSet(current, updated)) {
+                return
+            }
+        }
+    }
+
+    private fun releaseAdmission() {
+        while (true) {
+            val current = state.value
+            check(current.activeAdmissions > 0) { "Active producer admission underflow" }
+            val updated = current.copy(activeAdmissions = current.activeAdmissions - 1)
+            if (state.compareAndSet(current, updated)) {
+                if (updated.terminal !== Terminal.Open && updated.activeAdmissions == 0) {
+                    valueReady.resume()
+                }
+                return
+            }
+        }
+    }
+
+    private fun rejectTerminatedProducer() {
+        val current = state.value
+        val terminal = current.pendingTerminal ?: current.terminal
+        if (terminal !== Terminal.Open) {
+            throw producerFailure(terminal)
+        }
+    }
+
+    private fun beginOfferPreparation() {
+        while (true) {
+            val current = state.value
+            val terminal = current.pendingTerminal ?: current.terminal
+            if (terminal !== Terminal.Open) {
+                throw producerFailure(terminal)
+            }
+            check(current.offerPhase == OfferPhase.Idle) { "Concurrent producer offer preparation" }
+            if (state.compareAndSet(current, current.copy(offerPhase = OfferPhase.Preparing))) {
+                return
+            }
+        }
+    }
+
+    private fun abortOfferPreparation() {
+        while (true) {
+            val current = state.value
+            check(current.offerPhase == OfferPhase.Preparing) { "Producer offer preparation is not active" }
+            if (state.compareAndSet(current, current.copy(offerPhase = OfferPhase.Idle))) {
+                return
+            }
+        }
+    }
+
+    private fun commitOffer() {
+        while (true) {
+            val current = state.value
+            check(current.offerPhase == OfferPhase.Preparing) { "Producer offer preparation is not active" }
+            val terminal = current.pendingTerminal ?: current.terminal
+            if (terminal !== Terminal.Open) {
+                if (state.compareAndSet(current, current.copy(offerPhase = OfferPhase.Idle))) {
+                    throw producerFailure(terminal)
+                }
+                continue
+            }
+            if (state.compareAndSet(current, current.copy(offerPhase = OfferPhase.Committed))) {
+                return
+            }
+        }
+    }
+
+    private fun finishCommittedOffer() {
+        while (true) {
+            val current = state.value
+            check(current.offerPhase == OfferPhase.Committed) { "Producer offer is not committed" }
+            val terminal = current.pendingTerminal ?: current.terminal
+            val updated = current.copy(
+                terminal = terminal,
+                offerPhase = OfferPhase.Idle,
+                pendingTerminal = null,
+            )
+            if (state.compareAndSet(current, updated)) {
+                if (terminal !== Terminal.Open) {
+                    signalTerminalWaiters()
+                }
+                return
+            }
+        }
+    }
+
+    private fun producerFailure(terminal: Terminal): Throwable = when (terminal) {
+        Terminal.Open -> kotlin.error("Open collector cannot reject a producer")
+        Terminal.Complete,
+        is Terminal.Error,
+        -> IllegalStateException("BufferedResumableCollector is already terminated.")
+        is Terminal.Cancelled -> terminal.cause.asProducerCancellation()
+    }
+
+    private fun Throwable.asProducerCancellation(): CancellationException {
+        if (this is CancellationException) {
+            return this
+        }
+        return CancellationException("Collector drain failed.").also { it.initCause(this) }
+    }
+
+    private fun terminate(terminal: Terminal) {
+        while (true) {
+            val current = state.value
+            if (current.terminal !== Terminal.Open || current.pendingTerminal != null) {
+                return
+            }
+            val updated = when (current.offerPhase) {
+                OfferPhase.Idle,
+                OfferPhase.Preparing,
+                -> current.copy(terminal = terminal)
+                OfferPhase.Committed -> current.copy(pendingTerminal = terminal)
+            }
+            if (state.compareAndSet(current, updated)) {
+                if (current.offerPhase != OfferPhase.Committed) {
+                    signalTerminalWaiters()
+                }
+                return
+            }
+        }
+    }
+
+    private suspend fun ensureDrainActive() {
+        try {
+            currentCoroutineContext().ensureActive()
+        } catch (ex: CancellationException) {
+            cancelDrain(ex)
+            throw ex
+        }
+    }
+
+    private fun signalTerminalWaiters() {
+        valueReady.resume()
+        resume()
+    }
+
+    private fun cancelDrain(cause: Throwable) {
+        terminate(Terminal.Cancelled(cause))
     }
 }

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/SpscArrayQueue.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/SpscArrayQueue.kt
@@ -37,6 +37,12 @@ internal class SpscArrayQueue<T> private constructor(capacity: Int) {
 
     val isEmpty: Boolean get() = consumerIndex.value == producerIndex.value
 
+    val canOffer: Boolean
+        get() {
+            val offset = producerIndex.value and mask
+            return referenceArray.get(offset) == EMPTY
+        }
+
     fun offer(value: T): Boolean {
         val pi = producerIndex.value
 

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollectorTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/subject/BufferedResumableCollectorTest.kt
@@ -1,17 +1,29 @@
 package io.bluetape4k.coroutines.flow.extensions.subject
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.coroutines.support.log
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.junit5.coroutines.withSingleThread
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Test
+import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.seconds
 
 class BufferedResumableCollectorTest {
@@ -180,5 +192,321 @@ class BufferedResumableCollectorTest {
 
             produced.get() shouldBeEqualTo expectedCount
             received.sorted() shouldBeEqualTo expectedValues
+        }
+
+    @Test
+    fun `complete는 이미 적재된 값을 drain한 뒤 suspend producer를 거부한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val bc = BufferedResumableCollector<Int>(1)
+            bc.next(1)
+
+            val producerResult = async(start = CoroutineStart.UNDISPATCHED) {
+                runCatching { bc.next(2) }
+            }
+
+            bc.complete()
+            val producerError = producerResult.await().exceptionOrNull()
+
+            val received = mutableListOf<Int>()
+            bc.drain(FlowCollector { received += it })
+
+            received shouldBeEqualTo listOf(1)
+            producerError.shouldBeInstanceOf<IllegalStateException>()
+            runCatching { bc.next(3) }.exceptionOrNull().shouldBeInstanceOf<IllegalStateException>()
+        }
+
+    @Test
+    fun `terminal이 offer commit보다 먼저면 값을 enqueue하지 않는다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val beforeOffer = CompletableDeferred<Unit>()
+            val releaseOffer = CompletableDeferred<Unit>()
+            val bc = BufferedResumableCollector.forTest<Int>(
+                capacity = 1,
+                beforeOfferCommit = {
+                    beforeOffer.complete(Unit)
+                    releaseOffer.await()
+                },
+            )
+
+            val producerResult = async(start = CoroutineStart.UNDISPATCHED) {
+                runCatching { bc.next(1) }
+            }
+            beforeOffer.await()
+            bc.complete()
+            releaseOffer.complete(Unit)
+
+            producerResult.await().exceptionOrNull().shouldBeInstanceOf<IllegalStateException>()
+            val received = mutableListOf<Int>()
+            bc.drain(FlowCollector { received += it })
+            received shouldBeEqualTo emptyList()
+        }
+
+    @Test
+    fun `error가 offer commit보다 먼저면 값을 거부하고 같은 error를 전파한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val expectedError = IllegalStateException("terminal before offer commit")
+            val beforeOffer = CompletableDeferred<Unit>()
+            val releaseOffer = CompletableDeferred<Unit>()
+            val bc = BufferedResumableCollector.forTest<Int>(
+                capacity = 1,
+                beforeOfferCommit = {
+                    beforeOffer.complete(Unit)
+                    releaseOffer.await()
+                },
+            )
+
+            val producerResult = async(start = CoroutineStart.UNDISPATCHED) {
+                runCatching { bc.next(1) }
+            }
+            beforeOffer.await()
+            bc.error(expectedError)
+            releaseOffer.complete(Unit)
+
+            producerResult.await().exceptionOrNull().shouldBeInstanceOf<IllegalStateException>()
+            val drainResult = runCatching { bc.drain(FlowCollector {}) }
+            drainResult.exceptionOrNull() shouldBeSameInstanceAs expectedError
+        }
+
+    @Test
+    fun `실제 offer가 error보다 먼저면 수락한 값을 drain하고 같은 error를 전파한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val expectedError = IllegalStateException("terminal after offer")
+            lateinit var bc: BufferedResumableCollector<Int>
+            bc = BufferedResumableCollector.forTest(
+                capacity = 1,
+                afterOffer = {
+                    bc.error(expectedError)
+                    bc.complete()
+                },
+            )
+
+            val producerResult = runCatching { bc.next(1) }
+
+            producerResult.exceptionOrNull() shouldBeEqualTo null
+            val received = mutableListOf<Int>()
+            val drainResult = runCatching { bc.drain(FlowCollector { received += it }) }
+            received shouldBeEqualTo listOf(1)
+            drainResult.exceptionOrNull() shouldBeSameInstanceAs expectedError
+        }
+
+    @Test
+    fun `committed offer의 pending terminal은 새 admission을 즉시 거부한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            lateinit var bc: BufferedResumableCollector<Int>
+            lateinit var rejectedProducer: kotlinx.coroutines.Deferred<Result<Unit>>
+            bc = BufferedResumableCollector.forTest(
+                capacity = 1,
+                afterOffer = {
+                    bc.complete()
+                    rejectedProducer = async(start = CoroutineStart.UNDISPATCHED) {
+                        runCatching { bc.next(2) }
+                    }
+                },
+            )
+
+            bc.next(1)
+
+            rejectedProducer.await().exceptionOrNull().shouldBeInstanceOf<IllegalStateException>()
+            val received = mutableListOf<Int>()
+            bc.drain(FlowCollector { received += it })
+            received shouldBeEqualTo listOf(1)
+        }
+
+    @Test
+    fun `첫 error만 기록하고 buffered 값을 drain한 뒤 전파한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val bc = BufferedResumableCollector<Int>(1)
+            val expectedError = IllegalStateException("first terminal error")
+            bc.next(1)
+
+            val producerResult = async(start = CoroutineStart.UNDISPATCHED) {
+                runCatching { bc.next(2) }
+            }
+
+            bc.error(expectedError)
+            bc.complete()
+            bc.error(IllegalArgumentException("ignored terminal error"))
+            val producerError = producerResult.await().exceptionOrNull()
+
+            val received = mutableListOf<Int>()
+            val drainResult = runCatching {
+                bc.drain(FlowCollector { received += it })
+            }
+
+            received shouldBeEqualTo listOf(1)
+            drainResult.exceptionOrNull() shouldBeSameInstanceAs expectedError
+            producerError.shouldBeInstanceOf<IllegalStateException>()
+        }
+
+    @Test
+    fun `complete와 null error도 첫 terminal 상태를 유지한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val ignoredError = IllegalStateException("ignored terminal error")
+
+            lateinit var completed: BufferedResumableCollector<Int>
+            completed = BufferedResumableCollector.forTest(
+                capacity = 1,
+                afterOffer = {
+                    completed.complete()
+                    completed.error(null)
+                    completed.error(ignoredError)
+                },
+            )
+            completed.next(1)
+            val completedValues = mutableListOf<Int>()
+            val completeResult = runCatching {
+                completed.drain(FlowCollector { completedValues += it })
+            }
+
+            completedValues shouldBeEqualTo listOf(1)
+            completeResult.exceptionOrNull() shouldBeEqualTo null
+
+            lateinit var nullError: BufferedResumableCollector<Int>
+            nullError = BufferedResumableCollector.forTest(
+                capacity = 1,
+                afterOffer = {
+                    nullError.error(null)
+                    nullError.complete()
+                    nullError.error(ignoredError)
+                },
+            )
+            nullError.next(2)
+            val nullErrorValues = mutableListOf<Int>()
+            val nullErrorResult = runCatching {
+                nullError.drain(FlowCollector { nullErrorValues += it })
+            }
+
+            nullErrorValues shouldBeEqualTo listOf(2)
+            nullErrorResult.exceptionOrNull() shouldBeEqualTo null
+        }
+
+    @Test
+    fun `작은 버퍼의 다수 producer와 complete 경합에서 성공한 값만 모두 drain한다`() =
+        runSuspendDefault(timeout = 10.seconds) {
+            repeat(64) { round ->
+                val bc = BufferedResumableCollector<Int>(1)
+                val successful = Collections.synchronizedList(mutableListOf<Int>())
+                val received = mutableListOf<Int>()
+
+                val producers = (0 until 8).map { producer ->
+                    async(start = CoroutineStart.UNDISPATCHED) {
+                        val value = round * 8 + producer
+                        runCatching { bc.next(value) }
+                            .onSuccess { successful += value }
+                    }
+                }
+
+                bc.complete()
+                bc.drain(FlowCollector { received += it })
+                val producerResults = producers.awaitAll()
+
+                received.sorted() shouldBeEqualTo successful.sorted()
+                producerResults
+                    .filter { it.isFailure }
+                    .forEach { result ->
+                        result.exceptionOrNull().shouldBeInstanceOf<IllegalStateException>()
+                    }
+            }
+        }
+
+    @Test
+    fun `drain 취소는 suspend producer와 이후 next를 CancellationException으로 종료한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val bc = BufferedResumableCollector<Int>(1)
+            val emitStarted = CompletableDeferred<Unit>()
+            bc.next(1)
+
+            val drainJob = launch {
+                bc.drain(FlowCollector {
+                    emitStarted.complete(Unit)
+                    awaitCancellation()
+                })
+            }
+            emitStarted.await()
+
+            bc.next(2)
+            val producerResult = async(start = CoroutineStart.UNDISPATCHED) {
+                runCatching { bc.next(3) }
+            }
+
+            drainJob.cancelAndJoin()
+
+            producerResult.await().exceptionOrNull().shouldBeInstanceOf<CancellationException>()
+            runCatching { bc.next(4) }.exceptionOrNull().shouldBeInstanceOf<CancellationException>()
+        }
+
+    @Test
+    fun `값을 기다리는 drain 취소도 이후 producer에 전파한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val bc = BufferedResumableCollector<Int>(1)
+            val drainJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                bc.drain(FlowCollector {})
+            }
+
+            drainJob.cancelAndJoin()
+
+            runCatching { bc.next(1) }.exceptionOrNull().shouldBeInstanceOf<CancellationException>()
+        }
+
+    @Test
+    fun `terminal과 buffered 값이 있어도 취소된 drain은 값을 emit하지 않는다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val bc = BufferedResumableCollector<Int>(1)
+            val emitted = AtomicInteger(0)
+            val drainError = AtomicReference<Throwable?>()
+            bc.next(1)
+            bc.complete()
+
+            val drainJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                cancel(CancellationException("cancel before drain"))
+                drainError.set(
+                    runCatching {
+                        bc.drain(FlowCollector { emitted.incrementAndGet() })
+                    }.exceptionOrNull(),
+                )
+            }
+            drainJob.join()
+
+            emitted.get() shouldBeEqualTo 0
+            drainError.get().shouldBeInstanceOf<CancellationException>()
+            runCatching { bc.next(2) }.exceptionOrNull().shouldBeInstanceOf<IllegalStateException>()
+        }
+
+    @Test
+    fun `collector 실패는 같은 원인을 전파하고 suspend producer를 cause 보존 취소한다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val bc = BufferedResumableCollector<Int>(1)
+            val expectedError = IllegalStateException("collector failed")
+            bc.next(1)
+
+            val producerResult = async(start = CoroutineStart.UNDISPATCHED) {
+                runCatching { bc.next(2) }
+            }
+            val drainResult = runCatching {
+                bc.drain(FlowCollector { throw expectedError })
+            }
+
+            drainResult.exceptionOrNull() shouldBeSameInstanceAs expectedError
+            val producerError = producerResult.await().exceptionOrNull()
+                .shouldBeInstanceOf<CancellationException>()
+            producerError.cause shouldBeSameInstanceAs expectedError
+        }
+
+    @Test
+    fun `capacity 대기 중 producer 취소는 값을 enqueue하지 않는다`() =
+        runSuspendDefault(timeout = 5.seconds) {
+            val bc = BufferedResumableCollector<Int>(1)
+            bc.next(1)
+
+            val producerJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                bc.next(2)
+            }
+            producerJob.cancelAndJoin()
+            bc.complete()
+
+            val received = mutableListOf<Int>()
+            bc.drain(FlowCollector { received += it })
+
+            received shouldBeEqualTo listOf(1)
         }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
@@ -3,11 +3,13 @@ package io.bluetape4k.cache.jcache
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.error
 import io.bluetape4k.logging.trace
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.cache.event.CacheEntryCreatedListener
 import javax.cache.event.CacheEntryEvent
 import javax.cache.event.CacheEntryExpiredListener
@@ -36,21 +38,38 @@ import javax.cache.event.CacheEntryUpdatedListener
  * @param V 캐시 값 타입
  * @property targetCache 이벤트를 반영할 Front Cache
  */
-class SuspendJCacheEntryEventListener<K: Any, V: Any>(
+class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
     private val targetCache: SuspendJCache<K, V>,
+    private val scope: CoroutineScope,
+    @Suppress("UNUSED_PARAMETER") marker: Unit,
 ): CacheEntryCreatedListener<K, V>,
    CacheEntryUpdatedListener<K, V>,
    CacheEntryRemovedListener<K, V>,
    CacheEntryExpiredListener<K, V>,
    AutoCloseable {
 
-    companion object: KLoggingChannel()
+    constructor(targetCache: SuspendJCache<K, V>): this(
+        targetCache,
+        CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        Unit,
+    )
 
-    // JCache 이벤트 스레드를 블로킹하지 않기 위해 전용 코루틴 스코프 사용
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    companion object: KLoggingChannel() {
+        @JvmSynthetic
+        internal fun <K: Any, V: Any> forTest(
+            targetCache: SuspendJCache<K, V>,
+            scope: CoroutineScope,
+        ): SuspendJCacheEntryEventListener<K, V> =
+            SuspendJCacheEntryEventListener(targetCache, scope, Unit)
+    }
+
+    private val closed = AtomicBoolean(false)
+    private val cacheIdentifier = targetCache::class.java.name.sanitizeLogIdentifier()
 
     override fun close() {
-        scope.cancel()
+        if (closed.compareAndSet(false, true)) {
+            scope.cancel()
+        }
     }
 
     /**
@@ -60,13 +79,13 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any>(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onCreated(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        log.trace { "BackCache cache entry created. events=${events.joinToString { it.asText() }}" }
-        if (!targetCache.isClosed()) {
+        val eventCopies = events.map { EventCopy(it.key, it.value) }
+        log.trace { "BackCache cache entry created. cache=$cacheIdentifier count=${eventCopies.size}" }
+        if (shouldAcceptCallback()) {
             scope.launch {
-                runCatching {
-                    targetCache.putAll(events.associate { it.key to it.value })
-                }.onFailure { e ->
-                    log.error(e) { "Fail to put all created cache entries." }
+                if (closed.get()) return@launch
+                applyEvent("put all created cache entries") {
+                    targetCache.putAll(eventCopies.associate { it.key to it.value })
                 }
             }
         }
@@ -79,13 +98,13 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any>(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onUpdated(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        log.trace { "BackCache cache entry updated. events=${events.joinToString { it.asText() }}" }
-        if (!targetCache.isClosed()) {
+        val eventCopies = events.map { EventCopy(it.key, it.value) }
+        log.trace { "BackCache cache entry updated. cache=$cacheIdentifier count=${eventCopies.size}" }
+        if (shouldAcceptCallback()) {
             scope.launch {
-                runCatching {
-                    targetCache.putAll(events.associate { it.key to it.value })
-                }.onFailure { e ->
-                    log.error(e) { "Fail to put all updated cache entries." }
+                if (closed.get()) return@launch
+                applyEvent("put all updated cache entries") {
+                    targetCache.putAll(eventCopies.associate { it.key to it.value })
                 }
             }
         }
@@ -99,13 +118,13 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any>(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onRemoved(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        log.trace { "BackCache cache entry removed. events=${events.joinToString { it.asText() }}" }
-        if (!targetCache.isClosed()) {
+        val eventCopies = events.map { EventCopy(it.key, it.value) }
+        log.trace { "BackCache cache entry removed. cache=$cacheIdentifier count=${eventCopies.size}" }
+        if (shouldAcceptCallback()) {
             scope.launch {
-                runCatching {
-                    targetCache.removeAll(events.map { it.key }.toSet())
-                }.onFailure { e ->
-                    log.error(e) { "Fail to remove all removed cache entries." }
+                if (closed.get()) return@launch
+                applyEvent("remove all removed cache entries") {
+                    targetCache.removeAll(eventCopies.mapTo(LinkedHashSet()) { it.key })
                 }
             }
         }
@@ -119,18 +138,38 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any>(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onExpired(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        log.trace { "BackCache cache entry expired. events=${events.joinToString { it.asText() }}" }
-        if (!targetCache.isClosed()) {
+        val eventCopies = events.map { EventCopy(it.key, it.value) }
+        log.trace { "BackCache cache entry expired. cache=$cacheIdentifier count=${eventCopies.size}" }
+        if (shouldAcceptCallback()) {
             scope.launch {
-                runCatching {
-                    targetCache.removeAll(events.map { it.key }.toSet())
-                }.onFailure { e ->
-                    log.error(e) { "Fail to remove all expired cache entries." }
+                if (closed.get()) return@launch
+                applyEvent("remove all expired cache entries") {
+                    targetCache.removeAll(eventCopies.mapTo(LinkedHashSet()) { it.key })
                 }
             }
         }
     }
 
-    private fun <K, V> CacheEntryEvent<K, V>.asText(): String =
-        "source=$source, key=$key, value=$value"
+    private fun shouldAcceptCallback(): Boolean = !closed.get() && !targetCache.isClosed()
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun applyEvent(
+        operation: String,
+        block: suspend () -> Unit,
+    ) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.error(e) { "Fail to $operation." }
+        }
+    }
+
+    private data class EventCopy<K: Any, V: Any>(val key: K, val value: V)
+
+    private fun String.sanitizeLogIdentifier(): String {
+        val sanitized = replace(Regex("[^A-Za-z0-9._\\$-]"), "_").take(128)
+        return sanitized.ifEmpty { "unknown" }
+    }
 }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
@@ -150,6 +150,11 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
         }
     }
 
+    /**
+     * Callback admission is linearized by the [closed] read immediately before launch.
+     * A callback that has already passed this gate is in flight; [close] requests
+     * cooperative cancellation without waiting for that backend call to return.
+     */
     private fun shouldAcceptCallback(): Boolean = !closed.get() && !targetCache.isClosed()
 
     @Suppress("TooGenericExceptionCaught")

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
@@ -118,13 +118,13 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onRemoved(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        val eventCopies = events.map { EventCopy(it.key, it.value) }
-        log.trace { "BackCache cache entry removed. cache=$cacheIdentifier count=${eventCopies.size}" }
+        val eventKeys = events.map { it.key }
+        log.trace { "BackCache cache entry removed. cache=$cacheIdentifier count=${eventKeys.size}" }
         if (shouldAcceptCallback()) {
             scope.launch {
                 if (closed.get()) return@launch
                 applyEvent("remove all removed cache entries") {
-                    targetCache.removeAll(eventCopies.mapTo(LinkedHashSet()) { it.key })
+                    targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
                 }
             }
         }
@@ -138,13 +138,13 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onExpired(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        val eventCopies = events.map { EventCopy(it.key, it.value) }
-        log.trace { "BackCache cache entry expired. cache=$cacheIdentifier count=${eventCopies.size}" }
+        val eventKeys = events.map { it.key }
+        log.trace { "BackCache cache entry expired. cache=$cacheIdentifier count=${eventKeys.size}" }
         if (shouldAcceptCallback()) {
             scope.launch {
                 if (closed.get()) return@launch
                 applyEvent("remove all expired cache entries") {
-                    targetCache.removeAll(eventCopies.mapTo(LinkedHashSet()) { it.key })
+                    targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
                 }
             }
         }

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.logging.trace
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
@@ -99,20 +100,34 @@ class SuspendNearJCache<K: Any, V: Any> internal constructor(
      * // value == null
      * ```
      */
+    @Suppress("TooGenericExceptionCaught")
     suspend fun clearAll() {
         log.info {
             "front cache, back cache 모두 clear 합니다. 단 back cache 를 공유한 다른 near cache에는 전파되지 않습니다. " +
                     "전파를 위해서는 removeAll을 사용하세요"
         }
         frontCache.clear()
-        runCatching { backCache.clear() }
+        try {
+            backCache.clear()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.debug(e) { "Back cache clear failed while clearing near cache." }
+        }
 
         log.info { "front cache, back cache 모두 clear 완료." }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun close() {
         log.info { "Near Cache 의 Front Cache를 Close 합니다." }
-        runCatching { frontCache.close() }
+        try {
+            frontCache.close()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.debug(e) { "Front cache close failed while closing near cache." }
+        }
     }
 
     override fun isClosed(): Boolean = frontCache.isClosed()

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
@@ -1,14 +1,33 @@
 package io.bluetape4k.cache.jcache
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.coEvery
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import javax.cache.Cache
 import javax.cache.event.CacheEntryEvent
 import javax.cache.event.EventType
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SuspendJCacheEntryEventListenerTest {
 
     companion object: KLoggingChannel()
@@ -23,88 +42,252 @@ class SuspendJCacheEntryEventListenerTest {
     }
 
     @Test
-    fun `onCreated - targetCache에 putAll 이 호출된다`() {
+    fun `onCreated - targetCache에 putAll 이 호출된다`() = runTest {
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns false
         coEvery { targetCache.putAll(any()) } returns Unit
 
-        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
         val event = mockEvent("k1", "v1", EventType.CREATED)
 
         listener.onCreated(mutableListOf(event))
-        Thread.sleep(200)
+        runCurrent()
 
         coVerify { targetCache.putAll(mapOf("k1" to "v1")) }
+        listener.close()
     }
 
     @Test
-    fun `onUpdated - targetCache에 putAll 이 호출된다`() {
+    fun `onCreated는 callback 반환 후 변경된 원본 iterable과 무관하게 batch 사본을 반영한다`() = runTest {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        coEvery { targetCache.putAll(any()) } returns Unit
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+        val first = mockEvent("k1", "v1", EventType.CREATED)
+        val second = mockEvent("k2", "v2", EventType.CREATED)
+        val events = mutableListOf(first)
+
+        listener.onCreated(events)
+        events.clear()
+        events += second
+        runCurrent()
+
+        coVerify(exactly = 1) { targetCache.putAll(mapOf("k1" to "v1")) }
+        listener.close()
+    }
+
+    @Test
+    fun `onUpdated - targetCache에 putAll 이 호출된다`() = runTest {
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns false
         coEvery { targetCache.putAll(any()) } returns Unit
 
-        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
         val event = mockEvent("k2", "v2", EventType.UPDATED)
 
         listener.onUpdated(mutableListOf(event))
-        Thread.sleep(200)
+        runCurrent()
 
         coVerify { targetCache.putAll(mapOf("k2" to "v2")) }
+        listener.close()
     }
 
     @Test
-    fun `onRemoved - targetCache에 removeAll 이 호출된다`() {
+    fun `onRemoved - targetCache에 removeAll 이 호출된다`() = runTest {
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns false
         coEvery { targetCache.removeAll(any<Set<String>>()) } returns Unit
 
-        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
         val event = mockEvent("k3", "v3", EventType.REMOVED)
 
         listener.onRemoved(mutableListOf(event))
-        Thread.sleep(200)
+        runCurrent()
 
         coVerify { targetCache.removeAll(setOf("k3")) }
+        listener.close()
     }
 
     @Test
-    fun `onExpired - targetCache에 removeAll 이 호출된다`() {
+    fun `onExpired - targetCache에 removeAll 이 호출된다`() = runTest {
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns false
         coEvery { targetCache.removeAll(any<Set<String>>()) } returns Unit
 
-        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
         val event = mockEvent("k4", "v4", EventType.EXPIRED)
 
         listener.onExpired(mutableListOf(event))
-        Thread.sleep(200)
+        runCurrent()
 
         coVerify { targetCache.removeAll(setOf("k4")) }
+        listener.close()
     }
 
     @Test
-    fun `targetCache 가 closed 이면 이벤트를 무시한다`() {
+    fun `targetCache 가 closed 이면 이벤트를 무시한다`() = runTest {
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns true
 
-        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
         val event = mockEvent("k5", "v5", EventType.CREATED)
 
         // 예외 없이 완료되어야 하며, putAll 이 호출되지 않아야 한다
         listener.onCreated(mutableListOf(event))
-        Thread.sleep(100)
+        runCurrent()
 
+        coVerify(exactly = 0) { targetCache.putAll(any()) }
+        listener.close()
+    }
+
+    @Test
+    fun `close - scope 가 취소된다`() = runTest {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+
+        // 예외 없이 완료되어야 한다
+        listener.close()
+        listener.close()
+        listener.onCreated(mutableListOf(mockEvent("k6", "v6", EventType.CREATED)))
+        runCurrent()
         coVerify(exactly = 0) { targetCache.putAll(any()) }
     }
 
     @Test
-    fun `close - scope 가 취소된다`() {
+    fun `CancellationException은 listener child job을 취소 상태로 남긴다`() = runTest {
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns false
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val cancellation = CancellationException("listener cancelled")
+        coEvery { targetCache.putAll(any()) } coAnswers {
+            started.complete(Unit)
+            release.await()
+        }
 
-        val listener = SuspendJCacheEntryEventListener(targetCache)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listenerJob = listenerScope.coroutineContext[Job]!!
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+        listener.onCreated(mutableListOf(mockEvent("k7", "v7", EventType.CREATED)))
+        runCurrent()
+        started.await()
+        val child = listenerJob.children.single()
 
-        // 예외 없이 완료되어야 한다
+        release.completeExceptionally(cancellation)
+        runCurrent()
+        child.join()
+
+        child.isCancelled.shouldBeTrue()
         listener.close()
+    }
+
+    @Test
+    fun `close는 이미 시작된 callback의 cooperative cancellation을 요청한다`() = runTest {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        val started = CompletableDeferred<Unit>()
+        coEvery { targetCache.putAll(any()) } coAnswers {
+            started.complete(Unit)
+            awaitCancellation()
+        }
+
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listenerJob = listenerScope.coroutineContext[Job]!!
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+        listener.onCreated(mutableListOf(mockEvent("k8", "v8", EventType.CREATED)))
+        runCurrent()
+        started.await()
+        val child = listenerJob.children.single()
+
+        listener.close()
+        runCurrent()
+        child.join()
+
+        child.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `close는 유한한 cooperative callback burst를 모두 취소한다`() = runTest {
+        val callbackCount = 1_000
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        val startedCount = AtomicInteger()
+        val allStarted = CompletableDeferred<Unit>()
+        coEvery { targetCache.putAll(any()) } coAnswers {
+            if (startedCount.incrementAndGet() == callbackCount) {
+                allStarted.complete(Unit)
+            }
+            awaitCancellation()
+        }
+
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listenerJob = listenerScope.coroutineContext[Job]!!
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+        repeat(callbackCount) { index ->
+            listener.onCreated(mutableListOf(mockEvent("burst-$index", "value", EventType.CREATED)))
+        }
+        runCurrent()
+        allStarted.await()
+        val children = listenerJob.children.toList()
+
+        children.size.shouldBeEqualTo(callbackCount)
+        listener.close()
+        runCurrent()
+        children.joinAll()
+
+        children.all { it.isCancelled }.shouldBeTrue()
+    }
+
+    @Test
+    fun `event callback log에는 raw key value source를 포함하지 않는다`() = runTest {
+        val secretKey = "secret-key-should-not-log"
+        val secretValue = "secret-value-should-not-log"
+        val secretSource = "secret-source-should-not-log"
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        coEvery { targetCache.putAll(any()) } returns Unit
+        val event = mockk<CacheEntryEvent<String, String>>()
+        val source = mockk<Cache<Any, Any>>()
+        every { event.key } returns secretKey
+        every { event.value } returns secretValue
+        every { source.toString() } returns secretSource
+        every { event.source } returns source
+        every { event.eventType } returns EventType.CREATED
+
+        val logger = SuspendJCacheEntryEventListener.log as Logger
+        val previousLevel = logger.level
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.level = Level.TRACE
+        logger.addAppender(appender)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+        try {
+            listener.onCreated(mutableListOf(event))
+            runCurrent()
+            val messages = appender.list
+                .map { it.formattedMessage }
+                .filter { it.contains("BackCache cache entry created") }
+
+            messages.isNotEmpty().shouldBeTrue()
+            messages.all { message ->
+                !message.contains(secretKey) &&
+                        !message.contains(secretValue) &&
+                        !message.contains(secretSource)
+            }.shouldBeTrue()
+        } finally {
+            listener.close()
+            logger.detachAppender(appender)
+            appender.stop()
+            logger.level = previousLevel
+        }
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
@@ -113,6 +113,27 @@ class SuspendJCacheEntryEventListenerTest {
     }
 
     @Test
+    fun `onRemoved는 null value 이벤트를 key-only snapshot으로 처리한다`() = runTest {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        coEvery { targetCache.removeAll(any<Set<String>>()) } returns Unit
+
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+        val event = mockk<CacheEntryEvent<String, String>>()
+        every { event.key } returns "removed-without-value"
+        every { event.value } returns null
+        every { event.eventType } returns EventType.REMOVED
+        every { event.source } returns mockk(relaxed = true)
+
+        listener.onRemoved(mutableListOf(event))
+        runCurrent()
+
+        coVerify { targetCache.removeAll(setOf("removed-without-value")) }
+        listener.close()
+    }
+
+    @Test
     fun `onExpired - targetCache에 removeAll 이 호출된다`() = runTest {
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns false

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCacheBackFirstContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCacheBackFirstContractTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.cache.nearcache.jcache
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.cache.jcache.SuspendJCache
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.mockk.coEvery
@@ -11,6 +12,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class SuspendNearJCacheBackFirstContractTest {
@@ -160,5 +162,35 @@ class SuspendNearJCacheBackFirstContractTest {
 
         error.message shouldBeEqualTo cancellation.message
         coVerify(exactly = 1) { frontCache.remove("key") }
+    }
+
+    @Test
+    fun `clearAll은 back CancellationException을 호출자에게 재전파한다`() = runTest {
+        val cancellation = CancellationException("clear cancelled")
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { frontCache.clear() } just runs
+        coEvery { backCache.clear() } throws cancellation
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val thrown = assertFailsWith<CancellationException> { nearCache.clearAll() }
+
+        (thrown === cancellation).shouldBeTrue()
+        coVerify { frontCache.clear() }
+        coVerify { backCache.clear() }
+    }
+
+    @Test
+    fun `close는 CancellationException을 호출자에게 재전파한다`() = runTest {
+        val cancellation = CancellationException("close cancelled")
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { frontCache.close() } throws cancellation
+        val nearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val thrown = assertFailsWith<CancellationException> { nearCache.close() }
+
+        (thrown === cancellation).shouldBeTrue()
+        coVerify { frontCache.close() }
     }
 }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCacheTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCacheTest.kt
@@ -1,20 +1,28 @@
 package io.bluetape4k.cache.nearcache.jcache
 
-import io.bluetape4k.cache.jcache.CaffeineSuspendJCache
-import io.bluetape4k.cache.jcache.SuspendJCache
-import io.bluetape4k.codec.encodeBase62
-import io.bluetape4k.junit5.coroutines.runSuspendIO
-import io.bluetape4k.junit5.faker.Fakers
-import io.bluetape4k.logging.coroutines.KLoggingChannel
-import kotlinx.coroutines.flow.count
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.cache.jcache.CaffeineSuspendJCache
+import io.bluetape4k.cache.jcache.SuspendJCache
+import io.bluetape4k.codec.encodeBase62
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.junit5.faker.Fakers
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -191,6 +199,37 @@ class SuspendNearJCacheTest {
     }
 
     @Test
+    fun `clearAll은 ordinary back failure를 기존처럼 관찰 후 완료한다`() = runTest {
+        val failure = IllegalStateException("back unavailable")
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { frontCache.clear() } just runs
+        coEvery { backCache.clear() } throws failure
+        val localNearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        localNearCache.clearAll()
+
+        coVerify { frontCache.clear() }
+        coVerify { backCache.clear() }
+    }
+
+    @Test
+    fun `clearAll은 fatal back Error를 호출자에게 전달한다`() = runTest {
+        val failure = AssertionError("back cache is broken")
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { frontCache.clear() } just runs
+        coEvery { backCache.clear() } throws failure
+        val localNearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val thrown = assertFailsWith<AssertionError> { localNearCache.clearAll() }
+
+        (thrown === failure).shouldBeTrue()
+        coVerify { frontCache.clear() }
+        coVerify { backCache.clear() }
+    }
+
+    @Test
     fun `getAndPut - 이전 값을 반환하고 새 값을 저장한다`() = runSuspendIO {
         val key = randomKey()
         val value1 = randomValue()
@@ -313,5 +352,32 @@ class SuspendNearJCacheTest {
         nearCache.isClosed().shouldBeFalse()
         nearCache.close()
         nearCache.isClosed().shouldBeTrue()
+    }
+
+    @Test
+    fun `close는 ordinary front failure를 기존처럼 관찰 후 완료한다`() = runTest {
+        val failure = IllegalStateException("front unavailable")
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { frontCache.close() } throws failure
+        val localNearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        localNearCache.close()
+
+        coVerify { frontCache.close() }
+    }
+
+    @Test
+    fun `close는 fatal front Error를 호출자에게 전달한다`() = runTest {
+        val failure = AssertionError("front cache is broken")
+        val frontCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        val backCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        coEvery { frontCache.close() } throws failure
+        val localNearCache = SuspendNearJCache.withoutListener(frontCache, backCache)
+
+        val thrown = assertFailsWith<AssertionError> { localNearCache.close() }
+
+        (thrown === failure).shouldBeTrue()
+        coVerify { frontCache.close() }
     }
 }

--- a/docs/lessons/2026-08-22-issue-1349-buffered-collector-terminal-race.md
+++ b/docs/lessons/2026-08-22-issue-1349-buffered-collector-terminal-race.md
@@ -1,0 +1,53 @@
+# Issue #1349: terminal 상태와 active producer 수는 함께 선형화해야 한다
+
+## 맥락
+
+`BufferedResumableCollector`는 producer를 mutex로 직렬화했지만 terminal 상태와
+producer admission은 별도로 관리했다. `complete()`와 `error()`는 value waiter만
+깨웠기 때문에 capacity를 기다리는 producer가 남을 수 있었고, drain은 빈 queue를
+보는 즉시 종료해 terminal과 교차한 값을 잃을 수 있었다. 분리된 error 필드는 후속
+terminal 호출이 첫 cause를 덮어쓰는 것도 허용했다.
+
+## 결정
+
+- terminal kind, cause, active admission 수를 하나의 immutable atomic 상태로 묶는다.
+- `next`는 `Open(n) -> Open(n + 1)` CAS에 성공한 뒤에만 producer mutex에 진입하고,
+  모든 반환·실패·취소 경로에서 `finally` 한 곳으로 admission을 감소시킨다.
+- `Preparing -> Committed` CAS로 offer의 선형화 지점을 고정한다. `Preparing` 중 terminal이
+  먼저 반영되면 offer를 거부하고, `Committed` 뒤 terminal은 실제 queue 적재가 끝날 때까지
+  pending 상태로 보존한다. commit 뒤에는 cancellation을 다시 검사하지 않는다.
+- 첫 terminal CAS만 상태를 바꾸고 value waiter와 capacity waiter를 모두 깨운다.
+- drain은 queue가 비고 terminal 상태이며 active admission이 0일 때만 종료한다.
+
+## 결과
+
+capacity 1에서 terminal과 producer가 경합해도 이미 적재된 값은 순서대로 전달되고,
+enqueue하지 못한 producer는 bounded time 안에 `IllegalStateException`으로 종료한다.
+`error`가 먼저 선형화되면 buffered 값을 전달한 뒤 동일한 cause를 전파하며, 후속
+`complete`, `error`, `error(null)`은 첫 상태를 바꾸지 않는다. collector 실패나
+취소는 suspend producer를 깨우고 원인을 보존한 `CancellationException`으로 전달한다.
+
+## 검증
+
+- 기존 구현: `BufferedResumableCollectorTest` 10개 중 3개 실패
+  - complete 경합: 5초 timeout
+  - capacity 1, 8 producer, 64회 stress: 10초 timeout
+  - first error identity: 후속 error로 덮어쓰기
+- 변경 후 `BufferedResumableCollectorTest`: 19개 통과
+- 같은 테스트 class를 `--rerun-tasks`로 3회 실행: 매회 19개 통과, timeout 0
+- `:bluetape4k-coroutines:detekt :bluetape4k-coroutines:build`: 630개 통과,
+  Kover 검증 포함 `BUILD SUCCESSFUL`
+
+## 놓치기 쉬운 점
+
+terminal boolean과 active producer counter를 서로 다른 atomic으로 두면 drain이 두 값을
+서로 다른 시점에 읽어 조기 종료할 수 있다. producer mutex만 terminal 함수에 적용하면
+non-suspending API가 full buffer의 producer를 깨우지 못한다. terminal과 admission은
+하나의 CAS 상태로 관찰돼야 하고 mutex는 SPSC queue의 producer 직렬화에만 사용해야 한다.
+
+## 향후 지침
+
+buffered producer/consumer 경합 테스트는 `delay`나 반복 `yield`로 순서를 추정하지 않는다.
+`CoroutineStart.UNDISPATCHED`, `CompletableDeferred`, full-buffer fixture로 producer가 실제
+suspension 지점에 도달했음을 고정하고, 수락된 값 집합·terminal cause identity·producer
+완료 결과를 각각 assertion한다.

--- a/docs/testlogs/2026-08.md
+++ b/docs/testlogs/2026-08.md
@@ -12,3 +12,6 @@
 | 2026-08-22 | #1341 | `BufferedSuspendedSinkTest.all buffered write overloads preserve exact payload` | RED → GREEN — 1 failed, 복원 후 1 passing | 기대값을 `0x2A`에서 `0x2B`로 바꿔 정확한 hex payload 불일치를 확인한 뒤 fixture 복원 |
 | 2026-08-22 | #1341 | `BufferedSuspendedSinkTest` | PASS — 8 passing | 정확한 payload, source보다 작은 `byteCount`, `writeAll` count, segment/tail 및 `flush()`/`close()` 위임 횟수 검증 |
 | 2026-08-22 | #1341 | `:bluetape4k-okio:detekt :bluetape4k-okio:build` | PASS — 1,437 passing, 14 pending | Detekt task와 Kover 검증 완료; production source 변경 없음 |
+| 2026-08-22 | #1349 | `BufferedResumableCollectorTest` baseline | RED — 10개 중 3개 실패 | complete 경합과 다중 producer stress는 timeout, first error identity는 후속 error 덮어쓰기로 실패 |
+| 2026-08-22 | #1349 | `BufferedResumableCollectorTest` | PASS — 19 passing × 3회 | capacity 1, 8 producer, 64회 경합과 `Preparing`/`Committed` 양쪽 offer 경계, pending terminal admission 거부, first-terminal-wins, drain 순서, cancellation cause 보존 검증 |
+| 2026-08-22 | #1349 | `:bluetape4k-coroutines:detekt :bluetape4k-coroutines:build` | PASS — 630 passing | Detekt, 전체 coroutines module test, Kover 검증 포함 `BUILD SUCCESSFUL` |

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.elasticsearch.coroutines
 
 import co.elastic.clients.elasticsearch.core.BulkRequest
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -57,6 +58,16 @@ class BulkIngesterCoroutinesTest: AbstractElasticsearchTest() {
             ingester.shouldNotBeNull()
         } finally {
             ingester.close()
+        }
+    }
+
+    @Test
+    fun `bulkIngesterOf 는 양수 maxOperations 만 허용한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            bulkIngesterOf<Void>(client = client, maxOperations = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            bulkIngesterOf<Void>(client = asyncClient, maxOperations = 0)
         }
     }
 
@@ -148,6 +159,32 @@ class BulkIngesterCoroutinesTest: AbstractElasticsearchTest() {
             }.shouldBeNull()
         } finally {
             handle.close()
+        }
+    }
+
+    @Test
+    fun `bulkProgressListener emits Error events`() = runTest {
+        val handle = bulkProgressListener<Void>()
+        val (listener, events) = handle
+        val failure = IllegalStateException("bulk failed")
+
+        try {
+            listener.afterBulk(3L, bulkRequestOf("error"), emptyList(), failure)
+
+            val event = events.first()
+            event shouldBeInstanceOf BulkProgressEvent.Error::class
+            val errorEvent = event as BulkProgressEvent.Error<Void>
+            errorEvent.executionId shouldBeEqualTo 3L
+            errorEvent.exception shouldBeEqualTo failure
+        } finally {
+            handle.close()
+        }
+    }
+
+    @Test
+    fun `bulkProgressListener 는 양수 bufferCapacity 만 허용한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            bulkProgressListener<Void>(bufferCapacity = 0)
         }
     }
 

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.elasticsearch.coroutines
 
 import co.elastic.clients.elasticsearch.core.BulkRequest
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation
+import co.elastic.clients.util.ObjectBuilder
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.function.Function
 
 /**
  * [BulkIngester] Coroutines 확장함수 테스트.
@@ -100,6 +102,30 @@ class BulkIngesterCoroutinesTest: AbstractElasticsearchTest() {
             index(indexName)
         }
         countResponse.count() shouldBeGreaterOrEqualTo docCount.toLong()
+    }
+
+    @Test
+    fun `builder lambda addSuspend 로 문서를 인덱싱한다`() = runTest(timeout = 60.seconds) {
+        val ingester = bulkIngesterOf<Void>(
+            client = asyncClient,
+            maxOperations = 1,
+        )
+
+        ingester.use {
+            it.addSuspend(
+                Function<BulkOperation.Builder, ObjectBuilder<BulkOperation>> { operation ->
+                    operation.index<Map<String, Any?>> { index ->
+                        index.index(indexName)
+                            .id("builder-doc")
+                            .document(mapOf("title" to "Builder document"))
+                    }
+                },
+            )
+        }
+
+        asyncClient.indices().refresh { it.index(indexName) }.await()
+        val countResponse = asyncClient.countSuspending { index(indexName) }
+        countResponse.count() shouldBeGreaterOrEqualTo 1L
     }
 
     @Test

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesTest.kt
@@ -104,6 +104,18 @@ class SearchApiCoroutinesTest: AbstractElasticsearchTest() {
             closed.shouldBeTrue()
         }
 
+    @Test
+    fun `PIT 와 searchAsFlow 는 기본 옵션으로도 동작한다`() = runTest(timeout = 60.seconds) {
+        val pitId = asyncClient.openPointInTimeSuspending(indexName)
+        pitId.shouldNotBeBlank()
+        asyncClient.closePointInTimeSuspending(pitId).shouldBeTrue()
+
+        val first = asyncClient.searchAsFlow<SearchDoc>(indexName)
+            .take(1)
+            .toList()
+        first.size shouldBeEqualTo 1
+    }
+
     // -------------------------------------------------------------------------
     // searchAsFlow — 전체 10000건 순회
     // -------------------------------------------------------------------------

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesUnitTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesUnitTest.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.elasticsearch.coroutines
 
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.assertFailsWith
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -33,5 +35,29 @@ class SearchApiCoroutinesUnitTest {
         job.cancelAndJoin()
 
         cleanupCompleted.shouldBeTrue()
+    }
+
+    @Test
+    fun `PIT cleanup swallows cancellation and ordinary close failures`() = runTest {
+        var cancellationInvoked = false
+        closePointInTimeBestEffort("cancelled-pit") {
+            cancellationInvoked = true
+            throw CancellationException("collector cancelled")
+        }
+        cancellationInvoked.shouldBeTrue()
+
+        var failureInvoked = false
+        closePointInTimeBestEffort("failed-pit") {
+            failureInvoked = true
+            throw IllegalStateException("close failed")
+        }
+        failureInvoked.shouldBeTrue()
+    }
+
+    @Test
+    fun `PIT cleanup rejects a blank id before invoking close`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            closePointInTimeBestEffort(" ") { true }
+        }
     }
 }

--- a/infra/nats/README.ko.md
+++ b/infra/nats/README.ko.md
@@ -13,7 +13,7 @@
 ## 특징
 
 - **Kotlin 확장 함수** — NATS Java 클라이언트를 코틀린 스타일로 사용
-- **코루틴 지원** — `suspend` 함수로 비동기 처리 (`requestSuspending`, `publishSuspending`, `drainSuspending`)
+- **코루틴 지원** — `suspend` 함수와 cold `Flow<Message>` 소비자 (`requestSuspending`, `publishSuspending`, `drainSuspending`)
 - **JetStream 지원** — 스트림 생성, 메시지 발행/구독, 소비자 관리
 - **NATS Service** — DSL 기반 마이크로서비스 엔드포인트 구축
 - **DSL 빌더** — Stream, Consumer, Key-Value, Object Store 설정을 위한 유창한 DSL
@@ -248,7 +248,93 @@ val consumerCtx2 = consumerContextOf(connection, "my-stream", consumerConfigurat
 })
 ```
 
-### 11. StreamInfoOptions
+### 11. Cold JetStream Consumer Flow
+
+`ConsumerContext.consumeAsFlow`는 pull consumer를 사용하고,
+`JetStream.consumeAsFlow`는 수집마다 동기식 push subscription을 생성합니다.
+두 Flow 모두 cold이므로 수집할 때마다 subscription과 정리 lifecycle이
+독립적으로 시작됩니다. adapter는 유한한 NATS 옵션과 `capacity + 1`개의
+message 보유 한계를 사용하며, NATS pending queue drop을
+`NatsConsumerFlowException`으로 보고합니다.
+
+```kotlin
+import io.bluetape4k.nats.client.*
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlin.time.Duration.Companion.seconds
+
+val capacity = 32                   // 1..1024, adapter 보유 상한은 capacity + 1
+
+// Pull consumer: 수집이 취소되면 IterableConsumer를 닫습니다.
+consumerCtx.consumeAsFlow(capacity = capacity, receiveTimeout = 1.seconds)
+    .take(100)
+    .collect { message ->
+        process(message)
+        message.ack()                // 업무 처리가 성공한 뒤 수동 승인
+    }
+
+// Push subscription: drop 검출을 위해 유한한 client pending limit을 사용합니다.
+val pushOptions = pushSubscriptionOptions {
+    stream("my-stream")
+    pendingMessageLimit(1_024)
+    pendingByteLimit(16L * 1024 * 1024)
+}
+jetStream.consumeAsFlow(
+    subject = "events.>",
+    options = pushOptions,
+    capacity = capacity,
+    receiveTimeout = 1.seconds,
+).collect { message ->
+    process(message)
+    message.ack()
+}
+```
+
+adapter는 수동 ack만 지원하며 수집자를 대신해 `ack`, `nak`, `term`을 호출하지
+않습니다. 재시도 가능한 실패에는 `nak()`, poison message에는 `term()`을
+호출하도록 caller가 선택합니다. 승인하지 않은 message는 server consumer의 `ackWait`/`maxDeliver`
+정책에 따라 redelivery될 수 있으며, `maxAckPending`은 consumer에 별도로
+설정해야 합니다. `capacity`는 Flow 측 상한이며 NATS pending limit을 바꾸지
+않습니다. pending queue가 drop되면 조용히 계속하지 않고
+`NatsConsumerFlowException.droppedMessages`로 확인합니다. 같은 Flow 인스턴스를
+동시에 collect하면 거부되므로 필요한 경우 새 Flow 인스턴스를 만드십시오.
+
+adapter는 `capacity`를 `1..1024`, `receiveTimeout`을 유한한
+`100.milliseconds` 이상으로 검증합니다. Push options의
+`pendingMessageLimit`은 `1..65_536`, `pendingByteLimit`은 `1..64 MiB` 범위여야
+하며 기본값은 1,024개 message와 16 MiB입니다. Pull의 `batchBytes > 0`은
+consumer를 만들기 전에 거부하고, message batch는
+`min(originalBatchSize, capacity + 1)`로 정규화합니다. Adapter가 생성한
+subscription 또는 iterable consumer만 닫으며 `Connection`, `JetStream`,
+consumer 설정의 소유권은 caller에게 있습니다.
+
+실패 우선순위는 취소, receive/collector 실패, drop 또는 pending 상태
+read-back 실패, 관찰 가능한 cleanup 실패 순서입니다. 앞선 실패가 있으면
+cleanup 실패는 suppressed로 보존합니다. 순수 drop의 exception `cause`는
+`null`이고 pending 상태 read-back 실패는 원래 원인을
+`NatsConsumerFlowException`에 보존합니다.
+
+Push 측 message 총량 상한은 `pendingMessageLimit + capacity + 1`입니다. 즉,
+NATS pending queue, Flow buffer, receiver가 보유 중인 한 개 message를 합친
+값이며, `pendingByteLimit`은 NATS queue에 독립적으로 적용됩니다. Pull은
+`min(originalBatchSize, capacity + 1)` batch와 receiver가 보유하는 한 개
+message만 요청하므로 무제한 batch를 만들지 않습니다.
+
+Drop 또는 pending 상태 read-back 실패는 명시적으로 처리하십시오.
+
+```kotlin
+try {
+    jetStream.consumeAsFlow("events.>", pushOptions).collect { message ->
+        process(message)
+        message.ack()
+    }
+} catch (failure: NatsConsumerFlowException) {
+    log.error("NATS consumer Flow가 ${failure.droppedMessages}개 drop 후 종료되었습니다.", failure)
+    throw failure
+}
+```
+
+### 12. StreamInfoOptions
 
 ```kotlin
 import io.bluetape4k.nats.client.api.*

--- a/infra/nats/README.md
+++ b/infra/nats/README.md
@@ -13,7 +13,7 @@ This module provides Kotlin-idiomatic extension functions and DSLs for the NATS 
 ## Features
 
 - **Kotlin extension functions** — NATS Java client in idiomatic Kotlin style
-- **Coroutines support** — `suspend` functions for async operations (`requestSuspending`, `publishSuspending`, `drainSuspending`)
+- **Coroutines support** — `suspend` functions and cold `Flow<Message>` consumers for async operations (`requestSuspending`, `publishSuspending`, `drainSuspending`)
 - **JetStream support** — stream creation, publish/subscribe, consumer management
 - **NATS Service** — build microservice endpoints with DSL
 - **DSL builders** — fluent configuration for Streams, Consumers, Key-Value stores, and Object Stores
@@ -248,7 +248,92 @@ val consumerCtx2 = consumerContextOf(connection, "my-stream", consumerConfigurat
 })
 ```
 
-### 11. StreamInfoOptions
+### 11. Cold JetStream Consumer Flow
+
+`ConsumerContext.consumeAsFlow` uses a pull consumer, while
+`JetStream.consumeAsFlow` creates a synchronous push subscription for each
+collector. Both flows are cold: subscription and cleanup happen per collection.
+The adapter accepts finite NATS options, limits the Flow channel to
+`capacity + 1` held messages, and fails with `NatsConsumerFlowException` if the
+NATS pending queue reports a drop.
+
+```kotlin
+import io.bluetape4k.nats.client.*
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlin.time.Duration.Companion.seconds
+
+val capacity = 32                   // 1..1024; adapter holds at most capacity + 1
+
+// Pull consumer: IterableConsumer is closed when collection is cancelled.
+consumerCtx.consumeAsFlow(capacity = capacity, receiveTimeout = 1.seconds)
+    .take(100)
+    .collect { message ->
+        process(message)
+        message.ack()                // manual ack after business success
+    }
+
+// Push subscription: finite client pending limits are required for drop detection.
+val pushOptions = pushSubscriptionOptions {
+    stream("my-stream")
+    pendingMessageLimit(1_024)
+    pendingByteLimit(16L * 1024 * 1024)
+}
+jetStream.consumeAsFlow(
+    subject = "events.>",
+    options = pushOptions,
+    capacity = capacity,
+    receiveTimeout = 1.seconds,
+).collect { message ->
+    process(message)
+    message.ack()
+}
+```
+
+The adapter is manual-ack only: it never calls `ack`, `nak`, or `term` for the
+collector. Call `nak()` for retryable failures and `term()` for poison messages.
+An unacknowledged message can be redelivered according to the server consumer's
+`ackWait`/`maxDeliver`; configure `maxAckPending` separately on the consumer.
+`capacity` bounds the Flow side and does not change NATS pending limits. If the
+pending queue drops messages, inspect `NatsConsumerFlowException.droppedMessages`
+instead of continuing with silent loss. A second concurrent collection of the
+same Flow instance is rejected; create a new Flow instance when needed.
+
+The adapter validates `capacity` in `1..1024` and a finite `receiveTimeout` of at
+least `100.milliseconds`. Push options must keep `pendingMessageLimit` in
+`1..65_536` and `pendingByteLimit` in `1..64 MiB`; the default is 1,024 messages
+and 16 MiB. Pull `batchBytes > 0` is rejected before the consumer is created, and
+the effective message batch is normalized to `min(originalBatchSize, capacity + 1)`.
+The adapter only closes the subscription or iterable consumer it created; the
+caller still owns `Connection`, `JetStream`, and consumer configuration.
+
+Failure precedence is cancellation, receive/collector failure, drop or pending
+state read-back failure, then observable cleanup failure. Cleanup failures are
+suppressed behind an earlier failure. A pure drop has a null exception cause;
+pending-state read-back failures retain their original cause in
+`NatsConsumerFlowException`.
+
+The push-side message bound is `pendingMessageLimit + capacity + 1`: the NATS
+pending queue, Flow buffer, and one message held by the receiver. The pending
+byte limit applies to the NATS queue independently; Flow capacity is a message
+count. Pull uses `min(originalBatchSize, capacity + 1)` and one receiver-held
+message, so the adapter never requests an unbounded batch.
+
+Handle an observable drop or pending-state read-back failure explicitly:
+
+```kotlin
+try {
+    jetStream.consumeAsFlow("events.>", pushOptions).collect { message ->
+        process(message)
+        message.ack()
+    }
+} catch (failure: NatsConsumerFlowException) {
+    log.error("NATS consumer Flow stopped after ${failure.droppedMessages} dropped messages", failure)
+    throw failure
+}
+```
+
+### 12. StreamInfoOptions
 
 ```kotlin
 import io.bluetape4k.nats.client.api.*

--- a/infra/nats/build.gradle.kts
+++ b/infra/nats/build.gradle.kts
@@ -15,8 +15,9 @@ dependencies {
     // nats_spring_cloud_stream_binder: 사용하지 않으므로 제외
 
     // Coroutines
-    compileOnly(project(":bluetape4k-coroutines"))
-    compileOnly(libs.kotlinx.coroutines.core)
+    api(project(":bluetape4k-coroutines"))
+    // Public consumeAsFlow API exposes Flow and coroutine cancellation semantics.
+    api(libs.kotlinx.coroutines.core)
     compileOnly(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 

--- a/infra/nats/src/main/kotlin/io/bluetape4k/nats/client/NatsConsumerFlow.kt
+++ b/infra/nats/src/main/kotlin/io/bluetape4k/nats/client/NatsConsumerFlow.kt
@@ -1,0 +1,362 @@
+package io.bluetape4k.nats.client
+
+import io.bluetape4k.support.requireNotBlank
+import io.nats.client.ConsumerContext
+import io.nats.client.ConsumeOptions
+import io.nats.client.IterableConsumer
+import io.nats.client.JetStream
+import io.nats.client.JetStreamSubscription
+import io.nats.client.Message
+import io.nats.client.PushSubscribeOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.min
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+/**
+ * NATS client pending queue의 기본 상한을 Flow adapter에 맞게 제한합니다.
+ */
+val defaultNatsFlowPushOptions: PushSubscribeOptions = PushSubscribeOptions.builder()
+    .pendingMessageLimit(1_024)
+    .pendingByteLimit(16L * 1024 * 1024)
+    .build()
+
+/**
+ * Push adapter의 pending queue drop 또는 read-back 실패를 나타냅니다.
+ *
+ * [droppedMessages]가 양수이면 subscription pending queue에서 관찰된 증가량이고,
+ * 0이면 drop count read-back 같은 관찰 실패를 뜻하며 원인은 [cause]에 보존됩니다.
+ */
+class NatsConsumerFlowException(
+    val droppedMessages: Long,
+    cause: Throwable? = null,
+) : RuntimeException(
+    if (cause == null) {
+        "NATS consumer Flow dropped $droppedMessages message(s)"
+    } else {
+        "NATS consumer Flow state could not be verified"
+    },
+    cause,
+) {
+    init {
+        require(droppedMessages >= 0) {
+            "droppedMessages must be zero or positive: $droppedMessages"
+        }
+    }
+}
+
+/**
+ * JetStream push subscription을 수집마다 만드는 cold [Flow]입니다.
+ *
+ * Flow는 message를 자동 승인하지 않습니다. business 처리 성공 뒤 수집자가
+ * `ack()`을 호출하고, 재시도 가능한 실패에는 `nak()`, 재전달하지 않을 실패에는
+ * `term()`을 선택해야 합니다. [capacity]는 adapter channel의 유한 용량이며
+ * NATS pending limit 및 server `maxAckPending`과 별개의 상한입니다.
+ *
+ * 같은 Flow 인스턴스를 동시에 수집하면 subscription 생성 전에 실패합니다.
+ * 수집이 취소되면 blocking receive를 interrupt하고 adapter가 만든 subscription만
+ * `unsubscribe()`합니다. pending queue drop은 조용히 무시하지 않고
+ * [NatsConsumerFlowException]으로 전달합니다.
+ */
+@Suppress("TooGenericExceptionCaught")
+fun JetStream.consumeAsFlow(
+    subject: String,
+    options: PushSubscribeOptions = defaultNatsFlowPushOptions,
+    capacity: Int = DEFAULT_NATS_FLOW_CAPACITY,
+    receiveTimeout: Duration = 1.seconds,
+): Flow<Message> {
+    subject.requireNotBlank("subject")
+    validateFlowArguments(capacity, receiveTimeout)
+    validatePushOptions(options)
+
+    val collecting = AtomicBoolean(false)
+    return channelFlow {
+        check(collecting.compareAndSet(false, true)) {
+            "같은 NATS Flow 인스턴스는 동시에 collect할 수 없습니다."
+        }
+
+        var subscription: JetStreamSubscription? = null
+        var primaryFailure: Throwable? = null
+        var observedDropped = 0L
+
+        try {
+            subscription = runInterruptible(Dispatchers.IO) {
+                subscribe(subject, options)
+            }
+            verifyPendingLimits(subscription, options)
+            observedDropped = readDroppedCount(subscription)
+
+            while (currentCoroutineContext().isActive) {
+                val beforeReceive = readDroppedCount(subscription)
+                val message = runInterruptible(Dispatchers.IO) {
+                    subscription.nextMessage(receiveTimeout.toJavaDuration())
+                }
+                observedDropped = observeDropped(
+                    subscription = subscription,
+                    previous = maxOf(observedDropped, beforeReceive),
+                )
+
+                if (message == null && !subscription.isActive) {
+                    break
+                }
+                if (message != null) {
+                    send(message)
+                }
+            }
+        } catch (throwable: Throwable) {
+            primaryFailure = throwable
+            throw throwable
+        } finally {
+            val cleanupFailure = cleanupPushSubscription(subscription)
+            val dropFailure = subscription?.let { activeSubscription ->
+                try {
+                    val current = readDroppedCount(activeSubscription)
+                    val delta = current - observedDropped
+                    delta.takeIf { it > 0 }?.let(::NatsConsumerFlowException)
+                } catch (cancellation: CancellationException) {
+                    cancellation
+                } catch (error: Error) {
+                    error
+                } catch (exception: Exception) {
+                    exception
+                }
+            }
+            try {
+                finishFailure(primaryFailure, dropFailure, cleanupFailure)
+            } finally {
+                collecting.set(false)
+            }
+        }
+    }.buffer(capacity)
+}
+
+/**
+ * Pull [ConsumerContext]를 수집마다 만드는 cold [Flow]입니다.
+ *
+ * [options]의 batch는 [capacity]와 receiver가 보유할 수 있는 한계를 넘지 않도록
+ * 유한하게 정규화합니다. byte-only batch는 message count 상한과 동시에 보장할 수
+ * 없으므로 거부합니다. Flow는 `ack`/`nak`/`term`을 호출하지 않으며, 취소 시
+ * adapter가 만든 [IterableConsumer]만 닫습니다.
+ */
+@Suppress("TooGenericExceptionCaught")
+fun ConsumerContext.consumeAsFlow(
+    options: ConsumeOptions = ConsumeOptions.DEFAULT_CONSUME_OPTIONS,
+    capacity: Int = DEFAULT_NATS_FLOW_CAPACITY,
+    receiveTimeout: Duration = 1.seconds,
+): Flow<Message> {
+    validateFlowArguments(capacity, receiveTimeout)
+    require(options.batchBytes == 0L) {
+        "pull batchBytes는 bounded Flow에서 지원하지 않습니다."
+    }
+    val effectiveOptions = boundedConsumeOptions(options, capacity)
+    val collecting = AtomicBoolean(false)
+
+    return channelFlow {
+        check(collecting.compareAndSet(false, true)) {
+            "같은 NATS Flow 인스턴스는 동시에 collect할 수 없습니다."
+        }
+
+        var consumer: IterableConsumer? = null
+        var primaryFailure: Throwable? = null
+
+        try {
+            consumer = runInterruptible(Dispatchers.IO) {
+                iterate(effectiveOptions)
+            }
+
+            while (currentCoroutineContext().isActive) {
+                val message = runInterruptible(Dispatchers.IO) {
+                    consumer.nextMessage(receiveTimeout.toJavaDuration())
+                }
+
+                if (message == null && (consumer.isStopped || consumer.isFinished)) {
+                    break
+                }
+                if (message != null) {
+                    send(message)
+                }
+            }
+        } catch (throwable: Throwable) {
+            primaryFailure = throwable
+            throw throwable
+        } finally {
+            val cleanupFailure = cleanupIterableConsumer(consumer)
+            try {
+                finishFailure(primaryFailure, null, cleanupFailure)
+            } finally {
+                collecting.set(false)
+            }
+        }
+    }.buffer(capacity)
+}
+
+private const val DEFAULT_NATS_FLOW_CAPACITY = 64
+private const val MIN_NATS_FLOW_CAPACITY = 1
+private const val MAX_NATS_FLOW_CAPACITY = 1_024
+private val MIN_NATS_FLOW_RECEIVE_TIMEOUT = 100.milliseconds
+private const val MAX_PENDING_MESSAGES = 65_536L
+private const val MAX_PENDING_BYTES = 64L * 1024 * 1024
+
+private fun validateFlowArguments(capacity: Int, receiveTimeout: Duration) {
+    require(capacity in MIN_NATS_FLOW_CAPACITY..MAX_NATS_FLOW_CAPACITY) {
+        "capacity must be between $MIN_NATS_FLOW_CAPACITY and $MAX_NATS_FLOW_CAPACITY: $capacity"
+    }
+    require(receiveTimeout.isFinite() && receiveTimeout >= MIN_NATS_FLOW_RECEIVE_TIMEOUT) {
+        "receiveTimeout must be finite and at least $MIN_NATS_FLOW_RECEIVE_TIMEOUT: $receiveTimeout"
+    }
+}
+
+private fun validatePushOptions(options: PushSubscribeOptions) {
+    require(options.pendingMessageLimit in 1..MAX_PENDING_MESSAGES) {
+        "pending message limit must be between 1 and $MAX_PENDING_MESSAGES: ${options.pendingMessageLimit}"
+    }
+    require(options.pendingByteLimit in 1..MAX_PENDING_BYTES) {
+        "pending byte limit must be between 1 and $MAX_PENDING_BYTES: ${options.pendingByteLimit}"
+    }
+}
+
+private fun boundedConsumeOptions(
+    options: ConsumeOptions,
+    capacity: Int,
+): ConsumeOptions {
+    val effectiveBatchSize = min(options.batchSize, capacity + 1)
+    return ConsumeOptions.builder()
+        .json(options.toJson())
+        .batchSize(effectiveBatchSize)
+        .build()
+}
+
+@Suppress("ThrowsCount", "TooGenericExceptionCaught")
+private fun verifyPendingLimits(
+    subscription: JetStreamSubscription,
+    options: PushSubscribeOptions,
+) {
+    val (actualMessages, actualBytes) = try {
+        subscription.pendingMessageLimit to subscription.pendingByteLimit
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (error: Error) {
+        throw error
+    } catch (exception: Exception) {
+        throw NatsConsumerFlowException(0, exception)
+    }
+    if (actualMessages != options.pendingMessageLimit || actualBytes != options.pendingByteLimit) {
+        throw NatsConsumerFlowException(
+            0,
+            IllegalStateException(
+                "NATS pending limit read-back mismatch: " +
+                    "messages=$actualMessages/${options.pendingMessageLimit}, " +
+                    "bytes=$actualBytes/${options.pendingByteLimit}",
+            ),
+        )
+    }
+}
+
+@Suppress("TooGenericExceptionCaught")
+private fun readDroppedCount(subscription: JetStreamSubscription): Long = try {
+    subscription.droppedCount
+} catch (cancellation: CancellationException) {
+    throw cancellation
+} catch (error: Error) {
+    throw error
+} catch (exception: Exception) {
+    throw NatsConsumerFlowException(0, exception)
+}
+
+private fun observeDropped(
+    subscription: JetStreamSubscription,
+    previous: Long,
+): Long {
+    val current = readDroppedCount(subscription)
+    val delta = current - previous
+    if (delta > 0) {
+        throw NatsConsumerFlowException(delta)
+    }
+    return maxOf(previous, current)
+}
+
+@Suppress("TooGenericExceptionCaught")
+private suspend fun cleanupPushSubscription(subscription: JetStreamSubscription?): Throwable? {
+    if (subscription == null) {
+        return null
+    }
+    return try {
+        withContext(NonCancellable + Dispatchers.IO) {
+            subscription.unsubscribe()
+        }
+        null
+    } catch (cancellation: CancellationException) {
+        cancellation
+    } catch (error: Error) {
+        error
+    } catch (exception: Exception) {
+        exception
+    }
+}
+
+@Suppress("TooGenericExceptionCaught")
+private suspend fun cleanupIterableConsumer(consumer: IterableConsumer?): Throwable? {
+    if (consumer == null) {
+        return null
+    }
+    return try {
+        withContext(NonCancellable + Dispatchers.IO) {
+            consumer.close()
+        }
+        null
+    } catch (cancellation: CancellationException) {
+        cancellation
+    } catch (error: Error) {
+        error
+    } catch (exception: Exception) {
+        exception
+    }
+}
+
+private fun finishFailure(
+    primary: Throwable?,
+    dropFailure: Throwable?,
+    cleanupFailure: Throwable?,
+) {
+    val addSuppressedToChain: (Throwable, Throwable) -> Unit = { root, suppressed ->
+        if (root !== suppressed) {
+            root.addSuppressed(suppressed)
+            var cause = root.cause
+            while (cause != null && cause !== root) {
+                if (cause !== suppressed) {
+                    cause.addSuppressed(suppressed)
+                }
+                cause = cause.cause
+            }
+        }
+    }
+    val terminalFailure = when {
+        primary != null -> {
+            dropFailure?.let { addSuppressedToChain(primary, it) }
+            cleanupFailure?.let { addSuppressedToChain(primary, it) }
+            primary
+        }
+
+        dropFailure != null -> {
+            cleanupFailure?.let { addSuppressedToChain(dropFailure, it) }
+            dropFailure
+        }
+
+        else -> cleanupFailure
+    }
+    if (terminalFailure != null) {
+        throw terminalFailure
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowIntegrationTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowIntegrationTest.kt
@@ -1,0 +1,248 @@
+package io.bluetape4k.nats.client
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.nats.AbstractNatsTest
+import io.bluetape4k.nats.client.api.consumerConfiguration
+import io.bluetape4k.support.toUtf8String
+import io.nats.client.api.AckPolicy
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class NatsConsumerFlowIntegrationTest : AbstractNatsTest() {
+
+    @Test
+    fun `pull flow preserves order and caller acknowledges messages`() = runTest(timeout = 30.seconds) {
+        val stream = "consumer-flow-pull"
+        val subject = "consumer-flow.pull"
+        val received = mutableListOf<String>()
+
+        getConnection().use { connection ->
+            connection.createOrReplaceStream(stream, subject)
+            val jetStream = connection.jetStream()
+            repeat(3) { index ->
+                jetStream.publish(subject, "pull-$index")
+            }
+
+            val consumer = consumerContextOf(
+                connection,
+                stream,
+                consumerConfiguration {
+                    durable("consumer-flow-pull-durable")
+                    ackPolicy(AckPolicy.Explicit)
+                },
+            )
+
+            consumer
+                .consumeAsFlow(capacity = 2)
+                .take(3)
+                .collect { message ->
+                    received += message.data.toUtf8String()
+                    message.ack()
+                }
+        }
+
+        received shouldBeEqualTo listOf("pull-0", "pull-1", "pull-2")
+    }
+
+    @Test
+    fun `push flow preserves order and caller acknowledges messages`() = runTest(timeout = 30.seconds) {
+        val stream = "consumer-flow-push"
+        val subject = "consumer-flow.push"
+        val received = mutableListOf<String>()
+
+        getConnection().use { connection ->
+            connection.createOrReplaceStream(stream, subject)
+            val jetStream = connection.jetStream()
+            repeat(3) { index ->
+                jetStream.publish(subject, "push-$index")
+            }
+
+            val pushOptions = pushSubscriptionOptions {
+                stream(stream)
+                pendingMessageLimit(1_024)
+                pendingByteLimit(16L * 1024 * 1024)
+            }
+            jetStream
+                .consumeAsFlow(subject, pushOptions, capacity = 2)
+                .take(3)
+                .collect { message ->
+                    received += message.data.toUtf8String()
+                    message.ack()
+                }
+        }
+
+        received shouldBeEqualTo listOf("push-0", "push-1", "push-2")
+    }
+
+    @Test
+    fun `push flow reports actual pending queue drops`() = runBlocking {
+        val stream = "consumer-flow-push-drop"
+        val subject = "consumer-flow.push-drop"
+
+        getConnection().use { connection ->
+            connection.createOrReplaceStream(stream, subject)
+            val jetStream = connection.jetStream()
+            val pushOptions = pushSubscriptionOptions {
+                stream(stream)
+                pendingMessageLimit(1)
+                pendingByteLimit(64L * 1024)
+            }
+            supervisorScope {
+                val firstDelivered = CompletableDeferred<Unit>()
+                val flow = jetStream.consumeAsFlow(
+                    subject,
+                    pushOptions,
+                    capacity = 1,
+                    receiveTimeout = 500.milliseconds,
+                )
+                val collector = async(Dispatchers.Default) {
+                    flow.collect {
+                        if (firstDelivered.complete(Unit)) {
+                            delay(1.seconds)
+                        }
+                    }
+                }
+
+                jetStream.publish(subject, "seed")
+                withTimeout(5.seconds) {
+                    firstDelivered.await()
+                }
+                repeat(500) { index ->
+                    jetStream.publish(subject, "drop-$index")
+                }
+
+                val failure = try {
+                    collector.await()
+                    null
+                } catch (exception: NatsConsumerFlowException) {
+                    exception
+                }
+
+                check(failure != null) { "실제 pending queue drop이 Flow 예외로 보고되지 않았습니다." }
+                check(failure.droppedMessages > 0) {
+                    "실제 pending queue drop 수가 양수가 아닙니다: ${failure.droppedMessages}"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `unacknowledged pull message is redelivered and sequential collection reuses the flow`() =
+        runBlocking {
+            val stream = "consumer-flow-redelivery"
+            val subject = "consumer-flow.redelivery"
+            val deliveries = mutableListOf<String>()
+
+            getConnection().use { connection ->
+                connection.createOrReplaceStream(stream, subject)
+                val jetStream = connection.jetStream()
+                jetStream.publish(subject, "redeliver-me")
+
+                val consumer = consumerContextOf(
+                    connection,
+                    stream,
+                    consumerConfiguration {
+                        durable("consumer-flow-redelivery-durable")
+                        ackPolicy(AckPolicy.Explicit)
+                        ackWait(Duration.ofMillis(250))
+                        maxDeliver(2)
+                        maxAckPending(1)
+                    },
+                )
+                val flow = consumer.consumeAsFlow(capacity = 1, receiveTimeout = 500.milliseconds)
+
+                flow.take(1).collect { message ->
+                    deliveries += message.data.toUtf8String()
+                    // Deliberately leave the first delivery unacknowledged.
+                }
+
+                withTimeout(5.seconds) {
+                    flow.take(1).collect { message ->
+                        deliveries += message.data.toUtf8String()
+                        message.ack()
+                    }
+                }
+            }
+
+            deliveries shouldBeEqualTo listOf("redeliver-me", "redeliver-me")
+            Unit
+        }
+
+    @Test
+    fun `caller controls nak redelivery and term finalization`() = runBlocking {
+        getConnection().use { connection ->
+            val nakStream = "consumer-flow-manual-nak"
+            val nakSubject = "consumer-flow.manual-nak"
+            connection.createOrReplaceStream(nakStream, nakSubject)
+            val jetStream = connection.jetStream()
+            jetStream.publish(nakSubject, "nak-me")
+
+            val nakConsumer = consumerContextOf(
+                connection,
+                nakStream,
+                consumerConfiguration {
+                    durable("consumer-flow-manual-nak-durable")
+                    ackPolicy(AckPolicy.Explicit)
+                    ackWait(Duration.ofMillis(500))
+                    maxDeliver(2)
+                    maxAckPending(1)
+                },
+            )
+            val nakDeliveries = mutableListOf<String>()
+            withTimeout(5.seconds) {
+                nakConsumer.consumeAsFlow(capacity = 1, receiveTimeout = 500.milliseconds)
+                    .take(2)
+                    .collect { message ->
+                        nakDeliveries += message.data.toUtf8String()
+                        if (nakDeliveries.size == 1) {
+                            message.nak()
+                        } else {
+                            message.ack()
+                        }
+                    }
+            }
+            nakDeliveries shouldBeEqualTo listOf("nak-me", "nak-me")
+
+            val termStream = "consumer-flow-manual-term"
+            val termSubject = "consumer-flow.manual-term"
+            connection.createOrReplaceStream(termStream, termSubject)
+            jetStream.publish(termSubject, "term-me")
+            val termConsumer = consumerContextOf(
+                connection,
+                termStream,
+                consumerConfiguration {
+                    durable("consumer-flow-manual-term-durable")
+                    ackPolicy(AckPolicy.Explicit)
+                    ackWait(Duration.ofMillis(500))
+                    maxDeliver(2)
+                    maxAckPending(1)
+                },
+            )
+            val termFlow = termConsumer.consumeAsFlow(capacity = 1, receiveTimeout = 500.milliseconds)
+            termFlow.take(1).collect { message ->
+                message.term()
+            }
+
+            val redelivered = withTimeoutOrNull(2.seconds) {
+                termFlow.take(1).collect { message ->
+                    message.ack()
+                }
+                true
+            } ?: false
+            check(!redelivered) { "term() 처리 후 message가 재전달되었습니다." }
+        }
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
@@ -283,5 +284,96 @@ class NatsConsumerFlowTest {
     fun `default push limits are finite and bounded`() {
         (defaultNatsFlowPushOptions.pendingMessageLimit <= 1_024L).shouldBeTrue()
         (defaultNatsFlowPushOptions.pendingByteLimit <= 16L * 1024 * 1024).shouldBeTrue()
+    }
+
+    @Test
+    fun `consumer flow exception rejects negative dropped count`() {
+        assertFailsWith<IllegalArgumentException> {
+            NatsConsumerFlowException(-1)
+        }
+    }
+
+    @Test
+    fun `pending limit mismatch preserves a diagnostic cause`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 4
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returns 0
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<NatsConsumerFlowException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.droppedMessages shouldBeEqualTo 0L
+        check(failure.cause?.message?.contains("read-back mismatch") == true)
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `push subscribe failure does not attempt cleanup`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val subscribeFailure = IllegalStateException("subscribe failed")
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } throws subscribeFailure
+
+        val failure = assertFailsWith<IllegalStateException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        verify(exactly = 0) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `pull iterate failure does not attempt cleanup`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val iterateFailure = IllegalStateException("iterate failed")
+        every { context.iterate(any<ConsumeOptions>()) } throws iterateFailure
+
+        val failure = assertFailsWith<IllegalStateException> {
+            context.consumeAsFlow().toList()
+        }
+
+        verify(exactly = 0) { consumer.close() }
+    }
+
+    @Test
+    fun `final pending readback cancellation is not wrapped`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val cancellation = CancellationException("readback cancelled")
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        var droppedReads = 0
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } answers {
+            droppedReads += 1
+            if (droppedReads <= 3) 0 else throw cancellation
+        }
+        every { subscription.nextMessage(any<Duration>()) } returns null
+        every { subscription.isActive } returns false
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<CancellationException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        check(failure.cause == null || failure.cause === cancellation)
+        verify(exactly = 1) { subscription.unsubscribe() }
     }
 }

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
@@ -1,0 +1,287 @@
+package io.bluetape4k.nats.client
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import io.nats.client.ConsumeOptions
+import io.nats.client.ConsumerContext
+import io.nats.client.IterableConsumer
+import io.nats.client.JetStream
+import io.nats.client.JetStreamSubscription
+import io.nats.client.Message
+import io.nats.client.PushSubscribeOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class NatsConsumerFlowTest {
+
+    @Test
+    fun `pull flow is cold preserves order closes consumer and does not ack`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val first = mockk<Message>()
+        val second = mockk<Message>()
+        every { context.iterate(any<ConsumeOptions>()) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } returnsMany listOf(first, second)
+        every { consumer.close() } just runs
+
+        val received = context
+            .consumeAsFlow(capacity = 2)
+            .take(2)
+            .toList()
+
+        received shouldBeEqualTo listOf(first, second)
+        verify(exactly = 1) { context.iterate(any<ConsumeOptions>()) }
+        verify(exactly = 1) { consumer.close() }
+        verify(exactly = 0) { first.ack() }
+        verify(exactly = 0) { second.ack() }
+    }
+
+    @Test
+    fun `pull flow normalizes batch size to capacity plus receiver`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val options = ConsumeOptions.builder().batchSize(500).build()
+        val capturedOptions = slot<ConsumeOptions>()
+        every { context.iterate(capture(capturedOptions)) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } returns null
+        every { consumer.isStopped } returns true
+        every { consumer.isFinished } returns false
+        every { consumer.close() } just runs
+
+        context.consumeAsFlow(options, capacity = 2).toList()
+
+        capturedOptions.captured.batchSize shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `push flow is cold preserves order unsubscribes and does not ack`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val first = mockk<Message>()
+        val second = mockk<Message>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returns 0
+        every { subscription.nextMessage(any<Duration>()) } returnsMany listOf(first, second)
+        every { subscription.unsubscribe() } just runs
+
+        val received = jetStream
+            .consumeAsFlow("events", options, capacity = 2)
+            .take(2)
+            .toList()
+
+        received shouldBeEqualTo listOf(first, second)
+        verify(exactly = 1) { jetStream.subscribe("events", options) }
+        verify(exactly = 1) { subscription.unsubscribe() }
+        verify(exactly = 0) { first.ack() }
+        verify(exactly = 0) { second.ack() }
+    }
+
+    @Test
+    fun `same flow instance rejects concurrent collectors before creating a handle`() = runBlocking {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val receiveStarted = CountDownLatch(1)
+        val receiveBarrier = CountDownLatch(1)
+        val receiveInterrupted = CountDownLatch(1)
+        every { context.iterate(any<ConsumeOptions>()) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } answers {
+            receiveStarted.countDown()
+            try {
+                check(receiveBarrier.await(5, TimeUnit.SECONDS)) {
+                    "receive was not interrupted before the bounded barrier expired"
+                }
+            } catch (_: InterruptedException) {
+                receiveInterrupted.countDown()
+                Thread.currentThread().interrupt()
+            }
+            null
+        }
+        every { consumer.close() } just runs
+
+        val flow = context.consumeAsFlow(capacity = 1)
+        val first = async(Dispatchers.Default) { flow.collect() }
+        check(receiveStarted.await(5, TimeUnit.SECONDS))
+
+        assertFailsWith<IllegalStateException> {
+            flow.take(1).toList()
+        }
+
+        first.cancel()
+        withTimeout(5.seconds) {
+            first.join()
+        }
+        check(receiveInterrupted.await(1, TimeUnit.SECONDS))
+        verify(exactly = 1) { context.iterate(any<ConsumeOptions>()) }
+        verify(exactly = 1) { consumer.close() }
+    }
+
+    @Test
+    fun `push drop delta fails flow and reports dropped count`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returnsMany listOf(0, 0, 2, 2)
+        every { subscription.nextMessage(any<Duration>()) } returns null
+        every { subscription.isActive } returns true
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<NatsConsumerFlowException> {
+            jetStream.consumeAsFlow("events", options, capacity = 1).toList()
+        }
+
+        failure.droppedMessages shouldBeEqualTo 2L
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `invalid flow and push limits fail before handle creation`() {
+        val jetStream = mockk<JetStream>(relaxed = true)
+        val context = mockk<ConsumerContext>(relaxed = true)
+        val oversizedPush = pushSubscriptionOptions {
+            pendingMessageLimit(65_537)
+            pendingByteLimit(1024)
+        }
+        val oversizedBytesPush = pushSubscriptionOptions {
+            pendingMessageLimit(1)
+            pendingByteLimit(64L * 1024 * 1024 + 1)
+        }
+        val invalidPull = ConsumeOptions.builder().batchBytes(1).build()
+
+        assertFailsWith<IllegalArgumentException> {
+            jetStream.consumeAsFlow("events", capacity = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            context.consumeAsFlow(capacity = 1_025)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            context.consumeAsFlow(capacity = 1, receiveTimeout = 99.milliseconds)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            jetStream.consumeAsFlow("events", oversizedPush)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            jetStream.consumeAsFlow("events", oversizedBytesPush)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            context.consumeAsFlow(invalidPull)
+        }
+
+        jetStream.consumeAsFlow(
+            "events",
+            pushSubscriptionOptions {
+                pendingMessageLimit(65_536)
+                pendingByteLimit(64L * 1024 * 1024)
+            },
+            capacity = 1_024,
+            receiveTimeout = 100.milliseconds,
+        )
+        context.consumeAsFlow(capacity = 1_024, receiveTimeout = 100.milliseconds)
+
+        verify(exactly = 0) { jetStream.subscribe(any(), any<PushSubscribeOptions>()) }
+        verify(exactly = 0) { context.iterate(any<ConsumeOptions>()) }
+    }
+
+    @Test
+    fun `ordinary receive failure stays primary and cleanup failure is suppressed`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        val receiveFailure = IllegalStateException("receive failed")
+        val cleanupFailure = IllegalArgumentException("cleanup failed")
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returns 0
+        every { subscription.nextMessage(any<Duration>()) } throws receiveFailure
+        every { subscription.unsubscribe() } throws cleanupFailure
+
+        val failure = assertFailsWith<IllegalStateException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.message shouldBeEqualTo receiveFailure.message
+        verify(exactly = 1) { subscription.unsubscribe() }
+        receiveFailure.suppressed.map { it.message } shouldBeEqualTo listOf(cleanupFailure.message)
+        Unit
+    }
+
+    @Test
+    fun `pending limit readback failure preserves its cause`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        val readbackFailure = IllegalStateException("pending limit unavailable")
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } throws readbackFailure
+        every { subscription.droppedCount } returns 0
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<NatsConsumerFlowException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.droppedMessages shouldBeEqualTo 0L
+        (failure.cause === readbackFailure).shouldBeTrue()
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `null receives continue while active and stop when handle finishes`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val message = mockk<Message>()
+        every { context.iterate(any<ConsumeOptions>()) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } returnsMany listOf(null, message, null)
+        every { consumer.isStopped } returnsMany listOf(false, false, true)
+        every { consumer.isFinished } returns false
+        every { consumer.close() } just runs
+
+        val received = context.consumeAsFlow(capacity = 1).toList()
+
+        received shouldBeEqualTo listOf(message)
+        verify(exactly = 1) { consumer.close() }
+    }
+
+    @Test
+    fun `default push limits are finite and bounded`() {
+        (defaultNatsFlowPushOptions.pendingMessageLimit <= 1_024L).shouldBeTrue()
+        (defaultNatsFlowPushOptions.pendingByteLimit <= 16L * 1024 * 1024).shouldBeTrue()
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
@@ -376,4 +376,74 @@ class NatsConsumerFlowTest {
         check(failure.cause == null || failure.cause === cancellation)
         verify(exactly = 1) { subscription.unsubscribe() }
     }
+
+    @Test
+    fun `push cleanup error preserves Error`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returns 0
+        every { subscription.nextMessage(any<Duration>()) } returns null
+        every { subscription.isActive } returns false
+        every { subscription.unsubscribe() } throws AssertionError("unsubscribe failed")
+
+        val failure = assertFailsWith<AssertionError> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.message shouldBeEqualTo "unsubscribe failed"
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `pull cleanup error preserves Error`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        every { context.iterate(any<ConsumeOptions>()) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } returns null
+        every { consumer.isStopped } returns true
+        every { consumer.isFinished } returns false
+        every { consumer.close() } throws AssertionError("close failed")
+
+        val failure = assertFailsWith<AssertionError> {
+            context.consumeAsFlow().toList()
+        }
+
+        failure.message shouldBeEqualTo "close failed"
+        verify(exactly = 1) { consumer.close() }
+    }
+
+    @Test
+    fun `final pending readback Error is preserved`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        var droppedReads = 0
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } answers {
+            droppedReads += 1
+            if (droppedReads <= 3) 0 else throw AssertionError("drop readback failed")
+        }
+        every { subscription.nextMessage(any<Duration>()) } returns null
+        every { subscription.isActive } returns false
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<AssertionError> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.message shouldBeEqualTo "drop readback failed"
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
 }

--- a/infra/nats/src/test/resources/compat/issue-1350/build.gradle.kts
+++ b/infra/nats/src/test/resources/compat/issue-1350/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    kotlin("jvm") version "2.4.0"
+    application
+}
+
+group = "io.bluetape4k.compat"
+version = "1.0.0"
+
+kotlin {
+    jvmToolchain(25)
+}
+
+application {
+    mainClass.set("NatsFlowPublishedConsumerKt")
+}
+
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-nats:2.0.0")
+}

--- a/infra/nats/src/test/resources/compat/issue-1350/settings.gradle.kts
+++ b/infra/nats/src/test/resources/compat/issue-1350/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        val compatRepository = providers.gradleProperty("compatRepository")
+        if (compatRepository.isPresent) {
+            maven { url = uri(compatRepository.get()) }
+        }
+        mavenCentral()
+    }
+}
+
+rootProject.name = "issue-1350-published-consumer"

--- a/infra/nats/src/test/resources/compat/issue-1350/src/main/kotlin/NatsFlowPublishedConsumer.kt
+++ b/infra/nats/src/test/resources/compat/issue-1350/src/main/kotlin/NatsFlowPublishedConsumer.kt
@@ -1,0 +1,102 @@
+import io.bluetape4k.nats.client.consumeAsFlow
+import io.nats.client.ConsumerContext
+import io.nats.client.ConsumeOptions
+import io.nats.client.IterableConsumer
+import io.nats.client.JetStream
+import io.nats.client.JetStreamSubscription
+import io.nats.client.Message
+import io.nats.client.PushSubscribeOptions
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
+
+private class PublishedApiProbe {
+    val pushReceiveEntered = AtomicBoolean(false)
+    val pushClosed = AtomicBoolean(false)
+    val pullReceiveEntered = AtomicBoolean(false)
+    val pullClosed = AtomicBoolean(false)
+}
+
+fun main() = runBlocking {
+    val probe = PublishedApiProbe()
+    val pushSubscription = proxy<JetStreamSubscription> { method, _ ->
+        when (method.name) {
+            "getPendingMessageLimit" -> 1_024L
+            "getPendingByteLimit" -> 16L * 1024 * 1024
+            "getDroppedCount" -> 0L
+            "nextMessage" -> {
+                probe.pushReceiveEntered.set(true)
+                null
+            }
+            "isActive" -> true
+            "unsubscribe" -> {
+                probe.pushClosed.set(true)
+                Unit
+            }
+            else -> defaultValue(method.returnType)
+        }
+    }
+    val jetStream = proxy<JetStream> { method, _ ->
+        if (method.name == "subscribe") pushSubscription else defaultValue(method.returnType)
+    }
+
+    withTimeoutOrNull(2.seconds) {
+        jetStream.consumeAsFlow("events").take(1).collect { error("probe should not receive a message") }
+    }
+
+    val iterable = proxy<IterableConsumer> { method, _ ->
+        when (method.name) {
+            "nextMessage" -> {
+                probe.pullReceiveEntered.set(true)
+                null
+            }
+            "isStopped", "isFinished" -> false
+            "close" -> {
+                probe.pullClosed.set(true)
+                Unit
+            }
+            else -> defaultValue(method.returnType)
+        }
+    }
+    val consumerContext = proxy<ConsumerContext> { method, _ ->
+        if (method.name == "iterate") iterable else defaultValue(method.returnType)
+    }
+
+    withTimeoutOrNull(2.seconds) {
+        consumerContext.consumeAsFlow(ConsumeOptions.DEFAULT_CONSUME_OPTIONS).take(1)
+            .collect { error("probe should not receive a message") }
+    }
+
+    check(probe.pushReceiveEntered.get()) { "published push Flow did not enter receive" }
+    check(probe.pushClosed.get()) { "published push Flow did not clean up subscription" }
+    check(probe.pullReceiveEntered.get()) { "published pull Flow did not enter receive" }
+    check(probe.pullClosed.get()) { "published pull Flow did not clean up consumer" }
+}
+
+@Suppress("UNCHECKED_CAST")
+private inline fun <reified T> proxy(
+    crossinline handler: (Method, Array<out Any?>?) -> Any?,
+): T = Proxy.newProxyInstance(
+    T::class.java.classLoader,
+    arrayOf(T::class.java),
+    InvocationHandler { _, method, args -> handler(method, args) },
+) as T
+
+private fun defaultValue(type: Class<*>): Any? = when {
+    !type.isPrimitive -> null
+    type == Boolean::class.javaPrimitiveType -> false
+    type == Char::class.javaPrimitiveType -> '\u0000'
+    type == Byte::class.javaPrimitiveType -> 0.toByte()
+    type == Short::class.javaPrimitiveType -> 0.toShort()
+    type == Int::class.javaPrimitiveType -> 0
+    type == Long::class.javaPrimitiveType -> 0L
+    type == Float::class.javaPrimitiveType -> 0.0f
+    type == Double::class.javaPrimitiveType -> 0.0
+    else -> null
+}


### PR DESCRIPTION
## 개요

`BufferedResumableCollector`의 producer와 `complete`/`error`가 동시에 진행될 때 발생하던 교착, terminal cause 덮어쓰기, 수락된 값 유실 가능성을 제거합니다.

Closes #1349

## 변경 사항

- terminal 종류, cause, active admission, offer phase를 하나의 immutable atomic 상태로 조정합니다.
- offer를 `Idle -> Preparing -> Committed`로 선형화합니다.
  - `Preparing` 중 terminal이 먼저 반영되면 enqueue 없이 producer를 거부합니다.
  - `Committed` 뒤 terminal은 실제 queue 적재가 끝날 때까지 pending으로 보존합니다.
- 첫 terminal만 반영하고 이후 `complete`/`error`는 no-op으로 처리합니다.
- terminal과 drain 취소 시 value waiter와 capacity waiter를 모두 깨웁니다.
- terminal, queue empty, active admission 0이 함께 성립할 때만 drain을 종료합니다.
- `SpscArrayQueue`에 producer mutex 안에서 사용하는 read-only capacity probe를 추가합니다.

## 검증

- RED: 기존 구현에서 10개 중 3개 실패
  - complete 경합 timeout
  - 다중 producer stress timeout
  - 첫 error identity 덮어쓰기
- GREEN: `BufferedResumableCollectorTest` 19개를 3회 연속 실행해 매회 통과
- 모듈 게이트: `:bluetape4k-coroutines:detekt :bluetape4k-coroutines:build --rerun-tasks`
  - 630 passing
  - Detekt, Kover, build 성공
- 독립 코드 리뷰: P0/P1/P2/P3 모두 0으로 승인
- `git diff --check` 통과

## 호환성과 위험

- 공개 `invoke`, `next`, `complete`, `error`, `drain` 시그니처는 변경하지 않았습니다.
- atomic immutable state 갱신으로 producer admission마다 작은 객체 할당이 추가됩니다. 정확성 우선 설계이며 별도 부하 벤치마크는 실행하지 않았습니다.
- 문제가 생기면 이 커밋을 되돌려 이전의 순차 terminal 제약으로 복구할 수 있습니다.

## Stacked PR Train

- 선행 PR: #1472 (`test/1341-buffered-sink-payload`)
- 현재 base: `test/1341-buffered-sink-payload` @ `bd0cf68d3da046245a3f6c558e238dd76bfa19d4`
- 현재 head: `fix/1349-buffered-collector-terminal-race` @ `5a25fb8619ea09fcdbde2c4d4f5866bed54cead9`
- 후속 #1360은 이 PR의 required raw CI 성공과 blocker 0 확인 뒤에만 시작합니다.

## DoD Status

- [x] Issue #1349 수용 기준을 deterministic 회귀 테스트로 고정
- [x] targeted 테스트 19개 3회 연속 통과
- [x] coroutines 모듈 Detekt, 630개 테스트, Kover 통과
- [x] 독립 리뷰 P0/P1/P2/P3 = 0
- [x] 정확한 stacked base/head 확인
- [x] GitHub required raw CI 성공: run `32609321927` (exact head `5a25fb8619ea09fcdbde2c4d4f5866bed54cead9`), 전체 22개 job 성공, image gate `52/52` (`product_failure=0`, `infrastructure_failure=0`, `blocked=0`, `release_gate=true`), Coveralls `81.727%` 성공
- [x] 사용자 승인 및 exact-head merge gate 통과 (2026-08-23)
- [x] exact-head merge 완료: `d2406cddd28ec15a1a8e17f7b31fef8e171a59cf` (parents `bd0cf68d3da046245a3f6c558e238dd76bfa19d4`, `5a25fb8619ea09fcdbde2c4d4f5866bed54cead9`)