### PR TITLE
build: 도메인 CI 병렬화와 선택적 무거운 검증

### DIFF
--- a/.github/scripts/test-aggregate-kover-coverage.py
+++ b/.github/scripts/test-aggregate-kover-coverage.py
@@ -181,15 +181,20 @@ class AggregateKoverCoverageTest(unittest.TestCase):
         self.assertIn("'infra/nats'", workflow)
         self.assertIn("test-search-messaging, test-kafka-infra", workflow)
 
-    def test_ci_only_uploads_coveralls_after_successful_aggregation(self):
+    def test_ci_keeps_coveralls_out_of_path_filtered_coverage(self):
         workflow = CI_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("id: aggregate-coverage", workflow)
+        self.assertNotIn("coverallsapp/github-action@v2", workflow)
+
+    def test_nightly_uploads_coveralls_only_for_full_scope(self):
+        workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("name: Upload full-scope coverage to Coveralls", workflow)
+        self.assertIn("needs.plan.outputs.scope == 'full'", workflow)
+        self.assertIn("coverallsapp/github-action@v2", workflow)
+        self.assertIn("format: jacoco", workflow)
+        self.assertIn("! -path '*/nightly-coverage-testcontainers-*/*'", workflow)
         self.assertIn(
-            "if: ${{ steps.aggregate-coverage.outcome == 'success' && hashFiles('coverage-artifacts/**/reports/kover/report.xml') != '' }}",
-            workflow,
-        )
-        self.assertIn(
-            "if: ${{ steps.aggregate-coverage.outcome == 'success' && steps.coveralls-files.outcome == 'success' }}",
+            "if: ${{ needs.plan.outputs.scope == 'full' && steps.aggregate-coverage.outcome == 'success' && steps.full-coveralls-files.outcome == 'success' }}",
             workflow,
         )
 

--- a/.github/scripts/test-ci-domain-parallelization.py
+++ b/.github/scripts/test-ci-domain-parallelization.py
@@ -61,6 +61,18 @@ def inline_needs(block: str) -> set[str]:
     return {item.strip() for item in match.group(1).split(",")}
 
 
+def path_filter_block(workflow: str, filter_name: str) -> str:
+    marker = f"            {filter_name}:\n"
+    start = workflow.index(marker)
+    next_filter = re.search(
+        r"^            [a-z0-9][a-z0-9-]*:\n",
+        workflow[start + len(marker) :],
+        re.MULTILINE,
+    )
+    end = start + len(marker) + next_filter.start() if next_filter else len(workflow)
+    return workflow[start:end]
+
+
 class CiDomainParallelizationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -117,6 +129,53 @@ class CiDomainParallelizationTest(unittest.TestCase):
                 source = benchmark_test.read_text(encoding="utf-8")
                 self.assertIn("import org.junit.jupiter.api.Tag", source)
                 self.assertIn('@Tag("benchmark")', source)
+
+    def test_daily_image_gate_runs_only_for_relevant_changes_or_manual_dispatch(self):
+        gate = job_block(self.workflow, "testcontainers-image-gate")
+        self.assertIn(
+            "if: ${{ needs.changes.outputs['testcontainers-image-gate'] == 'true' || "
+            "github.event_name == 'workflow_dispatch' }}",
+            gate,
+        )
+        self.assertNotIn("needs.changes.outputs.shared", gate)
+
+    def test_daily_image_gate_filter_excludes_generic_workflow_and_contract_test_changes(self):
+        image_gate_filter = path_filter_block(self.workflow, "testcontainers-image-gate")
+        for required_path in (
+            "'testing/testcontainers/**'",
+            "'scripts/testcontainers_image_gate_manifest.json'",
+            "'scripts/testcontainers_image_gate.py'",
+            "'scripts/run_testcontainers_image_gate.py'",
+        ):
+            with self.subTest(required_path=required_path):
+                self.assertIn(required_path, image_gate_filter)
+
+        for excluded_path in (
+            "'.github/workflows/ci.yml'",
+            "'.github/workflows/nightly-tests.yml'",
+            "'.github/workflows/release.yml'",
+            "'scripts/test_testcontainers_contract.py'",
+            "'scripts/test_testcontainers_image_gate.py'",
+            "'scripts/test_run_testcontainers_image_gate.py'",
+        ):
+            with self.subTest(excluded_path=excluded_path):
+                self.assertNotIn(excluded_path, image_gate_filter)
+
+    def test_http_domain_tests_cover_both_local_mock_server_images(self):
+        io_http_filter = path_filter_block(self.workflow, "io-http")
+        self.assertIn("'testing/mock-web-server/**'", io_http_filter)
+        self.assertIn("'testing/mock-webflux-server/**'", io_http_filter)
+
+    def test_nightly_keeps_full_testcontainers_and_image_gate_verification(self):
+        nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+        image_gate = job_block(nightly, "test-testcontainers-image-gate")
+        self.assertIn(
+            "if: ${{ needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers' }}",
+            image_gate,
+        )
+        self.assertIn("--scope full", image_gate)
+        self.assertIn("test-testcontainers:", nightly)
+        self.assertIn("test-testcontainers-spring:", nightly)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test-ci-domain-parallelization.py
+++ b/.github/scripts/test-ci-domain-parallelization.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Daily CI domain dependency graph regression tests."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+
+DOMAIN_JOBS = (
+    "test-core",
+    "test-io",
+    "test-io-http",
+    "test-testcontainers-spring",
+    "testcontainers-image-gate",
+    "test-ktor",
+    "test-key-utils",
+    "test-infra",
+    "test-search-messaging",
+    "test-kafka-infra",
+    "test-telemetry-infra",
+    "test-data",
+)
+
+
+def job_block(workflow: str, job_name: str) -> str:
+    jobs = workflow[workflow.index("jobs:\n") + len("jobs:\n") :]
+    header = re.compile(rf"^  {re.escape(job_name)}:\n", re.MULTILINE)
+    match = header.search(jobs)
+    if match is None:
+        raise AssertionError(f"job not found: {job_name}")
+
+    next_job = re.search(r"^  [a-z0-9][a-z0-9-]*:\n", jobs[match.end() :], re.MULTILINE)
+    end = match.end() + next_job.start() if next_job else len(jobs)
+    return jobs[match.start() : end]
+
+
+def inline_needs(block: str) -> set[str]:
+    match = re.search(r"^    needs: \[([^]]+)]$", block, re.MULTILINE)
+    if match is None:
+        raise AssertionError("inline needs declaration not found")
+    return {item.strip() for item in match.group(1).split(",")}
+
+
+class CiDomainParallelizationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    def test_domain_jobs_run_after_gates_without_waiting_for_full_build(self):
+        expected_needs = {"changes", "catalog-governance"}
+        for job_name in DOMAIN_JOBS:
+            with self.subTest(job=job_name):
+                self.assertSetEqual(inline_needs(job_block(self.workflow, job_name)), expected_needs)
+
+    def test_full_build_remains_an_independent_required_check(self):
+        self.assertSetEqual(
+            inline_needs(job_block(self.workflow, "build")),
+            {"validate-wrapper", "catalog-governance"},
+        )
+        status_needs = inline_needs(job_block(self.workflow, "ci-status"))
+        self.assertIn("build", status_needs)
+        self.assertIn("coverage-report", status_needs)
+        self.assertIn("testcontainers-image-gate", status_needs)
+
+    def test_coverage_report_still_waits_for_every_coverage_job(self):
+        coverage_jobs = set(DOMAIN_JOBS) - {"testcontainers-image-gate"}
+        coverage_needs = inline_needs(job_block(self.workflow, "coverage-report"))
+        self.assertSetEqual(coverage_needs, coverage_jobs)
+        self.assertNotIn("build", coverage_needs)
+
+    def test_changes_job_runs_this_contract(self):
+        changes = job_block(self.workflow, "changes")
+        self.assertIn("Validate CI domain dependency graph", changes)
+        self.assertIn("python3 .github/scripts/test-ci-domain-parallelization.py -v", changes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test-ci-domain-parallelization.py
+++ b/.github/scripts/test-ci-domain-parallelization.py
@@ -10,6 +10,21 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+NIGHTLY_WORKFLOW = ROOT / ".github/workflows/nightly-tests.yml"
+ROOT_BUILD = ROOT / "build.gradle.kts"
+
+BENCHMARK_TESTS = (
+    ROOT / "infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/benchmark/LettuceThroughputBenchmark.kt",
+    ROOT / "infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/benchmark/RedissonConcurrencyBenchmark.kt",
+    ROOT / "io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmarkTest.kt",
+    ROOT / "utils/workflow/src/test/kotlin/io/bluetape4k/workflow/examples/OrderProcessingExecutionModelBenchmarkTest.kt",
+)
+
+BENCHMARK_PROJECTS = (
+    "protobuf-codec-benchmark",
+    "serializer-benchmark",
+    "web-framework-benchmark",
+)
 
 DOMAIN_JOBS = (
     "test-core",
@@ -77,6 +92,31 @@ class CiDomainParallelizationTest(unittest.TestCase):
         changes = job_block(self.workflow, "changes")
         self.assertIn("Validate CI domain dependency graph", changes)
         self.assertIn("python3 .github/scripts/test-ci-domain-parallelization.py -v", changes)
+
+    def test_ci_and_nightly_exclude_benchmark_tag(self):
+        for workflow_path in (CI_WORKFLOW, NIGHTLY_WORKFLOW):
+            with self.subTest(workflow=workflow_path.name):
+                workflow = workflow_path.read_text(encoding="utf-8")
+                self.assertIn("ORG_GRADLE_PROJECT_excludeBenchmarks: 'true'", workflow)
+
+    def test_ci_and_nightly_compile_builds_exclude_benchmark_projects(self):
+        for workflow_path in (CI_WORKFLOW, NIGHTLY_WORKFLOW):
+            build = job_block(workflow_path.read_text(encoding="utf-8"), "build")
+            for project_name in BENCHMARK_PROJECTS:
+                with self.subTest(workflow=workflow_path.name, project=project_name):
+                    self.assertIn(f"-x :{project_name}:build", build)
+
+    def test_root_test_tasks_honor_benchmark_exclusion_property(self):
+        root_build = ROOT_BUILD.read_text(encoding="utf-8")
+        self.assertIn('gradleProperty("excludeBenchmarks")', root_build)
+        self.assertIn('excludeTags("benchmark")', root_build)
+
+    def test_junit_benchmarks_use_the_benchmark_tag(self):
+        for benchmark_test in BENCHMARK_TESTS:
+            with self.subTest(test=benchmark_test.relative_to(ROOT)):
+                source = benchmark_test.read_text(encoding="utf-8")
+                self.assertIn("import org.junit.jupiter.api.Tag", source)
+                self.assertIn('@Tag("benchmark")', source)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1216,26 +1216,6 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Prepare Coveralls file list
-        id: coveralls-files
-        if: ${{ steps.aggregate-coverage.outcome == 'success' && hashFiles('coverage-artifacts/**/reports/kover/report.xml') != '' }}
-        run: |
-          files=$(find coverage-artifacts -type f -path '*/reports/kover/report.xml' -print | sort | paste -sd ' ' -)
-          if [ -z "$files" ]; then
-            echo 'No Kover report files found for Coveralls.' >&2
-            exit 1
-          fi
-          echo "files=$files" >> "$GITHUB_OUTPUT"
-
-      - name: Upload coverage to Coveralls
-        if: ${{ steps.aggregate-coverage.outcome == 'success' && steps.coveralls-files.outcome == 'success' }}
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ steps.coveralls-files.outputs.files }}
-          format: jacoco
-          fail-on-error: true
-
   # ── 9. 결과 집계 ──────────────────────────────────────────────────────────
   ci-status:
     name: CI Status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
         run: ruby scripts/validate-ci-kafka4-coverage.rb
       - name: Validate Kover coverage aggregation
         run: python3 .github/scripts/test-aggregate-kover-coverage.py -v
+      - name: Validate CI domain dependency graph
+        run: python3 .github/scripts/test-ci-domain-parallelization.py -v
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -333,7 +335,7 @@ jobs:
     name: Test / Core
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -402,7 +404,7 @@ jobs:
     name: Test / IO
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs.io == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -475,7 +477,7 @@ jobs:
     name: Test / IO HTTP
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs['io-http'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -553,7 +555,7 @@ jobs:
     name: Test / Testcontainers Spring bridge
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs['testcontainers-spring'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -599,7 +601,7 @@ jobs:
     name: Test / Testcontainers image startup-workload gate
     runs-on: ubuntu-latest
     timeout-minutes: 360
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs['testcontainers-image-gate'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -674,7 +676,7 @@ jobs:
     name: Test / Ktor
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs.ktor == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -739,7 +741,7 @@ jobs:
     name: Test / Key Utils
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs['key-utils'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -798,7 +800,7 @@ jobs:
     name: Test / Infra (Redis)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs.infra == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -881,7 +883,7 @@ jobs:
     name: Test / Search & Messaging
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs['search-messaging'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -936,7 +938,7 @@ jobs:
     name: Test / Kafka Infra
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs['kafka-infra'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -997,7 +999,7 @@ jobs:
     name: Test / Telemetry Infra
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs['telemetry-infra'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
@@ -1058,7 +1060,7 @@ jobs:
     name: Test / Data
     runs-on: ubuntu-latest
     timeout-minutes: 75
-    needs: [build, changes]
+    needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs.data == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ concurrency:
 env:
   JAVA_VERSION: '25'
   JAVA_DISTRIBUTION: 'temurin'
+  ORG_GRADLE_PROJECT_excludeBenchmarks: 'true'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '91f9ea9336b5ea991f5675323a1cf25ccfd6f5ed'
   GITLEAKS_VERSION: 'v8.30.1'
@@ -311,7 +312,11 @@ jobs:
       - name: Build (compile only)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew build -x test --parallel && break
+            ./gradlew build -x test \
+              -x :protobuf-codec-benchmark:build \
+              -x :serializer-benchmark:build \
+              -x :web-framework-benchmark:build \
+              --parallel && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
               - 'io/retrofit2/**'
               - 'io/vertx/**'
               - 'testing/mock-web-server/**'
+              - 'testing/mock-webflux-server/**'
             testcontainers-spring:
               - 'testing/testcontainers/**'
               - 'testing/testcontainers-spring/**'
@@ -194,13 +195,7 @@ jobs:
               - 'testing/testcontainers/**'
               - 'scripts/testcontainers_image_gate_manifest.json'
               - 'scripts/testcontainers_image_gate.py'
-              - 'scripts/test_testcontainers_contract.py'
-              - 'scripts/test_testcontainers_image_gate.py'
               - 'scripts/run_testcontainers_image_gate.py'
-              - 'scripts/test_run_testcontainers_image_gate.py'
-              - '.github/workflows/ci.yml'
-              - '.github/workflows/nightly-tests.yml'
-              - '.github/workflows/release.yml'
             ktor:
               - 'ktor/**'
             key-utils:
@@ -601,13 +596,13 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  # ── 4-d. 변경 Testcontainers image family startup/workload gate ──────────
+  # ── 4-d. 관련 변경 Testcontainers image family startup/workload gate ─────
   testcontainers-image-gate:
     name: Test / Testcontainers image startup-workload gate
     runs-on: ubuntu-latest
     timeout-minutes: 360
     needs: [changes, catalog-governance]
-    if: ${{ needs.changes.outputs['testcontainers-image-gate'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ needs.changes.outputs['testcontainers-image-gate'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   JAVA_VERSION: '25'
   JAVA_DISTRIBUTION: 'temurin'
+  ORG_GRADLE_PROJECT_excludeBenchmarks: 'true'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
@@ -303,12 +304,15 @@ jobs:
           gradle-version: wrapper
           cache-read-only: false
 
-      - name: Build (compile only, excluding examples)
+      - name: Build (compile only, excluding examples and benchmarks)
         shell: bash
         run: |
           set -euo pipefail
 
           excluded_tasks=(
+            -x :protobuf-codec-benchmark:build
+            -x :serializer-benchmark:build
+            -x :web-framework-benchmark:build
             -x :bluetape4k-examples-coroutines-demo:build
             -x :bluetape4k-examples-jpa-blazepersistence-demo:build
             -x :bluetape4k-examples-jpa-querydsl-demo:build

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1380,6 +1380,7 @@ jobs:
           merge-multiple: false
 
       - name: Aggregate Kover coverage summary
+        id: aggregate-coverage
         if: always()
         env:
           COVERAGE_DOWNLOAD_OUTCOME: ${{ steps.download-coverage.outcome }}
@@ -1404,6 +1405,37 @@ jobs:
           path: coverage-artifacts/
           if-no-files-found: error
           retention-days: 14
+
+      # Daily CI intentionally aggregates only changed domains. Keep that
+      # local, fail-closed summary separate from Coveralls' repository-wide
+      # comparison and publish external coverage only from the full scope.
+      - name: Prepare full-scope Coveralls file list
+        id: full-coveralls-files
+        if: ${{ needs.plan.outputs.scope == 'full' && steps.aggregate-coverage.outcome == 'success' && hashFiles('coverage-artifacts/**/reports/kover/report.xml') != '' }}
+        run: |
+          # Testcontainers matrix shards emit partial reports for the same
+          # module. The aggregate above still consumes every shard, but those
+          # duplicate partial files must not be compared as a repository-wide
+          # Coveralls baseline.
+          files=$(find coverage-artifacts \
+            -type f \
+            -path '*/reports/kover/report.xml' \
+            ! -path '*/nightly-coverage-testcontainers-*/*' \
+            -print | sort | paste -sd ' ' -)
+          if [ -z "$files" ]; then
+            echo 'No full-scope Kover report files found for Coveralls.' >&2
+            exit 1
+          fi
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Upload full-scope coverage to Coveralls
+        if: ${{ needs.plan.outputs.scope == 'full' && steps.aggregate-coverage.outcome == 'success' && steps.full-coveralls-files.outcome == 'success' }}
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ steps.full-coveralls-files.outputs.files }}
+          format: jacoco
+          fail-on-error: true
 
   # ── 결과 집계 ─────────────────────────────────────────────────────────────
   nightly-status:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,9 @@ val centralSnapshotsParallelism: Int = providers
 val projectGroup: String = providers.gradleProperty("projectGroup").get()
 val baseVersion: String = providers.gradleProperty("baseVersion").get()
 val snapshotVersion: String = providers.gradleProperty("snapshotVersion").get()
+val excludeBenchmarks = providers.gradleProperty("excludeBenchmarks")
+    .map(String::toBoolean)
+    .orElse(false)
 
 abstract class TestcontainersMutexService: BuildService<BuildServiceParameters.None>
 
@@ -344,6 +347,12 @@ subprojects {
 
         test {
             useJUnitPlatform()
+
+            if (excludeBenchmarks.get()) {
+                useJUnitPlatform {
+                    excludeTags("benchmark")
+                }
+            }
 
             // bluetape4k.* 시스템 프로퍼티를 테스트 JVM에 전달 (골든 이미지 갱신 모드 등)
             System.getProperties()

--- a/docs/lessons/2026-08-23-ci-domain-parallelization.md
+++ b/docs/lessons/2026-08-23-ci-domain-parallelization.md
@@ -22,6 +22,11 @@ Daily CI는 이미 `dorny/paths-filter`로 `core`, `io`, `infra`, `data` 등 변
   의도적으로 `skipped`인 경우만 report 부재를 허용한다.
 - `.github/scripts/test-ci-domain-parallelization.py`로 위 의존 그래프를 회귀 계약으로
   고정하고 `changes` job에서 실행한다.
+- 성능 수집은 일반 회귀 검증과 분리한다. `CI`와 `Nightly`는
+  `excludeBenchmarks=true`를 전달하고, 공통 Gradle test 설정은 `benchmark` tag가 붙은
+  JUnit benchmark만 제외한다.
+- 전체 compile build에서도 `protobuf-codec-benchmark`, `serializer-benchmark`,
+  `web-framework-benchmark`의 `build` task를 제외한다.
 
 ## 결과
 
@@ -34,6 +39,12 @@ Daily CI는 이미 `dorny/paths-filter`로 `core`, `io`, `infra`, `data` 등 변
 변경되면 기존 `shared` 규칙에 따라 모든 도메인 테스트가 계속 실행된다. 관련 없는
 테스트만 건너뛰되, 공통 빌드 계약의 영향 범위는 축소하지 않았다.
 
+별도 JMH task는 두 workflow에서 호출하지 않고, benchmark 전용 프로젝트도 compile
+build 대상에서 제외한다. 일반 `test`에 섞여 있던 Lettuce,
+Redisson, HTTP client, workflow 실행 모델 benchmark는 동일한 `benchmark` tag로 분류해
+CI 자원을 사용하지 않게 했다. benchmark fixture와 지원 코드의 correctness test는 일반
+회귀 테스트로 남겨 성능 실행 제외가 기능 검증 공백으로 이어지지 않게 했다.
+
 ## 검증
 
 - RED: 기존 workflow에서 12개 도메인 job이 `build`를 기다려 계약 테스트가 실패했다.
@@ -43,6 +54,10 @@ Daily CI는 이미 `dorny/paths-filter`로 `core`, `io`, `infra`, `data` 등 변
   `build`를 계속 집계하는지 확인했다.
 - `Coverage Report`가 image gate를 제외한 모든 coverage job을 계속 기다리는지
   확인했다.
+- benchmark 제외 계약은 RED 6 failures에서 시작해 workflow opt-out, Gradle tag filter,
+  네 benchmark class의 tag를 연결한 뒤 전체 7개 계약 테스트가 통과했다.
+- 네 benchmark class만 각각 선택한 Gradle 검증에서 모두 `0 passing`과
+  `No tests found for given includes`를 확인해 실행 계획에서 제외됐음을 증명했다.
 
 ## 놓친 점과 주의사항
 
@@ -64,6 +79,8 @@ Daily CI에서 시작 시점만 앞당겼으며, gate 내부 실행 방식이나
 - 도메인 job은 변경 감지와 공통 catalog 검증 뒤에 실행하고, 전체 `Build`와 병렬화한다.
 - 새 coverage job을 추가하면 `Coverage Report`의 `needs`, expected manifest, artifact
   계약을 같은 변경에서 갱신한다.
+- 새 JUnit benchmark는 `@Tag("benchmark")`를 붙인다. CI나 Nightly에 benchmark를 다시
+  포함하려면 일반 test에 섞지 말고 별도 opt-in workflow와 실행 예산을 둔다.
 - 첫 hosted PR 실행에서는 job 시작 시각과 전체 소요 시간을 비교해 병렬 실행이 실제로
   적용됐는지 확인한다.
 

--- a/docs/lessons/2026-08-23-ci-domain-parallelization.md
+++ b/docs/lessons/2026-08-23-ci-domain-parallelization.md
@@ -33,6 +33,11 @@ Daily CI는 이미 `dorny/paths-filter`로 `core`, `io`, `infra`, `data` 등 변
 - 각 도메인의 Testcontainers 사용 테스트는 유지하고, `mock-web-server`와
   `mock-webflux-server` 변경은 실제 소비자인 IO HTTP 도메인 테스트가 모두 받는다.
 - Nightly의 `full`·`testcontainers` scope와 release의 전체 image gate는 유지한다.
+- Daily coverage는 경로 필터로 선택된 부분 집계만 포함하므로 Coveralls 업로드를 하지
+  않는다. Daily의 Kover 집계와 fail-closed artifact 검증은 계속 유지한다.
+- Coveralls는 전체 저장소 범위를 보장하는 Nightly `full` scope에서만 업로드한다.
+  Testcontainers matrix shard의 동일 모듈 부분 report는 외부 비교 목록에서 제외하고,
+  로컬 Nightly aggregate에는 계속 포함한다.
 
 ## 결과
 
@@ -57,6 +62,13 @@ CI 자원을 사용하지 않게 했다. benchmark fixture와 지원 코드의 c
 Testcontainers 사용 테스트가 맡고, 전체 image family drift는 Nightly와 release gate가
 계속 검증한다.
 
+Coveralls 실패도 같은 범위 문제였다. PR `32640318114`의 Daily aggregate에는 45개
+Kover report가 있었고 custom aggregate는 `92.50%`였지만, `develop` 기준 실행
+`32632717769`는 path-filter 결과 2개 report만 업로드했다. 따라서 Coveralls가 서로 다른
+부분 집계를 저장소 전체 기준선으로 비교해 `Coverage decreased (-6.7%) to 81.715%`를
+보고했다. 이는 report 생성·업로드 실패가 아니라 외부 비교 범위가 불변하지 않았던
+계약 오류다.
+
 ## 검증
 
 - RED: 기존 workflow에서 12개 도메인 job이 `build`를 기다려 계약 테스트가 실패했다.
@@ -75,6 +87,13 @@ Testcontainers 사용 테스트가 맡고, 전체 image family drift는 Nightly�
   테스트가 통과했다.
 - Nightly의 `full`·`testcontainers` 전체 gate와 Testcontainers 본체·Spring bridge
   테스트가 유지되는지 계약으로 확인했다.
+- Coveralls 범위 계약은 Daily 업로드가 존재하는 상태에서 RED가 되었고, Daily 업로드
+  제거와 Nightly `full` 전용 업로드·Testcontainers shard 제외를 적용한 뒤 Kover 계약
+  테스트 26개, 도메인 CI 계약 테스트 12개, Kafka4/CSV coverage 검증, `actionlint`가
+  통과했다.
+- 수정 전 PR에서 GitHub Actions 자체는 모두 성공했고 Coveralls만 실패했으며, 현재
+  원인은 비동기 Coveralls 비교 범위로 재현했다. 새 head의 hosted CI에서 Daily에
+  `coverage/coveralls` status가 다시 생성되지 않는지 확인해야 한다.
 
 ## 놓친 점과 주의사항
 
@@ -87,6 +106,12 @@ Daily CI에서 image gate job이 `skipped`됐다는 결과는 image family cover
 검증했다는 뜻이 아니다. 이는 해당 diff가 별도 startup-workload 검증 대상이 아니라는
 트리거 판정의 증거이며, 전체 family coverage는 Nightly `full`·`testcontainers`와
 release gate의 성공으로 판단해야 한다.
+
+Daily Kover aggregate가 성공했다는 사실도 Coveralls 저장소 기준선과 동일한 범위를
+사용했다는 뜻이 아니다. path-filter CI에서는 외부 coverage publisher를 연결하지 말고,
+전체 범위가 보장되는 Nightly `full` 결과만 장기 기준선으로 사용해야 한다. Nightly
+matrix에 같은 모듈의 부분 report를 추가할 때는 Coveralls 입력에서 중복 shard를
+제외하거나 먼저 합치는 계약을 갱신한다.
 
 Manual Documentation은 Gradle module inventory와 `docs/manual/manifest.yaml`의
 모듈 목록도 대조한다. `bluetape4k-testcontainers-spring` 모듈이 추가된 뒤 manifest와
@@ -104,6 +129,8 @@ EN/KO manual이 함께 등록되지 않아, `build.gradle.kts` 변경만으로�
 - 도메인 job은 변경 감지와 공통 catalog 검증 뒤에 실행하고, 전체 `Build`와 병렬화한다.
 - 새 coverage job을 추가하면 `Coverage Report`의 `needs`, expected manifest, artifact
   계약을 같은 변경에서 갱신한다.
+- Coverage publisher는 invariant full-scope input에서만 실행한다. Daily처럼 선택된
+  도메인만 테스트하는 workflow에 Coveralls를 다시 연결하지 않는다.
 - 새 JUnit benchmark는 `@Tag("benchmark")`를 붙인다. CI나 Nightly에 benchmark를 다시
   포함하려면 일반 test에 섞지 말고 별도 opt-in workflow와 실행 예산을 둔다.
 - 새 Testcontainers image family나 gate 구현 파일을 추가하면 Daily image gate path

--- a/docs/lessons/2026-08-23-ci-domain-parallelization.md
+++ b/docs/lessons/2026-08-23-ci-domain-parallelization.md
@@ -27,6 +27,12 @@ Daily CI는 이미 `dorny/paths-filter`로 `core`, `io`, `infra`, `data` 등 변
   JUnit benchmark만 제외한다.
 - 전체 compile build에서도 `protobuf-codec-benchmark`, `serializer-benchmark`,
   `web-framework-benchmark`의 `build` task를 제외한다.
+- Daily CI의 별도 Testcontainers image gate는 `testing/testcontainers/**`, image gate
+  manifest·runner 변경 또는 `workflow_dispatch`에서만 실행한다. 일반 `shared` 변경과
+  workflow·계약 테스트 파일 변경만으로는 실행하지 않는다.
+- 각 도메인의 Testcontainers 사용 테스트는 유지하고, `mock-web-server`와
+  `mock-webflux-server` 변경은 실제 소비자인 IO HTTP 도메인 테스트가 모두 받는다.
+- Nightly의 `full`·`testcontainers` scope와 release의 전체 image gate는 유지한다.
 
 ## 결과
 
@@ -45,6 +51,12 @@ Redisson, HTTP client, workflow 실행 모델 benchmark는 동일한 `benchmark`
 CI 자원을 사용하지 않게 했다. benchmark fixture와 지원 코드의 correctness test는 일반
 회귀 테스트로 남겨 성능 실행 제외가 기능 검증 공백으로 이어지지 않게 했다.
 
+별도 image startup-workload gate는 52개 image family를 순차 검증하므로 일반 CI에서
+40분 이상 걸릴 수 있다. 이를 없애지는 않고, Daily CI에서는 Testcontainers 서버나 gate
+자체가 바뀌는 경우와 수동 실행으로 한정했다. 일반 모듈 변경은 해당 도메인의 실제
+Testcontainers 사용 테스트가 맡고, 전체 image family drift는 Nightly와 release gate가
+계속 검증한다.
+
 ## 검증
 
 - RED: 기존 workflow에서 12개 도메인 job이 `build`를 기다려 계약 테스트가 실패했다.
@@ -58,6 +70,11 @@ CI 자원을 사용하지 않게 했다. benchmark fixture와 지원 코드의 c
   네 benchmark class의 tag를 연결한 뒤 전체 7개 계약 테스트가 통과했다.
 - 네 benchmark class만 각각 선택한 Gradle 검증에서 모두 `0 passing`과
   `No tests found for given includes`를 확인해 실행 계획에서 제외됐음을 증명했다.
+- image gate 선택 실행 계약은 기존 workflow에서 일반 `shared`·workflow·계약 테스트
+  변경까지 트리거해 RED가 되었고, 관련 경로와 수동 실행만 남긴 뒤 전체 12개 계약
+  테스트가 통과했다.
+- Nightly의 `full`·`testcontainers` 전체 gate와 Testcontainers 본체·Spring bridge
+  테스트가 유지되는지 계약으로 확인했다.
 
 ## 놓친 점과 주의사항
 
@@ -66,8 +83,10 @@ path filter로 job이 `skipped`됐다는 사실은 해당 영역의 테스트 co
 새 도메인이나 공통 build logic을 추가할 때 filter와 의존 그래프 계약을 함께 갱신해야
 한다.
 
-Testcontainers image gate의 순차 실행 계약과 release gate는 이번 변경 범위가 아니다.
-Daily CI에서 시작 시점만 앞당겼으며, gate 내부 실행 방식이나 판정 조건은 바꾸지 않았다.
+Daily CI에서 image gate job이 `skipped`됐다는 결과는 image family coverage 자체를
+검증했다는 뜻이 아니다. 이는 해당 diff가 별도 startup-workload 검증 대상이 아니라는
+트리거 판정의 증거이며, 전체 family coverage는 Nightly `full`·`testcontainers`와
+release gate의 성공으로 판단해야 한다.
 
 전체 `Build`가 일찍 실패해도 이미 시작한 도메인 테스트는 계속 실행될 수 있어 실패한
 실행의 runner 사용량은 늘 수 있다. 성공 경로의 직렬 대기를 제거하고 독립된 실패 증거를
@@ -81,6 +100,9 @@ Daily CI에서 시작 시점만 앞당겼으며, gate 내부 실행 방식이나
   계약을 같은 변경에서 갱신한다.
 - 새 JUnit benchmark는 `@Tag("benchmark")`를 붙인다. CI나 Nightly에 benchmark를 다시
   포함하려면 일반 test에 섞지 말고 별도 opt-in workflow와 실행 예산을 둔다.
+- 새 Testcontainers image family나 gate 구현 파일을 추가하면 Daily image gate path
+  filter, manifest, 선택 계약을 함께 갱신한다. 일반 `shared` 트리거는 다시 추가하지 않는다.
+- mock server image를 추가하거나 이동하면 실제 소비 도메인의 path filter에도 연결한다.
 - 첫 hosted PR 실행에서는 job 시작 시각과 전체 소요 시간을 비교해 병렬 실행이 실제로
   적용됐는지 확인한다.
 

--- a/docs/lessons/2026-08-23-ci-domain-parallelization.md
+++ b/docs/lessons/2026-08-23-ci-domain-parallelization.md
@@ -88,6 +88,12 @@ Daily CI에서 image gate job이 `skipped`됐다는 결과는 image family cover
 트리거 판정의 증거이며, 전체 family coverage는 Nightly `full`·`testcontainers`와
 release gate의 성공으로 판단해야 한다.
 
+Manual Documentation은 Gradle module inventory와 `docs/manual/manifest.yaml`의
+모듈 목록도 대조한다. `bluetape4k-testcontainers-spring` 모듈이 추가된 뒤 manifest와
+EN/KO manual이 함께 등록되지 않아, `build.gradle.kts` 변경만으로도 이 계약이 실패했다.
+새 모듈을 추가할 때는 `manifest.yaml`, 생성된 manifest JSON, 양쪽 locale 문서를
+같은 변경에서 갱신하고 `exportManualModuleInventory`와 매뉴얼 검증을 실행한다.
+
 전체 `Build`가 일찍 실패해도 이미 시작한 도메인 테스트는 계속 실행될 수 있어 실패한
 실행의 runner 사용량은 늘 수 있다. 성공 경로의 직렬 대기를 제거하고 독립된 실패 증거를
 함께 수집하기 위한 의도적인 절충이며, `CI Status`는 어느 한쪽 실패도 성공으로 바꾸지 않는다.
@@ -108,11 +114,12 @@ release gate의 성공으로 판단해야 한다.
 
 ## 문서 SPW 감사
 
-- SPW-01: PASS — 대상 독자는 CI 유지보수자이고, 근거는 현재 `ci.yml`, 계약 테스트,
-  최근 Actions 실행이다.
-- SPW-02: PASS — 배경, 결정, 결과, 검증, 놓친 점, 향후 가드를 기록했다.
+- SPW-01: PASS — 대상 독자는 CI 유지보수자이고, 근거는 현재 `ci.yml`, Manual
+  Documentation 실행, `testcontainers-spring` README·소스·테스트다.
+- SPW-02: PASS — 배경, 결정, 결과, 검증, 매뉴얼 manifest 보수, 놓친 점, 향후 가드를
+  기록했다.
 - SPW-03: PASS — 식별자와 명령을 보존하고 한국어 기술 문장으로 작성했다.
-- SPW-04: PASS — 의존 그래프와 coverage fail-closed 계약을 workflow 및 테스트와
-  대조했다.
-- SPW-05: PASS — 최종 diff와 Markdown을 다시 읽어 구조, 링크, 식별자, 검증 범위를
-  확인했다.
+- SPW-04: PASS — 의존 그래프, coverage fail-closed 계약, Gradle inventory와 manual
+  manifest 정렬을 workflow·검증기·소스와 대조했다.
+- SPW-05: PASS — 최종 diff와 EN/KO Markdown을 다시 읽고 매뉴얼 계약·링크·식별자·검증
+  범위를 확인했다.

--- a/docs/lessons/2026-08-23-ci-domain-parallelization.md
+++ b/docs/lessons/2026-08-23-ci-domain-parallelization.md
@@ -1,0 +1,79 @@
+# 도메인 CI는 전체 Build와 병렬로 실행해야 한다
+
+## 배경
+
+Daily CI는 이미 `dorny/paths-filter`로 `core`, `io`, `infra`, `data` 등 변경 영역을
+구분하고 관련 테스트만 선택했다. 그러나 선택된 모든 도메인 job이 `Build`를 `needs`로
+참조해, 전체 `./gradlew build -x test --parallel`이 끝난 뒤에야 테스트를 시작했다.
+단일 도메인 변경에서도 전체 compile 시간과 도메인 테스트 시간이 직렬로 더해졌다.
+
+최근 `develop` 실행
+[`32630371344`](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32630371344)에서도
+관련 없는 도메인 job은 건너뛰었지만, `Test / Key Utils`는 `Build` 완료 뒤에 실행됐다.
+
+## 결정
+
+- 전체 `Build`와 publication metadata 검증은 독립된 필수 check로 유지한다.
+- 도메인 test job과 Testcontainers image gate는 `changes`와
+  `catalog-governance`만 선행조건으로 삼는다.
+- `CI Status`는 계속 `build`, 도메인 test job, image gate, `coverage-report`를 모두
+  집계해 실패를 닫힌 상태로 처리한다.
+- `Coverage Report`는 실행된 coverage job의 artifact를 계속 요구하고, 모든 관련 job이
+  의도적으로 `skipped`인 경우만 report 부재를 허용한다.
+- `.github/scripts/test-ci-domain-parallelization.py`로 위 의존 그래프를 회귀 계약으로
+  고정하고 `changes` job에서 실행한다.
+
+## 결과
+
+도메인 test job은 전체 `Build`와 동시에 시작할 수 있다. 따라서 일반적인 단일 도메인
+변경의 실행 경로는 `Build + 도메인 테스트`의 합이 아니라 두 작업 중 더 오래 걸리는
+시간에 가까워진다. 실제 절감 시간은 GitHub-hosted runner 대기 시간과 Gradle cache
+상태에 따라 달라지므로 첫 PR 실행에서 확인해야 한다.
+
+`build.gradle.kts`, `settings.gradle.kts`, `gradle/**`, `ci.yml` 같은 공통 경로가
+변경되면 기존 `shared` 규칙에 따라 모든 도메인 테스트가 계속 실행된다. 관련 없는
+테스트만 건너뛰되, 공통 빌드 계약의 영향 범위는 축소하지 않았다.
+
+## 검증
+
+- RED: 기존 workflow에서 12개 도메인 job이 `build`를 기다려 계약 테스트가 실패했다.
+- GREEN: 도메인 job의 `needs`를 `changes`, `catalog-governance`로 바꾼 뒤 계약 테스트
+  4개가 통과했다.
+- `Build`는 `validate-wrapper`, `catalog-governance`를 계속 기다리고 `CI Status`가
+  `build`를 계속 집계하는지 확인했다.
+- `Coverage Report`가 image gate를 제외한 모든 coverage job을 계속 기다리는지
+  확인했다.
+
+## 놓친 점과 주의사항
+
+path filter로 job이 `skipped`됐다는 사실은 해당 영역의 테스트 coverage가 검증됐다는
+뜻이 아니다. 변경 영향이 공통 경계를 통과할 수 있는 파일은 `shared`에 유지하고,
+새 도메인이나 공통 build logic을 추가할 때 filter와 의존 그래프 계약을 함께 갱신해야
+한다.
+
+Testcontainers image gate의 순차 실행 계약과 release gate는 이번 변경 범위가 아니다.
+Daily CI에서 시작 시점만 앞당겼으며, gate 내부 실행 방식이나 판정 조건은 바꾸지 않았다.
+
+전체 `Build`가 일찍 실패해도 이미 시작한 도메인 테스트는 계속 실행될 수 있어 실패한
+실행의 runner 사용량은 늘 수 있다. 성공 경로의 직렬 대기를 제거하고 독립된 실패 증거를
+함께 수집하기 위한 의도적인 절충이며, `CI Status`는 어느 한쪽 실패도 성공으로 바꾸지 않는다.
+
+## 향후 지침
+
+- 새 도메인 test job은 `Build`를 직렬 선행조건으로 추가하지 않는다.
+- 도메인 job은 변경 감지와 공통 catalog 검증 뒤에 실행하고, 전체 `Build`와 병렬화한다.
+- 새 coverage job을 추가하면 `Coverage Report`의 `needs`, expected manifest, artifact
+  계약을 같은 변경에서 갱신한다.
+- 첫 hosted PR 실행에서는 job 시작 시각과 전체 소요 시간을 비교해 병렬 실행이 실제로
+  적용됐는지 확인한다.
+
+## 문서 SPW 감사
+
+- SPW-01: PASS — 대상 독자는 CI 유지보수자이고, 근거는 현재 `ci.yml`, 계약 테스트,
+  최근 Actions 실행이다.
+- SPW-02: PASS — 배경, 결정, 결과, 검증, 놓친 점, 향후 가드를 기록했다.
+- SPW-03: PASS — 식별자와 명령을 보존하고 한국어 기술 문장으로 작성했다.
+- SPW-04: PASS — 의존 그래프와 coverage fail-closed 계약을 workflow 및 테스트와
+  대조했다.
+- SPW-05: PASS — 최종 diff와 Markdown을 다시 읽어 구조, 링크, 식별자, 검증 범위를
+  확인했다.

--- a/docs/manual/en/modules/bluetape4k-testcontainers-spring.md
+++ b/docs/manual/en/modules/bluetape4k-testcontainers-spring.md
@@ -1,0 +1,107 @@
+---
+manualId: bluetape4k-testcontainers-spring
+title: "Spring Testcontainers Property Bridge"
+description: "Connect PropertyExportingServer properties to Spring Test's DynamicPropertyRegistry without changing core server lifecycle or JVM system properties."
+kind: library
+group: testing
+learningOrder: 1150
+---
+
+# Spring Testcontainers Property Bridge
+
+## Problem {#problem}
+
+Spring integration tests often need container endpoints as dynamic application properties. The core `bluetape4k-testcontainers` module deliberately remains independent of Spring, so a test needs a small adapter that preserves the core property contract while registering values with Spring Test.
+
+## When to use {#when-to-use}
+
+Use `bluetape4k-testcontainers-spring` when a Spring Test context consumes properties exported by a `PropertyExportingServer`. Use the core module's `registerSystemProperties()` API instead when the test explicitly needs JVM system properties. Do not add this bridge to a non-Spring test or expect it to start, stop, or configure a container.
+
+## Coordinates {#coordinates}
+
+```kotlin
+dependencies {
+    testImplementation(platform("io.github.bluetape4k:bluetape4k-dependencies:<version>"))
+    testImplementation("io.github.bluetape4k:bluetape4k-testcontainers-spring")
+}
+```
+
+Gradle project path: `:bluetape4k-testcontainers-spring`. Source directory: `testing/testcontainers-spring`.
+
+## Concepts {#concepts}
+
+`PropertyExportingServer` supplies a `propertyNamespace`, a set of `propertyKeys()`, and the current `properties()`. The bridge maps each key to `testcontainers.{namespace}.{key}` and registers a lazy supplier with Spring's `DynamicPropertyRegistry`. The bridge owns only registration; the test still owns the server lifecycle.
+
+## Quick start {#quick-start}
+
+Register a server from a static `@DynamicPropertySource` method:
+
+```kotlin
+import io.bluetape4k.testcontainers.spring.registerDynamicProperties
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+
+companion object {
+    @DynamicPropertySource
+    @JvmStatic
+    fun registerProperties(registry: DynamicPropertyRegistry) {
+        RedisServer.Launcher.redis.registerDynamicProperties(registry)
+    }
+}
+```
+
+Start and stop `RedisServer.Launcher.redis` through the test's existing lifecycle. The bridge reads values only when Spring evaluates the registered supplier.
+
+## API by task {#api-by-task}
+
+| Task | Entry point | Contract |
+| --- | --- | --- |
+| Register server properties with Spring | `PropertyExportingServer.registerDynamicProperties(registry)` | Registers one lazy supplier for every key returned by `propertyKeys()`. |
+| Keep core and Spring boundaries separate | `PropertyExportingServer` from `bluetape4k-testcontainers` | Reuses the core namespace and property map without adding Spring to the core module. |
+
+## Patterns {#patterns}
+
+Call the extension once from the test's `@DynamicPropertySource` method and keep container startup in the server launcher or test fixture. Because suppliers are lazy and uncached, a value is read from `properties()` for each Spring evaluation. Use one registration path for a key when possible; duplicate registrations are passed to Spring's registry ordering semantics rather than overwritten by this bridge.
+
+## Integrations {#integrations}
+
+The module depends on `bluetape4k-testcontainers` for `PropertyExportingServer` and on Spring Test for `DynamicPropertyRegistry`. It is an optional adapter, not Spring Boot auto-configuration. The release catalog supplies the compatible Spring Test version; consumers should not pin a separate version for this module.
+
+## Configuration {#configuration}
+
+No additional configuration file or system property is introduced. A server with namespace `redis` and key `host` is exposed as `testcontainers.redis.host`. The source namespace and key set remain the core server's responsibility.
+
+## Failures {#failures}
+
+If `propertyKeys()` declares a key that is absent from `properties()`, the supplier throws `IllegalStateException` when Spring evaluates the value. Exceptions raised by `properties()` are propagated with their original type and message. The bridge does not preflight duplicate keys, cache values, or translate server exceptions.
+
+## Operations {#operations}
+
+The bridge does not start or stop containers and does not mutate JVM system properties. Keep resource ownership, readiness, shutdown, and diagnostics in the existing `PropertyExportingServer` launcher or test fixture. This keeps Spring context setup independent from container lifecycle decisions.
+
+## Testing {#testing}
+
+Run the focused module tests:
+
+```bash
+./gradlew :bluetape4k-testcontainers-spring:test --no-configuration-cache
+```
+
+[`PropertyExportingServerDynamicPropertyRegistryTest`](../../../../testing/testcontainers-spring/src/test/kotlin/io/bluetape4k/testcontainers/spring/PropertyExportingServerDynamicPropertyRegistryTest.kt) verifies key mapping, lazy and repeated supplier evaluation, missing-key failures, exception propagation, duplicate registration delegation, and JVM system property preservation without Docker.
+
+## Workshops {#workshops}
+
+No dedicated workshop is registered for this adapter. The module README and focused contract test provide the runnable usage and lifecycle evidence.
+
+## Limitations {#limitations}
+
+This module supports Spring Test's dynamic property registry only. It does not provide Spring Boot auto-configuration, container startup, property caching, collision resolution, or migration of existing workshop helpers. Recheck the server's property contract when the core module changes.
+
+## Sources {#sources}
+
+- [Module README](../../../../testing/testcontainers-spring/README.md)
+- [Module build](../../../../testing/testcontainers-spring/build.gradle.kts)
+- [`PropertyExportingServerDynamicPropertyRegistry`](../../../../testing/testcontainers-spring/src/main/kotlin/io/bluetape4k/testcontainers/spring/PropertyExportingServerDynamicPropertyRegistry.kt)
+- [`PropertyExportingServerDynamicPropertyRegistryTest`](../../../../testing/testcontainers-spring/src/test/kotlin/io/bluetape4k/testcontainers/spring/PropertyExportingServerDynamicPropertyRegistryTest.kt)
+- [`PropertyExportingServer`](../../../../testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/PropertyExportingServer.kt)

--- a/docs/manual/generated/manifest.json
+++ b/docs/manual/generated/manifest.json
@@ -2569,6 +2569,31 @@
       ]
     },
     {
+      "artifact": "io.github.bluetape4k:bluetape4k-testcontainers-spring",
+      "en": "en/modules/bluetape4k-testcontainers-spring.md",
+      "gradlePath": ":bluetape4k-testcontainers-spring",
+      "group": "testing",
+      "id": "bluetape4k-testcontainers-spring",
+      "kind": "library",
+      "ko": "ko/modules/bluetape4k-testcontainers-spring.md",
+      "learningOrder": 1150,
+      "sourceDir": "testing/testcontainers-spring",
+      "sourcePaths": [
+        "testing/testcontainers-spring/src/main/kotlin"
+      ],
+      "testPaths": [
+        "testing/testcontainers-spring/src/test/kotlin",
+        "testing/testcontainers-spring/src/test/resources"
+      ],
+      "title": {
+        "en": "Spring Testcontainers Property Bridge",
+        "ko": "Spring Testcontainers 프로퍼티 브리지"
+      },
+      "workshops": [
+
+      ]
+    },
+    {
       "artifact": "io.github.bluetape4k:bluetape4k-tink",
       "en": "en/modules/bluetape4k-tink.md",
       "gradlePath": ":bluetape4k-tink",

--- a/docs/manual/ko/modules/bluetape4k-testcontainers-spring.md
+++ b/docs/manual/ko/modules/bluetape4k-testcontainers-spring.md
@@ -1,0 +1,107 @@
+---
+manualId: bluetape4k-testcontainers-spring
+title: "Spring Testcontainers 프로퍼티 브리지"
+description: "core 서버의 생명주기나 JVM system property를 바꾸지 않고 PropertyExportingServer 프로퍼티를 Spring Test의 DynamicPropertyRegistry에 연결합니다."
+kind: library
+group: testing
+learningOrder: 1150
+---
+
+# Spring Testcontainers 프로퍼티 브리지
+
+## 해결하는 문제 {#problem}
+
+Spring 통합 테스트는 컨테이너 endpoint를 애플리케이션 프로퍼티로 동적으로 주입해야 하는 경우가 많습니다. `bluetape4k-testcontainers` core 모듈은 Spring과 분리된 상태를 유지하므로, core의 프로퍼티 계약을 보존하면서 Spring Test에 값을 등록하는 작은 adapter가 필요합니다.
+
+## 사용 시점 {#when-to-use}
+
+Spring Test context가 `PropertyExportingServer`가 내보내는 프로퍼티를 사용할 때 `bluetape4k-testcontainers-spring`을 선택합니다. JVM system property가 명시적으로 필요한 테스트라면 core 모듈의 `registerSystemProperties()` API를 사용합니다. Spring이 아닌 테스트에는 이 bridge를 추가하지 말고, 이 모듈이 컨테이너를 시작·중지하거나 설정한다고 가정하지 않습니다.
+
+## 의존성 좌표 {#coordinates}
+
+```kotlin
+dependencies {
+    testImplementation(platform("io.github.bluetape4k:bluetape4k-dependencies:<version>"))
+    testImplementation("io.github.bluetape4k:bluetape4k-testcontainers-spring")
+}
+```
+
+Gradle project path는 `:bluetape4k-testcontainers-spring`, source directory는 `testing/testcontainers-spring`입니다.
+
+## 핵심 개념 {#concepts}
+
+`PropertyExportingServer`는 `propertyNamespace`, `propertyKeys()`, 현재 값을 반환하는 `properties()`를 제공합니다. bridge는 각 키를 `testcontainers.{namespace}.{key}` 형식으로 바꾸고 Spring의 `DynamicPropertyRegistry`에 lazy supplier로 등록합니다. 등록만 bridge의 책임이며 server 생명주기는 테스트가 계속 소유합니다.
+
+## 빠른 시작 {#quick-start}
+
+static `@DynamicPropertySource` 메서드에서 server를 등록합니다.
+
+```kotlin
+import io.bluetape4k.testcontainers.spring.registerDynamicProperties
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+
+companion object {
+    @DynamicPropertySource
+    @JvmStatic
+    fun registerProperties(registry: DynamicPropertyRegistry) {
+        RedisServer.Launcher.redis.registerDynamicProperties(registry)
+    }
+}
+```
+
+`RedisServer.Launcher.redis`의 시작과 종료는 기존 테스트 생명주기에서 처리합니다. bridge는 Spring이 등록된 supplier를 평가할 때만 값을 읽습니다.
+
+## 작업별 API {#api-by-task}
+
+| 작업 | 진입점 | 계약 |
+| --- | --- | --- |
+| server 프로퍼티를 Spring에 등록 | `PropertyExportingServer.registerDynamicProperties(registry)` | `propertyKeys()`가 반환한 각 키에 대해 lazy supplier 하나를 등록합니다. |
+| core와 Spring 경계 유지 | `bluetape4k-testcontainers`의 `PropertyExportingServer` | core의 namespace와 프로퍼티 맵을 재사용하며 core 모듈에 Spring 의존성을 추가하지 않습니다. |
+
+## 권장 패턴 {#patterns}
+
+테스트의 `@DynamicPropertySource` 메서드에서 extension을 한 번 호출하고 컨테이너 시작은 기존 server launcher나 fixture에 맡깁니다. supplier는 lazy하고 값을 캐시하지 않으므로 Spring이 평가할 때마다 `properties()`에서 값을 읽습니다. 하나의 키에는 가능한 한 하나의 등록 경로만 사용하고, 중복 등록이 필요하면 이 bridge가 덮어쓰지 않고 Spring registry의 등록 순서 semantics에 위임한다는 점을 고려합니다.
+
+## 통합 {#integrations}
+
+이 모듈은 `PropertyExportingServer`를 위해 `bluetape4k-testcontainers`에 의존하고, `DynamicPropertyRegistry`를 위해 Spring Test에 의존합니다. Spring Boot auto-configuration이 아니라 선택형 adapter입니다. 호환되는 Spring Test 버전은 release catalog가 제공하므로 이 모듈을 사용하는 쪽에서 별도 버전을 고정하지 않습니다.
+
+## 설정 {#configuration}
+
+추가 설정 파일이나 system property를 만들지 않습니다. namespace가 `redis`이고 키가 `host`인 server는 `testcontainers.redis.host`로 노출됩니다. namespace와 키 집합은 기존 core server가 관리합니다.
+
+## 실패 처리 {#failures}
+
+`propertyKeys()`가 선언한 키가 `properties()`에 없으면 Spring이 값을 평가하는 시점에 `IllegalStateException`이 발생합니다. `properties()`에서 발생한 예외는 원래 타입과 메시지를 유지한 채 전달됩니다. bridge는 중복 키를 사전 검사하지 않고, 값을 캐시하거나 server 예외를 변환하지도 않습니다.
+
+## 운영 {#operations}
+
+bridge는 컨테이너를 시작·중지하지 않고 JVM system property도 변경하지 않습니다. resource ownership, readiness, shutdown, diagnostic은 기존 `PropertyExportingServer` launcher나 테스트 fixture에서 관리합니다. 이렇게 해야 Spring context 구성과 컨테이너 생명주기 결정을 분리할 수 있습니다.
+
+## 테스트 {#testing}
+
+집중 테스트는 다음 명령으로 실행합니다.
+
+```bash
+./gradlew :bluetape4k-testcontainers-spring:test --no-configuration-cache
+```
+
+[`PropertyExportingServerDynamicPropertyRegistryTest`](../../../../testing/testcontainers-spring/src/test/kotlin/io/bluetape4k/testcontainers/spring/PropertyExportingServerDynamicPropertyRegistryTest.kt)는 Docker 없이 key mapping, lazy 및 반복 supplier 평가, 누락 키 실패, 예외 전달, 중복 등록 위임, JVM system property 보존을 검증합니다.
+
+## 워크숍 {#workshops}
+
+이 adapter에 연결된 전용 workshop은 등록되어 있지 않습니다. 모듈 README와 집중 계약 테스트가 실행 가능한 사용법과 생명주기 근거를 제공합니다.
+
+## 제한 사항 {#limitations}
+
+이 모듈은 Spring Test의 dynamic property registry만 지원합니다. Spring Boot auto-configuration, 컨테이너 자동 시작, 프로퍼티 캐시, 충돌 해결, 기존 workshop helper의 migration은 제공하지 않습니다. core 모듈이 변경되면 server 프로퍼티 계약을 다시 확인해야 합니다.
+
+## 근거 {#sources}
+
+- [모듈 README](../../../../testing/testcontainers-spring/README.ko.md)
+- [모듈 build](../../../../testing/testcontainers-spring/build.gradle.kts)
+- [`PropertyExportingServerDynamicPropertyRegistry`](../../../../testing/testcontainers-spring/src/main/kotlin/io/bluetape4k/testcontainers/spring/PropertyExportingServerDynamicPropertyRegistry.kt)
+- [`PropertyExportingServerDynamicPropertyRegistryTest`](../../../../testing/testcontainers-spring/src/test/kotlin/io/bluetape4k/testcontainers/spring/PropertyExportingServerDynamicPropertyRegistryTest.kt)
+- [`PropertyExportingServer`](../../../../testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/PropertyExportingServer.kt)

--- a/docs/manual/manifest.yaml
+++ b/docs/manual/manifest.yaml
@@ -1795,6 +1795,24 @@ modules:
   - testing/testcontainers/src/test/kotlin
   - testing/testcontainers/src/test/resources
   workshops: []
+- id: bluetape4k-testcontainers-spring
+  title:
+    en: "Spring Testcontainers Property Bridge"
+    ko: "Spring Testcontainers 프로퍼티 브리지"
+  learningOrder: 1150
+  gradlePath: ":bluetape4k-testcontainers-spring"
+  sourceDir: testing/testcontainers-spring
+  kind: library
+  group: testing
+  artifact: io.github.bluetape4k:bluetape4k-testcontainers-spring
+  en: en/modules/bluetape4k-testcontainers-spring.md
+  ko: ko/modules/bluetape4k-testcontainers-spring.md
+  sourcePaths:
+  - testing/testcontainers-spring/src/main/kotlin
+  testPaths:
+  - testing/testcontainers-spring/src/test/kotlin
+  - testing/testcontainers-spring/src/test/resources
+  workshops: []
 - id: bluetape4k-tink
   title:
     en: "Google Tink Cryptography"

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/benchmark/RedissonConcurrencyBenchmark.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/benchmark/RedissonConcurrencyBenchmark.kt
@@ -13,6 +13,7 @@ import io.bluetape4k.assertions.shouldBeGreaterThan
 import org.redisson.client.codec.StringCodec
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.io.File
@@ -25,6 +26,7 @@ import kotlin.system.measureTimeMillis
  * 결과는 .omc/self-improve-redisson/state/benchmark_last.json 에 기록됩니다.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@Tag("benchmark")
 class RedissonConcurrencyBenchmark {
 
     companion object: KLogging() {

--- a/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmarkTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/benchmark/HttpClientBenchmarkTest.kt
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestMethodOrder
@@ -55,6 +56,7 @@ import kotlin.system.measureTimeMillis
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@Tag("benchmark")
 class HttpClientBenchmarkTest {
 
     companion object: KLogging() {

--- a/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/examples/OrderProcessingExecutionModelBenchmarkTest.kt
+++ b/utils/workflow/src/test/kotlin/io/bluetape4k/workflow/examples/OrderProcessingExecutionModelBenchmarkTest.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.workflow.api.WorkReport
 import io.bluetape4k.workflow.api.workContext
 import io.bluetape4k.workflow.core.sequentialFlow
 import io.bluetape4k.workflow.coroutines.suspendSequentialFlow
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -18,6 +19,7 @@ import kotlin.time.TimeSource
 /**
  * 동기(Virtual Threads)와 코루틴 워크플로 실행 시간을 같은 시나리오로 비교하는 benchmark 성격의 테스트입니다.
  */
+@Tag("benchmark")
 class OrderProcessingExecutionModelBenchmarkTest {
 
     companion object: KLogging()


### PR DESCRIPTION
## 요약

변경된 도메인만 실행하는 Daily CI와 전체 범위를 검증하는 Nightly CI의 coverage
publisher 범위를 분리합니다. 기존 CI 병렬화·benchmark 제외·Testcontainers image gate
선택 실행·`testcontainers-spring` 매뉴얼 보수와 함께 Daily의 잘못된 Coveralls 외부
비교 실패를 제거했습니다.

## 원인

수정 전 Daily CI는 path-filter로 선택된 도메인의 Kover report만 Coveralls에 업로드하고
있었습니다. PR 실행 [32640318114](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32640318114)은
45개 report와 custom aggregate `92.50%`를 만들었지만, `develop` 기준 실행 `32632717769`는
2개 report만 사용했습니다. Coveralls가 서로 다른 부분 집계를 저장소 전체 기준선으로
비교해 [build 81316561](https://coveralls.io/builds/81316561)의
`Coverage decreased (-6.7%) to 81.715%` status를 남긴 것이 실패 원인이었습니다.

## 변경 내용

- Daily `ci.yml`에서 Coveralls 업로드를 제거하고 Kover aggregate·fail-closed artifact
  검증은 유지했습니다.
- Nightly `full` scope의 coverage-report에만 Coveralls 업로드를 추가했습니다.
- Nightly Testcontainers matrix shard의 동일 모듈 부분 report는 외부 Coveralls 목록에서
  제외하고 custom Nightly aggregate에는 계속 포함합니다.
- 기존 Daily/Nightly benchmark 제외, 도메인 병렬 실행, 선택적 image gate,
  `testcontainers-spring` manual manifest 보수는 유지했습니다.
- 재발 방지 계약을 `.github/scripts/test-aggregate-kover-coverage.py`에 추가하고,
  결정과 범위 주의를 `docs/lessons/2026-08-23-ci-domain-parallelization.md`에 기록했습니다.

## 검증

- `python3 .github/scripts/test-aggregate-kover-coverage.py -v`: PASS (26 tests)
- `python3 .github/scripts/test-ci-domain-parallelization.py -v`: PASS (12 tests)
- `ruby scripts/validate-ci-kafka4-coverage.rb`: PASS
- `ruby scripts/validate-ci-csv-coverage.rb`: PASS
- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`: PASS
- Korean terminology audit 및 `git diff --check`: PASS
- hosted Manual Documentation [32643316915](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32643316915): PASS
- hosted CI [32643316941](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32643316941): PASS
  (Build, 모든 활성 도메인 test, Coverage Report, CI Status); image startup-workload gate는
  정책상 `skipped`
- 새 PR checks에는 `coverage/coveralls` status가 생성되지 않았습니다.
- Nightly full Coveralls 업로드는 scheduled full run에서 실행될 때까지 미검증입니다.

## 검토 메모

- Daily path-filter coverage는 Coveralls 저장소 기준선으로 사용하지 않습니다.
- 전체 coverage publisher는 Nightly `full`에서만 실행하며, matrix shard를 추가할 때는
  Coveralls 입력의 중복 report 필터/병합 계약을 함께 갱신해야 합니다.
- Daily image gate의 `skipped`는 전체 image family 검증 증거가 아니며, 전체 gate는 Nightly
  및 release workflow가 담당합니다.

## 메타데이터

- PR: #1481, base `develop`, head `chore/ci-parallel-domain-tests`
- Head: `c5182eca24aa939dbb40ce1fac1cdd0898fdce82`
- Assignee: `debop`
- Labels: `build`, `ci`, `performance`
- Issue linkage: 관련 issue 없음

## DoD Status

Required checks: 8/12; N/A: 2; Pending: 4

| Check | Status | Evidence | Next action |
|------|--------|----------|-------------|
| CG-07 - Targeted proof | PASS | 26 + 12 contract tests, Kafka4/CSV validators, actionlint, terminology audit | none |
| CG-09 - Lesson | PASS | `docs/lessons/2026-08-23-ci-domain-parallelization.md` | none |
| CG-10 - Pre-PR proof | PASS | Lore commit `c5182eca24aa939dbb40ce1fac1cdd0898fdce82`, `git diff --check` | none |
| CG-11 - Delivery authority | PASS | repository/base/head and user approval confirmed | none |
| CG-12 - Publish head | PASS | local=remote=`c5182eca24aa939dbb40ce1fac1cdd0898fdce82` | none |
| CG-12A - Guidance refresh | PASS | current guidance and gate contracts read back | none |
| CG-13 - PR metadata | PASS | PR #1481, assignee/labels/base/head/body read back | none |
| CG-14 - CI/review | PASS | CI `32643316941`, Manual Documentation `32643316915`, reviews/comments 0, Coveralls absent | none |
| CG-15 - Merge-ready report | PASS | exact head `c5182eca24aa939dbb40ce1fac1cdd0898fdce82`, `MERGEABLE`, `CLEAN` | merge only after separate approval |
| CG-16 - Fresh merge approval | PENDING | merge approval is a separate gate | obtain explicit approval |
| CG-17 - Merge | PENDING | not executed | never auto-merge |
| CG-18 - Sync/cleanup | PENDING | merge not authorized | perform only after merge |
| Issue linkage | N/A | no related open issue | none |
| Product Gradle tests | N/A | workflow/config/lesson changes only | hosted CI contract is the proof |

Final status: PENDING (merge approval is intentionally outstanding; PR is merge-ready)

