### PR TITLE
CI Testcontainers image gate를 Nightly full 전용으로 한정

### DIFF
--- a/.github/scripts/test-ci-domain-parallelization.py
+++ b/.github/scripts/test-ci-domain-parallelization.py
@@ -31,7 +31,6 @@ DOMAIN_JOBS = (
     "test-io",
     "test-io-http",
     "test-testcontainers-spring",
-    "testcontainers-image-gate",
     "test-ktor",
     "test-key-utils",
     "test-infra",
@@ -92,10 +91,10 @@ class CiDomainParallelizationTest(unittest.TestCase):
         status_needs = inline_needs(job_block(self.workflow, "ci-status"))
         self.assertIn("build", status_needs)
         self.assertIn("coverage-report", status_needs)
-        self.assertIn("testcontainers-image-gate", status_needs)
+        self.assertNotIn("testcontainers-image-gate", status_needs)
 
     def test_coverage_report_still_waits_for_every_coverage_job(self):
-        coverage_jobs = set(DOMAIN_JOBS) - {"testcontainers-image-gate"}
+        coverage_jobs = set(DOMAIN_JOBS)
         coverage_needs = inline_needs(job_block(self.workflow, "coverage-report"))
         self.assertSetEqual(coverage_needs, coverage_jobs)
         self.assertNotIn("build", coverage_needs)
@@ -130,36 +129,9 @@ class CiDomainParallelizationTest(unittest.TestCase):
                 self.assertIn("import org.junit.jupiter.api.Tag", source)
                 self.assertIn('@Tag("benchmark")', source)
 
-    def test_daily_image_gate_runs_only_for_relevant_changes_or_manual_dispatch(self):
-        gate = job_block(self.workflow, "testcontainers-image-gate")
-        self.assertIn(
-            "if: ${{ needs.changes.outputs['testcontainers-image-gate'] == 'true' || "
-            "github.event_name == 'workflow_dispatch' }}",
-            gate,
-        )
-        self.assertNotIn("needs.changes.outputs.shared", gate)
-
-    def test_daily_image_gate_filter_excludes_generic_workflow_and_contract_test_changes(self):
-        image_gate_filter = path_filter_block(self.workflow, "testcontainers-image-gate")
-        for required_path in (
-            "'testing/testcontainers/**'",
-            "'scripts/testcontainers_image_gate_manifest.json'",
-            "'scripts/testcontainers_image_gate.py'",
-            "'scripts/run_testcontainers_image_gate.py'",
-        ):
-            with self.subTest(required_path=required_path):
-                self.assertIn(required_path, image_gate_filter)
-
-        for excluded_path in (
-            "'.github/workflows/ci.yml'",
-            "'.github/workflows/nightly-tests.yml'",
-            "'.github/workflows/release.yml'",
-            "'scripts/test_testcontainers_contract.py'",
-            "'scripts/test_testcontainers_image_gate.py'",
-            "'scripts/test_run_testcontainers_image_gate.py'",
-        ):
-            with self.subTest(excluded_path=excluded_path):
-                self.assertNotIn(excluded_path, image_gate_filter)
+    def test_ci_excludes_image_gate_and_keeps_spring_bridge(self):
+        self.assertNotIn("testcontainers-image-gate", self.workflow)
+        self.assertIn("test-testcontainers-spring:", self.workflow)
 
     def test_http_domain_tests_cover_both_local_mock_server_images(self):
         io_http_filter = path_filter_block(self.workflow, "io-http")
@@ -170,7 +142,7 @@ class CiDomainParallelizationTest(unittest.TestCase):
         nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
         image_gate = job_block(nightly, "test-testcontainers-image-gate")
         self.assertIn(
-            "if: ${{ needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers' }}",
+            "if: ${{ needs.plan.outputs.scope == 'full' }}",
             image_gate,
         )
         self.assertIn("--scope full", image_gate)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
       io: ${{ steps.filter.outputs.io }}
       io-http: ${{ steps.filter.outputs.io-http }}
       testcontainers-spring: ${{ steps.filter.outputs.testcontainers-spring }}
-      testcontainers-image-gate: ${{ steps.filter.outputs.testcontainers-image-gate }}
       ktor: ${{ steps.filter.outputs.ktor }}
       key-utils: ${{ steps.filter.outputs.key-utils }}
       infra: ${{ steps.filter.outputs.infra }}
@@ -191,11 +190,6 @@ jobs:
             testcontainers-spring:
               - 'testing/testcontainers/**'
               - 'testing/testcontainers-spring/**'
-            testcontainers-image-gate:
-              - 'testing/testcontainers/**'
-              - 'scripts/testcontainers_image_gate_manifest.json'
-              - 'scripts/testcontainers_image_gate.py'
-              - 'scripts/run_testcontainers_image_gate.py'
             ktor:
               - 'ktor/**'
             key-utils:
@@ -593,81 +587,6 @@ jobs:
         with:
           name: coverage-testcontainers-spring
           path: '**/build/reports/kover/'
-          if-no-files-found: error
-          retention-days: 30
-
-  # ── 4-d. 관련 변경 Testcontainers image family startup/workload gate ─────
-  testcontainers-image-gate:
-    name: Test / Testcontainers image startup-workload gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
-    needs: [changes, catalog-governance]
-    if: ${{ needs.changes.outputs['testcontainers-image-gate'] == 'true' || github.event_name == 'workflow_dispatch' }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-java@v5.7.0
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.12'
-
-      - uses: gradle/actions/setup-gradle@v6.3.0
-        with:
-          gradle-version: wrapper
-          cache-read-only: true
-
-      - name: Collect changed paths
-        id: changed-paths
-        shell: bash
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          BEFORE_SHA: ${{ github.event.before || '' }}
-          CURRENT_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          base_sha="$PR_BASE_SHA"
-          if [[ -z "$base_sha" ]]; then
-            base_sha="$BEFORE_SHA"
-          fi
-          if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
-            git diff --name-only HEAD^ HEAD > "$RUNNER_TEMP/testcontainers-changed-paths.txt"
-          else
-            git diff --name-only "$base_sha" "$CURRENT_SHA" > "$RUNNER_TEMP/testcontainers-changed-paths.txt"
-          fi
-          sed -n '1,120p' "$RUNNER_TEMP/testcontainers-changed-paths.txt"
-
-      - name: Run changed image family gate sequentially
-        env:
-          DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
-          TESTCONTAINERS_REGISTRY_MIRROR: ${{ vars.TESTCONTAINERS_REGISTRY_MIRROR || '' }}
-          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-        run: >-
-          python3 scripts/run_testcontainers_image_gate.py
-          --scope changed
-          --changed-path-file "$RUNNER_TEMP/testcontainers-changed-paths.txt"
-          --report-dir build/reports/testcontainers-image-gate
-          --max-attempts 2
-          --timeout-minutes 30
-
-      - name: Publish image gate summary
-        if: always()
-        run: |
-          if [ -f build/reports/testcontainers-image-gate/summary.md ]; then
-            cat build/reports/testcontainers-image-gate/summary.md
-          fi
-
-      - name: Upload image gate evidence
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: testcontainers-image-gate-${{ github.run_id }}
-          path: build/reports/testcontainers-image-gate/
           if-no-files-found: error
           retention-days: 30
 
@@ -1221,7 +1140,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, testcontainers-image-gate, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
+    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1199,13 +1199,13 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  # ── Testcontainers image startup/workload gate — 단일 순차 lane ───────────
+  # ── Testcontainers image startup/workload gate — full Nightly 전용 ────────
   test-testcontainers-image-gate:
     name: Test / Testcontainers image startup-workload gate
     runs-on: ubuntu-latest
     timeout-minutes: 360
     needs: [build, plan]
-    if: ${{ needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers' }}
+    if: ${{ needs.plan.outputs.scope == 'full' }}
     env:
       TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'
       DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
@@ -1263,10 +1263,11 @@ jobs:
     name: Test / Testcontainers Spring bridge
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Keep the JVM-only bridge after the Docker-backed Testcontainers lane so
-    # repository-level Testcontainers verification remains sequential.
+    # Full Nightly waits for the Docker-backed image gate. A targeted
+    # testcontainers dispatch has no image gate and may run this JVM-only bridge
+    # after its matrix completes.
     needs: [test-testcontainers, test-testcontainers-image-gate, plan]
-    if: ${{ needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers' }}
+    if: ${{ always() && (needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers') && needs.test-testcontainers.result == 'success' && (needs.test-testcontainers-image-gate.result == 'success' || needs.test-testcontainers-image-gate.result == 'skipped') }}
     steps:
       - uses: actions/checkout@v7
 

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -59,20 +59,19 @@ class TestTestcontainersImageGate(unittest.TestCase):
             " ".join(validate_manifest(invalid, self.root)),
         )
 
-    def test_ci_workflow_runs_changed_gate_and_uploads_evidence(self) -> None:
+    def test_ci_workflow_excludes_image_gate(self) -> None:
         workflow = (self.root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-        self.assertIn("testcontainers-image-gate:", workflow)
-        self.assertIn("--scope changed", workflow)
-        self.assertIn("--changed-path-file", workflow)
-        self.assertIn("build/reports/testcontainers-image-gate/", workflow)
-        self.assertIn("testcontainers-image-gate, test-ktor", workflow)
+        self.assertNotIn("testcontainers-image-gate", workflow)
+        self.assertIn("test-testcontainers-spring:", workflow)
 
-    def test_nightly_runs_full_gate_sequentially_before_spring_bridge(self) -> None:
+    def test_nightly_runs_full_gate_only_before_spring_bridge(self) -> None:
         workflow = (self.root / ".github/workflows/nightly-tests.yml").read_text(encoding="utf-8")
         self.assertIn("test-testcontainers-image-gate:", workflow)
+        self.assertIn("if: ${{ needs.plan.outputs.scope == 'full' }}", workflow)
         self.assertIn("--scope full", workflow)
         self.assertIn("TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'", workflow)
         self.assertIn("needs: [test-testcontainers, test-testcontainers-image-gate, plan]", workflow)
+        self.assertIn("needs.test-testcontainers-image-gate.result == 'skipped'", workflow)
         self.assertIn("- test-testcontainers-image-gate", workflow)
 
     def test_release_publish_depends_on_full_gate_summary(self) -> None:

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -171,15 +171,17 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 manifest는 고정 image/tag와 Kotlin wrapper, 대표 테스트 클래스, readiness 계약,
 workload 증거, 진단 명령을 연결합니다.
 
-동일한 실행기를 PR CI, Nightly, 안정 버전 배포 workflow에서 사용합니다. 선택된
-family는 `max-parallel: 1`로 순차 실행하고 `success`, `product_failure`,
+동일한 실행기를 전체 Nightly와 안정 버전 배포 workflow에서 사용합니다. PR은
+저비용 JVM·모듈 검증을 유지하고 Docker 기반 family gate는 전체 Nightly/배포
+경로로 한정합니다. 선택된 family는 `max-parallel: 1`로 순차 실행하고
+`success`, `product_failure`,
 `infrastructure_failure`, `blocked`로 분류하며 `summary.json`, `summary.md`,
 family별 JSON을 남깁니다. 안정 버전 배포는 `52/52`, `release_gate=true`,
 모든 실패 분류 0을 요구합니다. Docker Hub 인증과 mirror 설정은 환경변수 또는
 CI secret으로만 전달하며, 증거에는 credential을 기록하지 않습니다.
 
 <!-- TESTCONTAINERS_IMAGE_GATE_COMMAND_START -->
-저장소 루트에서 변경 family gate를 실행합니다.
+특정 변경을 조사할 때 저장소 루트에서 대상 family gate를 실행합니다.
 
 ```bash
 python3 scripts/run_testcontainers_image_gate.py \

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -167,8 +167,10 @@ The 52 Docker-backed server families are declared in
 The manifest links each pinned image/tag to its Kotlin wrapper, representative
 test class, readiness contract, workload evidence, and diagnostic commands.
 
-The same runner is used by pull-request CI, Nightly, and the stable release
-workflow. It executes the selected families sequentially (`max-parallel: 1`),
+The same runner is used by the full Nightly and stable release workflows. Pull
+requests keep their low-cost JVM and module checks; the Docker-backed family
+gate is intentionally reserved for the full Nightly/release path. The runner
+executes the selected families sequentially (`max-parallel: 1`),
 records `success`, `product_failure`, `infrastructure_failure`, or `blocked`,
 and writes `summary.json`, `summary.md`, and one JSON file per family. Stable
 publication requires `52/52`, `release_gate=true`, and zero failure-classification
@@ -176,7 +178,8 @@ counts. Docker Hub authentication and mirror settings are supplied through
 environment variables or CI secrets; credentials are redacted from evidence.
 
 <!-- TESTCONTAINERS_IMAGE_GATE_COMMAND_START -->
-Run the changed-family gate from the repository root:
+Run a targeted local family gate from the repository root when investigating a
+specific change:
 
 ```bash
 python3 scripts/run_testcontainers_image_gate.py \


### PR DESCRIPTION
## 요약

- PR CI의 `Test / Testcontainers image startup-workload gate` job과 관련 path filter/required dependency를 제거했습니다.
- Nightly image gate는 `scope == 'full'`에서만 실행되도록 제한했습니다.
- Nightly 수동 `testcontainers` 범위의 JVM-only Spring bridge는 계속 실행되며, stable release의 full `52/52` gate는 유지했습니다.
- 관련 CI 계약 테스트와 Testcontainers README(영문/국문)를 갱신했습니다.

## 배경

PR CI에서 변경 family image gate가 순차적으로 실행되며 30분 이상 소요될 수 있었습니다. PR CI는 저비용 모듈 검증에 집중하고 Docker 기반 전체 family 검증은 Nightly full과 release 경로에 남깁니다.

## 검증

- `python3 -m unittest scripts.test_testcontainers_image_gate scripts.test_run_testcontainers_image_gate -v` (19 passed)
- `python3 .github/scripts/test-ci-domain-parallelization.py -v` (11 passed)
- `python3 -m unittest scripts.test_release_workflow_policy -v` (8 passed)
- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml .github/workflows/release.yml`
- YAML parsing, `py_compile`, `git diff --check`

## DoD Status

- 상태: DONE
- PR CI image gate 제거: 완료
- Nightly full-only image gate: 완료
- Release full gate 보존: 완료
- 실제 GitHub-hosted Actions 실행: PR check에서 확인 예정