### PR TITLE
[cache][atomicity] EntryProcessor lease 만료 stale commit 차단

### DIFF
--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -271,8 +271,20 @@ Caffeine           |
   던지면 해당 키에는 변경 내용을 커밋하지 않습니다.
 - `ttlSeconds`가 설정된 경우 `invoke`로 갱신한 값도 캐시 hash TTL을 다시 적용하고,
   등록된 `CacheEntryUpdatedListener`에 갱신 이벤트를 전달합니다.
-- 분산 락의 기본 lease는 1분, 획득 대기는 5분입니다. 프로세서는 기본 lease 안에
-  완료되어야 하며, 더 긴 실행 시간을 허용하는 정책은 별도 설정 계약으로 다룹니다.
+- 분산 락의 기본 lease는 1분, 획득 대기는 5분입니다. 긴 프로세서는
+  `LettuceCacheConfig.lockLeaseSeconds`로 캐시별 lease를 조정할 수 있습니다.
+
+  ```kotlin
+  val sessions = LettuceJCaching.getOrCreate<String, String>(
+      redisClient,
+      "sessions",
+      lettuceCacheConfigOf(lockLeaseSeconds = 120),
+  )
+  ```
+
+- 프로세서가 lease보다 오래 실행되면 `entry.commit()`을 거부합니다. 락 소유권
+  검증과 값/TTL 쓰기를 하나의 Redis 트랜잭션으로 처리하므로, 이후 락을 획득한
+  호출자의 결과를 이전 호출자의 stale 값이 덮어쓰지 않습니다.
 
 ```kotlin
 import io.bluetape4k.cache.jcache.LettuceJCaching

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -123,8 +123,20 @@ connections and cache instances.
   refreshes the configured cache hash TTL and dispatches the corresponding
   cache-entry listener event.
 - The default lock lease is one minute and the default acquisition wait is five
-  minutes. Processors must finish within the default lease; a longer execution
-  policy is a separate configuration contract.
+  minutes. Set `LettuceCacheConfig.lockLeaseSeconds` for processors that need a
+  longer lease:
+
+  ```kotlin
+  val sessions = LettuceJCaching.getOrCreate<String, String>(
+      redisClient,
+      "sessions",
+      lettuceCacheConfigOf(lockLeaseSeconds = 120),
+  )
+  ```
+
+- If a processor outlives its lease, its `entry.commit()` is rejected. The
+  ownership check and the value/TTL write are committed as one Redis
+  transaction, so a later lock owner cannot be overwritten by a stale result.
 
 ## Factory (`LettuceCaches`)
 

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCacheConfig.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCacheConfig.kt
@@ -17,6 +17,11 @@ import javax.cache.configuration.MutableConfiguration
  * - Redis 7 이하에서는 `HSET/HMSET + EXPIRE` fallback 경로를 사용합니다.
  * - `null`이면 만료를 사용하지 않습니다.
  *
+ * ## EntryProcessor 락 lease 계약
+ * - [lockLeaseSeconds]는 EntryProcessor read-modify-write 락의 lease(초)입니다.
+ * - lease 만료 뒤 늦게 도착한 commit은 원자적 소유권 검증에서 거부됩니다.
+ * - 기본값은 60초이며, 긴 processor는 캐시별로 충분히 큰 값을 지정해야 합니다.
+ *
  * ```kotlin
  * val config = lettuceCacheConfigOf<String, String>(ttlSeconds = 300)
  * // config.ttlSeconds == 300L
@@ -34,6 +39,18 @@ class LettuceCacheConfig<K: Any, V: Any>(
     keyType: Class<K>,
     valueType: Class<V>,
 ): MutableConfiguration<K, V>() {
+    companion object {
+        /** EntryProcessor 분산 락 lease 기본값(초)입니다. */
+        const val DEFAULT_LOCK_LEASE_SECONDS: Long = 60L
+    }
+
+    /** EntryProcessor 분산 락 lease(초)입니다. 양수만 허용합니다. */
+    var lockLeaseSeconds: Long = DEFAULT_LOCK_LEASE_SECONDS
+        set(value) {
+            require(value > 0) { "lockLeaseSeconds는 양수여야 합니다." }
+            field = value
+        }
+
     init {
         setTypes(keyType, valueType)
     }
@@ -55,11 +72,14 @@ inline fun <reified K: Any, reified V: Any> lettuceCacheConfigOf(
     noinline keyCodec: ((K) -> String)? = null,
     noinline keyDecoder: ((String) -> K)? = null,
     codec: LettuceBinaryCodec<*> = LettuceBinaryCodecs.lz4Fory<Any>(),
-): LettuceCacheConfig<K, V> = LettuceCacheConfig(
+    lockLeaseSeconds: Long = LettuceCacheConfig.DEFAULT_LOCK_LEASE_SECONDS,
+): LettuceCacheConfig<K, V> = LettuceCacheConfig<K, V>(
     ttlSeconds = ttlSeconds,
     keyCodec = keyCodec,
     keyDecoder = keyDecoder,
     codec = codec,
     keyType = K::class.java,
     valueType = V::class.java,
-)
+).apply {
+    this.lockLeaseSeconds = lockLeaseSeconds
+}

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceJCache.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceJCache.kt
@@ -37,6 +37,8 @@ import javax.cache.processor.MutableEntry
  * - 리소스 close 실패는 [CacheException]으로 호출자에게 전파하며, wrapper는 닫힌
  *   상태로 유지됩니다.
  * - 직렬화는 [codec]의 serializer로 처리하며, 기본값은 LZ4+Fory 기반 직렬화입니다.
+ * - [LettuceCacheConfig.lockLeaseSeconds]로 EntryProcessor 락 lease를 조정할 수 있으며,
+ *   lease 만료 후 도착한 stale commit은 원자적 소유권 검증에서 거부됩니다.
  */
 class LettuceJCache<K: Any, V: Any>(
     private val map: LettuceMap<ByteArray>,
@@ -58,6 +60,11 @@ class LettuceJCache<K: Any, V: Any>(
     private val listeners = ConcurrentHashMap<CacheEntryListenerConfiguration<K, V>, CacheEntryListener<K, V>>()
 
     private val ttlDuration: Duration? by lazy { ttlSeconds?.let(Duration::ofSeconds) }
+    private val lockLeaseDuration: Duration by lazy {
+        val leaseSeconds = (configuration as? LettuceCacheConfig<*, *>)?.lockLeaseSeconds
+            ?: LettuceCacheConfig.DEFAULT_LOCK_LEASE_SECONDS
+        Duration.ofSeconds(leaseSeconds)
+    }
 
     private fun checkNotClosed() {
         check(!closed.value) { "LettuceCache[$cacheName]가 이미 닫혀 있습니다." }
@@ -68,8 +75,17 @@ class LettuceJCache<K: Any, V: Any>(
      * EntryProcessor의 read-modify-write와 일반 쓰기가 서로 다른 Lettuce 연결에서
      * 실행되어도 같은 cacheName에 대해 직렬화되도록 호출마다 새 토큰을 사용합니다.
      */
-    private fun <R> withWriteLock(block: () -> R): R =
-        map.withDistributedLock(UUID.randomUUID().toString().toByteArray(), block = block)
+    private fun <R> withWriteLock(block: () -> R): R {
+        val token = UUID.randomUUID().toString().toByteArray()
+        return map.withDistributedLock(token, leaseTime = lockLeaseDuration, block = block)
+    }
+
+    private fun <R> withEntryProcessorLock(block: (ByteArray) -> R): R {
+        val token = UUID.randomUUID().toString().toByteArray()
+        return map.withDistributedLock(token, leaseTime = lockLeaseDuration) {
+            block(token)
+        }
+    }
 
     private fun encodeKey(key: K): String = keyCodec(key)
 
@@ -348,7 +364,7 @@ class LettuceJCache<K: Any, V: Any>(
         vararg arguments: Any?,
     ): T {
         checkNotClosed()
-        return withWriteLock {
+        return withEntryProcessorLock { token ->
             val field = encodeKey(key)
             val entry = MutableEntryImpl(key, field)
             val result = try {
@@ -356,7 +372,7 @@ class LettuceJCache<K: Any, V: Any>(
             } catch (e: Exception) {
                 throw EntryProcessorException(e)
             }
-            entry.commit()
+            entry.commit(token)
             result
         }
     }
@@ -465,17 +481,21 @@ class LettuceJCache<K: Any, V: Any>(
 
         override fun <T> unwrap(clazz: Class<T>): T = clazz.cast(this)
 
-        fun commit() {
+        fun commit(token: ByteArray) {
             ensureLoaded()
             when {
                 removeRequested && exists -> {
-                    val removed = map.remove(field) > 0L
-                    if (removed) dispatchEvent(EventType.REMOVED, key, null)
+                    check(map.removeIfLockOwned(field, token)) {
+                        "LettuceCache[$cacheName] EntryProcessor commit을 적용할 때 분산 락 소유권을 잃었습니다."
+                    }
+                    dispatchEvent(EventType.REMOVED, key, null)
                 }
                 removeRequested -> Unit
                 updatedValue != null      -> {
                     val value = updatedValue ?: return
-                    putTtl(field, encodeValue(value))
+                    check(map.putTtlIfLockOwned(field, encodeValue(value), ttlDuration, token)) {
+                        "LettuceCache[$cacheName] EntryProcessor commit을 적용할 때 분산 락 소유권을 잃었습니다."
+                    }
                     val eventType = if (exists) EventType.UPDATED else EventType.CREATED
                     dispatchEvent(eventType, key, value)
                 }

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.TimeUnit
 import javax.cache.CacheException
+import javax.cache.configuration.MutableConfiguration
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration
 import javax.cache.event.CacheEntryEvent
 import javax.cache.event.CacheEntryUpdatedListener
@@ -222,6 +223,56 @@ class LettuceJCacheTest {
     }
 
     @Test
+    fun `invoke removes an existing entry through the lock-owned delete`() {
+        cache.put("key1", "value1")
+
+        cache.invoke(
+            "key1",
+            EntryProcessor<String, String, String> { entry: MutableEntry<String, String>, _: Array<out Any?> ->
+                entry.remove()
+                "removed"
+            }
+        ) shouldBeEqualTo "removed"
+
+        cache.containsKey("key1").shouldBeFalse()
+
+        cache.invoke(
+            "missing",
+            EntryProcessor<String, String, String> { entry: MutableEntry<String, String>, _: Array<out Any?> ->
+                entry.remove()
+                "missing"
+            }
+        ) shouldBeEqualTo "missing"
+        cache.containsKey("missing").shouldBeFalse()
+    }
+
+    @Test
+    fun `entry processor uses the default lease for a generic JCache configuration`() {
+        val mapName = "invoke-default-lease-" + UUID.randomUUID().toString().take(8)
+        val connection = RedisServers.redisClient.connect(LettuceCacheManager.STRING_BYTES_CODEC)
+        val fallbackCache = LettuceJCache(
+            map = LettuceMap(connection, mapName),
+            codec = LettuceBinaryCodecs.lz4Fory<Int>(),
+            cacheManager = manager as LettuceCacheManager,
+            configuration = MutableConfiguration<String, Int>().setTypes(String::class.java, Int::class.java),
+            closeResource = { connection.close() },
+        )
+
+        try {
+            fallbackCache.invoke(
+                "key",
+                EntryProcessor<String, Int, Int> { entry: MutableEntry<String, Int>, _: Array<out Any?> ->
+                    entry.setValue(1)
+                    1
+                }
+            ) shouldBeEqualTo 1
+            fallbackCache.get("key") shouldBeEqualTo 1
+        } finally {
+            runCatching { fallbackCache.close() }
+        }
+    }
+
+    @Test
     fun `invokeAll returns result per key`() {
         cache.put("k1", "v1")
         cache.put("k2", "v2")
@@ -299,6 +350,62 @@ class LettuceJCacheTest {
                             check(releaseProcessor.await(5, TimeUnit.SECONDS))
                             entry.setValue(1)
                             1
+                        }
+                    )
+                    null
+                } catch (error: Throwable) {
+                    error
+                }
+            }
+
+            check(processorEntered.await(5, TimeUnit.SECONDS))
+            await.atMost(5, TimeUnit.SECONDS).until {
+                RedisServers.redisClient.connect(StringCodec.UTF8).use { connection ->
+                    connection.sync().exists(lockKey) == 0L
+                }
+            }
+
+            second.invoke(
+                "counter",
+                EntryProcessor<String, Int, Int> { entry: MutableEntry<String, Int>, _: Array<out Any?> ->
+                    entry.setValue(2)
+                    2
+                }
+            ) shouldBeEqualTo 2
+
+            releaseProcessor.countDown()
+            firstInvocation.get(5, TimeUnit.SECONDS).shouldBeInstanceOf<IllegalStateException>()
+            first.get("counter") shouldBeEqualTo 2
+        } finally {
+            releaseProcessor.countDown()
+            executor.shutdownNow()
+            runCatching { first.clear() }
+            runCatching { first.close() }
+            runCatching { second.close() }
+        }
+    }
+
+    @Test
+    fun `invoke rejects stale removal after lease expiry and lock handoff`() {
+        val mapName = "invoke-remove-lease-expiry-" + UUID.randomUUID().toString().take(8)
+        val first = standaloneCache(mapName, lockLeaseSeconds = 1)
+        val second = standaloneCache(mapName, lockLeaseSeconds = 1)
+        val processorEntered = CountDownLatch(1)
+        val releaseProcessor = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        val lockKey = "$mapName:__bluetape4k:lock"
+
+        try {
+            first.put("counter", 0)
+            val firstInvocation = executor.submit<Throwable?> {
+                try {
+                    first.invoke(
+                        "counter",
+                        EntryProcessor<String, Int, String> { entry: MutableEntry<String, Int>, _: Array<out Any?> ->
+                            processorEntered.countDown()
+                            check(releaseProcessor.await(5, TimeUnit.SECONDS))
+                            entry.remove()
+                            "removed"
                         }
                     )
                     null

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
@@ -20,6 +21,8 @@ import io.bluetape4k.assertions.assertFailsWith
 import java.net.URI
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.TimeUnit
 import javax.cache.CacheException
@@ -276,6 +279,62 @@ class LettuceJCacheTest {
     }
 
     @Test
+    fun `invoke rejects stale commit after lease expiry and lock handoff`() {
+        val mapName = "invoke-lease-expiry-" + UUID.randomUUID().toString().take(8)
+        val first = standaloneCache(mapName, lockLeaseSeconds = 1)
+        val second = standaloneCache(mapName, lockLeaseSeconds = 1)
+        val processorEntered = CountDownLatch(1)
+        val releaseProcessor = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        val lockKey = "$mapName:__bluetape4k:lock"
+
+        try {
+            first.put("counter", 0)
+            val firstInvocation = executor.submit<Throwable?> {
+                try {
+                    first.invoke(
+                        "counter",
+                        EntryProcessor<String, Int, Int> { entry: MutableEntry<String, Int>, _: Array<out Any?> ->
+                            processorEntered.countDown()
+                            check(releaseProcessor.await(5, TimeUnit.SECONDS))
+                            entry.setValue(1)
+                            1
+                        }
+                    )
+                    null
+                } catch (error: Throwable) {
+                    error
+                }
+            }
+
+            check(processorEntered.await(5, TimeUnit.SECONDS))
+            await.atMost(5, TimeUnit.SECONDS).until {
+                RedisServers.redisClient.connect(StringCodec.UTF8).use { connection ->
+                    connection.sync().exists(lockKey) == 0L
+                }
+            }
+
+            second.invoke(
+                "counter",
+                EntryProcessor<String, Int, Int> { entry: MutableEntry<String, Int>, _: Array<out Any?> ->
+                    entry.setValue(2)
+                    2
+                }
+            ) shouldBeEqualTo 2
+
+            releaseProcessor.countDown()
+            firstInvocation.get(5, TimeUnit.SECONDS).shouldBeInstanceOf<IllegalStateException>()
+            first.get("counter") shouldBeEqualTo 2
+        } finally {
+            releaseProcessor.countDown()
+            executor.shutdownNow()
+            runCatching { first.clear() }
+            runCatching { first.close() }
+            runCatching { second.close() }
+        }
+    }
+
+    @Test
     fun `invoke exception does not commit a partial entry update`() {
         cache.put("key1", "original")
 
@@ -351,10 +410,16 @@ class LettuceJCacheTest {
         }
     }
 
-    private fun standaloneCache(mapName: String): LettuceJCache<String, Int> {
+    private fun standaloneCache(
+        mapName: String,
+        lockLeaseSeconds: Long = LettuceCacheConfig.DEFAULT_LOCK_LEASE_SECONDS,
+    ): LettuceJCache<String, Int> {
         val connection = RedisServers.redisClient.connect(LettuceCacheManager.STRING_BYTES_CODEC)
         val map = LettuceMap<ByteArray>(connection, mapName)
-        val configuration = lettuceCacheConfigOf<String, Int>(codec = LettuceBinaryCodecs.lz4Fory<Int>())
+        val configuration = lettuceCacheConfigOf<String, Int>(
+            codec = LettuceBinaryCodecs.lz4Fory<Int>(),
+            lockLeaseSeconds = lockLeaseSeconds,
+        )
         return LettuceJCache(
             map = map,
             codec = LettuceBinaryCodecs.lz4Fory<Int>(),

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
@@ -105,6 +105,13 @@ class LettuceJCacheTest {
     }
 
     @Test
+    fun `lock lease seconds must be positive`() {
+        assertFailsWith<IllegalArgumentException> {
+            lettuceCacheConfigOf<String, String>(lockLeaseSeconds = 0)
+        }
+    }
+
+    @Test
     fun `putIfAbsent applies ttl when configured`() {
         val ttlCache = manager.createCache(
             "ttl-cache-" + UUID.randomUUID().toString().take(8),

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMap.kt
@@ -303,6 +303,77 @@ open class LettuceMap<V: Any>(
         return blockResult.getOrThrow()
     }
 
+    /**
+     * 현재 분산 락 토큰을 보유한 경우에만 필드를 쓰기 트랜잭션으로 갱신합니다.
+     *
+     * `WATCH/MULTI/EXEC`로 락 키를 감시하므로 소유권을 확인한 뒤 lease가 만료되거나
+     * 다른 호출자가 락을 인수하면 트랜잭션 전체가 취소됩니다. 따라서 lease 만료 후
+     * 이전 호출자가 늦게 도착해 stale 값을 기록하는 것을 막을 수 있습니다.
+     *
+     * @param field 설정할 필드명
+     * @param value 설정할 값
+     * @param ttl 적용할 Hash key TTL (null이면 TTL 없음)
+     * @param token 현재 분산 락 소유 토큰
+     * @return 트랜잭션이 커밋되었으면 true, 락 소유권이 없거나 변경되었으면 false
+     */
+    fun putTtlIfLockOwned(field: String, value: V, ttl: Duration?, token: V): Boolean =
+        executeIfLockOwned(token) {
+            if (ttl == null) {
+                syncCommands.hset(mapKey, field, value)
+            } else if (supportsHSetEx) {
+                syncCommands.hsetex(mapKey, HSetExArgs.Builder.ex(ttl), mapOf(field to value))
+            } else {
+                syncCommands.hset(mapKey, field, value)
+                syncCommands.expire(mapKey, ttl)
+            }
+        }
+
+    /**
+     * 현재 분산 락 토큰을 보유한 경우에만 필드를 삭제합니다.
+     *
+     * @param field 삭제할 필드명
+     * @param token 현재 분산 락 소유 토큰
+     * @return 트랜잭션이 커밋되었으면 true, 락 소유권이 없거나 변경되었으면 false
+     */
+    fun removeIfLockOwned(field: String, token: V): Boolean =
+        executeIfLockOwned(token) {
+            syncCommands.hdel(mapKey, field)
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun executeIfLockOwned(token: V, block: () -> Unit): Boolean {
+        val lockKey = "$mapKey$LOCK_SUFFIX"
+        var transactionStarted = false
+        syncCommands.watch(lockKey)
+        return try {
+            if (!lockTokenMatches(syncCommands.get(lockKey), token)) return false
+            syncCommands.multi()
+            transactionStarted = true
+            block()
+            commitWatchedTransaction()
+        } catch (error: Exception) {
+            if (transactionStarted) runCatching { syncCommands.discard() }
+            throw error
+        } finally {
+            runCatching { syncCommands.unwatch() }
+        }
+    }
+
+    private fun commitWatchedTransaction(): Boolean {
+        val result = syncCommands.exec()
+        if (result.wasDiscarded()) return false
+        result.forEach { outcome ->
+            if (outcome is Throwable) throw outcome
+        }
+        return true
+    }
+
+    private fun lockTokenMatches(actual: V?, expected: V): Boolean =
+        when {
+            actual is ByteArray && expected is ByteArray -> actual.contentEquals(expected)
+            else -> actual == expected
+        }
+
     private fun releaseDistributedLock(lockKey: String, token: V) {
         val released = syncCommands.eval<Long>(
             RELEASE_LOCK_SCRIPT,

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
@@ -4,6 +4,10 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
+import io.lettuce.core.HSetExArgs
+import io.lettuce.core.TransactionResult
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.StringCodec
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -13,6 +17,9 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContainAll
 import io.bluetape4k.assertions.shouldHaveSize
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -212,6 +219,74 @@ class LettuceMapTest: AbstractLettuceTest() {
         }
 
         map.get("field") shouldBeEqualTo "updated"
+    }
+
+    @Test
+    fun `락 소유권 검증 쓰기는 fallback TTL과 삭제를 원자적으로 적용`() {
+        map.withDistributedLock("owner") {
+            map.putTtlIfLockOwned(
+                field = "field",
+                value = "updated",
+                ttl = Duration.ofSeconds(30),
+                token = "owner",
+            ).shouldBeTrue()
+            connection.sync().ttl(map.mapKey) shouldBeGreaterThan 0L
+            map.removeIfLockOwned("field", "owner").shouldBeTrue()
+        }
+
+        map.get("field").shouldBeNull()
+    }
+
+    @Test
+    fun `락 소유권 검증 트랜잭션은 Redis 명령 실패 후 discard`() {
+        connection.sync().set(map.mapKey, "wrong-type")
+
+        try {
+            assertFailsWith<Exception> {
+                map.withDistributedLock("owner") {
+                    map.putTtlIfLockOwned("field", "value", ttl = null, token = "owner")
+                }
+            }
+        } finally {
+            connection.sync().del(map.mapKey)
+        }
+    }
+
+    @Test
+    fun `락 소유권 검증 쓰기는 HSETEX 지원 경로를 커밋`() {
+        val commands = mockk<RedisCommands<String, String>>(relaxed = true)
+        val mockedConnection = mockk<StatefulRedisConnection<String, String>>()
+        val transaction = mockk<TransactionResult>()
+        every { mockedConnection.sync() } returns commands
+        every { commands.get("mock-map:__bluetape4k:lock") } returns "owner"
+        every { transaction.wasDiscarded() } returns false
+        every { transaction.iterator() } returns mutableListOf<Any>().iterator()
+        every { commands.exec() } returns transaction
+
+        val hsetExMap = LettuceMap(mockedConnection, "mock-map", supportsHSetEx = true)
+
+        hsetExMap.putTtlIfLockOwned("field", "value", Duration.ofSeconds(30), "owner")
+            .shouldBeTrue()
+
+        verify(exactly = 1) {
+            commands.hsetex("mock-map", any<HSetExArgs>(), mapOf("field" to "value"))
+        }
+    }
+
+    @Test
+    fun `락 소유권 검증 쓰기는 WATCH 변경으로 discard된 트랜잭션을 거부`() {
+        val commands = mockk<RedisCommands<String, String>>(relaxed = true)
+        val mockedConnection = mockk<StatefulRedisConnection<String, String>>()
+        val transaction = mockk<TransactionResult>()
+        every { mockedConnection.sync() } returns commands
+        every { commands.get("mock-map:__bluetape4k:lock") } returns "owner"
+        every { transaction.wasDiscarded() } returns true
+        every { commands.exec() } returns transaction
+
+        val watchedMap = LettuceMap(mockedConnection, "mock-map")
+
+        watchedMap.putTtlIfLockOwned("field", "value", ttl = null, token = "owner")
+            .shouldBeFalse()
     }
 
     @Test

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
@@ -274,6 +274,42 @@ class LettuceMapTest: AbstractLettuceTest() {
     }
 
     @Test
+    fun `락 소유권 검증은 ByteArray 토큰을 내용 기준으로 비교`() {
+        val commands = mockk<RedisCommands<String, ByteArray>>(relaxed = true)
+        val mockedConnection = mockk<StatefulRedisConnection<String, ByteArray>>()
+        val transaction = mockk<TransactionResult>()
+        val token = "owner".toByteArray()
+
+        every { mockedConnection.sync() } returns commands
+        every { commands.get("mock-map:__bluetape4k:lock") } returns token.copyOf()
+        every { transaction.wasDiscarded() } returns false
+        every { transaction.iterator() } returns mutableListOf<Any>().iterator()
+        every { commands.exec() } returns transaction
+
+        val byteMap = LettuceMap(mockedConnection, "mock-map")
+
+        byteMap.putTtlIfLockOwned("field", "value".toByteArray(), ttl = null, token = token)
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `락 소유권 조회 실패는 트랜잭션 시작 전에도 연결을 정리`() {
+        val commands = mockk<RedisCommands<String, String>>(relaxed = true)
+        val mockedConnection = mockk<StatefulRedisConnection<String, String>>()
+        every { mockedConnection.sync() } returns commands
+        every { commands.get("mock-map:__bluetape4k:lock") } throws IllegalStateException("조회 실패")
+
+        val failingMap = LettuceMap(mockedConnection, "mock-map")
+
+        assertFailsWith<IllegalStateException> {
+            failingMap.putTtlIfLockOwned("field", "value", ttl = null, token = "owner")
+        }
+
+        verify(exactly = 1) { commands.unwatch() }
+        verify(exactly = 0) { commands.discard() }
+    }
+
+    @Test
     fun `락 소유권 검증 쓰기는 WATCH 변경으로 discard된 트랜잭션을 거부`() {
         val commands = mockk<RedisCommands<String, String>>(relaxed = true)
         val mockedConnection = mockk<StatefulRedisConnection<String, String>>()

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
@@ -203,6 +203,18 @@ class LettuceMapTest: AbstractLettuceTest() {
     }
 
     @Test
+    fun `락 소유권 검증 쓰기는 소유 토큰이 일치할 때만 커밋`() {
+        map.put("field", "before")
+
+        map.withDistributedLock("owner") {
+            map.putTtlIfLockOwned("field", "updated", ttl = null, token = "owner").shouldBeTrue()
+            map.putTtlIfLockOwned("field", "stale", ttl = null, token = "other").shouldBeFalse()
+        }
+
+        map.get("field") shouldBeEqualTo "updated"
+    }
+
+    @Test
     fun `putAll - 빈 맵은 무시`() {
         map.putAll(emptyMap())
         map.isEmpty().shouldBeTrue()

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
@@ -326,6 +326,28 @@ class LettuceMapTest: AbstractLettuceTest() {
     }
 
     @Test
+    fun `락 소유권 검증 트랜잭션 결과의 Redis 오류를 전파하고 discard`() {
+        val commands = mockk<RedisCommands<String, String>>(relaxed = true)
+        val mockedConnection = mockk<StatefulRedisConnection<String, String>>()
+        val transaction = mockk<TransactionResult>()
+        val redisError = IllegalStateException("트랜잭션 명령 실패")
+        every { mockedConnection.sync() } returns commands
+        every { commands.get("mock-map:__bluetape4k:lock") } returns "owner"
+        every { transaction.wasDiscarded() } returns false
+        every { transaction.iterator() } returns mutableListOf<Any>(redisError).iterator()
+        every { commands.exec() } returns transaction
+
+        val error = assertFailsWith<IllegalStateException> {
+            LettuceMap(mockedConnection, "mock-map")
+                .putTtlIfLockOwned("field", "value", ttl = null, token = "owner")
+        }
+
+        error shouldBeEqualTo redisError
+        verify(exactly = 1) { commands.discard() }
+        verify(exactly = 1) { commands.unwatch() }
+    }
+
+    @Test
     fun `putAll - 빈 맵은 무시`() {
         map.putAll(emptyMap())
         map.isEmpty().shouldBeTrue()


### PR DESCRIPTION
## 배경

`LettuceJCache.EntryProcessor`가 processor 실행 중 분산락 lease가 만료된 뒤에도 늦은 쓰기를 반영할 수 있어, 두 cache 인스턴스가 같은 키를 처리할 때 원자성 계약이 깨질 수 있었습니다.

Fixes #1448

## 변경 사항

- `LettuceCacheConfig.lockLeaseSeconds`로 EntryProcessor lease를 명시적으로 설정할 수 있게 했습니다.
- lease 기본값은 60초로 유지하고, 0 이하 값은 즉시 거부합니다.
- EntryProcessor commit을 Redis `WATCH`/`MULTI`/`EXEC` 경로로 전환해 lock token 소유권과 실제 쓰기를 같은 트랜잭션에서 검증합니다.
- lease가 만료된 호출의 stale update/remove는 `IllegalStateException`으로 거부하고 listener는 성공한 commit 이후에만 호출합니다.
- 영문/국문 README와 KDoc에 lease·stale commit 계약을 기록했습니다.

## 검증

- RED: lease 만료 뒤 첫 processor의 늦은 commit이 두 번째 processor의 값을 덮어쓰는 회귀 테스트를 먼저 재현했습니다.
- GREEN: 동일 회귀 테스트 통과.
- `:bluetape4k-cache-lettuce:test :bluetape4k-cache-lettuce:koverXmlReport --no-build-cache`: 461 tests passed.
- `:bluetape4k-lettuce:test :bluetape4k-lettuce:koverXmlReport --no-build-cache`: 920 tests passed.
- CI와 동일한 Infra 전체 테스트: `redisson 316`, `lettuce 920`, `cache-lettuce 461`, `cache-redisson 442` tests passed.
- `LettuceMapTest`: lock-owned HSETEX/fallback TTL, Redis 명령 실패 discard, WATCH 변경 discard, ByteArray 토큰 비교, WATCH 이전 조회 실패 정리 및 EXEC 결과 Redis 오류 전파 경로를 포함해 targeted 30 tests 통과.
- `LettuceJCacheTest`: 기존 entry 제거, 기본 lease 설정, lease 만료 stale 제거 거부, lease 양수 계약을 포함해 targeted 31 tests 통과.
- `:bluetape4k-cache-lettuce:detekt` 및 `:bluetape4k-lettuce:detekt`: exit 0.
- Kover XML 보고서를 두 모듈에서 생성해 보강된 변경 경로의 실행 증거를 확인했습니다.
- CI aggregate와 동일한 Kover method-level 집계: `67,313 covered / 3,709 missed (94.78% instruction)`.
- `git diff --check`: 통과.

Coveralls의 이전 외부 상태는 `Coverage decreased (-6.4%) to 82.083%`, `Coverage decreased (-6.1%) to 82.345%`, `82.377%`로 실패했으며, 운영 코드 변경 없이 승인된 두 테스트 파일에 실제 Redis와 경계 mock 기반 커버리지 보강을 추가했습니다. 최신 head `f0130bf82df362393b4464fdf602b6a9fd5a1f55`의 Actions run `32643191386`은 Build·Infra 테스트·Coverage Report·CI Status가 모두 성공했고, CI artifact를 공식 Coveralls reporter `v0.6.22`로 재현한 raw line rate는 `88.765%`였습니다. 그러나 exact head의 외부 `coverage/coveralls` status는 여전히 `Coverage decreased (-6.1%) to 82.358%`로 실패하여 [Coveralls build](https://coveralls.io/builds/81316953) 게이트가 해소되지 않았습니다. 이 외부 회계 불일치가 남아 있으므로 머지는 보류합니다.

## DoD Status

- [x] lease 설정 또는 갱신 경로 제공
- [x] lease 만료 후 commit 원자적 거부
- [x] 두 cache 인스턴스 간 processor 장기 실행 회귀 테스트
- [x] lock 획득 실패·processor 예외·취소/timeout·release 경로 점검
- [x] lease/atomicity 문서·KDoc·설정 API 정렬
- [x] lock-owned write 및 EntryProcessor commit 커버리지 보강 테스트와 Kover XML 증거
- [x] 구현 커밋 및 원격 브랜치 push
- [ ] 새 push의 GitHub CI·Coveralls 및 리뷰 완료 (Actions는 성공했지만 Coveralls `82.358%` 외부 status 실패)
- [ ] exact-head merge 승인 및 merge
