### PR TITLE
[cache][consistency] NearJCache 조건부 mutation 결과를 back 기준으로 일치시킨다

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -154,6 +154,14 @@ local front를 조정합니다. 따라서 front를 먼저 읽고 back을 별도�
 왕복을 사용하지 않으며, back provider 실패 시 front를 변경하기 전에
 예외를 전달합니다.
 
+`putIfAbsent`, `remove`, `remove(key, oldValue)`, `replace`도 back provider의
+원자 조건부 연산을 먼저 수행하고 그 결과를 호출자에게 반환합니다.
+`isSynchronous=false`인 설정에서도 조건부 결과를 확정하기 위해 해당 back
+호출은 완료될 때까지 기다립니다. 성공하면 새 값을 front에 반영하고, 조건이
+충족되지 않으면 front key를 제거하여 stale 값을 남기지 않습니다. back 호출이
+실패하면 front를 변경하지 않으며, back commit 후 front 반영이 실패해도 front
+key를 invalidate한 뒤 원래 예외를 전달합니다.
+
 마지막 write-through의 operation ID·operation 이름·completion을 함께 상관관계로
 관찰하려면 `nearCache.lastBackCacheWrite`를 사용하세요. 이 값은 하나의 원자
 스냅숏이며 completion stage는 읽기 전용입니다. 기존

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -109,6 +109,15 @@ provider's atomic compound operation and then reconcile the local front cache;
 they do not implement a front-read/back-write round trip. A provider failure is
 propagated before the front cache is changed.
 
+`putIfAbsent`, `remove`, `remove(key, oldValue)`, and both `replace` overloads
+also execute the back provider's atomic conditional operation first and return
+that back result. Even when `isSynchronous=false`, the back call is awaited so
+the blocking API can return the logical result. A successful result reconciles
+the new value into the front cache; a condition miss removes the front key so
+stale data is not retained. A back failure leaves the front untouched, while a
+front reconciliation failure after a back commit invalidates the key and
+rethrows the original exception.
+
 Use `nearCache.lastBackCacheWrite` when correlating the latest write-through
 operation ID, operation name, and completion. It is one atomic observation
 snapshot, and its completion stage is read-only. The legacy

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCache.kt
@@ -67,6 +67,11 @@ data class BackCacheWriteCompletion(
  * - **유연한 동기화**: 동기/비동기 모드 지원
  * - **자동 만료 감지**: 백그라운드 스레드로 Back Cache 만료 감지 및 Front Cache 갱신
  *
+ * 조건부 mutation인 `putIfAbsent`, `remove`, `remove(key, oldValue)`, `replace`는
+ * Back Cache의 원자 결과를 먼저 확정합니다. 성공한 경우에만 Front Cache를 반영하고,
+ * 조건 불충족 결과나 Front 보정 실패에서는 해당 key를 invalidate하여 stale 값을
+ * 반환하지 않습니다. Back 호출이 실패하면 Front mutation을 수행하지 않습니다.
+ *
  * ```kotlin
  * // Redis를 Back Cache로 사용하는 NearCache 생성
  * val nearCache = NearCache(
@@ -895,24 +900,15 @@ class NearJCache<K: Any, V: Any> private constructor(
     override fun putIfAbsent(key: K, value: V): Boolean {
         val recording = statisticsRecorder.current()
         val startedAt = recording.startTimeNanos()
-        val inserted = mutationGate.withLock {
-            frontCache.putIfAbsent(key, value).also { inserted ->
-                if (inserted) {
-                    mutationEpoch.incrementAndGet()
-                    syncBackCache(
-                        operation = "putIfAbsent",
-                        expectedBackWriteGeneration = backWriteGeneration.get(),
-                        selfEventMatcher = SelfEventMatcher(
-                            keys = setOf(key),
-                            eventTypes = setOf(EventType.CREATED),
-                            values = mapOf(key to value),
-                        ),
-                    ) {
-                        if (!backCache.containsKey(key)) {
-                            backCache.put(key, value)
-                        }
-                    }
-                }
+        val inserted = runBackFirstConditionalMutation(
+            operation = "putIfAbsent",
+            key = key,
+            backMutation = { backCache.putIfAbsent(key, value) },
+        ) { committed ->
+            if (committed) {
+                frontCache.put(key, value)
+            } else {
+                frontCache.remove(key)
             }
         }
         if (inserted) recording.recordPut(startedAt, 1L)
@@ -922,20 +918,12 @@ class NearJCache<K: Any, V: Any> private constructor(
     override fun remove(key: K): Boolean {
         val recording = statisticsRecorder.current()
         val startedAt = recording.startTimeNanos()
-        val removed = mutationGate.withLock {
-            frontCache.remove(key).also { removed ->
-                if (removed) {
-                    mutationEpoch.incrementAndGet()
-                    syncBackCache(
-                        operation = "remove",
-                        expectedBackWriteGeneration = backWriteGeneration.get(),
-                        selfEventMatcher = SelfEventMatcher(
-                            keys = setOf(key),
-                            eventTypes = setOf(EventType.REMOVED),
-                        ),
-                    ) { backCache.remove(key) }
-                }
-            }
+        val removed = runBackFirstConditionalMutation(
+            operation = "remove",
+            key = key,
+            backMutation = { backCache.remove(key) },
+        ) {
+            frontCache.remove(key)
         }
         if (removed) recording.recordRemove(startedAt, 1L)
         return removed
@@ -944,25 +932,12 @@ class NearJCache<K: Any, V: Any> private constructor(
     override fun remove(key: K, oldValue: V): Boolean {
         val recording = statisticsRecorder.current()
         val startedAt = recording.startTimeNanos()
-        val removed = mutationGate.withLock {
-            frontCache.remove(key, oldValue).also { removed ->
-                if (removed) {
-                    mutationEpoch.incrementAndGet()
-                    syncBackCache(
-                        operation = "remove(key, oldValue)",
-                        expectedBackWriteGeneration = backWriteGeneration.get(),
-                        selfEventMatcher = SelfEventMatcher(
-                            keys = setOf(key),
-                            eventTypes = setOf(EventType.REMOVED),
-                        ),
-                    ) {
-                        // Back cache listener 전파를 remove(key) 경로로 통일하기 위해 값 비교 후 단일 키 삭제를 사용한다.
-                        if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
-                            backCache.remove(key)
-                        }
-                    }
-                }
-            }
+        val removed = runBackFirstConditionalMutation(
+            operation = "remove(key, oldValue)",
+            key = key,
+            backMutation = { backCache.remove(key, oldValue) },
+        ) {
+            frontCache.remove(key)
         }
         if (removed) recording.recordRemove(startedAt, 1L)
         return removed
@@ -1030,24 +1005,15 @@ class NearJCache<K: Any, V: Any> private constructor(
     override fun replace(key: K, oldValue: V, newValue: V): Boolean {
         val recording = statisticsRecorder.current()
         val startedAt = recording.startTimeNanos()
-        val replaced = mutationGate.withLock {
-            frontCache.replace(key, oldValue, newValue).also { replaced ->
-                if (replaced) {
-                    mutationEpoch.incrementAndGet()
-                    syncBackCache(
-                        operation = "replace(key, oldValue, newValue)",
-                        expectedBackWriteGeneration = backWriteGeneration.get(),
-                        selfEventMatcher = SelfEventMatcher(
-                            keys = setOf(key),
-                            eventTypes = setOf(EventType.UPDATED),
-                            values = mapOf(key to newValue),
-                        ),
-                    ) {
-                        if (backCache.containsKey(key) && backCache.get(key) == oldValue) {
-                            backCache.put(key, newValue)
-                        }
-                    }
-                }
+        val replaced = runBackFirstConditionalMutation(
+            operation = "replace(key, oldValue, newValue)",
+            key = key,
+            backMutation = { backCache.replace(key, oldValue, newValue) },
+        ) { committed ->
+            if (committed) {
+                frontCache.put(key, newValue)
+            } else {
+                frontCache.remove(key)
             }
         }
         if (replaced) recording.recordPut(startedAt, 1L)
@@ -1057,25 +1023,15 @@ class NearJCache<K: Any, V: Any> private constructor(
     override fun replace(key: K, value: V): Boolean {
         val recording = statisticsRecorder.current()
         val startedAt = recording.startTimeNanos()
-        val replaced = mutationGate.withLock {
-            frontCache.replace(key, value).also { replaced ->
-                if (replaced) {
-                    mutationEpoch.incrementAndGet()
-                    syncBackCache(
-                        operation = "replace",
-                        expectedBackWriteGeneration = backWriteGeneration.get(),
-                        selfEventMatcher = SelfEventMatcher(
-                            keys = setOf(key),
-                            eventTypes = setOf(EventType.UPDATED),
-                            values = mapOf(key to value),
-                        ),
-                    ) {
-                        // Redisson 에서는 replace 가 event 를 발생시키지 않습니다.
-                        if (backCache.containsKey(key)) {
-                            backCache.put(key, value)
-                        }
-                    }
-                }
+        val replaced = runBackFirstConditionalMutation(
+            operation = "replace",
+            key = key,
+            backMutation = { backCache.replace(key, value) },
+        ) { committed ->
+            if (committed) {
+                frontCache.put(key, value)
+            } else {
+                frontCache.remove(key)
             }
         }
         if (replaced) recording.recordPut(startedAt, 1L)
@@ -1254,6 +1210,44 @@ class NearJCache<K: Any, V: Any> private constructor(
         }
         @Suppress("UNCHECKED_CAST")
         return value as R
+    }
+
+    /**
+     * 조건부 mutation은 Back Cache의 원자 결과를 먼저 확정한 뒤 Front Cache를
+     * 보정합니다. Front 반영 중 예외가 발생하면 key를 invalidate하여 부분 반영을
+     * 숨기고, Back 호출이 실패한 경우에는 Front를 건드리지 않습니다.
+     */
+    private fun <R> runBackFirstConditionalMutation(
+        operation: String,
+        key: K,
+        backMutation: () -> R,
+        frontMutation: (R) -> Unit,
+    ): R = compoundGate.withLock {
+        mutationGate.withLock { mutationEpoch.incrementAndGet() }
+        val result = runCompoundBackCacheOperation(operation, backMutation)
+        mutationGate.withLock {
+            syncFrontAfterBack(
+                sync = { frontMutation(result) },
+                invalidate = { frontCache.remove(key) },
+            )
+        }
+        result
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun syncFrontAfterBack(sync: () -> Unit, invalidate: () -> Unit) {
+        try {
+            sync()
+        } catch (failure: Throwable) {
+            try {
+                invalidate()
+            } catch (invalidateFailure: Throwable) {
+                if (invalidateFailure !== failure) {
+                    failure.addSuppressed(invalidateFailure)
+                }
+            }
+            throw failure
+        }
     }
 
     private fun recordCompoundGet(

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConditionalMutationContractTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheConditionalMutationContractTest.kt
@@ -1,0 +1,226 @@
+package io.bluetape4k.cache.nearcache.jcache
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.cache.jcache.JCache
+import io.bluetape4k.cache.jcache.JCaching
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.UUID
+import javax.cache.configuration.MutableConfiguration
+
+class NearJCacheConditionalMutationContractTest {
+
+    @Test
+    fun `putIfAbsent는 back 원자 결과를 반환하고 실패 시 stale front를 제거한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { frontCache.putIfAbsent("key", "new") } returns true
+        every { backCache.putIfAbsent("key", "new") } returns false
+        every { frontCache.remove("key") } returns true
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        nearCache.putIfAbsent("key", "new").shouldBeFalse()
+
+        verifyOrder {
+            backCache.putIfAbsent("key", "new")
+            frontCache.remove("key")
+        }
+    }
+
+    @Test
+    fun `remove와 replace는 front miss에서도 back 원자 결과와 front 보정을 사용한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        every { backCache.remove("remove") } returns true
+        every { backCache.remove("remove-old", "old") } returns true
+        every { backCache.replace("replace-old", "old", "new") } returns true
+        every { backCache.replace("replace", "new") } returns true
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        nearCache.remove("remove").shouldBeTrue()
+        nearCache.remove("remove-old", "old").shouldBeTrue()
+        nearCache.replace("replace-old", "old", "new").shouldBeTrue()
+        nearCache.replace("replace", "new").shouldBeTrue()
+
+        verifyOrder {
+            backCache.remove("remove")
+            frontCache.remove("remove")
+        }
+        verifyOrder {
+            backCache.remove("remove-old", "old")
+            frontCache.remove("remove-old")
+        }
+        verifyOrder {
+            backCache.replace("replace-old", "old", "new")
+            frontCache.put("replace-old", "new")
+        }
+        verifyOrder {
+            backCache.replace("replace", "new")
+            frontCache.put("replace", "new")
+        }
+    }
+
+    @Test
+    fun `front miss와 back hit 조건부 mutation은 최종 두 tier 상태를 back 기준으로 맞춘다`() {
+        val configuration = MutableConfiguration<String, String>()
+            .setTypes(String::class.java, String::class.java)
+            .setStoreByValue(false)
+        val cacheName = "issue-1447-${UUID.randomUUID()}"
+        val frontCache = JCaching.Caffeine.getOrCreate("$cacheName-front", configuration)
+        val backCache = JCaching.Caffeine.getOrCreate("$cacheName-back", configuration)
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(
+                frontCacheConfiguration = configuration,
+                isSynchronous = true,
+            ),
+        )
+
+        try {
+            backCache.put("put-if-absent", "old")
+            nearCache.putIfAbsent("put-if-absent", "new").shouldBeFalse()
+            backCache.get("put-if-absent") shouldBeEqualTo "old"
+            frontCache.containsKey("put-if-absent").shouldBeFalse()
+
+            backCache.put("remove", "old")
+            nearCache.remove("remove").shouldBeTrue()
+            backCache.containsKey("remove").shouldBeFalse()
+            frontCache.containsKey("remove").shouldBeFalse()
+
+            backCache.put("remove-old", "old")
+            nearCache.remove("remove-old", "old").shouldBeTrue()
+            backCache.containsKey("remove-old").shouldBeFalse()
+            frontCache.containsKey("remove-old").shouldBeFalse()
+
+            backCache.put("replace-old", "old")
+            nearCache.replace("replace-old", "old", "new").shouldBeTrue()
+            backCache.get("replace-old") shouldBeEqualTo "new"
+            frontCache.get("replace-old") shouldBeEqualTo "new"
+
+            backCache.put("replace", "old")
+            nearCache.replace("replace", "new").shouldBeTrue()
+            backCache.get("replace") shouldBeEqualTo "new"
+            frontCache.get("replace") shouldBeEqualTo "new"
+        } finally {
+            nearCache.close()
+            backCache.close()
+        }
+    }
+
+    @Test
+    fun `back 조건부 mutation 실패는 front를 변경하지 않고 원래 예외를 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val failure = IllegalStateException("back cache is unavailable")
+        every { backCache.replace("key", "new") } throws failure
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        val error = assertFailsWith<IllegalStateException> {
+            nearCache.replace("key", "new")
+        }
+
+        error shouldBeEqualTo failure
+        verify(exactly = 0) { frontCache.put(any(), any()) }
+        verify(exactly = 0) { frontCache.remove(any()) }
+    }
+
+    @Test
+    fun `back cancellation은 front 변경 없이 호출자에게 재전파된다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val cancellation = CancellationException("back cache cancelled")
+        every { backCache.putIfAbsent("key", "new") } throws cancellation
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        val error = assertFailsWith<CancellationException> {
+            nearCache.putIfAbsent("key", "new")
+        }
+
+        error shouldBeEqualTo cancellation
+        verify(exactly = 0) { frontCache.put(any(), any()) }
+        verify(exactly = 0) { frontCache.remove(any()) }
+    }
+
+    @Test
+    fun `back commit 후 front 보정 실패는 front를 invalidate하고 원래 예외를 전달한다`() {
+        val frontCache = mockk<JCache<String, String>>(relaxed = true)
+        val backCache = mockk<JCache<String, String>>(relaxed = true)
+        val frontFailure = IllegalStateException("front cache is unavailable")
+        every { backCache.putIfAbsent("key", "new") } returns true
+        every { frontCache.put("key", "new") } throws frontFailure
+        every { frontCache.remove("key") } returns true
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(isSynchronous = true),
+        )
+
+        val error = assertFailsWith<IllegalStateException> {
+            nearCache.putIfAbsent("key", "new")
+        }
+
+        error shouldBeEqualTo frontFailure
+        verify(exactly = 1) { frontCache.remove("key") }
+    }
+
+    @Test
+    fun `동시 putIfAbsent는 back 원자 결과 하나만 성공시키고 최종 값을 보존한다`() {
+        val configuration = MutableConfiguration<String, String>()
+            .setTypes(String::class.java, String::class.java)
+            .setStoreByValue(false)
+        val cacheName = "issue-1447-concurrent-${UUID.randomUUID()}"
+        val frontCache = JCaching.Caffeine.getOrCreate("$cacheName-front", configuration)
+        val backCache = JCaching.Caffeine.getOrCreate("$cacheName-back", configuration)
+        val nearCache = NearJCache(
+            frontCache = frontCache,
+            backCache = backCache,
+            config = NearJCacheConfig(
+                frontCacheConfiguration = configuration,
+                isSynchronous = true,
+            ),
+        )
+        val outcomes = ConcurrentLinkedQueue<Boolean>()
+
+        try {
+            MultithreadingTester()
+                .workers(8)
+                .rounds(4)
+                .add { outcomes.add(nearCache.putIfAbsent("key", "value")) }
+                .run()
+
+            outcomes.count { it }.shouldBeEqualTo(1)
+            backCache.get("key") shouldBeEqualTo "value"
+            nearCache.get("key") shouldBeEqualTo "value"
+            frontCache.get("key") shouldBeEqualTo "value"
+        } finally {
+            nearCache.close()
+            backCache.close()
+        }
+    }
+}

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughFailureTest.kt
@@ -52,9 +52,7 @@ class NearJCacheWriteThroughFailureTest {
     fun `동기 putIfAbsent는 back cache 실패를 전달한다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
-        every { frontCache.putIfAbsent("key", "value") } returns true
-        every { backCache.containsKey("key") } returns false
-        every { backCache.put("key", "value") } throws failure
+        every { backCache.putIfAbsent("key", "value") } throws failure
 
         val nearCache = newNearCache(frontCache, backCache)
 
@@ -81,10 +79,7 @@ class NearJCacheWriteThroughFailureTest {
     fun `동기 조건부 remove는 back cache 실패를 전달한다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
-        every { frontCache.remove("key", "old") } returns true
-        every { backCache.containsKey("key") } returns true
-        every { backCache.get("key") } returns "old"
-        every { backCache.remove("key") } throws failure
+        every { backCache.remove("key", "old") } throws failure
 
         val nearCache = newNearCache(frontCache, backCache)
 
@@ -97,9 +92,7 @@ class NearJCacheWriteThroughFailureTest {
     fun `동기 replace는 back cache 실패를 전달한다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
-        every { frontCache.replace("key", "value") } returns true
-        every { backCache.containsKey("key") } returns true
-        every { backCache.put("key", "value") } throws failure
+        every { backCache.replace("key", "value") } throws failure
 
         val nearCache = newNearCache(frontCache, backCache)
 
@@ -112,10 +105,7 @@ class NearJCacheWriteThroughFailureTest {
     fun `동기 조건부 replace는 back cache 실패를 전달한다`() {
         val frontCache = mockk<JCache<String, String>>(relaxed = true)
         val backCache = mockk<JCache<String, String>>(relaxed = true)
-        every { frontCache.replace("key", "old", "new") } returns true
-        every { backCache.containsKey("key") } returns true
-        every { backCache.get("key") } returns "old"
-        every { backCache.put("key", "new") } throws failure
+        every { backCache.replace("key", "old", "new") } throws failure
 
         val nearCache = newNearCache(frontCache, backCache)
 

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheWriteThroughReentrancyTest.kt
@@ -65,13 +65,10 @@ class NearJCacheWriteThroughReentrancyTest {
     private fun testPutIfAbsent() {
         runInlineListenerOperation(
             operation = "putIfAbsent",
-            configureFront = { frontCache ->
-                every { frontCache.putIfAbsent("key", "value") } returns true
-            },
             configureBack = { backCache, fire ->
-                every { backCache.containsKey("key") } returns false
-                every { backCache.put("key", "value") } answers {
+                every { backCache.putIfAbsent("key", "value") } answers {
                     fire(EventType.CREATED)
+                    true
                 }
             },
             invoke = { it.putIfAbsent("key", "value") },
@@ -103,13 +100,10 @@ class NearJCacheWriteThroughReentrancyTest {
     private fun testReplace() {
         runInlineListenerOperation(
             operation = "replace",
-            configureFront = { frontCache ->
-                every { frontCache.replace("key", "value") } returns true
-            },
             configureBack = { backCache, fire ->
-                every { backCache.containsKey("key") } returns true
-                every { backCache.put("key", "value") } answers {
+                every { backCache.replace("key", "value") } answers {
                     fire(EventType.UPDATED)
+                    true
                 }
             },
             invoke = { it.replace("key", "value") },

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheOperationStatisticsTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/management/NearJCacheOperationStatisticsTest.kt
@@ -196,8 +196,7 @@ class NearJCacheOperationStatisticsTest {
     @Test
     fun `putIfAbsent는 실제 삽입 성공만 put으로 기록한다`() {
         val fixture = statisticsEnabledFixture()
-        every { fixture.front.putIfAbsent("key", "value") } returnsMany listOf(true, false)
-        every { fixture.back.containsKey("key") } returns false
+        every { fixture.back.putIfAbsent("key", "value") } returnsMany listOf(true, false)
 
         fixture.cache.putIfAbsent("key", "value").shouldBeTrue()
         fixture.cache.putIfAbsent("key", "value") shouldBeEqualTo false
@@ -208,8 +207,8 @@ class NearJCacheOperationStatisticsTest {
     @Test
     fun `replace overload는 실제 교체 성공만 put으로 기록한다`() {
         val fixture = statisticsEnabledFixture()
-        every { fixture.front.replace("key", "value") } returnsMany listOf(true, false)
-        every { fixture.front.replace("key", "old", "new") } returnsMany listOf(true, false)
+        every { fixture.back.replace("key", "value") } returnsMany listOf(true, false)
+        every { fixture.back.replace("key", "old", "new") } returnsMany listOf(true, false)
 
         fixture.cache.replace("key", "value").shouldBeTrue()
         fixture.cache.replace("key", "value") shouldBeEqualTo false
@@ -222,8 +221,8 @@ class NearJCacheOperationStatisticsTest {
     @Test
     fun `remove overload는 실제 삭제 성공만 removal로 기록한다`() {
         val fixture = statisticsEnabledFixture()
-        every { fixture.front.remove("key") } returnsMany listOf(true, false)
-        every { fixture.front.remove("key", "old") } returnsMany listOf(true, false)
+        every { fixture.back.remove("key") } returnsMany listOf(true, false)
+        every { fixture.back.remove("key", "old") } returnsMany listOf(true, false)
 
         fixture.cache.remove("key").shouldBeTrue()
         fixture.cache.remove("key") shouldBeEqualTo false

--- a/docs/lessons/2026-08-23-issue-1447-nearjcache-conditional-mutation.md
+++ b/docs/lessons/2026-08-23-issue-1447-nearjcache-conditional-mutation.md
@@ -1,0 +1,62 @@
+# #1447 NearJCache 조건부 mutation의 back-first 계약
+
+## 맥락
+
+`NearJCache`의 blocking `putIfAbsent`, `remove`, `remove(key, oldValue)`,
+`replace`가 front cache 결과를 먼저 사용하고, 그 결과가 성공일 때만 back
+cache를 조회하거나 변경하고 있었다. 정상적인 front eviction이나 두 번째
+NearCache 인스턴스에서는 front가 miss이고 back만 값을 보유할 수 있으므로,
+이 순서는 JCache 반환값과 논리적인 2-tier 상태를 불일치시켰다.
+
+## 결정
+
+- 네 조건부 연산은 JCache back provider의 원자 API를 먼저 호출한다.
+- blocking 반환값은 front가 아니라 back 원자 결과로 결정한다. 결과를 반환해야
+  하므로 `NearJCacheConfig.isSynchronous=false`여도 해당 back 호출은 완료될
+  때까지 기다린다.
+- back 성공 후 성공 결과는 front에 반영하고, 조건 불충족 결과는 front key를
+  제거해 stale 값을 남기지 않는다.
+- back 호출이 실패하면 front mutation을 수행하지 않는다. back commit 후 front
+  보정이 실패하면 front key를 invalidate하고 원래 예외를 전달한다.
+- `SuspendNearJCache`의 기존 back-first 일반 mutation 계약과 같은 기준을
+  blocking API에도 적용하되, blocking provider 호출의 timeout/cancellation은
+  `NearJCache`의 동기 write 경계를 따른다.
+
+## 결과
+
+front miss/back hit 상태에서 `putIfAbsent`, `remove`, 두 `replace` overload가
+back 상태와 같은 성공·실패 결과를 반환하고, 성공 후 front/back 값이 같은
+상태로 수렴한다. 조건부 mutation 경합에서는 back 원자 연산이 성공자를
+결정하며, 실패한 호출의 front invalidate가 남은 stale 값을 노출하지 않는다.
+
+## 검증
+
+- RED: front `putIfAbsent`가 `true`여도 back `putIfAbsent`가 `false`이면
+  blocking API가 `true`를 반환하던 회귀 테스트가 실패했다.
+- GREEN: `NearJCacheConditionalMutationContractTest`에서 front miss/back hit
+  4개 연산, back 실패·cancellation, front 보정 실패·invalidate, 동시
+  `putIfAbsent`를 검증했다.
+- 기존 `NearJCacheWriteThroughFailureTest`,
+  `NearJCacheWriteThroughReentrancyTest`,
+  `NearJCacheOperationStatisticsTest`를 새 back-first 호출 경계에 맞춰
+  갱신하고 통과시켰다.
+- `./gradlew :bluetape4k-cache-core:test --rerun-tasks`로 전체 모듈 회귀를
+  확인했고 `711 passing`, `BUILD SUCCESSFUL`을 기록했다.
+- `:bluetape4k-cache-hazelcast:test`의 `HazelcastNearJCacheTest` 6개,
+  `:bluetape4k-cache-lettuce:test`의 NearJCache 회귀 74개,
+  `:bluetape4k-cache-redisson:test`의 `RedissonNearJCacheTest` 73개가 모두
+  통과했다.
+- `./gradlew :bluetape4k-cache-core:detekt --rerun-tasks`와
+  `./gradlew :bluetape4k-cache-core:build -x test --rerun-tasks`가 모두
+  `BUILD SUCCESSFUL`로 완료됐다. detekt 출력의 기존 `magic number`,
+  `LargeClass`, `ReturnCount` 항목은 이번 변경 파일이 아닌 기존 코드의
+  비차단 경고다.
+
+## 놓치기 쉬운 점과 후속 guard
+
+NearCache의 front는 빠른 복사본이지 조건부 mutation의 기준 데이터 원본이
+아니다. 새 blocking 조건부 연산을 추가할 때 front read/compare/write 조합을
+사용하지 말고, back provider가 제공하는 원자 API를 먼저 호출한 뒤 front를
+reconcile한다. back 결과가 false인 경우에도 front를 그대로 보존하지 말고
+invalidate하여 다음 read가 back의 논리값을 다시 채우게 한다. back commit 뒤
+front 반영 실패와 provider cancellation도 별도 계약 테스트로 유지한다.


### PR DESCRIPTION
## 요약
- `NearJCache`의 blocking 조건부 mutation을 back provider 원자 API 기준으로 정렬합니다.
- front miss/back hit, 조건 불충족, provider 실패·취소, front 보정 실패 경계를 계약 테스트로 고정합니다.
- cache-core README와 한국어 lesson에 back-first 계약과 후속 guard를 기록합니다.

## 구현
- `putIfAbsent`, `remove`, `remove(key, oldValue)`, `replace` 두 overload가 back 결과를 반환하도록 변경
- 성공 결과는 front에 반영하고 조건 불충족 결과는 front key를 invalidate
- back 실패 시 front mutation을 생략하고, front 보정 실패 시 invalidate 후 원래 예외 재전파

## 검증
- `./gradlew :bluetape4k-cache-core:test --rerun-tasks` — `711 passing`
- Hazelcast NearJCache — `6 passing`
- Lettuce NearJCache 회귀 — `74 passing`
- Redisson NearJCache — `73 passing`
- `./gradlew :bluetape4k-cache-core:detekt --rerun-tasks` — `BUILD SUCCESSFUL` (기존 비차단 경고만 출력)
- `./gradlew :bluetape4k-cache-core:build -x test --rerun-tasks` — `BUILD SUCCESSFUL`
- `git diff --check` — 통과
- 원격 CI run `32631994198` — `success`; `Test / Key Utils`에서 `:bluetape4k-cache-core:test` 실행, path-filtered job은 의도된 `skipping`

Fixes #1447

## DoD Status
- 상태: CI_PASS_REVIEW_PENDING
- 로컬·provider·원격 CI 검증 완료
- 리뷰와 별도 merge 승인 대기