### PR TITLE
[cache][성능] #1474 bounded admission 설계 기준 고정

### DIFF
--- a/docs/review/2026-08-23-issue-1474-bounded-admission-plan-review.md
+++ b/docs/review/2026-08-23-issue-1474-bounded-admission-plan-review.md
@@ -1,0 +1,122 @@
+# #1474 bounded admission 구현 계획 검토
+
+## 검토 범위와 기준
+
+- 대상 계획: `docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md`
+- 기준 설계: `docs/superpowers/specs/2026-08-23-issue-1474-bounded-admission-design.md`
+- 설계 검토: `docs/review/2026-08-23-issue-1474-bounded-admission-spec-review.md`
+- 저장소 규칙: `AGENTS.md`, `bluetape-workflow`, `bluetape-full-feature`,
+  `bluetape-kotlin-patterns`, `kotlin-coroutines-skill`
+- 검토 방식: Performance, Stability, Security, Operator/Ops, Developer/API,
+  User/Caller 여섯 관점과 main-session 통합
+
+## 통합 판정
+
+| 우선순위 | 관점 | 근거 | 조치 | 재검토 |
+| --- | --- | --- | --- | --- |
+| P0 | 전체 | 승인 설계의 범위, 비범위, 중지 조건이 계획에 반영됨 | 없음 | main 통합 완료 |
+| P1 | 전체 | 구현 순서가 worktree → RED → GREEN → module gate → static/API → review/commit → verification으로 닫힘 | 없음 | main 통합 완료 |
+| P2 | Performance | admission 이전에 batch 사본을 만드는 기존 의미를 유지하므로 overflow에서도 entry 사본 할당은 발생함 | payload 크기 상한은 이번 범위 밖으로 고정하고, finite burst에서 child 수·accepted 호출 수만 측정 | Task 2, 6 |
+| P2 | Stability | `CoroutineStart.LAZY`가 시작되지 않는 close/취소 경로에서 permit이 stranded될 수 있음 | 취소된 scope의 두 callback 테스트로 `job.start() == false` caller-side release를 결정적으로 검증하도록 계획 보강 | Task 2 Step 4 |
+| P2 | Stability | child의 일반 예외와 `CancellationException`은 서로 다른 sibling/lifecycle 의미를 가짐 | 일반 예외 sibling 격리 테스트를 별도 단계로 추가하고 기존 cancellation 테스트와 분리 | Task 2 Step 3, 5 |
+| P2 | Security | overflow log가 raw key/value/source를 포함하면 기존 redaction 계약을 깨뜨림 | `maxInFlightCallbacks = 1`의 포화 callback에 secret token을 넣고 operation/cache id/cap만 남는지 검증 | Task 2 Step 6 |
+| P2 | Operator/Ops | public metric 또는 runtime tuning surface가 없으면 overflow 규모를 운영 중 직접 계측할 수 없음 | 승인 설계대로 sanitized debug log만 제공하고 metric backend·public configuration은 별도 후속 범위로 유지 | Task 3, 6 |
+| P2 | Developer/API | public one-argument constructor와 provider registration을 건드리면 누적 train의 ABI 경계가 흔들림 | cap은 top-level private 기본값과 `@JvmSynthetic internal forTest`에만 두고, `javap` 및 near-cache contract gate를 실행 | Task 3–5 |
+| P2 | User/Caller | overflow가 durable delivery로 오해될 수 있음 | Korean KDoc에 non-blocking admission, 기본 cap 64, 즉시 거부, close 무대기 의미를 명시하고 README 변경은 N/A로 기록 | Task 3, 5 |
+
+## 여섯 관점별 확인
+
+### Performance
+
+- `tryAcquire()`만 callback thread의 admission 경로에 두고 suspend 또는 내부 queue를
+  추가하지 않는다.
+- listener별 child job 상한을 injected cap으로 검증하며, batch 내부 entry 수에 새 제한을
+  추가하지 않는다.
+- `runBlocking`, `Thread.sleep`, 전역 scope, blocking join/drain을 금지하는 source scan이
+  Task 6에 있다.
+- payload 할당량 benchmark는 승인 설계의 비범위이며, 이 판단을 P2 disposition으로
+  기록했다.
+
+### Stability
+
+- `finally` permit 반환, `CancellationException` 재전파, `SupervisorJob` sibling 격리,
+  `close()`의 cancel-only 동작을 각각 테스트한다.
+- 취소된 scope 테스트가 lazy child 미시작 경로를 덮어 close 경쟁에서의 이중 반환과
+  permit 고갈을 구분한다.
+- Testcontainers 변경은 없고, full module test는 저장소의 순차 실행 규칙을 따른다.
+
+### Security
+
+- 기존 trace/error log와 새 overflow debug log 모두 sanitized cache id와 operation 같은
+  low-cardinality 값만 기록한다.
+- secret key/value/source token 부재를 `ListAppender`로 검증하며 event payload의
+  `toString()`을 로그에 넣지 않는다.
+
+### Operator/Ops
+
+- overflow는 조용한 성공으로 포장하지 않고 debug log로 관찰 가능하게 한다.
+- metric backend, public cap tuning, release/dispatch는 범위 밖이며 계획의 N/A와
+  explicit exclusions에 기록되어 있다.
+- 실패 시 구현 commit만 branch-local revert하고 `develop`은 변경하지 않는 rollback이
+  Task 8에 있다.
+
+### Developer/API
+
+- 기존 source의 `EventCopy`, `associate`, `LinkedHashSet`, `applyEvent` 경계를 유지한다.
+- cap 검증은 양수 조건을 요구하고, public JVM constructor descriptor는 `javap`로
+  확인한다.
+- near-cache 등록 코드는 수정하지 않고 기존 registration/back-first contract test를
+  실행한다.
+- 새 dependency/module/catalog 등록이 없고 기존 local `Semaphore` 사용 패턴과 맞는다.
+
+### User/Caller
+
+- 기본 64는 내부 정책이며 caller가 조정할 수 있는 public API가 아니다.
+- 포화 callback은 best-effort listener의 명시적 거부이며 durable delivery가 아님을
+  KDoc과 설계 문서에서 설명한다.
+- public usage 예제와 README는 API 변경이 없으므로 변경하지 않는다.
+
+## Step 3-R 필수 조건 확인
+
+| 조건 | 판정 | 계획 근거 |
+| --- | --- | --- |
+| 모든 설계 수용 기준의 concrete task 매핑 | PASS | Task 2–6 및 Task 8 최종 DoD |
+| 실행 가능한 task 순서 | PASS | worktree 생성 후 RED에서 test seam을 추가하고 GREEN에서 source를 변경 |
+| 후속 산출물에 대한 선행 의존성 없음 | PASS | review/commit과 verification worktree는 implementation head 이후에 실행 |
+| 성공·실패·edge·concurrency·coroutine·lifecycle·backend 경로 | PASS | listener tests, cancellation/close/race, near-cache registration contract |
+| 구체적인 검증 명령 | PASS | `repo-test-summary`, `detekt`, `build`, `javap`, `git diff --check`, terminology audit |
+| README/KDoc 및 localized 문서 판단 | PASS | KDoc 수정, README/localized README N/A 근거 기록 |
+| 모듈/BOM/CI/coverage/Testcontainers 판단 | PASS | module/dependency/catalog/CI/Kover/container 변경 N/A, full module gate 실행 |
+| cancellation/dispatcher 경계 | PASS | `scope.launch`, `SupervisorJob`, `CancellationException`, cancel-only close |
+| 성능·안정성 및 자원 정리 | PASS | cap/count barrier, permit release 두 경로, blocking 금지 source scan |
+| rollback·compatibility·migration | PASS | ABI/provider gate와 branch-local revert, reapproval 중지 조건 |
+
+## 수정 및 재검토 이력
+
+main-session 통합에서 다음 계획 결함을 즉시 보완했다.
+
+1. plan의 writer audit 경로 오탈자와 trailing whitespace를 실제 설치 경로로 수정했다.
+2. overflow-redaction 테스트의 cap을 `1`로 명시하여 두 번째 callback이 실제로
+   overflow되는 조건을 고정했다.
+3. 일반 예외가 sibling을 취소하지 않는 회귀 테스트를 추가했다.
+4. 취소된 scope에서 lazy child가 시작되지 않는 경로의 caller-side permit 반환 테스트를
+   추가했다.
+
+수정 후 plan은 placeholder/path scan, `git diff --check`, Korean terminology audit를
+통과했다. P0=0, P1=0이며 P2는 위 표의 범위·검증 조치로 모두 처분되었다.
+
+## 결론
+
+계획은 구현에 전달할 수 있다. 다음 단계는 `feat/issue-1474-bounded-admission`
+worktree를 정확한 plan head에서 만들고, 계획된 RED 테스트를 먼저 실행하는 것이다.
+PR 생성과 merge는 이 검토의 범위가 아니며 fresh authority와 별도 exact-head 승인이
+필요하다.
+
+### 검토 DoD
+
+- [x] 여섯 관점 검토 및 main-session 통합
+- [x] P0/P1 없음
+- [x] P2 처분 및 계획 반영
+- [x] 설계 수용 기준과 verification command 매핑
+- [x] rollback, ABI, provider registration, README/KDoc 경계 확인
+- [x] plan self-review, diff check, Korean terminology audit

--- a/docs/review/2026-08-23-issue-1474-bounded-admission-spec-review.md
+++ b/docs/review/2026-08-23-issue-1474-bounded-admission-spec-review.md
@@ -1,0 +1,75 @@
+# #1474 bounded admission 설계 spec review
+
+## 검토 범위와 근거
+
+- 대상 artifact: `docs/superpowers/specs/2026-08-23-issue-1474-bounded-admission-design.md`
+- 기준 commit: `6e993fd74`
+- live authority: [bluetape4k-projects #1474](https://github.com/bluetape4k/bluetape4k-projects/issues/1474)
+- local evidence: `SuspendJCacheEntryEventListener.kt`,
+  `SuspendJCacheEntryEventListenerTest.kt`, `SuspendNearJCache.kt`
+- baseline: `SuspendJCacheEntryEventListenerTest` 12 passing
+- review method: performance, stability, security, operator/Ops, developer/API,
+  user/caller six lenses와 main-session integration
+
+## Six-lens 결과
+
+| Priority | Lens | Evidence | Required edit / disposition | Rerun |
+| --- | --- | --- | --- | --- |
+| P2 | performance | 선택 설계의 `Semaphore.tryAcquire()`는 callback job 수를 cap으로 제한하지만 callback iterable 사본 생성과 batch 내부 entry 수는 제한하지 않는다. | spec의 “batch 내부 entry 수에는 새 상한을 추가하지 않는다”와 중지 조건으로 범위를 명시했다. payload-size bound는 별도 후속 설계로 남긴다. | main integration에서 범위 문구 재확인 |
+| P2 | stability | `close()`와 permit 획득/`scope.launch`가 경쟁할 수 있고 close 시 accepted job 완료를 보장하지 않는다. | #1360 cooperative cancellation 계약과 `finally` permit 반환을 명시했다. 구현 plan에서 launch 전후 permit 누수와 close race 테스트를 구체화한다. | stability plan lane |
+| P3 | security | overflow/기존 callback log에 raw key/value/source를 넣지 않아 payload 노출면을 줄인다. | 추가 수정 없음. log appender redaction 검증을 plan에 유지한다. | security plan lane |
+| P2 | operator/Ops | public metric API를 추가하지 않아 overflow rate를 metric으로 수집하지 않는다. | 이번 issue는 admission 계약과 결정적 검증 범위다. sanitized debug log를 운영 신호로 문서화하고 metric backend는 비범위로 유지한다. | operator plan lane |
+| P2 | developer/API | public constructor와 provider registration은 유지되지만 `forTest` cap 주입은 internal API다. | `@JvmSynthetic internal` test seam과 positive-cap validation을 plan에 고정한다. public API/ABI gate를 추가한다. | developer/API plan lane |
+| P2 | user/caller | cap 초과 callback은 거부되므로 listener는 durable delivery가 아니다. default `64`는 public tuning API 없이 고정된다. | best-effort/overflow 경계와 별도 durable delivery 설계를 spec에 명시했다. KDoc에 caller-facing caveat를 추가한다. | user/caller plan lane |
+
+## Main-session integration
+
+### Contradiction check
+
+- `accepted`는 `tryAcquire()` 성공으로 정의하고, close race에서는 완료가 아닌
+  cooperative cancellation을 우선한다. 따라서 “accepted event 무손실”은 close가
+  개입하지 않은 정상 drain 구간의 정확한 한 번의 apply 시도로 해석한다.
+- 대안 A는 queue를 만들지 않으므로 queueing proof는 queue depth `0`과 in-flight
+  child bound로 검증한다. 대안 C의 worker cancellation 문제를 다시 도입하지
+  않는다.
+- `targetCache.isClosed()` rejection과 semaphore overflow rejection은 서로 다른
+  경계이며, 두 경우 모두 JCache callback에는 예외를 반환하지 않는다.
+
+### Coverage check
+
+- 범위/비범위: PASS
+- alternatives와 선택 근거: PASS
+- linearization/overflow/event semantics: PASS
+- cancellation/close/ordinary exception: PASS
+- failure modes: PASS, 6개
+- compatibility/ABI/provider registration: PASS
+- deterministic tests와 validation commands: PASS
+- docs/KDoc/PR/merge side-effect boundary: PASS
+
+### Severity verdict
+
+P0=0, P1=0. P2 5건은 모두 선택 범위와 후속 검증 작업으로 disposition했으며,
+P3 1건은 추가 수정 없이 pass다. 구현은 spec 의미를 바꾸지 않는 범위에서
+계속할 수 있다.
+
+## Writer gate
+
+- SPW-01: PASS — cache-core maintainer/reviewer audience, #1474 outcome, live issue,
+  source paths, baseline, exclusions와 unknowns를 고정했다.
+- SPW-02: PASS — spec contract와 review contract가 각각 문제·대안·경계·실패
+  모드·호환성·수용 기준·DoD와 finding disposition을 포함한다.
+- SPW-03: PASS — Korean technical register와 identifier/code token 보존을
+  적용했고 `audit-korean-terms.mjs` 결과 findings=0이다.
+- SPW-04: PASS — source path, issue URL, baseline command, constructor,
+  registration, exception/불변 사본 근거를 현재 artifact와 대조했다.
+- SPW-05: PASS — 최종 Markdown read-back, heading/table/list/code formatting,
+  P0/P1 verdict와 remaining P2 disposition을 확인했다.
+
+## Step DoD
+
+- [x] six-lens review 수행
+- [x] main integration으로 중복·모순·근거·범위 확인
+- [x] P0=0, P1=0
+- [x] P2/P3 disposition 기록
+- [x] writer SPW-01..05 기록
+- [x] 구현 전 승인된 설계와 exact stop condition 확인

--- a/docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md
+++ b/docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md
@@ -146,7 +146,16 @@ module, dependency, registration, or container behavior changes.
   This proves `finally { admission.release() }` rather than only checking a job
   status.
 
-- [ ] **Step 4: Add ordinary-exception sibling isolation.**
+- [ ] **Step 4: Prove the lazy close-before-start permit release.**
+
+  Create the listener with a cancelled `SupervisorJob` in its scope and
+  `maxInFlightCallbacks = 1`. Submit two callbacks while capturing the
+  sanitized overflow logger. Both lazy jobs must fail to start, neither backend
+  operation may run, and the second submission must not emit an admission-full
+  log. This deterministically exercises the `job.start() == false` branch and
+  proves that the caller-side release does not strand the permit.
+
+- [ ] **Step 5: Add ordinary-exception sibling isolation.**
 
   Configure `maxInFlightCallbacks = 2`. Make the first `putAll` throw a regular
   `IllegalStateException` and the second `putAll` complete a deferred. Submit
@@ -155,7 +164,7 @@ module, dependency, registration, or container behavior changes.
   operation and sanitized cache id. This preserves the existing broad-exception
   isolation contract while the semaphore permit is returned.
 
-- [ ] **Step 5: Add deterministic close and overflow-redaction cases.**
+- [ ] **Step 6: Add deterministic close and overflow-redaction cases.**
 
   - Use `maxInFlightCallbacks = 2`, eight `awaitCancellation()` callbacks, and
     a barrier that completes after two callbacks start. Assert the listener job
@@ -170,7 +179,7 @@ module, dependency, registration, or container behavior changes.
   The RED result must either lack an overflow log or show the old unbounded
   second child; no timing sleeps are allowed.
 
-- [ ] **Step 6: Run only the new tests to verify RED.**
+- [ ] **Step 7: Run only the new tests to verify RED.**
 
   Run from the implementation worktree:
 

--- a/docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md
+++ b/docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md
@@ -223,8 +223,8 @@ module, dependency, registration, or container behavior changes.
 
   Validate `maxInFlightCallbacks > 0` with `require` before constructing the
   `Semaphore`, then create `private val admission = Semaphore(maxInFlightCallbacks)`.
-  Import only `kotlinx.coroutines.sync.Semaphore` and the coroutine start type
-  needed by the lazy-start release guard; add no dependency.
+  Import `io.bluetape4k.logging.debug`, `kotlinx.coroutines.CoroutineStart`, and
+  `kotlinx.coroutines.sync.Semaphore`; add no dependency.
 
 - [ ] **Step 2: Add the submit helper with explicit close and permit-race handling.**
 
@@ -352,15 +352,17 @@ insufficient to prove the unchanged registration contract.
   ```bash
   jar_path=$(find cache/cache-core/build/libs -maxdepth 1 \
     -name 'bluetape4k-cache-core-*.jar' ! -name '*sources*' ! -name '*javadoc*' \
+    ! -name '*test-fixtures*' \
     | head -1)
   test -n "$jar_path"
   javap -classpath "$jar_path" \
     io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListener \
-    | rg 'public io\.bluetape4k\.cache\.jcache\.SuspendJCacheEntryEventListener'
+    | rg '^  public .*SuspendJCacheEntryEventListener\(io\.bluetape4k\.cache\.jcache\.SuspendJCache<.*>\);$'
   ```
 
-  Expected: the one-argument public constructor remains present; no public
-  capacity constructor or public metrics type appears.
+  Expected: exactly the one-argument public constructor remains present. Kotlin's
+  synthetic `DefaultConstructorMarker` bridge is ignored by the exact signature
+  filter; no public capacity constructor or public metrics type appears.
 
 - [ ] **Step 3: Run source/documentation hygiene checks.**
 

--- a/docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md
+++ b/docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md
@@ -1,0 +1,473 @@
+# #1474 bounded admission Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `test-driven-development` and the matching Kotlin/domain skills. Execute the checked steps in order and keep each RED/GREEN result as evidence.
+
+**Goal:** `SuspendJCacheEntryEventListener`가 callback burst에서 listener별 in-flight job 수를 bounded non-blocking admission으로 제한하고, accepted event·overflow·close cancellation 계약을 결정적으로 검증하도록 만든다.
+
+**Architecture:** 기존 callback별 child fan-out을 유지하되 listener 내부 `Semaphore` permit으로 admission을 선형화한다. `tryAcquire()` 성공 callback만 `scope.launch`를 만들고, 포화 callback은 queue/coalescing 없이 즉시 거부한다. child `finally`에서 permit을 반환하고 `close()`는 기존처럼 `scope.cancel()`만 호출한다.
+
+**Tech Stack:** Kotlin 2.4, kotlinx.coroutines `Semaphore`, `CoroutineScope`, `SupervisorJob`, `kotlinx-coroutines-test`, JUnit 5, MockK, bluetape4k assertions, Gradle 9.7.0.
+
+---
+
+## 승인된 근거와 공통 경계
+
+- Spec: `docs/superpowers/specs/2026-08-23-issue-1474-bounded-admission-design.md`
+- Spec review: `docs/review/2026-08-23-issue-1474-bounded-admission-spec-review.md`
+- Issue: [#1474](https://github.com/bluetape4k/bluetape4k-projects/issues/1474)
+- Base: `origin/develop` at `f7c1cf1bb9da7ea2d6811f2833582ab0f434d15d`
+- Spec branch: `feat/issue-1474-spec`
+- Implementation branch/worktree: `feat/issue-1474-bounded-admission`
+- Verification branch/worktree: `feat/issue-1474-verification`
+- Public contract to preserve: `SuspendJCacheEntryEventListener(SuspendJCache<K, V>)`
+  JVM descriptor, #1360 cancellation propagation, immutable event copy,
+  event-kind invalidation semantics, sanitized logs, and
+  `SuspendNearJCache` provider registration.
+- Explicit exclusions: public capacity configuration, coalescing, global ordering,
+  new dependency/module, Testcontainers changes, release/tag/publish/merge.
+
+## File map
+
+| File | Responsibility | Planned change |
+| --- | --- | --- |
+| `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt` | JCache callback admission, event copy, lifecycle, target-cache apply | Add private bounded `Semaphore`, internal test-only cap injection, submit helper, overflow log, Korean KDoc update; preserve public constructor and event operations. |
+| `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt` | Deterministic listener behavior proof | Replace unbounded 1,000-child characterization with bounded finite-burst tests; add overflow/redaction, permit-return, positive-cap validation, and close race cases; retain all #1360 tests. |
+| `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheContractTest.kt` | Provider registration lifecycle contract | Read-only review and targeted execution; modify only if the existing assertion cannot prove registration remains unchanged. |
+| `docs/superpowers/specs/2026-08-23-issue-1474-bounded-admission-design.md` | Approved design source | No implementation edits; reopen only if a P0/P1 or factual drift requires reapproval. |
+| `docs/review/2026-08-23-issue-1474-bounded-admission-spec-review.md` | Six-lens spec review evidence | Append only if plan/implementation evidence changes the spec verdict. |
+
+README, localized README, module registration, BOM/catalog, CI workflow, Kover
+configuration, and Testcontainers fixtures are scoped N/A: no public API surface,
+module, dependency, registration, or container behavior changes.
+
+## Task 1: Prepare implementation worktree and record risk controls
+
+**Files:** no tracked source change.
+
+- [ ] **Step 1: Create the implementation worktree from the committed spec branch.**
+
+  Run from the canonical repository worktree:
+
+  ```bash
+  git worktree add -b feat/issue-1474-bounded-admission \
+    .worktrees/feat/issue-1474-bounded-admission feat/issue-1474-spec
+  ```
+
+  Expected: new linked worktree is on `feat/issue-1474-bounded-admission`, its
+  HEAD equals the spec branch HEAD, and canonical `develop` remains clean.
+
+- [ ] **Step 2: Re-read authority and record the concurrency risk checklist.**
+
+  In the implementation worktree, re-read the applicable `AGENTS.md` files,
+  `bluetape-workflow` common gates, `bluetape-kotlin-patterns`,
+  `references/testing.md`, `kotlin-coroutines-skill`, and this plan. Record these
+  controls before editing:
+
+  1. `tryAcquire()` never suspends the JCache callback thread.
+  2. A permit is released on normal completion, ordinary exception, and child
+     cancellation; a lazy job that cannot start releases its permit explicitly.
+  3. `CancellationException` is rethrown before broad `Exception` handling.
+  4. `close()` calls `scope.cancel()` without join/drain.
+  5. The public constructor and listener registration are unchanged.
+
+  Expected: clean feature worktree, no unrelated dirty paths, and a written
+  implementation risk note in the workflow evidence.
+
+## Task 2: RED — add bounded admission and lifecycle tests before production edits
+
+**Files:**
+
+- Modify: `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt`
+
+- [ ] **Step 1: Add the positive-cap test seam expectation.**
+
+  Add a test that calls:
+
+  ```kotlin
+  assertFailsWith<IllegalArgumentException> {
+      SuspendJCacheEntryEventListener.forTest(
+          targetCache = targetCache,
+          scope = listenerScope,
+          maxInFlightCallbacks = 0,
+      )
+  }
+  ```
+
+  Use `io.bluetape4k.assertions.assertFailsWith`, not JUnit or Kotlin test
+  `assertFailsWith`. The expected RED failure is that `forTest` does not yet
+  accept `maxInFlightCallbacks`.
+
+- [ ] **Step 2: Replace the unbounded 1,000-child characterization with a bounded burst test.**
+
+  Rename the test to
+  ``bounded admission은 callback job 수와 accepted operation 수를 제한한다``
+  and use this setup:
+
+  ```kotlin
+  val maxInFlight = 2
+  val callbackCount = 8
+  val startedCount = AtomicInteger()
+  val allStarted = CompletableDeferred<Unit>()
+  val release = CompletableDeferred<Unit>()
+  coEvery { targetCache.putAll(any()) } coAnswers {
+      if (startedCount.incrementAndGet() == maxInFlight) {
+          allStarted.complete(Unit)
+      }
+      release.await()
+  }
+  val listener = SuspendJCacheEntryEventListener.forTest(
+      targetCache = targetCache,
+      scope = listenerScope,
+      maxInFlightCallbacks = maxInFlight,
+  )
+  repeat(callbackCount) { index ->
+      listener.onCreated(mutableListOf(mockEvent("burst-$index", "value", EventType.CREATED)))
+  }
+  runCurrent()
+  allStarted.await()
+  listenerJob.children.toList().size.shouldBeEqualTo(maxInFlight)
+  release.complete(Unit)
+  runCurrent()
+  coVerify(exactly = maxInFlight) { targetCache.putAll(any()) }
+  listener.close()
+  ```
+
+  The test must assert that only two callbacks are accepted and applied once,
+  while six overflow callbacks do not create child jobs. The RED result must be
+  the old implementation creating eight children and eight calls.
+
+- [ ] **Step 3: Add a permit-return test for child cancellation.**
+
+  Configure `maxInFlightCallbacks = 1`. The first `putAll` completes its
+  `started` deferred and then completes exceptionally with
+  `CancellationException`. After `runCurrent()` observes the first child
+  cancellation, submit a second created event whose `putAll` completes a second
+  deferred. Assert the second event runs and `coVerify(exactly = 2)` succeeds.
+  This proves `finally { admission.release() }` rather than only checking a job
+  status.
+
+- [ ] **Step 4: Add ordinary-exception sibling isolation.**
+
+  Configure `maxInFlightCallbacks = 2`. Make the first `putAll` throw a regular
+  `IllegalStateException` and the second `putAll` complete a deferred. Submit
+  both events before `runCurrent()`, then assert the second operation completes,
+  the listener scope remains active, and the error log contains only the
+  operation and sanitized cache id. This preserves the existing broad-exception
+  isolation contract while the semaphore permit is returned.
+
+- [ ] **Step 5: Add deterministic close and overflow-redaction cases.**
+
+  - Use `maxInFlightCallbacks = 2`, eight `awaitCancellation()` callbacks, and
+    a barrier that completes after two callbacks start. Assert the listener job
+    has two children, call `close()` without joining in the production path, and
+    then join only in the test to assert both children are cancelled.
+  - Attach a `ListAppender<ILoggingEvent>` at `TRACE`, configure
+    `maxInFlightCallbacks = 1`, block the first callback with
+    `awaitCancellation()`, submit a second callback containing secret key,
+    value, and source tokens, and assert the overflow log contains only
+    operation/cache id/cap and none of those raw tokens.
+
+  The RED result must either lack an overflow log or show the old unbounded
+  second child; no timing sleeps are allowed.
+
+- [ ] **Step 6: Run only the new tests to verify RED.**
+
+  Run from the implementation worktree:
+
+  ```bash
+  repo-test-summary -- ./gradlew :bluetape4k-cache-core:test \
+    --tests 'io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListenerTest' \
+    --rerun-tasks
+  ```
+
+  Expected: compilation may fail until the test seam exists, or the new tests
+  fail with the old unbounded behavior. Do not edit production code until the
+  failure is attributable to the missing bounded admission behavior.
+
+## Task 3: GREEN — implement the smallest bounded admission change
+
+**Files:**
+
+- Modify: `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt`
+
+- [ ] **Step 1: Add the private admission state and test-only constructor seam.**
+
+  Preserve the public constructor delegation and add an internal-only parameter:
+
+  ```kotlin
+  private const val DEFAULT_MAX_IN_FLIGHT_CALLBACKS = 64
+
+  private constructor(
+      private val targetCache: SuspendJCache<K, V>,
+      private val scope: CoroutineScope,
+      private val maxInFlightCallbacks: Int,
+      @Suppress("UNUSED_PARAMETER") marker: Unit,
+  ) : ...
+
+  constructor(targetCache: SuspendJCache<K, V>) : this(
+      targetCache,
+      CoroutineScope(SupervisorJob() + Dispatchers.IO),
+      DEFAULT_MAX_IN_FLIGHT_CALLBACKS,
+      Unit,
+  )
+  ```
+
+  Validate `maxInFlightCallbacks > 0` with `require` before constructing the
+  `Semaphore`, then create `private val admission = Semaphore(maxInFlightCallbacks)`.
+  Import only `kotlinx.coroutines.sync.Semaphore` and the coroutine start type
+  needed by the lazy-start release guard; add no dependency.
+
+- [ ] **Step 2: Add the submit helper with explicit close and permit-race handling.**
+
+  Replace the four repeated `scope.launch` blocks with one helper equivalent to:
+
+  ```kotlin
+  private fun submit(operation: String, block: suspend () -> Unit) {
+      if (!shouldAcceptCallback()) return
+      if (!admission.tryAcquire()) {
+          log.debug {
+              "Reject callback because admission is full. " +
+                  "operation=$operation cache=$cacheIdentifier maxInFlight=$maxInFlightCallbacks"
+          }
+          return
+      }
+      if (!shouldAcceptCallback()) {
+          admission.release()
+          return
+      }
+
+      val job = scope.launch(start = CoroutineStart.LAZY) {
+          try {
+              if (!closed.get()) {
+                  applyEvent(operation, block)
+              }
+          } finally {
+              admission.release()
+          }
+      }
+      if (!job.start()) {
+          admission.release()
+      }
+  }
+  ```
+
+  `CoroutineStart.LAZY` plus `Job.start()` handles the close-before-start race:
+  a job that never starts cannot execute `finally`, so the caller releases its
+  permit when `start()` returns `false`. A started job releases exactly once in
+  `finally`. Keep `CancellationException` handling inside the existing
+  `applyEvent` unchanged.
+
+- [ ] **Step 3: Route each callback through `submit` without changing snapshots.**
+
+  Keep the synchronous copy and trace log exactly before admission:
+
+  ```kotlin
+  val eventCopies = events.map { EventCopy(it.key, it.value) }
+  log.trace { "BackCache cache entry created. cache=$cacheIdentifier count=${eventCopies.size}" }
+  submit("put all created cache entries") {
+      targetCache.putAll(eventCopies.associate { it.key to it.value })
+  }
+  ```
+
+  Apply the same shape to updated, removed, and expired. Removed/expired must
+  keep `toCollection(LinkedHashSet())`; created/updated must keep `associate`.
+  `shouldAcceptCallback()` remains the pre-admission `closed` and target-cache
+  check, and no event payload is added to any log.
+
+- [ ] **Step 4: Extend the internal test factory and Korean KDoc.**
+
+  Add `maxInFlightCallbacks: Int = DEFAULT_MAX_IN_FLIGHT_CALLBACKS` to the
+  `@JvmSynthetic internal forTest` factory only. Update the class KDoc to state
+  that callback admission is non-blocking, the default cap is `64` in-flight
+  callback jobs, overflow is rejected without an internal queue, and `close()`
+  requests cancellation without waiting. Do not add a public configuration
+  parameter or change the example registration code.
+
+- [ ] **Step 5: Run the focused tests to verify GREEN.**
+
+  ```bash
+  repo-test-summary -- ./gradlew :bluetape4k-cache-core:test \
+    --tests 'io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListenerTest' \
+    --rerun-tasks
+  ```
+
+  Expected: every existing #1360 test plus the new bounded admission, permit
+  return, close, and redaction tests pass. If the result flakes, stop and
+  diagnose coroutine scheduling or mock synchronization before changing the
+  assertions.
+
+## Task 4: Verify provider registration and module behavior
+
+**Files:** no expected source change; modify only if an existing assertion is
+insufficient to prove the unchanged registration contract.
+
+- [ ] **Step 1: Run listener and provider contract tests sequentially.**
+
+  ```bash
+  repo-test-summary -- ./gradlew :bluetape4k-cache-core:test \
+    --tests 'io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListenerTest' \
+    --tests 'io.bluetape4k.cache.nearcache.jcache.NearJCacheContractTest' \
+    --tests 'io.bluetape4k.cache.nearcache.jcache.SuspendNearJCacheBackFirstContractTest' \
+    --rerun-tasks
+  ```
+
+  Expected: listener tests and registration/back-first contract tests pass with
+  the same listener factory path and no registration diff.
+
+- [ ] **Step 2: Run the complete affected module test before coverage.**
+
+  ```bash
+  repo-test-summary -- ./gradlew :bluetape4k-cache-core:test --rerun-tasks
+  ```
+
+  Expected: `BUILD SUCCESSFUL`; any Testcontainers-backed task is kept
+  sequential and diagnosed from raw output rather than treated as skipped
+  success.
+
+## Task 5: Static, API, and source-contract verification
+
+**Files:** no expected source change.
+
+- [ ] **Step 1: Run Kotlin static analysis and module build.**
+
+  ```bash
+  repo-test-summary -- ./gradlew :bluetape4k-cache-core:detekt --rerun-tasks
+  repo-test-summary -- ./gradlew :bluetape4k-cache-core:build -x test --rerun-tasks
+  ```
+
+  Expected: both commands pass without new detekt findings or compilation
+  warnings that hide a lifecycle problem.
+
+- [ ] **Step 2: Prove the public constructor descriptor is unchanged.**
+
+  ```bash
+  jar_path=$(find cache/cache-core/build/libs -maxdepth 1 \
+    -name 'bluetape4k-cache-core-*.jar' ! -name '*sources*' ! -name '*javadoc*' \
+    | head -1)
+  test -n "$jar_path"
+  javap -classpath "$jar_path" \
+    io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListener \
+    | rg 'public io\.bluetape4k\.cache\.jcache\.SuspendJCacheEntryEventListener'
+  ```
+
+  Expected: the one-argument public constructor remains present; no public
+  capacity constructor or public metrics type appears.
+
+- [ ] **Step 3: Run source/documentation hygiene checks.**
+
+  ```bash
+  git diff --check
+  node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+    cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt \
+    cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
+  ```
+
+  Use the installed path `/Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs`. Expected: diff check clean and terminology findings either zero or explicitly dispositioned in the final review. No README parity task is required because public usage/API is unchanged.
+
+## Task 6: Performance/stability scan and final review
+
+**Files:**
+
+- Review: implementation source/test diff and approved spec/plan.
+- Create if needed: `docs/review/2026-08-23-issue-1474-bounded-admission-code-review.md`
+
+- [ ] **Step 1: Inspect the scoped diff and run the performance/stability checklist.**
+
+  Confirm all of the following from source and tests:
+
+  - no `runBlocking`, `GlobalScope`, blocking wait, or `Thread.sleep` was added;
+  - `tryAcquire()` is the only admission wait point and never suspends;
+  - max child jobs never exceed the injected cap;
+  - lazy-start close race releases a permit exactly once;
+  - ordinary exceptions do not cancel sibling children;
+  - `CancellationException` remains visible to the child job;
+  - no raw payload enters logs;
+  - no public constructor, registration, module, dependency, or README drift.
+
+- [ ] **Step 2: Run final targeted proof after any review repair.**
+
+  ```bash
+  repo-test-summary -- ./gradlew :bluetape4k-cache-core:test \
+    --tests 'io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListenerTest' \
+    --tests 'io.bluetape4k.cache.nearcache.jcache.NearJCacheContractTest' \
+    --rerun-tasks
+  git diff --check
+  git status --short --branch
+  ```
+
+  Expected: all targeted tests pass, diff check is clean, and only the planned
+  source/test/KDoc paths are dirty.
+
+- [ ] **Step 3: Commit the implementation slice using Lore trailers.**
+
+  ```bash
+  git add cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt \
+    cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
+  git commit -m "callback burst admission을 bounded non-blocking 정책으로 제한한다" \
+    -m "#1474의 in-flight callback 상한과 overflow 거부를 구현해 listener fan-out을 제한한다." \
+    -m "Constraint: JCache callback은 동기 API이고 #1360의 cancellation·ABI·registration 계약을 유지해야 한다.
+Rejected: 내부 queue/coalescing | callback ordering과 cancellation 의미를 변경한다.
+Confidence: high
+Scope-risk: moderate
+Directive: permit 선형화와 close race 검증을 유지하고 public capacity API를 추가하지 않는다.
+Tested: focused listener tests, provider contract tests, full cache-core test, detekt, build, javap, diff check.
+Not-tested: live CI and PR review remain pending."
+  ```
+
+## Task 7: Create the verification train slice
+
+**Files:** no implementation change unless Task 6 review requires a narrowly
+scoped doc/test repair.
+
+- [ ] **Step 1: Create verification worktree from the exact implementation head.**
+
+  ```bash
+  git worktree add -b feat/issue-1474-verification \
+    .worktrees/feat/issue-1474-verification feat/issue-1474-bounded-admission
+  git -C .worktrees/feat/issue-1474-verification rev-parse HEAD
+  git -C .worktrees/feat/issue-1474-bounded-admission rev-parse HEAD
+  ```
+
+  Expected: both SHAs match before verification edits; preserve both linked
+  worktrees until exact-head delivery and cleanup authority is complete.
+
+- [ ] **Step 2: Re-read current issue metadata and prepare the no-PR/PR boundary.**
+
+  ```bash
+  gh issue view 1474 --json number,title,state,assignees,milestone,labels,url
+  git status --short --branch
+  ```
+
+  Keep PR creation pending until common gate CG-11 has fresh authority naming
+  `bluetape4k/bluetape4k-projects`, base `develop`, and the exact head branch.
+  Never merge or enable auto-merge from this plan.
+
+## Task 8: Final DoD and rollback
+
+- [ ] **Step 1: Map every spec criterion to fresh evidence.**
+
+  The final report must include: cap/linearization/overflow proof; accepted
+  call count and no duplication; redaction; close cancellation/no join; provider
+  registration; public constructor `javap`; full module test; detekt/build;
+  diff check; exact local head; P0/P1 verdict; and any P2 disposition.
+
+- [ ] **Step 2: Roll back only by branch-local commit revert if a proof fails.**
+
+  Do not reset or mutate `develop`. If implementation proof fails, retain the
+  spec and review commits, revert only the implementation commit on
+  `feat/issue-1474-bounded-admission`, repair the tests/design, and rerun the
+  RED/GREEN sequence. If the approved semantics need coalescing or a public
+  API, stop and return to spec approval instead of widening this train.
+
+## Plan self-review
+
+- [x] Every spec acceptance criterion maps to Tasks 2–6 and a final DoD row.
+- [x] Task order is executable: worktree → RED → GREEN → module/contract tests →
+  static/API proof → review/commit → verification train.
+- [x] No implementation task depends on a later artifact.
+- [x] Success, overflow, edge, cancellation, close race, exception, logging,
+  provider registration, and ABI paths are explicit.
+- [x] README/module/catalog/CI/Testcontainers hazards are explicitly N/A with
+  scope evidence.
+- [x] Rollback and reapproval conditions are explicit.
+- [x] Placeholder scan is clean; commands use actual paths and task names.

--- a/docs/superpowers/specs/2026-08-23-issue-1474-bounded-admission-design.md
+++ b/docs/superpowers/specs/2026-08-23-issue-1474-bounded-admission-design.md
@@ -1,0 +1,191 @@
+# #1474 `SuspendJCacheEntryEventListener` bounded admission 설계
+
+## 문제와 목표
+
+선행 작업 #1360은 `SuspendJCacheEntryEventListener`의
+`CancellationException` 전파, `close()` lifecycle, 불변 이벤트 사본,
+provider registration contract를 고정했다. 현재 구현은 JCache callback마다
+`scope.launch`를 하나씩 만들기 때문에 callback burst가 크면 in-flight job 수가
+burst 크기만큼 증가한다.
+
+이번 작업의 목표는 callback fan-out의 admission 상한과 overflow 정책을
+명시하고, accepted callback의 처리 의미와 기존 cancellation/close 계약을
+유지하는 것이다.
+
+## 현재 근거
+
+| 근거 | 확인 결과 |
+| --- | --- |
+| live issue | [#1474](https://github.com/bluetape4k/bluetape4k-projects/issues/1474) 는 `OPEN`, 담당 `debop`, milestone `2.0.0`, labels `test`, `performance`, `tech-debt`, `cache`다. |
+| 선행 구현 | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt`가 callback마다 child job을 만들고 `close()`에서 `scope.cancel()`만 호출한다. |
+| 등록 경로 | `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/SuspendNearJCache.kt`가 `MutableCacheEntryListenerConfiguration`으로 listener를 등록한다. |
+| 기존 설계 | `docs/superpowers/specs/2026-08-22-issue-1419-coroutine-contract-train-design.md`는 callback별 fan-out과 unbounded burst follow-up을 명시한다. |
+| baseline | `repo-test-summary -- ./gradlew :bluetape4k-cache-core:test --tests 'io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListenerTest' --rerun-tasks` 결과 `12 passing`, `BUILD SUCCESSFUL`이다. |
+
+## 범위와 비범위
+
+### 범위
+
+- listener 내부 callback admission cap을 추가한다.
+- accepted/overflow-rejected 경계를 코드와 KDoc에 문서화한다.
+- finite burst, in-flight job 수, accepted 처리, overflow 로그, close 후
+  cooperative cancellation을 결정적으로 검증한다.
+- 기존 listener event 종류별 front-cache 반영과 provider registration contract를
+  회귀 검증한다.
+
+### 비범위
+
+- #1360의 `CancellationException` propagation, 불변 이벤트 사본,
+  public one-argument constructor ABI 변경
+- per-key coalescing, global ordering, backend가 지원하지 않는 강제 중단
+- 새 public configuration API, dependency, module, metric backend
+- release, tag, publish, integration branch merge
+
+## 대안 검토
+
+### 대안 A — bounded non-blocking admission (선택)
+
+listener별 `Semaphore` permit 수를 in-flight callback job 상한으로 사용한다.
+JCache callback은 동기 API이므로 permit을 기다리지 않고 `tryAcquire()`만
+호출한다. permit을 얻은 callback만 child job을 만들고, 포화 상태의 callback은
+즉시 거부한다. 내부 queue를 두지 않으므로 queue depth는 항상 0이고 callback
+job 수 자체가 상한이 된다.
+
+장점은 기존 callback별 child job과 child 단위 cancellation 전파를 유지하면서
+unbounded fan-out만 제거하는 점이다. 단점은 포화 시 callback을 거부하므로
+accepted가 아닌 event는 이 listener가 보장하지 않는다는 점이다. 이 거부는
+조용한 drop이 아니라 명시적인 overflow 정책과 sanitized debug log로 드러낸다.
+
+### 대안 B — bounded per-key coalescing
+
+대기 중인 key별 최신 event만 유지하고 같은 key의 이전 event를 대체한다.
+unique key가 cap을 넘을 때의 overflow와 created/updated/removed/expired
+선형화 지점을 추가로 정의해야 하며, event ordering 의미가 바뀐다. #1360의
+event 종류별 반영 의미를 보존하는 것보다 복잡도가 크므로 이번 작업에서는
+채택하지 않는다.
+
+### 대안 C — bounded channel + worker pool
+
+bounded `Channel`에 callback batch를 넣고 고정 worker가 처리한다. queue에
+accepted된 event가 worker cancellation으로 남을 수 있고, worker가
+`CancellationException`으로 종료되는 기존 child 계약을 다시 설계해야 한다.
+callback별 cancellation을 유지하면서 queue semantics까지 검증해야 하므로
+대안 A보다 위험하다.
+
+## 선택 설계
+
+### Admission과 data flow
+
+1. `onCreated`/`onUpdated`는 callback 반환 전에 iterable을 `EventCopy` map으로
+   복사한다. `onRemoved`/`onExpired`는 key를 `LinkedHashSet`으로 복사한다.
+2. 기존과 같은 count/type trace log를 기록한다. raw key, value, source는
+   기록하지 않는다.
+3. `closed == false`이고 `targetCache.isClosed() == false`인 경우에만
+   admission을 시도한다. 이미 닫힌 target은 overflow가 아니라 pre-admission
+   rejection이다.
+4. `Semaphore.tryAcquire()` 성공을 accepted 선형화 지점으로 삼는다. permit이
+   없으면 callback을 동기적으로 거부하고 cap과 operation을 포함한
+   low-cardinality debug log를 남긴다. callback thread는 절대 기다리지 않는다.
+5. accepted callback은 기존 `scope.launch` child 하나에서 한 번만
+   `putAll` 또는 `removeAll`을 시도한다. child의 `finally`에서 permit을
+   반환한다.
+
+기본 cap은 listener 인스턴스당 `64`개 in-flight callback job이다. cap은
+callback batch 수에 적용하며 batch 내부 entry 수에는 새 상한을 추가하지
+않는다. public one-argument constructor는 그대로 유지하고, 작은 cap을
+주입하는 경로는 `@JvmSynthetic internal forTest`에만 둔다.
+
+### Event 종류별 반영
+
+- created/updated: 불변 이벤트 사본을 `Map<K, V>`로 만들고
+  `targetCache.putAll(...)`을 호출한다.
+- removed/expired: 불변 key 사본을 `Set<K>`로 만들고
+  `targetCache.removeAll(...)`을 호출한다.
+- 같은 batch 안의 중복 key와 기존 `associate`/`LinkedHashSet` 결과는
+  선행 구현과 동일하게 유지한다.
+- 전역 ordering은 보장하지 않는다. permit 획득 순서나 dispatcher scheduling은
+  API 계약이 아니다.
+
+### Error와 lifecycle
+
+- `CancellationException`은 broad catch보다 먼저 재전파한다. permit은
+  `finally`에서 반환한다.
+- 일반 `Exception`은 기존처럼 operation과 sanitized cache id만 error log로
+  남기고 sibling child의 처리를 계속한다.
+- `close()`는 `closed.compareAndSet(false, true)` 성공 시 `scope.cancel()`을
+  호출한다. join, drain, blocking wait를 하지 않는다.
+- admission 이후 `close()`와 경쟁하는 callback은 cooperative cancellation
+  대상이다. close가 callback 완료를 보장하지 않는다는 #1360 계약을 유지한다.
+- 한 child의 `CancellationException`은 `SupervisorJob` 아래 sibling child를
+  취소하지 않는다. listener scope 자체가 취소되면 남은 callback도 함께
+  취소된다.
+
+### 관측성과 로그
+
+overflow log에는 `operation`, sanitized `cache id`, admission cap만 포함한다.
+key, value, event source의 `toString()` 결과와 raw payload는 포함하지 않는다.
+이번 작업에는 public metrics API를 추가하지 않는다. 테스트는 target operation
+호출 수, child job 수, barrier 상태, log appender를 사용해 accepted/overflow와
+상한을 측정한다.
+
+## 호환성
+
+- `SuspendJCacheEntryEventListener(SuspendJCache<K, V>)` public constructor와
+  기존 JVM descriptor를 유지한다.
+- `SuspendNearJCache`의 `MutableCacheEntryListenerConfiguration` factory와
+  listener provider registration 코드는 변경하지 않는다.
+- 새 dependency/module/catalog 등록은 없다.
+- overflow는 best-effort listener의 명시적 admission 정책이다. 포화 시 모든
+  외부 event를 수용해야 하는 durable delivery 계약은 이번 listener가
+  제공하지 않으며, 그 요구는 별도 설계가 필요하다.
+
+## 실패 모드와 완화
+
+| 실패 모드 | 관찰 가능한 결과 | 완화/검증 |
+| --- | --- | --- |
+| callback burst가 cap을 초과 | permit 없는 callback이 즉시 거부되고 job 수가 cap을 넘지 않음 | `runTest` barrier로 finite burst와 accepted/overflow 호출 수를 검증 |
+| admission과 `close()`가 경쟁 | accepted child가 cooperative cancellation을 받고 close는 반환을 기다리지 않음 | `CompletableDeferred`/`awaitCancellation`으로 cancellation과 non-join을 검증 |
+| target operation이 `CancellationException`을 던짐 | 해당 child만 취소되고 permit이 반환됨 | child 상태와 sibling 처리, `finally` permit 반환을 검증 |
+| target operation이 일반 예외를 던짐 | error log 후 sibling은 계속 처리 | MockK `coAnswers`와 `coVerify`로 예외 격리를 검증 |
+| callback iterable이 반환 후 변경됨 | 이미 복사한 불변 이벤트 사본만 front cache에 반영됨 | 기존 불변 이벤트 사본 회귀 테스트 유지 |
+| overflow 로그에 payload가 섞임 | 민감한 key/value/source 노출 위험 | `ListAppender`에서 raw token 부재를 검증 |
+
+## 수용 기준과 검증 매핑
+
+| 이슈 수용 기준 | 설계 증거 | 검증 |
+| --- | --- | --- |
+| admission 상한/선형화/overflow 문서화 | `tryAcquire()` 성공 지점, cap `64`, 즉시 거부 정책, 본 spec/KDoc | bounded burst test와 source/KDoc review |
+| accepted event 손실·중복 없음 | accepted callback당 child 하나, `putAll`/`removeAll` 한 번, permit 반환 | barrier 기반 call count와 child bound |
+| raw payload 로그 없음 | sanitized cache id와 operation/cap만 로깅 | 기존 redaction + overflow log test |
+| close 후 cooperative cancellation | `scope.cancel()` only, no join/drain | `awaitCancellation` child test |
+| #1360 targeted/module gate 회귀 없음 | constructor/exception/불변 사본/event semantics 유지 | targeted test, module test, detekt/build |
+| provider registration contract 유지 | `SuspendNearJCache` registration path 비변경 | near-cache registration contract test |
+
+## 구현 순서와 stacked train
+
+현재 branch `feat/issue-1474-spec`에는 이 설계 문서만 커밋한다.
+
+다음 train은 아래 순서로 구성한다.
+
+1. `feat/issue-1474-spec`: 이 spec과 설계 검증 증거
+2. `feat/issue-1474-bounded-admission`: spec을 base로 listener와 회귀 테스트
+3. `feat/issue-1474-verification`: 독립 검증, 문서/KDoc 보완, final checklist
+
+각 branch는 `develop`을 최종 base로 하는 누적 head를 유지한다. PR 생성은
+approved plan의 정확한 repository/base/head 권한을 fresh-read한 뒤 수행하며,
+merge는 별도의 exact-head approval 없이는 수행하지 않는다.
+
+## 설계 DoD
+
+- [x] 문제, 현재 근거, 범위와 비범위가 명시됨
+- [x] bounded admission, coalescing, channel 대안을 비교하고 admission을 선택함
+- [x] 선형화 지점, overflow, event 반영, cancellation/close 계약이 명시됨
+- [x] 실패 모드 6개와 완화/검증 방법이 매핑됨
+- [x] public ABI, provider registration, dependency 범위가 고정됨
+- [x] 수용 기준과 deterministic test/validation 명령이 매핑됨
+- [x] stacked train과 PR/merge side-effect 경계가 명시됨
+
+중지 조건은 다음 중 하나다. public ABI 또는 provider registration을 바꿔야
+하거나, accepted event의 의미를 coalescing/order 보장으로 바꿔야 하거나,
+bounded test가 상한·cancellation·accepted call count를 결정적으로 증명하지
+못하면 구현을 중지하고 설계 승인을 다시 받는다.


### PR DESCRIPTION
## 요약

#1474의 callback burst bounded admission 후속 구현을 위한 설계·계획·검토 기준을
고정합니다. 선택안은 listener별 `Semaphore.tryAcquire()` 기반 non-blocking admission이며,
기본 cap은 64, overflow는 내부 queue 없이 즉시 거부합니다.

## 포함 범위

- bounded admission, overflow, cancellation/close, event 반영과 로그 경계를 설계
- 대안 비교와 수용 기준, RED→GREEN 구현 순서, static/API/회귀 검증 명령 고정
- 여섯 관점 spec/plan review와 P0/P1 수렴 기록

## 제외 범위

- listener source/test 구현, public capacity API, coalescing, global ordering
- release/tag/publish/merge

## 검증

- baseline listener test: 12 passing
- spec/plan self-review, `git diff --check`, Korean terminology audit: PASS
- 설계 review와 plan review: P0=0, P1=0

## Stacked train

1. 이 PR: `feat/issue-1474-spec` → `develop`
2. 다음 PR: `feat/issue-1474-bounded-admission` → `feat/issue-1474-spec`
3. 다음 PR: `feat/issue-1474-verification` → `feat/issue-1474-bounded-admission`

Refs #1474

## DoD Status

- [x] 승인된 bounded admission 설계와 구현 계획 문서화
- [x] six-lens spec/plan review P0=0, P1=0
- [ ] 후속 implementation/verification PR과 live CI는 다음 train slice에서 수행
