### PR TITLE
[testcontainers][ci] README/KDoc 계약을 PR CI에서 항상 검증

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches: [develop, main]
     paths-ignore:
-      - '**.md'
       - 'docs/**'
       - '.gitignore'
       - '.editorconfig'
@@ -23,7 +22,6 @@ on:
   pull_request:
     branches: [develop, main]
     paths-ignore:
-      - '**.md'
       - 'docs/**'
       - '.gitignore'
       - '.editorconfig'
@@ -77,7 +75,7 @@ jobs:
           gradle-version: wrapper
       - name: Verify static JVM release contract
         run: python3 -m unittest scripts/test_jvm_release_contract.py -v
-      - name: Verify Testcontainers image-tag and documentation contract
+      - name: Verify Testcontainers source/documentation parity contract
         run: python3 -m unittest scripts/test_testcontainers_contract.py -v
       - name: Verify compiled classfile contract
         run: ./scripts/check-jvm-release-contract.sh

--- a/scripts/test_jvm_release_contract.py
+++ b/scripts/test_jvm_release_contract.py
@@ -15,6 +15,7 @@ EXPECTED_ISLAND = {
     "bluetape4k-virtualthread-jdk21",
 }
 COMMON_TOKENS = ("2.0.0", "1.13.x", "Java 25", "Java 21")
+HTTP_READMES = ("io/http/README.md", "io/http/README.ko.md")
 
 
 def read(relative: str) -> str:
@@ -98,6 +99,12 @@ class JvmReleaseContractTest(unittest.TestCase):
             self.assertIn("`bluetape4k/mock-webflux-server` | `2.0.0`", source)
             self.assertNotIn("`bluetape4k/mock-web-server` | `1.13.0`", source)
             self.assertNotIn("`bluetape4k/mock-webflux-server` | `1.13.0`", source)
+
+    def test_jdk_baseline_is_25_in_both_http_readmes(self) -> None:
+        for relative in HTTP_READMES:
+            content = read(relative)
+            self.assertIn("JDK 25", content, relative)
+            self.assertNotIn("JDK 21", content, relative)
 
     def test_readme_locales_share_the_migration_contract(self) -> None:
         english = block(read("README.md"))

--- a/scripts/test_testcontainers_contract.py
+++ b/scripts/test_testcontainers_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the Testcontainers image-tag and documentation contract."""
+"""Validate the Testcontainers source/documentation parity contract."""
 
 from __future__ import annotations
 
@@ -7,15 +7,17 @@ import re
 import unittest
 from pathlib import Path
 
-from scripts.testcontainers_image_gate import load_manifest, validate_manifest
-
-
 ROOT = Path(__file__).resolve().parents[1]
 KOTLIN_ROOT = ROOT / "testing/testcontainers/src/main/kotlin"
 README_EN = ROOT / "testing/testcontainers/README.md"
 README_KO = ROOT / "testing/testcontainers/README.ko.md"
 MINISTACK_SOURCE = KOTLIN_ROOT / "io/bluetape4k/testcontainers/aws/MiniStackServer.kt"
-HTTP_READMES = (ROOT / "io/http/README.md", ROOT / "io/http/README.ko.md")
+MINISTACK_KMS_TEST = (
+    ROOT
+    / "testing/testcontainers/src/test/kotlin"
+    / "io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt"
+)
+CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
 
 
 def read(path: Path) -> str:
@@ -117,11 +119,61 @@ class TestTestcontainersContract(unittest.TestCase):
                         stale.append(f"{name}: literal tag {value!r}")
         self.assertEqual([], stale, "stale KDoc tag literals: " + "; ".join(stale))
 
-    def test_jdk_baseline_is_25_in_both_http_readmes(self) -> None:
-        for path in HTTP_READMES:
+    def test_markdown_changes_run_the_contract_job(self) -> None:
+        workflow = read(CI_WORKFLOW)
+        self.assertIn("jvm-release-contract:", workflow)
+        self.assertIn("scripts/test_testcontainers_contract.py", workflow)
+
+        event_pattern = re.compile(
+            r"^  (?P<event>push|pull_request):\n"
+            r"(?P<body>.*?)(?=^  (?:push|pull_request|workflow_dispatch):|^concurrency:)",
+            re.MULTILINE | re.DOTALL,
+        )
+        events = {
+            match.group("event"): match.group("body")
+            for match in event_pattern.finditer(workflow)
+        }
+        self.assertEqual({"push", "pull_request"}, set(events))
+        for event, body in events.items():
+            self.assertNotIn("**.md", body, f"README changes are ignored for {event}")
+
+    def test_kdoc_defaults_reference_bounded_images_and_architecture_tags(self) -> None:
+        mysql = read(KOTLIN_ROOT / "io/bluetape4k/testcontainers/database/MySQL5Server.kt")
+        self.assertRegex(mysql, r"@param\s+image\s+docker image \(기본: \[IMAGE\]\)")
+        self.assertNotIn("(기본: `mysql`)", mysql)
+
+        ignite = read(KOTLIN_ROOT / "io/bluetape4k/testcontainers/storage/Ignite2Server.kt")
+        self.assertIn("withTag(DEFAULT_TAG)", ignite)
+        self.assertIn("tag = DEFAULT_TAG", ignite)
+        self.assertRegex(ignite, r"@param\s+tag\s+Docker 이미지 태그.*\[DEFAULT_TAG\]")
+        self.assertNotIn("withTag(TAG)", ignite)
+        self.assertNotIn("tag = TAG", ignite)
+
+        for path in (README_EN, README_KO):
             content = read(path)
-            self.assertIn("JDK 25", content, path.as_posix())
-            self.assertNotIn("JDK 21", content, path.as_posix())
+            self.assertIn("Ignite2Server", content, path.as_posix())
+            self.assertIn("2.18.0", content, path.as_posix())
+            self.assertIn("-arm64", content, path.as_posix())
+
+    def test_ministack_disabled_inventory_matches_pinned_tag_and_known_errors(self) -> None:
+        source = read(MINISTACK_KMS_TEST)
+        pinned_tag = str(self.sources["MiniStackServer"]["tag"])
+        entries = {
+            match.group("action"): match.group("reason")
+            for match in re.finditer(
+                rf'@Disabled\("(?P<reason>MiniStack v{re.escape(pinned_tag)} 미지원: (?P<action>[A-Za-z]+)[^"]*)"\)',
+                source,
+            )
+        }
+        expected = {
+            "CreateGrant": "create grant",
+            "ListGrants": "list grants",
+            "RevokeGrant": "revoke grant",
+        }
+        self.assertEqual(set(expected), set(entries))
+        for action, test_name in expected.items():
+            self.assertIn("Unknown action 400", entries[action])
+            self.assertIn(f"fun `{test_name}`", source)
 
     def test_ministack_grant_limitation_is_explicit(self) -> None:
         source = read(MINISTACK_SOURCE)
@@ -138,11 +190,6 @@ class TestTestcontainersContract(unittest.TestCase):
                 self.assertIn("not supported", content)
             else:
                 self.assertIn("지원하지 않", content)
-
-    def test_image_gate_manifest_matches_this_contract(self) -> None:
-        manifest = load_manifest(ROOT / "scripts/testcontainers_image_gate_manifest.json")
-        self.assertEqual([], validate_manifest(manifest, ROOT))
-
 
 if __name__ == "__main__":
     result = unittest.main(verbosity=2, exit=False)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL5Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/database/MySQL5Server.kt
@@ -50,7 +50,7 @@ class MySQL5Server private constructor(
          * // server.url.startsWith("jdbc:mysql://") == true (시작 후)
          * ```
          *
-         * @param image             docker image (기본: `mysql`)
+         * @param image             docker image (기본: [IMAGE])
          * @param tag               docker image tag (기본: [TAG])
          * @param useDefaultPort    기본 포트를 사용할지 여부 (기본: `false`)
          * @param reuse             재사용 여부 (기본: `false`)

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
@@ -57,7 +57,7 @@ class Ignite2Server private constructor(
          * [DockerImageName]으로 [Ignite2Server]를 생성합니다.
          *
          * ```kotlin
-         * val image = DockerImageName.parse("apacheignite/ignite").withTag(TAG)
+         * val image = DockerImageName.parse("apacheignite/ignite").withTag(DEFAULT_TAG)
          * val server = Ignite2Server(image)
          * // server.isRunning == false
          * ```
@@ -77,12 +77,12 @@ class Ignite2Server private constructor(
          * 이미지 이름과 태그로 [Ignite2Server]를 생성합니다.
          *
          * ```kotlin
-         * val server = Ignite2Server(image = "apacheignite/ignite", tag = TAG)
+         * val server = Ignite2Server(image = "apacheignite/ignite", tag = DEFAULT_TAG)
          * // server.url.contains(":10800") == true (시작 후)
          * ```
          *
          * @param image          Docker 이미지 이름, blank이면 [IllegalArgumentException]이 발생합니다.
-         * @param tag            Docker 이미지 태그, blank이면 [IllegalArgumentException]이 발생합니다.
+         * @param tag            Docker 이미지 태그, blank이면 [IllegalArgumentException]이 발생합니다 (기본: [DEFAULT_TAG]; aarch64에서는 [TAG]-arm64).
          * @param useDefaultPort `true`면 10800 포트를 고정 바인딩합니다.
          * @param reuse          컨테이너 재사용 여부입니다.
          */

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/aws/ministack/services/MiniStackKMSTest.kt
@@ -141,7 +141,7 @@ class MiniStackKMSTest: AbstractMiniStackServiceTest() {
 
     @Test
     @Order(9)
-    @Disabled("MiniStack v1.4.14 미지원: RevokeGrant — create grant가 비활성화되어 grantId 없음")
+    @Disabled("MiniStack v1.4.14 미지원: RevokeGrant (Unknown action 400) — create grant가 비활성화되어 grantId 없음")
     fun `revoke grant`() {
         val response = kmsClient.revokeGrant { it.keyId(keyId).grantId(grantId) }
         response.sdkHttpResponse().isSuccessful.shouldBeTrue()


### PR DESCRIPTION
## 요약

Issue #1462의 Testcontainers 소스·문서 계약을 README-only PR에서도 검증하도록 CI와 정적 계약을 보강합니다.

## 구현

- `.github/workflows/ci.yml`에서 push/pull_request의 `**.md` 제외를 제거하고 기존 `jvm-release-contract` 필수 job을 유지했습니다.
- Testcontainers 계약 checker를 source/documentation parity 범위로 좁히고, JDK HTTP README 검사는 JVM release contract로 이동했습니다.
- MySQL5 KDoc 기본 image를 `[IMAGE]`로, Ignite2 예제·기본 tag를 architecture-aware `[DEFAULT_TAG]`로 고정했습니다.
- MiniStack KMS `@Disabled` 세 항목이 pinned tag와 `Unknown action 400` 근거를 유지하는 인벤토리 검사를 추가했습니다.
- runtime image startup/workload 보장은 기존 #1337 image gate 범위로 남겼습니다.

Closes #1462

## 검증

- `python3 -m unittest scripts.test_codeql_workflow_policy scripts.test_jvm_release_contract scripts.test_release_workflow_policy scripts.test_run_testcontainers_image_gate scripts.test_testcontainers_contract scripts.test_testcontainers_image_gate -v` — 48 passed
- `python3 .github/scripts/test-ci-domain-parallelization.py -v` — 12 passed
- `actionlint .github/workflows/ci.yml`, `python3 -m py_compile ...`, `git diff --check` — 통과
- `./gradlew :bluetape4k-testcontainers:test --tests '...MiniStackKMSTest' --no-build-cache --no-configuration-cache` — 15 tests, 12 passed, 3 disabled
- 전체 Testcontainers 모듈은 451 tests 중 25 skipped, WireMock 8건이 `NoHttpResponseException`으로 실패했습니다. 변경 범위 밖이며 WireMock 단독 재실행은 8/8 통과했습니다.

## DoD Status

- [x] README/KDoc 변경이 PR CI의 계약 job을 트리거함
- [x] EN/KO README와 Kotlin IMAGE/TAG parity 검증 유지
- [x] MySQL5/Ignite2/MiniStack bounded default·제한 근거 검증
- [x] 정적 계약·workflow syntax·관련 targeted Testcontainers 검증
- [x] GitHub PR exact-head CI 및 review 확인 (22/22 checks PASS; review/comment 0건)