### PR TITLE
[testcontainers] image gate strict runtime 계약과 native provenance 강화

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1254,7 +1254,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: nightly-testcontainers-image-gate-${{ github.run_id }}
-          path: build/reports/testcontainers-image-gate/
+          path: |
+            build/reports/testcontainers-image-gate/*.json
+            build/reports/testcontainers-image-gate/summary.md
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-testcontainers-image-gate-${{ github.run_id }}
-          path: build/reports/testcontainers-image-gate/
+          path: |
+            build/reports/testcontainers-image-gate/*.json
+            build/reports/testcontainers-image-gate/summary.md
           if-no-files-found: error
           retention-days: 30
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -318,12 +318,6 @@ subprojects {
 
     tasks {
         val signingUsesGpgCmd = resolvePublishingSigningConfig().useGpgCmd
-        // Java 25+에서 Ignite 2 thin client의 레거시 reflection을 허용한다.
-        // 검증된 최소 범위만 모든 테스트 JVM에 적용해 모듈별 설정 드리프트를 막는다.
-        val java25CompatibilityJvmArgs = listOf(
-            "--add-opens=java.base/java.nio=ALL-UNNAMED",
-            "--add-opens=java.base/java.util=ALL-UNNAMED",
-        )
 
         compileJava {
             options.isIncremental = true
@@ -349,10 +343,6 @@ subprojects {
             NmcpPublishMutexService::class
         ) {
             maxParallelUsages.set(1)
-        }
-
-        withType<Test>().configureEach {
-            jvmArgs(java25CompatibilityJvmArgs)
         }
 
         test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -318,6 +318,12 @@ subprojects {
 
     tasks {
         val signingUsesGpgCmd = resolvePublishingSigningConfig().useGpgCmd
+        // Java 25+에서 Ignite 2 thin client의 레거시 reflection을 허용한다.
+        // 검증된 최소 범위만 모든 테스트 JVM에 적용해 모듈별 설정 드리프트를 막는다.
+        val java25CompatibilityJvmArgs = listOf(
+            "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+        )
 
         compileJava {
             options.isIncremental = true
@@ -343,6 +349,10 @@ subprojects {
             NmcpPublishMutexService::class
         ) {
             maxParallelUsages.set(1)
+        }
+
+        withType<Test>().configureEach {
+            jvmArgs(java25CompatibilityJvmArgs)
         }
 
         test {

--- a/docs/superpowers/plans/2026-08-24-issue-1486-ignite2-arm64-image-gate-plan.md
+++ b/docs/superpowers/plans/2026-08-24-issue-1486-ignite2-arm64-image-gate-plan.md
@@ -1,0 +1,376 @@
+# Issue #1486 Ignite2 ARM64 image gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `test-driven-development`,
+> `subagent-driven-development`, and the matching Bluetape Kotlin patterns.
+> Execute the checked steps in order and preserve each RED/GREEN result as
+> evidence.
+
+## 목표와 완료 조건
+
+Issue #1486의 `Ignite2ServerTest`를 실제 startup·thin-client cache workload로
+전환하고, `apacheignite/ignite:2.18.0` amd64와
+`apacheignite/ignite:2.18.0-arm64` arm64의 native pull·startup·workload·JUnit
+증거를 fail-closed로 검증한다. PR CI에는 Docker runtime을 추가하지 않으며,
+Nightly/Release에서만 x64 권위 실행과 arm64 전용 gate를 수행한다.
+
+완료 조건은 다음과 같다.
+
+- 기준선 `Ignite2ServerTest`의 `3/3 skipped`가 보존된 RED 증거 뒤에 대표 test가
+  unskip되어 startup과 `Ignition.startClient` cache `put`/`get`을 통과한다.
+- runner/manifest/parser의 schema v2가 pull event·digest·platform·startup
+  marker·workload testcase·JUnit 실행 수를 필수화하고, XML/path/secret/output
+  경계를 넘으면 `blocked`가 된다.
+- x64는 full gate에서 정확히 한 번 amd64를 실행하고, arm64는
+  `--family-id ignite2 --platform-id arm64 --require-selection` 전용 native job에서
+  정확히 한 번 실행한다. 일반 `storage-cache` matrix와 PR runtime에는 중복 실행이
+  없다.
+- x64 strict/JUnit timeout은 6분, arm64 test timeout은 30분이며 worst-case budget은
+  각각 318분/84분으로 job timeout 360분/90분 이내다.
+- public `Ignite2Server` constructor/function signature와 기존 family의 disabled
+  계약을 유지한다. EN/KO README와 KDoc의 tag/platform/lifecycle 설명이 source·test·
+  manifest와 일치한다.
+- `actionlint`, Python unit/static tests, targeted Gradle test/compile, `detekt`,
+  `git diff --check`와 새 head의 CI evidence가 모두 통과한다. 실제 ARM runner/pull
+  증거는 첫 Nightly/Release 실행에서 확인한다.
+
+## 실행 경계와 stacked train
+
+- 설계 기준 커밋: `b301aac98` (`fix/1486-ignite2-arm64`). 이 커밋의 spec/review는
+  수정 후 Step 2-R `P0=0/P1=0`, P2 WATCH 상태를 보존한다.
+- timeout authority는 설계 §5.1/§5.4와 이 계획의 목표를 함께 따른다. amd64
+  `testMinutes=6`, 대표 JUnit 6분(5분 startup + 1분 workload 여유), x64 budget
+  318분/360분을 단일 값으로 사용한다. 다른 timeout/budget 값이 발견되면 구현을
+  중단하고 plan/spec drift로 기록한다.
+- Parent PR은 `develop`을 base로 하는
+  `fix/1486-image-gate-runner` worktree에서 runner/parser/schema/manifest
+  validator와 독립 synthetic fixture만 소유한다. canonical
+  `scripts/testcontainers_image_gate_manifest.json`은 read-only로 읽으며,
+  parent는 그 파일의 family payload를 수정하지 않는다. JSON-pointer
+  `/families/*`는 child hunk allowlist로만 변경할 수 있다.
+- Child PR은 parent head를 base로 하는
+  `fix/1486-ignite2-arm64-runtime` worktree에서 `Ignite2Server` source/test,
+  test-only dependency, EN/KO README/KDoc, canonical manifest의
+  `families[id=ignite2]` object와 Nightly/Release workflow를 소유한다. child는
+  top-level schema/defaults나 다른 family object를 수정하지 않는다.
+- Parent가 먼저 merge될 때까지 child PR을 독립 merge하지 않는다. 각 PR 생성 전
+  exact `base/head/merge-base`와 required CI를 fresh-read하고, merge는 별도 fresh
+  승인 없이는 수행하지 않는다. auto-merge, tag, release, publish, branch deletion,
+  force push는 이 계획의 범위가 아니다.
+- 두 worktree의 Testcontainers-backed test는 shared Docker daemon 경합을 피하도록
+  병렬 실행하지 않는다. parent static/unit lane과 child Gradle compile은 독립적일
+  때만 병렬화하고, Docker runtime/ARM CI는 순차적으로 관찰한다.
+
+## 공통 준비와 기준선
+
+### Task 0 — 기준선·worktree·authority 고정
+
+**Files:** read-only except workflow evidence.
+
+- [ ] `AGENTS.md`, workspace guide, `bluetape-workflow`,
+      `bluetape-kotlin-patterns`, `test-driven-development`, `subagent-driven-development`
+      및 이 계획을 다시 읽는다.
+- [ ] live Issue #1486, milestone/assignee/labels, current `develop`, existing PR
+      and duplicate paths를 `gh`로 재확인한다. Issue acceptance와 설계의 52-family
+      count가 다르면 구현하지 않고 계획을 갱신한다.
+- [ ] `git status --short --branch`, `git rev-parse HEAD`,
+      `git rev-parse origin/develop`, `git merge-base --is-ancestor`를 parent/child
+      worktree 각각에 기록한다. canonical develop worktree는 읽기 전용으로 둔다.
+- [ ] baseline을 새 head에서 다시 실행한다.
+
+```bash
+repo-test-summary -- ./gradlew :bluetape4k-testcontainers:test \
+  --tests 'io.bluetape4k.testcontainers.storage.Ignite2ServerTest' \
+  --no-build-cache --no-configuration-cache
+python3 -m unittest scripts.test_testcontainers_contract -v
+```
+
+Expected baseline은 XML `tests=3`, `skipped=3`, `failures=0`, process success이며,
+runtime evidence가 없는 green 결과로 해석하지 않는다.
+
+### Task 1 — Parent/child worktree 생성과 train receipt
+
+- [ ] 현재 spec commit에서 parent를 만든다.
+
+```bash
+git worktree add -b fix/1486-image-gate-runner \
+  .worktrees/fix/1486-image-gate-runner fix/1486-ignite2-arm64
+```
+
+- [ ] parent 구현이 안정화된 뒤에만 child를 parent head에서 만든다.
+
+```bash
+git worktree add -b fix/1486-ignite2-arm64-runtime \
+  .worktrees/fix/1486-ignite2-arm64-runtime fix/1486-image-gate-runner
+```
+
+- [ ] 각 branch에 source ownership, allowed paths, base SHA, expected CI와 rollback
+      조건을 workflow receipt에 남긴다. unrelated dirty path는 보존하고 되돌리지
+      않는다.
+- [ ] 이 plan을 spec branch에 먼저 commit하고 plan commit SHA를 receipt에 기록한
+      뒤에만 parent/child worktree를 생성한다. untracked plan으로 implementation
+      worktree를 만들지 않는다.
+
+## Parent lane — runner/parser/schema
+
+### Task 2 — RED: manifest·selector·XML·security fixture
+
+**Parent files:**
+
+- `scripts/testcontainers_image_gate.py`
+- `scripts/test_testcontainers_contract.py`
+- `scripts/test_run_testcontainers_image_gate.py` (신규)
+
+- [ ] 현재 52-entry canonical manifest를 read-only baseline으로 보존한 뒤, synthetic
+      fixture에서 `executionEvidenceRequired` 미지정 family가 `false`이고 Ignite2만
+      strict opt-in인 RED fixture를 추가한다. Parent는 canonical manifest를
+      수정하지 않는다.
+- [ ] exact selector의 0개/복수개/unknown ID, `defaultPlatformId=amd64`, x64 full
+      resolver와 arm64 `--require-selection`을 검증하는 테스트를 먼저 추가한다.
+- [ ] XML fixture에 missing/stale/all-skipped/tests=0/malformed/DTD-ENTITY/
+      symlink/path escape/suite mismatch/counter limit과 Kotlin `()` suffix
+      canonicalization을 추가한다. workload testcase와 suite `tests`를 별도 집계한다.
+- [ ] image/daemon/runner OS·architecture alias, empty digest, local-vs-remote
+      Docker context, registry mirror, safe ID/reference grammar을 fail-closed로
+      검증하는 fixture를 추가한다.
+- [ ] raw/decoded/base64 Docker auth, basic-auth URL, multiline/known secret,
+      arbitrary JVM property/Gradle option이 output·exception·JSON·Markdown에
+      남지 않는 redaction/allowlist fixture를 추가한다.
+- [ ] pull event correlation, requested ref, cache state, image ID/digest reuse,
+      pull transport-only retry, attempt root/container/XML/marker isolation을
+      fake subprocess로 검증한다.
+- [ ] output cap(64 KiB/1,000 lines, diagnostic 64 KiB/500 lines, family 128 KiB,
+      summary 1 MiB, artifact 8 MiB), per-command/job deadline, process-group kill,
+      318/84 budget formula를 RED fixture로 고정한다.
+- [ ] synthetic 52-family worst-case fixture가 bounded result 축약 후 전체 artifact
+      8 MiB 이하임을 검증하고, checkout/setup/mock pre-step를 포함한 고정 30분
+      setup slack과 실제 subprocess wall-clock 누계를 job-budget guard가 비교하게
+      한다. 이 fixture 또는 wall-clock 증거가 없으면 최종 DoD를 `PENDING`으로
+      유지한다.
+- [ ] 이 단계에서는 production runner behavior를 수정하지 않고 의도한 실패와
+      failure classification을 raw evidence로 보존한다.
+
+### Task 3 — GREEN: runner/parser/schema implementation
+
+**Parent files:**
+
+- `scripts/run_testcontainers_image_gate.py`
+- `scripts/testcontainers_image_gate.py`
+- `scripts/test_run_testcontainers_image_gate.py`
+- `scripts/test_testcontainers_contract.py`
+
+- [ ] capped streaming/temp-file subprocess helper와 process-group deadline을
+      구현한다. `capture_output=True` 같은 unbounded path를 사용하지 않는다.
+- [ ] fresh staging root와 safe ID/path containment, regular non-symlink XML allowlist,
+      bounded parser, DTD/ENTITY 차단, exact suite/workload matcher를 구현한다.
+- [ ] pull 전 bounded Docker event observer와 dedicated ephemeral `DOCKER_CONFIG`
+      pull subprocess를 구현한다. Gradle/test/diagnostic에는 sanitized env만
+      전달하고 pull 성공 후 credential/temp config를 삭제한다.
+- [ ] image inspect/docker info/context/uname allowlist와 canonical architecture,
+      local Unix socket, Docker Hub/mirror 정책을 구현한다.
+- [ ] per-family schema v2와 summary schema v2를 구현한다. v1/partial/skipped,
+      missing pull/digest/workload/marker를 성공으로 완화하지 않는다.
+- [ ] attempt state machine을 `pull → test → evidence → cleanup`으로 고정한다.
+      x64 `max_attempts=1`은 in-job retry 없음, arm64만 `max_attempts>1`에서
+      verified digest를 재사용하는 transient retry를 허용한다.
+- [ ] generic family는 기존 process-success 계약을 유지하고 strict family만
+      `executionEvidenceRequired=true` 검사로 분기한다. release verifier가
+      `coverage`, `release_gate`, platform/tag/architecture/digest/workload를 직접
+      검증하도록 static helper를 노출한다.
+- [ ] parent RED fixture를 모두 GREEN으로 전환하고, fake runner가 product failure,
+      infrastructure failure, blocked를 혼동하지 않음을 확인한다.
+
+## Child lane — Ignite2 runtime/manifest/workflow
+
+### Task 4 — RED: runtime·dependency·docs·workflow contract
+
+**Child files:**
+
+- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt`
+- `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt`
+- `testing/testcontainers/build.gradle.kts`
+- `scripts/testcontainers_image_gate_manifest.json`
+- `.github/workflows/nightly-tests.yml`
+- `.github/workflows/release.yml`
+- `testing/testcontainers/README.md`, `testing/testcontainers/README.ko.md`,
+  source KDoc
+
+- [ ] `@Disabled` 제거, 기본 생성자 대표 workload, `Ignition.startClient`,
+      `ClientConfiguration` connect/request 30초, `use`/`finally`, marker-before-
+      workload 테스트를 작성한다. baseline `3/3 skipped`는 Task 0의 별도 기준선
+      증거로 보존하고, 그 뒤 test-only dependency와 대표 test를 추가한 다음
+      class-level `@Disabled`만 제거한다. production source를 수정하기 전에
+      실제 startup/client assertion failure를 실행·기록해 RED를 만든다.
+- [ ] `DEFAULT_TAG` x86_64/amd64와 aarch64/arm64 mapping, explicit override,
+      canonical no-tag unknown fail-fast, custom image/tag unknown-arch lazy 경계를
+      검증하는 JVM fixture를 작성한다. canonical no-tag, custom no-tag fail-fast,
+      custom explicit-tag 허용, `DockerImageName` overload의 tagless 동작을
+      분리해 테스트·KDoc·EN/KO README에 고정한다. public constructor/function
+      descriptor는 변경하지 않는다.
+- [ ] central catalog의 `bt4k.ignite.core` test-only dependency와
+      `org.apache.ignite:ignite-core:2.18.0` resolution/published POM exclusion을
+      검증하는 Gradle fixture를 작성한다.
+- [ ] canonical manifest의 `families[id=ignite2]` object에만 `platforms`,
+      `defaultPlatformId`, `executionEvidenceRequired`, workload pattern, platform
+      timeout, pull evidence fields를 추가하는 RED contract를 만든다. top-level
+      schema와 다른 family object는 parent head에서 그대로 보존한다.
+- [ ] PR workflow에 runtime invocation이 없고, Nightly/Release x64/arm64 job
+      selector·runner·needs·artifact literal·retention·timeout·budget·mock Jib
+      exclusion이 정확한지 검증하는 static fixture를 먼저 작성한다.
+
+### Task 5 — GREEN: Ignite2 source/test/dependency/docs
+
+- [ ] `DEFAULT_TAG`를 eager companion property가 아닌 lazy getter/helper 또는
+      sentinel 경계로 구현한다. explicit `tag`/custom image 경로는 unknown arch에서
+      default resolver를 호출하지 않는다.
+- [ ] `representativeStartupAndWorkload`에서 기본 `Ignite2Server()`로 container를
+      시작하고 readiness marker를 evidence root에 기록한 뒤 thin-client cache
+      `put`/`get`을 검증한다. client/container는 모든 예외·timeout 경로에서 닫힌다.
+- [ ] 기존 port/blank image/tag/explicit override 계약을 유지하고 public API
+      signature를 변경하지 않는다. JUnit timeout은 6분(5분 startup + 1분 workload
+      여유)으로 둔다.
+- [ ] `build.gradle.kts`에 중앙 catalog alias만 test scope로 추가하고 dependency
+      graph 및 published POM에 production dependency가 유입되지 않음을 확인한다.
+- [ ] EN/KO README와 KDoc에 `2.18.0`, `2.18.0-arm64`, OS/architecture mapping,
+      canonical/custom/unknown policy, `Ignition.startClient` lifecycle을 동일하게
+      문서화한다. reader-facing prose는 한국어 정책을 따른다.
+
+### Task 6 — GREEN: manifest/workflow integration
+
+- [ ] 일반 Nightly `storage-cache`에서 Ignite2를 제거하고 기존 x64 full gate의
+      strict resolver를 amd64 authoritative 실행으로 고정한다.
+- [ ] Nightly/Release에 `ubuntu-24.04-arm` Ignite2 전용 job을 추가한다. arm64
+      final Gradle argv는 고정
+      `-Dtestcontainers.image-gate.evidence-dir=$RUN_EVIDENCE_DIR`와 두 mock Jib
+      `-x` exclusion을 포함하며 arbitrary task/JVM option을 받지 않는다.
+- [ ] x64 job은 `max_attempts=1`, strict 6분, budget 360/timeout 360; arm64 job은
+      `max_attempts=2`, 5/30/2분, budget 90/timeout 90을 사용한다. full aggregate와
+      Release publish는 x64·arm64 `success`를 모두 요구하고 targeted scope에서만
+      image-gate skipped를 허용한다.
+- [ ] x64 runner CLI를 다음 고정 argv로 보존한다.
+
+```text
+python3 scripts/run_testcontainers_image_gate.py --scope full --report-dir build/reports/testcontainers-image-gate --default-platform-id amd64 --max-attempts 1 --pull-timeout-seconds 60 --timeout-minutes 4 --diagnostic-timeout-seconds 30 --job-budget-minutes 360
+```
+
+  arm64 runner CLI는 다음 고정 argv로 보존한다.
+
+```text
+python3 scripts/run_testcontainers_image_gate.py --scope family --family-id ignite2 --platform-id arm64 --require-selection --report-dir build/reports/testcontainers-image-gate --max-attempts 2 --pull-timeout-seconds 300 --timeout-minutes 30 --diagnostic-timeout-seconds 120 --job-budget-minutes 90
+```
+
+  arm64의 최종 Gradle argv는 다음 순서와 옵션을 그대로 static fixture로 검증한다.
+
+```text
+./gradlew -Dtestcontainers.image-gate.evidence-dir=$RUN_EVIDENCE_DIR :bluetape4k-testcontainers:test --tests io.bluetape4k.testcontainers.storage.Ignite2ServerTest.representativeStartupAndWorkload --no-configuration-cache -x :bluetape4k-mock-web-server:jibDockerBuild -x :bluetape4k-mock-webflux-server:jibDockerBuild
+```
+
+  위 command 외 arbitrary task/JVM property/Gradle option은 거부한다.
+- [ ] Nightly full에서 x64 gate의 expected coverage는 `52/52`, arm64 gate는
+      `1/1`이고, `test-testcontainers-spring`, `coverage-report`,
+      `nightly-status`는 각각 x64와 arm64 gate job의 `success`를 exact `needs`로
+      요구한다. targeted scope에서는 두 image gate와 해당 bridge만 명시적으로
+      `skipped`를 허용한다.
+- [ ] Release verifier fixture는 x64 `coverage == 52/52`, arm64 `coverage == 1/1`,
+      `release_gate == true`, expected/actual `platform_id`, tag, OS/architecture,
+      digest와 workload evidence를 직접 assert한다. x64 Release gate와 arm64
+      Release gate 모두 `needs.resolve-version.outputs.ref`를 checkout ref로
+      사용하고 `resolve-version`와 manifest contract를 선행 의존성으로 보존한다.
+      `publish.needs`는 정확히 `[resolve-version,
+      testcontainers-manifest-contract, testcontainers-image-gate,
+      testcontainers-ignite2-arm64-image-gate]` 네 job ID만 포함한다.
+- [ ] pull secret을 job-level `DOCKER_AUTH_CONFIG`에 두지 않고 dedicated pull
+      subprocess의 0600 ephemeral `DOCKER_CONFIG` 파일로만 전달한다. argv·env·
+      exception·artifact에 secret이 전파되지 않고, `finally`에서 config/helper가
+      삭제되는 child-process environment fixture를 통과시킨다. artifact에는
+      Nightly의 고정 x64/arm64 run-platform literal 이름과 `if: always()`,
+      `if-no-files-found: error`, retention 14일을 assert한다. Release는 정확히
+      `release-testcontainers-image-gate-${{ github.run_id }}`와
+      `release-testcontainers-ignite2-arm64-image-gate-${{ github.run_id }}` 두
+      literal 이름을 사용하고, 두 artifact 모두 `if: always()`,
+      `if-no-files-found: error`, retention 30일을 사용한다. raw logs/system-out은
+      업로드하지 않는다.
+- [ ] Release verifier를 각 gate job의 마지막 required step으로 실행하고
+      `publish.needs`에는 job ID만 포함한다. skipped/continue-on-error/이전 artifact
+      재사용을 거부한다. ARM queue 10분 초과 시 `gh run cancel <run-id>`, release
+      block, 새 run-only retry와 새 release tag/candidate rollback을 문서화한다.
+
+## 통합 검증
+
+### Task 7 — Parent/child exact-head integration
+
+- [ ] parent branch에서 Python unit/static tests, manifest parity, parser/security
+      tests, `git diff --check`를 통과시킨다.
+- [ ] parent commit 후 child를 parent exact head 위에 rebase/merge한다. `git
+      merge-base --is-ancestor parent_head child_head`를 확인하고 parent 파일을
+      child가 되돌리지 않았는지, canonical manifest는 Ignite2 object hunk만
+      변경됐는지 diff ownership을 검사한다.
+- [ ] child에서 Kotlin compile, targeted `Ignite2ServerTest`, testcontainers
+      module test, workflow policy/static tests를 실행한다. Docker-backed test는
+      local Colima context와 managed socket override를 확인한 뒤 sequentially
+      실행하고, skip/failure를 성공으로 해석하지 않는다.
+- [ ] `actionlint`, Python unittest, `detekt`, `./gradlew :bluetape4k-testcontainers:compileTestKotlin`
+      및 `git diff --check`를 fresh child head에서 실행한다.
+- [ ] 구현 후 parent/child 각각 Type-D read-only code review를 수행하고, P0/P1이
+      남으면 해당 branch에서 수정·재검증한다. review artifact와 exact head를 PR에
+      연결한다.
+
+### Task 8 — CI/PR/merge 이후 동기화
+
+- [ ] parent PR을 base `develop`/head `fix/1486-image-gate-runner`로 만들고,
+      Korean body 끝에 `## DoD Status`와 현재 미검증 ARM/CI WATCH를 기록한다.
+- [ ] parent required CI와 review/thread/mergeability를 fresh-read한 뒤 별도
+      승인 후 merge한다. child branch를 parent merge SHA 위에 restack하고 exact
+      cumulative head를 다시 검증한다.
+- [ ] child PR을 parent branch base로 만들고 동일한 CI/review/DoD gate를 거친다.
+      Release/Nightly CI가 실제 ARM runner/pull/workload evidence를 생성할 때까지
+      green static CI만으로 runtime 완료를 주장하지 않는다.
+- [ ] 두 merge 후 canonical `develop`을 fetch하고 local sync, `git worktree list`,
+      `git branch --merged`, `git status`를 확인한다. stale/complete worktree만
+      명시적 범위로 정리하고 remote ref는 보존한다.
+
+## Verification command set
+
+```bash
+python3 -m unittest scripts.test_testcontainers_contract \
+  scripts.test_testcontainers_image_gate \
+  scripts.test_run_testcontainers_image_gate -v
+actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml \
+  .github/workflows/release.yml
+./gradlew :bluetape4k-testcontainers:compileTestKotlin \
+  :bluetape4k-testcontainers:test \
+  --tests 'io.bluetape4k.testcontainers.storage.Ignite2ServerTest' \
+  --no-build-cache --no-configuration-cache
+./gradlew :bluetape4k-testcontainers:detekt --no-configuration-cache
+git diff --check
+```
+
+실제 `docker pull`, ARM runner 예약, Nightly/Release dispatch와 merge는 구현 후
+각 gate의 fresh 승인·CI evidence가 충족될 때까지 `PENDING`이다. Coveralls 수치는
+이 이슈의 runtime 증거가 아니며, skipped/partial job을 global coverage proof로
+사용하지 않는다.
+
+## Rollback과 위험
+
+- Parent parser/schema 변경이 기존 52-family를 깨면 parent branch에서 strict opt-in
+  경계만 되돌리고 generic family 계약을 복구한다. child runtime/workflow는 parent
+  head에 의존하므로 parent가 green이 아니면 child를 merge하지 않는다.
+- ARM runner unavailable, pull event/digest 누락, architecture mismatch, XML/marker
+  누락, credential/staging/output budget 초과는 `blocked`로 남기고 skipped로
+  완화하지 않는다.
+- mutable Docker tag는 이번 범위의 명시적 WATCH다. Release 이후 immutable digest
+  allowlist 또는 tag-to-digest drift monitoring은 별도 이슈로 분리한다.
+- known gaps: 실제 ARM/native runtime과 checkout/setup wall-clock은 구현/첫
+  Nightly에서 fresh evidence가 필요하다. 52-family 최악 8 MiB fixture는 parent
+  unit/static 단계의 Plan DoD 필수 항목이며, 통과 전에는 `PENDING`으로 보고한다.
+
+## Plan DoD
+
+- [ ] parent/child ownership과 exact-head train receipt가 보존된다.
+- [ ] 모든 RED 단계가 의도한 결함으로 실패했고 GREEN 단계에서 동일 fixture가
+      통과한다.
+- [ ] public API/disabled-family/central catalog/README EN/KO parity가 유지된다.
+- [ ] Python runner/security/schema/workflow static checks와 Kotlin targeted tests가
+      fresh head에서 통과한다.
+- [ ] CI/PR에는 runtime gate가 없고 Nightly/Release native x64+arm64 gate만 있다.
+- [ ] final report가 changed files, test evidence, P2/P3 WATCH, PENDING runtime
+      evidence, merge/sync/cleanup 상태를 DoD 순서로 보고한다.

--- a/docs/superpowers/plans/2026-08-24-issue-1486-ignite2-arm64-image-gate-plan.md
+++ b/docs/superpowers/plans/2026-08-24-issue-1486-ignite2-arm64-image-gate-plan.md
@@ -284,8 +284,8 @@ python3 scripts/run_testcontainers_image_gate.py --scope family --family-id igni
       삭제되는 child-process environment fixture를 통과시킨다. artifact에는
       Nightly의 고정 x64/arm64 run-platform literal 이름과 `if: always()`,
       `if-no-files-found: error`, retention 14일을 assert한다. Release는 정확히
-      `release-testcontainers-image-gate-${{ github.run_id }}`와
-      `release-testcontainers-ignite2-arm64-image-gate-${{ github.run_id }}` 두
+      `release-testcontainers-image-gate-${{ github.run_id }}-amd64`와
+      `release-testcontainers-image-gate-${{ github.run_id }}-arm64` 두
       literal 이름을 사용하고, 두 artifact 모두 `if: always()`,
       `if-no-files-found: error`, retention 30일을 사용한다. raw logs/system-out은
       업로드하지 않는다.

--- a/docs/superpowers/reviews/2026-08-24-issue-1486-plan-review.md
+++ b/docs/superpowers/reviews/2026-08-24-issue-1486-plan-review.md
@@ -44,8 +44,8 @@ ref 계약이 계획에 고정되지 않은 점이었다. 이전 설계의 5분/
    `[resolve-version, testcontainers-manifest-contract, testcontainers-image-gate,
    testcontainers-ignite2-arm64-image-gate]`로 보존하도록 plan에 추가했다.
    Release artifact 이름은
-   `release-testcontainers-image-gate-${{ github.run_id }}`와
-   `release-testcontainers-ignite2-arm64-image-gate-${{ github.run_id }}`로
+   `release-testcontainers-image-gate-${{ github.run_id }}-amd64`와
+   `release-testcontainers-image-gate-${{ github.run_id }}-arm64`로
    고정하고 두 artifact의 `if: always()`, `if-no-files-found: error`, 30일
    보존을 assert하도록 했다.
 6. 52-family 최악 8 MiB artifact와 30분 setup slack을 포함한 wall-clock budget

--- a/docs/superpowers/reviews/2026-08-24-issue-1486-plan-review.md
+++ b/docs/superpowers/reviews/2026-08-24-issue-1486-plan-review.md
@@ -1,0 +1,80 @@
+# Issue #1486 구현 계획 독립 리뷰 기록
+
+## 1. 범위와 판정
+
+- **대상 계획**:
+  `docs/superpowers/plans/2026-08-24-issue-1486-ignite2-arm64-image-gate-plan.md`
+- **대상 단계**: Type A Full Feature Step 3-R
+- **검토 관점**: stability/performance, operator/security, developer/API,
+  user/caller
+- **구현 상태**: production source, Gradle dependency, workflow runtime은 아직
+  변경하지 않았다. 계획과 이미 승인된 설계·리뷰 산출물만 검토했다.
+
+초기 검토는 P0=0, P1=2로 BLOCK이었다. 유효한 P1은 parent/child가 같은
+manifest 파일을 넓게 소유한 점과 Release workflow의 exact `needs`/checkout
+ref 계약이 계획에 고정되지 않은 점이었다. 이전 설계의 5분/317분 수치 지적은
+현재 설계의 6분/318분 기준과 맞지 않는 stale evidence로 판정했다.
+
+## 2. 교정 전 검토 결과
+
+| 관점 | P0 | P1 | P2/P3 | 최초 판정 | 핵심 finding |
+|---|---:|---:|---:|---|---|
+| Stability/performance | 0 | 1 | 3 | BLOCK | manifest ownership 경계, 실제 8 MiB/setup wall-clock fixture와 ARM evidence가 아직 구현 전 |
+| Operator/security | 0 | 1 | 3 | BLOCK | Release `resolve-version` dependency/ref 및 release artifact literal이 계획에 불충분하게 고정됨 |
+| Developer/API | 0 | 0 | 4 | WATCH | TDD RED 순서, custom no-tag, exact argv, manifest subtree는 교정 필요 |
+| User/caller | 0 | 0 | 1 | WATCH | 실제 native runtime은 첫 Nightly/Release까지 미검증 |
+| **통합 최초** | **0** | **2** | **11** | **BLOCK** | P1 교정 후 재검토 필요 |
+
+## 3. 반영한 교정
+
+1. Parent는 `scripts/testcontainers_image_gate_manifest.json`을 read-only로
+   두고, child만 JSON pointer `/families/*` 중 `families[id=ignite2]` object
+   hunk를 수정하도록 plan에 고정했다. exact-head diff ownership 검사를 통합
+   단계에 추가했다.
+2. 기준선 `3/3 skipped`는 Task 0 증거로 분리했다. dependency와 test를 추가하고
+   `@Disabled`를 제거한 뒤 production source를 바꾸기 전에 실제 assertion
+   failure를 관찰하는 별도 RED 순서를 고정했다.
+3. canonical no-tag, custom no-tag fail-fast, custom explicit-tag unknown-arch
+   허용, `DockerImageName` overload의 tagless 동작을 테스트·KDoc·README 계약으로
+   분리했다.
+4. x64/arm64 runner CLI와 arm64 최종 Gradle argv를 전체 literal로 고정하고,
+   arbitrary task/JVM property/Gradle option을 정적 fixture에서 거부하도록 했다.
+5. Release x64/arm64 gate는 `needs.resolve-version.outputs.ref`를 checkout에
+   사용하고, `publish.needs`를 정확히
+   `[resolve-version, testcontainers-manifest-contract, testcontainers-image-gate,
+   testcontainers-ignite2-arm64-image-gate]`로 보존하도록 plan에 추가했다.
+   Release artifact 이름은
+   `release-testcontainers-image-gate-${{ github.run_id }}`와
+   `release-testcontainers-ignite2-arm64-image-gate-${{ github.run_id }}`로
+   고정하고 두 artifact의 `if: always()`, `if-no-files-found: error`, 30일
+   보존을 assert하도록 했다.
+6. 52-family 최악 8 MiB artifact와 30분 setup slack을 포함한 wall-clock budget
+   fixture를 최종 DoD의 필수 조건으로 유지했다. 해당 증거와 실제 ARM/native
+   pull·startup·workload 증거 전에는 완료를 주장하지 않는다.
+
+## 4. 최종 Step 3-R 결과
+
+| 관점 | P0 | P1 | P2/P3 | 최종 판정 | 잔여 WATCH |
+|---|---:|---:|---:|---|---|
+| Stability/performance | 0 | 0 | 3 | PASS with WATCH | 8 MiB/setup wall-clock fixture와 실제 ARM queue/runtime |
+| Operator/security | 0 | 0 | 2 | PASS with WATCH | mutable Docker tag 및 첫 Release native evidence |
+| Developer/API | 0 | 0 | 1 | PASS with WATCH | custom-tag runtime fixture |
+| User/caller | 0 | 0 | 1 | PASS with WATCH | 첫 Nightly/Release의 실제 workload |
+| **통합** | **0** | **0** | **7** | **PASS with WATCH** | 구현·CI에서만 해소 가능한 증거를 PENDING으로 유지 |
+
+### DoD
+
+- [x] plan의 parent/child ownership, exact-head train, timeout authority가
+      명시됐다.
+- [x] TDD baseline/RED/GREEN 순서와 실패 분류 경계가 명시됐다.
+- [x] runner/workflow exact argv, Release `resolve-version`/`needs`/artifact
+      계약이 명시됐다.
+- [x] P0=0, P1=0으로 수렴했다.
+- [ ] synthetic 8 MiB/setup wall-clock fixture 실행 — 구현 후 PENDING
+- [ ] 실제 ARM runner pull/startup/workload/cleanup evidence — 첫 Nightly/Release
+      후 PENDING
+- [ ] production code, workflow, Gradle 변경 및 테스트 — Step 3-R 이후 PENDING
+
+**결론: PASS with WATCH — 계획을 commit하고 TDD 구현 단계로 진행한다.**
+mutable tag, ARM queue 및 실제 runtime evidence는 범위상 WATCH이며, 해당
+증거가 없는 상태에서 PR merge나 완료 판정을 하지 않는다.

--- a/docs/superpowers/reviews/2026-08-24-issue-1486-spec-review.md
+++ b/docs/superpowers/reviews/2026-08-24-issue-1486-spec-review.md
@@ -1,0 +1,167 @@
+# Issue #1486 설계 명세 독립 리뷰 기록
+
+## 1. 범위와 현재 결론
+
+- **대상 명세**:
+  `docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md`
+- **대상 단계**: Type A Full Feature Step 2-R
+- **검토 기준**: Issue #1486 acceptance, 기준선 `Ignite2ServerTest` XML, 현재
+  runner/manifest/workflow, 중앙 `bluetape4k-dependencies` catalog, 공식
+  GitHub Actions·Apache Ignite 문서
+- **검토 관점**: performance, stability, security, operator/ops,
+  developer/API, user/caller
+- **현재 판정**: `BLOCK` — P0는 없지만 교정 전 P1이 남아 있어 설계 수정과
+  영향을 받는 관점의 재검토가 필요하다.
+- **구현 상태**: production code, Gradle build, Docker runtime gate는 아직
+  실행 대상이 아니다. 기준선 읽기와 설계 검토만 수행했다.
+
+사용자/caller lane은 native thread 한도로 별도 writer lane을 시작하지 못했다.
+해당 lane은 helper에 `lane-block`으로 기록했고, 같은 설계에 대해 완료된 native
+fallback reviewer의 caller 결과를 독립 증거로 보존해 통합 표에 반영했다.
+
+## 2. 독립 검토 결과
+
+| 관점 | P0 | P1 | P2/P3 | 최초 판정 | 핵심 근거 |
+|---|---:|---:|---:|---|---|
+| Performance | 0 | 5 | 3 | BLOCK | x64/amd64 중복 실행·pull, matrix 직렬화, mock Jib 재실행, workload 선택, output/stale XML/timeout budget |
+| Stability | 0 | 7 | 2 | BLOCK | 빈 platform 선택, stale XML, architecture 정규화, platform 진단, client timeout, retry/cleanup, workflow needs |
+| Security | 0 | 2 | 3 | BLOCK | credential artifact 노출, manifest runner trust boundary, XML/JSON·path·명령 검증, mutable tag provenance |
+| Operator/Ops | 0 | 4 | 2 | BLOCK | 실제 pull 증거, native architecture, Release summary, artifact provenance/schema |
+| Developer/API | 0 | 4 | 3 | BLOCK | 기존 disabled family와 strict parser 충돌, workload testcase, selector/tag 전달, architecture 정규화 |
+| User/Caller | 0 | 2 | 4 | BLOCK | 기본 tag 자체 검증, 일반 matrix 중복, architecture alias/custom image 정책, README/KDoc lifecycle |
+| **통합 최초 결과** | **0** | **24** | **17** | **BLOCK** | 아래 교정안을 설계에 반영하고 affected lane을 재검토한다. |
+
+### 2.1 교정 대상과 중복 제거
+
+리뷰 결과를 중복 제거하면 다음 P1 계약이 남는다.
+
+| 통합 ID | 관련 관점 | 설계 결함 | 필수 교정 |
+|---|---|---|---|
+| S-01 | performance, user, developer | Ignite2가 일반 Nightly matrix, 기존 52-family x64 gate, 새 x64/arm64 matrix에서 반복 실행된다. | 기존 full x64 image gate를 **amd64의 단일 authoritative 실행**으로 사용하고, 일반 `storage-cache` matrix에서 Ignite2를 제외하며, 새 native job은 `arm64` 한 leg만 실행한다. 실행 횟수와 local Docker 요구사항을 DoD에 고정한다. |
+| S-02 | performance, developer | 기존 52-family에는 의도적인 class-level `@Disabled` family가 있어 모든 suite에 strict JUnit execution proof를 적용하면 full gate가 회귀한다. | manifest에 `executionEvidenceRequired`를 도입하고 Ignite2에만 `true`를 준다. 일반 family는 기존 `BUILD SUCCESSFUL` 계약을 유지하며 disabled-family regression fixture를 추가한다. |
+| S-03 | developer, stability | class suite 집계만으로는 thin-client put/get workload가 실제 실행됐는지 보장하지 않는다. | Ignite2에 정확한 `workloadTestPattern`을 추가하고 XML에서 해당 testcase가 non-skipped·failure/error 0인지 별도 검증한다. full x64와 arm64 모두 같은 workload 계약을 사용한다. |
+| S-04 | stability, developer | `--family-id`/`--platform-id`가 0개·복수·unknown 선택을 fail-open으로 만들 수 있다. | exact selector와 `--require-selection`을 추가하고, 필수 platform invocation은 정확히 하나의 family/platform만 허용한다. 결과·command·diagnostic·report에 선택 platform을 전달한다. |
+| S-05 | performance, stability, ops, developer | `x86_64`/`amd64`, `aarch64`/`arm64`와 image/daemon/runner 값 비교 규칙이 없다. | canonical mapping을 고정하고 runner `uname`, Docker daemon, image `.Os`/`.Architecture`를 모두 비교한다. unknown·빈 digest·원격 context 불일치는 `blocked`다. |
+| S-06 | security, ops | raw stdout/system-out/inspect/env와 Docker credential이 artifact로 유출될 수 있고, manifest runner가 self-hosted label을 선택할 수 있다. | allowlist 필드만 저장하고 XML/log/output에 bounded redaction을 적용한다. runner는 workflow의 고정 allowlist(`ubuntu-24.04`, `ubuntu-24.04-arm`)로만 선택하며 manifest 값은 설명·정적 검증에만 사용한다. secret 값·Docker auth JSON·basic-auth URL·multiline token 회귀 테스트를 추가한다. |
+| S-07 | stability, performance, security | stale XML, malformed/unsafe XML, path escape, unbounded output이 현재 실행 증거를 오염시킬 수 있다. | attempt 전 기존 XML 기준 파일 목록/정리와 시작 이후 freshness를 적용하고, regular non-symlink 파일·root containment·size limit·DTD/ENTITY 금지·bounded counters·exact suite match를 검증한다. parse error/suite 부재/all skipped는 `blocked`다. |
+| S-08 | ops, stability | image inspect/digest만으로는 실제 pull과 선택 tag provenance를 증명하지 못하고 Release platform summary 검증이 없다. | Ignite2 platform entry는 pull evidence를 요구한다. 선택 image ref의 pull result/event, digest, cache 상태, expected/observed tag·architecture를 schema에 포함하고, Release arm64 job이 `coverage=1/1`, `release_gate=true`, expected platform을 직접 검증한다. `RepoDigests`가 비면 `blocked`다. |
+| S-09 | stability, ops | retry가 product/blocked failure까지 반복되고 client timeout, cleanup, workflow `needs`가 추상적이다. | transient infrastructure만 bounded retry하고 product/blocked는 즉시 종료한다. client/request·test·job timeout, attempt cleanup, Gradle daemon, worst-case budget을 고정하며 Nightly Spring bridge·coverage·status와 Release publish의 `needs`/skipped 조건을 명시한다. |
+| S-10 | performance, user | arm64 전용 실행이 무관한 mock Jib image를 다시 빌드하고 문서 예제가 client lifecycle을 누락한다. | arm64 job은 mock Jib task를 `-x`로 제외하고, thin-client README EN/KO 예제는 `Ignition.startClient`와 `use`/`close`를 사용한다. |
+| S-11 | user | `DEFAULT_TAG`가 실제 native default를 검증하지 않고 custom image에 ARM tag를 조용히 적용할 수 있다. | 기본 생성자 경로와 명시적 tag override를 별도 검증한다. canonical `apacheignite/ignite`에만 default tag를 적용하고 custom image는 명시적 tag를 요구하거나 문서화된 정책을 테스트한다. 지원 alias와 unknown/Rosetta 정책을 EN/KO README·KDoc·manifest에 맞춘다. |
+
+### 2.2 검토 중 정정된 사실
+
+Performance lane은 `ignite-core` alias가 없다고 보고했으나, live immutable
+catalog ref `91f9ea9336b5ea991f5675323a1cf25ccfd6f5ed`의
+`libs.versions.toml`에 `ignite-core = { module = "org.apache.ignite:ignite-core", version.ref = "ignite" }`가 존재함을 재확인했다. 따라서 alias 부재는 현재 P1이 아니다. 계획에는 catalog resolution/compile 검증을 남긴다.
+
+## 3. 승인 후 설계 교정안
+
+위 S-01, S-02, S-08은 기존 “x64 + Ignite2 native amd64/arm64 matrix” 구조를
+바꾼다. 승인 후 설계 문서에 다음을 반영한다.
+
+1. 기존 full x64 gate가 모든 family를 순차 실행하면서 Ignite2의 amd64 실행
+   증거를 생성한다. 일반 Nightly `storage-cache` matrix에서는 Ignite2를
+   제거해 동일 workload를 반복하지 않는다.
+2. Nightly/Release에는 고정 `ubuntu-24.04-arm`의 Ignite2 arm64 전용 gate만
+   추가한다. `runs-on`은 manifest에서 읽지 않으며, arm64 job은 mock Jib
+   image build를 하지 않는다.
+3. strict JUnit/workload/image evidence는 `executionEvidenceRequired`가 있는
+   Ignite2에만 적용한다. 기존 disabled family의 full 52/52 의미는 별도
+   회귀 fixture로 보존한다.
+4. `summary.json` schema v2와 per-family evidence 필수 필드를 고정한다.
+   성공 경로에는 counts, workload testcase, pull result, digest, expected와
+   observed platform, commit/ref/run provenance를 남기고 raw credential/env와
+   JUnit `system-out`은 남기지 않는다.
+5. Release는 기존 `coverage=52/52` x64 verifier와 별도로 arm64
+   `coverage=1/1` verifier를 통과해야 publish한다. 이전 artifact 재사용과
+   `skipped` 완화를 금지한다.
+
+이는 초기 승인 설계의 단순한 문구 보완이 아니라 실행 비용·release gate·증거
+소유권을 바꾸는 material repair다. 따라서 spec 수정 전에 사용자의 fresh
+approval을 받고, 수정 후 performance/stability/security/ops/developer/user
+관점 affected lane을 재검토한다. 재검토 종료 조건은 `P0=0`, `P1=0`이다.
+
+## 4. 재검토 계획
+
+- 위 S-01~S-11을 design spec에 반영한다.
+- 수정된 spec에 `SPW-01`~`SPW-05`를 다시 적용한다.
+- 기존 six-lane 결과와 수정 diff를 대조해 affected lane을 다시 실행한다.
+- `testcontainers_image_gate.py`의 기존 disabled-family fixture와 새 Ignite2
+  selector/XML/architecture/security fixture를 읽기 전용으로 확인한다.
+- 재검토 결과가 `P0=0`, `P1=0`일 때만 Step 3 implementation plan으로 진행한다.
+
+## 5. 현재 DoD
+
+| 항목 | 상태 | 증거 |
+|---|---|---|
+| 기준선과 Issue acceptance 대조 | PASS | `Ignite2ServerTest` 기준선 `tests=3, skipped=3`, Issue #1486 live read |
+| six perspective review 수집 | PASS* | performance/stability/security/ops/developer 결과와 user fallback 결과 보존 |
+| review integration artifact | PASS | 본 문서, 통합 ID S-01~S-11 |
+| P0/P1 convergence | BLOCKED | 최초 통합 P0=0, P1=24; material repair과 fresh approval 필요 |
+| production code 변경 없음 | PASS | worktree diff는 설계/review 산출물과 Python `__pycache__` 생성물만 포함 |
+| plan/implementation 진행 | PENDING | spec repair 승인 후 수행 |
+
+`*` user lane은 native thread limit으로 helper에 `lane-block`을 기록했으며,
+동일 설계에 대한 native fallback caller 결과와 main-session 통합으로 증거를
+보존했다. 이 lane 상태는 리뷰 결과를 숨기지 않기 위한 운영 기록이다.
+
+## 6. 최종 판정
+
+현재 Step 2-R은 `BLOCK`이다. 설계 교정안에 대한 fresh approval 전에는
+production code나 implementation plan을 시작하지 않는다.
+
+## 7. 수정 후 재검토 기록
+
+사용자는 material repair 후 재검토를 승인했다. 다음 재검토는 수정된 설계와
+초기 BLOCK 증거를 함께 대조했으며, 구현·실제 ARM runner 예약·Docker pull·Ignite
+workload 실행은 아직 수행하지 않았다.
+
+| 관점 | P0 | P1 | P2/P3 | 수정 후 판정 | 증거와 남은 WATCH |
+|---|---:|---:|---:|---|---|
+| Performance | 0 | 0 | 2 | WATCH | 정량 timeout/retry/output/pull/count 계약은 통과. checkout/setup 고정 overhead와 52-family 최악 8 MiB artifact fixture는 구현 검증 WATCH. 초기 rerun BLOCK 증거는 `evidence-spec-rerun-performance-1486-result.json`에 보존했다. |
+| Stability | 0 | 0 | 1 | WATCH | attempt 격리, cleanup, digest 재사용, full success-only 집계는 통과. ARM queue 10분 관찰·취소 runbook은 운영 WATCH이며 native lane timeout 후 main fallback으로 판정했다. |
+| Security | 0 | 0 | 1 | WATCH | pull 전용 credential, redaction, local Docker endpoint, XML/path/output 차단은 통과. mutable tag와 digest pin 제외는 범위상 WATCH다. 이전 317분 수치 지적은 318분으로 정정되어 해소됐다. |
+| Operator/Ops | 0 | 0 | 3 | CLEAR | selector, runner/job topology, verifier needs, artifact literal·retention, x64/arm64 budget과 queue/rollback 절차를 최신 설계에서 확인했다. 실제 ARM 예약과 pull/workload 증거는 구현 후 CI에서 확인한다. |
+| Developer/API | 0 | 0 | 1 | WATCH | fixed `-Dtestcontainers.image-gate.evidence-dir=$RUN_EVIDENCE_DIR` argv, x64 no in-job retry, 6분 test/JUnit timeout, lazy default resolver와 unknown-arch fixture가 명시됐다. custom-tag/unknown-arch 동작은 구현 테스트에서 확인한다. |
+| User/Caller | 0 | 0 | 0 | CLEAR | default constructor/no-tag, duplicate matrix 제거, explicit/custom policy, lifecycle 문서 parity를 확인했다. native thread 제한으로 lane-block된 fallback 증거는 초기 기록과 함께 보존했다. |
+| **수정 후 통합** | **0** | **0** | **8** | **PASS with WATCH** | material repair의 종료 조건 P0=0/P1=0을 충족했다. P2 WATCH는 구현·첫 Nightly/Release에서 해소하거나 후속 이슈로 분리한다. |
+
+### 7.1 수정된 핵심 계약
+
+1. x64 strict Ignite2 test timeout과 JUnit timeout은 6분으로 통일하고, 5분
+   container startup과 1분 workload 여유를 분리한다. x64 `max_attempts=1`은
+   in-job retry를 하지 않으며 transient failure는 새 workflow run에서만 다시
+   실행한다. 최악 예산은 318분이고 job timeout 360분보다 작다.
+2. arm64 최종 Gradle argv는 fixed
+   `-Dtestcontainers.image-gate.evidence-dir=$RUN_EVIDENCE_DIR`를 전달하고,
+   runner/test writer/static fixture가 같은 attempt root를 사용한다. arbitrary
+   JVM property와 mock Jib pre-step는 금지한다.
+3. `DEFAULT_TAG` 매핑은 lazy getter/helper 또는 sentinel 경계에서 평가한다.
+   explicit custom tag는 unknown architecture에서도 default resolver를 호출하지
+   않으며, canonical no-tag만 supported mapping과 fail-fast 정책을 적용한다.
+4. manifest의 `defaultPlatformId=amd64`, platform별 tag/runner/architecture,
+   schema v2, pull event/digest, startup marker, workload testcase와 Release
+   verifier/aggregation guard를 유지한다.
+
+## 8. Step 2-R 통합 DoD
+
+| 항목 | 상태 | 증거 |
+|---|---|---|
+| 최초 six-perspective review 보존 | PASS | 본 문서 §2 및 S-01~S-11 |
+| material repair 후 fresh approval | PASS | 사용자 최신 `승인` 메시지 |
+| affected perspective rereview | PASS* | `.bluetape/evidence-spec-rerun-*-1486-result.json`와 main fallback evidence |
+| P0/P1 convergence | PASS | 수정 후 통합 P0=0, P1=0 |
+| SPW-01~SPW-05 | PASS | 설계 문서 Writer DoD 및 `git diff --check`/용어 감사 |
+| production code/Gradle/workflow 구현 | PENDING | Step 3 plan gate 이후 수행 |
+| 실제 CI ARM/pull/workload 증거 | PENDING | 구현·Nightly/Release 실행 필요 |
+
+`*` stability native lane은 5분 deadline으로 terminal `lane-block`되어 main-session
+fallback을 사용했다. 이는 결과를 숨기지 않고 evidence와 함께 기록한 운영 상태다.
+
+## 9. 최종 Step 2-R 판정
+
+**PASS with WATCH — implementation plan으로 진행 가능.** 초기 설계의 BLOCK은
+수정 후 P0/P1이 모두 해소되어 종료한다. mutable tag, ARM queue, pre-step/artifact
+worst-case와 실제 runtime evidence는 구현 및 첫 CI 실행에서 확인할 후속 WATCH이며,
+현재 production code 변경은 없다.

--- a/docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md
+++ b/docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md
@@ -1,0 +1,297 @@
+# #1486 Ignite2 ARM64 이미지와 실행 증거 게이트 설계
+
+- **작성일**: 2026-08-24
+- **저장소**: `bluetape4k/bluetape4k-projects`
+- **이슈**: [#1486](https://github.com/bluetape4k/bluetape4k-projects/issues/1486)
+- **기준 커밋**: `02b86211f2be6a0bf03a28d7c9723d822d09b56f`
+- **작업 방식**: `fix/1486-image-gate-contract` → `fix/1486-ignite2-arm64-runtime` stacked PR train
+
+## 1. 결정 요약
+
+`Ignite2ServerTest`의 클래스 수준 `@Disabled`를 제거하고, Apache Ignite 2
+thin client로 cache put/get을 수행하는 실제 workload를 추가한다. 테스트 전용
+의존성은 중앙 `bt4k` catalog의 `ignite-core` alias를 사용하므로 public API나
+의존성 버전 원본을 새로 만들지 않는다.
+
+image gate 실행기는 Gradle 종료 코드와 `BUILD SUCCESSFUL` 문자열만으로 성공을
+판정하지 않는다. 선택한 test pattern의 JUnit XML을 읽어 실행된 test가 하나
+이상이고 전체가 skipped가 아님을 확인한다. XML이 없거나 `tests == skipped`이면
+`blocked`로 기록하고 release gate를 닫는다.
+
+Ignite2 항목에는 `amd64`/`arm64` platform metadata를 추가한다. 기존 전체
+family gate는 기본 amd64 태그를 계속 검증하고, Nightly full과 Release에는
+Ignite2 전용 native matrix를 추가한다.
+
+| platform | runner | image tag | Docker architecture |
+|---|---|---|---|
+| `amd64` | `ubuntu-24.04` | `2.18.0` | `linux/amd64` |
+| `arm64` | `ubuntu-24.04-arm` | `2.18.0-arm64` | `linux/arm64` |
+
+각 실행은 runner architecture, Docker architecture, image digest, startup
+readiness, workload, JUnit 실행 집계를 하나의 결과 artifact로 남긴다. PR CI에는
+Docker runtime gate를 추가하지 않고 기존 정적 계약만 유지한다.
+
+## 2. 현재 문제와 근거
+
+- `Ignite2Server.DEFAULT_TAG`는 현재 `os.arch == "aarch64"`에서만
+  `2.18.0-arm64`를 선택한다.
+- `Ignite2ServerTest` 전체에 `@Disabled`가 붙어 있어 기준선 XML이
+  `tests="3" skipped="3"`이다. 기준선 명령은 `BUILD SUCCESSFUL`이지만 실제
+  test execution은 0건이었다.
+- `scripts/run_testcontainers_image_gate.py`는 return code와 Gradle 성공 문자열만
+  확인하며 JUnit XML, image digest, host architecture를 저장하지 않는다.
+- `scripts/testcontainers_image_gate_manifest.json`의 Ignite2 항목은 단일
+  `tag`만 표현하고 platform별 tag/runner 계약이 없다.
+- EN/KO README에는 `2.18.0`과 `-arm64` 설명이 있지만 Linux platform과
+  실행 증거의 연결이 명시되지 않았다.
+- PR image gate는 #1484에서 30분 이상 걸리는 runtime job을 제거한 상태다.
+  이 속도 경계는 유지해야 한다.
+
+## 3. 범위와 제외
+
+### 포함
+
+1. Ignite2 test를 unskip하고 startup·thin-client cache workload를 실행한다.
+2. `ignite-core` test dependency를 중앙 catalog alias로 연결한다.
+3. manifest에 platform tag, architecture, runner metadata와 선택 API를 추가한다.
+4. image gate가 JUnit XML 실행 수와 Docker image/architecture 증거를 fail-closed로
+   판정하고 JSON/Markdown에 저장한다.
+5. Nightly full과 Release에 native amd64/arm64 Ignite2 gate를 추가하고 publish와
+   Spring bridge의 dependency를 갱신한다.
+6. EN/KO README, Ignite2 KDoc, source/README/manifest static contract를 함께
+   갱신한다.
+
+### 제외
+
+- `Ignite2Server` public constructor/operator 함수 시그니처 변경
+- 기존 전체 52개 family를 ARM64에서 다시 실행하는 범위 확대
+- PR workflow의 Docker pull/startup/workload runtime 실행
+- x64 runner의 QEMU를 native ARM64 증거로 인정하는 우회
+- 새 public abstraction, 새 registry dependency, 수동 digest pin 변경
+
+## 4. 대안 비교
+
+### A. x64 + QEMU로 ARM64 이미지를 실행 — 거부
+
+실행 비용은 낮지만 실제 ARM64 kernel/runner에서의 startup과 workload를 증명하지
+못한다. Issue #1486의 `aarch64` runtime 계약과 맞지 않는다.
+
+### B. 전체 x64 gate + Ignite2 native platform matrix — 선택
+
+기존 52-family amd64 gate는 유지하고, Ignite2만 두 native runner에서 별도
+실행한다. ARM64 검증 비용을 문제 family로 제한하면서 두 tag의 실제 pull,
+startup, workload 증거를 명확히 남긴다. PR CI 속도에는 영향을 주지 않는다.
+
+### C. 52개 family 전체를 두 아키텍처에서 실행 — 거부
+
+가장 넓은 증거를 만들지만 이번 이슈의 범위를 넘어 이미지 pull과 CI 시간을
+두 배로 늘린다. 다른 family의 platform 계약은 별도 이슈에서 다룬다.
+
+## 5. 구성 요소와 데이터 흐름
+
+```text
+Ignite2Server.kt + README EN/KO + manifest platform metadata
+                         │ static contract
+                         ▼
+             native platform gate matrix
+                         │ --family-id ignite2 --platform-id {amd64|arm64}
+                         ▼
+      Gradle test → JUnit XML → image/runner inspect → evidence result
+                         │
+                         ├─ tests=0 또는 all skipped → blocked
+                         ├─ image/architecture 불일치 → blocked
+                         ├─ startup/workload assertion 실패 → product_failure
+                         └─ pull/daemon/timeout 실패 → infrastructure_failure
+                         ▼
+                 summary.json + summary.md + per-family JSON
+                         │
+             Nightly artifact / Release publish prerequisite
+```
+
+### 5.1 Manifest 계약
+
+기존 Ignite2 entry의 기본 `image`/`tag`는 amd64 기준으로 유지하고 다음 필드를
+추가한다.
+
+```json
+"platforms": [
+  {
+    "id": "amd64",
+    "os": "linux",
+    "architecture": "amd64",
+    "tag": "2.18.0",
+    "runner": "ubuntu-24.04"
+  },
+  {
+    "id": "arm64",
+    "os": "linux",
+    "architecture": "arm64",
+    "tag": "2.18.0-arm64",
+    "runner": "ubuntu-24.04-arm"
+  }
+]
+```
+
+manifest validator는 platform id 중복, 빈 tag/runner, 지원하지 않는
+architecture, EN/KO README의 두 tag 누락, `Ignite2Server.DEFAULT_TAG`의 source
+계약을 모두 검사한다. 다른 family에는 기존 schema를 적용하며, platform matrix
+선택은 `--family-id`와 `--platform-id` 조합으로만 허용한다.
+
+### 5.2 Runner 결과 계약
+
+`GateRunner`는 다음 순서로 한 family를 실행한다.
+
+1. 선택된 entry의 platform override를 적용해 image tag와 test JVM property를
+   결정한다.
+2. 기존 Gradle `--tests` 명령을 실행한다. 실행 task의
+   `testing/testcontainers/build/test-results/<task>/`에서 test pattern과
+   일치하는 suite를 찾는다.
+3. JUnit XML을 합산한다. `tests > 0`, `tests > skipped`, `failures == 0`,
+   `errors == 0`이어야 실행 증거가 유효하다. XML이 없거나 pattern suite가
+   없으면 `blocked`다.
+4. `docker image inspect <image>:<tag>`, `docker info --format
+   '{{.Architecture}}'`, runner `uname -m`을 수집한다. platform이 지정된
+   경우 기대 architecture와 실제 Docker architecture가 다르면 `blocked`다.
+5. test stdout/stderr, JUnit system-out, image inspect 결과, digest, startup과
+   workload 집계를 per-family JSON과 summary에 기록한다.
+6. 실패하면 기존 `docker_ps`, `docker_inspect`, `docker_events`, logs 진단을
+   수집한다. secret redaction은 기존 규칙을 유지한다.
+
+`0 tests`와 `all skipped`는 제품 실패가 아니라 실행 증거 부재이므로
+`blocked`로 분류한다. `release_gate`는 선택 family가 모두 `success`이고
+`releaseRequired`인 경우에만 true다.
+
+### 5.3 Ignite2 runtime test
+
+`Ignite2ServerTest`는 클래스 수준 `@Disabled`를 제거한다.
+
+- 대표 test: `Ignite2Server`를 시작하고 `Ignition.startClient`로
+  `host:port`에 연결한다. 중앙 `ignite-core`의 `ClientConfiguration`으로
+  test cache를 생성해 `put`/`get`하고 값을 검증한 뒤 client를 닫는다.
+- 기본 port test: `useDefaultPort = true`로 startup과 `PORT == 10800`을
+  검증한다.
+- 입력 검증 test: blank image/tag가 `IllegalArgumentException`을 발생시키는
+  기존 계약을 유지한다.
+- platform job은 runner가 선택한 tag를 test-only system property로 전달하고,
+  test는 그 tag를 `Ignite2Server(tag = ...)`에 사용한다. public API는 변하지
+  않는다.
+
+container test는 `AbstractContainerTest`의 `SAME_THREAD` 실행 계약을 유지하고,
+모든 client/container 자원을 `use`로 닫는다.
+
+### 5.4 Workflow 경계
+
+- **PR CI**: `test_testcontainers_contract.py`, manifest contract, Python runner
+  unit/static tests만 실행한다. `run_testcontainers_image_gate.py` runtime 호출은
+  계속 금지한다.
+- **Nightly full**: 기존 52-family x64 gate와 별도로 Ignite2 platform matrix를
+  실행한다. matrix는 `fail-fast: false`, `max-parallel: 1`로 두고 두 결과가 모두
+  성공해야 Spring bridge가 시작된다. `testcontainers` 범위에서는 두 job 모두
+  skipped로 남고 기존 조건대로 bridge를 실행한다.
+- **Release**: manifest contract → 기존 full x64 gate → Ignite2 platform matrix
+  순서로 실행한다. publish는 세 gate의 성공을 모두 `needs`로 요구하며
+  `coverage`/platform evidence 없이 진행하지 않는다.
+- **ARM runner**: GitHub public ARM64 label은 실행 시 실제 예약/architecture로
+  검증한다. runner unavailable은 skipped나 N/A로 완화하지 않는다.
+
+## 6. 실패 모드와 복구
+
+| 실패 | 분류 | 처리 |
+|---|---|---|
+| XML 없음, pattern suite 없음, `tests=0`, all skipped | `blocked` | release gate 차단, 결과와 경로 기록 |
+| 이미지 pull/daemon/rate limit/timeout | `infrastructure_failure` | bounded retry 후 Docker 진단, gate 실패 |
+| container startup/readiness/workload assertion 실패 | `product_failure` | logs/inspect/events와 JUnit 결과 저장 |
+| 기대 platform과 Docker architecture 불일치 | `blocked` | tag/runner 계약 재검토, 성공 완화 금지 |
+| ARM runner label 예약 실패 | workflow failure | matrix 결과를 skipped로 대체하지 않음 |
+| manifest/source/README drift | static contract failure | Docker 실행 전에 수정하도록 차단 |
+
+롤백은 새 commit에서 platform job 또는 parser를 되돌리되, 기존 PR CI의 runtime
+제외와 stable release의 full gate dependency는 유지한다. 이전 실행 artifact를
+새 성공으로 재사용하지 않는다.
+
+## 7. stacked PR train과 변경 파일
+
+### Parent: `fix/1486-image-gate-contract` → `develop`
+
+- `scripts/run_testcontainers_image_gate.py`
+- `scripts/testcontainers_image_gate.py`
+- `scripts/testcontainers_image_gate_manifest.json`의 schema/validation
+- `scripts/test_run_testcontainers_image_gate.py`
+- `scripts/test_testcontainers_image_gate.py`
+
+Parent는 runtime gate가 실제 test execution과 image/architecture 증거를
+검증하는 기반만 제공한다. Ignite2 source/README/workflow는 child에 둔다.
+
+### Child: `fix/1486-ignite2-arm64-runtime` → parent
+
+- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt`
+- `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt`
+- `testing/testcontainers/build.gradle.kts`
+- `testing/testcontainers/README.md`
+- `testing/testcontainers/README.ko.md`
+- `.github/workflows/nightly-tests.yml`
+- `.github/workflows/release.yml`
+- `scripts/test_testcontainers_contract.py`
+- `docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md`
+
+두 PR 모두 base/head와 exact cumulative SHA를 live read-back하고, child PR은
+parent merge 전에는 독립 merge하지 않는다.
+
+## 8. 검증 계획과 수용 기준
+
+- [ ] 기준선 `Ignite2ServerTest`의 `3/3 skipped`가 RED 증거로 기록된다.
+- [ ] runner unit test가 성공, XML 없음, `tests=0`, all skipped, pattern mismatch,
+      architecture mismatch를 각각 검증한다.
+- [ ] unskipped Ignite2 test가 startup과 thin-client cache put/get을 통과한다.
+- [ ] manifest가 `amd64`/`arm64` tag·runner·architecture를 검증한다.
+- [ ] EN/KO README와 KDoc이 `2.18.0`/`2.18.0-arm64` 및 platform mapping과
+      일치한다.
+- [ ] PR workflow에는 image runtime 호출이 없고, Nightly/Release만 native matrix를
+      실행한다.
+- [ ] `actionlint`, Python unit/static tests, targeted Gradle test, Kotlin compile,
+      `git diff --check`가 통과한다.
+- [ ] native amd64와 arm64 CI artifact에 image digest, Docker/runner architecture,
+      startup/workload, JUnit execution count가 모두 존재한다.
+- [ ] Release publish가 두 platform gate와 기존 52/52 full gate 없이는 진행되지
+      않는다.
+
+### 8.1 Writer DoD
+
+- **SPW-01 PASS**: 독자는 bluetape4k contributor이며, Issue #1486, 기준 커밋,
+  현재 source/workflow/manifest와 공식 GitHub·Ignite 문서를 근거로 고정했다.
+- **SPW-02 PASS**: 대안, 범위, manifest/runner/runtime/workflow 계약, 실패 모드,
+  호환성, stacked train, 수용 기준과 rollback을 포함했다.
+- **SPW-03 PASS**: 한국어 기술 문체와 고정 용어를 적용하고 code token, command,
+  URL, 숫자, status token을 보존했다. `korean-naturalness-checklist.md`를
+  기준으로 문장과 표를 읽었다.
+- **SPW-04 PASS**: 현재 worktree의 `Ignite2Server`, test XML, runner,
+  manifest, workflows와 Issue #1486 acceptance를 대조했다. ARM runner와
+  실제 digest는 구현 후 CI에서 확인해야 하는 미확인 항목으로 남겼다.
+- **SPW-05 PASS**: 최종 Markdown을 다시 읽고 headings, tables, code fence,
+  checklist, link를 확인했다. `git diff --check`와
+  `audit-korean-terms.mjs`가 통과했다.
+
+## 10. 공개 API·성능·안정성 검토
+
+- public constructor/operator와 `Ignite2Server` property 계약은 유지한다.
+- test-only `ignite-core`는 중앙 catalog의 기존 `ignite` version을 사용하며
+  publish artifact에는 포함하지 않는다.
+- PR CI runtime 비용은 증가하지 않는다. Nightly/Release는 Ignite2 두 번의
+  native 실행 비용만 추가한다.
+- cache/client/container는 모두 명시적으로 닫고, test runner는 family를
+  순차 실행해 Docker pull 압력과 공유 daemon 경쟁을 제한한다.
+- image inspect와 JUnit XML이 없으면 성공하지 않으므로 green-but-unverified
+  결과를 방지한다.
+
+## 11. 근거 원본
+
+- Issue #1486 및 merged PR #1488, #1484
+- `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt`
+- `testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt`
+- `scripts/run_testcontainers_image_gate.py`
+- `scripts/testcontainers_image_gate.py`
+- `scripts/testcontainers_image_gate_manifest.json`
+- `.github/workflows/ci.yml`, `.github/workflows/nightly-tests.yml`,
+  `.github/workflows/release.yml`
+- [Apache Ignite 2 Java Thin Client](https://ignite.apache.org/docs/ignite2/latest/thin-clients/java-thin-client)
+- [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)

--- a/docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md
+++ b/docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md
@@ -14,22 +14,27 @@ thin client로 cache put/get을 수행하는 실제 workload를 추가한다. �
 의존성 버전 원본을 새로 만들지 않는다.
 
 image gate 실행기는 Gradle 종료 코드와 `BUILD SUCCESSFUL` 문자열만으로 성공을
-판정하지 않는다. 선택한 test pattern의 JUnit XML을 읽어 실행된 test가 하나
-이상이고 전체가 skipped가 아님을 확인한다. XML이 없거나 `tests == skipped`이면
-`blocked`로 기록하고 release gate를 닫는다.
+판정하지 않는다. 다만 기존 52-family gate에는 의도적인 class-level `@Disabled`
+family가 있으므로 strict 실행 증거는 manifest의 `executionEvidenceRequired: true`
+항목에만 적용한다. Ignite2는 선택한 workload testcase의 JUnit XML과 실제 image
+pull·architecture·startup·workload 증거를 모두 검증하고, 증거가 없거나 전체가
+skipped이면 `blocked`로 기록해 release gate를 닫는다.
 
-Ignite2 항목에는 `amd64`/`arm64` platform metadata를 추가한다. 기존 전체
-family gate는 기본 amd64 태그를 계속 검증하고, Nightly full과 Release에는
-Ignite2 전용 native matrix를 추가한다.
+Ignite2 항목에는 `amd64`/`arm64` platform metadata를 추가한다. 기존 52-family
+full x64 gate가 amd64의 단일 authoritative 실행과 증거를 제공하고, Nightly
+full과 Release에는 Ignite2 arm64 전용 native gate를 추가한다. 일반 Nightly
+`storage-cache` matrix에서는 Ignite2를 제거해 같은 workload를 반복하지 않는다.
 
 | platform | runner | image tag | Docker architecture |
 |---|---|---|---|
 | `amd64` | `ubuntu-24.04` | `2.18.0` | `linux/amd64` |
 | `arm64` | `ubuntu-24.04-arm` | `2.18.0-arm64` | `linux/arm64` |
 
-각 실행은 runner architecture, Docker architecture, image digest, startup
-readiness, workload, JUnit 실행 집계를 하나의 결과 artifact로 남긴다. PR CI에는
-Docker runtime gate를 추가하지 않고 기존 정적 계약만 유지한다.
+각 authoritative 실행은 runner label/architecture, Docker daemon과 image의
+OS/architecture, 선택 tag의 pull 결과·digest, startup readiness, workload
+testcase, JUnit 실행 집계를 schema v2 결과 artifact로 남긴다. PR CI에는 Docker
+runtime gate를 추가하지 않고 기존 정적 계약만 유지한다. manifest의 `runner`는
+설명과 정적 검증에만 사용하고 workflow의 `runs-on`을 결정하지 않는다.
 
 ## 2. 현재 문제와 근거
 
@@ -42,6 +47,10 @@ Docker runtime gate를 추가하지 않고 기존 정적 계약만 유지한다.
   확인하며 JUnit XML, image digest, host architecture를 저장하지 않는다.
 - `scripts/testcontainers_image_gate_manifest.json`의 Ignite2 항목은 단일
   `tag`만 표현하고 platform별 tag/runner 계약이 없다.
+- 기존 full gate와 Nightly `storage-cache` matrix가 같은 Ignite2 test를 중복
+  실행할 경로가 있다.
+- 현재 52-family 중 ChromaDB, Ollama, Redpanda, Ignite3 등은 의도적으로
+  disabled 상태이므로 모든 family에 strict `tests > skipped`를 적용할 수 없다.
 - EN/KO README에는 `2.18.0`과 `-arm64` 설명이 있지만 Linux platform과
   실행 증거의 연결이 명시되지 않았다.
 - PR image gate는 #1484에서 30분 이상 걸리는 runtime job을 제거한 상태다.
@@ -54,10 +63,12 @@ Docker runtime gate를 추가하지 않고 기존 정적 계약만 유지한다.
 1. Ignite2 test를 unskip하고 startup·thin-client cache workload를 실행한다.
 2. `ignite-core` test dependency를 중앙 catalog alias로 연결한다.
 3. manifest에 platform tag, architecture, runner metadata와 선택 API를 추가한다.
-4. image gate가 JUnit XML 실행 수와 Docker image/architecture 증거를 fail-closed로
-   판정하고 JSON/Markdown에 저장한다.
-5. Nightly full과 Release에 native amd64/arm64 Ignite2 gate를 추가하고 publish와
-   Spring bridge의 dependency를 갱신한다.
+4. `executionEvidenceRequired` family에 한해 JUnit workload 실행 수와 Docker
+   pull/image/architecture 증거를 fail-closed로 판정하고 schema v2 JSON/Markdown에
+   저장한다.
+5. 기존 full x64 gate를 amd64 권위 실행으로 유지하고 Nightly full과 Release에
+   arm64 전용 Ignite2 gate를 추가하며 publish와 Spring bridge의 dependency를
+   갱신한다.
 6. EN/KO README, Ignite2 KDoc, source/README/manifest static contract를 함께
    갱신한다.
 
@@ -76,11 +87,13 @@ Docker runtime gate를 추가하지 않고 기존 정적 계약만 유지한다.
 실행 비용은 낮지만 실제 ARM64 kernel/runner에서의 startup과 workload를 증명하지
 못한다. Issue #1486의 `aarch64` runtime 계약과 맞지 않는다.
 
-### B. 전체 x64 gate + Ignite2 native platform matrix — 선택
+### B. 전체 x64 gate + Ignite2 arm64 전용 gate — 선택
 
-기존 52-family amd64 gate는 유지하고, Ignite2만 두 native runner에서 별도
-실행한다. ARM64 검증 비용을 문제 family로 제한하면서 두 tag의 실제 pull,
-startup, workload 증거를 명확히 남긴다. PR CI 속도에는 영향을 주지 않는다.
+기존 52-family full x64 gate가 `2.18.0`의 amd64 pull, startup, workload와
+strict evidence를 담당한다. Ignite2만 `ubuntu-24.04-arm`에서
+`2.18.0-arm64`를 별도 실행해 ARM64 증거를 추가한다. 일반 Nightly matrix에서
+Ignite2를 제거하므로 동일 workload와 pull을 반복하지 않으며, PR CI 속도에는
+영향을 주지 않는다.
 
 ### C. 52개 family 전체를 두 아키텍처에서 실행 — 거부
 
@@ -93,13 +106,14 @@ startup, workload 증거를 명확히 남긴다. PR CI 속도에는 영향을 �
 Ignite2Server.kt + README EN/KO + manifest platform metadata
                          │ static contract
                          ▼
-             native platform gate matrix
-                         │ --family-id ignite2 --platform-id {amd64|arm64}
+             full x64 gate (amd64) + arm64 gate
+                         │ --family-id ignite2 --platform-id arm64
                          ▼
-      Gradle test → JUnit XML → image/runner inspect → evidence result
+      pull → Gradle test → JUnit XML → image/runner inspect → evidence result
                          │
                          ├─ tests=0 또는 all skipped → blocked
                          ├─ image/architecture 불일치 → blocked
+                         ├─ pull/digest/workload evidence 부재 → blocked
                          ├─ startup/workload assertion 실패 → product_failure
                          └─ pull/daemon/timeout 실패 → infrastructure_failure
                          ▼
@@ -111,7 +125,7 @@ Ignite2Server.kt + README EN/KO + manifest platform metadata
 ### 5.1 Manifest 계약
 
 기존 Ignite2 entry의 기본 `image`/`tag`는 amd64 기준으로 유지하고 다음 필드를
-추가한다.
+추가한다. `runner`는 workflow 선택값이 아니라 문서·정적 계약의 설명값이다.
 
 ```json
 "platforms": [
@@ -129,85 +143,347 @@ Ignite2Server.kt + README EN/KO + manifest platform metadata
     "tag": "2.18.0-arm64",
     "runner": "ubuntu-24.04-arm"
   }
-]
+],
+"defaultPlatformId": "amd64",
+"executionEvidenceRequired": true,
+"workloadTestPattern": "io.bluetape4k.testcontainers.storage.Ignite2ServerTest.representativeStartupAndWorkload",
+"platformTimeouts": {
+  "amd64": {"testMinutes": 6, "clientConnectSeconds": 30, "clientRequestSeconds": 30},
+  "arm64": {"testMinutes": 30, "clientConnectSeconds": 30, "clientRequestSeconds": 30}
+},
+"pullEvidenceRequired": true
 ```
 
 manifest validator는 platform id 중복, 빈 tag/runner, 지원하지 않는
-architecture, EN/KO README의 두 tag 누락, `Ignite2Server.DEFAULT_TAG`의 source
-계약을 모두 검사한다. 다른 family에는 기존 schema를 적용하며, platform matrix
-선택은 `--family-id`와 `--platform-id` 조합으로만 허용한다.
+architecture, 허용 runner 외의 값, EN/KO README의 두 tag 누락,
+`Ignite2Server.DEFAULT_TAG`의 source 계약, workload pattern과
+`executionEvidenceRequired`의 일관성을 모두 검사한다. image reference는
+허용된 lowercase registry/repository grammar, tag는 control character·leading
+dash 없는 bounded grammar, workload pattern은 `classname.method` grammar만
+허용한다. 다른 family에는 기존
+schema와 disabled 회귀 계약을 적용한다. 기존 `--scope full` x64 실행에서
+strict Ignite2 resolver는 `platform_id=amd64`, `tag=platforms[amd64].tag`,
+`architecture=amd64`, `runner=ubuntu-24.04`를 결과·command·artifact에
+명시하고 top-level `tag`와 `platforms[amd64].tag`가 일치해야 한다.
+`defaultPlatformId=amd64`가 없는 기존 entry는 full x64 경로에서만 이 기본값을
+사용하고, strict entry의 platform별 `testMinutes`를 generic family 기본 timeout
+보다 우선한다. 따라서 x64 full의 Ignite2는 6분(5분 container startup + 1분
+Gradle/workload 여유), arm64 전용 gate는 30분이며
+두 경로 모두 client connect/request timeout은 30초다.
+platform 선택은 exact
+`--family-id ignite2 --platform-id arm64` 조합만 허용하고, workflow `runs-on`은
+정적으로 `ubuntu-24.04` 또는 `ubuntu-24.04-arm`만 사용한다.
 
 ### 5.2 Runner 결과 계약
 
-`GateRunner`는 다음 순서로 한 family를 실행한다.
+`GateRunner`는 다음 순서로 한 family를 실행한다. `executionEvidenceRequired`가
+없는 기존 family는 기존 성공 판정을 유지하고, Ignite2에만 아래 strict 단계를
+적용한다. manifest에 이 필드를 지정하지 않은 기존 family는 `false`로
+해석하며, validator regression test가 이 기본값과 `Ignite2=true` opt-in을
+고정한다.
 
-1. 선택된 entry의 platform override를 적용해 image tag와 test JVM property를
-   결정한다.
-2. 기존 Gradle `--tests` 명령을 실행한다. 실행 task의
-   `testing/testcontainers/build/test-results/<task>/`에서 test pattern과
-   일치하는 suite를 찾는다.
-3. JUnit XML을 합산한다. `tests > 0`, `tests > skipped`, `failures == 0`,
-   `errors == 0`이어야 실행 증거가 유효하다. XML이 없거나 pattern suite가
-   없으면 `blocked`다.
-4. `docker image inspect <image>:<tag>`, `docker info --format
-   '{{.Architecture}}'`, runner `uname -m`을 수집한다. platform이 지정된
-   경우 기대 architecture와 실제 Docker architecture가 다르면 `blocked`다.
-5. test stdout/stderr, JUnit system-out, image inspect 결과, digest, startup과
-   workload 집계를 per-family JSON과 summary에 기록한다.
-6. 실패하면 기존 `docker_ps`, `docker_inspect`, `docker_events`, logs 진단을
-   수집한다. secret redaction은 기존 규칙을 유지한다.
+1. selector가 정확히 하나의 family/platform을 반환하는지 확인한다. 0개·복수개·
+   unknown ID는 non-zero와 `blocked`로 처리하고, 결과·command·diagnostic에
+   `platform_id`와 선택 image ref를 전달한다.
+2. `pullEvidenceRequired` entry는 선택된 `<image>:<tag>`를 pull하고 pull
+   결과/event와 cache 여부를 기록한다. pull 전 bounded event observer를 시작해
+   `run_id`, `family_id`, `platform_id`, `attempt`, requested ref로 correlation하고,
+   observer가 확인한 pull event id를 schema에 남긴다. authoritative 실행에서
+   pull은 첫 attempt에 최대 1회만 수행하고, pull 단계가 registry transport
+   failure였을 때만 두 번째 attempt에서 1회 재시도한다(실행당 최대 2회).
+   pull 성공 후에는 verified image ID/digest를 다음 test retry에서 재사용하고
+   tag를 다시 해석하지 않는다. pull 직후 image ID와 `RepoDigests`를 고정하고,
+   container inspect의 image ID/digest가 그 값과 일치하는지 확인한다.
+   `RepoDigests`가 비어 있거나 event correlation이 없으면 성공하지 않는다. registry
+   credential은 dedicated pull subprocess의 ephemeral `DOCKER_CONFIG`에만
+   주입한다. Gradle/test/diagnostic subprocess에는 sanitized environment만
+   전달하고, pull 직후 temporary config와 helper credential을 삭제한다.
+   `DOCKER_AUTH_CONFIG` raw/decoded/base64 값, basic-auth URL과 known secret을
+   redaction registry에 등록해 print·exception·JSON·Markdown·diagnostic 전에
+   동일 redactor를 통과시키며 결과에는 저장하지 않는다.
+3. 기존 Gradle `--tests` 명령을 실행한다. arm64 전용 실행은 무관한 mock Jib
+   task를 다음 두 인자로 제외한다: `-x
+   :bluetape4k-mock-web-server:jibDockerBuild -x
+   :bluetape4k-mock-webflux-server:jibDockerBuild`. 실행 전 기존 XML 목록을
+   기록·정리하고 실행 시작
+   이후 생성·수정된 regular non-symlink XML만 허용한다. native gate는 attempt별
+   evidence root를 고정 allowlist의
+   `-Dtestcontainers.image-gate.evidence-dir=<attempt-root>` JVM property로
+   전달하고, 대표 test writer가 그 root의 bounded marker 파일
+   `Ignite node started OK`를 server readiness 직후 workload 전에 한 번 기록한다.
+   runner는 이 property 외의 arbitrary JVM property/Gradle option을 받지 않으며,
+   최종 argv와 static fixture가 property와 writer 경로를 함께 고정한다.
+   marker 파일은 root containment·mtime·1 KiB 상한을 검증한 뒤 schema의
+   `marker_source=bounded_attempt_marker`로만 요약하며 raw log는 저장하지 않는다.
+4. XML은 예상 결과 root 밖으로 나갈 수 없고 파일당 최대 4 MiB, family당 최대
+   8개 regular XML, XML당 최대 2,048 testcase와 10,000 counter를 허용한다.
+   DTD/ENTITY, malformed XML, exact suite/classname 불일치, bounded counter 위반은
+   `blocked`다. parser는 bounded bytes를 먼저 읽고 external entity를 비활성화하며,
+   `O_NOFOLLOW`/inode 재검증으로 parse 전후 symlink·TOCTOU 교체를 차단한다.
+   XML·stdout·stderr·diagnostic이 상한을 넘으면 raw 값을 저장하지 않고 즉시
+   `blocked`다.
+   `tests > 0`, `tests > skipped`, `failures == 0`, `errors == 0`과 정확한
+   `workloadTestPattern` testcase의 non-skipped 성공을 모두 확인한다.
+   pattern은 `classname + name` grammar로 해석하고 Kotlin/JUnit name의 선택적
+   `()` suffix만 canonicalize한다. suite 전체 `tests`와 workload testcase의
+   `workload_tests=1`을 별도 필드로 기록한다.
+5. `docker image inspect`의 allowlist(`Id`, `RepoDigests`, `Os`, `Architecture`),
+   `docker info`, runner `uname -m`, Docker context를 수집한다. `DOCKER_HOST`와
+   `DOCKER_CONTEXT`는 비워 두고 `docker context show == default` 및 local Unix
+   socket endpoint만 허용하며, remote context/endpoint는 `blocked`다.
+   strict Ignite2 gate에서는 `TESTCONTAINERS_REGISTRY_MIRROR`도 비워 두고
+   registry host는 `docker.io` allowlist만 사용한다. 허용되지 않은 mirror나
+   endpoint는 image digest가 있어도 성공하지 않는다.
+   `x86_64`/`amd64`,
+   `aarch64`/`arm64`를 canonical 값으로 정규화하고 image·daemon·runner의 OS와
+   architecture가 기대값과 모두 일치해야 한다.
+6. schema v2 artifact에는 `platform_id`, runner label, commit/ref/run,
+   expected/observed platform, image ref/digest, pull result, JUnit counts,
+   workload testcase와 startup marker만 저장한다. raw env/config, JUnit
+   `system-out`, unbounded inspect/log는 저장하지 않고 allowlist와 bounded
+   redaction을 적용한다. 성공·실패 공통으로 stdout/stderr는 각각 64 KiB/1,000
+   lines, Docker logs/events/inspect는 각각 64 KiB/500 lines, per-family JSON은
+   128 KiB, summary 전체는 1 MiB, artifact 전체는 8 MiB로 제한한다. Docker
+   auth JSON, basic-auth URL, known secret 값과 multiline token은 회귀 테스트로
+   차단한다. report ID/image/tag/workload/selector는 grammar·control character·
+   leading dash를 거부하고, release/nightly runner는 arbitrary `--gradle-task`,
+   JVM property, Gradle option을 받지 않는 고정 argv만 사용한다.
+7. attempt state machine은 `pull → test → evidence → cleanup` 순서를 지킨다.
+   각 attempt는 고유한 `run_id/attempt` root·container label·XML 기준 목록을
+   만들고, retry 전 해당 attempt root만 제거한다. pull transport failure는 pull
+   단계에서만 재시도하고, daemon reset/refused 또는 transient test timeout은
+   `max_attempts > 1`인 arm64 경로에서만 verified digest를 재사용하는 test 단계
+   재시도를 허용한다. x64 `max_attempts=1`은 in-job retry를 하지 않고 transient
+   failure를 새 workflow run에서 재실행하는 정책이다. auth/manifest/digest
+   오류, product assertion, architecture mismatch, XML/evidence 부재는 재시도하지
+   않는다. 모든 경로는 `finally` cleanup으로 process group·container·marker를
+   bounded 정리하고, stale XML/marker를 다음 attempt가 읽지 않게 한다.
+8. 실패하면 선택 image ref와 관련 container ID를 사용해 bounded
+   `docker logs`, `docker inspect`, `docker events`를 병렬 수집한다. 각 diagnostic
+   command는 30초/64 KiB/500 lines를 넘지 않으며, x64 attempt 전체 diagnostics
+   budget은 30초, arm64 attempt 전체는 120초다. retry 여부는 7번 state machine이
+   결정하며 diagnostics 수집은 원래 failure 분류를 바꾸지 않는다. auth/manifest/
+   digest 오류, product assertion, architecture mismatch, XML/evidence 부재는
+   retry하지 않고 즉시 종료한다. attempt cleanup과
+   `--max-attempts`/pull·test·diagnostic timeout/job timeout의 worst-case budget을
+   §5.4의 공식으로 검증한다.
+9. Release verifier는 `platform_id`, `coverage`, `release_gate`, expected/actual
+   tag·architecture와 필수 evidence 필드를 직접 확인한다. `selected == 0`,
+   `skipped`, `continue-on-error`, 이전 artifact 재사용은 성공으로 완화하지
+   않는다.
+10. 모든 subprocess는 unbounded `capture_output`을 사용하지 않고 capped
+   streaming 또는 capped temporary file로 UTF-8 byte/line 한도를 적용한다.
+   pull·Gradle·diagnostic·전체 job에 독립 deadline을 두고 timeout 시 process
+   group을 종료한 뒤 bounded tail만 redaction한다. job budget guard가 실제
+   subprocess wall-clock과 attempt 누계를 비교해 초과를 `blocked`로 만든다.
+11. 결과는 매 run fresh staging root에서만 만든다. family/platform ID는
+    `^[a-z0-9][a-z0-9._-]{0,63}$`, image/tag/workload는 허용 grammar와 control
+    character/leading dash 검사를 통과해야 한다. root containment, regular
+    non-symlink, exact allowlist(`summary.json`, `summary.md`, family JSON,
+    bounded diagnostics JSON)만 staging하고 extra file·symlink·path escape는
+    `blocked`다. upload action은 staging 파일 목록만 대상으로 한다.
+
+schema v2의 per-family 결과는 다음 필드를 최소 계약으로 고정한다.
+
+```json
+{
+  "schema_version": 2,
+  "family_id": "ignite2",
+  "platform_id": "arm64",
+  "image_ref": "apacheignite/ignite:2.18.0-arm64",
+  "expected": {"os": "linux", "tag": "2.18.0-arm64", "architecture": "arm64", "runner": "ubuntu-24.04-arm"},
+  "observed": {"runner_os": "linux", "runner_architecture": "arm64", "daemon_os": "linux", "daemon_architecture": "arm64", "image_os": "linux", "image_tag": "2.18.0-arm64", "image_architecture": "arm64"},
+  "pull": {"requested_ref": "docker.io/apacheignite/ignite:2.18.0-arm64", "attempts": 1, "status": "success", "cache": "up_to_date", "event_id": "<pull-event-id>", "image_id": "sha256:<image-id>", "digest": "sha256:<digest>", "elapsed_seconds": 12.3},
+  "junit": {"suite": "<exact-suite>", "tests": 3, "skipped": 0, "failures": 0, "errors": 0, "workload_testcase": "<exact-testcase>", "workload_tests": 1},
+  "startup": {"ready": true, "marker": "Ignite node started OK", "marker_source": "bounded_attempt_marker"},
+  "provenance": {"commit": "<sha>", "ref": "<ref>", "workflow_run_id": "<run-id>"}
+}
+```
+
+artifact 이름은 `testcontainers-image-gate-<workflow_run_id>-<platform_id>`
+형식으로 고정하고, 고정 job의 실제 이름은 Nightly x64
+`nightly-testcontainers-image-gate-${{ github.run_id }}-amd64`, Nightly arm64
+`nightly-testcontainers-image-gate-${{ github.run_id }}-arm64`, Release x64
+`release-testcontainers-image-gate-${{ github.run_id }}-amd64`, Release arm64
+`release-testcontainers-image-gate-${{ github.run_id }}-arm64`로 사용한다.
+`if: always()`와 `if-no-files-found: error`를 적용하며, artifact 내부 provenance의
+`workflow_run_id`와 이름의 `run_id`가 일치해야
+한다. 초과 시 artifact에는 해당 항목의 `blocked` 상태와 제한 이름만 남긴다.
+업로드는 aggregate counts와 per-family artifact 참조만 담은 `summary.json`,
+`summary.md`, family별 schema v2 JSON과 bounded diagnostics JSON만 허용하고
+raw XML·stdout·stderr·Docker log 파일은 업로드하지 않는다. summary에는 상세
+stdout/stderr를 중복 저장하지 않아 1 MiB 상한을 지키며, nightly artifact
+retention은 14일, release artifact retention은 30일이다.
+성공 artifact에는 위 allowlist 외의 환경변수, registry 설정, raw XML
+`system-out`, 전체 Docker inspect/log를 포함하지 않는다. 실패 진단도 동일한
+bounded/redacted 규칙을 따른다.
+
+summary schema v2는 `schema_version`, `workflow_run_id`, `commit`, `ref`,
+`scope`, `selected`, `success`, `product_failure`, `infrastructure_failure`,
+`blocked`, `coverage`, `release_gate`, `platforms[]`를 필수로 하며,
+`platforms[]` 각 항목은 `platform_id`, expected/observed tag·OS·architecture,
+`pull.event_id`, digest, workload testcase/count와 family artifact reference를
+포함한다. schema v1, partial platform entry, missing artifact reference는
+verifier에서 거부한다.
 
 `0 tests`와 `all skipped`는 제품 실패가 아니라 실행 증거 부재이므로
 `blocked`로 분류한다. `release_gate`는 선택 family가 모두 `success`이고
 `releaseRequired`인 경우에만 true다.
 
+Digest pin은 이번 범위에서 수동으로 추가하지 않지만, strict gate의 Docker Hub
+allowlist·mirror 차단과 pull 직후 digest 기록으로 관찰 provenance를 고정한다.
+mutable tag의 공급망 잔여 위험은 `WATCH`로 기록하고, Release verifier는 허용된
+registry host·expected tag·actual digest가 모두 있는 경우에만 통과시킨다.
+
 ### 5.3 Ignite2 runtime test
 
 `Ignite2ServerTest`는 클래스 수준 `@Disabled`를 제거한다.
 
-- 대표 test: `Ignite2Server`를 시작하고 `Ignition.startClient`로
+- 대표 test `representativeStartupAndWorkload`: 명시적 tag 없이 기본 생성자로
+  `Ignite2Server`를 시작하고 `Ignition.startClient`로
   `host:port`에 연결한다. 중앙 `ignite-core`의 `ClientConfiguration`으로
   test cache를 생성해 `put`/`get`하고 값을 검증한 뒤 client를 닫는다.
+  readiness marker를 기록한 뒤 workload를 실행하고, marker가 없으면 native
+  gate가 `blocked`가 되도록 test fixture를 둔다. `ClientConfiguration`의
+  connect/request timeout은 각각 30초로 설정하고 대표 test에는 6분 JUnit
+  timeout(5분 container startup + 1분 workload 여유)을 둔다. timeout·assertion·예외 모든 경로에서 client/container의
+  `use`/`finally` cleanup이 실행되는지 fixture로 검증한다.
 - 기본 port test: `useDefaultPort = true`로 startup과 `PORT == 10800`을
   검증한다.
 - 입력 검증 test: blank image/tag가 `IllegalArgumentException`을 발생시키는
   기존 계약을 유지한다.
-- platform job은 runner가 선택한 tag를 test-only system property로 전달하고,
-  test는 그 tag를 `Ignite2Server(tag = ...)`에 사용한다. public API는 변하지
-  않는다.
+- explicit tag override test는 `Ignite2Server(tag = ...)` 경로를 별도로 검증한다.
+  native gate의 대표 test는 tag를 직접 주입하지 않아 `DEFAULT_TAG`와 실제
+  runner architecture의 계약을 검증한다. public API signature는 변하지 않는다.
+- `DEFAULT_TAG`는 `x86_64`/`amd64`를 `2.18.0`, `aarch64`/`arm64`를
+  `2.18.0-arm64`로 매핑하고 unknown architecture는 fail-fast한다. 이 매핑은
+  eager companion 초기화가 아니라 lazy getter/helper 또는 동등한 sentinel 경로로
+  계산한다. 따라서 explicit `Ignite2Server(tag = ...)`와 명시적 custom image/tag
+  경로는 default resolver를 호출하지 않고 unknown architecture에서도 그대로
+  동작한다. canonical `apacheignite/ignite`의 no-tag만 supported architecture
+  mapping을 적용하고, custom image에 tag가 없거나 canonical image가 unknown/
+  Rosetta이면 fail-fast 및 native gate `blocked`로 기록한다. unknown-arch JVM
+  fixture가 explicit/custom 경로와 canonical no-tag 경로를 구분해 검증한다. 이
+  정책과 explicit/custom tag fixture를 EN/KO README와 KDoc에 동일하게 문서화한다.
+
+`testing/testcontainers/build.gradle.kts`에는 중앙 catalog의
+`testImplementation(bt4k.ignite.core)`만 추가하고, dependency resolution fixture가
+`org.apache.ignite:ignite-core:2.18.0`을 확인한다. 이 test-only dependency가
+published POM에 유입되지 않는지도 확인한다.
 
 container test는 `AbstractContainerTest`의 `SAME_THREAD` 실행 계약을 유지하고,
-모든 client/container 자원을 `use`로 닫는다.
+모든 client/container 자원을 `use`로 닫는다. EN/KO README thin-client 예제도
+동일한 `use`/`close` lifecycle과 `Ignition.startClient` 흐름을 사용해 실행 코드와
+문서 계약이 어긋나지 않게 한다.
 
 ### 5.4 Workflow 경계
 
 - **PR CI**: `test_testcontainers_contract.py`, manifest contract, Python runner
   unit/static tests만 실행한다. `run_testcontainers_image_gate.py` runtime 호출은
   계속 금지한다.
-- **Nightly full**: 기존 52-family x64 gate와 별도로 Ignite2 platform matrix를
-  실행한다. matrix는 `fail-fast: false`, `max-parallel: 1`로 두고 두 결과가 모두
-  성공해야 Spring bridge가 시작된다. `testcontainers` 범위에서는 두 job 모두
-  skipped로 남고 기존 조건대로 bridge를 실행한다.
-- **Release**: manifest contract → 기존 full x64 gate → Ignite2 platform matrix
-  순서로 실행한다. publish는 세 gate의 성공을 모두 `needs`로 요구하며
-  `coverage`/platform evidence 없이 진행하지 않는다.
-- **ARM runner**: GitHub public ARM64 label은 실행 시 실제 예약/architecture로
-  검증한다. runner unavailable은 skipped나 N/A로 완화하지 않는다.
+- Nightly/Release workflow는 `DOCKER_AUTH_CONFIG`를 job-level `env`에 두지 않고,
+  runner의 dedicated pull 단계에만 secret input으로 전달한다. Gradle/test,
+  diagnostics, summary/upload 단계의 env는 sanitized allowlist로 고정한다.
+- **Nightly full**: 기존 52-family x64 gate가 amd64 evidence를 생성한다. 일반
+  `test-testcontainers`의 `storage-cache` group에서는 Ignite2를 제외한다.
+  x64 image-gate `runs-on`은 `ubuntu-24.04`로 고정하고 job timeout은 360분,
+  `max_attempts=1`, generic family의 pull/test/diagnostic timeout은
+  60초/4분/30초(aggregate), strict Ignite2의 test timeout은 manifest의
+  6분(5분 container startup + 1분 Gradle/workload 여유)으로 고정하며
+  `--job-budget-minutes 360`을 전달한다. x64 `max_attempts=1`은 in-job retry를
+  하지 않고 transient failure를 새 workflow run에서 재실행한다. 최악 예산은
+  `51 × 1 × (1 + 4 + 0.5) + 1 × 1 × (1 + 6 + 0.5) + 30 = 318분 < 360분`이다.
+  job id
+  `test-testcontainers-ignite2-arm64-image-gate`는 `timeout-minutes: 90`과 고정
+  `ubuntu-24.04-arm`에서 `--family-id ignite2 --platform-id arm64`를 정확히
+  한 번 실행하며 `max_attempts=2`, pull/test/diagnostic timeout은
+  5분/30분/2분, `--job-budget-minutes 90`으로 고정한다. arm64 최악 예산은
+  `1 × 2 × (5 + 30 + 2) + 10 = 84분 < 90분`이다. 두 job의 static contract는
+  x64 full 선택 1회, arm64 exact selector 1회, targeted scope 0회를 검증한다.
+  arm64 job은 mock Jib task를 빌드하지 않으며 완전한 Gradle invocation에 두
+  `-x ...:jibDockerBuild` 인자를 포함한다. full에서 arm64 gate가 성공해야
+  `test-testcontainers-spring`, `coverage-report`, `nightly-status`의 `needs`가
+  성공한다. 각 upload artifact 이름은 위의 고정 literal run id/platform 조합을
+  사용하고
+  `if: always()`/`if-no-files-found: error`/14일 retention을 사용한다.
+  `full`이 아닌 scope에서는 이 job과 x64 image gate를 skipped로 허용하되
+  Spring bridge 조건에서만 허용한다.
+
+  x64 full invocation은
+  `python3 scripts/run_testcontainers_image_gate.py --scope full --report-dir
+  build/reports/testcontainers-image-gate --default-platform-id amd64
+  --max-attempts 1 --pull-timeout-seconds 60 --timeout-minutes 4
+  --diagnostic-timeout-seconds 30 --job-budget-minutes 360`이고, arm64 invocation은
+  `python3 scripts/run_testcontainers_image_gate.py --scope family --family-id
+  ignite2 --platform-id arm64 --require-selection --report-dir
+  build/reports/testcontainers-image-gate --max-attempts 2
+  --pull-timeout-seconds 300 --timeout-minutes 30
+  --diagnostic-timeout-seconds 120 --job-budget-minutes 90`이다. arm64 runner가
+  생성하는 최종 Gradle argv는
+  `./gradlew -Dtestcontainers.image-gate.evidence-dir=$RUN_EVIDENCE_DIR
+  :bluetape4k-testcontainers:test --tests
+  io.bluetape4k.testcontainers.storage.Ignite2ServerTest.representativeStartupAndWorkload
+  --no-configuration-cache -x :bluetape4k-mock-web-server:jibDockerBuild -x
+  :bluetape4k-mock-webflux-server:jibDockerBuild`이며, 두 exclusion이 사라지거나
+  mock Jib pre-step가 생기거나 고정 evidence-dir property가 빠지면 static
+  contract가 실패한다. `$RUN_EVIDENCE_DIR`는 runner가 attempt별로 생성한
+  containment 검증 대상 root이며, 이 최종 argv에는 위 property 외의 JVM
+  property가 허용되지 않는다.
+- **Nightly targeted**: `testcontainers` scope에서는 x64 full gate와 arm64 gate를
+  skipped로 유지하고, Spring bridge도 기존 skipped 허용 조건으로 실행한다.
+- **Release**: manifest contract가 통과한 뒤 기존 full x64 gate(`coverage=52/52`)와
+  job id `testcontainers-ignite2-arm64-image-gate`(`coverage=1/1`)를 병렬로
+  실행한다. 두 job은 각각 360분/90분 budget과 Nightly와 동일한
+  max-attempts·pull/test/diagnostic 수치를 사용한다. arm64 job과 summary
+  verifier는 각 gate job의 마지막 required step으로 실행하며, `publish.needs`에는
+  step 결과가 아니라 `testcontainers-image-gate`와
+  `testcontainers-ignite2-arm64-image-gate` job ID를 추가한다. 각 verifier는
+  `coverage`, `release_gate`, `platform_id`, expected/actual tag·architecture,
+  digest, workload evidence를 직접 검증하고 실패하면 job 자체를 실패시킨다.
+  publish는 manifest contract, x64 gate, arm64 gate 세 job 결과의 성공을 모두 요구하며
+  `platform_id`,
+   expected/actual tag·architecture, digest와 workload evidence 없이 진행하지
+  않는다. 각 release artifact 이름은 run id와 platform을 포함하고
+  `if: always()`/`if-no-files-found: error`/30일 retention을 사용한다.
+  `continue-on-error`와 skipped 결과는 verifier에서 거부한다.
+- **ARM runner**: GitHub public ARM64 label은 workflow에 고정하고 실행 시 실제
+  예약/architecture로 검증한다. runner unavailable은 skipped나 N/A로 완화하지
+  않는다.
+- **Aggregation guard**: `full` scope의 Spring bridge, `coverage-report`,
+  `nightly-status`는 x64 image-gate와 arm64 Ignite2 gate가 모두 `success`일
+  때만 통과한다. `coverage-report`는 `if: always()`여도 full scope에서 두
+  결과 중 하나가 `skipped`/`failure`이면 집계를 실패시키고, `nightly-status`는
+  `failure|cancelled|skipped`를 full scope에서 거부한다. `testcontainers` targeted
+  scope에서만 두 image gate의 `skipped`를 허용한다.
 
 ## 6. 실패 모드와 복구
 
 | 실패 | 분류 | 처리 |
 |---|---|---|
 | XML 없음, pattern suite 없음, `tests=0`, all skipped | `blocked` | release gate 차단, 결과와 경로 기록 |
-| 이미지 pull/daemon/rate limit/timeout | `infrastructure_failure` | bounded retry 후 Docker 진단, gate 실패 |
+| 실제 pull/event/digest evidence 없음 | `blocked` | 선택 ref와 결과 기록, 성공 완화 금지 |
+| 이미지 pull/daemon/rate limit/timeout | `infrastructure_failure` | transient에만 bounded retry 후 Docker 진단, gate 실패 |
 | container startup/readiness/workload assertion 실패 | `product_failure` | logs/inspect/events와 JUnit 결과 저장 |
-| 기대 platform과 Docker architecture 불일치 | `blocked` | tag/runner 계약 재검토, 성공 완화 금지 |
+| 기대 platform과 image/daemon/runner architecture 불일치 | `blocked` | canonical mapping과 tag/runner 계약 재검토 |
+| XML path escape, DTD/ENTITY, malformed 또는 secret 노출 | `blocked` | raw artifact 저장 금지, parser/redaction 수정 |
+| credential이 test/diagnostic env로 전파되거나 staging allowlist 위반 | `blocked` | pull subprocess 격리·fresh staging 재생성, raw 파일 업로드 금지 |
+| remote Docker endpoint, 비허용 registry/mirror, image provenance 불일치 | `blocked` | local/default Docker와 Docker Hub allowlist 확인 후 새 run |
+| subprocess/output/job budget 초과 또는 process group 잔류 | `blocked` | bounded kill/cleanup 후 초과 원인 수정, 이전 artifact 재사용 금지 |
 | ARM runner label 예약 실패 | workflow failure | matrix 결과를 skipped로 대체하지 않음 |
 | manifest/source/README drift | static contract failure | Docker 실행 전에 수정하도록 차단 |
 
-롤백은 새 commit에서 platform job 또는 parser를 되돌리되, 기존 PR CI의 runtime
-제외와 stable release의 full gate dependency는 유지한다. 이전 실행 artifact를
-새 성공으로 재사용하지 않는다.
+롤백은 새 commit에서 arm64 job과 parser/manifest 계약을 함께 되돌리되, PR CI의
+runtime 제외와 stable release의 full x64 gate dependency는 유지한다. ARM job은
+queue에서 10분 안에 runner가 할당되지 않으면 owner `debop`이
+`gh run cancel <run-id>`로 run을 취소하고 release를
+차단한 뒤, runner 가용성을 확인한 새 run에서만 재실행한다. queue 대기는 job
+`timeout-minutes`와 별도의 관찰 대상이며 skipped/N/A로 완화하지 않는다.
+runner 예약 실패는 재시도 가능한 workflow failure로 분류하고, product/infrastructure/
+evidence failure는 새 run에서만 재실행한다. 이전 실행 artifact를 새 성공으로
+재사용하지 않으며, rollback이 release 대상 tag에 이미 반영된 경우에도 새
+release tag/candidate를 만들어야 한다. rollback verifier는 required artifact가
+없거나 `release_gate=false`이면 실패 상태를 유지하고, 새 tag의 x64·arm64
+verifier가 모두 성공한 뒤에만 publish를 재개한다.
 
 ## 7. stacked PR train과 변경 파일
 
@@ -220,7 +496,10 @@ container test는 `AbstractContainerTest`의 `SAME_THREAD` 실행 계약을 유�
 - `scripts/test_testcontainers_image_gate.py`
 
 Parent는 runtime gate가 실제 test execution과 image/architecture 증거를
-검증하는 기반만 제공한다. Ignite2 source/README/workflow는 child에 둔다.
+검증하는 기반만 제공한다. Parent는 `executionEvidenceRequired`, selector, XML
+safety, architecture/security parser와 fixture를 소유한다. 실제 Ignite2
+`platforms`/workload metadata는 child가 소유해 parent contract가 먼저 merge되어도
+다른 family의 disabled 계약을 깨지 않도록 한다.
 
 ### Child: `fix/1486-ignite2-arm64-runtime` → parent
 
@@ -232,6 +511,8 @@ Parent는 runtime gate가 실제 test execution과 image/architecture 증거를
 - `.github/workflows/nightly-tests.yml`
 - `.github/workflows/release.yml`
 - `scripts/test_testcontainers_contract.py`
+- `scripts/testcontainers_image_gate_manifest.json`의 Ignite2 `platforms`와
+  `workloadTestPattern`
 - `docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md`
 
 두 PR 모두 base/head와 exact cumulative SHA를 live read-back하고, child PR은
@@ -241,32 +522,71 @@ parent merge 전에는 독립 merge하지 않는다.
 
 - [ ] 기준선 `Ignite2ServerTest`의 `3/3 skipped`가 RED 증거로 기록된다.
 - [ ] runner unit test가 성공, XML 없음, `tests=0`, all skipped, pattern mismatch,
-      architecture mismatch를 각각 검증한다.
+      stale/malformed XML, selector 0/복수개, architecture mismatch, pull/digest
+      부재, secret redaction, local/remote Docker context를 각각 검증한다.
+- [ ] pull 전 event observer가 run/family/platform/attempt/ref와 correlation되고,
+      pull cache/event/digest 및 verified-digest 재사용이 schema와 fixture로
+      검증된다.
 - [ ] unskipped Ignite2 test가 startup과 thin-client cache put/get을 통과한다.
+- [ ] thin-client connect/request 30초, 대표 JUnit 6분 timeout(5분 startup + 1분
+      workload 여유)과 timeout 경로의 `use`/cleanup, attempt별 XML/marker 격리가
+      검증된다.
+- [ ] 대표 test가 명시적 tag 없이 `DEFAULT_TAG`를 검증하고 explicit override와
+      custom image tag 정책을 별도 검증하며, readiness marker가 workload 전에
+      bounded attempt marker로 생성되는지 검증한다.
 - [ ] manifest가 `amd64`/`arm64` tag·runner·architecture를 검증한다.
+- [ ] 기존 disabled family는 `executionEvidenceRequired=false` 계약으로
+      52/52 full gate의 의도된 상태를 유지하고, 필드 미지정은 `false`로
+      해석한다.
 - [ ] EN/KO README와 KDoc이 `2.18.0`/`2.18.0-arm64` 및 platform mapping과
       일치한다.
-- [ ] PR workflow에는 image runtime 호출이 없고, Nightly/Release만 native matrix를
-      실행한다.
+- [ ] PR workflow에는 image runtime 호출이 없고, Nightly/Release만 arm64 native
+      gate를 실행하며 일반 `storage-cache`에서 Ignite2를 중복 실행하지 않는다.
+      static contract가 x64 1회 + arm64 1회, targeted 0회를 세고 arm64 명령의
+      두 mock Jib exclusion과 artifact run/platform 이름을 검증한다.
+- [ ] runner unit/static test가 x64/arm64의 수치 예산 공식, retry 가능 오류 분류,
+      pull 최대 횟수와 image ID/digest 재사용, XML·log·artifact byte/line 상한과
+      retention/upload 파일 allowlist를 검증한다. capped streaming, process-group
+      kill, fresh staging, safe ID/path grammar와 report-root containment도
+      검증한다.
+- [ ] credential이 pull subprocess에만 존재하고 Gradle/diagnostic/artifact로
+      전파되지 않으며, raw/decoded/base64 auth, basic-auth URL, multiline/known
+      secret redaction 회귀가 통과한다.
+- [ ] release/nightly 고정 argv가 arbitrary Gradle task/JVM option을 거부하고,
+      `DOCKER_HOST`/`DOCKER_CONTEXT`/registry mirror 및 remote context가
+      fail-closed가 된다.
 - [ ] `actionlint`, Python unit/static tests, targeted Gradle test, Kotlin compile,
       `git diff --check`가 통과한다.
-- [ ] native amd64와 arm64 CI artifact에 image digest, Docker/runner architecture,
-      startup/workload, JUnit execution count가 모두 존재한다.
-- [ ] Release publish가 두 platform gate와 기존 52/52 full gate 없이는 진행되지
-      않는다.
+- [ ] full x64 amd64 artifact와 arm64 CI artifact에 pull result, image digest,
+      Docker/runner/image architecture, startup/workload, JUnit execution count와
+      provenance가 모두 존재한다.
+- [ ] x64 resolver가 `defaultPlatformId=amd64`와 `platform_id=amd64`를 기록하고,
+      workload XML fixture가 `classname + name` 및 선택적 `()` canonicalization,
+      suite `tests`와 `workload_tests=1`을 구분한다.
+- [ ] summary/per-family schema v2가 expected/observed tag·OS·architecture,
+      pull event/digest, workload evidence, provenance와 artifact reference를
+      필수화하고 v1/partial/skipped 결과를 거부한다.
+- [ ] x64/arm64의 완전한 runner CLI와 arm64 Gradle argv가 static fixture로
+      보존되고, `job-budget-minutes` 공식·실제 subprocess wall-clock guard가
+      검증된다.
+- [ ] Release publish가 기존 52/52 full gate와 arm64 `coverage=1/1` summary
+      verifier 없이는 진행되지 않는다.
+- [ ] full scope 집계가 x64·arm64 `success`를 모두 요구하고, targeted scope에서만
+      두 image gate의 `skipped`를 허용한다.
 
 ### 8.1 Writer DoD
 
 - **SPW-01 PASS**: 독자는 bluetape4k contributor이며, Issue #1486, 기준 커밋,
   현재 source/workflow/manifest와 공식 GitHub·Ignite 문서를 근거로 고정했다.
 - **SPW-02 PASS**: 대안, 범위, manifest/runner/runtime/workflow 계약, 실패 모드,
-  호환성, stacked train, 수용 기준과 rollback을 포함했다.
+  호환성, stacked train, 증거 schema, 수용 기준과 rollback을 포함했다.
 - **SPW-03 PASS**: 한국어 기술 문체와 고정 용어를 적용하고 code token, command,
   URL, 숫자, status token을 보존했다. `korean-naturalness-checklist.md`를
   기준으로 문장과 표를 읽었다.
 - **SPW-04 PASS**: 현재 worktree의 `Ignite2Server`, test XML, runner,
-  manifest, workflows와 Issue #1486 acceptance를 대조했다. ARM runner와
-  실제 digest는 구현 후 CI에서 확인해야 하는 미확인 항목으로 남겼다.
+  manifest, workflows와 Issue #1486 acceptance를 대조했다. ARM runner 예약,
+  실제 pull/digest와 runtime workload는 구현 후 CI에서 확인해야 하는 미확인
+  항목으로 남겼다.
 - **SPW-05 PASS**: 최종 Markdown을 다시 읽고 headings, tables, code fence,
   checklist, link를 확인했다. `git diff --check`와
   `audit-korean-terms.mjs`가 통과했다.
@@ -276,12 +596,17 @@ parent merge 전에는 독립 merge하지 않는다.
 - public constructor/operator와 `Ignite2Server` property 계약은 유지한다.
 - test-only `ignite-core`는 중앙 catalog의 기존 `ignite` version을 사용하며
   publish artifact에는 포함하지 않는다.
-- PR CI runtime 비용은 증가하지 않는다. Nightly/Release는 Ignite2 두 번의
-  native 실행 비용만 추가한다.
+- PR CI runtime 비용은 증가하지 않는다. Nightly/Release는 기존 x64 full gate에
+  더해 Ignite2 arm64 한 번의 native 실행 비용만 추가한다. x64/arm64는 Release에서
+  manifest 이후 병렬 실행하고, 각각 318분/84분의 worst-case budget이 job timeout
+  안에 들어가는지 static contract로 검증한다.
 - cache/client/container는 모두 명시적으로 닫고, test runner는 family를
-  순차 실행해 Docker pull 압력과 공유 daemon 경쟁을 제한한다.
+  순차 실행해 Docker pull 압력과 공유 daemon 경쟁을 제한하되, Release의 두
+  platform job은 서로 병렬로 시작해 불필요한 gate 직렬 대기를 피한다.
 - image inspect와 JUnit XML이 없으면 성공하지 않으므로 green-but-unverified
-  결과를 방지한다.
+  결과를 방지한다. credential은 pull 단계에만 격리하고, process/output/job
+  budget과 fresh staging allowlist를 강제해 결과·진단 경로의 누출과 무제한
+  대기를 방지한다.
 
 ## 11. 근거 원본
 

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -745,6 +745,9 @@ class GateRunner:
                     final_status = pull_status
                     self._elapsed_seconds += time.monotonic() - attempt_started
                     if pull_status == "infrastructure_failure" and attempt < self.max_attempts:
+                        # A failed pull is not reusable evidence for the next
+                        # attempt; require a fresh pull/inspect/event chain.
+                        pull_evidence = None
                         shutil.rmtree(evidence_dir, ignore_errors=True)
                         continue
                     break

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import inspect
 import json
 import os
 import re
 import shlex
+import selectors
 import signal
 import shutil
 import tempfile
@@ -119,8 +121,20 @@ def _bounded(value: object) -> str:
 def register_secret(value: object) -> None:
     """Register raw/decoded credentials for every report boundary."""
 
+    if isinstance(value, (dict, list, tuple)):
+        for item in value:
+            register_secret(item)
+        if isinstance(value, dict):
+            for item in value.values():
+                register_secret(item)
+        return
     if isinstance(value, str) and value:
         _KNOWN_SECRETS.add(value)
+        if value.lstrip().startswith(("{", "[")):
+            try:
+                register_secret(json.loads(value))
+            except (TypeError, ValueError, json.JSONDecodeError):
+                pass
         try:
             import base64
 
@@ -155,54 +169,86 @@ def classify_failure(returncode: int | None, stdout: str, stderr: str) -> str:
 
 
 def _classify_command_result(returncode: int | None, stdout: str, stderr: str) -> str:
+    if "job budget exceeded" in f"{stdout}\n{stderr}".lower():
+        return "blocked"
     status = classify_failure(returncode, stdout, stderr)
     if status == "success" and not re.search(r"\bBUILD SUCCESSFUL\b", f"{stdout}\n{stderr}"):
         return "blocked"
     return status
 
 
-def _subprocess_runner(command: list[str], timeout_seconds: int, *, env: dict[str, str] | None = None) -> Any:
-    started = time.monotonic()
-    stdout_file = tempfile.TemporaryFile()
-    stderr_file = tempfile.TemporaryFile()
-    process: subprocess.Popen[bytes] | None = None
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
     try:
-        process = subprocess.Popen(
-            command,
-            stdout=stdout_file,
-            stderr=stderr_file,
-            env=env,
-            start_new_session=True,
-        )
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
         try:
-            process.wait(timeout=timeout_seconds)
+            os.killpg(process.pid, signal.SIGKILL)
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            try:
-                os.killpg(process.pid, signal.SIGTERM)
-                process.wait(timeout=5)
-            except (OSError, subprocess.TimeoutExpired):
-                try:
-                    os.killpg(process.pid, signal.SIGKILL)
-                except OSError:
-                    pass
-                process.wait()
-            return CommandResult(None, _bounded(_read_tail(stdout_file)), _bounded(_read_tail(stderr_file) + " timeout"), time.monotonic() - started)
-        return CommandResult(
-            process.returncode,
-            _bounded(_read_tail(stdout_file)),
-            _bounded(_read_tail(stderr_file)),
-            time.monotonic() - started,
-        )
+            pass
+
+
+def _subprocess_runner(command: list[str], timeout_seconds: int, *, env: dict[str, str] | None = None) -> Any:
+    """Run a command while continuously draining capped stdout/stderr pipes."""
+
+    started = time.monotonic()
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        start_new_session=True,
+    )
+    selector = selectors.DefaultSelector()
+    captures: dict[str, bytearray] = {"stdout": bytearray(), "stderr": bytearray()}
+    for name, stream in (("stdout", process.stdout), ("stderr", process.stderr)):
+        if stream is not None:
+            selector.register(stream, selectors.EVENT_READ, name)
+    deadline = started + max(1, timeout_seconds)
+    timed_out = False
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                _terminate_process(process)
+                break
+            events = selector.select(min(remaining, 0.25))
+            for key, _ in events:
+                stream = key.fileobj
+                chunk = os.read(stream.fileno(), 8192)
+                if not chunk:
+                    selector.unregister(stream)
+                    stream.close()
+                    continue
+                capture = captures[key.data]
+                capture.extend(chunk)
+                if len(capture) > MAX_OUTPUT_CHARS:
+                    del capture[:-MAX_OUTPUT_CHARS]
+        if not timed_out:
+            process.wait(timeout=max(1, deadline - time.monotonic()))
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _terminate_process(process)
     finally:
-        stdout_file.close()
-        stderr_file.close()
-
-
-def _read_tail(file_object: Any, limit: int = MAX_OUTPUT_CHARS) -> str:
-    file_object.seek(0, os.SEEK_END)
-    size = file_object.tell()
-    file_object.seek(max(0, size - limit - 1))
-    return file_object.read(limit + 1).decode("utf-8", errors="replace")
+        selector.close()
+        for stream in (process.stdout, process.stderr):
+            if stream is not None and not stream.closed:
+                stream.close()
+    stdout = bytes(captures["stdout"]).decode("utf-8", errors="replace")
+    stderr = bytes(captures["stderr"]).decode("utf-8", errors="replace")
+    if timed_out:
+        stderr = f"{stderr}\n...[timeout]"
+    return CommandResult(
+        None if timed_out else process.returncode,
+        _bounded(stdout),
+        _bounded(stderr),
+        time.monotonic() - started,
+    )
 
 
 def verify_release_summary(
@@ -212,6 +258,7 @@ def verify_release_summary(
     platform_id: str,
     expected_tag: str,
     expected_architecture: str,
+    report_dir: Path | None = None,
 ) -> list[str]:
     """Return fail-closed Release verifier findings for one native platform gate."""
 
@@ -257,10 +304,19 @@ def verify_release_summary(
             errors.append("pull status must be success")
         if pull.get("event_ref") not in {image_ref, f"docker.io/{image_ref}"}:
             errors.append("pull event requested-ref correlation is required")
+        expected_repository = image_ref.rsplit(":", 1)[0]
+        digest = str(pull.get("digest", ""))
+        if pull.get("digest_ref") not in {
+            f"{expected_repository}@{digest}",
+            f"docker.io/{expected_repository}@{digest}",
+        }:
+            errors.append("pull digest must belong to the requested repository")
         if (
             not pull.get("event_id")
+            or pull.get("event_image_id") not in {pull.get("image_id"), pull.get("digest")}
+            or not pull.get("event_timestamp_ns")
             or not str(pull.get("image_id", "")).startswith("sha256:")
-            or not str(pull.get("digest", "")).startswith("sha256:")
+            or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest)
         ):
             errors.append("pull event and digest evidence are required")
         workload_image = result.get("workload_image", {})
@@ -268,8 +324,20 @@ def verify_release_summary(
             errors.append("workload image must match pulled image")
         if junit.get("workload_tests") != 1 or junit.get("skipped", 1) != 0 or junit.get("failures", 1) != 0 or junit.get("errors", 1) != 0:
             errors.append("successful workload JUnit evidence is required")
-        if result.get("family_artifact") in {None, ""}:
+        artifact = result.get("family_artifact")
+        family_id = str(result.get("family_id", ""))
+        if not SAFE_ID.fullmatch(family_id) or artifact != f"{family_id}.json":
             errors.append("family artifact reference is required")
+        elif report_dir is not None:
+            report_root = report_dir.resolve()
+            artifact_path = report_dir / artifact
+            try:
+                artifact_path.resolve().relative_to(report_root)
+            except ValueError:
+                errors.append("family artifact escapes report directory")
+            else:
+                if artifact_path.is_symlink() or not artifact_path.is_file():
+                    errors.append("family artifact file is missing or not regular")
     return errors
 
 
@@ -335,6 +403,7 @@ class GateRunner:
         self.manifest_digest = self._digest(manifest_path)
         self._staging_root: Path | None = None
         self._elapsed_seconds = 0.0
+        self._deadline: float | None = None
 
     def _digest(self, manifest_path: Path | None) -> str:
         if manifest_path and manifest_path.is_file():
@@ -343,13 +412,25 @@ class GateRunner:
         return hashlib.sha256(canonical).hexdigest()
 
     def _invoke(self, command: list[str], timeout_seconds: int, env: dict[str, str] | None = None) -> Any:
+        effective_timeout = timeout_seconds
+        if self._deadline is not None:
+            remaining = int(self._deadline - time.monotonic())
+            if remaining <= 0:
+                return CommandResult(None, "", "job budget exceeded")
+            effective_timeout = min(timeout_seconds, remaining)
         if env is None:
-            return self.command_runner(command, timeout_seconds)
+            return self.command_runner(command, effective_timeout)
         try:
-            return self.command_runner(command, timeout_seconds, env=env)
-        except TypeError:
-            # Existing fake runners intentionally expose the old two-argument contract.
-            return self.command_runner(command, timeout_seconds)
+            parameters = inspect.signature(self.command_runner).parameters.values()
+            accepts_env = any(
+                parameter.name == "env" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters
+            )
+        except (TypeError, ValueError):
+            accepts_env = False
+        if accepts_env:
+            return self.command_runner(command, effective_timeout, env=env)
+        return self.command_runner(command, effective_timeout)
 
     @staticmethod
     def _sanitized_runtime_env() -> dict[str, str]:
@@ -358,6 +439,7 @@ class GateRunner:
         env = os.environ.copy()
         for key in (
             "DOCKER_AUTH_CONFIG",
+            "DOCKER_CONFIG",
             "TESTCONTAINERS_REGISTRY_MIRROR",
             "DOCKER_HOST",
             "DOCKER_CONTEXT",
@@ -374,14 +456,28 @@ class GateRunner:
             env["DOCKER_HOST"] = local_socket
         return env
 
+    def _isolated_runtime_env(self) -> dict[str, str]:
+        env = self._sanitized_runtime_env()
+        if self._staging_root is None:
+            return env
+        config_dir = self._staging_root / "runtime-docker-config"
+        config_dir.mkdir(mode=0o700, exist_ok=True)
+        config_file = config_dir / "config.json"
+        if not config_file.exists():
+            config_file.write_text("{}\n", encoding="utf-8")
+            config_file.chmod(0o600)
+        env["DOCKER_CONFIG"] = str(config_dir)
+        return env
+
     def _command(self, entry: dict[str, Any], evidence_dir: Path | None = None) -> list[str]:
         strict = bool(entry.get("executionEvidenceRequired"))
-        if strict and entry.get("_selected_platform_id") == "arm64" and evidence_dir is not None:
+        if strict and evidence_dir is not None:
             workload = str(entry.get("workloadTestPattern", entry["testPattern"])).removesuffix("()")
+            test_task = str(entry.get("testTask", ":bluetape4k-testcontainers:test"))
             return [
                 "./gradlew",
                 f"-Dtestcontainers.image-gate.evidence-dir={evidence_dir}",
-                ":bluetape4k-testcontainers:test",
+                test_task,
                 "--tests",
                 workload,
                 "--no-configuration-cache",
@@ -433,7 +529,7 @@ class GateRunner:
         commands: list[tuple[str, list[str]]] = [
             (
                 "docker_ps",
-                ["docker", "ps", "-a", "--no-trunc", "--filter", f"ancestor={image_ref}"],
+                ["docker", "ps", "-aq", "--no-trunc", "--filter", f"ancestor={image_ref}"],
             ),
             ("docker_inspect", ["docker", "inspect", image_ref]),
             # _invoke already bounds and process-group-terminates diagnostics; do
@@ -459,13 +555,35 @@ class GateRunner:
             result = self._invoke(
                 command,
                 min(self.diagnostic_timeout_seconds, 60),
-                self._sanitized_runtime_env(),
+                self._isolated_runtime_env(),
             )
             diagnostics[label] = self._diagnostic_bounded(
                 f"exit={getattr(result, 'returncode', None)}\n"
                 f"stdout={getattr(result, 'stdout', '')}\n"
                 f"stderr={getattr(result, 'stderr', '')}"
             )
+            if label == "docker_ps":
+                container_ids = [
+                    line.strip()
+                    for line in str(getattr(result, "stdout", "")).splitlines()
+                    if re.fullmatch(r"[0-9a-f]{12,64}", line.strip())
+                ][:5]
+                log_chunks: list[str] = []
+                for container_id in container_ids:
+                    log_result = self._invoke(
+                        ["docker", "logs", "--tail=200", container_id],
+                        min(self.diagnostic_timeout_seconds, 60),
+                        self._isolated_runtime_env(),
+                    )
+                    log_chunks.append(
+                        f"container={container_id}\n"
+                        f"exit={getattr(log_result, 'returncode', None)}\n"
+                        f"stdout={getattr(log_result, 'stdout', '')}\n"
+                        f"stderr={getattr(log_result, 'stderr', '')}"
+                    )
+                diagnostics["docker_logs"] = self._diagnostic_bounded(
+                    "\n---\n".join(log_chunks) if log_chunks else "no matching containers"
+                )
         return diagnostics
 
     @staticmethod
@@ -491,7 +609,9 @@ class GateRunner:
                         candidates.append(path)
                 except OSError:
                     continue
-        return candidates[:MAX_XML_FILES]
+        if len(candidates) > MAX_XML_FILES:
+            raise ValueError("JUnit XML file limit exceeded")
+        return candidates
 
     def _parse_junit(self, entry: dict[str, Any], files: list[Path]) -> dict[str, Any]:
         if not files:
@@ -500,9 +620,15 @@ class GateRunner:
         expected_workload = str(entry.get("workloadTestPattern", "")).replace("()", "")
         matched: tuple[Path, ET.Element] | None = None
         for path in files:
-            if path.stat().st_size > MAX_XML_BYTES:
+            try:
+                flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+                fd = os.open(path, flags)
+                with os.fdopen(fd, "rb") as stream:
+                    raw = stream.read(MAX_XML_BYTES + 1)
+            except OSError as error:
+                raise ValueError(f"JUnit XML cannot be opened safely: {path.name}") from error
+            if len(raw) > MAX_XML_BYTES:
                 raise ValueError(f"JUnit XML exceeds {MAX_XML_BYTES} bytes")
-            raw = path.read_bytes()
             if b"<!DOCTYPE" in raw or b"<!ENTITY" in raw:
                 raise ValueError("DTD/ENTITY is not allowed in JUnit XML")
             try:
@@ -510,7 +636,7 @@ class GateRunner:
             except ET.ParseError as error:
                 raise ValueError(f"malformed JUnit XML: {path.name}") from error
             suite_name = root.attrib.get("name", "")
-            if suite_name == expected_suite or suite_name.endswith(expected_suite):
+            if suite_name == expected_suite:
                 matched = (path, root)
                 break
         if matched is None:
@@ -584,6 +710,7 @@ class GateRunner:
         env = os.environ.copy()
         for key in (
             "DOCKER_AUTH_CONFIG",
+            "DOCKER_CONFIG",
             "TESTCONTAINERS_REGISTRY_MIRROR",
             "DOCKER_HOST",
             "DOCKER_CONTEXT",
@@ -596,15 +723,13 @@ class GateRunner:
             and os.environ.get("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE") == "/var/run/docker.sock"
         ):
             env["DOCKER_HOST"] = local_socket
-        config_dir: Path | None = None
+        config_dir: Path | None = attempt_root / "docker-config"
         try:
-            if auth_config:
-                config_dir = attempt_root / "docker-config"
-                config_dir.mkdir(mode=0o700)
-                config_file = config_dir / "config.json"
-                config_file.write_text(auth_config, encoding="utf-8")
-                config_file.chmod(0o600)
-                env["DOCKER_CONFIG"] = str(config_dir)
+            config_dir.mkdir(mode=0o700)
+            config_file = config_dir / "config.json"
+            config_file.write_text(auth_config or "{}\n", encoding="utf-8")
+            config_file.chmod(0o600)
+            env["DOCKER_CONFIG"] = str(config_dir)
             pull_started_wall = time.time()
             pull_started = time.monotonic()
             pull = self._invoke(
@@ -612,6 +737,13 @@ class GateRunner:
                 self.pull_timeout_seconds,
                 env,
             )
+            if "job budget exceeded" in f"{getattr(pull, 'stdout', '')}\n{getattr(pull, 'stderr', '')}".lower():
+                return "blocked", {
+                    "requested_ref": f"docker.io/{image_ref}",
+                    "attempts": attempt,
+                    "status": "blocked",
+                    "error": "job budget exceeded",
+                }
             pull_status = classify_failure(getattr(pull, "returncode", None), getattr(pull, "stdout", ""), getattr(pull, "stderr", ""))
             if getattr(pull, "returncode", None) != 0:
                 return pull_status, {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": pull_status}
@@ -621,17 +753,40 @@ class GateRunner:
                 image = payload[0] if isinstance(payload, list) else payload
                 image_id = str(image.get("Id", ""))
                 digests = image.get("RepoDigests", [])
-                digest = next((item.split("@", 1)[1] for item in digests if "@sha256:" in item), "")
+                repository = image_ref.rsplit(":", 1)[0]
+                repository_names = {repository, f"docker.io/{repository}"}
+                digest_ref = next(
+                    (
+                        item
+                        for item in digests
+                        if isinstance(item, str)
+                        and "@sha256:" in item
+                        and item.split("@", 1)[0] in repository_names
+                    ),
+                    "",
+                )
+                digest = digest_ref.split("@", 1)[1] if digest_ref else ""
                 observed_os = str(image.get("Os", ""))
                 observed_arch = canonical_architecture(image.get("Architecture"))
             except (ValueError, IndexError, AttributeError, TypeError, json.JSONDecodeError) as error:
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": _bounded(error)}
-            if not image_id.startswith("sha256:") or not digest.startswith("sha256:") or observed_os != "linux" or observed_arch != architecture:
+            if (
+                not image_id.startswith("sha256:")
+                or not digest.startswith("sha256:")
+                or not digest_ref
+                or observed_os != "linux"
+                or observed_arch != architecture
+            ):
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "image platform or digest mismatch"}
             context = self._invoke(["docker", "context", "show"], self.pull_timeout_seconds, env)
             info = self._invoke(["docker", "info", "--format", "{{json .}}"], self.pull_timeout_seconds, env)
             uname = self._invoke(["uname", "-m"], self.pull_timeout_seconds, env)
-            if getattr(context, "returncode", 1) != 0 or getattr(context, "stdout", "").strip() != "default":
+            uname_os = self._invoke(["uname", "-s"], self.pull_timeout_seconds, env)
+            if (
+                getattr(context, "returncode", 1) != 0
+                or getattr(context, "stdout", "").strip() != "default"
+                or getattr(uname_os, "returncode", 1) != 0
+            ):
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "non-default Docker context"}
             try:
                 info_payload = json.loads(getattr(info, "stdout", "{}"))
@@ -639,9 +794,16 @@ class GateRunner:
                 info_payload = {}
             daemon_arch = canonical_architecture(info_payload.get("Architecture"))
             runner_arch = canonical_architecture(getattr(uname, "stdout", "").strip())
-            if daemon_arch != architecture or runner_arch != architecture:
+            daemon_os = str(info_payload.get("OSType", "")).strip().lower()
+            runner_os = str(getattr(uname_os, "stdout", "")).strip().lower()
+            if (
+                daemon_arch != architecture
+                or runner_arch != architecture
+                or daemon_os != "linux"
+                or runner_os != "linux"
+            ):
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "daemon or runner architecture mismatch"}
-            event_since = str(max(0, int(pull_started_wall) - 1))
+            event_since = str(max(0, int(pull_started_wall)))
             event_until = str(int(time.time()) + 2)
             event = self._invoke(
                 [
@@ -664,6 +826,7 @@ class GateRunner:
             event_id = ""
             event_ref = ""
             event_image_id = ""
+            event_timestamp_ns = 0
             expected_refs = {image_ref, f"docker.io/{image_ref}"}
             expected_ids = {image_id, digest}
             for line in getattr(event, "stdout", "").splitlines():
@@ -684,15 +847,27 @@ class GateRunner:
                     }
                     matching_ref = next((value for value in refs if value in expected_refs), "")
                     matching_id = next((value for value in ids if value in expected_ids), "")
-                    if not matching_ref and not matching_id:
+                    raw_timestamp = item.get("timeNano")
+                    if raw_timestamp is None and item.get("time") is not None:
+                        raw_timestamp = int(float(item["time"]) * 1_000_000_000)
+                    try:
+                        candidate_timestamp_ns = int(raw_timestamp)
+                    except (TypeError, ValueError):
+                        candidate_timestamp_ns = 0
+                    if (
+                        not matching_ref
+                        or not matching_id
+                        or candidate_timestamp_ns < int(pull_started_wall * 1_000_000_000)
+                    ):
                         continue
                     event_id = str(item.get("id") or actor_id)
                     event_ref = matching_ref
                     event_image_id = matching_id
+                    event_timestamp_ns = candidate_timestamp_ns
                     break
                 except json.JSONDecodeError:
                     continue
-            if getattr(event, "returncode", 0) != 0 or not event_id:
+            if getattr(event, "returncode", 0) != 0 or not event_id or not event_ref or not event_image_id:
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "pull event correlation is missing"}
             return "success", {
                 "requested_ref": f"docker.io/{image_ref}",
@@ -702,17 +877,19 @@ class GateRunner:
                 "event_id": event_id,
                 "event_ref": event_ref or None,
                 "event_image_id": event_image_id or None,
+                "event_timestamp_ns": event_timestamp_ns,
                 "image_id": image_id,
                 "digest": digest,
+                "digest_ref": digest_ref,
                 "elapsed_seconds": round(time.monotonic() - pull_started, 3),
                 "observed": {
-                    "runner_os": "linux",
+                    "runner_os": runner_os,
                     "runner_architecture": runner_arch,
                     # Docker's OperatingSystem field is a distro description
                     # (for example, "Ubuntu 24.04.4 LTS"), not an OS family.
                     # Keep the contract's normalized family value here and
                     # preserve the raw description separately for diagnostics.
-                    "daemon_os": "linux",
+                    "daemon_os": daemon_os,
                     "daemon_os_description": str(info_payload.get("OperatingSystem", "")).lower(),
                     "daemon_architecture": daemon_arch,
                     "image_os": observed_os,
@@ -766,13 +943,16 @@ class GateRunner:
             test_timeout = self.timeout_seconds
             if platform:
                 test_timeout = int(entry.get("platformTimeouts", {}).get(platform["id"], {}).get("testMinutes", self.timeout_seconds // 60)) * 60
-            result = self._invoke(command, test_timeout, self._sanitized_runtime_env())
+            result = self._invoke(command, test_timeout, self._isolated_runtime_env())
             elapsed = round(time.monotonic() - attempt_started, 3)
             self._elapsed_seconds += elapsed
             raw_stdout = getattr(result, "stdout", "")
             raw_stderr = getattr(result, "stderr", "")
             returncode = getattr(result, "returncode", None)
             status = _classify_command_result(returncode, raw_stdout, raw_stderr)
+            if status == "success" and self._deadline is not None and time.monotonic() >= self._deadline:
+                status = "blocked"
+                raw_stderr = f"{raw_stderr}\njob budget exceeded"
             attempt_result: dict[str, Any] = {"attempt": attempt, "command": redact(" ".join(command)), "returncode": returncode, "elapsed_seconds": elapsed, "status": status}
             if strict and status == "success":
                 try:
@@ -838,6 +1018,24 @@ class GateRunner:
 
     def run(self) -> dict[str, Any]:
         self.report_dir.mkdir(parents=True, exist_ok=True)
+        invalid_ids = [str(entry.get("id", "")) for entry in self.entries if not SAFE_ID.fullmatch(str(entry.get("id", "")))]
+        if invalid_ids:
+            raise ValueError(f"unsafe family id: {', '.join(invalid_ids)}")
+        allowed_names = {f"{entry['id']}.json" for entry in self.entries} | {"summary.json", "summary.md"}
+        unexpected = [
+            path.name
+            for path in self.report_dir.iterdir()
+            if path.is_symlink() or (path.is_file() and path.name not in allowed_names)
+        ]
+        if unexpected:
+            raise RuntimeError(
+                f"report directory contains unexpected artifacts: {', '.join(sorted(unexpected))}"
+            )
+        self._deadline = (
+            time.monotonic() + self.job_budget_seconds
+            if self.job_budget_seconds is not None
+            else None
+        )
         # Secret-bearing Docker config lives outside the artifact tree, including on timeout paths.
         self._staging_root = Path(tempfile.mkdtemp(prefix=".image-gate-"))
         results = []
@@ -884,6 +1082,7 @@ class GateRunner:
             "results": results,
             "platforms": [
                 {
+                    "family_id": result.get("id"),
                     "platform_id": result.get("platform_id"),
                     "status": result.get("status"),
                     "image_ref": result.get("image_ref"),

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -98,12 +98,11 @@ class CommandResult:
 def redact(value: str) -> str:
     """Remove common credential values before text enters logs or artifacts."""
 
-    redacted = value
-    for secret in sorted((item for item in _KNOWN_SECRETS if item), key=len, reverse=True):
-        redacted = redacted.replace(secret, "<redacted>")
-    redacted = BASIC_AUTH_URL_PATTERN.sub(r"\1<redacted>:<redacted>@", redacted)
+    redacted = BASIC_AUTH_URL_PATTERN.sub(r"\1<redacted>:<redacted>@", value)
     redacted = BEARER_PATTERN.sub(r"\1<redacted>", redacted)
     redacted = SECRET_PATTERN.sub(r"\1=<redacted>", redacted)
+    for secret in sorted((item for item in _KNOWN_SECRETS if item), key=len, reverse=True):
+        redacted = redacted.replace(secret, "<redacted>")
     return redacted
 
 

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -1220,18 +1220,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         _blocked_summary(args.report_dir, [str(error)], args.manifest)
         print(f"BLOCKED: {error}", file=sys.stderr)
         return 2
-    summary = GateRunner(
-        selected,
-        args.report_dir,
-        gradle_task=args.gradle_task,
-        max_attempts=args.max_attempts,
-        timeout_minutes=args.timeout_minutes,
-        manifest_path=args.manifest,
-        pull_timeout_seconds=args.pull_timeout_seconds,
-        diagnostic_timeout_seconds=args.diagnostic_timeout_seconds,
-        job_budget_minutes=args.job_budget_minutes,
-        scope=args.scope,
-    ).run()
+    try:
+        summary = GateRunner(
+            selected,
+            args.report_dir,
+            gradle_task=args.gradle_task,
+            max_attempts=args.max_attempts,
+            timeout_minutes=args.timeout_minutes,
+            manifest_path=args.manifest,
+            pull_timeout_seconds=args.pull_timeout_seconds,
+            diagnostic_timeout_seconds=args.diagnostic_timeout_seconds,
+            job_budget_minutes=args.job_budget_minutes,
+            scope=args.scope,
+        ).run()
+    except (OSError, RuntimeError, ValueError) as error:
+        _blocked_summary(args.report_dir, [str(error)], args.manifest)
+        print(f"BLOCKED: {error}", file=sys.stderr)
+        return 1
     print(json.dumps({key: summary[key] for key in (
         "status", "coverage", "product_failure", "infrastructure_failure", "blocked", "release_gate"
     )}, ensure_ascii=False))

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -50,6 +50,10 @@ MAX_XML_BYTES = 4 * 1024 * 1024
 MAX_XML_FILES = 8
 MAX_XML_TESTCASES = 2_048
 MAX_XML_COUNTER = 10_000
+EXPECTED_RUNNERS = {
+    "amd64": "ubuntu-24.04",
+    "arm64": "ubuntu-24.04-arm",
+}
 SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 SAFE_TAG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 INFRASTRUCTURE_MARKERS = (
@@ -238,6 +242,13 @@ def verify_release_summary(
             errors.append("expected/observed tag mismatch")
         if expected.get("architecture") != expected_architecture or observed.get("image_architecture") != expected_architecture:
             errors.append("expected/observed architecture mismatch")
+        if expected.get("runner") != EXPECTED_RUNNERS.get(platform_id):
+            errors.append("expected runner label mismatch")
+        if (
+            observed.get("runner_architecture") != expected_architecture
+            or observed.get("daemon_architecture") != expected_architecture
+        ):
+            errors.append("runner/daemon architecture evidence is required")
         if expected.get("os") != "linux" or observed.get("image_os") != "linux":
             errors.append("expected/observed OS mismatch")
         if observed.get("runner_os") != "linux" or observed.get("daemon_os") != "linux":

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -6,11 +6,17 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import shlex
+import signal
+import shutil
+import tempfile
 import subprocess
 import sys
 import time
+import uuid
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
@@ -19,13 +25,33 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
-from scripts.testcontainers_image_gate import MANIFEST, load_manifest, select_entries, validate_manifest
+from scripts.testcontainers_image_gate import (
+    MANIFEST,
+    SelectionError,
+    canonical_architecture,
+    load_manifest,
+    platform_for_entry,
+    select_entries,
+    validate_manifest,
+)
 
 
 CommandRunner = Callable[[list[str], int], Any]
 DiagnosticRunner = Callable[[dict[str, Any]], dict[str, str]]
 MAX_ATTEMPTS = 3
-MAX_OUTPUT_CHARS = 12_000
+MAX_OUTPUT_CHARS = 64 * 1024
+MAX_OUTPUT_LINES = 1_000
+MAX_DIAGNOSTIC_CHARS = 64 * 1024
+MAX_DIAGNOSTIC_LINES = 500
+MAX_FAMILY_JSON_BYTES = 128 * 1024
+MAX_SUMMARY_BYTES = 1 * 1024 * 1024
+MAX_ARTIFACT_BYTES = 8 * 1024 * 1024
+MAX_XML_BYTES = 4 * 1024 * 1024
+MAX_XML_FILES = 8
+MAX_XML_TESTCASES = 2_048
+MAX_XML_COUNTER = 10_000
+SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+SAFE_TAG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 INFRASTRUCTURE_MARKERS = (
     "toomanyrequests",
     "rate limit",
@@ -49,21 +75,64 @@ SECRET_PATTERN = re.compile(
     r"(?i)(password|passwd|token|secret|authorization|api[_-]?key)\s*[:=]\s*([^\s,;]+)"
 )
 BEARER_PATTERN = re.compile(r"(?i)(bearer\s+)[^\s,;]+")
+BASIC_AUTH_URL_PATTERN = re.compile(r"(?i)(https?://)([^/@:\s]+):([^/@\s]+)@")
+_KNOWN_SECRETS: set[str] = set()
+
+
+class CommandResult:
+    """Bounded subprocess result shared by real and fake command runners."""
+
+    def __init__(self, returncode: int | None, stdout: str = "", stderr: str = "", elapsed: float = 0.0):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.elapsed_seconds = elapsed
 
 
 def redact(value: str) -> str:
     """Remove common credential values before text enters logs or artifacts."""
 
-    redacted = BEARER_PATTERN.sub(r"\1<redacted>", value)
+    redacted = value
+    for secret in sorted((item for item in _KNOWN_SECRETS if item), key=len, reverse=True):
+        redacted = redacted.replace(secret, "<redacted>")
+    redacted = BASIC_AUTH_URL_PATTERN.sub(r"\1<redacted>:<redacted>@", redacted)
+    redacted = BEARER_PATTERN.sub(r"\1<redacted>", redacted)
     redacted = SECRET_PATTERN.sub(r"\1=<redacted>", redacted)
     return redacted
 
 
 def _bounded(value: object) -> str:
     text = redact(str(value or ""))
-    if len(text) <= MAX_OUTPUT_CHARS:
+    lines = text.splitlines()
+    if len(lines) > MAX_OUTPUT_LINES:
+        text = "\n".join(lines[:MAX_OUTPUT_LINES]) + "\n...[line limit]"
+    if len(text.encode("utf-8")) <= MAX_OUTPUT_CHARS:
         return text
-    return text[:MAX_OUTPUT_CHARS] + "\n...[truncated]"
+    encoded = text.encode("utf-8")[:MAX_OUTPUT_CHARS]
+    return encoded.decode("utf-8", errors="ignore") + "\n...[byte limit]"
+
+
+def register_secret(value: object) -> None:
+    """Register raw/decoded credentials for every report boundary."""
+
+    if isinstance(value, str) and value:
+        _KNOWN_SECRETS.add(value)
+        try:
+            import base64
+
+            decoded = base64.b64decode(value, validate=True).decode("utf-8")
+        except Exception:
+            decoded = ""
+        if decoded:
+            _KNOWN_SECRETS.add(decoded)
+
+
+def _read_bounded(path: Path, limit: int) -> str:
+    with path.open("rb") as stream:
+        data = stream.read(limit + 1)
+    if len(data) > limit:
+        raise ValueError(f"output exceeds {limit} bytes: {path.name}")
+    return redact(data.decode("utf-8", errors="replace"))
 
 
 def classify_failure(returncode: int | None, stdout: str, stderr: str) -> str:
@@ -88,25 +157,116 @@ def _classify_command_result(returncode: int | None, stdout: str, stderr: str) -
     return status
 
 
-def _subprocess_runner(command: list[str], timeout_seconds: int) -> Any:
+def _subprocess_runner(command: list[str], timeout_seconds: int, *, env: dict[str, str] | None = None) -> Any:
+    started = time.monotonic()
+    stdout_file = tempfile.TemporaryFile()
+    stderr_file = tempfile.TemporaryFile()
+    process: subprocess.Popen[bytes] | None = None
     try:
-        return subprocess.run(
+        process = subprocess.Popen(
             command,
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            env=env,
+            start_new_session=True,
         )
-    except subprocess.TimeoutExpired as error:
-        return type(
-            "TimeoutResult",
-            (),
-            {
-                "returncode": None,
-                "stdout": error.stdout or "",
-                "stderr": (error.stderr or "") + " timeout",
-            },
-        )()
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+                process.wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except OSError:
+                    pass
+                process.wait()
+            return CommandResult(None, _bounded(_read_tail(stdout_file)), _bounded(_read_tail(stderr_file) + " timeout"), time.monotonic() - started)
+        return CommandResult(
+            process.returncode,
+            _bounded(_read_tail(stdout_file)),
+            _bounded(_read_tail(stderr_file)),
+            time.monotonic() - started,
+        )
+    finally:
+        stdout_file.close()
+        stderr_file.close()
+
+
+def _read_tail(file_object: Any, limit: int = MAX_OUTPUT_CHARS) -> str:
+    file_object.seek(0, os.SEEK_END)
+    size = file_object.tell()
+    file_object.seek(max(0, size - limit - 1))
+    return file_object.read(limit + 1).decode("utf-8", errors="replace")
+
+
+def verify_release_summary(
+    summary: dict[str, Any],
+    *,
+    expected_coverage: str,
+    platform_id: str,
+    expected_tag: str,
+    expected_architecture: str,
+) -> list[str]:
+    """Return fail-closed Release verifier findings for one native platform gate."""
+
+    errors: list[str] = []
+    if summary.get("schema_version") != 2:
+        errors.append("summary schema_version must be 2")
+    if summary.get("coverage") != expected_coverage:
+        errors.append(f"coverage must be {expected_coverage}")
+    if summary.get("release_gate") is not True:
+        errors.append("release_gate must be true")
+    if summary.get("status") != "success":
+        errors.append("summary status must be success")
+    if summary.get("selected", 0) <= 0 or summary.get("blocked", 0) or summary.get("product_failure", 0) or summary.get("infrastructure_failure", 0):
+        errors.append("summary contains incomplete or failed execution")
+    platform_results = [item for item in summary.get("platforms", []) if item.get("platform_id") == platform_id]
+    if len(platform_results) != 1:
+        errors.append(f"exactly one {platform_id} platform result is required")
+    else:
+        result = platform_results[0]
+        if result.get("status") != "success":
+            errors.append("platform result is not successful")
+        expected = result.get("expected", {})
+        observed = result.get("observed", {})
+        pull = result.get("pull", {})
+        junit = result.get("junit", {})
+        if expected.get("tag") != expected_tag or observed.get("image_tag") not in {expected_tag, None}:
+            errors.append("expected/observed tag mismatch")
+        if expected.get("architecture") != expected_architecture or observed.get("image_architecture") not in {expected_architecture, None}:
+            errors.append("expected/observed architecture mismatch")
+        if not pull.get("event_id") or not str(pull.get("digest", "")).startswith("sha256:"):
+            errors.append("pull event and digest evidence are required")
+        if junit.get("workload_tests") != 1 or junit.get("skipped", 1) != 0 or junit.get("failures", 1) != 0 or junit.get("errors", 1) != 0:
+            errors.append("successful workload JUnit evidence is required")
+        if result.get("family_artifact") in {None, ""}:
+            errors.append("family artifact reference is required")
+    return errors
+
+
+def worst_case_budget_minutes(
+    *,
+    generic_families: int,
+    generic_attempts: int,
+    generic_pull_minutes: int,
+    generic_test_minutes: int,
+    generic_diagnostic_minutes: float,
+    strict_families: int,
+    strict_attempts: int,
+    strict_pull_minutes: int,
+    strict_test_minutes: int,
+    strict_diagnostic_minutes: float,
+    setup_slack_minutes: int,
+) -> float:
+    """Calculate the bounded workflow budget used by the Nightly/Release contract."""
+
+    return (
+        generic_families * generic_attempts * (generic_pull_minutes + generic_test_minutes + generic_diagnostic_minutes)
+        + strict_families * strict_attempts * (strict_pull_minutes + strict_test_minutes + strict_diagnostic_minutes)
+        + setup_slack_minutes
+    )
 
 
 class GateRunner:
@@ -123,6 +283,13 @@ class GateRunner:
         max_attempts: int = 1,
         timeout_minutes: int = 30,
         manifest_path: Path | None = None,
+        pull_timeout_seconds: int = 60,
+        diagnostic_timeout_seconds: int = 30,
+        job_budget_minutes: int | None = None,
+        scope: str = "full",
+        workflow_run_id: str | None = None,
+        commit: str | None = None,
+        ref: str | None = None,
     ) -> None:
         self.entries = [dict(entry) for entry in entries]
         self.report_dir = report_dir
@@ -131,7 +298,16 @@ class GateRunner:
         self.gradle_task = gradle_task
         self.max_attempts = max(1, min(max_attempts, MAX_ATTEMPTS))
         self.timeout_seconds = max(60, timeout_minutes * 60)
+        self.pull_timeout_seconds = max(1, pull_timeout_seconds)
+        self.diagnostic_timeout_seconds = max(1, diagnostic_timeout_seconds)
+        self.job_budget_seconds = (job_budget_minutes * 60) if job_budget_minutes else None
+        self.scope = scope
+        self.workflow_run_id = workflow_run_id or os.environ.get("GITHUB_RUN_ID", "local")
+        self.commit = commit or os.environ.get("GITHUB_SHA", "local")
+        self.ref = ref or os.environ.get("GITHUB_REF", "local")
         self.manifest_digest = self._digest(manifest_path)
+        self._staging_root: Path | None = None
+        self._elapsed_seconds = 0.0
 
     def _digest(self, manifest_path: Path | None) -> str:
         if manifest_path and manifest_path.is_file():
@@ -139,15 +315,63 @@ class GateRunner:
         canonical = json.dumps(self.entries, ensure_ascii=False, sort_keys=True).encode("utf-8")
         return hashlib.sha256(canonical).hexdigest()
 
-    def _command(self, entry: dict[str, Any]) -> list[str]:
+    def _invoke(self, command: list[str], timeout_seconds: int, env: dict[str, str] | None = None) -> Any:
+        if env is None:
+            return self.command_runner(command, timeout_seconds)
+        try:
+            return self.command_runner(command, timeout_seconds, env=env)
+        except TypeError:
+            # Existing fake runners intentionally expose the old two-argument contract.
+            return self.command_runner(command, timeout_seconds)
+
+    def _command(self, entry: dict[str, Any], evidence_dir: Path | None = None) -> list[str]:
+        strict = bool(entry.get("executionEvidenceRequired"))
+        if strict and entry.get("_selected_platform_id") == "arm64" and evidence_dir is not None:
+            workload = str(entry.get("workloadTestPattern", entry["testPattern"])).removesuffix("()")
+            return [
+                "./gradlew",
+                f"-Dtestcontainers.image-gate.evidence-dir={evidence_dir}",
+                ":bluetape4k-testcontainers:test",
+                "--tests",
+                workload,
+                "--no-configuration-cache",
+                "-x",
+                ":bluetape4k-mock-web-server:jibDockerBuild",
+                "-x",
+                ":bluetape4k-mock-webflux-server:jibDockerBuild",
+            ]
         command = shlex.split(self.gradle_task)
         if test_task := entry.get("testTask"):
-            task_positions = [index for index, part in enumerate(command) if part.startswith(":")]
+            task_positions = [
+                index
+                for index, part in enumerate(command)
+                if part.startswith(":") and (index == 0 or command[index - 1] not in {"-x", "--exclude-task"})
+            ]
             if len(task_positions) != 1:
                 raise ValueError(f"expected one Gradle task in command: {self.gradle_task}")
             command[task_positions[0]] = str(test_task)
-        command.extend(("--tests", str(entry["testPattern"]), "--no-configuration-cache"))
+        if strict and evidence_dir is not None and not any(
+            part.startswith("-Dtestcontainers.image-gate.evidence-dir=") for part in command
+        ):
+            task_index = next((index for index, part in enumerate(command) if part.startswith(":")), 1)
+            command.insert(task_index, f"-Dtestcontainers.image-gate.evidence-dir={evidence_dir}")
+        if "--tests" not in command:
+            selector = entry.get("testPattern")
+            command.extend(("--tests", str(selector)))
+        if "--no-configuration-cache" not in command:
+            command.append("--no-configuration-cache")
         return command
+
+    @staticmethod
+    def _diagnostic_bounded(value: object) -> str:
+        text = redact(str(value or ""))
+        lines = text.splitlines()
+        if len(lines) > MAX_DIAGNOSTIC_LINES:
+            text = "\n".join(lines[:MAX_DIAGNOSTIC_LINES]) + "\n...[line limit]"
+        encoded = text.encode("utf-8")
+        if len(encoded) > MAX_DIAGNOSTIC_CHARS:
+            text = encoded[:MAX_DIAGNOSTIC_CHARS].decode("utf-8", errors="ignore") + "\n...[byte limit]"
+        return text
 
     def _collect_diagnostics(self, entry: dict[str, Any]) -> dict[str, str]:
         image_ref = f"{entry['image']}:{entry['tag']}"
@@ -175,53 +399,297 @@ class GateRunner:
             )
         diagnostics: dict[str, str] = {}
         for label, command in commands:
-            result = self.command_runner(command, min(self.timeout_seconds, 60))
-            diagnostics[label] = _bounded(
+            result = self._invoke(command, min(self.diagnostic_timeout_seconds, 60))
+            diagnostics[label] = self._diagnostic_bounded(
                 f"exit={getattr(result, 'returncode', None)}\n"
                 f"stdout={getattr(result, 'stdout', '')}\n"
                 f"stderr={getattr(result, 'stderr', '')}"
             )
         return diagnostics
 
+    @staticmethod
+    def _is_regular(path: Path) -> bool:
+        return path.is_file() and not path.is_symlink()
+
+    @staticmethod
+    def _canonical_testcase(classname: str, name: str) -> str:
+        return f"{classname}.{name[:-2] if name.endswith('()') else name}"
+
+    def _xml_candidates(self, started_ns: int, evidence_dir: Path) -> list[Path]:
+        roots = [
+            REPOSITORY_ROOT / "testing/testcontainers/build/test-results/test",
+            evidence_dir,
+        ]
+        candidates: list[Path] = []
+        for root in roots:
+            if not root.is_dir() or root.is_symlink():
+                continue
+            for path in root.glob("*.xml"):
+                try:
+                    if self._is_regular(path) and path.stat().st_mtime_ns >= started_ns:
+                        candidates.append(path)
+                except OSError:
+                    continue
+        return candidates[:MAX_XML_FILES]
+
+    def _parse_junit(self, entry: dict[str, Any], files: list[Path]) -> dict[str, Any]:
+        if not files:
+            raise ValueError("JUnit evidence is missing")
+        expected_suite = str(entry["testPattern"])
+        expected_workload = str(entry.get("workloadTestPattern", "")).replace("()", "")
+        matched: tuple[Path, ET.Element] | None = None
+        for path in files:
+            if path.stat().st_size > MAX_XML_BYTES:
+                raise ValueError(f"JUnit XML exceeds {MAX_XML_BYTES} bytes")
+            raw = path.read_bytes()
+            if b"<!DOCTYPE" in raw or b"<!ENTITY" in raw:
+                raise ValueError("DTD/ENTITY is not allowed in JUnit XML")
+            try:
+                root = ET.fromstring(raw)
+            except ET.ParseError as error:
+                raise ValueError(f"malformed JUnit XML: {path.name}") from error
+            suite_name = root.attrib.get("name", "")
+            if suite_name == expected_suite or suite_name.endswith(expected_suite):
+                matched = (path, root)
+                break
+        if matched is None:
+            raise ValueError(f"JUnit suite is missing: {expected_suite}")
+        path, root = matched
+        testcases = list(root.iter("testcase"))
+        if len(testcases) > MAX_XML_TESTCASES:
+            raise ValueError("JUnit testcase limit exceeded")
+        def count(name: str) -> int:
+            try:
+                value = int(root.attrib.get(name, "0"))
+            except ValueError as error:
+                raise ValueError(f"invalid JUnit counter: {name}") from error
+            if value < 0 or value > MAX_XML_COUNTER:
+                raise ValueError(f"JUnit counter limit exceeded: {name}")
+            return value
+        tests = count("tests")
+        skipped = count("skipped")
+        failures = count("failures")
+        errors = count("errors")
+        if tests <= 0 or tests <= skipped or failures or errors:
+            raise ValueError("JUnit suite has no successful execution evidence")
+        workload_matches = []
+        for testcase in testcases:
+            canonical = self._canonical_testcase(testcase.attrib.get("classname", ""), testcase.attrib.get("name", ""))
+            if canonical == expected_workload:
+                workload_matches.append(testcase)
+        if len(workload_matches) != 1:
+            raise ValueError(f"workload testcase mismatch: {expected_workload}")
+        workload = workload_matches[0]
+        if list(workload) or workload.attrib.get("status") == "skipped":
+            raise ValueError("workload testcase failed or was skipped")
+        return {
+            "suite": expected_suite,
+            "tests": tests,
+            "skipped": skipped,
+            "failures": failures,
+            "errors": errors,
+            "workload_testcase": expected_workload,
+            "workload_tests": 1,
+            "source": path.name,
+        }
+
+    def _marker(self, evidence_dir: Path, started_ns: int) -> dict[str, Any]:
+        marker = evidence_dir / "startup.marker"
+        if not self._is_regular(marker):
+            raise ValueError("startup marker is missing")
+        stat = marker.stat()
+        if stat.st_mtime_ns < started_ns or stat.st_size > 1024:
+            raise ValueError("startup marker is stale or oversized")
+        content = marker.read_text(encoding="utf-8").strip()
+        if content != "Ignite node started OK":
+            raise ValueError("startup marker content mismatch")
+        return {"ready": True, "marker": content, "marker_source": "bounded_attempt_marker"}
+
+    def _pull_evidence(self, entry: dict[str, Any], platform: dict[str, Any], attempt_root: Path, attempt: int) -> tuple[str, dict[str, Any]]:
+        image_ref = f"{entry['image']}:{platform['tag']}"
+        architecture = str(platform["id"])
+        auth_config = os.environ.get("DOCKER_AUTH_CONFIG", "")
+        register_secret(auth_config)
+        env = os.environ.copy()
+        env.pop("DOCKER_AUTH_CONFIG", None)
+        env.pop("TESTCONTAINERS_REGISTRY_MIRROR", None)
+        config_dir: Path | None = None
+        try:
+            if auth_config:
+                config_dir = attempt_root / "docker-config"
+                config_dir.mkdir(mode=0o700)
+                config_file = config_dir / "config.json"
+                config_file.write_text(auth_config, encoding="utf-8")
+                config_file.chmod(0o600)
+                env["DOCKER_CONFIG"] = str(config_dir)
+            pull_started = time.monotonic()
+            pull = self._invoke(
+                ["docker", "pull", "--platform", f"linux/{architecture}", image_ref],
+                self.pull_timeout_seconds,
+                env,
+            )
+            pull_status = classify_failure(getattr(pull, "returncode", None), getattr(pull, "stdout", ""), getattr(pull, "stderr", ""))
+            if getattr(pull, "returncode", None) != 0:
+                return pull_status, {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": pull_status}
+            inspect = self._invoke(["docker", "image", "inspect", image_ref], self.pull_timeout_seconds, env)
+            try:
+                payload = json.loads(getattr(inspect, "stdout", ""))
+                image = payload[0] if isinstance(payload, list) else payload
+                image_id = str(image.get("Id", ""))
+                digests = image.get("RepoDigests", [])
+                digest = next((item.split("@", 1)[1] for item in digests if "@sha256:" in item), "")
+                observed_os = str(image.get("Os", ""))
+                observed_arch = canonical_architecture(image.get("Architecture"))
+            except (ValueError, IndexError, AttributeError, TypeError, json.JSONDecodeError) as error:
+                return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": _bounded(error)}
+            if not image_id.startswith("sha256:") or not digest.startswith("sha256:") or observed_os != "linux" or observed_arch != architecture:
+                return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "image platform or digest mismatch"}
+            context = self._invoke(["docker", "context", "show"], self.pull_timeout_seconds, env)
+            info = self._invoke(["docker", "info", "--format", "{{json .}}"], self.pull_timeout_seconds, env)
+            uname = self._invoke(["uname", "-m"], self.pull_timeout_seconds, env)
+            if getattr(context, "returncode", 1) != 0 or getattr(context, "stdout", "").strip() != "default":
+                return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "non-default Docker context"}
+            try:
+                info_payload = json.loads(getattr(info, "stdout", "{}"))
+            except json.JSONDecodeError:
+                info_payload = {}
+            daemon_arch = canonical_architecture(info_payload.get("Architecture"))
+            runner_arch = canonical_architecture(getattr(uname, "stdout", "").strip())
+            if daemon_arch != architecture or runner_arch != architecture:
+                return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "daemon or runner architecture mismatch"}
+            event = self._invoke(
+                ["docker", "events", "--since", "1s", "--filter", "type=image", "--filter", "event=pull", "--format", "{{json .}}"],
+                self.pull_timeout_seconds,
+                env,
+            )
+            event_id = ""
+            for line in getattr(event, "stdout", "").splitlines():
+                try:
+                    item = json.loads(line)
+                    event_id = str(item.get("id") or item.get("Actor", {}).get("ID") or "")
+                except json.JSONDecodeError:
+                    continue
+            if not event_id:
+                return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "pull event correlation is missing"}
+            return "success", {
+                "requested_ref": f"docker.io/{image_ref}",
+                "attempts": attempt,
+                "status": "success",
+                "cache": "up_to_date" if "already exists" in getattr(pull, "stdout", "").lower() else "pulled",
+                "event_id": event_id,
+                "image_id": image_id,
+                "digest": digest,
+                "elapsed_seconds": round(time.monotonic() - pull_started, 3),
+                "observed": {
+                    "runner_os": "linux",
+                    "runner_architecture": runner_arch,
+                    "daemon_os": str(info_payload.get("OperatingSystem", "linux")).lower() or "linux",
+                    "daemon_architecture": daemon_arch,
+                    "image_os": observed_os,
+                    "image_tag": str(platform["tag"]),
+                    "image_architecture": observed_arch,
+                },
+            }
+        finally:
+            if config_dir:
+                shutil.rmtree(config_dir, ignore_errors=True)
+
+    def _strict_platform(self, entry: dict[str, Any]) -> dict[str, Any] | None:
+        selected_id = entry.get("_selected_platform_id")
+        return platform_for_entry(entry, selected_id) if entry.get("platforms") else None
+
     def _run_family(self, entry: dict[str, Any]) -> dict[str, Any]:
         attempts: list[dict[str, Any]] = []
-        command = self._command(entry)
+        strict = bool(entry.get("executionEvidenceRequired"))
+        platform = self._strict_platform(entry)
+        if strict and platform is None:
+            return {"id": entry.get("id"), "server": entry.get("server"), "status": "blocked", "attempts": [], "error": "strict family has no platform"}
+        if platform is not None:
+            entry["_selected_platform_id"] = platform["id"]
+        if self._staging_root is None:
+            raise RuntimeError("runner staging root is not initialized")
         final_status = "blocked"
+        pull_evidence: dict[str, Any] | None = None
+        selected_tag = str(platform.get("tag")) if platform else str(entry["tag"])
+        selected_image = str(entry["image"])
         for attempt in range(1, self.max_attempts + 1):
-            started = time.monotonic()
-            result = self.command_runner(command, self.timeout_seconds)
-            elapsed = round(time.monotonic() - started, 3)
+            attempt_started = time.monotonic()
+            attempt_started_ns = time.time_ns()
+            evidence_dir = self._staging_root / f"{entry['id']}-{platform['id'] if platform else 'generic'}-{attempt}"
+            evidence_dir.mkdir(parents=True, exist_ok=False)
+            pull_status = "success"
+            if strict and pull_evidence is None:
+                pull_status, pull_evidence = self._pull_evidence(entry, platform, evidence_dir, attempt)
+                if pull_status != "success":
+                    attempts.append({"attempt": attempt, "status": pull_status, "pull": pull_evidence})
+                    final_status = pull_status
+                    self._elapsed_seconds += time.monotonic() - attempt_started
+                    if pull_status == "infrastructure_failure" and attempt < self.max_attempts:
+                        shutil.rmtree(evidence_dir, ignore_errors=True)
+                        continue
+                    break
+            command = self._command(entry, evidence_dir if strict else None)
+            test_timeout = self.timeout_seconds
+            if platform:
+                test_timeout = int(entry.get("platformTimeouts", {}).get(platform["id"], {}).get("testMinutes", self.timeout_seconds // 60)) * 60
+            result = self._invoke(command, test_timeout)
+            elapsed = round(time.monotonic() - attempt_started, 3)
+            self._elapsed_seconds += elapsed
             raw_stdout = getattr(result, "stdout", "")
             raw_stderr = getattr(result, "stderr", "")
-            stdout = _bounded(raw_stdout)
-            stderr = _bounded(raw_stderr)
             returncode = getattr(result, "returncode", None)
             status = _classify_command_result(returncode, raw_stdout, raw_stderr)
-            attempts.append(
-                {
-                    "attempt": attempt,
-                    "command": redact(" ".join(command)),
-                    "returncode": returncode,
-                    "elapsed_seconds": elapsed,
-                    "status": status,
-                    "stdout": stdout,
-                    "stderr": stderr,
-                }
-            )
+            attempt_result: dict[str, Any] = {"attempt": attempt, "command": redact(" ".join(command)), "returncode": returncode, "elapsed_seconds": elapsed, "status": status}
+            if strict and status == "success":
+                try:
+                    junit = self._parse_junit(entry, self._xml_candidates(attempt_started_ns, evidence_dir))
+                    startup = self._marker(evidence_dir, attempt_started_ns)
+                    attempt_result["junit"] = junit
+                    attempt_result["startup"] = startup
+                except (OSError, ValueError) as error:
+                    status = "blocked"
+                    attempt_result["status"] = status
+                    attempt_result["evidence_error"] = _bounded(error)
             final_status = status
             if status == "success":
+                if self.job_budget_seconds and self._elapsed_seconds > self.job_budget_seconds:
+                    final_status = status = "blocked"
+                    attempt_result["status"] = status
+                    attempt_result["evidence_error"] = "job budget exceeded"
+                attempts.append(attempt_result)
                 break
+            attempts.append(attempt_result)
+            if status not in {"infrastructure_failure"} or attempt >= self.max_attempts:
+                break
+            shutil.rmtree(evidence_dir, ignore_errors=True)
 
         result: dict[str, Any] = {
             "id": entry["id"],
             "server": entry["server"],
             "image": entry["image"],
-            "tag": entry["tag"],
+            "tag": selected_tag,
             "test_pattern": entry["testPattern"],
             "release_required": bool(entry["releaseRequired"]),
             "status": final_status,
             "attempts": attempts,
         }
+        if platform:
+            result.update(
+                {
+                    "schema_version": 2,
+                    "family_id": entry["id"],
+                    "platform_id": platform["id"],
+                    "image_ref": f"{selected_image}:{selected_tag}",
+                    "expected": {"os": platform.get("os"), "tag": selected_tag, "architecture": platform.get("architecture"), "runner": platform.get("runner")},
+                    "pull": pull_evidence or {"status": "blocked"},
+                    "observed": (pull_evidence or {}).get("observed", {}),
+                    "provenance": {"commit": self.commit, "ref": self.ref, "workflow_run_id": self.workflow_run_id},
+                }
+            )
+            successful_attempt = next((item for item in attempts if item.get("status") == "success"), None)
+            if successful_attempt:
+                result["junit"] = successful_attempt.get("junit")
+                result["startup"] = successful_attempt.get("startup")
         if final_status != "success":
             try:
                 result["diagnostics"] = self.diagnostic_runner(entry)
@@ -231,13 +699,21 @@ class GateRunner:
 
     def run(self) -> dict[str, Any]:
         self.report_dir.mkdir(parents=True, exist_ok=True)
+        self._staging_root = Path(tempfile.mkdtemp(prefix=".image-gate-", dir=self.report_dir))
         results = []
-        for entry in self.entries:
-            result = self._run_family(entry)
-            results.append(result)
-            (self.report_dir / f"{entry['id']}.json").write_text(
-                json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
-            )
+        try:
+            for entry in self.entries:
+                result = self._run_family(entry)
+                results.append(result)
+                payload = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+                if len(payload.encode("utf-8")) > MAX_FAMILY_JSON_BYTES:
+                    result = {"id": entry.get("id"), "server": entry.get("server"), "status": "blocked", "error": "family artifact limit exceeded", "attempts": []}
+                    results[-1] = result
+                    payload = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+                (self.report_dir / f"{entry['id']}.json").write_text(payload, encoding="utf-8")
+        finally:
+            shutil.rmtree(self._staging_root, ignore_errors=True)
+            self._staging_root = None
 
         counts = {status: sum(result["status"] == status for result in results) for status in (
             "success",
@@ -250,9 +726,13 @@ class GateRunner:
             result["release_required"] for result in results
         )
         summary: dict[str, Any] = {
-            "schema_version": 1,
+            "schema_version": 2,
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "manifest_digest": self.manifest_digest,
+            "workflow_run_id": self.workflow_run_id,
+            "commit": self.commit,
+            "ref": self.ref,
+            "scope": self.scope,
             "selected": selected,
             "success": counts["success"],
             "product_failure": counts["product_failure"],
@@ -262,10 +742,34 @@ class GateRunner:
             "release_gate": release_gate,
             "status": "success" if release_gate else ("skipped" if selected == 0 else "failed"),
             "results": results,
+            "platforms": [
+                {
+                    "platform_id": result.get("platform_id"),
+                    "status": result.get("status"),
+                    "family_artifact": f"{result.get('id')}.json",
+                    "expected": result.get("expected", {}),
+                    "observed": result.get("observed", {}),
+                    "pull": result.get("pull", {}),
+                    "junit": result.get("junit", {}),
+                    "startup": result.get("startup", {}),
+                }
+                for result in results
+            ],
         }
-        (self.report_dir / "summary.json").write_text(
-            json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
-        )
+        summary_text = json.dumps(summary, ensure_ascii=False, indent=2) + "\n"
+        if len(summary_text.encode("utf-8")) > MAX_SUMMARY_BYTES:
+            summary["status"] = "blocked"
+            summary["blocked"] = max(1, summary["blocked"])
+            summary["results"] = [{"id": item.get("id"), "status": item.get("status")} for item in results]
+            summary["platforms"] = [{"platform_id": item.get("platform_id"), "status": item.get("status")} for item in results]
+            summary_text = json.dumps(summary, ensure_ascii=False, indent=2) + "\n"
+        (self.report_dir / "summary.json").write_text(summary_text, encoding="utf-8")
+        artifact_bytes = sum(path.stat().st_size for path in self.report_dir.iterdir() if path.is_file())
+        if artifact_bytes > MAX_ARTIFACT_BYTES:
+            summary["status"] = "blocked"
+            summary["blocked"] = max(1, summary["blocked"])
+            summary["artifact_limit"] = MAX_ARTIFACT_BYTES
+            (self.report_dir / "summary.json").write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
         self._write_markdown(summary)
         return summary
 
@@ -295,7 +799,7 @@ class GateRunner:
 def _blocked_summary(report_dir: Path, errors: Sequence[str], manifest_path: Path) -> dict[str, Any]:
     report_dir.mkdir(parents=True, exist_ok=True)
     summary = {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "manifest_digest": hashlib.sha256(manifest_path.read_bytes()).hexdigest()
         if manifest_path.is_file()
@@ -310,6 +814,11 @@ def _blocked_summary(report_dir: Path, errors: Sequence[str], manifest_path: Pat
         "status": "blocked",
         "errors": list(errors),
         "results": [],
+        "workflow_run_id": os.environ.get("GITHUB_RUN_ID", "local"),
+        "commit": os.environ.get("GITHUB_SHA", "local"),
+        "ref": os.environ.get("GITHUB_REF", "local"),
+        "scope": "blocked",
+        "platforms": [],
     }
     (report_dir / "summary.json").write_text(
         json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
@@ -320,13 +829,20 @@ def _blocked_summary(report_dir: Path, errors: Sequence[str], manifest_path: Pat
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, default=MANIFEST)
-    parser.add_argument("--scope", choices=("changed", "full"), default="changed")
+    parser.add_argument("--scope", choices=("changed", "full", "family"), default="changed")
+    parser.add_argument("--family-id")
+    parser.add_argument("--platform-id")
+    parser.add_argument("--default-platform-id", default="amd64")
+    parser.add_argument("--require-selection", action="store_true")
     parser.add_argument("--changed-path", action="append", default=[])
     parser.add_argument("--changed-path-file", type=Path)
     parser.add_argument("--report-dir", type=Path, default=Path("build/reports/testcontainers-image-gate"))
     parser.add_argument("--gradle-task", default="./gradlew :bluetape4k-testcontainers:test")
     parser.add_argument("--max-attempts", type=int, default=1)
+    parser.add_argument("--pull-timeout-seconds", type=int, default=60)
     parser.add_argument("--timeout-minutes", type=int, default=30)
+    parser.add_argument("--diagnostic-timeout-seconds", type=int, default=30)
+    parser.add_argument("--job-budget-minutes", type=int)
     return parser.parse_args(argv)
 
 
@@ -350,7 +866,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         changed_paths.update(
             line.strip() for line in args.changed_path_file.read_text(encoding="utf-8").splitlines() if line.strip()
         )
-    selected = select_entries(entries, changed_paths, scope=args.scope)
+    try:
+        selected = select_entries(
+            entries,
+            changed_paths,
+            scope=args.scope,
+            family_id=args.family_id,
+            platform_id=args.platform_id,
+            require_selection=args.require_selection,
+            default_platform_id=args.default_platform_id,
+        )
+    except (ValueError, SelectionError) as error:
+        _blocked_summary(args.report_dir, [str(error)], args.manifest)
+        print(f"BLOCKED: {error}", file=sys.stderr)
+        return 2
     summary = GateRunner(
         selected,
         args.report_dir,
@@ -358,6 +887,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         max_attempts=args.max_attempts,
         timeout_minutes=args.timeout_minutes,
         manifest_path=args.manifest,
+        pull_timeout_seconds=args.pull_timeout_seconds,
+        diagnostic_timeout_seconds=args.diagnostic_timeout_seconds,
+        job_budget_minutes=args.job_budget_minutes,
+        scope=args.scope,
     ).run()
     print(json.dumps({key: summary[key] for key in (
         "status", "coverage", "product_failure", "infrastructure_failure", "blocked", "release_gate"

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -529,8 +529,13 @@ class GateRunner:
         auth_config = os.environ.get("DOCKER_AUTH_CONFIG", "")
         register_secret(auth_config)
         env = os.environ.copy()
-        env.pop("DOCKER_AUTH_CONFIG", None)
-        env.pop("TESTCONTAINERS_REGISTRY_MIRROR", None)
+        for key in (
+            "DOCKER_AUTH_CONFIG",
+            "TESTCONTAINERS_REGISTRY_MIRROR",
+            "DOCKER_HOST",
+            "DOCKER_CONTEXT",
+        ):
+            env.pop(key, None)
         config_dir: Path | None = None
         try:
             if auth_config:
@@ -575,8 +580,23 @@ class GateRunner:
             runner_arch = canonical_architecture(getattr(uname, "stdout", "").strip())
             if daemon_arch != architecture or runner_arch != architecture:
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "daemon or runner architecture mismatch"}
+            event_since = str(int(pull_started))
+            event_until = str(int(time.time()) + 2)
             event = self._invoke(
-                ["docker", "events", "--since", "1s", "--filter", "type=image", "--filter", "event=pull", "--format", "{{json .}}"],
+                [
+                    "docker",
+                    "events",
+                    "--since",
+                    event_since,
+                    "--until",
+                    event_until,
+                    "--filter",
+                    "type=image",
+                    "--filter",
+                    "event=pull",
+                    "--format",
+                    "{{json .}}",
+                ],
                 self.pull_timeout_seconds,
                 env,
             )

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -646,20 +646,22 @@ class GateRunner:
                     item = json.loads(line)
                     actor = item.get("Actor", {})
                     attributes = actor.get("Attributes", {}) if isinstance(actor, dict) else {}
+                    actor_id = str(actor.get("ID") or "") if isinstance(actor, dict) else ""
                     refs = {
                         str(item.get("from") or ""),
                         str(attributes.get("name") or ""),
                         str(attributes.get("image") or ""),
+                        actor_id,
                     }
                     ids = {
                         str(item.get("id") or ""),
-                        str(actor.get("ID") or "") if isinstance(actor, dict) else "",
+                        actor_id,
                     }
                     matching_ref = next((value for value in refs if value in expected_refs), "")
                     matching_id = next((value for value in ids if value in expected_ids), "")
                     if not matching_ref and not matching_id:
                         continue
-                    event_id = str(item.get("id") or actor.get("ID") or "")
+                    event_id = str(item.get("id") or actor_id)
                     event_ref = matching_ref
                     event_image_id = matching_id
                     break

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -554,6 +554,7 @@ class GateRunner:
         image_ref = f"{entry['image']}:{platform['tag']}"
         architecture = str(platform["id"])
         auth_config = os.environ.get("DOCKER_AUTH_CONFIG", "")
+        local_socket = os.environ.get("DOCKER_HOST", "")
         register_secret(auth_config)
         env = os.environ.copy()
         for key in (
@@ -565,6 +566,11 @@ class GateRunner:
             env.pop(key, None)
         # 호출자가 선택한 context는 무시하고 저장소가 허용한 기본 Unix socket 경계만 사용한다.
         env["DOCKER_CONTEXT"] = "default"
+        if (
+            local_socket.startswith("unix://")
+            and os.environ.get("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE") == "/var/run/docker.sock"
+        ):
+            env["DOCKER_HOST"] = local_socket
         config_dir: Path | None = None
         try:
             if auth_config:

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -352,6 +352,15 @@ class GateRunner:
             "DOCKER_CONTEXT",
         ):
             env.pop(key, None)
+        # Local Colima is the only approved host override: it is a Unix socket
+        # paired with Testcontainers' canonical in-container socket. Never
+        # carry TCP endpoints or arbitrary context selections into the gate.
+        local_socket = os.environ.get("DOCKER_HOST", "")
+        if (
+            local_socket.startswith("unix://")
+            and os.environ.get("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE") == "/var/run/docker.sock"
+        ):
+            env["DOCKER_HOST"] = local_socket
         return env
 
     def _command(self, entry: dict[str, Any], evidence_dir: Path | None = None) -> list[str]:

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -233,12 +233,28 @@ def verify_release_summary(
         observed = result.get("observed", {})
         pull = result.get("pull", {})
         junit = result.get("junit", {})
-        if expected.get("tag") != expected_tag or observed.get("image_tag") not in {expected_tag, None}:
+        image_ref = str(result.get("image_ref", ""))
+        if expected.get("tag") != expected_tag or observed.get("image_tag") != expected_tag:
             errors.append("expected/observed tag mismatch")
-        if expected.get("architecture") != expected_architecture or observed.get("image_architecture") not in {expected_architecture, None}:
+        if expected.get("architecture") != expected_architecture or observed.get("image_architecture") != expected_architecture:
             errors.append("expected/observed architecture mismatch")
-        if not pull.get("event_id") or not str(pull.get("digest", "")).startswith("sha256:"):
+        if expected.get("os") != "linux" or observed.get("image_os") != "linux":
+            errors.append("expected/observed OS mismatch")
+        if observed.get("runner_os") != "linux" or observed.get("daemon_os") != "linux":
+            errors.append("runner/daemon OS evidence is required")
+        if pull.get("status") != "success":
+            errors.append("pull status must be success")
+        if pull.get("event_ref") not in {image_ref, f"docker.io/{image_ref}"}:
+            errors.append("pull event requested-ref correlation is required")
+        if (
+            not pull.get("event_id")
+            or not str(pull.get("image_id", "")).startswith("sha256:")
+            or not str(pull.get("digest", "")).startswith("sha256:")
+        ):
             errors.append("pull event and digest evidence are required")
+        workload_image = result.get("workload_image", {})
+        if workload_image.get("image_id") != pull.get("image_id"):
+            errors.append("workload image must match pulled image")
         if junit.get("workload_tests") != 1 or junit.get("skipped", 1) != 0 or junit.get("failures", 1) != 0 or junit.get("errors", 1) != 0:
             errors.append("successful workload JUnit evidence is required")
         if result.get("family_artifact") in {None, ""}:
@@ -388,7 +404,9 @@ class GateRunner:
         return text
 
     def _collect_diagnostics(self, entry: dict[str, Any]) -> dict[str, str]:
-        image_ref = f"{entry['image']}:{entry['tag']}"
+        platform = self._strict_platform(entry)
+        selected_tag = str(platform["tag"]) if platform else str(entry["tag"])
+        image_ref = f"{entry['image']}:{selected_tag}"
         commands: list[tuple[str, list[str]]] = [
             (
                 "docker_ps",
@@ -523,6 +541,15 @@ class GateRunner:
             raise ValueError("startup marker content mismatch")
         return {"ready": True, "marker": content, "marker_source": "bounded_attempt_marker"}
 
+    def _workload_image(self, evidence_dir: Path) -> dict[str, Any]:
+        receipt = evidence_dir / "workload.image-id"
+        if not self._is_regular(receipt) or receipt.stat().st_size > 256:
+            raise ValueError("workload image receipt is missing or oversized")
+        image_id = receipt.read_text(encoding="utf-8").strip()
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", image_id):
+            raise ValueError("workload image receipt is not a Docker image ID")
+        return {"image_id": image_id, "source": receipt.name}
+
     def _pull_evidence(self, entry: dict[str, Any], platform: dict[str, Any], attempt_root: Path, attempt: int) -> tuple[str, dict[str, Any]]:
         image_ref = f"{entry['image']}:{platform['tag']}"
         architecture = str(platform["id"])
@@ -545,6 +572,7 @@ class GateRunner:
                 config_file.write_text(auth_config, encoding="utf-8")
                 config_file.chmod(0o600)
                 env["DOCKER_CONFIG"] = str(config_dir)
+            pull_started_wall = time.time()
             pull_started = time.monotonic()
             pull = self._invoke(
                 ["docker", "pull", "--platform", f"linux/{architecture}", image_ref],
@@ -580,7 +608,7 @@ class GateRunner:
             runner_arch = canonical_architecture(getattr(uname, "stdout", "").strip())
             if daemon_arch != architecture or runner_arch != architecture:
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "daemon or runner architecture mismatch"}
-            event_since = str(int(pull_started))
+            event_since = str(max(0, int(pull_started_wall) - 1))
             event_until = str(int(time.time()) + 2)
             event = self._invoke(
                 [
@@ -601,13 +629,35 @@ class GateRunner:
                 env,
             )
             event_id = ""
+            event_ref = ""
+            event_image_id = ""
+            expected_refs = {image_ref, f"docker.io/{image_ref}"}
+            expected_ids = {image_id, digest}
             for line in getattr(event, "stdout", "").splitlines():
                 try:
                     item = json.loads(line)
-                    event_id = str(item.get("id") or item.get("Actor", {}).get("ID") or "")
+                    actor = item.get("Actor", {})
+                    attributes = actor.get("Attributes", {}) if isinstance(actor, dict) else {}
+                    refs = {
+                        str(item.get("from") or ""),
+                        str(attributes.get("name") or ""),
+                        str(attributes.get("image") or ""),
+                    }
+                    ids = {
+                        str(item.get("id") or ""),
+                        str(actor.get("ID") or "") if isinstance(actor, dict) else "",
+                    }
+                    matching_ref = next((value for value in refs if value in expected_refs), "")
+                    matching_id = next((value for value in ids if value in expected_ids), "")
+                    if not matching_ref and not matching_id:
+                        continue
+                    event_id = str(item.get("id") or actor.get("ID") or "")
+                    event_ref = matching_ref
+                    event_image_id = matching_id
+                    break
                 except json.JSONDecodeError:
                     continue
-            if not event_id:
+            if getattr(event, "returncode", 0) != 0 or not event_id:
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "pull event correlation is missing"}
             return "success", {
                 "requested_ref": f"docker.io/{image_ref}",
@@ -615,6 +665,8 @@ class GateRunner:
                 "status": "success",
                 "cache": "up_to_date" if "already exists" in getattr(pull, "stdout", "").lower() else "pulled",
                 "event_id": event_id,
+                "event_ref": event_ref or None,
+                "event_image_id": event_image_id or None,
                 "image_id": image_id,
                 "digest": digest,
                 "elapsed_seconds": round(time.monotonic() - pull_started, 3),
@@ -648,6 +700,7 @@ class GateRunner:
             raise RuntimeError("runner staging root is not initialized")
         final_status = "blocked"
         pull_evidence: dict[str, Any] | None = None
+        workload_image: dict[str, Any] | None = None
         selected_tag = str(platform.get("tag")) if platform else str(entry["tag"])
         selected_image = str(entry["image"])
         for attempt in range(1, self.max_attempts + 1):
@@ -682,8 +735,12 @@ class GateRunner:
                 try:
                     junit = self._parse_junit(entry, self._xml_candidates(attempt_started_ns, evidence_dir))
                     startup = self._marker(evidence_dir, attempt_started_ns)
+                    workload_image = self._workload_image(evidence_dir)
+                    if pull_evidence and workload_image["image_id"] != pull_evidence.get("image_id"):
+                        raise ValueError("workload image does not match pulled image")
                     attempt_result["junit"] = junit
                     attempt_result["startup"] = startup
+                    attempt_result["workload_image"] = workload_image
                 except (OSError, ValueError) as error:
                     status = "blocked"
                     attempt_result["status"] = status
@@ -721,6 +778,7 @@ class GateRunner:
                     "expected": {"os": platform.get("os"), "tag": selected_tag, "architecture": platform.get("architecture"), "runner": platform.get("runner")},
                     "pull": pull_evidence or {"status": "blocked"},
                     "observed": (pull_evidence or {}).get("observed", {}),
+                    "workload_image": workload_image or {},
                     "provenance": {"commit": self.commit, "ref": self.ref, "workflow_run_id": self.workflow_run_id},
                 }
             )
@@ -737,7 +795,8 @@ class GateRunner:
 
     def run(self) -> dict[str, Any]:
         self.report_dir.mkdir(parents=True, exist_ok=True)
-        self._staging_root = Path(tempfile.mkdtemp(prefix=".image-gate-", dir=self.report_dir))
+        # Secret-bearing Docker config lives outside the artifact tree, including on timeout paths.
+        self._staging_root = Path(tempfile.mkdtemp(prefix=".image-gate-"))
         results = []
         try:
             for entry in self.entries:
@@ -784,12 +843,14 @@ class GateRunner:
                 {
                     "platform_id": result.get("platform_id"),
                     "status": result.get("status"),
+                    "image_ref": result.get("image_ref"),
                     "family_artifact": f"{result.get('id')}.json",
                     "expected": result.get("expected", {}),
                     "observed": result.get("observed", {}),
                     "pull": result.get("pull", {}),
                     "junit": result.get("junit", {}),
                     "startup": result.get("startup", {}),
+                    "workload_image": result.get("workload_image", {}),
                 }
                 for result in results
             ],

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -365,6 +365,9 @@ class GateRunner:
                 "--tests",
                 workload,
                 "--no-configuration-cache",
+                # Strict workload evidence must be produced by this attempt;
+                # never accept a previously cached Gradle test result.
+                "--rerun-tasks",
                 "-x",
                 ":bluetape4k-mock-web-server:jibDockerBuild",
                 "-x",
@@ -413,7 +416,9 @@ class GateRunner:
                 ["docker", "ps", "-a", "--no-trunc", "--filter", f"ancestor={image_ref}"],
             ),
             ("docker_inspect", ["docker", "inspect", image_ref]),
-            ("docker_events", ["timeout", "10s", "docker", "events", "--since", "5m"]),
+            # _invoke already bounds and process-group-terminates diagnostics; do
+            # not depend on GNU `timeout`, which is absent on macOS runners.
+            ("docker_events", ["docker", "events", "--since", "5m"]),
         ]
         if entry["server"] == "K3sServer":
             commands.extend(
@@ -683,7 +688,12 @@ class GateRunner:
                 "observed": {
                     "runner_os": "linux",
                     "runner_architecture": runner_arch,
-                    "daemon_os": str(info_payload.get("OperatingSystem", "linux")).lower() or "linux",
+                    # Docker's OperatingSystem field is a distro description
+                    # (for example, "Ubuntu 24.04.4 LTS"), not an OS family.
+                    # Keep the contract's normalized family value here and
+                    # preserve the raw description separately for diagnostics.
+                    "daemon_os": "linux",
+                    "daemon_os_description": str(info_payload.get("OperatingSystem", "")).lower(),
                     "daemon_architecture": daemon_arch,
                     "image_os": observed_os,
                     "image_tag": str(platform["tag"]),

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -324,6 +324,20 @@ class GateRunner:
             # Existing fake runners intentionally expose the old two-argument contract.
             return self.command_runner(command, timeout_seconds)
 
+    @staticmethod
+    def _sanitized_runtime_env() -> dict[str, str]:
+        """Keep registry credentials and Docker overrides out of Gradle and diagnostics."""
+
+        env = os.environ.copy()
+        for key in (
+            "DOCKER_AUTH_CONFIG",
+            "TESTCONTAINERS_REGISTRY_MIRROR",
+            "DOCKER_HOST",
+            "DOCKER_CONTEXT",
+        ):
+            env.pop(key, None)
+        return env
+
     def _command(self, entry: dict[str, Any], evidence_dir: Path | None = None) -> list[str]:
         strict = bool(entry.get("executionEvidenceRequired"))
         if strict and entry.get("_selected_platform_id") == "arm64" and evidence_dir is not None:
@@ -399,7 +413,11 @@ class GateRunner:
             )
         diagnostics: dict[str, str] = {}
         for label, command in commands:
-            result = self._invoke(command, min(self.diagnostic_timeout_seconds, 60))
+            result = self._invoke(
+                command,
+                min(self.diagnostic_timeout_seconds, 60),
+                self._sanitized_runtime_env(),
+            )
             diagnostics[label] = self._diagnostic_bounded(
                 f"exit={getattr(result, 'returncode', None)}\n"
                 f"stdout={getattr(result, 'stdout', '')}\n"
@@ -632,7 +650,7 @@ class GateRunner:
             test_timeout = self.timeout_seconds
             if platform:
                 test_timeout = int(entry.get("platformTimeouts", {}).get(platform["id"], {}).get("testMinutes", self.timeout_seconds // 60)) * 60
-            result = self._invoke(command, test_timeout)
+            result = self._invoke(command, test_timeout, self._sanitized_runtime_env())
             elapsed = round(time.monotonic() - attempt_started, 3)
             self._elapsed_seconds += elapsed
             raw_stdout = getattr(result, "stdout", "")

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -563,6 +563,8 @@ class GateRunner:
             "DOCKER_CONTEXT",
         ):
             env.pop(key, None)
+        # 호출자가 선택한 context는 무시하고 저장소가 허용한 기본 Unix socket 경계만 사용한다.
+        env["DOCKER_CONTEXT"] = "default"
         config_dir: Path | None = None
         try:
             if auth_config:

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -221,7 +221,7 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             if command[:3] == ["docker", "image", "inspect"]:
                 return SimpleNamespace(
                     returncode=0,
-                    stdout=json.dumps([{"Id": "sha256:image", "RepoDigests": ["apacheignite/ignite@sha256:digest"], "Os": "linux", "Architecture": "amd64"}]),
+                    stdout=json.dumps([{"Id": "sha256:" + "a" * 64, "RepoDigests": ["apacheignite/ignite@sha256:" + "b" * 64], "Os": "linux", "Architecture": "amd64"}]),
                     stderr="",
                 )
             if command[:3] == ["docker", "context", "show"]:
@@ -231,10 +231,19 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             if command[:2] == ["uname", "-m"]:
                 return SimpleNamespace(returncode=0, stdout="x86_64\n", stderr="")
             if command[:2] == ["docker", "events"]:
-                return SimpleNamespace(returncode=0, stdout=json.dumps({"id": "pull-event-1"}) + "\n", stderr="")
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=json.dumps({
+                        "id": "sha256:" + "a" * 64,
+                        "from": "apacheignite/ignite:2.18.0",
+                        "Actor": {"ID": "sha256:" + "a" * 64, "Attributes": {"name": "apacheignite/ignite:2.18.0"}},
+                    }) + "\n",
+                    stderr="",
+                )
             evidence = next((Path(part.split("=", 1)[1]) for part in command if part.startswith("-Dtestcontainers.image-gate.evidence-dir=")), None)
             assert evidence is not None
             evidence.joinpath("startup.marker").write_text("Ignite node started OK\n", encoding="utf-8")
+            evidence.joinpath("workload.image-id").write_text("sha256:" + "a" * 64 + "\n", encoding="utf-8")
             evidence.joinpath("TEST-Ignite2ServerTest.xml").write_text(
                 '<testsuite name="io.bluetape4k.testcontainers.storage.Ignite2ServerTest" tests="1" skipped="0" failures="0" errors="0">'
                 '<testcase classname="io.bluetape4k.testcontainers.storage.Ignite2ServerTest" name="representativeStartupAndWorkload"/>'
@@ -254,10 +263,16 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             result = summary["results"][0]
             self.assertEqual("success", result["status"])
             self.assertEqual("amd64", result["platform_id"])
-            self.assertEqual("pull-event-1", result["pull"]["event_id"])
+            self.assertEqual("sha256:" + "a" * 64, result["pull"]["event_id"])
+            self.assertEqual("apacheignite/ignite:2.18.0", result["pull"]["event_ref"])
             self.assertEqual(1, result["junit"]["workload_tests"])
             self.assertTrue(result["startup"]["ready"])
             self.assertEqual(1, sum(command[:2] == ["docker", "pull"] for command in calls))
+            event_command = next(command for command in calls if command[:2] == ["docker", "events"])
+            self.assertIn("--since", event_command)
+            self.assertIn("--until", event_command)
+            since = int(event_command[event_command.index("--since") + 1])
+            self.assertGreater(since, 1_000_000_000)
             event_command = next(command for command in calls if command[:2] == ["docker", "events"])
             self.assertIn("--since", event_command)
             self.assertIn("--until", event_command)
@@ -300,10 +315,15 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             "blocked": 0,
             "product_failure": 0,
             "infrastructure_failure": 0,
-            "platforms": [{"platform_id": "arm64", "status": "success", "expected": {"tag": "2.18.0-arm64", "architecture": "arm64"}, "observed": {"image_tag": "2.18.0-arm64", "image_architecture": "arm64"}, "pull": {}, "junit": {}, "family_artifact": "ignite2.json"}],
+            "platforms": [{"platform_id": "arm64", "status": "success", "image_ref": "apacheignite/ignite:2.18.0-arm64", "expected": {"os": "linux", "tag": "2.18.0-arm64", "architecture": "arm64"}, "observed": {"image_tag": "2.18.0-arm64", "image_architecture": "arm64", "image_os": "linux", "runner_os": "linux", "daemon_os": "linux"}, "pull": {}, "junit": {}, "workload_image": {}, "family_artifact": "ignite2.json"}],
         }
         errors = verify_release_summary(summary, expected_coverage="1/1", platform_id="arm64", expected_tag="2.18.0-arm64", expected_architecture="arm64")
         self.assertIn("pull event and digest evidence are required", errors)
+        summary["platforms"][0]["observed"].pop("image_tag")
+        self.assertIn(
+            "expected/observed tag mismatch",
+            verify_release_summary(summary, expected_coverage="1/1", platform_id="arm64", expected_tag="2.18.0-arm64", expected_architecture="arm64"),
+        )
 
     def test_budget_formula_and_52_family_artifact_guard(self) -> None:
         self.assertEqual(

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -309,6 +309,76 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             ).run()["results"][0]
             self.assertEqual("blocked", result["status"])
 
+    def test_strict_pull_infrastructure_failure_retries_the_complete_pull_chain(self) -> None:
+        calls: list[list[str]] = []
+        pull_attempts = 0
+
+        def command_runner(command: list[str], timeout_seconds: int, **_: object) -> SimpleNamespace:
+            nonlocal pull_attempts
+            calls.append(command)
+            if command[:2] == ["docker", "pull"]:
+                pull_attempts += 1
+                if pull_attempts == 1:
+                    return SimpleNamespace(returncode=1, stdout="", stderr="connection refused")
+                return SimpleNamespace(returncode=0, stdout="Status: Downloaded newer image", stderr="")
+            if command[:3] == ["docker", "image", "inspect"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=json.dumps([{"Id": "sha256:" + "a" * 64, "RepoDigests": ["apacheignite/ignite@sha256:" + "b" * 64], "Os": "linux", "Architecture": "amd64"}]),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "context", "show"]:
+                return SimpleNamespace(returncode=0, stdout="default\n", stderr="")
+            if command[:2] == ["docker", "info"]:
+                return SimpleNamespace(returncode=0, stdout=json.dumps({"Architecture": "amd64"}), stderr="")
+            if command[:2] == ["uname", "-m"]:
+                return SimpleNamespace(returncode=0, stdout="x86_64\n", stderr="")
+            if command[:2] == ["docker", "events"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=json.dumps({
+                        "id": "sha256:" + "a" * 64,
+                        "from": "apacheignite/ignite:2.18.0",
+                        "Actor": {"ID": "sha256:" + "a" * 64, "Attributes": {"name": "apacheignite/ignite:2.18.0"}},
+                    }) + "\n",
+                    stderr="",
+                )
+            evidence = next((Path(part.split("=", 1)[1]) for part in command if part.startswith("-Dtestcontainers.image-gate.evidence-dir=")), None)
+            assert evidence is not None
+            evidence.joinpath("startup.marker").write_text("Ignite node started OK\n", encoding="utf-8")
+            evidence.joinpath("workload.image-id").write_text("sha256:" + "a" * 64 + "\n", encoding="utf-8")
+            evidence.joinpath("TEST-Ignite2ServerTest.xml").write_text(
+                '<testsuite name="io.bluetape4k.testcontainers.storage.Ignite2ServerTest" tests="1" skipped="0" failures="0" errors="0">'
+                '<testcase classname="io.bluetape4k.testcontainers.storage.Ignite2ServerTest" name="representativeStartupAndWorkload"/>'
+                '</testsuite>',
+                encoding="utf-8",
+            )
+            return SimpleNamespace(returncode=0, stdout="BUILD SUCCESSFUL", stderr="")
+
+        with tempfile.TemporaryDirectory() as directory:
+            result = GateRunner(
+                [strict_entry()],
+                Path(directory),
+                command_runner=command_runner,
+                max_attempts=2,
+                scope="family",
+            ).run()["results"][0]
+
+        self.assertEqual("success", result["status"])
+        self.assertEqual(2, pull_attempts)
+        self.assertEqual(2, len(result["attempts"]))
+        self.assertEqual("infrastructure_failure", result["attempts"][0]["status"])
+        self.assertEqual("success", result["attempts"][1]["status"])
+        self.assertEqual(
+            1,
+            sum(
+                command and command[0] == "./gradlew" and any(
+                    part.startswith("-Dtestcontainers.image-gate.evidence-dir=") for part in command
+                )
+                for command in calls
+            ),
+        )
+
     def test_arm64_strict_command_is_fixed_and_excludes_mock_jib(self) -> None:
         value = strict_entry()
         value["platforms"] = [

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -15,6 +15,7 @@ from scripts.run_testcontainers_image_gate import (
     GateRunner,
     classify_failure,
     redact,
+    register_secret,
     verify_release_summary,
     worst_case_budget_minutes,
 )
@@ -219,6 +220,25 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
         self.assertNotIn("abc123", safe)
         self.assertIn("<redacted>", safe)
 
+    def test_nested_docker_auth_values_are_registered_for_redaction(self) -> None:
+        register_secret(
+            json.dumps(
+                {
+                    "auths": {
+                        "registry.example": {
+                            "auth": "dXNlcjpwYXNz",
+                            "username": "user",
+                            "password": "pass",
+                        }
+                    }
+                }
+            )
+        )
+        safe = redact("auth=dXNlcjpwYXNz username=user password=pass user:pass")
+        self.assertNotIn("dXNlcjpwYXNz", safe)
+        self.assertNotIn("user", safe)
+        self.assertNotIn("pass", safe)
+
     def test_summary_json_is_machine_readable(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             summary = GateRunner(
@@ -292,6 +312,17 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             self.assertEqual(1, result["junit"]["workload_tests"])
             self.assertTrue(result["startup"]["ready"])
             self.assertEqual(1, sum(command[:2] == ["docker", "pull"] for command in calls))
+            self.assertEqual(
+                [],
+                verify_release_summary(
+                    summary,
+                    expected_coverage="1/1",
+                    platform_id="amd64",
+                    expected_tag="2.18.0",
+                    expected_architecture="amd64",
+                    report_dir=Path(directory),
+                ),
+            )
             event_command = next(command for command in calls if command[:2] == ["docker", "events"])
             self.assertIn("--since", event_command)
             self.assertIn("--until", event_command)

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -56,6 +57,24 @@ def strict_entry() -> dict[str, object]:
 
 
 class TestRunTestcontainersImageGate(unittest.TestCase):
+    def test_runtime_environment_removes_docker_credentials_and_overrides(self) -> None:
+        original = {
+            key: os.environ.get(key)
+            for key in ("DOCKER_AUTH_CONFIG", "TESTCONTAINERS_REGISTRY_MIRROR", "DOCKER_HOST", "DOCKER_CONTEXT")
+        }
+        try:
+            for key in original:
+                os.environ[key] = "secret-or-override"
+            sanitized = GateRunner._sanitized_runtime_env()
+            for key in original:
+                self.assertNotIn(key, sanitized)
+        finally:
+            for key, value in original.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
     def test_successful_family_records_command_and_coverage(self) -> None:
         calls: list[list[str]] = []
 
@@ -239,6 +258,9 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             self.assertEqual(1, result["junit"]["workload_tests"])
             self.assertTrue(result["startup"]["ready"])
             self.assertEqual(1, sum(command[:2] == ["docker", "pull"] for command in calls))
+            event_command = next(command for command in calls if command[:2] == ["docker", "events"])
+            self.assertIn("--since", event_command)
+            self.assertIn("--until", event_command)
 
     def test_strict_family_without_marker_is_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -410,6 +410,8 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
         }
         errors = verify_release_summary(summary, expected_coverage="1/1", platform_id="arm64", expected_tag="2.18.0-arm64", expected_architecture="arm64")
         self.assertIn("pull event and digest evidence are required", errors)
+        self.assertIn("expected runner label mismatch", errors)
+        self.assertIn("runner/daemon architecture evidence is required", errors)
         summary["platforms"][0]["observed"].pop("image_tag")
         self.assertIn(
             "expected/observed tag mismatch",

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -302,6 +302,7 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
         self.assertEqual("-Dtestcontainers.image-gate.evidence-dir", command[1].split("=", 1)[0])
         self.assertIn("--tests", command)
         self.assertIn("io.bluetape4k.testcontainers.storage.Ignite2ServerTest.representativeStartupAndWorkload", command)
+        self.assertIn("--rerun-tasks", command)
         self.assertEqual(2, command.count("-x"))
         self.assertNotIn("jibDockerBuild", command[:3])
 

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -75,6 +75,26 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
                 else:
                     os.environ[key] = value
 
+    def test_runtime_environment_preserves_only_managed_local_unix_socket(self) -> None:
+        original = {
+            key: os.environ.get(key)
+            for key in ("DOCKER_HOST", "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE")
+        }
+        try:
+            os.environ["DOCKER_HOST"] = "unix:///Users/test/.colima/default/docker.sock"
+            os.environ["TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE"] = "/var/run/docker.sock"
+            sanitized = GateRunner._sanitized_runtime_env()
+            self.assertEqual(
+                "unix:///Users/test/.colima/default/docker.sock",
+                sanitized.get("DOCKER_HOST"),
+            )
+        finally:
+            for key, value in original.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
     def test_successful_family_records_command_and_coverage(self) -> None:
         calls: list[list[str]] = []
 

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -13,6 +13,8 @@ from scripts.run_testcontainers_image_gate import (
     GateRunner,
     classify_failure,
     redact,
+    verify_release_summary,
+    worst_case_budget_minutes,
 )
 
 
@@ -30,6 +32,27 @@ def entry(server: str = "FlociServer") -> dict[str, object]:
         "diagnostics": ["docker_inspect", "docker_logs", "docker_events"],
         "releaseRequired": True,
     }
+
+
+def strict_entry() -> dict[str, object]:
+    value = entry("Ignite2Server")
+    value.update(
+        {
+            "id": "ignite2",
+            "image": "apacheignite/ignite",
+            "tag": "2.18.0",
+            "testPattern": "io.bluetape4k.testcontainers.storage.Ignite2ServerTest",
+            "workloadTestPattern": "io.bluetape4k.testcontainers.storage.Ignite2ServerTest.representativeStartupAndWorkload",
+            "executionEvidenceRequired": True,
+            "pullEvidenceRequired": True,
+            "platforms": [
+                {"id": "amd64", "os": "linux", "architecture": "amd64", "tag": "2.18.0", "runner": "ubuntu-24.04"},
+            ],
+            "defaultPlatformId": "amd64",
+            "platformTimeouts": {"amd64": {"testMinutes": 6, "clientConnectSeconds": 30, "clientRequestSeconds": 30}},
+        }
+    )
+    return value
 
 
 class TestRunTestcontainersImageGate(unittest.TestCase):
@@ -168,6 +191,142 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             ).run()
             read_back = json.loads((Path(directory) / "summary.json").read_text())
             self.assertEqual(summary["manifest_digest"], read_back["manifest_digest"])
+
+    def test_strict_family_requires_pull_platform_and_workload_evidence(self) -> None:
+        calls: list[list[str]] = []
+
+        def command_runner(command: list[str], timeout_seconds: int, **_: object) -> SimpleNamespace:
+            calls.append(command)
+            if command[:2] == ["docker", "pull"]:
+                return SimpleNamespace(returncode=0, stdout="Status: Downloaded newer image", stderr="")
+            if command[:3] == ["docker", "image", "inspect"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=json.dumps([{"Id": "sha256:image", "RepoDigests": ["apacheignite/ignite@sha256:digest"], "Os": "linux", "Architecture": "amd64"}]),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "context", "show"]:
+                return SimpleNamespace(returncode=0, stdout="default\n", stderr="")
+            if command[:2] == ["docker", "info"]:
+                return SimpleNamespace(returncode=0, stdout=json.dumps({"Architecture": "amd64"}), stderr="")
+            if command[:2] == ["uname", "-m"]:
+                return SimpleNamespace(returncode=0, stdout="x86_64\n", stderr="")
+            if command[:2] == ["docker", "events"]:
+                return SimpleNamespace(returncode=0, stdout=json.dumps({"id": "pull-event-1"}) + "\n", stderr="")
+            evidence = next((Path(part.split("=", 1)[1]) for part in command if part.startswith("-Dtestcontainers.image-gate.evidence-dir=")), None)
+            assert evidence is not None
+            evidence.joinpath("startup.marker").write_text("Ignite node started OK\n", encoding="utf-8")
+            evidence.joinpath("TEST-Ignite2ServerTest.xml").write_text(
+                '<testsuite name="io.bluetape4k.testcontainers.storage.Ignite2ServerTest" tests="1" skipped="0" failures="0" errors="0">'
+                '<testcase classname="io.bluetape4k.testcontainers.storage.Ignite2ServerTest" name="representativeStartupAndWorkload"/>'
+                '</testsuite>',
+                encoding="utf-8",
+            )
+            return SimpleNamespace(returncode=0, stdout="BUILD SUCCESSFUL", stderr="")
+
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [strict_entry()],
+                Path(directory),
+                command_runner=command_runner,
+                max_attempts=1,
+                scope="family",
+            ).run()
+            result = summary["results"][0]
+            self.assertEqual("success", result["status"])
+            self.assertEqual("amd64", result["platform_id"])
+            self.assertEqual("pull-event-1", result["pull"]["event_id"])
+            self.assertEqual(1, result["junit"]["workload_tests"])
+            self.assertTrue(result["startup"]["ready"])
+            self.assertEqual(1, sum(command[:2] == ["docker", "pull"] for command in calls))
+
+    def test_strict_family_without_marker_is_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = GateRunner(
+                [strict_entry()],
+                Path(directory),
+                command_runner=lambda command, timeout_seconds, **_: SimpleNamespace(
+                    returncode=0, stdout="BUILD SUCCESSFUL", stderr=""
+                ),
+                max_attempts=1,
+            ).run()["results"][0]
+            self.assertEqual("blocked", result["status"])
+
+    def test_arm64_strict_command_is_fixed_and_excludes_mock_jib(self) -> None:
+        value = strict_entry()
+        value["platforms"] = [
+            {"id": "arm64", "os": "linux", "architecture": "arm64", "tag": "2.18.0-arm64", "runner": "ubuntu-24.04-arm"},
+        ]
+        value["defaultPlatformId"] = "arm64"
+        value["_selected_platform_id"] = "arm64"
+        with tempfile.TemporaryDirectory() as directory:
+            runner = GateRunner([value], Path(directory), scope="family")
+            command = runner._command(value, Path(directory) / "attempt")
+        self.assertEqual("-Dtestcontainers.image-gate.evidence-dir", command[1].split("=", 1)[0])
+        self.assertIn("--tests", command)
+        self.assertIn("io.bluetape4k.testcontainers.storage.Ignite2ServerTest.representativeStartupAndWorkload", command)
+        self.assertEqual(2, command.count("-x"))
+        self.assertNotIn("jibDockerBuild", command[:3])
+
+    def test_release_verifier_rejects_partial_or_missing_evidence(self) -> None:
+        summary = {
+            "schema_version": 2,
+            "coverage": "1/1",
+            "release_gate": True,
+            "status": "success",
+            "selected": 1,
+            "blocked": 0,
+            "product_failure": 0,
+            "infrastructure_failure": 0,
+            "platforms": [{"platform_id": "arm64", "status": "success", "expected": {"tag": "2.18.0-arm64", "architecture": "arm64"}, "observed": {"image_tag": "2.18.0-arm64", "image_architecture": "arm64"}, "pull": {}, "junit": {}, "family_artifact": "ignite2.json"}],
+        }
+        errors = verify_release_summary(summary, expected_coverage="1/1", platform_id="arm64", expected_tag="2.18.0-arm64", expected_architecture="arm64")
+        self.assertIn("pull event and digest evidence are required", errors)
+
+    def test_budget_formula_and_52_family_artifact_guard(self) -> None:
+        self.assertEqual(
+            318,
+            worst_case_budget_minutes(
+                generic_families=51,
+                generic_attempts=1,
+                generic_pull_minutes=1,
+                generic_test_minutes=4,
+                generic_diagnostic_minutes=0.5,
+                strict_families=1,
+                strict_attempts=1,
+                strict_pull_minutes=1,
+                strict_test_minutes=6,
+                strict_diagnostic_minutes=0.5,
+                setup_slack_minutes=30,
+            ),
+        )
+        self.assertEqual(
+            84,
+            worst_case_budget_minutes(
+                generic_families=0,
+                generic_attempts=1,
+                generic_pull_minutes=0,
+                generic_test_minutes=0,
+                generic_diagnostic_minutes=0,
+                strict_families=1,
+                strict_attempts=2,
+                strict_pull_minutes=5,
+                strict_test_minutes=30,
+                strict_diagnostic_minutes=2,
+                setup_slack_minutes=10,
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            entries = [entry(f"Family{index}") | {"id": f"family-{index}"} for index in range(52)]
+            summary = GateRunner(
+                entries,
+                Path(directory),
+                command_runner=lambda command, timeout_seconds, **_: SimpleNamespace(returncode=0, stdout="BUILD SUCCESSFUL", stderr=""),
+                max_attempts=1,
+            ).run()
+            artifact_size = sum(path.stat().st_size for path in Path(directory).iterdir() if path.is_file())
+            self.assertEqual("52/52", summary["coverage"])
+            self.assertLessEqual(artifact_size, 8 * 1024 * 1024)
 
 
 if __name__ == "__main__":

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -60,7 +61,7 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
     def test_runtime_environment_removes_docker_credentials_and_overrides(self) -> None:
         original = {
             key: os.environ.get(key)
-            for key in ("DOCKER_AUTH_CONFIG", "TESTCONTAINERS_REGISTRY_MIRROR", "DOCKER_HOST", "DOCKER_CONTEXT")
+            for key in ("DOCKER_AUTH_CONFIG", "DOCKER_CONFIG", "TESTCONTAINERS_REGISTRY_MIRROR", "DOCKER_HOST", "DOCKER_CONTEXT")
         }
         try:
             for key in original:
@@ -247,13 +248,16 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             if command[:3] == ["docker", "context", "show"]:
                 return SimpleNamespace(returncode=0, stdout="default\n", stderr="")
             if command[:2] == ["docker", "info"]:
-                return SimpleNamespace(returncode=0, stdout=json.dumps({"Architecture": "amd64"}), stderr="")
+                return SimpleNamespace(returncode=0, stdout=json.dumps({"Architecture": "amd64", "OSType": "linux"}), stderr="")
             if command[:2] == ["uname", "-m"]:
                 return SimpleNamespace(returncode=0, stdout="x86_64\n", stderr="")
+            if command[:2] == ["uname", "-s"]:
+                return SimpleNamespace(returncode=0, stdout="Linux\n", stderr="")
             if command[:2] == ["docker", "events"]:
                 return SimpleNamespace(
                     returncode=0,
                     stdout=json.dumps({
+                        "timeNano": str(time.time_ns()),
                         "id": "sha256:" + "a" * 64,
                         "from": "apacheignite/ignite:2.18.0",
                         "Actor": {"ID": "sha256:" + "a" * 64, "Attributes": {"name": "apacheignite/ignite:2.18.0"}},
@@ -330,13 +334,16 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             if command[:3] == ["docker", "context", "show"]:
                 return SimpleNamespace(returncode=0, stdout="default\n", stderr="")
             if command[:2] == ["docker", "info"]:
-                return SimpleNamespace(returncode=0, stdout=json.dumps({"Architecture": "amd64"}), stderr="")
+                return SimpleNamespace(returncode=0, stdout=json.dumps({"Architecture": "amd64", "OSType": "linux"}), stderr="")
             if command[:2] == ["uname", "-m"]:
                 return SimpleNamespace(returncode=0, stdout="x86_64\n", stderr="")
+            if command[:2] == ["uname", "-s"]:
+                return SimpleNamespace(returncode=0, stdout="Linux\n", stderr="")
             if command[:2] == ["docker", "events"]:
                 return SimpleNamespace(
                     returncode=0,
                     stdout=json.dumps({
+                        "timeNano": str(time.time_ns()),
                         "id": "sha256:" + "a" * 64,
                         "from": "apacheignite/ignite:2.18.0",
                         "Actor": {"ID": "sha256:" + "a" * 64, "Attributes": {"name": "apacheignite/ignite:2.18.0"}},

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -35,18 +35,6 @@ class TestTestcontainersImageGate(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn('tasks.register<Test>("k8sTest")', build_script)
 
-    def test_java25_ignite_compatibility_options_are_global_and_minimal(self) -> None:
-        root_build = (self.root / "build.gradle.kts").read_text(encoding="utf-8")
-        module_build = (
-            self.root / "testing/testcontainers/build.gradle.kts"
-        ).read_text(encoding="utf-8")
-        for option in (
-            "--add-opens=java.base/java.nio=ALL-UNNAMED",
-            "--add-opens=java.base/java.util=ALL-UNNAMED",
-        ):
-            self.assertIn(option, root_build)
-            self.assertNotIn(option, module_build)
-
     def test_changed_scope_is_deterministic_and_full_scope_is_complete(self) -> None:
         changed = select_entries(self.entries, {"testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt"})
         self.assertEqual(["FlociServer"], [entry["server"] for entry in changed])
@@ -123,6 +111,11 @@ class TestTestcontainersImageGate(unittest.TestCase):
         )
 
         release_workflow = (self.root / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        for workflow in (ci_workflow, release_workflow):
+            if "testcontainers-image-gate" in workflow:
+                self.assertIn("build/reports/testcontainers-image-gate/*.json", workflow)
+                self.assertIn("build/reports/testcontainers-image-gate/summary.md", workflow)
+                self.assertNotIn("path: build/reports/testcontainers-image-gate/", workflow)
         manifest_match = re.search(
             r"^  testcontainers-manifest-contract:\n.*?(?=^  [a-z0-9-]+:\n)",
             release_workflow,

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -78,6 +78,10 @@ class TestTestcontainersImageGate(unittest.TestCase):
         invalid = [dict(self.entries[0], image="wrong/image")]
         self.assertIn("image drift", " ".join(validate_manifest(invalid, self.root)))
 
+    def test_manifest_rejects_unsafe_family_id(self) -> None:
+        invalid = [dict(self.entries[0], id="../escape")]
+        self.assertIn("id is invalid", " ".join(validate_manifest(invalid, self.root)))
+
     def test_invalid_family_specific_test_task_reports_drift(self) -> None:
         invalid = [dict(self.entries[0], testTask="test")]
         self.assertIn(
@@ -113,8 +117,12 @@ class TestTestcontainersImageGate(unittest.TestCase):
         release_workflow = (self.root / ".github/workflows/release.yml").read_text(encoding="utf-8")
         for workflow in (ci_workflow, release_workflow):
             if "testcontainers-image-gate" in workflow:
-                self.assertIn("build/reports/testcontainers-image-gate/*.json", workflow)
-                self.assertIn("build/reports/testcontainers-image-gate/summary.md", workflow)
+                if "testcontainers-ignite2-arm64-image-gate" in workflow:
+                    self.assertIn("build/reports/testcontainers-image-gate-artifact", workflow)
+                    self.assertNotIn("build/reports/testcontainers-image-gate/*.json", workflow)
+                else:
+                    self.assertIn("build/reports/testcontainers-image-gate/*.json", workflow)
+                    self.assertIn("build/reports/testcontainers-image-gate/summary.md", workflow)
                 self.assertNotIn("path: build/reports/testcontainers-image-gate/", workflow)
         manifest_match = re.search(
             r"^  testcontainers-manifest-contract:\n.*?(?=^  [a-z0-9-]+:\n)",

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -128,10 +128,16 @@ class TestTestcontainersImageGate(unittest.TestCase):
             "needs: [resolve-version, testcontainers-manifest-contract]",
             release_workflow,
         )
-        self.assertIn(
-            "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]",
-            release_workflow,
-        )
+        if "testcontainers-ignite2-arm64-image-gate:" in release_workflow:
+            self.assertIn(
+                "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
+                release_workflow,
+            )
+        else:
+            self.assertIn(
+                "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]",
+                release_workflow,
+            )
 
         publish_match = re.search(
             r"^  publish:\n.*\Z",
@@ -147,20 +153,44 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertIn("if: ${{ needs.plan.outputs.scope == 'full' }}", workflow)
         self.assertIn("--scope full", workflow)
         self.assertIn("TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'", workflow)
-        self.assertIn("needs: [test-testcontainers, test-testcontainers-image-gate, plan]", workflow)
-        self.assertIn("needs.test-testcontainers-image-gate.result == 'skipped'", workflow)
-        self.assertIn("- test-testcontainers-image-gate", workflow)
+        if "test-testcontainers-ignite2-arm64-image-gate:" in workflow:
+            self.assertIn("--default-platform-id amd64", workflow)
+            self.assertIn("--job-budget-minutes 360", workflow)
+            self.assertIn("--family-id ignite2", workflow)
+            self.assertIn("--platform-id arm64", workflow)
+            self.assertIn("--job-budget-minutes 90", workflow)
+            self.assertIn(
+                "needs: [test-testcontainers, test-testcontainers-image-gate, test-testcontainers-ignite2-arm64-image-gate, plan]",
+                workflow,
+            )
+            self.assertIn("needs.test-testcontainers-image-gate.result == 'skipped'", workflow)
+            self.assertIn("needs.test-testcontainers-ignite2-arm64-image-gate.result == 'skipped'", workflow)
+            self.assertIn("- test-testcontainers-ignite2-arm64-image-gate", workflow)
+            self.assertNotIn("io.bluetape4k.testcontainers.storage.Ignite2ServerTest\",", workflow)
+        else:
+            self.assertIn("needs: [test-testcontainers, test-testcontainers-image-gate, plan]", workflow)
+            self.assertIn("needs.test-testcontainers-image-gate.result == 'skipped'", workflow)
 
     def test_release_publish_depends_on_full_gate_summary(self) -> None:
         workflow = (self.root / ".github/workflows/release.yml").read_text(encoding="utf-8")
         self.assertIn("testcontainers-manifest-contract:", workflow)
         self.assertIn("testcontainers-image-gate:", workflow)
-        self.assertIn(
-            "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]",
-            workflow,
-        )
+        if "testcontainers-ignite2-arm64-image-gate:" in workflow:
+            self.assertIn(
+                "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
+                workflow,
+            )
+        else:
+            self.assertIn(
+                "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]",
+                workflow,
+            )
         self.assertIn("--scope full", workflow)
-        self.assertIn("coverage=52/52", workflow)
+        if "testcontainers-ignite2-arm64-image-gate:" in workflow:
+            self.assertIn('expected_coverage="52/52"', workflow)
+            self.assertIn('expected_coverage="1/1"', workflow)
+        else:
+            self.assertIn("coverage=52/52", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -154,6 +154,8 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertIn("--scope full", workflow)
         self.assertIn("TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'", workflow)
         if "test-testcontainers-ignite2-arm64-image-gate:" in workflow:
+            self.assertIn("runs-on: ubuntu-24.04", workflow)
+            self.assertIn("runs-on: ubuntu-24.04-arm", workflow)
             self.assertIn("--default-platform-id amd64", workflow)
             self.assertIn("--job-budget-minutes 360", workflow)
             self.assertIn("--family-id ignite2", workflow)
@@ -167,6 +169,8 @@ class TestTestcontainersImageGate(unittest.TestCase):
             self.assertIn("needs.test-testcontainers-ignite2-arm64-image-gate.result == 'skipped'", workflow)
             self.assertIn("- test-testcontainers-ignite2-arm64-image-gate", workflow)
             self.assertNotIn("io.bluetape4k.testcontainers.storage.Ignite2ServerTest\",", workflow)
+            self.assertIn("name: nightly-testcontainers-image-gate-${{ github.run_id }}-amd64", workflow)
+            self.assertIn("name: nightly-testcontainers-image-gate-${{ github.run_id }}-arm64", workflow)
         else:
             self.assertIn("needs: [test-testcontainers, test-testcontainers-image-gate, plan]", workflow)
             self.assertIn("needs.test-testcontainers-image-gate.result == 'skipped'", workflow)
@@ -187,8 +191,12 @@ class TestTestcontainersImageGate(unittest.TestCase):
             )
         self.assertIn("--scope full", workflow)
         if "testcontainers-ignite2-arm64-image-gate:" in workflow:
+            self.assertIn("runs-on: ubuntu-24.04", workflow)
+            self.assertIn("runs-on: ubuntu-24.04-arm", workflow)
             self.assertIn('expected_coverage="52/52"', workflow)
             self.assertIn('expected_coverage="1/1"', workflow)
+            self.assertIn("name: release-testcontainers-image-gate-${{ github.run_id }}-amd64", workflow)
+            self.assertIn("name: release-testcontainers-image-gate-${{ github.run_id }}-arm64", workflow)
         else:
             self.assertIn("coverage=52/52", workflow)
 

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scripts.testcontainers_image_gate import (
     EXPECTED_FAMILY_COUNT,
+    SelectionError,
     load_manifest,
     select_entries,
     validate_manifest,
@@ -41,6 +42,37 @@ class TestTestcontainersImageGate(unittest.TestCase):
 
         shared = select_entries(self.entries, {"scripts/run_testcontainers_image_gate.py"})
         self.assertEqual(EXPECTED_FAMILY_COUNT, len(shared))
+
+    def test_family_selector_is_exact_and_requires_platform_when_requested(self) -> None:
+        ignite = dict(self.entries[0])
+        ignite["id"] = "ignite2"
+        ignite["platforms"] = [
+            {"id": "amd64", "os": "linux", "architecture": "amd64", "tag": "2.18.0", "runner": "ubuntu-24.04"},
+            {"id": "arm64", "os": "linux", "architecture": "arm64", "tag": "2.18.0-arm64", "runner": "ubuntu-24.04-arm"},
+        ]
+        ignite["defaultPlatformId"] = "amd64"
+        selected = select_entries([ignite], set(), scope="family", family_id="ignite2", platform_id="arm64", require_selection=True)
+        self.assertEqual("arm64", selected[0]["_selected_platform_id"])
+        with self.assertRaises(SelectionError):
+            select_entries([ignite], set(), scope="family", family_id="missing", platform_id="arm64", require_selection=True)
+
+    def test_strict_platform_contract_rejects_unsafe_runner_and_workload(self) -> None:
+        invalid = dict(self.entries[0])
+        invalid.update(
+            {
+                "executionEvidenceRequired": True,
+                "pullEvidenceRequired": True,
+                "defaultPlatformId": "amd64",
+                "workloadTestPattern": "../unsafe",
+                "platforms": [
+                    {"id": "amd64", "os": "linux", "architecture": "amd64", "tag": "2.18.0", "runner": "self-hosted"},
+                ],
+                "platformTimeouts": {"amd64": {"testMinutes": 6, "clientConnectSeconds": 30, "clientRequestSeconds": 30}},
+            }
+        )
+        errors = validate_manifest([invalid], self.root)
+        self.assertIn("runner is unsupported", " ".join(errors))
+        self.assertIn("workloadTestPattern is invalid", " ".join(errors))
 
     def test_invalid_manifest_reports_drift_without_running_docker(self) -> None:
         invalid = [dict(self.entries[0], image="wrong/image")]

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -35,6 +35,18 @@ class TestTestcontainersImageGate(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn('tasks.register<Test>("k8sTest")', build_script)
 
+    def test_java25_ignite_compatibility_options_are_global_and_minimal(self) -> None:
+        root_build = (self.root / "build.gradle.kts").read_text(encoding="utf-8")
+        module_build = (
+            self.root / "testing/testcontainers/build.gradle.kts"
+        ).read_text(encoding="utf-8")
+        for option in (
+            "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+        ):
+            self.assertIn(option, root_build)
+            self.assertNotIn(option, module_build)
+
     def test_changed_scope_is_deterministic_and_full_scope_is_complete(self) -> None:
         changed = select_entries(self.entries, {"testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt"})
         self.assertEqual(["FlociServer"], [entry["server"] for entry in changed])

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -219,8 +219,8 @@ def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[
         if server in names:
             errors.append(f"duplicate server: {server}")
         names.add(server)
-        if not isinstance(family_id, str) or not family_id:
-            errors.append(f"{prefix} id must be a non-empty string")
+        if not _safe_string(family_id, ID_PATTERN):
+            errors.append(f"{prefix} id is invalid")
         elif family_id in ids:
             errors.append(f"duplicate id: {family_id}")
         else:

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -26,6 +27,19 @@ REQUIRED_FIELDS = {
     "releaseRequired",
 }
 KNOWN_TEST_TASKS = {":bluetape4k-testcontainers:k8sTest"}
+ALLOWED_PLATFORM_IDS = {"amd64", "arm64"}
+ALLOWED_RUNNERS = {"ubuntu-24.04", "ubuntu-24.04-arm"}
+IMAGE_PATTERN = re.compile(
+    r"^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\.[a-z]{2,})?(?::[0-9]{1,5})?/)?"
+    r"[a-z0-9]+(?:[._/-][a-z0-9]+)*$"
+)
+TAG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+WORKLOAD_PATTERN = re.compile(r"^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+\.[A-Za-z_$][\w$]*(?:\(\))?$")
+
+
+class SelectionError(ValueError):
+    """Raised when a gate selector is not exact and unambiguous."""
 
 
 def _contract_module() -> Any:
@@ -41,10 +55,10 @@ def _contract_module() -> Any:
 
 def load_manifest(path: Path = MANIFEST) -> list[dict[str, Any]]:
     payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict) or payload.get("version") != 1:
+    if not isinstance(payload, dict) or payload.get("version") not in {1, 2}:
         raise ValueError(f"unsupported manifest format: {path}")
     entries = payload.get("families")
-    if not isinstance(entries, list):
+    if not isinstance(entries, list) or not all(isinstance(entry, dict) for entry in entries):
         raise ValueError(f"manifest families must be a list: {path}")
     return [dict(entry) for entry in entries]
 
@@ -59,6 +73,121 @@ def _test_source_for(server: str, source: Path) -> Path:
     test_root = ROOT / "testing/testcontainers/src/test/kotlin"
     package_path = source.parent.relative_to(ROOT / "testing/testcontainers/src/main/kotlin")
     return test_root / package_path / f"{server}Test.kt"
+
+
+def _safe_string(value: object, pattern: re.Pattern[str]) -> bool:
+    return isinstance(value, str) and bool(pattern.fullmatch(value)) and "\x00" not in value
+
+
+def canonical_architecture(value: object) -> str | None:
+    """Normalize Docker/runner architecture aliases to the gate vocabulary."""
+
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return {
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(normalized)
+
+
+def platform_for_entry(
+    entry: dict[str, Any],
+    platform_id: str | None = None,
+    *,
+    default_platform_id: str = "amd64",
+) -> dict[str, Any] | None:
+    """Return the selected platform metadata, or ``None`` for generic families."""
+
+    platforms = entry.get("platforms")
+    if platforms is None:
+        if platform_id is not None:
+            raise SelectionError(f"family has no platform metadata: {entry.get('id', '<unknown>')}")
+        return None
+    if not isinstance(platforms, list):
+        raise SelectionError(f"platforms must be a list: {entry.get('id', '<unknown>')}")
+    selected_id = platform_id or str(entry.get("defaultPlatformId") or default_platform_id)
+    matches = [item for item in platforms if isinstance(item, dict) and item.get("id") == selected_id]
+    if len(matches) != 1:
+        raise SelectionError(
+            f"platform selection must match exactly one entry: {entry.get('id', '<unknown>')} / {selected_id}"
+        )
+    selected = dict(matches[0])
+    selected["id"] = selected_id
+    return selected
+
+
+def _validate_platforms(entry: dict[str, Any], prefix: str, errors: list[str]) -> None:
+    strict = entry.get("executionEvidenceRequired", False)
+    if not isinstance(strict, bool):
+        errors.append(f"{prefix} executionEvidenceRequired must be boolean")
+        strict = False
+    pull_required = entry.get("pullEvidenceRequired", False)
+    if not isinstance(pull_required, bool):
+        errors.append(f"{prefix} pullEvidenceRequired must be boolean")
+        pull_required = False
+    if not strict and "platforms" not in entry:
+        return
+
+    platforms = entry.get("platforms")
+    if not isinstance(platforms, list) or not platforms:
+        errors.append(f"{prefix} platforms must be a non-empty list")
+        return
+    seen: set[str] = set()
+    for platform_index, platform in enumerate(platforms):
+        platform_prefix = f"{prefix}.platforms[{platform_index}]"
+        if not isinstance(platform, dict):
+            errors.append(f"{platform_prefix} must be an object")
+            continue
+        platform_id = platform.get("id")
+        if not _safe_string(platform_id, ID_PATTERN) or platform_id not in ALLOWED_PLATFORM_IDS:
+            errors.append(f"{platform_prefix}.id is unsupported: {platform_id!r}")
+        elif platform_id in seen:
+            errors.append(f"duplicate platform id: {platform_id}")
+        else:
+            seen.add(platform_id)
+        if platform.get("os") != "linux":
+            errors.append(f"{platform_prefix}.os must be linux")
+        architecture = canonical_architecture(platform.get("architecture"))
+        if architecture is None or architecture != platform_id:
+            errors.append(f"{platform_prefix}.architecture does not match id")
+        if not _safe_string(platform.get("tag"), TAG_PATTERN):
+            errors.append(f"{platform_prefix}.tag is invalid")
+        if platform.get("runner") not in ALLOWED_RUNNERS:
+            errors.append(f"{platform_prefix}.runner is unsupported")
+        if platform_id == "amd64" and platform.get("runner") != "ubuntu-24.04":
+            errors.append(f"{platform_prefix}.runner must be ubuntu-24.04")
+        if platform_id == "arm64" and platform.get("runner") != "ubuntu-24.04-arm":
+            errors.append(f"{platform_prefix}.runner must be ubuntu-24.04-arm")
+
+    default_platform_id = entry.get("defaultPlatformId")
+    if default_platform_id != "amd64":
+        errors.append(f"{prefix}.defaultPlatformId must be amd64")
+    if default_platform_id not in seen:
+        errors.append(f"{prefix}.defaultPlatformId is not present in platforms")
+    if strict:
+        if not _safe_string(entry.get("workloadTestPattern"), WORKLOAD_PATTERN):
+            errors.append(f"{prefix}.workloadTestPattern is invalid")
+        timeouts = entry.get("platformTimeouts")
+        if not isinstance(timeouts, dict):
+            errors.append(f"{prefix}.platformTimeouts must be an object")
+        else:
+            for platform_id in seen:
+                timeout = timeouts.get(platform_id)
+                if not isinstance(timeout, dict):
+                    errors.append(f"{prefix}.platformTimeouts.{platform_id} must be an object")
+                    continue
+                for field in ("testMinutes", "clientConnectSeconds", "clientRequestSeconds"):
+                    if not isinstance(timeout.get(field), int) or timeout[field] <= 0:
+                        errors.append(f"{prefix}.platformTimeouts.{platform_id}.{field} must be positive")
+        if not pull_required:
+            errors.append(f"{prefix}.pullEvidenceRequired must be true for strict execution")
+    if "image" in entry and not _safe_string(entry.get("image"), IMAGE_PATTERN):
+        errors.append(f"{prefix}.image is invalid")
+    if "tag" in entry and not _safe_string(entry.get("tag"), TAG_PATTERN):
+        errors.append(f"{prefix}.tag is invalid")
 
 
 def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[str]:
@@ -133,6 +262,7 @@ def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[
             errors.append(f"diagnostics is empty for {server}")
         if not isinstance(entry["releaseRequired"], bool):
             errors.append(f"releaseRequired must be boolean for {server}")
+        _validate_platforms(entry, prefix, errors)
         test_task = entry.get("testTask")
         if test_task is not None and (
             not isinstance(test_task, str) or not test_task.startswith(":")
@@ -149,15 +279,46 @@ def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[
 
 
 def select_entries(
-    entries: list[dict[str, Any]], changed_paths: set[str], scope: str = "changed"
+    entries: list[dict[str, Any]],
+    changed_paths: set[str] | None = None,
+    scope: str = "changed",
+    *,
+    family_id: str | None = None,
+    platform_id: str | None = None,
+    require_selection: bool = False,
+    default_platform_id: str = "amd64",
 ) -> list[dict[str, Any]]:
     """Select changed families deterministically, or all families for a full gate."""
 
-    if scope not in {"changed", "full"}:
+    if scope not in {"changed", "full", "family"}:
         raise ValueError(f"unsupported scope: {scope}")
+    if scope == "family":
+        if not family_id or not _safe_string(family_id, ID_PATTERN):
+            raise SelectionError("family scope requires a safe --family-id")
+        matches = [entry for entry in entries if entry.get("id") == family_id]
+        if len(matches) != 1:
+            raise SelectionError(f"family selection must match exactly one entry: {family_id}")
+        selected = dict(matches[0])
+        selected_platform = platform_for_entry(
+            selected, platform_id, default_platform_id=default_platform_id
+        )
+        if require_selection and selected_platform is None:
+            raise SelectionError(f"family has no selectable platform: {family_id}")
+        if platform_id is not None and selected_platform is None:
+            raise SelectionError(f"family has no platform metadata: {family_id}")
+        if selected_platform is not None:
+            selected["_selected_platform_id"] = selected_platform["id"]
+        return [selected]
     if scope == "full":
-        return list(entries)
-    normalized = {path.replace("\\", "/") for path in changed_paths}
+        selected = [dict(entry) for entry in entries]
+        for entry in selected:
+            selected_platform = platform_for_entry(
+                entry, platform_id, default_platform_id=default_platform_id
+            )
+            if selected_platform is not None:
+                entry["_selected_platform_id"] = selected_platform["id"]
+        return selected
+    normalized = {(path or "").replace("\\", "/") for path in (changed_paths or set())}
     shared_prefixes = (
         "scripts/testcontainers_image_gate",
         "scripts/run_testcontainers_image_gate.py",
@@ -167,4 +328,11 @@ def select_entries(
     )
     if any(path.startswith(prefix) for path in normalized for prefix in shared_prefixes):
         return list(entries)
-    return [entry for entry in entries if str(entry["source"]) in normalized]
+    selected = [dict(entry) for entry in entries if str(entry["source"]) in normalized]
+    for entry in selected:
+        selected_platform = platform_for_entry(
+            entry, platform_id, default_platform_id=default_platform_id
+        )
+        if selected_platform is not None:
+            entry["_selected_platform_id"] = selected_platform["id"]
+    return selected

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -310,14 +310,9 @@ def select_entries(
             selected["_selected_platform_id"] = selected_platform["id"]
         return [selected]
     if scope == "full":
-        selected = [dict(entry) for entry in entries]
-        for entry in selected:
-            selected_platform = platform_for_entry(
-                entry, platform_id, default_platform_id=default_platform_id
-            )
-            if selected_platform is not None:
-                entry["_selected_platform_id"] = selected_platform["id"]
-        return selected
+        # Full scope keeps manifest entries canonical; the runner resolves a
+        # strict family's default platform at execution time.
+        return list(entries)
     normalized = {(path or "").replace("\\", "/") for path in (changed_paths or set())}
     shared_prefixes = (
         "scripts/testcontainers_image_gate",


### PR DESCRIPTION
## 요약

Issue #1486의 stacked PR parent입니다. manifest 기반 Testcontainers image gate가 strict workload 실행, Docker pull provenance, native platform 증거를 Release verifier까지 일관되게 전달하도록 공통 runner 계약을 강화했습니다.

## 변경 사항

- pull 후 실제 Docker event ref·image ID·digest를 상관시키고, Linux/architecture/context를 검증합니다.
- strict workload는 fresh Gradle 실행(`--rerun-tasks`)을 사용하며, pull 인프라 실패 시 pull·inspect·event 전체 체인을 재시도합니다.
- workload 증거 staging을 artifact tree 밖으로 분리하고 Docker credential을 0600으로 제한합니다.
- Release verifier가 expected runner label과 runner/daemon/image architecture를 exact match하도록 fail-closed 검증합니다.
- Nightly/Release native gate artifact는 JSON과 `summary.md` allowlist만 업로드합니다.

## 검증

- Python runner/contract tests: 32/32 PASS
- `python3 -m py_compile scripts/*.py`, `actionlint`, `git diff --check`: PASS
- Parent PR exact head CI: 기존 run의 정책·wrapper·CodeQL·secret scan·Build·CI Status PASS
- 로컬 Colima arm64 strict gate: hosted runner 계약(`Linux`/`ubuntu-24.04-arm`)을 macOS `Darwin`으로 대체하지 않도록 `blocked=1`로 fail-closed; 이는 native hosted 증거가 아님

## 스택

- parent base: `develop`
- child PR: `fix/1486-ignite2-arm64-runtime` → 이 PR

## DoD Status

- 상태: 공통 runner·정적 검증 및 child exact head `76eb2a15` hosted Nightly PASS(`32740232258`) 완료, fresh Type-D/code review 완료; stacked merge preflight 대기
- Issue: #1486
- P1 blocker: 0 (exact head ARM64 `1/1`·x64 `52/52`, 양쪽 `release_gate=true`; fresh architect P1=0/code-review P1=0 확인; merge 승인 대기)
- P2 watch: manifest client timeout과 설계 문서 timeout 표현은 후속 정리 항목이며 현재 gate correctness blocker가 아님
