### PR TITLE
[cache][성능] #1474 bounded listener admission 구현

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
@@ -1,14 +1,17 @@
 package io.bluetape4k.cache.jcache
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
 import io.bluetape4k.logging.trace
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.cache.event.CacheEntryCreatedListener
 import javax.cache.event.CacheEntryEvent
@@ -16,11 +19,17 @@ import javax.cache.event.CacheEntryExpiredListener
 import javax.cache.event.CacheEntryRemovedListener
 import javax.cache.event.CacheEntryUpdatedListener
 
+private const val DEFAULT_MAX_IN_FLIGHT_CALLBACKS = 64
+
 /**
  * Back Cache의 엔트리 이벤트(생성/수정/삭제/만료)를 수신하여 Front Cache([targetCache])에 반영하는 리스너입니다.
  *
  * JCache 이벤트 콜백은 동기식으로 호출되므로, `runBlocking` 대신 전용 [kotlinx.coroutines.CoroutineScope]에서
  * `launch`를 사용하여 스레드 풀 고갈과 데드락을 방지합니다.
+ * callback admission은 non-blocking `tryAcquire()`로 선형화하며, 기본적으로
+ * listener마다 최대 64개의 in-flight callback job만 허용합니다. 상한에 도달한
+ * callback은 내부 queue 없이 즉시 거부하고 sanitized debug log를 남깁니다.
+ * [close]는 취소를 요청하지만 callback 완료를 기다리지 않습니다.
  *
  * ```kotlin
  * val frontCache = CaffeineSuspendJCache<String, Int> { maximumSize(1000) }
@@ -41,6 +50,7 @@ import javax.cache.event.CacheEntryUpdatedListener
 class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
     private val targetCache: SuspendJCache<K, V>,
     private val scope: CoroutineScope,
+    private val maxInFlightCallbacks: Int,
     @Suppress("UNUSED_PARAMETER") marker: Unit,
 ): CacheEntryCreatedListener<K, V>,
    CacheEntryUpdatedListener<K, V>,
@@ -51,6 +61,7 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
     constructor(targetCache: SuspendJCache<K, V>): this(
         targetCache,
         CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        DEFAULT_MAX_IN_FLIGHT_CALLBACKS,
         Unit,
     )
 
@@ -59,12 +70,18 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
         internal fun <K: Any, V: Any> forTest(
             targetCache: SuspendJCache<K, V>,
             scope: CoroutineScope,
+            maxInFlightCallbacks: Int = DEFAULT_MAX_IN_FLIGHT_CALLBACKS,
         ): SuspendJCacheEntryEventListener<K, V> =
-            SuspendJCacheEntryEventListener(targetCache, scope, Unit)
+            SuspendJCacheEntryEventListener(targetCache, scope, maxInFlightCallbacks, Unit)
+    }
+
+    init {
+        require(maxInFlightCallbacks > 0) { "maxInFlightCallbacks must be positive" }
     }
 
     private val closed = AtomicBoolean(false)
     private val cacheIdentifier = targetCache::class.java.name.sanitizeLogIdentifier()
+    private val admission = Semaphore(maxInFlightCallbacks)
 
     override fun close() {
         if (closed.compareAndSet(false, true)) {
@@ -81,13 +98,8 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
     override fun onCreated(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
         val eventCopies = events.map { EventCopy(it.key, it.value) }
         log.trace { "BackCache cache entry created. cache=$cacheIdentifier count=${eventCopies.size}" }
-        if (shouldAcceptCallback()) {
-            scope.launch {
-                if (closed.get()) return@launch
-                applyEvent("put all created cache entries") {
-                    targetCache.putAll(eventCopies.associate { it.key to it.value })
-                }
-            }
+        submit("put all created cache entries") {
+            targetCache.putAll(eventCopies.associate { it.key to it.value })
         }
     }
 
@@ -100,13 +112,8 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
     override fun onUpdated(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
         val eventCopies = events.map { EventCopy(it.key, it.value) }
         log.trace { "BackCache cache entry updated. cache=$cacheIdentifier count=${eventCopies.size}" }
-        if (shouldAcceptCallback()) {
-            scope.launch {
-                if (closed.get()) return@launch
-                applyEvent("put all updated cache entries") {
-                    targetCache.putAll(eventCopies.associate { it.key to it.value })
-                }
-            }
+        submit("put all updated cache entries") {
+            targetCache.putAll(eventCopies.associate { it.key to it.value })
         }
     }
 
@@ -120,13 +127,8 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
     override fun onRemoved(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
         val eventKeys = events.map { it.key }
         log.trace { "BackCache cache entry removed. cache=$cacheIdentifier count=${eventKeys.size}" }
-        if (shouldAcceptCallback()) {
-            scope.launch {
-                if (closed.get()) return@launch
-                applyEvent("remove all removed cache entries") {
-                    targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
-                }
-            }
+        submit("remove all removed cache entries") {
+            targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
         }
     }
 
@@ -140,20 +142,43 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
     override fun onExpired(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
         val eventKeys = events.map { it.key }
         log.trace { "BackCache cache entry expired. cache=$cacheIdentifier count=${eventKeys.size}" }
-        if (shouldAcceptCallback()) {
-            scope.launch {
-                if (closed.get()) return@launch
-                applyEvent("remove all expired cache entries") {
-                    targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
+        submit("remove all expired cache entries") {
+            targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
+        }
+    }
+
+    private fun submit(operation: String, block: suspend () -> Unit) {
+        if (!shouldAcceptCallback()) return
+        if (!admission.tryAcquire()) {
+            log.debug {
+                "Reject callback because admission is full. " +
+                        "operation=$operation cache=$cacheIdentifier maxInFlight=$maxInFlightCallbacks"
+            }
+            return
+        }
+        if (!shouldAcceptCallback()) {
+            admission.release()
+        } else {
+            val job = scope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    if (!closed.get()) {
+                        applyEvent(operation, block)
+                    }
+                } finally {
+                    admission.release()
                 }
+            }
+            if (!job.start()) {
+                admission.release()
             }
         }
     }
 
     /**
-     * Callback admission is linearized by the [closed] read immediately before launch.
-     * A callback that has already passed this gate is in flight; [close] requests
-     * cooperative cancellation without waiting for that backend call to return.
+     * Callback admission is linearized by a successful [Semaphore.tryAcquire] after
+     * the closed and target-cache checks. A callback that owns a permit is in flight;
+     * [close] requests cooperative cancellation without waiting for that backend call
+     * to return.
      */
     private fun shouldAcceptCallback(): Boolean = !closed.get() && !targetCache.isClosed()
 
@@ -167,7 +192,7 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            log.error(e) { "Fail to $operation." }
+            log.error(e) { "Fail to $operation. cache=$cacheIdentifier" }
         }
     }
 

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -39,6 +40,21 @@ class SuspendJCacheEntryEventListenerTest {
         every { event.eventType } returns eventType
         every { event.source } returns mockk(relaxed = true)
         return event
+    }
+
+    @Test
+    fun `maxInFlightCallbacks는 양수여야 한다`() = runTest {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+
+        assertFailsWith<IllegalArgumentException> {
+            SuspendJCacheEntryEventListener.forTest(
+                targetCache = targetCache,
+                scope = listenerScope,
+                maxInFlightCallbacks = 0,
+            )
+        }
     }
 
     @Test
@@ -188,16 +204,26 @@ class SuspendJCacheEntryEventListenerTest {
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns false
         val started = CompletableDeferred<Unit>()
+        val secondStarted = CompletableDeferred<Unit>()
         val release = CompletableDeferred<Unit>()
         val cancellation = CancellationException("listener cancelled")
+        val invocationCount = AtomicInteger()
         coEvery { targetCache.putAll(any()) } coAnswers {
-            started.complete(Unit)
-            release.await()
+            if (invocationCount.incrementAndGet() == 1) {
+                started.complete(Unit)
+                release.await()
+            } else {
+                secondStarted.complete(Unit)
+            }
         }
 
         val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
         val listenerJob = listenerScope.coroutineContext[Job]!!
-        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+        val listener = SuspendJCacheEntryEventListener.forTest(
+            targetCache,
+            listenerScope,
+            maxInFlightCallbacks = 1,
+        )
         listener.onCreated(mutableListOf(mockEvent("k7", "v7", EventType.CREATED)))
         runCurrent()
         started.await()
@@ -208,6 +234,12 @@ class SuspendJCacheEntryEventListenerTest {
         child.join()
 
         child.isCancelled.shouldBeTrue()
+
+        listener.onCreated(mutableListOf(mockEvent("k7-second", "v7-second", EventType.CREATED)))
+        runCurrent()
+        secondStarted.await()
+        coVerify(exactly = 2) { targetCache.putAll(any()) }
+
         listener.close()
     }
 
@@ -237,14 +269,52 @@ class SuspendJCacheEntryEventListenerTest {
     }
 
     @Test
-    fun `close는 유한한 cooperative callback burst를 모두 취소한다`() = runTest {
-        val callbackCount = 1_000
+    fun `bounded admission은 callback job 수와 accepted operation 수를 제한한다`() = runTest {
+        val maxInFlight = 2
+        val callbackCount = 8
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        val startedCount = AtomicInteger()
+        val allStarted = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        coEvery { targetCache.putAll(any()) } coAnswers {
+            if (startedCount.incrementAndGet() == maxInFlight) {
+                allStarted.complete(Unit)
+            }
+            release.await()
+        }
+
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listenerJob = listenerScope.coroutineContext[Job]!!
+        val listener = SuspendJCacheEntryEventListener.forTest(
+            targetCache,
+            listenerScope,
+            maxInFlightCallbacks = maxInFlight,
+        )
+        repeat(callbackCount) { index ->
+            listener.onCreated(mutableListOf(mockEvent("burst-$index", "value", EventType.CREATED)))
+        }
+        runCurrent()
+        allStarted.await()
+
+        listenerJob.children.toList().size.shouldBeEqualTo(maxInFlight)
+        release.complete(Unit)
+        runCurrent()
+
+        coVerify(exactly = maxInFlight) { targetCache.putAll(any()) }
+        listener.close()
+    }
+
+    @Test
+    fun `close는 bounded cooperative callback burst를 모두 취소한다`() = runTest {
+        val maxInFlight = 2
+        val callbackCount = 8
         val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
         every { targetCache.isClosed() } returns false
         val startedCount = AtomicInteger()
         val allStarted = CompletableDeferred<Unit>()
         coEvery { targetCache.putAll(any()) } coAnswers {
-            if (startedCount.incrementAndGet() == callbackCount) {
+            if (startedCount.incrementAndGet() == maxInFlight) {
                 allStarted.complete(Unit)
             }
             awaitCancellation()
@@ -252,20 +322,163 @@ class SuspendJCacheEntryEventListenerTest {
 
         val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
         val listenerJob = listenerScope.coroutineContext[Job]!!
-        val listener = SuspendJCacheEntryEventListener.forTest(targetCache, listenerScope)
+        val listener = SuspendJCacheEntryEventListener.forTest(
+            targetCache,
+            listenerScope,
+            maxInFlightCallbacks = maxInFlight,
+        )
         repeat(callbackCount) { index ->
-            listener.onCreated(mutableListOf(mockEvent("burst-$index", "value", EventType.CREATED)))
+            listener.onCreated(mutableListOf(mockEvent("close-burst-$index", "value", EventType.CREATED)))
         }
         runCurrent()
         allStarted.await()
         val children = listenerJob.children.toList()
 
-        children.size.shouldBeEqualTo(callbackCount)
+        children.size.shouldBeEqualTo(maxInFlight)
         listener.close()
         runCurrent()
         children.joinAll()
 
         children.all { it.isCancelled }.shouldBeTrue()
+    }
+
+    @Test
+    fun `취소된 scope에서 시작되지 않은 lazy child도 permit을 반환한다`() = runTest {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        coEvery { targetCache.putAll(any()) } returns Unit
+
+        val logger = SuspendJCacheEntryEventListener.log as Logger
+        val previousLevel = logger.level
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.level = Level.DEBUG
+        logger.addAppender(appender)
+        val cancelledJob = SupervisorJob().apply { cancel() }
+        val listenerScope = CoroutineScope(coroutineContext + cancelledJob)
+        val listener = SuspendJCacheEntryEventListener.forTest(
+            targetCache,
+            listenerScope,
+            maxInFlightCallbacks = 1,
+        )
+        try {
+            listener.onCreated(mutableListOf(mockEvent("lazy-1", "value", EventType.CREATED)))
+            listener.onCreated(mutableListOf(mockEvent("lazy-2", "value", EventType.CREATED)))
+            runCurrent()
+
+            appender.list
+                .map { it.formattedMessage }
+                .count { it.contains("admission is full") }
+                .shouldBeEqualTo(0)
+            coVerify(exactly = 0) { targetCache.putAll(any()) }
+        } finally {
+            listener.close()
+            logger.detachAppender(appender)
+            appender.stop()
+            logger.level = previousLevel
+        }
+    }
+
+    @Test
+    fun `일반 예외는 sibling callback을 취소하지 않는다`() = runTest {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        val invocationCount = AtomicInteger()
+        val secondStarted = CompletableDeferred<Unit>()
+        coEvery { targetCache.putAll(any()) } coAnswers {
+            if (invocationCount.incrementAndGet() == 1) {
+                throw IllegalStateException("backend failure")
+            }
+            secondStarted.complete(Unit)
+        }
+
+        val logger = SuspendJCacheEntryEventListener.log as Logger
+        val previousLevel = logger.level
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.level = Level.ERROR
+        logger.addAppender(appender)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listenerJob = listenerScope.coroutineContext[Job]!!
+        val listener = SuspendJCacheEntryEventListener.forTest(
+            targetCache,
+            listenerScope,
+            maxInFlightCallbacks = 2,
+        )
+        try {
+            listener.onCreated(mutableListOf(mockEvent("exception-1", "value", EventType.CREATED)))
+            listener.onCreated(mutableListOf(mockEvent("exception-2", "value", EventType.CREATED)))
+            runCurrent()
+            secondStarted.await()
+
+            listenerJob.isActive.shouldBeTrue()
+            coVerify(exactly = 2) { targetCache.putAll(any()) }
+            val errorMessages = appender.list
+                .map { it.formattedMessage }
+                .filter { it.contains("Fail to put all created cache entries") }
+            errorMessages.isNotEmpty().shouldBeTrue()
+            errorMessages.all { it.contains("cache=") && !it.contains("backend failure") }.shouldBeTrue()
+        } finally {
+            listener.close()
+            logger.detachAppender(appender)
+            appender.stop()
+            logger.level = previousLevel
+        }
+    }
+
+    @Test
+    fun `admission overflow log에는 raw payload가 포함되지 않는다`() = runTest {
+        val secretKey = "overflow-secret-key"
+        val secretValue = "overflow-secret-value"
+        val secretSource = "overflow-secret-source"
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        val started = CompletableDeferred<Unit>()
+        coEvery { targetCache.putAll(any()) } coAnswers {
+            started.complete(Unit)
+            awaitCancellation()
+        }
+        val overflowEvent = mockk<CacheEntryEvent<String, String>>()
+        val source = mockk<Cache<Any, Any>>()
+        every { overflowEvent.key } returns secretKey
+        every { overflowEvent.value } returns secretValue
+        every { overflowEvent.eventType } returns EventType.CREATED
+        every { source.toString() } returns secretSource
+        every { overflowEvent.source } returns source
+
+        val logger = SuspendJCacheEntryEventListener.log as Logger
+        val previousLevel = logger.level
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.level = Level.DEBUG
+        logger.addAppender(appender)
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(
+            targetCache,
+            listenerScope,
+            maxInFlightCallbacks = 1,
+        )
+        try {
+            listener.onCreated(mutableListOf(mockEvent("first", "value", EventType.CREATED)))
+            runCurrent()
+            started.await()
+            listener.onCreated(mutableListOf(overflowEvent))
+            runCurrent()
+
+            val overflowMessages = appender.list
+                .map { it.formattedMessage }
+                .filter { it.contains("admission is full") }
+            overflowMessages.isNotEmpty().shouldBeTrue()
+            overflowMessages.all { message ->
+                message.contains("operation=put all created cache entries") &&
+                        !message.contains(secretKey) &&
+                        !message.contains(secretValue) &&
+                        !message.contains(secretSource)
+            }.shouldBeTrue()
+        } finally {
+            listener.close()
+            runCurrent()
+            logger.detachAppender(appender)
+            appender.stop()
+            logger.level = previousLevel
+        }
     }
 
     @Test

--- a/docs/review/2026-08-23-issue-1474-bounded-admission-code-review.md
+++ b/docs/review/2026-08-23-issue-1474-bounded-admission-code-review.md
@@ -1,0 +1,96 @@
+# #1474 bounded admission 구현 코드 검토
+
+## 검토 범위와 기준
+
+- 저장소: `bluetape4k/bluetape4k-projects`
+- 모듈 slice: `cache/cache-core` 단일 모듈
+- 기준 SHA: `f7c1cf1bb9da7ea2d6811f2833582ab0f434d15d`
+- 현재 구현 head: `ee2e7cd625` + 미커밋 구현 diff
+- 구현 소스: `cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt`
+- 회귀 테스트: `cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt`
+- 설계/계획: `docs/superpowers/specs/2026-08-23-issue-1474-bounded-admission-design.md`,
+  `docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md`
+- 검토 방식: Performance, Stability, Security, Operator/Ops, Developer/API,
+  User/Caller 여섯 관점과 main-session 통합
+
+## 검증 증거
+
+| 증거 | 결과 |
+| --- | --- |
+| focused listener test | 17 passing, `BUILD SUCCESSFUL in 27s` |
+| listener + near-cache contract | 73 passing, `BUILD SUCCESSFUL in 18s` |
+| full `cache-core` test | 704 passing, `BUILD SUCCESSFUL in 1m 1s` |
+| `:bluetape4k-cache-core:detekt --rerun-tasks` | exit 0; 변경 listener 파일 finding 없음. 기존 near-cache/memoizer/문서 테스트 finding은 별도 scope로 유지 |
+| `:bluetape4k-cache-core:build -x test --rerun-tasks` | exit 0, `BUILD SUCCESSFUL in 6s` |
+| public constructor ABI | main jar `bluetape4k-cache-core-2.0.0.jar`에서 one-argument `SuspendJCache` constructor 정확히 1개 매칭; Kotlin synthetic bridge는 필터 제외 |
+| source hygiene | `git diff --check` PASS, Korean terminology audit 2 files / findings=0 |
+| concurrency scan | listener production source에 `GlobalScope`, `runBlocking(`, `Thread.sleep`, `delay`, monitor, `runCatching` 없음 |
+
+## 여섯 관점 통합 결과
+
+| 우선순위 | 관점 | 근거 | 조치/처분 |
+| --- | --- | --- | --- |
+| P0 | 전체 | 승인 범위 밖 public API, global ordering, coalescing, dependency, provider registration 변경 없음 | 없음 |
+| P1 | 전체 | permit 수명, callback cancellation, close, raw payload redaction, ABI를 현재 테스트와 정적 증거로 닫음 | 없음 |
+| P2 | Performance | `tryAcquire()`는 callback thread에서 대기하지 않지만 event batch 사본은 admission 전에 기존처럼 생성됨 | payload 크기 상한은 승인 설계의 비범위로 유지; child/accepted call finite burst 증거를 사용 |
+| P2 | Stability | `finally`와 `job.start() == false` 두 경로가 permit을 반환하고 close는 join하지 않음 | cancellation, cancelled scope, bounded close burst 테스트로 처분 |
+| P2 | Security | overflow/error/trace log에 raw key·value·source를 넣지 않음 | overflow secret token 및 기존 trace redaction 테스트로 처분 |
+| P2 | Operator/Ops | overflow 관측은 low-cardinality debug log이며 public metric은 없음 | 승인된 운영 범위; metric backend와 runtime tuning은 후속 이슈 범위 |
+| P2 | Developer/API | `forTest`에만 cap 주입, public one-argument constructor와 registration 경로 유지 | `javap`, near-cache contract, full module test로 처분 |
+| P2 | User/Caller | 기본 64와 overflow best-effort 의미가 KDoc에 추가되고 durable delivery로 과장하지 않음 | README/examples는 public API 불변으로 N/A |
+
+## 구현·테스트 대응표
+
+| 요구 | 구현 증거 | 테스트 증거 |
+| --- | --- | --- |
+| listener별 bounded non-blocking admission | private `Semaphore(64)`, `tryAcquire`, 즉시 debug 거부 | 8 callback / cap 2에서 child 2개와 `putAll` 2회 |
+| accepted callback 무손실·중복 없음 | permit 소유 child당 backend operation 한 번 | bounded burst `coVerify(exactly = 2)` 및 기존 event 종류별 테스트 |
+| permit 회수 | child `finally`, lazy job 미시작 caller-side release, post-close pre-admission release | CancellationException 후 두 번째 callback, cancelled scope 두 callback, close burst |
+| 오류·취소 계약 | `CancellationException` broad catch 선행 재전파, 일반 `Exception` error log 후 sibling 유지 | child cancellation 상태, 일반 예외 sibling·error log, full module |
+| close lifecycle | `closed.compareAndSet` 후 `scope.cancel()`만 호출 | started child close 후 join은 test-only, 두 child 모두 cancelled |
+| log redaction | operation·sanitized cache id·cap만 기록 | overflow secret token, 기존 callback trace redaction |
+| ABI/provider 호환 | public constructor unchanged, `SuspendNearJCache` registration 미수정 | exact `javap`, `NearJCacheContractTest`, `SuspendNearJCacheBackFirstContractTest` |
+
+## 성능·안정성 quick scan
+
+- `scope.launch(start = CoroutineStart.LAZY)` 후 즉시 `Job.start()`하므로 callback
+  thread는 permit을 기다리거나 backend를 직접 호출하지 않는다.
+- cap 포화 시 내부 queue/coalescing이 없고, overflow callback은 한 번의 debug log 후
+  반환한다.
+- permit은 정상 완료, 일반 예외, `CancellationException`, close 취소, lazy 미시작의
+  모든 경로에서 반환된다.
+- source의 `runBlocking`은 KDoc에서 금지 예시로만 언급되며 production 호출이 아니다.
+  테스트의 `source.toString()`는 raw payload가 로그로 유출되지 않는지 검증하는 mock
+  fixture일 뿐 production path가 아니다.
+- Testcontainers나 다른 module source는 변경하지 않았고 full module test는 순차 실행했다.
+
+## 문서·릴리스·운영 경계
+
+- 새 class/API가 아니므로 README/localized README, examples, BOM/catalog, module
+  registration, CI/Nightly, Kover, CHANGELOG/release note는 N/A다.
+- public KDoc는 Korean prose로 bounded admission, 기본 cap, overflow 거부, close
+  무대기 동작을 설명한다.
+- PR 생성은 아직 하지 않았으며 CG-11 fresh authority가 필요하다. merge, auto-merge,
+  publish, tag, branch 삭제는 실행하지 않았다.
+- detekt 출력에 기존 near-cache/memoizer 및 documentation test finding이 존재하지만
+  task exit는 0이고 변경 listener 파일은 finding이 없다. 이 baseline은 별도 정리 범위다.
+
+## 최종 판정
+
+- P0: 0
+- P1: 0
+- P2: 5건 모두 승인된 비범위 또는 fresh test/static evidence로 처분
+- P3: 없음
+- 코드 검토 게이트: PASS
+
+다음 단계는 구현 source/test와 이 review artifact를 Lore commit으로 고정하고,
+exact implementation head에서 verification worktree를 만드는 것이다. PR 생성은
+fresh repository/base/head 권한 확인 후 별도 단계로 남긴다.
+
+### DoD
+
+- [x] 여섯 관점 review와 main-session 통합
+- [x] P0/P1 수렴
+- [x] 요구사항·위험·테스트·정적/API 증거 매핑
+- [x] diff/source hygiene 및 Korean terminology audit
+- [x] PR/merge/release side-effect 경계 기록

--- a/docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md
+++ b/docs/superpowers/plans/2026-08-23-issue-1474-bounded-admission-plan.md
@@ -223,8 +223,8 @@ module, dependency, registration, or container behavior changes.
 
   Validate `maxInFlightCallbacks > 0` with `require` before constructing the
   `Semaphore`, then create `private val admission = Semaphore(maxInFlightCallbacks)`.
-  Import only `kotlinx.coroutines.sync.Semaphore` and the coroutine start type
-  needed by the lazy-start release guard; add no dependency.
+  Import `io.bluetape4k.logging.debug`, `kotlinx.coroutines.CoroutineStart`, and
+  `kotlinx.coroutines.sync.Semaphore`; add no dependency.
 
 - [ ] **Step 2: Add the submit helper with explicit close and permit-race handling.**
 
@@ -352,15 +352,17 @@ insufficient to prove the unchanged registration contract.
   ```bash
   jar_path=$(find cache/cache-core/build/libs -maxdepth 1 \
     -name 'bluetape4k-cache-core-*.jar' ! -name '*sources*' ! -name '*javadoc*' \
+    ! -name '*test-fixtures*' \
     | head -1)
   test -n "$jar_path"
   javap -classpath "$jar_path" \
     io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListener \
-    | rg 'public io\.bluetape4k\.cache\.jcache\.SuspendJCacheEntryEventListener'
+    | rg '^  public .*SuspendJCacheEntryEventListener\(io\.bluetape4k\.cache\.jcache\.SuspendJCache<.*>\);$'
   ```
 
-  Expected: the one-argument public constructor remains present; no public
-  capacity constructor or public metrics type appears.
+  Expected: exactly the one-argument public constructor remains present. Kotlin's
+  synthetic `DefaultConstructorMarker` bridge is ignored by the exact signature
+  filter; no public capacity constructor or public metrics type appears.
 
 - [ ] **Step 3: Run source/documentation hygiene checks.**
 


### PR DESCRIPTION
## 요약

#1474 승인 설계에 따라 `SuspendJCacheEntryEventListener`의 callback fan-out을
listener별 bounded non-blocking admission으로 제한합니다.

## 변경 내용

- private `Semaphore` cap 64와 `tryAcquire()` 선형화, 포화 callback 즉시 거부
- child `finally` 및 lazy `job.start() == false` 경로의 permit 반환
- 기존 event 사본, created/updated `putAll`, removed/expired `removeAll`,
  `CancellationException`, `close()` cancel-only, provider registration 유지
- overflow/error/trace 로그의 sanitized payload 경계와 Korean KDoc 보강
- test-only `@JvmSynthetic internal forTest` cap 주입 및 양수 검증

## 검증

- focused listener: 17 passing
- listener/provider contract: 73 passing
- 전체 `cache-core`: 704 passing
- detekt exit 0, cache-core build exit 0, main jar `javap` one-argument constructor gate PASS
- `git diff --check`, Korean terminology audit, concurrency quick scan PASS
- code review artifact: six lenses P0=0, P1=0

## Stacked train

- parent PR: `feat/issue-1474-spec` → `develop`
- 이 PR: `feat/issue-1474-bounded-admission` → `feat/issue-1474-spec`
- child PR: `feat/issue-1474-verification` → `feat/issue-1474-bounded-admission`

Refs #1474

## DoD Status

- [x] bounded admission, overflow, cancellation/close, redaction 구현
- [x] 기존 ABI/provider/event semantics 회귀 검증
- [x] local module/static/API/code review PASS
- [ ] live CI/review와 exact-head merge approval은 별도 gate
