### PR TITLE
[feat] NATS JetStream Consumer를 취소·backpressure 안전한 Flow API로 노출

### DIFF
--- a/.github/scripts/test-aggregate-kover-coverage.py
+++ b/.github/scripts/test-aggregate-kover-coverage.py
@@ -166,6 +166,21 @@ class AggregateKoverCoverageTest(unittest.TestCase):
             self.assertIn(module, workflow)
         self.assertIn("--expected-module", workflow)
 
+    def test_ci_routes_search_messaging_changes_to_nats_and_elasticsearch(self):
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("search-messaging: ${{ steps.filter.outputs.search-messaging }}", workflow)
+        self.assertIn("'infra/elasticsearch/**'", workflow)
+        self.assertIn("'infra/nats/**'", workflow)
+        self.assertIn("test-search-messaging:", workflow)
+        self.assertIn(":bluetape4k-elasticsearch:test --max-workers=1", workflow)
+        self.assertIn(":bluetape4k-nats:test --max-workers=1", workflow)
+        self.assertIn(":bluetape4k-elasticsearch:koverXmlReport --max-workers=1", workflow)
+        self.assertIn(":bluetape4k-nats:koverXmlReport --max-workers=1", workflow)
+        self.assertIn("test-search-messaging=${{ needs.test-search-messaging.result }}", workflow)
+        self.assertIn("'infra/elasticsearch'", workflow)
+        self.assertIn("'infra/nats'", workflow)
+        self.assertIn("test-search-messaging, test-kafka-infra", workflow)
+
     def test_ci_only_uploads_coveralls_after_successful_aggregation(self):
         workflow = CI_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("id: aggregate-coverage", workflow)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
       ktor: ${{ steps.filter.outputs.ktor }}
       key-utils: ${{ steps.filter.outputs.key-utils }}
       infra: ${{ steps.filter.outputs.infra }}
+      search-messaging: ${{ steps.filter.outputs.search-messaging }}
       kafka-infra: ${{ steps.filter.outputs.kafka-infra }}
       telemetry-infra: ${{ steps.filter.outputs.telemetry-infra }}
       data: ${{ steps.filter.outputs.data }}
@@ -207,6 +208,9 @@ jobs:
               - 'infra/lettuce/**'
               - 'cache/cache-lettuce/**'
               - 'cache/cache-redisson/**'
+            search-messaging:
+              - 'infra/elasticsearch/**'
+              - 'infra/nats/**'
             kafka-infra:
               - 'infra/kafka/**'
               - 'infra/kafka4/**'
@@ -872,7 +876,62 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  # ── 7-a. Kafka Infra 테스트 (Testcontainers) ────────────────────────────
+  # ── 7-a. Search & Messaging 테스트 (Testcontainers) ─────────────────────
+  test-search-messaging:
+    name: Test / Search & Messaging
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['search-messaging'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test search and messaging modules
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: bash
+          command: |
+            ./gradlew :bluetape4k-elasticsearch:test --max-workers=1 --no-configuration-cache
+            ./gradlew :bluetape4k-nats:test --max-workers=1 --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: |
+          ./gradlew :bluetape4k-elasticsearch:koverXmlReport --max-workers=1 --no-configuration-cache
+          ./gradlew :bluetape4k-nats:koverXmlReport --max-workers=1 --no-configuration-cache
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-search-messaging
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-search-messaging
+          path: '**/build/reports/kover/'
+          if-no-files-found: error
+          retention-days: 30
+
+  # ── 7-b. Kafka Infra 테스트 (Testcontainers) ────────────────────────────
   test-kafka-infra:
     name: Test / Kafka Infra
     runs-on: ubuntu-latest
@@ -1075,7 +1134,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test-core, test-io, test-io-http, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data]
+    needs: [test-core, test-io, test-io-http, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data]
     if: always()
     steps:
       - uses: actions/checkout@v7
@@ -1091,6 +1150,7 @@ jobs:
             test-ktor=${{ needs.test-ktor.result }}
             test-key-utils=${{ needs.test-key-utils.result }}
             test-infra=${{ needs.test-infra.result }}
+            test-search-messaging=${{ needs.test-search-messaging.result }}
             test-kafka-infra=${{ needs.test-kafka-infra.result }}
             test-telemetry-infra=${{ needs.test-telemetry-infra.result }}
             test-data=${{ needs.test-data.result }}
@@ -1105,6 +1165,12 @@ jobs:
               'infra/redisson' \
               'cache/cache-redisson' \
               > coverage-artifacts/expected-modules.manifest
+          fi
+          if grep -q '^test-search-messaging=success$' coverage-artifacts/expected-jobs.manifest; then
+            printf '%s\n' \
+              'infra/elasticsearch' \
+              'infra/nats' \
+              >> coverage-artifacts/expected-modules.manifest
           fi
           if grep -q '=success$' coverage-artifacts/expected-jobs.manifest; then
             echo 'has_expected=true' >> "$GITHUB_OUTPUT"
@@ -1173,7 +1239,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, testcontainers-image-gate, test-ktor, test-key-utils, test-infra, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
+    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, testcontainers-image-gate, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@
   한다 ([#1335](https://github.com/bluetape4k/bluetape4k-projects/issues/1335)).
 <!-- issue-1335-java25-semver:end -->
 
+### 추가
+
+- NATS JetStream `ConsumerContext` pull consumer와 `JetStream` push
+  subscription을 수집마다 생성·정리하는 cold `Flow<Message>` API를 추가했다.
+  유한한 Flow 용량과 NATS pending limit을 검증하고, 취소 시 adapter 소유
+  handle만 닫으며 pending queue drop은 `NatsConsumerFlowException`으로
+  보고한다. adapter는 manual ack만 제공해 업무 처리 성공 뒤 caller가
+  `ack()`/`nak()`/`term()`을 선택하도록 한다
+  ([#1350](https://github.com/bluetape4k/bluetape4k-projects/issues/1350)).
+
 ### 버그 수정
 
 - `BufferedSuspendedSink` 회귀 테스트가 모든 `write`/`writeAll` 오버로드의 정확한

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.elasticsearch.coroutines
 
 import co.elastic.clients.elasticsearch.core.BulkRequest
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -57,6 +58,16 @@ class BulkIngesterCoroutinesTest: AbstractElasticsearchTest() {
             ingester.shouldNotBeNull()
         } finally {
             ingester.close()
+        }
+    }
+
+    @Test
+    fun `bulkIngesterOf 는 양수 maxOperations 만 허용한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            bulkIngesterOf<Void>(client = client, maxOperations = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            bulkIngesterOf<Void>(client = asyncClient, maxOperations = 0)
         }
     }
 
@@ -148,6 +159,32 @@ class BulkIngesterCoroutinesTest: AbstractElasticsearchTest() {
             }.shouldBeNull()
         } finally {
             handle.close()
+        }
+    }
+
+    @Test
+    fun `bulkProgressListener emits Error events`() = runTest {
+        val handle = bulkProgressListener<Void>()
+        val (listener, events) = handle
+        val failure = IllegalStateException("bulk failed")
+
+        try {
+            listener.afterBulk(3L, bulkRequestOf("error"), emptyList(), failure)
+
+            val event = events.first()
+            event shouldBeInstanceOf BulkProgressEvent.Error::class
+            val errorEvent = event as BulkProgressEvent.Error<Void>
+            errorEvent.executionId shouldBeEqualTo 3L
+            errorEvent.exception shouldBeEqualTo failure
+        } finally {
+            handle.close()
+        }
+    }
+
+    @Test
+    fun `bulkProgressListener 는 양수 bufferCapacity 만 허용한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            bulkProgressListener<Void>(bufferCapacity = 0)
         }
     }
 

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/BulkIngesterCoroutinesTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.elasticsearch.coroutines
 
 import co.elastic.clients.elasticsearch.core.BulkRequest
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation
+import co.elastic.clients.util.ObjectBuilder
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.function.Function
 
 /**
  * [BulkIngester] Coroutines 확장함수 테스트.
@@ -100,6 +102,30 @@ class BulkIngesterCoroutinesTest: AbstractElasticsearchTest() {
             index(indexName)
         }
         countResponse.count() shouldBeGreaterOrEqualTo docCount.toLong()
+    }
+
+    @Test
+    fun `builder lambda addSuspend 로 문서를 인덱싱한다`() = runTest(timeout = 60.seconds) {
+        val ingester = bulkIngesterOf<Void>(
+            client = asyncClient,
+            maxOperations = 1,
+        )
+
+        ingester.use {
+            it.addSuspend(
+                Function<BulkOperation.Builder, ObjectBuilder<BulkOperation>> { operation ->
+                    operation.index<Map<String, Any?>> { index ->
+                        index.index(indexName)
+                            .id("builder-doc")
+                            .document(mapOf("title" to "Builder document"))
+                    }
+                },
+            )
+        }
+
+        asyncClient.indices().refresh { it.index(indexName) }.await()
+        val countResponse = asyncClient.countSuspending { index(indexName) }
+        countResponse.count() shouldBeGreaterOrEqualTo 1L
     }
 
     @Test

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesTest.kt
@@ -104,6 +104,18 @@ class SearchApiCoroutinesTest: AbstractElasticsearchTest() {
             closed.shouldBeTrue()
         }
 
+    @Test
+    fun `PIT 와 searchAsFlow 는 기본 옵션으로도 동작한다`() = runTest(timeout = 60.seconds) {
+        val pitId = asyncClient.openPointInTimeSuspending(indexName)
+        pitId.shouldNotBeBlank()
+        asyncClient.closePointInTimeSuspending(pitId).shouldBeTrue()
+
+        val first = asyncClient.searchAsFlow<SearchDoc>(indexName)
+            .take(1)
+            .toList()
+        first.size shouldBeEqualTo 1
+    }
+
     // -------------------------------------------------------------------------
     // searchAsFlow — 전체 10000건 순회
     // -------------------------------------------------------------------------

--- a/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesUnitTest.kt
+++ b/infra/elasticsearch/src/test/kotlin/io/bluetape4k/elasticsearch/coroutines/SearchApiCoroutinesUnitTest.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.elasticsearch.coroutines
 
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.assertFailsWith
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -33,5 +35,29 @@ class SearchApiCoroutinesUnitTest {
         job.cancelAndJoin()
 
         cleanupCompleted.shouldBeTrue()
+    }
+
+    @Test
+    fun `PIT cleanup swallows cancellation and ordinary close failures`() = runTest {
+        var cancellationInvoked = false
+        closePointInTimeBestEffort("cancelled-pit") {
+            cancellationInvoked = true
+            throw CancellationException("collector cancelled")
+        }
+        cancellationInvoked.shouldBeTrue()
+
+        var failureInvoked = false
+        closePointInTimeBestEffort("failed-pit") {
+            failureInvoked = true
+            throw IllegalStateException("close failed")
+        }
+        failureInvoked.shouldBeTrue()
+    }
+
+    @Test
+    fun `PIT cleanup rejects a blank id before invoking close`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            closePointInTimeBestEffort(" ") { true }
+        }
     }
 }

--- a/infra/nats/README.ko.md
+++ b/infra/nats/README.ko.md
@@ -13,7 +13,7 @@
 ## 특징
 
 - **Kotlin 확장 함수** — NATS Java 클라이언트를 코틀린 스타일로 사용
-- **코루틴 지원** — `suspend` 함수로 비동기 처리 (`requestSuspending`, `publishSuspending`, `drainSuspending`)
+- **코루틴 지원** — `suspend` 함수와 cold `Flow<Message>` 소비자 (`requestSuspending`, `publishSuspending`, `drainSuspending`)
 - **JetStream 지원** — 스트림 생성, 메시지 발행/구독, 소비자 관리
 - **NATS Service** — DSL 기반 마이크로서비스 엔드포인트 구축
 - **DSL 빌더** — Stream, Consumer, Key-Value, Object Store 설정을 위한 유창한 DSL
@@ -248,7 +248,93 @@ val consumerCtx2 = consumerContextOf(connection, "my-stream", consumerConfigurat
 })
 ```
 
-### 11. StreamInfoOptions
+### 11. Cold JetStream Consumer Flow
+
+`ConsumerContext.consumeAsFlow`는 pull consumer를 사용하고,
+`JetStream.consumeAsFlow`는 수집마다 동기식 push subscription을 생성합니다.
+두 Flow 모두 cold이므로 수집할 때마다 subscription과 정리 lifecycle이
+독립적으로 시작됩니다. adapter는 유한한 NATS 옵션과 `capacity + 1`개의
+message 보유 한계를 사용하며, NATS pending queue drop을
+`NatsConsumerFlowException`으로 보고합니다.
+
+```kotlin
+import io.bluetape4k.nats.client.*
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlin.time.Duration.Companion.seconds
+
+val capacity = 32                   // 1..1024, adapter 보유 상한은 capacity + 1
+
+// Pull consumer: 수집이 취소되면 IterableConsumer를 닫습니다.
+consumerCtx.consumeAsFlow(capacity = capacity, receiveTimeout = 1.seconds)
+    .take(100)
+    .collect { message ->
+        process(message)
+        message.ack()                // 업무 처리가 성공한 뒤 수동 승인
+    }
+
+// Push subscription: drop 검출을 위해 유한한 client pending limit을 사용합니다.
+val pushOptions = pushSubscriptionOptions {
+    stream("my-stream")
+    pendingMessageLimit(1_024)
+    pendingByteLimit(16L * 1024 * 1024)
+}
+jetStream.consumeAsFlow(
+    subject = "events.>",
+    options = pushOptions,
+    capacity = capacity,
+    receiveTimeout = 1.seconds,
+).collect { message ->
+    process(message)
+    message.ack()
+}
+```
+
+adapter는 수동 ack만 지원하며 수집자를 대신해 `ack`, `nak`, `term`을 호출하지
+않습니다. 재시도 가능한 실패에는 `nak()`, poison message에는 `term()`을
+호출하도록 caller가 선택합니다. 승인하지 않은 message는 server consumer의 `ackWait`/`maxDeliver`
+정책에 따라 redelivery될 수 있으며, `maxAckPending`은 consumer에 별도로
+설정해야 합니다. `capacity`는 Flow 측 상한이며 NATS pending limit을 바꾸지
+않습니다. pending queue가 drop되면 조용히 계속하지 않고
+`NatsConsumerFlowException.droppedMessages`로 확인합니다. 같은 Flow 인스턴스를
+동시에 collect하면 거부되므로 필요한 경우 새 Flow 인스턴스를 만드십시오.
+
+adapter는 `capacity`를 `1..1024`, `receiveTimeout`을 유한한
+`100.milliseconds` 이상으로 검증합니다. Push options의
+`pendingMessageLimit`은 `1..65_536`, `pendingByteLimit`은 `1..64 MiB` 범위여야
+하며 기본값은 1,024개 message와 16 MiB입니다. Pull의 `batchBytes > 0`은
+consumer를 만들기 전에 거부하고, message batch는
+`min(originalBatchSize, capacity + 1)`로 정규화합니다. Adapter가 생성한
+subscription 또는 iterable consumer만 닫으며 `Connection`, `JetStream`,
+consumer 설정의 소유권은 caller에게 있습니다.
+
+실패 우선순위는 취소, receive/collector 실패, drop 또는 pending 상태
+read-back 실패, 관찰 가능한 cleanup 실패 순서입니다. 앞선 실패가 있으면
+cleanup 실패는 suppressed로 보존합니다. 순수 drop의 exception `cause`는
+`null`이고 pending 상태 read-back 실패는 원래 원인을
+`NatsConsumerFlowException`에 보존합니다.
+
+Push 측 message 총량 상한은 `pendingMessageLimit + capacity + 1`입니다. 즉,
+NATS pending queue, Flow buffer, receiver가 보유 중인 한 개 message를 합친
+값이며, `pendingByteLimit`은 NATS queue에 독립적으로 적용됩니다. Pull은
+`min(originalBatchSize, capacity + 1)` batch와 receiver가 보유하는 한 개
+message만 요청하므로 무제한 batch를 만들지 않습니다.
+
+Drop 또는 pending 상태 read-back 실패는 명시적으로 처리하십시오.
+
+```kotlin
+try {
+    jetStream.consumeAsFlow("events.>", pushOptions).collect { message ->
+        process(message)
+        message.ack()
+    }
+} catch (failure: NatsConsumerFlowException) {
+    log.error("NATS consumer Flow가 ${failure.droppedMessages}개 drop 후 종료되었습니다.", failure)
+    throw failure
+}
+```
+
+### 12. StreamInfoOptions
 
 ```kotlin
 import io.bluetape4k.nats.client.api.*

--- a/infra/nats/README.md
+++ b/infra/nats/README.md
@@ -13,7 +13,7 @@ This module provides Kotlin-idiomatic extension functions and DSLs for the NATS 
 ## Features
 
 - **Kotlin extension functions** — NATS Java client in idiomatic Kotlin style
-- **Coroutines support** — `suspend` functions for async operations (`requestSuspending`, `publishSuspending`, `drainSuspending`)
+- **Coroutines support** — `suspend` functions and cold `Flow<Message>` consumers for async operations (`requestSuspending`, `publishSuspending`, `drainSuspending`)
 - **JetStream support** — stream creation, publish/subscribe, consumer management
 - **NATS Service** — build microservice endpoints with DSL
 - **DSL builders** — fluent configuration for Streams, Consumers, Key-Value stores, and Object Stores
@@ -248,7 +248,92 @@ val consumerCtx2 = consumerContextOf(connection, "my-stream", consumerConfigurat
 })
 ```
 
-### 11. StreamInfoOptions
+### 11. Cold JetStream Consumer Flow
+
+`ConsumerContext.consumeAsFlow` uses a pull consumer, while
+`JetStream.consumeAsFlow` creates a synchronous push subscription for each
+collector. Both flows are cold: subscription and cleanup happen per collection.
+The adapter accepts finite NATS options, limits the Flow channel to
+`capacity + 1` held messages, and fails with `NatsConsumerFlowException` if the
+NATS pending queue reports a drop.
+
+```kotlin
+import io.bluetape4k.nats.client.*
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlin.time.Duration.Companion.seconds
+
+val capacity = 32                   // 1..1024; adapter holds at most capacity + 1
+
+// Pull consumer: IterableConsumer is closed when collection is cancelled.
+consumerCtx.consumeAsFlow(capacity = capacity, receiveTimeout = 1.seconds)
+    .take(100)
+    .collect { message ->
+        process(message)
+        message.ack()                // manual ack after business success
+    }
+
+// Push subscription: finite client pending limits are required for drop detection.
+val pushOptions = pushSubscriptionOptions {
+    stream("my-stream")
+    pendingMessageLimit(1_024)
+    pendingByteLimit(16L * 1024 * 1024)
+}
+jetStream.consumeAsFlow(
+    subject = "events.>",
+    options = pushOptions,
+    capacity = capacity,
+    receiveTimeout = 1.seconds,
+).collect { message ->
+    process(message)
+    message.ack()
+}
+```
+
+The adapter is manual-ack only: it never calls `ack`, `nak`, or `term` for the
+collector. Call `nak()` for retryable failures and `term()` for poison messages.
+An unacknowledged message can be redelivered according to the server consumer's
+`ackWait`/`maxDeliver`; configure `maxAckPending` separately on the consumer.
+`capacity` bounds the Flow side and does not change NATS pending limits. If the
+pending queue drops messages, inspect `NatsConsumerFlowException.droppedMessages`
+instead of continuing with silent loss. A second concurrent collection of the
+same Flow instance is rejected; create a new Flow instance when needed.
+
+The adapter validates `capacity` in `1..1024` and a finite `receiveTimeout` of at
+least `100.milliseconds`. Push options must keep `pendingMessageLimit` in
+`1..65_536` and `pendingByteLimit` in `1..64 MiB`; the default is 1,024 messages
+and 16 MiB. Pull `batchBytes > 0` is rejected before the consumer is created, and
+the effective message batch is normalized to `min(originalBatchSize, capacity + 1)`.
+The adapter only closes the subscription or iterable consumer it created; the
+caller still owns `Connection`, `JetStream`, and consumer configuration.
+
+Failure precedence is cancellation, receive/collector failure, drop or pending
+state read-back failure, then observable cleanup failure. Cleanup failures are
+suppressed behind an earlier failure. A pure drop has a null exception cause;
+pending-state read-back failures retain their original cause in
+`NatsConsumerFlowException`.
+
+The push-side message bound is `pendingMessageLimit + capacity + 1`: the NATS
+pending queue, Flow buffer, and one message held by the receiver. The pending
+byte limit applies to the NATS queue independently; Flow capacity is a message
+count. Pull uses `min(originalBatchSize, capacity + 1)` and one receiver-held
+message, so the adapter never requests an unbounded batch.
+
+Handle an observable drop or pending-state read-back failure explicitly:
+
+```kotlin
+try {
+    jetStream.consumeAsFlow("events.>", pushOptions).collect { message ->
+        process(message)
+        message.ack()
+    }
+} catch (failure: NatsConsumerFlowException) {
+    log.error("NATS consumer Flow stopped after ${failure.droppedMessages} dropped messages", failure)
+    throw failure
+}
+```
+
+### 12. StreamInfoOptions
 
 ```kotlin
 import io.bluetape4k.nats.client.api.*

--- a/infra/nats/build.gradle.kts
+++ b/infra/nats/build.gradle.kts
@@ -15,8 +15,9 @@ dependencies {
     // nats_spring_cloud_stream_binder: 사용하지 않으므로 제외
 
     // Coroutines
-    compileOnly(project(":bluetape4k-coroutines"))
-    compileOnly(libs.kotlinx.coroutines.core)
+    api(project(":bluetape4k-coroutines"))
+    // Public consumeAsFlow API exposes Flow and coroutine cancellation semantics.
+    api(libs.kotlinx.coroutines.core)
     compileOnly(libs.kotlinx.coroutines.reactor)
     testImplementation(libs.kotlinx.coroutines.test)
 

--- a/infra/nats/src/main/kotlin/io/bluetape4k/nats/client/NatsConsumerFlow.kt
+++ b/infra/nats/src/main/kotlin/io/bluetape4k/nats/client/NatsConsumerFlow.kt
@@ -1,0 +1,362 @@
+package io.bluetape4k.nats.client
+
+import io.bluetape4k.support.requireNotBlank
+import io.nats.client.ConsumerContext
+import io.nats.client.ConsumeOptions
+import io.nats.client.IterableConsumer
+import io.nats.client.JetStream
+import io.nats.client.JetStreamSubscription
+import io.nats.client.Message
+import io.nats.client.PushSubscribeOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.min
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+/**
+ * NATS client pending queue의 기본 상한을 Flow adapter에 맞게 제한합니다.
+ */
+val defaultNatsFlowPushOptions: PushSubscribeOptions = PushSubscribeOptions.builder()
+    .pendingMessageLimit(1_024)
+    .pendingByteLimit(16L * 1024 * 1024)
+    .build()
+
+/**
+ * Push adapter의 pending queue drop 또는 read-back 실패를 나타냅니다.
+ *
+ * [droppedMessages]가 양수이면 subscription pending queue에서 관찰된 증가량이고,
+ * 0이면 drop count read-back 같은 관찰 실패를 뜻하며 원인은 [cause]에 보존됩니다.
+ */
+class NatsConsumerFlowException(
+    val droppedMessages: Long,
+    cause: Throwable? = null,
+) : RuntimeException(
+    if (cause == null) {
+        "NATS consumer Flow dropped $droppedMessages message(s)"
+    } else {
+        "NATS consumer Flow state could not be verified"
+    },
+    cause,
+) {
+    init {
+        require(droppedMessages >= 0) {
+            "droppedMessages must be zero or positive: $droppedMessages"
+        }
+    }
+}
+
+/**
+ * JetStream push subscription을 수집마다 만드는 cold [Flow]입니다.
+ *
+ * Flow는 message를 자동 승인하지 않습니다. business 처리 성공 뒤 수집자가
+ * `ack()`을 호출하고, 재시도 가능한 실패에는 `nak()`, 재전달하지 않을 실패에는
+ * `term()`을 선택해야 합니다. [capacity]는 adapter channel의 유한 용량이며
+ * NATS pending limit 및 server `maxAckPending`과 별개의 상한입니다.
+ *
+ * 같은 Flow 인스턴스를 동시에 수집하면 subscription 생성 전에 실패합니다.
+ * 수집이 취소되면 blocking receive를 interrupt하고 adapter가 만든 subscription만
+ * `unsubscribe()`합니다. pending queue drop은 조용히 무시하지 않고
+ * [NatsConsumerFlowException]으로 전달합니다.
+ */
+@Suppress("TooGenericExceptionCaught")
+fun JetStream.consumeAsFlow(
+    subject: String,
+    options: PushSubscribeOptions = defaultNatsFlowPushOptions,
+    capacity: Int = DEFAULT_NATS_FLOW_CAPACITY,
+    receiveTimeout: Duration = 1.seconds,
+): Flow<Message> {
+    subject.requireNotBlank("subject")
+    validateFlowArguments(capacity, receiveTimeout)
+    validatePushOptions(options)
+
+    val collecting = AtomicBoolean(false)
+    return channelFlow {
+        check(collecting.compareAndSet(false, true)) {
+            "같은 NATS Flow 인스턴스는 동시에 collect할 수 없습니다."
+        }
+
+        var subscription: JetStreamSubscription? = null
+        var primaryFailure: Throwable? = null
+        var observedDropped = 0L
+
+        try {
+            subscription = runInterruptible(Dispatchers.IO) {
+                subscribe(subject, options)
+            }
+            verifyPendingLimits(subscription, options)
+            observedDropped = readDroppedCount(subscription)
+
+            while (currentCoroutineContext().isActive) {
+                val beforeReceive = readDroppedCount(subscription)
+                val message = runInterruptible(Dispatchers.IO) {
+                    subscription.nextMessage(receiveTimeout.toJavaDuration())
+                }
+                observedDropped = observeDropped(
+                    subscription = subscription,
+                    previous = maxOf(observedDropped, beforeReceive),
+                )
+
+                if (message == null && !subscription.isActive) {
+                    break
+                }
+                if (message != null) {
+                    send(message)
+                }
+            }
+        } catch (throwable: Throwable) {
+            primaryFailure = throwable
+            throw throwable
+        } finally {
+            val cleanupFailure = cleanupPushSubscription(subscription)
+            val dropFailure = subscription?.let { activeSubscription ->
+                try {
+                    val current = readDroppedCount(activeSubscription)
+                    val delta = current - observedDropped
+                    delta.takeIf { it > 0 }?.let(::NatsConsumerFlowException)
+                } catch (cancellation: CancellationException) {
+                    cancellation
+                } catch (error: Error) {
+                    error
+                } catch (exception: Exception) {
+                    exception
+                }
+            }
+            try {
+                finishFailure(primaryFailure, dropFailure, cleanupFailure)
+            } finally {
+                collecting.set(false)
+            }
+        }
+    }.buffer(capacity)
+}
+
+/**
+ * Pull [ConsumerContext]를 수집마다 만드는 cold [Flow]입니다.
+ *
+ * [options]의 batch는 [capacity]와 receiver가 보유할 수 있는 한계를 넘지 않도록
+ * 유한하게 정규화합니다. byte-only batch는 message count 상한과 동시에 보장할 수
+ * 없으므로 거부합니다. Flow는 `ack`/`nak`/`term`을 호출하지 않으며, 취소 시
+ * adapter가 만든 [IterableConsumer]만 닫습니다.
+ */
+@Suppress("TooGenericExceptionCaught")
+fun ConsumerContext.consumeAsFlow(
+    options: ConsumeOptions = ConsumeOptions.DEFAULT_CONSUME_OPTIONS,
+    capacity: Int = DEFAULT_NATS_FLOW_CAPACITY,
+    receiveTimeout: Duration = 1.seconds,
+): Flow<Message> {
+    validateFlowArguments(capacity, receiveTimeout)
+    require(options.batchBytes == 0L) {
+        "pull batchBytes는 bounded Flow에서 지원하지 않습니다."
+    }
+    val effectiveOptions = boundedConsumeOptions(options, capacity)
+    val collecting = AtomicBoolean(false)
+
+    return channelFlow {
+        check(collecting.compareAndSet(false, true)) {
+            "같은 NATS Flow 인스턴스는 동시에 collect할 수 없습니다."
+        }
+
+        var consumer: IterableConsumer? = null
+        var primaryFailure: Throwable? = null
+
+        try {
+            consumer = runInterruptible(Dispatchers.IO) {
+                iterate(effectiveOptions)
+            }
+
+            while (currentCoroutineContext().isActive) {
+                val message = runInterruptible(Dispatchers.IO) {
+                    consumer.nextMessage(receiveTimeout.toJavaDuration())
+                }
+
+                if (message == null && (consumer.isStopped || consumer.isFinished)) {
+                    break
+                }
+                if (message != null) {
+                    send(message)
+                }
+            }
+        } catch (throwable: Throwable) {
+            primaryFailure = throwable
+            throw throwable
+        } finally {
+            val cleanupFailure = cleanupIterableConsumer(consumer)
+            try {
+                finishFailure(primaryFailure, null, cleanupFailure)
+            } finally {
+                collecting.set(false)
+            }
+        }
+    }.buffer(capacity)
+}
+
+private const val DEFAULT_NATS_FLOW_CAPACITY = 64
+private const val MIN_NATS_FLOW_CAPACITY = 1
+private const val MAX_NATS_FLOW_CAPACITY = 1_024
+private val MIN_NATS_FLOW_RECEIVE_TIMEOUT = 100.milliseconds
+private const val MAX_PENDING_MESSAGES = 65_536L
+private const val MAX_PENDING_BYTES = 64L * 1024 * 1024
+
+private fun validateFlowArguments(capacity: Int, receiveTimeout: Duration) {
+    require(capacity in MIN_NATS_FLOW_CAPACITY..MAX_NATS_FLOW_CAPACITY) {
+        "capacity must be between $MIN_NATS_FLOW_CAPACITY and $MAX_NATS_FLOW_CAPACITY: $capacity"
+    }
+    require(receiveTimeout.isFinite() && receiveTimeout >= MIN_NATS_FLOW_RECEIVE_TIMEOUT) {
+        "receiveTimeout must be finite and at least $MIN_NATS_FLOW_RECEIVE_TIMEOUT: $receiveTimeout"
+    }
+}
+
+private fun validatePushOptions(options: PushSubscribeOptions) {
+    require(options.pendingMessageLimit in 1..MAX_PENDING_MESSAGES) {
+        "pending message limit must be between 1 and $MAX_PENDING_MESSAGES: ${options.pendingMessageLimit}"
+    }
+    require(options.pendingByteLimit in 1..MAX_PENDING_BYTES) {
+        "pending byte limit must be between 1 and $MAX_PENDING_BYTES: ${options.pendingByteLimit}"
+    }
+}
+
+private fun boundedConsumeOptions(
+    options: ConsumeOptions,
+    capacity: Int,
+): ConsumeOptions {
+    val effectiveBatchSize = min(options.batchSize, capacity + 1)
+    return ConsumeOptions.builder()
+        .json(options.toJson())
+        .batchSize(effectiveBatchSize)
+        .build()
+}
+
+@Suppress("ThrowsCount", "TooGenericExceptionCaught")
+private fun verifyPendingLimits(
+    subscription: JetStreamSubscription,
+    options: PushSubscribeOptions,
+) {
+    val (actualMessages, actualBytes) = try {
+        subscription.pendingMessageLimit to subscription.pendingByteLimit
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (error: Error) {
+        throw error
+    } catch (exception: Exception) {
+        throw NatsConsumerFlowException(0, exception)
+    }
+    if (actualMessages != options.pendingMessageLimit || actualBytes != options.pendingByteLimit) {
+        throw NatsConsumerFlowException(
+            0,
+            IllegalStateException(
+                "NATS pending limit read-back mismatch: " +
+                    "messages=$actualMessages/${options.pendingMessageLimit}, " +
+                    "bytes=$actualBytes/${options.pendingByteLimit}",
+            ),
+        )
+    }
+}
+
+@Suppress("TooGenericExceptionCaught")
+private fun readDroppedCount(subscription: JetStreamSubscription): Long = try {
+    subscription.droppedCount
+} catch (cancellation: CancellationException) {
+    throw cancellation
+} catch (error: Error) {
+    throw error
+} catch (exception: Exception) {
+    throw NatsConsumerFlowException(0, exception)
+}
+
+private fun observeDropped(
+    subscription: JetStreamSubscription,
+    previous: Long,
+): Long {
+    val current = readDroppedCount(subscription)
+    val delta = current - previous
+    if (delta > 0) {
+        throw NatsConsumerFlowException(delta)
+    }
+    return maxOf(previous, current)
+}
+
+@Suppress("TooGenericExceptionCaught")
+private suspend fun cleanupPushSubscription(subscription: JetStreamSubscription?): Throwable? {
+    if (subscription == null) {
+        return null
+    }
+    return try {
+        withContext(NonCancellable + Dispatchers.IO) {
+            subscription.unsubscribe()
+        }
+        null
+    } catch (cancellation: CancellationException) {
+        cancellation
+    } catch (error: Error) {
+        error
+    } catch (exception: Exception) {
+        exception
+    }
+}
+
+@Suppress("TooGenericExceptionCaught")
+private suspend fun cleanupIterableConsumer(consumer: IterableConsumer?): Throwable? {
+    if (consumer == null) {
+        return null
+    }
+    return try {
+        withContext(NonCancellable + Dispatchers.IO) {
+            consumer.close()
+        }
+        null
+    } catch (cancellation: CancellationException) {
+        cancellation
+    } catch (error: Error) {
+        error
+    } catch (exception: Exception) {
+        exception
+    }
+}
+
+private fun finishFailure(
+    primary: Throwable?,
+    dropFailure: Throwable?,
+    cleanupFailure: Throwable?,
+) {
+    val addSuppressedToChain: (Throwable, Throwable) -> Unit = { root, suppressed ->
+        if (root !== suppressed) {
+            root.addSuppressed(suppressed)
+            var cause = root.cause
+            while (cause != null && cause !== root) {
+                if (cause !== suppressed) {
+                    cause.addSuppressed(suppressed)
+                }
+                cause = cause.cause
+            }
+        }
+    }
+    val terminalFailure = when {
+        primary != null -> {
+            dropFailure?.let { addSuppressedToChain(primary, it) }
+            cleanupFailure?.let { addSuppressedToChain(primary, it) }
+            primary
+        }
+
+        dropFailure != null -> {
+            cleanupFailure?.let { addSuppressedToChain(dropFailure, it) }
+            dropFailure
+        }
+
+        else -> cleanupFailure
+    }
+    if (terminalFailure != null) {
+        throw terminalFailure
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowIntegrationTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowIntegrationTest.kt
@@ -1,0 +1,248 @@
+package io.bluetape4k.nats.client
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.nats.AbstractNatsTest
+import io.bluetape4k.nats.client.api.consumerConfiguration
+import io.bluetape4k.support.toUtf8String
+import io.nats.client.api.AckPolicy
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class NatsConsumerFlowIntegrationTest : AbstractNatsTest() {
+
+    @Test
+    fun `pull flow preserves order and caller acknowledges messages`() = runTest(timeout = 30.seconds) {
+        val stream = "consumer-flow-pull"
+        val subject = "consumer-flow.pull"
+        val received = mutableListOf<String>()
+
+        getConnection().use { connection ->
+            connection.createOrReplaceStream(stream, subject)
+            val jetStream = connection.jetStream()
+            repeat(3) { index ->
+                jetStream.publish(subject, "pull-$index")
+            }
+
+            val consumer = consumerContextOf(
+                connection,
+                stream,
+                consumerConfiguration {
+                    durable("consumer-flow-pull-durable")
+                    ackPolicy(AckPolicy.Explicit)
+                },
+            )
+
+            consumer
+                .consumeAsFlow(capacity = 2)
+                .take(3)
+                .collect { message ->
+                    received += message.data.toUtf8String()
+                    message.ack()
+                }
+        }
+
+        received shouldBeEqualTo listOf("pull-0", "pull-1", "pull-2")
+    }
+
+    @Test
+    fun `push flow preserves order and caller acknowledges messages`() = runTest(timeout = 30.seconds) {
+        val stream = "consumer-flow-push"
+        val subject = "consumer-flow.push"
+        val received = mutableListOf<String>()
+
+        getConnection().use { connection ->
+            connection.createOrReplaceStream(stream, subject)
+            val jetStream = connection.jetStream()
+            repeat(3) { index ->
+                jetStream.publish(subject, "push-$index")
+            }
+
+            val pushOptions = pushSubscriptionOptions {
+                stream(stream)
+                pendingMessageLimit(1_024)
+                pendingByteLimit(16L * 1024 * 1024)
+            }
+            jetStream
+                .consumeAsFlow(subject, pushOptions, capacity = 2)
+                .take(3)
+                .collect { message ->
+                    received += message.data.toUtf8String()
+                    message.ack()
+                }
+        }
+
+        received shouldBeEqualTo listOf("push-0", "push-1", "push-2")
+    }
+
+    @Test
+    fun `push flow reports actual pending queue drops`() = runBlocking {
+        val stream = "consumer-flow-push-drop"
+        val subject = "consumer-flow.push-drop"
+
+        getConnection().use { connection ->
+            connection.createOrReplaceStream(stream, subject)
+            val jetStream = connection.jetStream()
+            val pushOptions = pushSubscriptionOptions {
+                stream(stream)
+                pendingMessageLimit(1)
+                pendingByteLimit(64L * 1024)
+            }
+            supervisorScope {
+                val firstDelivered = CompletableDeferred<Unit>()
+                val flow = jetStream.consumeAsFlow(
+                    subject,
+                    pushOptions,
+                    capacity = 1,
+                    receiveTimeout = 500.milliseconds,
+                )
+                val collector = async(Dispatchers.Default) {
+                    flow.collect {
+                        if (firstDelivered.complete(Unit)) {
+                            delay(1.seconds)
+                        }
+                    }
+                }
+
+                jetStream.publish(subject, "seed")
+                withTimeout(5.seconds) {
+                    firstDelivered.await()
+                }
+                repeat(500) { index ->
+                    jetStream.publish(subject, "drop-$index")
+                }
+
+                val failure = try {
+                    collector.await()
+                    null
+                } catch (exception: NatsConsumerFlowException) {
+                    exception
+                }
+
+                check(failure != null) { "실제 pending queue drop이 Flow 예외로 보고되지 않았습니다." }
+                check(failure.droppedMessages > 0) {
+                    "실제 pending queue drop 수가 양수가 아닙니다: ${failure.droppedMessages}"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `unacknowledged pull message is redelivered and sequential collection reuses the flow`() =
+        runBlocking {
+            val stream = "consumer-flow-redelivery"
+            val subject = "consumer-flow.redelivery"
+            val deliveries = mutableListOf<String>()
+
+            getConnection().use { connection ->
+                connection.createOrReplaceStream(stream, subject)
+                val jetStream = connection.jetStream()
+                jetStream.publish(subject, "redeliver-me")
+
+                val consumer = consumerContextOf(
+                    connection,
+                    stream,
+                    consumerConfiguration {
+                        durable("consumer-flow-redelivery-durable")
+                        ackPolicy(AckPolicy.Explicit)
+                        ackWait(Duration.ofMillis(250))
+                        maxDeliver(2)
+                        maxAckPending(1)
+                    },
+                )
+                val flow = consumer.consumeAsFlow(capacity = 1, receiveTimeout = 500.milliseconds)
+
+                flow.take(1).collect { message ->
+                    deliveries += message.data.toUtf8String()
+                    // Deliberately leave the first delivery unacknowledged.
+                }
+
+                withTimeout(5.seconds) {
+                    flow.take(1).collect { message ->
+                        deliveries += message.data.toUtf8String()
+                        message.ack()
+                    }
+                }
+            }
+
+            deliveries shouldBeEqualTo listOf("redeliver-me", "redeliver-me")
+            Unit
+        }
+
+    @Test
+    fun `caller controls nak redelivery and term finalization`() = runBlocking {
+        getConnection().use { connection ->
+            val nakStream = "consumer-flow-manual-nak"
+            val nakSubject = "consumer-flow.manual-nak"
+            connection.createOrReplaceStream(nakStream, nakSubject)
+            val jetStream = connection.jetStream()
+            jetStream.publish(nakSubject, "nak-me")
+
+            val nakConsumer = consumerContextOf(
+                connection,
+                nakStream,
+                consumerConfiguration {
+                    durable("consumer-flow-manual-nak-durable")
+                    ackPolicy(AckPolicy.Explicit)
+                    ackWait(Duration.ofMillis(500))
+                    maxDeliver(2)
+                    maxAckPending(1)
+                },
+            )
+            val nakDeliveries = mutableListOf<String>()
+            withTimeout(5.seconds) {
+                nakConsumer.consumeAsFlow(capacity = 1, receiveTimeout = 500.milliseconds)
+                    .take(2)
+                    .collect { message ->
+                        nakDeliveries += message.data.toUtf8String()
+                        if (nakDeliveries.size == 1) {
+                            message.nak()
+                        } else {
+                            message.ack()
+                        }
+                    }
+            }
+            nakDeliveries shouldBeEqualTo listOf("nak-me", "nak-me")
+
+            val termStream = "consumer-flow-manual-term"
+            val termSubject = "consumer-flow.manual-term"
+            connection.createOrReplaceStream(termStream, termSubject)
+            jetStream.publish(termSubject, "term-me")
+            val termConsumer = consumerContextOf(
+                connection,
+                termStream,
+                consumerConfiguration {
+                    durable("consumer-flow-manual-term-durable")
+                    ackPolicy(AckPolicy.Explicit)
+                    ackWait(Duration.ofMillis(500))
+                    maxDeliver(2)
+                    maxAckPending(1)
+                },
+            )
+            val termFlow = termConsumer.consumeAsFlow(capacity = 1, receiveTimeout = 500.milliseconds)
+            termFlow.take(1).collect { message ->
+                message.term()
+            }
+
+            val redelivered = withTimeoutOrNull(2.seconds) {
+                termFlow.take(1).collect { message ->
+                    message.ack()
+                }
+                true
+            } ?: false
+            check(!redelivered) { "term() 처리 후 message가 재전달되었습니다." }
+        }
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
@@ -283,5 +284,96 @@ class NatsConsumerFlowTest {
     fun `default push limits are finite and bounded`() {
         (defaultNatsFlowPushOptions.pendingMessageLimit <= 1_024L).shouldBeTrue()
         (defaultNatsFlowPushOptions.pendingByteLimit <= 16L * 1024 * 1024).shouldBeTrue()
+    }
+
+    @Test
+    fun `consumer flow exception rejects negative dropped count`() {
+        assertFailsWith<IllegalArgumentException> {
+            NatsConsumerFlowException(-1)
+        }
+    }
+
+    @Test
+    fun `pending limit mismatch preserves a diagnostic cause`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 4
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returns 0
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<NatsConsumerFlowException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.droppedMessages shouldBeEqualTo 0L
+        check(failure.cause?.message?.contains("read-back mismatch") == true)
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `push subscribe failure does not attempt cleanup`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val subscribeFailure = IllegalStateException("subscribe failed")
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } throws subscribeFailure
+
+        val failure = assertFailsWith<IllegalStateException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        verify(exactly = 0) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `pull iterate failure does not attempt cleanup`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val iterateFailure = IllegalStateException("iterate failed")
+        every { context.iterate(any<ConsumeOptions>()) } throws iterateFailure
+
+        val failure = assertFailsWith<IllegalStateException> {
+            context.consumeAsFlow().toList()
+        }
+
+        verify(exactly = 0) { consumer.close() }
+    }
+
+    @Test
+    fun `final pending readback cancellation is not wrapped`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val cancellation = CancellationException("readback cancelled")
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        var droppedReads = 0
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } answers {
+            droppedReads += 1
+            if (droppedReads <= 3) 0 else throw cancellation
+        }
+        every { subscription.nextMessage(any<Duration>()) } returns null
+        every { subscription.isActive } returns false
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<CancellationException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        check(failure.cause == null || failure.cause === cancellation)
+        verify(exactly = 1) { subscription.unsubscribe() }
     }
 }

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
@@ -1,0 +1,287 @@
+package io.bluetape4k.nats.client
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import io.nats.client.ConsumeOptions
+import io.nats.client.ConsumerContext
+import io.nats.client.IterableConsumer
+import io.nats.client.JetStream
+import io.nats.client.JetStreamSubscription
+import io.nats.client.Message
+import io.nats.client.PushSubscribeOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class NatsConsumerFlowTest {
+
+    @Test
+    fun `pull flow is cold preserves order closes consumer and does not ack`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val first = mockk<Message>()
+        val second = mockk<Message>()
+        every { context.iterate(any<ConsumeOptions>()) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } returnsMany listOf(first, second)
+        every { consumer.close() } just runs
+
+        val received = context
+            .consumeAsFlow(capacity = 2)
+            .take(2)
+            .toList()
+
+        received shouldBeEqualTo listOf(first, second)
+        verify(exactly = 1) { context.iterate(any<ConsumeOptions>()) }
+        verify(exactly = 1) { consumer.close() }
+        verify(exactly = 0) { first.ack() }
+        verify(exactly = 0) { second.ack() }
+    }
+
+    @Test
+    fun `pull flow normalizes batch size to capacity plus receiver`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val options = ConsumeOptions.builder().batchSize(500).build()
+        val capturedOptions = slot<ConsumeOptions>()
+        every { context.iterate(capture(capturedOptions)) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } returns null
+        every { consumer.isStopped } returns true
+        every { consumer.isFinished } returns false
+        every { consumer.close() } just runs
+
+        context.consumeAsFlow(options, capacity = 2).toList()
+
+        capturedOptions.captured.batchSize shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `push flow is cold preserves order unsubscribes and does not ack`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val first = mockk<Message>()
+        val second = mockk<Message>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returns 0
+        every { subscription.nextMessage(any<Duration>()) } returnsMany listOf(first, second)
+        every { subscription.unsubscribe() } just runs
+
+        val received = jetStream
+            .consumeAsFlow("events", options, capacity = 2)
+            .take(2)
+            .toList()
+
+        received shouldBeEqualTo listOf(first, second)
+        verify(exactly = 1) { jetStream.subscribe("events", options) }
+        verify(exactly = 1) { subscription.unsubscribe() }
+        verify(exactly = 0) { first.ack() }
+        verify(exactly = 0) { second.ack() }
+    }
+
+    @Test
+    fun `same flow instance rejects concurrent collectors before creating a handle`() = runBlocking {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val receiveStarted = CountDownLatch(1)
+        val receiveBarrier = CountDownLatch(1)
+        val receiveInterrupted = CountDownLatch(1)
+        every { context.iterate(any<ConsumeOptions>()) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } answers {
+            receiveStarted.countDown()
+            try {
+                check(receiveBarrier.await(5, TimeUnit.SECONDS)) {
+                    "receive was not interrupted before the bounded barrier expired"
+                }
+            } catch (_: InterruptedException) {
+                receiveInterrupted.countDown()
+                Thread.currentThread().interrupt()
+            }
+            null
+        }
+        every { consumer.close() } just runs
+
+        val flow = context.consumeAsFlow(capacity = 1)
+        val first = async(Dispatchers.Default) { flow.collect() }
+        check(receiveStarted.await(5, TimeUnit.SECONDS))
+
+        assertFailsWith<IllegalStateException> {
+            flow.take(1).toList()
+        }
+
+        first.cancel()
+        withTimeout(5.seconds) {
+            first.join()
+        }
+        check(receiveInterrupted.await(1, TimeUnit.SECONDS))
+        verify(exactly = 1) { context.iterate(any<ConsumeOptions>()) }
+        verify(exactly = 1) { consumer.close() }
+    }
+
+    @Test
+    fun `push drop delta fails flow and reports dropped count`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returnsMany listOf(0, 0, 2, 2)
+        every { subscription.nextMessage(any<Duration>()) } returns null
+        every { subscription.isActive } returns true
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<NatsConsumerFlowException> {
+            jetStream.consumeAsFlow("events", options, capacity = 1).toList()
+        }
+
+        failure.droppedMessages shouldBeEqualTo 2L
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `invalid flow and push limits fail before handle creation`() {
+        val jetStream = mockk<JetStream>(relaxed = true)
+        val context = mockk<ConsumerContext>(relaxed = true)
+        val oversizedPush = pushSubscriptionOptions {
+            pendingMessageLimit(65_537)
+            pendingByteLimit(1024)
+        }
+        val oversizedBytesPush = pushSubscriptionOptions {
+            pendingMessageLimit(1)
+            pendingByteLimit(64L * 1024 * 1024 + 1)
+        }
+        val invalidPull = ConsumeOptions.builder().batchBytes(1).build()
+
+        assertFailsWith<IllegalArgumentException> {
+            jetStream.consumeAsFlow("events", capacity = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            context.consumeAsFlow(capacity = 1_025)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            context.consumeAsFlow(capacity = 1, receiveTimeout = 99.milliseconds)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            jetStream.consumeAsFlow("events", oversizedPush)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            jetStream.consumeAsFlow("events", oversizedBytesPush)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            context.consumeAsFlow(invalidPull)
+        }
+
+        jetStream.consumeAsFlow(
+            "events",
+            pushSubscriptionOptions {
+                pendingMessageLimit(65_536)
+                pendingByteLimit(64L * 1024 * 1024)
+            },
+            capacity = 1_024,
+            receiveTimeout = 100.milliseconds,
+        )
+        context.consumeAsFlow(capacity = 1_024, receiveTimeout = 100.milliseconds)
+
+        verify(exactly = 0) { jetStream.subscribe(any(), any<PushSubscribeOptions>()) }
+        verify(exactly = 0) { context.iterate(any<ConsumeOptions>()) }
+    }
+
+    @Test
+    fun `ordinary receive failure stays primary and cleanup failure is suppressed`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        val receiveFailure = IllegalStateException("receive failed")
+        val cleanupFailure = IllegalArgumentException("cleanup failed")
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returns 0
+        every { subscription.nextMessage(any<Duration>()) } throws receiveFailure
+        every { subscription.unsubscribe() } throws cleanupFailure
+
+        val failure = assertFailsWith<IllegalStateException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.message shouldBeEqualTo receiveFailure.message
+        verify(exactly = 1) { subscription.unsubscribe() }
+        receiveFailure.suppressed.map { it.message } shouldBeEqualTo listOf(cleanupFailure.message)
+        Unit
+    }
+
+    @Test
+    fun `pending limit readback failure preserves its cause`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        val readbackFailure = IllegalStateException("pending limit unavailable")
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } throws readbackFailure
+        every { subscription.droppedCount } returns 0
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<NatsConsumerFlowException> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.droppedMessages shouldBeEqualTo 0L
+        (failure.cause === readbackFailure).shouldBeTrue()
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `null receives continue while active and stop when handle finishes`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        val message = mockk<Message>()
+        every { context.iterate(any<ConsumeOptions>()) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } returnsMany listOf(null, message, null)
+        every { consumer.isStopped } returnsMany listOf(false, false, true)
+        every { consumer.isFinished } returns false
+        every { consumer.close() } just runs
+
+        val received = context.consumeAsFlow(capacity = 1).toList()
+
+        received shouldBeEqualTo listOf(message)
+        verify(exactly = 1) { consumer.close() }
+    }
+
+    @Test
+    fun `default push limits are finite and bounded`() {
+        (defaultNatsFlowPushOptions.pendingMessageLimit <= 1_024L).shouldBeTrue()
+        (defaultNatsFlowPushOptions.pendingByteLimit <= 16L * 1024 * 1024).shouldBeTrue()
+    }
+}

--- a/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
+++ b/infra/nats/src/test/kotlin/io/bluetape4k/nats/client/NatsConsumerFlowTest.kt
@@ -376,4 +376,74 @@ class NatsConsumerFlowTest {
         check(failure.cause == null || failure.cause === cancellation)
         verify(exactly = 1) { subscription.unsubscribe() }
     }
+
+    @Test
+    fun `push cleanup error preserves Error`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } returns 0
+        every { subscription.nextMessage(any<Duration>()) } returns null
+        every { subscription.isActive } returns false
+        every { subscription.unsubscribe() } throws AssertionError("unsubscribe failed")
+
+        val failure = assertFailsWith<AssertionError> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.message shouldBeEqualTo "unsubscribe failed"
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
+
+    @Test
+    fun `pull cleanup error preserves Error`() = runTest {
+        val context = mockk<ConsumerContext>()
+        val consumer = mockk<IterableConsumer>()
+        every { context.iterate(any<ConsumeOptions>()) } returns consumer
+        every { consumer.nextMessage(any<Duration>()) } returns null
+        every { consumer.isStopped } returns true
+        every { consumer.isFinished } returns false
+        every { consumer.close() } throws AssertionError("close failed")
+
+        val failure = assertFailsWith<AssertionError> {
+            context.consumeAsFlow().toList()
+        }
+
+        failure.message shouldBeEqualTo "close failed"
+        verify(exactly = 1) { consumer.close() }
+    }
+
+    @Test
+    fun `final pending readback Error is preserved`() = runTest {
+        val jetStream = mockk<JetStream>()
+        val subscription = mockk<JetStreamSubscription>()
+        val options = pushSubscriptionOptions {
+            pendingMessageLimit(8)
+            pendingByteLimit(1024)
+        }
+        var droppedReads = 0
+        every { jetStream.subscribe("events", options) } returns subscription
+        every { subscription.pendingMessageLimit } returns 8
+        every { subscription.pendingByteLimit } returns 1024
+        every { subscription.droppedCount } answers {
+            droppedReads += 1
+            if (droppedReads <= 3) 0 else throw AssertionError("drop readback failed")
+        }
+        every { subscription.nextMessage(any<Duration>()) } returns null
+        every { subscription.isActive } returns false
+        every { subscription.unsubscribe() } just runs
+
+        val failure = assertFailsWith<AssertionError> {
+            jetStream.consumeAsFlow("events", options).toList()
+        }
+
+        failure.message shouldBeEqualTo "drop readback failed"
+        verify(exactly = 1) { subscription.unsubscribe() }
+    }
 }

--- a/infra/nats/src/test/resources/compat/issue-1350/build.gradle.kts
+++ b/infra/nats/src/test/resources/compat/issue-1350/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    kotlin("jvm") version "2.4.0"
+    application
+}
+
+group = "io.bluetape4k.compat"
+version = "1.0.0"
+
+kotlin {
+    jvmToolchain(25)
+}
+
+application {
+    mainClass.set("NatsFlowPublishedConsumerKt")
+}
+
+dependencies {
+    implementation("io.github.bluetape4k:bluetape4k-nats:2.0.0")
+}

--- a/infra/nats/src/test/resources/compat/issue-1350/settings.gradle.kts
+++ b/infra/nats/src/test/resources/compat/issue-1350/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        val compatRepository = providers.gradleProperty("compatRepository")
+        if (compatRepository.isPresent) {
+            maven { url = uri(compatRepository.get()) }
+        }
+        mavenCentral()
+    }
+}
+
+rootProject.name = "issue-1350-published-consumer"

--- a/infra/nats/src/test/resources/compat/issue-1350/src/main/kotlin/NatsFlowPublishedConsumer.kt
+++ b/infra/nats/src/test/resources/compat/issue-1350/src/main/kotlin/NatsFlowPublishedConsumer.kt
@@ -1,0 +1,102 @@
+import io.bluetape4k.nats.client.consumeAsFlow
+import io.nats.client.ConsumerContext
+import io.nats.client.ConsumeOptions
+import io.nats.client.IterableConsumer
+import io.nats.client.JetStream
+import io.nats.client.JetStreamSubscription
+import io.nats.client.Message
+import io.nats.client.PushSubscribeOptions
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
+
+private class PublishedApiProbe {
+    val pushReceiveEntered = AtomicBoolean(false)
+    val pushClosed = AtomicBoolean(false)
+    val pullReceiveEntered = AtomicBoolean(false)
+    val pullClosed = AtomicBoolean(false)
+}
+
+fun main() = runBlocking {
+    val probe = PublishedApiProbe()
+    val pushSubscription = proxy<JetStreamSubscription> { method, _ ->
+        when (method.name) {
+            "getPendingMessageLimit" -> 1_024L
+            "getPendingByteLimit" -> 16L * 1024 * 1024
+            "getDroppedCount" -> 0L
+            "nextMessage" -> {
+                probe.pushReceiveEntered.set(true)
+                null
+            }
+            "isActive" -> true
+            "unsubscribe" -> {
+                probe.pushClosed.set(true)
+                Unit
+            }
+            else -> defaultValue(method.returnType)
+        }
+    }
+    val jetStream = proxy<JetStream> { method, _ ->
+        if (method.name == "subscribe") pushSubscription else defaultValue(method.returnType)
+    }
+
+    withTimeoutOrNull(2.seconds) {
+        jetStream.consumeAsFlow("events").take(1).collect { error("probe should not receive a message") }
+    }
+
+    val iterable = proxy<IterableConsumer> { method, _ ->
+        when (method.name) {
+            "nextMessage" -> {
+                probe.pullReceiveEntered.set(true)
+                null
+            }
+            "isStopped", "isFinished" -> false
+            "close" -> {
+                probe.pullClosed.set(true)
+                Unit
+            }
+            else -> defaultValue(method.returnType)
+        }
+    }
+    val consumerContext = proxy<ConsumerContext> { method, _ ->
+        if (method.name == "iterate") iterable else defaultValue(method.returnType)
+    }
+
+    withTimeoutOrNull(2.seconds) {
+        consumerContext.consumeAsFlow(ConsumeOptions.DEFAULT_CONSUME_OPTIONS).take(1)
+            .collect { error("probe should not receive a message") }
+    }
+
+    check(probe.pushReceiveEntered.get()) { "published push Flow did not enter receive" }
+    check(probe.pushClosed.get()) { "published push Flow did not clean up subscription" }
+    check(probe.pullReceiveEntered.get()) { "published pull Flow did not enter receive" }
+    check(probe.pullClosed.get()) { "published pull Flow did not clean up consumer" }
+}
+
+@Suppress("UNCHECKED_CAST")
+private inline fun <reified T> proxy(
+    crossinline handler: (Method, Array<out Any?>?) -> Any?,
+): T = Proxy.newProxyInstance(
+    T::class.java.classLoader,
+    arrayOf(T::class.java),
+    InvocationHandler { _, method, args -> handler(method, args) },
+) as T
+
+private fun defaultValue(type: Class<*>): Any? = when {
+    !type.isPrimitive -> null
+    type == Boolean::class.javaPrimitiveType -> false
+    type == Char::class.javaPrimitiveType -> '\u0000'
+    type == Byte::class.javaPrimitiveType -> 0.toByte()
+    type == Short::class.javaPrimitiveType -> 0.toShort()
+    type == Int::class.javaPrimitiveType -> 0
+    type == Long::class.javaPrimitiveType -> 0L
+    type == Float::class.javaPrimitiveType -> 0.0f
+    type == Double::class.javaPrimitiveType -> 0.0
+    else -> null
+}


### PR DESCRIPTION
## 요약

`#1350`의 NATS JetStream pull/push consumer를 cold `Flow<Message>`로 노출했습니다.
PR #1475의 정확한 head `3832154d5a5752d8a5406b461e2cbcb408a0bc13` 위에 쌓은 세 번째 train item입니다.

## 변경 사항

- `ConsumerContext.consumeAsFlow`와 `JetStream.consumeAsFlow` 공개 API 추가
- `capacity`, timeout, push pending limit, pull batchBytes를 사전 검증하고 bounded batch/backpressure 적용
- blocking receive를 `runInterruptible(Dispatchers.IO)`로 감싸 취소 시 interrupt하고 adapter가 만든 handle만 정리
- manual ack 계약 고정: adapter는 `ack`/`nak`/`term`을 호출하지 않으며 caller가 처리 결과를 결정
- pending queue drop/read-back 실패를 `NatsConsumerFlowException`으로 보고하고 cancellation·receive·cleanup 실패 우선순위와 suppressed 원인 보존
- NATS 단위 18개, Testcontainers 통합 5개, 실제 drop·nak·term·redelivery·취소 경계 검증 추가
- published-consumer compatibility fixture와 README/README.ko.md/KDoc/CHANGELOG 반영
- `search-messaging` CI lane에서 Elasticsearch와 NATS 테스트·Kover를 순차 실행하고 coverage manifest 연결

## 검증

- `NatsConsumerFlowTest`: 18 passing
- `NatsConsumerFlowIntegrationTest`: 5 passing
- 최신 Search & Messaging raw CI: Elasticsearch 41 passing (`BUILD SUCCESSFUL`), NATS 188 passing (`BUILD SUCCESSFUL`)
- `publication_pom_audit_test.rb`: 5 runs, 12 assertions, 0 failures
- `publication_module_metadata_audit_test.rb`: 6 runs, 16 assertions, 0 failures
- published-consumer fixture: `BUILD SUCCESSFUL` (직접 product dependency 1개)
- CI route/coverage tests: Python 25개, YAML/CSV/Kafka4 validator 통과
- search-messaging coverage 보강: Elasticsearch callback/PIT cleanup/argument 경계 테스트와 기본 옵션 경계가 포함된 Kover 282/333 lines covered
- Detekt는 변경 파일 신규 finding 없이 기존 예제·기존 확장 파일 baseline만 보고
- 최신 head `c0af65c223fef4ab877c3c77c1ab1cbd2fd04660`의 raw CI run `32584336385`은 22개 required job과 `CI Status`를 포함해 23개 job이 모두 success했습니다. `Coverage Report`는 Coveralls API 응답 `Job #32584336385.1` (`https://coveralls.io/jobs/186632820`)과 commit status `81.751%`를 read-back했습니다.

## 호환성과 위험

- 기존 NATS consumer API와 manual ack 의미를 유지하고, 신규 Flow API는 adapter가 만든 subscription/consumer handle만 정리합니다.
- push pending limit과 pull batch/bytes 검증으로 receiver가 보유한 메시지를 포함한 bounded backpressure를 보장하며, drop delta는 `NatsConsumerFlowException`으로 보고합니다.
- 테스트 컴파일러의 기존 `Expression is unused` 경고(line 240)는 JUnit discovery를 위한 명시적 `Unit` 표현 때문에 남아 있으며, 변경 파일 신규 Detekt finding은 없습니다.

## Stacked PR Train

- 선행 PR: #1475 (`fix/1360-suspend-jcache-cancellation`)
- 현재 base: `fix/1360-suspend-jcache-cancellation` @ `3832154d5a5752d8a5406b461e2cbcb408a0bc13`
- merge 전 head: `feat/1350-nats-consumer-flow` @ `c0af65c223fef4ab877c3c77c1ab1cbd2fd04660`
- merge commit: `0969966254aa2eb966cacada1c6b0b4692b69ea4`
- 후속 train item은 이 PR의 required raw CI 성공과 blocker 0 확인 뒤에만 진행합니다.

Closes #1350

## DoD Status

- [x] #1350 NATS JetStream pull/push cold Flow 공개 API와 manual ack 계약 구현
- [x] bounded backpressure, drop/read-back 진단, cancellation/cleanup 실패 우선순위 구현
- [x] NATS 단위 18개와 Testcontainers 통합 5개 통과
- [x] 최신 Search & Messaging raw CI에서 Elasticsearch 41개와 NATS 188개 테스트 및 NATS/Elasticsearch Kover 보고 성공
- [x] Elasticsearch coverage 회귀 경계와 기본 옵션 경계 테스트 통과, Kover 282/333 lines covered
- [x] publication POM/module metadata audit 및 published-consumer compatibility fixture 통과
- [x] Korean README/README.ko.md/KDoc/CHANGELOG와 CI route/coverage manifest 반영
- [x] 새 head `c0af65c223fef4ab877c3c77c1ab1cbd2fd04660` hosted required checks 재실행 및 Coveralls read-back: run `32584336385`, 23/23 jobs success, Coveralls job `186632820`, `coverage/coveralls`·`coverage/coveralls (push)` 모두 success (`81.751%`)
- [x] Issue #1350와 PR #1476 metadata read-back: assignee `debop`, labels 4개, milestone `2.0.0`
- [x] 사용자 merge 승인 및 exact-head merge 완료: merge commit `0969966254aa2eb966cacada1c6b0b4692b69ea4`
