### PR TITLE
[testcontainers][arm64] Ignite2 기본 태그와 workload gate 검증

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -127,7 +127,6 @@ jobs:
                   "group": "storage-cache",
                   "test_patterns": " ".join([
                       "io.bluetape4k.testcontainers.storage.HazelcastServerTest",
-                      "io.bluetape4k.testcontainers.storage.Ignite2ServerTest",
                       "io.bluetape4k.testcontainers.storage.Ignite3ServerTest",
                       "io.bluetape4k.testcontainers.storage.InfluxDBServerTest",
                       "io.bluetape4k.testcontainers.storage.MinIOServerTest",
@@ -1202,14 +1201,12 @@ jobs:
   # ── Testcontainers image startup/workload gate — full Nightly 전용 ────────
   test-testcontainers-image-gate:
     name: Test / Testcontainers image startup-workload gate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
     needs: [build, plan]
     if: ${{ needs.plan.outputs.scope == 'full' }}
     env:
       TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'
-      DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
-      TESTCONTAINERS_REGISTRY_MIRROR: ${{ vars.TESTCONTAINERS_REGISTRY_MIRROR || '' }}
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
     steps:
       - uses: actions/checkout@v7
@@ -1235,12 +1232,38 @@ jobs:
         run: ./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
 
       - name: Run full image family gate sequentially
+        env:
+          DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
         run: >-
           python3 scripts/run_testcontainers_image_gate.py
           --scope full
           --report-dir build/reports/testcontainers-image-gate
-          --max-attempts 2
-          --timeout-minutes 30
+          --default-platform-id amd64
+          --max-attempts 1
+          --pull-timeout-seconds 60
+          --timeout-minutes 4
+          --diagnostic-timeout-seconds 30
+          --job-budget-minutes 360
+
+      - name: Verify nightly image gate summary
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          from scripts.run_testcontainers_image_gate import verify_release_summary
+
+          summary = json.loads(Path("build/reports/testcontainers-image-gate/summary.json").read_text(encoding="utf-8"))
+          errors = verify_release_summary(
+              summary,
+              expected_coverage="52/52",
+              platform_id="amd64",
+              expected_tag="2.18.0",
+              expected_architecture="amd64",
+          )
+          if errors:
+              raise SystemExit("; ".join(errors))
+          PY
 
       - name: Publish image gate summary
         if: always()
@@ -1253,7 +1276,86 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: nightly-testcontainers-image-gate-${{ github.run_id }}
+          name: nightly-testcontainers-image-gate-${{ github.run_id }}-amd64
+          path: |
+            build/reports/testcontainers-image-gate/*.json
+            build/reports/testcontainers-image-gate/summary.md
+          if-no-files-found: error
+          retention-days: 14
+
+  test-testcontainers-ignite2-arm64-image-gate:
+    name: Test / Testcontainers Ignite2 arm64 image gate
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    needs: [build, plan]
+    if: ${{ needs.plan.outputs.scope == 'full' }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Run Ignite2 arm64 image gate
+        env:
+          DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
+        run: >-
+          python3 scripts/run_testcontainers_image_gate.py
+          --scope family
+          --family-id ignite2
+          --platform-id arm64
+          --require-selection
+          --report-dir build/reports/testcontainers-image-gate
+          --max-attempts 2
+          --pull-timeout-seconds 300
+          --timeout-minutes 30
+          --diagnostic-timeout-seconds 120
+          --job-budget-minutes 90
+
+      - name: Verify Ignite2 arm64 image gate summary
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          from scripts.run_testcontainers_image_gate import verify_release_summary
+
+          summary = json.loads(Path("build/reports/testcontainers-image-gate/summary.json").read_text(encoding="utf-8"))
+          errors = verify_release_summary(
+              summary,
+              expected_coverage="1/1",
+              platform_id="arm64",
+              expected_tag="2.18.0-arm64",
+              expected_architecture="arm64",
+          )
+          if errors:
+              raise SystemExit("; ".join(errors))
+          PY
+
+      - name: Publish Ignite2 arm64 image gate summary
+        if: always()
+        run: |
+          if [ -f build/reports/testcontainers-image-gate/summary.md ]; then
+            cat build/reports/testcontainers-image-gate/summary.md
+          fi
+
+      - name: Upload Ignite2 arm64 image gate evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-testcontainers-image-gate-${{ github.run_id }}-arm64
           path: |
             build/reports/testcontainers-image-gate/*.json
             build/reports/testcontainers-image-gate/summary.md
@@ -1268,8 +1370,8 @@ jobs:
     # Full Nightly waits for the Docker-backed image gate. A targeted
     # testcontainers dispatch has no image gate and may run this JVM-only bridge
     # after its matrix completes.
-    needs: [test-testcontainers, test-testcontainers-image-gate, plan]
-    if: ${{ always() && (needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers') && needs.test-testcontainers.result == 'success' && (needs.test-testcontainers-image-gate.result == 'success' || needs.test-testcontainers-image-gate.result == 'skipped') }}
+    needs: [test-testcontainers, test-testcontainers-image-gate, test-testcontainers-ignite2-arm64-image-gate, plan]
+    if: ${{ always() && (needs.plan.outputs.scope == 'full' || needs.plan.outputs.scope == 'testcontainers') && needs.test-testcontainers.result == 'success' && ((needs.plan.outputs.scope == 'full' && needs.test-testcontainers-image-gate.result == 'success' && needs.test-testcontainers-ignite2-arm64-image-gate.result == 'success') || (needs.plan.outputs.scope == 'testcontainers' && needs.test-testcontainers-image-gate.result == 'skipped' && needs.test-testcontainers-ignite2-arm64-image-gate.result == 'skipped')) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -1327,6 +1429,7 @@ jobs:
       - test-spring-docker
       - test-testcontainers
       - test-testcontainers-image-gate
+      - test-testcontainers-ignite2-arm64-image-gate
       - test-testcontainers-spring
     if: always()
     steps:
@@ -1372,6 +1475,16 @@ jobs:
           else
             echo 'has_expected=false' >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Require both native image gates for full Nightly
+        if: ${{ needs.plan.outputs.scope == 'full' }}
+        env:
+          X64_GATE_RESULT: ${{ needs.test-testcontainers-image-gate.result }}
+          ARM64_GATE_RESULT: ${{ needs.test-testcontainers-ignite2-arm64-image-gate.result }}
+        run: |
+          set -euo pipefail
+          test "$X64_GATE_RESULT" = success
+          test "$ARM64_GATE_RESULT" = success
 
       - name: Download all coverage artifacts
         id: download-coverage
@@ -1459,6 +1572,7 @@ jobs:
       - test-spring-docker
       - test-testcontainers
       - test-testcontainers-image-gate
+      - test-testcontainers-ignite2-arm64-image-gate
       - test-testcontainers-spring
       - coverage-report
     if: always()
@@ -1466,10 +1580,17 @@ jobs:
       - name: Check all jobs
         env:
           RESULTS: ${{ join(needs.*.result, ',') }}
+          SCOPE: ${{ needs.plan.outputs.scope }}
+          X64_GATE_RESULT: ${{ needs.test-testcontainers-image-gate.result }}
+          ARM64_GATE_RESULT: ${{ needs.test-testcontainers-ignite2-arm64-image-gate.result }}
         run: |
           echo "Nightly results: $RESULTS"
           if echo "$RESULTS" | grep -qE "failure|cancelled"; then
             echo "Nightly tests failed"
+            exit 1
+          fi
+          if [ "$SCOPE" = full ] && { [ "$X64_GATE_RESULT" != success ] || [ "$ARM64_GATE_RESULT" != success ]; }; then
+            echo "Full Nightly native image gates are not both successful"
             exit 1
           fi
           echo "Nightly tests passed"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1260,6 +1260,7 @@ jobs:
               platform_id="amd64",
               expected_tag="2.18.0",
               expected_architecture="amd64",
+              report_dir=Path("build/reports/testcontainers-image-gate"),
           )
           if errors:
               raise SystemExit("; ".join(errors))
@@ -1272,14 +1273,35 @@ jobs:
             cat build/reports/testcontainers-image-gate/summary.md
           fi
 
+      - name: Stage exact image gate evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf build/reports/testcontainers-image-gate-artifact
+          mkdir -p build/reports/testcontainers-image-gate-artifact
+          python3 - <<'PY'
+          import shutil
+          from pathlib import Path
+          from scripts.testcontainers_image_gate import load_manifest
+
+          report = Path("build/reports/testcontainers-image-gate")
+          stage = Path("build/reports/testcontainers-image-gate-artifact")
+          names = [f"{entry['id']}.json" for entry in load_manifest()]
+          names.extend(("summary.json", "summary.md"))
+          for name in names:
+              source = report / name
+              if source.is_symlink() or not source.is_file():
+                  raise SystemExit(f"missing exact image-gate artifact: {source}")
+              shutil.copy2(source, stage / name)
+          PY
+
       - name: Upload image gate evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: nightly-testcontainers-image-gate-${{ github.run_id }}-amd64
           path: |
-            build/reports/testcontainers-image-gate/*.json
-            build/reports/testcontainers-image-gate/summary.md
+            build/reports/testcontainers-image-gate-artifact
           if-no-files-found: error
           retention-days: 14
 
@@ -1339,6 +1361,7 @@ jobs:
               platform_id="arm64",
               expected_tag="2.18.0-arm64",
               expected_architecture="arm64",
+              report_dir=Path("build/reports/testcontainers-image-gate"),
           )
           if errors:
               raise SystemExit("; ".join(errors))
@@ -1351,14 +1374,25 @@ jobs:
             cat build/reports/testcontainers-image-gate/summary.md
           fi
 
+      - name: Stage exact Ignite2 arm64 image gate evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf build/reports/testcontainers-image-gate-artifact
+          mkdir -p build/reports/testcontainers-image-gate-artifact
+          for name in ignite2.json summary.json summary.md; do
+            test -f "build/reports/testcontainers-image-gate/$name"
+            test ! -L "build/reports/testcontainers-image-gate/$name"
+            cp -p "build/reports/testcontainers-image-gate/$name" "build/reports/testcontainers-image-gate-artifact/$name"
+          done
+
       - name: Upload Ignite2 arm64 image gate evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: nightly-testcontainers-image-gate-${{ github.run_id }}-arm64
           path: |
-            build/reports/testcontainers-image-gate/*.json
-            build/reports/testcontainers-image-gate/summary.md
+            build/reports/testcontainers-image-gate-artifact
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,11 +146,34 @@ jobs:
               platform_id="amd64",
               expected_tag="2.18.0",
               expected_architecture="amd64",
+              report_dir=Path("build/reports/testcontainers-image-gate"),
           )
           if errors:
               raise SystemExit("; ".join(errors))
           print(f"coverage={summary['coverage']}")
           print(f"manifest_digest={summary['manifest_digest']}")
+          PY
+
+      - name: Stage exact image gate evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf build/reports/testcontainers-image-gate-artifact
+          mkdir -p build/reports/testcontainers-image-gate-artifact
+          python3 - <<'PY'
+          import shutil
+          from pathlib import Path
+          from scripts.testcontainers_image_gate import load_manifest
+
+          report = Path("build/reports/testcontainers-image-gate")
+          stage = Path("build/reports/testcontainers-image-gate-artifact")
+          names = [f"{entry['id']}.json" for entry in load_manifest()]
+          names.extend(("summary.json", "summary.md"))
+          for name in names:
+              source = report / name
+              if source.is_symlink() or not source.is_file():
+                  raise SystemExit(f"missing exact image-gate artifact: {source}")
+              shutil.copy2(source, stage / name)
           PY
 
       - name: Upload image gate evidence
@@ -159,8 +182,7 @@ jobs:
         with:
           name: release-testcontainers-image-gate-${{ github.run_id }}-amd64
           path: |
-            build/reports/testcontainers-image-gate/*.json
-            build/reports/testcontainers-image-gate/summary.md
+            build/reports/testcontainers-image-gate-artifact
           if-no-files-found: error
           retention-days: 30
 
@@ -223,10 +245,23 @@ jobs:
               platform_id="arm64",
               expected_tag="2.18.0-arm64",
               expected_architecture="arm64",
+              report_dir=Path("build/reports/testcontainers-image-gate"),
           )
           if errors:
               raise SystemExit("; ".join(errors))
           PY
+
+      - name: Stage exact Ignite2 arm64 image gate evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf build/reports/testcontainers-image-gate-artifact
+          mkdir -p build/reports/testcontainers-image-gate-artifact
+          for name in ignite2.json summary.json summary.md; do
+            test -f "build/reports/testcontainers-image-gate/$name"
+            test ! -L "build/reports/testcontainers-image-gate/$name"
+            cp -p "build/reports/testcontainers-image-gate/$name" "build/reports/testcontainers-image-gate-artifact/$name"
+          done
 
       - name: Upload Ignite2 arm64 image gate evidence
         if: always()
@@ -234,8 +269,7 @@ jobs:
         with:
           name: release-testcontainers-image-gate-${{ github.run_id }}-arm64
           path: |
-            build/reports/testcontainers-image-gate/*.json
-            build/reports/testcontainers-image-gate/summary.md
+            build/reports/testcontainers-image-gate-artifact
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,9 @@ jobs:
   testcontainers-image-gate:
     name: Verify Testcontainers image gate
     needs: [resolve-version, testcontainers-manifest-contract]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
     env:
-      DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
-      TESTCONTAINERS_REGISTRY_MIRROR: ${{ vars.TESTCONTAINERS_REGISTRY_MIRROR || '' }}
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
     steps:
       - uses: actions/checkout@v7
@@ -118,12 +116,18 @@ jobs:
         run: ./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
 
       - name: Run full image family gate
+        env:
+          DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
         run: >-
           python3 scripts/run_testcontainers_image_gate.py
           --scope full
           --report-dir build/reports/testcontainers-image-gate
-          --max-attempts 2
-          --timeout-minutes 30
+          --default-platform-id amd64
+          --max-attempts 1
+          --pull-timeout-seconds 60
+          --timeout-minutes 4
+          --diagnostic-timeout-seconds 30
+          --job-budget-minutes 360
 
       - name: Verify stable release gate summary
         shell: bash
@@ -132,15 +136,19 @@ jobs:
           python3 - <<'PY'
           import json
           from pathlib import Path
+          from scripts.run_testcontainers_image_gate import verify_release_summary
 
           summary_path = Path("build/reports/testcontainers-image-gate/summary.json")
           summary = json.loads(summary_path.read_text(encoding="utf-8"))
-          if summary.get("coverage") != "52/52":
-              raise SystemExit(f"stable release requires coverage=52/52, got {summary.get('coverage')!r}")
-          if summary.get("release_gate") is not True:
-              raise SystemExit("stable release image gate is not green")
-          if any(summary.get(key, 0) for key in ("product_failure", "infrastructure_failure", "blocked")):
-              raise SystemExit("stable release image gate contains a failure classification")
+          errors = verify_release_summary(
+              summary,
+              expected_coverage="52/52",
+              platform_id="amd64",
+              expected_tag="2.18.0",
+              expected_architecture="amd64",
+          )
+          if errors:
+              raise SystemExit("; ".join(errors))
           print(f"coverage={summary['coverage']}")
           print(f"manifest_digest={summary['manifest_digest']}")
           PY
@@ -149,7 +157,82 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: release-testcontainers-image-gate-${{ github.run_id }}
+          name: release-testcontainers-image-gate-${{ github.run_id }}-amd64
+          path: |
+            build/reports/testcontainers-image-gate/*.json
+            build/reports/testcontainers-image-gate/summary.md
+          if-no-files-found: error
+          retention-days: 30
+
+  testcontainers-ignite2-arm64-image-gate:
+    name: Verify Testcontainers Ignite2 arm64 image gate
+    needs: [resolve-version, testcontainers-manifest-contract]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-version.outputs.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Run Ignite2 arm64 image gate
+        env:
+          DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
+        run: >-
+          python3 scripts/run_testcontainers_image_gate.py
+          --scope family
+          --family-id ignite2
+          --platform-id arm64
+          --require-selection
+          --report-dir build/reports/testcontainers-image-gate
+          --max-attempts 2
+          --pull-timeout-seconds 300
+          --timeout-minutes 30
+          --diagnostic-timeout-seconds 120
+          --job-budget-minutes 90
+
+      - name: Verify Ignite2 arm64 release gate summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          from scripts.run_testcontainers_image_gate import verify_release_summary
+
+          summary = json.loads(Path("build/reports/testcontainers-image-gate/summary.json").read_text(encoding="utf-8"))
+          errors = verify_release_summary(
+              summary,
+              expected_coverage="1/1",
+              platform_id="arm64",
+              expected_tag="2.18.0-arm64",
+              expected_architecture="arm64",
+          )
+          if errors:
+              raise SystemExit("; ".join(errors))
+          PY
+
+      - name: Upload Ignite2 arm64 image gate evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-testcontainers-image-gate-${{ github.run_id }}-arm64
           path: |
             build/reports/testcontainers-image-gate/*.json
             build/reports/testcontainers-image-gate/summary.md
@@ -158,7 +241,7 @@ jobs:
 
   publish:
     name: Publish RELEASE to Maven Central Portal
-    needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]
+    needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]
     runs-on: ubuntu-latest
     environment: maven-central-release
     steps:

--- a/docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md
+++ b/docs/superpowers/specs/2026-08-24-issue-1486-ignite2-arm64-image-gate-design.md
@@ -188,13 +188,17 @@ platform 선택은 exact
 2. `pullEvidenceRequired` entry는 선택된 `<image>:<tag>`를 pull하고 pull
    결과/event와 cache 여부를 기록한다. pull 전 bounded event observer를 시작해
    `run_id`, `family_id`, `platform_id`, `attempt`, requested ref로 correlation하고,
-   observer가 확인한 pull event id를 schema에 남긴다. authoritative 실행에서
+   observer가 확인한 pull event id를 schema에 남긴다. hosted Docker가 ID 없는
+   text event를 반환하면 exact requested ref와 pull 이후 event timestamp를
+   deterministic receipt로 남기고, 직후 image inspect의 image ID/digest에
+   binding한다. authoritative 실행에서
    pull은 첫 attempt에 최대 1회만 수행하고, pull 단계가 registry transport
    failure였을 때만 두 번째 attempt에서 1회 재시도한다(실행당 최대 2회).
    pull 성공 후에는 verified image ID/digest를 다음 test retry에서 재사용하고
    tag를 다시 해석하지 않는다. pull 직후 image ID와 `RepoDigests`를 고정하고,
    container inspect의 image ID/digest가 그 값과 일치하는지 확인한다.
-   `RepoDigests`가 비어 있거나 event correlation이 없으면 성공하지 않는다. registry
+   `RepoDigests`가 비어 있거나 requested ref·timestamp correlation 및 post-pull
+   image binding이 없으면 성공하지 않는다. registry
    credential은 dedicated pull subprocess의 ephemeral `DOCKER_CONFIG`에만
    주입한다. Gradle/test/diagnostic subprocess에는 sanitized environment만
    전달하고, pull 직후 temporary config와 helper credential을 삭제한다.

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -91,11 +91,29 @@ _KNOWN_SECRETS: set[str] = set()
 class CommandResult:
     """Bounded subprocess result shared by real and fake command runners."""
 
-    def __init__(self, returncode: int | None, stdout: str = "", stderr: str = "", elapsed: float = 0.0):
+    def __init__(
+        self,
+        returncode: int | None,
+        stdout: str = "",
+        stderr: str = "",
+        elapsed: float = 0.0,
+        *,
+        stdout_overflow: bool = False,
+        stderr_overflow: bool = False,
+    ):
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
         self.elapsed_seconds = elapsed
+        self.stdout_overflow = stdout_overflow
+        self.stderr_overflow = stderr_overflow
+
+
+def _has_output_overflow(result: object) -> bool:
+    return bool(
+        getattr(result, "stdout_overflow", False)
+        or getattr(result, "stderr_overflow", False)
+    )
 
 
 def redact(value: str) -> str:
@@ -187,9 +205,18 @@ def _read_bounded(path: Path, limit: int) -> str:
     return redact(data.decode("utf-8", errors="replace"))
 
 
-def classify_failure(returncode: int | None, stdout: str, stderr: str) -> str:
+def classify_failure(
+    returncode: int | None,
+    stdout: str,
+    stderr: str,
+    *,
+    stdout_overflow: bool = False,
+    stderr_overflow: bool = False,
+) -> str:
     """Classify a command result without conflating registry/daemon failures with product bugs."""
 
+    if stdout_overflow or stderr_overflow:
+        return "blocked"
     if returncode == 0:
         return "success"
     haystack = f"{stdout}\n{stderr}".lower()
@@ -202,10 +229,25 @@ def classify_failure(returncode: int | None, stdout: str, stderr: str) -> str:
     return "product_failure"
 
 
-def _classify_command_result(returncode: int | None, stdout: str, stderr: str) -> str:
+def _classify_command_result(
+    returncode: int | None,
+    stdout: str,
+    stderr: str,
+    *,
+    stdout_overflow: bool = False,
+    stderr_overflow: bool = False,
+) -> str:
+    if stdout_overflow or stderr_overflow:
+        return "blocked"
     if "job budget exceeded" in f"{stdout}\n{stderr}".lower():
         return "blocked"
-    status = classify_failure(returncode, stdout, stderr)
+    status = classify_failure(
+        returncode,
+        stdout,
+        stderr,
+        stdout_overflow=stdout_overflow,
+        stderr_overflow=stderr_overflow,
+    )
     if status == "success" and not re.search(r"\bBUILD SUCCESSFUL\b", f"{stdout}\n{stderr}"):
         return "blocked"
     return status
@@ -239,6 +281,7 @@ def _subprocess_runner(command: list[str], timeout_seconds: int, *, env: dict[st
     )
     selector = selectors.DefaultSelector()
     captures: dict[str, bytearray] = {"stdout": bytearray(), "stderr": bytearray()}
+    overflows = {"stdout": False, "stderr": False}
     for name, stream in (("stdout", process.stdout), ("stderr", process.stderr)):
         if stream is not None:
             selector.register(stream, selectors.EVENT_READ, name)
@@ -262,6 +305,7 @@ def _subprocess_runner(command: list[str], timeout_seconds: int, *, env: dict[st
                 capture = captures[key.data]
                 capture.extend(chunk)
                 if len(capture) > MAX_OUTPUT_CHARS:
+                    overflows[key.data] = True
                     del capture[:-MAX_OUTPUT_CHARS]
         if not timed_out:
             process.wait(timeout=max(1, deadline - time.monotonic()))
@@ -282,6 +326,8 @@ def _subprocess_runner(command: list[str], timeout_seconds: int, *, env: dict[st
         _bounded(stdout),
         _bounded(stderr),
         time.monotonic() - started,
+        stdout_overflow=overflows["stdout"],
+        stderr_overflow=overflows["stderr"],
     )
 
 
@@ -790,10 +836,31 @@ class GateRunner:
                     "status": "blocked",
                     "error": "job budget exceeded",
                 }
-            pull_status = classify_failure(getattr(pull, "returncode", None), getattr(pull, "stdout", ""), getattr(pull, "stderr", ""))
-            if getattr(pull, "returncode", None) != 0:
-                return pull_status, {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": pull_status}
+            pull_status = classify_failure(
+                getattr(pull, "returncode", None),
+                getattr(pull, "stdout", ""),
+                getattr(pull, "stderr", ""),
+                stdout_overflow=bool(getattr(pull, "stdout_overflow", False)),
+                stderr_overflow=bool(getattr(pull, "stderr_overflow", False)),
+            )
+            if pull_status != "success":
+                error = "pull command output overflow" if _has_output_overflow(pull) else None
+                evidence = {
+                    "requested_ref": f"docker.io/{image_ref}",
+                    "attempts": attempt,
+                    "status": pull_status,
+                }
+                if error:
+                    evidence["error"] = error
+                return pull_status, evidence
             inspect = self._invoke(["docker", "image", "inspect", image_ref], self.pull_timeout_seconds, env)
+            if _has_output_overflow(inspect):
+                return "blocked", {
+                    "requested_ref": f"docker.io/{image_ref}",
+                    "attempts": attempt,
+                    "status": "blocked",
+                    "error": "image inspect output overflow",
+                }
             try:
                 payload = json.loads(getattr(inspect, "stdout", ""))
                 image = payload[0] if isinstance(payload, list) else payload
@@ -828,6 +895,13 @@ class GateRunner:
             info = self._invoke(["docker", "info", "--format", "{{json .}}"], self.pull_timeout_seconds, env)
             uname = self._invoke(["uname", "-m"], self.pull_timeout_seconds, env)
             uname_os = self._invoke(["uname", "-s"], self.pull_timeout_seconds, env)
+            if any(_has_output_overflow(item) for item in (context, info, uname, uname_os)):
+                return "blocked", {
+                    "requested_ref": f"docker.io/{image_ref}",
+                    "attempts": attempt,
+                    "status": "blocked",
+                    "error": "Docker environment output overflow",
+                }
             if (
                 getattr(context, "returncode", 1) != 0
                 or getattr(context, "stdout", "").strip() != "default"
@@ -869,6 +943,13 @@ class GateRunner:
                 self.pull_timeout_seconds,
                 env,
             )
+            if _has_output_overflow(event):
+                return "blocked", {
+                    "requested_ref": f"docker.io/{image_ref}",
+                    "attempts": attempt,
+                    "status": "blocked",
+                    "error": "Docker event output overflow",
+                }
             event_id = ""
             event_id_source = ""
             event_ref = ""
@@ -1031,11 +1112,23 @@ class GateRunner:
             raw_stdout = getattr(result, "stdout", "")
             raw_stderr = getattr(result, "stderr", "")
             returncode = getattr(result, "returncode", None)
-            status = _classify_command_result(returncode, raw_stdout, raw_stderr)
+            stdout_overflow = bool(getattr(result, "stdout_overflow", False))
+            stderr_overflow = bool(getattr(result, "stderr_overflow", False))
+            status = _classify_command_result(
+                returncode,
+                raw_stdout,
+                raw_stderr,
+                stdout_overflow=stdout_overflow,
+                stderr_overflow=stderr_overflow,
+            )
             if status == "success" and self._deadline is not None and time.monotonic() >= self._deadline:
                 status = "blocked"
                 raw_stderr = f"{raw_stderr}\njob budget exceeded"
             attempt_result: dict[str, Any] = {"attempt": attempt, "command": redact(" ".join(command)), "returncode": returncode, "elapsed_seconds": elapsed, "status": status}
+            if stdout_overflow:
+                attempt_result["stdout_overflow"] = True
+            if stderr_overflow:
+                attempt_result["stderr_overflow"] = True
             if strict and status == "success":
                 try:
                     junit = self._parse_junit(entry, self._xml_candidates(attempt_started_ns, evidence_dir))

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -127,15 +127,20 @@ def redact(value: str) -> str:
     return redacted
 
 
-def _bounded(value: object) -> str:
+def _bounded_with_overflow(value: object) -> tuple[str, bool]:
     text = redact(str(value or ""))
     lines = text.splitlines()
+    overflow = len(lines) > MAX_OUTPUT_LINES
     if len(lines) > MAX_OUTPUT_LINES:
         text = "\n".join(lines[:MAX_OUTPUT_LINES]) + "\n...[line limit]"
     if len(text.encode("utf-8")) <= MAX_OUTPUT_CHARS:
-        return text
+        return text, overflow
     encoded = text.encode("utf-8")[:MAX_OUTPUT_CHARS]
-    return encoded.decode("utf-8", errors="ignore") + "\n...[byte limit]"
+    return encoded.decode("utf-8", errors="ignore") + "\n...[byte limit]", True
+
+
+def _bounded(value: object) -> str:
+    return _bounded_with_overflow(value)[0]
 
 
 def register_secret(value: object) -> None:
@@ -319,15 +324,17 @@ def _subprocess_runner(command: list[str], timeout_seconds: int, *, env: dict[st
                 stream.close()
     stdout = bytes(captures["stdout"]).decode("utf-8", errors="replace")
     stderr = bytes(captures["stderr"]).decode("utf-8", errors="replace")
+    bounded_stdout, stdout_bounded_overflow = _bounded_with_overflow(stdout)
+    bounded_stderr, stderr_bounded_overflow = _bounded_with_overflow(stderr)
     if timed_out:
-        stderr = f"{stderr}\n...[timeout]"
+        bounded_stderr = f"{bounded_stderr}\n...[timeout]"
     return CommandResult(
         None if timed_out else process.returncode,
-        _bounded(stdout),
-        _bounded(stderr),
+        bounded_stdout,
+        bounded_stderr,
         time.monotonic() - started,
-        stdout_overflow=overflows["stdout"],
-        stderr_overflow=overflows["stderr"],
+        stdout_overflow=overflows["stdout"] or stdout_bounded_overflow,
+        stderr_overflow=overflows["stderr"] or stderr_bounded_overflow,
     )
 
 

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -82,6 +82,9 @@ SECRET_PATTERN = re.compile(
 )
 BEARER_PATTERN = re.compile(r"(?i)(bearer\s+)[^\s,;]+")
 BASIC_AUTH_URL_PATTERN = re.compile(r"(?i)(https?://)([^/@:\s]+):([^/@\s]+)@")
+DOCKER_TEXT_PULL_EVENT_PATTERN = re.compile(
+    r"^(?P<timestamp>\S+)\s+image\s+pull\s+(?P<ref>\S+)(?:\s|$)"
+)
 _KNOWN_SECRETS: set[str] = set()
 
 
@@ -142,6 +145,38 @@ def register_secret(value: object) -> None:
             decoded = ""
         if decoded:
             _KNOWN_SECRETS.add(decoded)
+
+
+def _parse_iso_timestamp_ns(value: object) -> int:
+    """Parse Docker's ISO event timestamp without losing nanosecond precision."""
+
+    text = str(value or "").strip()
+    match = re.fullmatch(
+        r"(?P<date>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})"
+        r"(?:\.(?P<fraction>\d{1,9}))?(?P<zone>Z|[+-]\d{2}:\d{2})",
+        text,
+    )
+    if not match:
+        return 0
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        seconds = int(parsed.timestamp())
+    except ValueError:
+        return 0
+    fraction = int((match.group("fraction") or "").ljust(9, "0") or "0")
+    return seconds * 1_000_000_000 + fraction
+
+
+def _parse_text_pull_event(line: str) -> tuple[str, int] | None:
+    """Parse a Docker text event into its requested reference and timestamp."""
+
+    match = DOCKER_TEXT_PULL_EVENT_PATTERN.match(line.strip())
+    if not match:
+        return None
+    timestamp_ns = _parse_iso_timestamp_ns(match.group("timestamp"))
+    if timestamp_ns <= 0:
+        return None
+    return match.group("ref"), timestamp_ns
 
 
 def _read_bounded(path: Path, limit: int) -> str:
@@ -310,6 +345,18 @@ def verify_release_summary(
             f"docker.io/{expected_repository}@{digest}",
         }:
             errors.append("pull digest must belong to the requested repository")
+        event_id_source = pull.get("event_id_source")
+        event_image_id_source = pull.get("event_image_id_source")
+        if event_id_source not in {"docker_event", "ref_timestamp_receipt"}:
+            errors.append("pull event ID source is required")
+        if event_image_id_source not in {"docker_event", "post_pull_inspect"}:
+            errors.append("pull event image ID source is required")
+        if event_id_source == "ref_timestamp_receipt" and pull.get("event_id") != (
+            f"ref_timestamp:{pull.get('event_timestamp_ns')}:{pull.get('event_ref')}"
+        ):
+            errors.append("pull text event receipt is invalid")
+        if event_image_id_source == "post_pull_inspect" and pull.get("event_image_id") != pull.get("image_id"):
+            errors.append("post-pull inspect image ID binding is required")
         if (
             not pull.get("event_id")
             or pull.get("event_image_id") not in {pull.get("image_id"), pull.get("digest")}
@@ -823,14 +870,18 @@ class GateRunner:
                 env,
             )
             event_id = ""
+            event_id_source = ""
             event_ref = ""
             event_image_id = ""
+            event_image_id_source = ""
             event_timestamp_ns = 0
             expected_refs = {image_ref, f"docker.io/{image_ref}"}
             expected_ids = {image_id, digest}
             for line in getattr(event, "stdout", "").splitlines():
                 try:
                     item = json.loads(line)
+                    if not isinstance(item, dict):
+                        continue
                     actor = item.get("Actor", {})
                     attributes = actor.get("Attributes", {}) if isinstance(actor, dict) else {}
                     actor_id = str(actor.get("ID") or "") if isinstance(actor, dict) else ""
@@ -855,18 +906,48 @@ class GateRunner:
                         candidate_timestamp_ns = 0
                     if (
                         not matching_ref
-                        or not matching_id
                         or candidate_timestamp_ns < int(pull_started_wall * 1_000_000_000)
                     ):
                         continue
-                    event_id = str(item.get("id") or actor_id)
                     event_ref = matching_ref
-                    event_image_id = matching_id
                     event_timestamp_ns = candidate_timestamp_ns
+                    if matching_id:
+                        event_id = str(item.get("id") or actor_id)
+                        event_id_source = "docker_event"
+                        event_image_id = matching_id
+                        event_image_id_source = "docker_event"
+                    else:
+                        event_id = f"ref_timestamp:{event_timestamp_ns}:{event_ref}"
+                        event_id_source = "ref_timestamp_receipt"
+                        event_image_id = image_id
+                        event_image_id_source = "post_pull_inspect"
                     break
                 except json.JSONDecodeError:
-                    continue
-            if getattr(event, "returncode", 0) != 0 or not event_id or not event_ref or not event_image_id:
+                    text_event = _parse_text_pull_event(line)
+                    if text_event is None:
+                        continue
+                    text_ref, candidate_timestamp_ns = text_event
+                    matching_ref = text_ref if text_ref in expected_refs else ""
+                    if (
+                        not matching_ref
+                        or candidate_timestamp_ns < int(pull_started_wall * 1_000_000_000)
+                    ):
+                        continue
+                    event_ref = matching_ref
+                    event_timestamp_ns = candidate_timestamp_ns
+                    event_id = f"ref_timestamp:{event_timestamp_ns}:{event_ref}"
+                    event_id_source = "ref_timestamp_receipt"
+                    event_image_id = image_id
+                    event_image_id_source = "post_pull_inspect"
+                    break
+            if (
+                getattr(event, "returncode", 0) != 0
+                or not event_id
+                or not event_ref
+                or not event_image_id
+                or not event_id_source
+                or not event_image_id_source
+            ):
                 return "blocked", {"requested_ref": f"docker.io/{image_ref}", "attempts": attempt, "status": "blocked", "error": "pull event correlation is missing"}
             return "success", {
                 "requested_ref": f"docker.io/{image_ref}",
@@ -874,8 +955,10 @@ class GateRunner:
                 "status": "success",
                 "cache": "up_to_date" if "already exists" in getattr(pull, "stdout", "").lower() else "pulled",
                 "event_id": event_id,
+                "event_id_source": event_id_source,
                 "event_ref": event_ref or None,
                 "event_image_id": event_image_id or None,
+                "event_image_id_source": event_image_id_source,
                 "event_timestamp_ns": event_timestamp_ns,
                 "image_id": image_id,
                 "digest": digest,

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -68,6 +68,15 @@ def release_policy_errors(workflow: str) -> list[str]:
         "coverage=52/52" in workflow or "expected_coverage=\"52/52\"" in workflow
     ):
         errors.append("release workflow must verify the full 52/52 image gate")
+    arm_contract = (
+        "testcontainers-ignite2-arm64-image-gate" in workflow
+        and "--scope family" in workflow
+        and "--family-id ignite2" in workflow
+        and "--platform-id arm64" in workflow
+        and "expected_coverage=\"1/1\"" in workflow
+    )
+    if not arm_contract:
+        errors.append("release workflow must verify the exact Ignite2 arm64 1/1 image gate")
     return errors
 
 
@@ -141,6 +150,12 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
         )
         errors = release_policy_errors(mutated)
         self.assertIn("full Testcontainers image gate must wait for the manifest contract", errors)
+
+    def test_release_workflow_blocks_arm_gate_without_exact_selector(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace("--platform-id arm64", "--platform-id amd64")
+        errors = release_policy_errors(mutated)
+        self.assertIn("release workflow must verify the exact Ignite2 arm64 1/1 image gate", errors)
 
     def test_snapshot_workflow_is_not_coupled_to_issue_754_release_state(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -49,21 +49,24 @@ def release_policy_errors(workflow: str) -> list[str]:
         "resolve-version",
         "testcontainers-manifest-contract",
         "testcontainers-image-gate",
+        "testcontainers-ignite2-arm64-image-gate",
         "publish",
     }
     if job_ids(workflow) != expected_jobs:
         errors.append(
             "release workflow must contain resolve-version, testcontainers-manifest-contract, "
-            "testcontainers-image-gate, and publish jobs"
+            "testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate, and publish jobs"
         )
     if "needs: [resolve-version, testcontainers-manifest-contract]" not in workflow:
         errors.append("full Testcontainers image gate must wait for the manifest contract")
     if (
-        "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]"
+        "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]"
         not in workflow
     ):
         errors.append("publish must depend on the manifest contract and full image gate")
-    if "--scope full" not in workflow or "coverage=52/52" not in workflow:
+    if "--scope full" not in workflow or not (
+        "coverage=52/52" in workflow or "expected_coverage=\"52/52\"" in workflow
+    ):
         errors.append("release workflow must verify the full 52/52 image gate")
     return errors
 
@@ -124,7 +127,7 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
     def test_release_workflow_blocks_publish_without_full_image_gate(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
-            "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]",
+            "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
             "needs: resolve-version",
         )
         errors = release_policy_errors(mutated)

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import time
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -331,6 +332,88 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             event_command = next(command for command in calls if command[:2] == ["docker", "events"])
             self.assertIn("--since", event_command)
             self.assertIn("--until", event_command)
+
+    def test_strict_family_accepts_text_pull_event_bound_to_post_pull_inspect(self) -> None:
+        """Hosted Docker may emit text pull events without an event/image ID."""
+
+        def command_runner(command: list[str], timeout_seconds: int, **_: object) -> SimpleNamespace:
+            if command[:2] == ["docker", "pull"]:
+                return SimpleNamespace(returncode=0, stdout="Status: Downloaded newer image", stderr="")
+            if command[:3] == ["docker", "image", "inspect"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=json.dumps(
+                        [
+                            {
+                                "Id": "sha256:" + "a" * 64,
+                                "RepoDigests": ["apacheignite/ignite@sha256:" + "b" * 64],
+                                "Os": "linux",
+                                "Architecture": "amd64",
+                            }
+                        ]
+                    ),
+                    stderr="",
+                )
+            if command[:3] == ["docker", "context", "show"]:
+                return SimpleNamespace(returncode=0, stdout="default\n", stderr="")
+            if command[:2] == ["docker", "info"]:
+                return SimpleNamespace(returncode=0, stdout=json.dumps({"Architecture": "amd64", "OSType": "linux"}), stderr="")
+            if command[:2] == ["uname", "-m"]:
+                return SimpleNamespace(returncode=0, stdout="x86_64\n", stderr="")
+            if command[:2] == ["uname", "-s"]:
+                return SimpleNamespace(returncode=0, stdout="Linux\n", stderr="")
+            if command[:2] == ["docker", "events"]:
+                timestamp = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=(
+                        f"{timestamp} image pull apacheignite/ignite:2.18.0 "
+                        "(name=apacheignite/ignite, org.opencontainers.image.ref.name=ubuntu)\n"
+                    ),
+                    stderr="",
+                )
+            evidence = next(
+                (
+                    Path(part.split("=", 1)[1])
+                    for part in command
+                    if part.startswith("-Dtestcontainers.image-gate.evidence-dir=")
+                ),
+                None,
+            )
+            assert evidence is not None
+            evidence.joinpath("startup.marker").write_text("Ignite node started OK\n", encoding="utf-8")
+            evidence.joinpath("workload.image-id").write_text("sha256:" + "a" * 64 + "\n", encoding="utf-8")
+            evidence.joinpath("TEST-Ignite2ServerTest.xml").write_text(
+                '<testsuite name="io.bluetape4k.testcontainers.storage.Ignite2ServerTest" tests="1" skipped="0" failures="0" errors="0">'
+                '<testcase classname="io.bluetape4k.testcontainers.storage.Ignite2ServerTest" name="representativeStartupAndWorkload"/>'
+                "</testsuite>",
+                encoding="utf-8",
+            )
+            return SimpleNamespace(returncode=0, stdout="BUILD SUCCESSFUL", stderr="")
+
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [strict_entry()],
+                Path(directory),
+                command_runner=command_runner,
+                max_attempts=1,
+                scope="family",
+            ).run()
+
+        result = summary["results"][0]
+        self.assertEqual("success", result["status"])
+        self.assertEqual("apacheignite/ignite:2.18.0", result["pull"]["event_ref"])
+        self.assertEqual("post_pull_inspect", result["pull"]["event_image_id_source"])
+        self.assertEqual(
+            [],
+            verify_release_summary(
+                summary,
+                expected_coverage="1/1",
+                platform_id="amd64",
+                expected_tag="2.18.0",
+                expected_architecture="amd64",
+            ),
+        )
 
     def test_strict_family_without_marker_is_blocked(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import tempfile
 import time
 import unittest
@@ -14,6 +15,9 @@ from types import SimpleNamespace
 
 from scripts.run_testcontainers_image_gate import (
     GateRunner,
+    MAX_OUTPUT_CHARS,
+    _classify_command_result,
+    _subprocess_runner,
     classify_failure,
     redact,
     register_secret,
@@ -213,6 +217,54 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             ).run()
             self.assertEqual("success", summary["results"][0]["status"])
             self.assertTrue(summary["release_gate"])
+
+    def test_stdout_overflow_with_zero_exit_is_blocked(self) -> None:
+        command = [
+            sys.executable,
+            "-c",
+            f"import sys; sys.stdout.write('x' * {MAX_OUTPUT_CHARS + 1}); sys.stdout.flush()",
+        ]
+
+        result = _subprocess_runner(command, timeout_seconds=5)
+
+        self.assertEqual(0, result.returncode)
+        self.assertTrue(result.stdout_overflow)
+        self.assertFalse(result.stderr_overflow)
+        self.assertLessEqual(len(result.stdout.encode("utf-8")), MAX_OUTPUT_CHARS)
+        self.assertEqual(
+            "blocked",
+            _classify_command_result(
+                result.returncode,
+                result.stdout,
+                result.stderr,
+                stdout_overflow=result.stdout_overflow,
+                stderr_overflow=result.stderr_overflow,
+            ),
+        )
+
+    def test_stderr_overflow_with_zero_exit_is_blocked(self) -> None:
+        command = [
+            sys.executable,
+            "-c",
+            f"import sys; sys.stdout.write('BUILD SUCCESSFUL\\n'); sys.stderr.write('x' * {MAX_OUTPUT_CHARS + 1}); sys.stderr.flush()",
+        ]
+
+        result = _subprocess_runner(command, timeout_seconds=5)
+
+        self.assertEqual(0, result.returncode)
+        self.assertFalse(result.stdout_overflow)
+        self.assertTrue(result.stderr_overflow)
+        self.assertLessEqual(len(result.stderr.encode("utf-8")), MAX_OUTPUT_CHARS)
+        self.assertEqual(
+            "blocked",
+            _classify_command_result(
+                result.returncode,
+                result.stdout,
+                result.stderr,
+                stdout_overflow=result.stdout_overflow,
+                stderr_overflow=result.stderr_overflow,
+            ),
+        )
 
     def test_secret_redaction_applies_to_artifact_text(self) -> None:
         safe = redact("TOKEN=super-secret password=hunter2 Authorization: Bearer abc123")

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 from scripts.run_testcontainers_image_gate import (
     GateRunner,
     MAX_OUTPUT_CHARS,
+    MAX_OUTPUT_LINES,
     _classify_command_result,
     _subprocess_runner,
     classify_failure,
@@ -255,6 +256,54 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
         self.assertFalse(result.stdout_overflow)
         self.assertTrue(result.stderr_overflow)
         self.assertLessEqual(len(result.stderr.encode("utf-8")), MAX_OUTPUT_CHARS)
+        self.assertEqual(
+            "blocked",
+            _classify_command_result(
+                result.returncode,
+                result.stdout,
+                result.stderr,
+                stdout_overflow=result.stdout_overflow,
+                stderr_overflow=result.stderr_overflow,
+            ),
+        )
+
+    def test_stdout_line_overflow_with_zero_exit_is_blocked(self) -> None:
+        command = [
+            sys.executable,
+            "-c",
+            f"import sys; sys.stdout.write('x\\n' * {MAX_OUTPUT_LINES + 1}); sys.stdout.write('BUILD SUCCESSFUL\\n'); sys.stdout.flush()",
+        ]
+
+        result = _subprocess_runner(command, timeout_seconds=5)
+
+        self.assertEqual(0, result.returncode)
+        self.assertTrue(result.stdout_overflow)
+        self.assertFalse(result.stderr_overflow)
+        self.assertIn("...[line limit]", result.stdout)
+        self.assertEqual(
+            "blocked",
+            _classify_command_result(
+                result.returncode,
+                result.stdout,
+                result.stderr,
+                stdout_overflow=result.stdout_overflow,
+                stderr_overflow=result.stderr_overflow,
+            ),
+        )
+
+    def test_stderr_line_overflow_with_zero_exit_is_blocked(self) -> None:
+        command = [
+            sys.executable,
+            "-c",
+            f"import sys; sys.stdout.write('BUILD SUCCESSFUL\\n'); sys.stderr.write('x\\n' * {MAX_OUTPUT_LINES + 1}); sys.stderr.flush()",
+        ]
+
+        result = _subprocess_runner(command, timeout_seconds=5)
+
+        self.assertEqual(0, result.returncode)
+        self.assertFalse(result.stdout_overflow)
+        self.assertTrue(result.stderr_overflow)
+        self.assertIn("...[line limit]", result.stderr)
         self.assertEqual(
             "blocked",
             _classify_command_result(

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -35,6 +35,27 @@ class TestTestcontainersImageGate(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn('tasks.register<Test>("k8sTest")', build_script)
 
+    def test_java25_ignite_options_are_module_scoped_and_minimal(self) -> None:
+        root_build = (self.root / "build.gradle.kts").read_text(encoding="utf-8")
+        module_build = (
+            self.root / "testing/testcontainers/build.gradle.kts"
+        ).read_text(encoding="utf-8")
+        self.assertIn("tasks.withType<Test>().configureEach", module_build)
+        for option in (
+            "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+        ):
+            self.assertIn(option, module_build)
+            self.assertNotIn(option, root_build)
+
+    def test_ignite_workload_receipt_matches_the_long_arm_timeout_contract(self) -> None:
+        source = (
+            self.root
+            / "testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt"
+        ).read_text(encoding="utf-8")
+        self.assertIn('Files.writeString(root.resolve("workload.image-id")', source)
+        self.assertIn("@Timeout(value = 30, unit = TimeUnit.MINUTES)", source)
+
     def test_changed_scope_is_deterministic_and_full_scope_is_complete(self) -> None:
         changed = select_entries(self.entries, {"testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/aws/FlociServer.kt"})
         self.assertEqual(["FlociServer"], [entry["server"] for entry in changed])

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -41,6 +41,7 @@ class TestTestcontainersImageGate(unittest.TestCase):
             self.root / "testing/testcontainers/build.gradle.kts"
         ).read_text(encoding="utf-8")
         self.assertIn("tasks.withType<Test>().configureEach", module_build)
+        self.assertIn('systemProperty("testcontainers.image-gate.evidence-dir", it)', module_build)
         for option in (
             "--add-opens=java.base/java.nio=ALL-UNNAMED",
             "--add-opens=java.base/java.util=ALL-UNNAMED",

--- a/scripts/testcontainers_image_gate_manifest.json
+++ b/scripts/testcontainers_image_gate_manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "families": [
     {
       "id": "dynamo-db-local",
@@ -763,6 +763,38 @@
       "testPattern": "io.bluetape4k.testcontainers.storage.Ignite2ServerTest",
       "readiness": "testcontainers_wait_strategy_and_workload_readiness",
       "workload": "io.bluetape4k.testcontainers.storage.Ignite2ServerTest:representative_test",
+      "platforms": [
+        {
+          "id": "amd64",
+          "os": "linux",
+          "architecture": "amd64",
+          "tag": "2.18.0",
+          "runner": "ubuntu-24.04"
+        },
+        {
+          "id": "arm64",
+          "os": "linux",
+          "architecture": "arm64",
+          "tag": "2.18.0-arm64",
+          "runner": "ubuntu-24.04-arm"
+        }
+      ],
+      "defaultPlatformId": "amd64",
+      "executionEvidenceRequired": true,
+      "workloadTestPattern": "io.bluetape4k.testcontainers.storage.Ignite2ServerTest.representativeStartupAndWorkload",
+      "platformTimeouts": {
+        "amd64": {
+          "testMinutes": 6,
+          "clientConnectSeconds": 30,
+          "clientRequestSeconds": 30
+        },
+        "arm64": {
+          "testMinutes": 30,
+          "clientConnectSeconds": 30,
+          "clientRequestSeconds": 30
+        }
+      },
+      "pullEvidenceRequired": true,
       "diagnostics": [
         "docker_inspect",
         "docker_logs",

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -100,6 +100,13 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 재현 가능한 로컬·CI 실행을 위해 변경 가능한 `latest`, major-only, rolling minor
 태그는 사용하지 않습니다.
 
+`Ignite2Server`는 canonical `apacheignite/ignite` 이미지를 지연 해석합니다.
+`x86_64`/`amd64`에서는 `2.18.0`, `aarch64`/`arm64`에서는
+`2.18.0-arm64`를 사용합니다. canonical tag를 생략한 상태에서 지원하지 않는
+아키텍처를 만나면 즉시 실패합니다. Custom image는 명시적인 tag가 필요하고,
+명시한 custom tag는 모든 아키텍처에서 허용됩니다. 아래처럼 서버와
+`IgniteClient`를 `use`/`close`로 함께 정리하세요.
+
 | 그룹 | 서버 | 이미지 | 기본 태그 |
 |---|---|---|---|
 | AWS | `DynamoDbLocalServer` | `amazon/dynamodb-local` | `3.3.1` |
@@ -146,7 +153,7 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 | Storage | `ElasticsearchOssServer` | `docker.elastic.co/elasticsearch/elasticsearch-oss` | `7.10.2` |
 | Storage | `ElasticsearchServer` | `docker.elastic.co/elasticsearch/elasticsearch` | `9.5.0` |
 | Storage | `HazelcastServer` | `hazelcast/hazelcast` | `5.7.0-slim-jdk25` |
-| Storage | `Ignite2Server` | `apacheignite/ignite` | `2.18.0` (aarch64는 `-arm64`) |
+| Storage | `Ignite2Server` | `apacheignite/ignite` | `2.18.0` (x86_64/amd64) 또는 `2.18.0-arm64` (aarch64/arm64) |
 | Storage | `Ignite3Server` | `apacheignite/ignite` | `3.1.0` |
 | Storage | `InfluxDBServer` | `influxdb` | `2.9.1` |
 | Storage | `MinIOServer` | `minio/minio` | `RELEASE.2025-07-23T15-54-02Z` (호환성 fixture) |
@@ -459,11 +466,20 @@ val client = HazelcastClient.newHazelcastClient(
     ClientConfig().apply { networkConfig.addAddress("${hazelcast.host}:${hazelcast.port}") }
 )
 
-// Apache Ignite 2.x — 씬 클라이언트 포트 10800
-val ignite2 = Ignite2Server.Launcher.ignite2
-val client = IgniteClient.start(ClientConfiguration().apply {
-    setAddresses("${ignite2.host}:${ignite2.port}")
-})
+// Apache Ignite 2.x — native 이미지 tag와 씬 클라이언트 포트 10800
+Ignite2Server().use { ignite2 ->
+    ignite2.start()
+    Ignition.startClient(
+        ClientConfiguration()
+            .setAddresses(ignite2.url)
+            .setTimeout(30_000)
+            .setRequestTimeout(30_000),
+    ).use { client ->
+        val cache = client.getOrCreateCache<String, String>("example-cache")
+        cache.put("key", "value")
+        check(cache.get("key") == "value")
+    }
+}
 
 // Apache Ignite 3.x — 클러스터 자동 초기화, 씬 클라이언트 포트 10800
 val ignite3 = Ignite3Server.Launcher.ignite3

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -107,6 +107,12 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 명시한 custom tag는 모든 아키텍처에서 허용됩니다. 아래처럼 서버와
 `IgniteClient`를 `use`/`close`로 함께 정리하세요.
 
+Java 25+에서 Ignite 2 thin-client 테스트에 필요한 JVM 옵션은
+`--add-opens=java.base/java.nio=ALL-UNNAMED`와
+`--add-opens=java.base/java.util=ALL-UNNAMED` 두 개로 확정했습니다. 이 옵션은
+`bluetape4k-testcontainers` 모듈의 `Test` 태스크에만 적용하며 저장소 전체의
+전역 JVM 기본값으로 사용하지 않습니다.
+
 | 그룹 | 서버 | 이미지 | 기본 태그 |
 |---|---|---|---|
 | AWS | `DynamoDbLocalServer` | `amazon/dynamodb-local` | `3.3.1` |

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -95,6 +95,13 @@ The defaults below are pinned to the latest stable image tag verified on
 2026-08-10. Mutable `latest`, major-only, and rolling minor tags are avoided so
 that Testcontainers runs remain reproducible across local machines and CI.
 
+`Ignite2Server` resolves the canonical `apacheignite/ignite` image lazily:
+`x86_64`/`amd64` uses `2.18.0`, while `aarch64`/`arm64` uses
+`2.18.0-arm64`. An unknown architecture fails fast when the canonical tag is
+omitted. Custom images must provide an explicit tag; an explicit custom tag is
+accepted on any architecture. Start the server and close both the server and
+the `IgniteClient` with `use`/`close` as shown below.
+
 | Group | Server | Image | Default tag |
 |---|---|---|---|
 | AWS | `DynamoDbLocalServer` | `amazon/dynamodb-local` | `3.3.1` |
@@ -141,7 +148,7 @@ that Testcontainers runs remain reproducible across local machines and CI.
 | Storage | `ElasticsearchOssServer` | `docker.elastic.co/elasticsearch/elasticsearch-oss` | `7.10.2` |
 | Storage | `ElasticsearchServer` | `docker.elastic.co/elasticsearch/elasticsearch` | `9.5.0` |
 | Storage | `HazelcastServer` | `hazelcast/hazelcast` | `5.7.0-slim-jdk25` |
-| Storage | `Ignite2Server` | `apacheignite/ignite` | `2.18.0` (`-arm64` on aarch64) |
+| Storage | `Ignite2Server` | `apacheignite/ignite` | `2.18.0` (x86_64/amd64) or `2.18.0-arm64` (aarch64/arm64) |
 | Storage | `Ignite3Server` | `apacheignite/ignite` | `3.1.0` |
 | Storage | `InfluxDBServer` | `influxdb` | `2.9.1` |
 | Storage | `MinIOServer` | `minio/minio` | `RELEASE.2025-07-23T15-54-02Z` (compatibility fixture) |
@@ -496,11 +503,20 @@ val client = HazelcastClient.newHazelcastClient(
     ClientConfig().apply { networkConfig.addAddress("${hazelcast.host}:${hazelcast.port}") }
 )
 
-// Apache Ignite 2.x — thin client port 10800
-val ignite2 = Ignite2Server.Launcher.ignite2
-val client = IgniteClient.start(ClientConfiguration().apply {
-    setAddresses("${ignite2.host}:${ignite2.port}")
-})
+// Apache Ignite 2.x — native image tag and thin-client port 10800
+Ignite2Server().use { ignite2 ->
+    ignite2.start()
+    Ignition.startClient(
+        ClientConfiguration()
+            .setAddresses(ignite2.url)
+            .setTimeout(30_000)
+            .setRequestTimeout(30_000),
+    ).use { client ->
+        val cache = client.getOrCreateCache<String, String>("example-cache")
+        cache.put("key", "value")
+        check(cache.get("key") == "value")
+    }
+}
 
 // Apache Ignite 3.x — auto cluster-init, thin client port 10800
 val ignite3 = Ignite3Server.Launcher.ignite3

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -102,6 +102,12 @@ omitted. Custom images must provide an explicit tag; an explicit custom tag is
 accepted on any architecture. Start the server and close both the server and
 the `IgniteClient` with `use`/`close` as shown below.
 
+On Java 25+, the Ignite 2 thin-client tests use only
+`--add-opens=java.base/java.nio=ALL-UNNAMED` and
+`--add-opens=java.base/java.util=ALL-UNNAMED`. These options are scoped to the
+`bluetape4k-testcontainers` module's `Test` tasks; they are not global JVM
+defaults for the repository.
+
 | Group | Server | Image | Default tag |
 |---|---|---|---|
 | AWS | `DynamoDbLocalServer` | `amazon/dynamodb-local` | `3.3.1` |

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -43,6 +43,10 @@ tasks.withType<Test>().configureEach {
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
         "--add-opens=java.base/java.util=ALL-UNNAMED",
     )
+    // Strict image gate 증거 경로를 실제 테스트 JVM에도 전달합니다.
+    System.getProperty("testcontainers.image-gate.evidence-dir")?.let {
+        systemProperty("testcontainers.image-gate.evidence-dir", it)
+    }
 }
 
 tasks.test {

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -40,6 +40,11 @@ kover {
 tasks.test {
     dependsOn(":bluetape4k-mock-web-server:jibDockerBuild")
     dependsOn(":bluetape4k-mock-webflux-server:jibDockerBuild")
+    // Ignite 2.18 thin client reflects on java.nio.Buffer under Java 25.
+    jvmArgs(
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+    )
     useJUnitPlatform {
         // K3s requires a privileged Docker runner. Excluded from regular CI by default.
         // Enable with: ./gradlew :bluetape4k-testcontainers:test -PincludeK8s
@@ -74,6 +79,9 @@ dependencies {
 
     api(libs.testcontainers)
     api(libs.testcontainers.junit.jupiter)
+
+    // Ignite 2 thin-client workload is test-only; it must not enter the published POM.
+    testImplementation(bt4k.ignite.core)
 
     api(libs.awaitility.kotlin)
 

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -40,11 +40,6 @@ kover {
 tasks.test {
     dependsOn(":bluetape4k-mock-web-server:jibDockerBuild")
     dependsOn(":bluetape4k-mock-webflux-server:jibDockerBuild")
-    // Ignite 2.18 thin client reflects on java.nio.Buffer under Java 25.
-    jvmArgs(
-        "--add-opens=java.base/java.nio=ALL-UNNAMED",
-        "--add-opens=java.base/java.util=ALL-UNNAMED",
-    )
     useJUnitPlatform {
         // K3s requires a privileged Docker runner. Excluded from regular CI by default.
         // Enable with: ./gradlew :bluetape4k-testcontainers:test -PincludeK8s

--- a/testing/testcontainers/build.gradle.kts
+++ b/testing/testcontainers/build.gradle.kts
@@ -37,6 +37,14 @@ kover {
 
 // testcontainers 테스트 실행 전 mock-server Docker 이미지를 자동으로 빌드합니다.
 // Jib은 소스 변경이 없으면 up-to-date 체크로 스킵하므로 매번 느리지 않습니다.
+// Java 25+에서 Ignite 2 thin client의 레거시 reflection에 필요한 최소 범위입니다.
+tasks.withType<Test>().configureEach {
+    jvmArgs(
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+    )
+}
+
 tasks.test {
     dependsOn(":bluetape4k-mock-web-server:jibDockerBuild")
     dependsOn(":bluetape4k-mock-webflux-server:jibDockerBuild")

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
@@ -61,6 +61,7 @@ class Ignite2Server private constructor(
             get() = defaultTagForArchitecture(System.getProperty("os.arch"))
 
         private const val DEFAULT_TAG_SENTINEL = "__ignite2_default_tag__"
+        private const val STARTUP_TIMEOUT_MINUTES = 5L
 
         private fun defaultTagForArchitecture(architecture: String?): String = when (architecture?.lowercase()) {
             "x86_64", "amd64" -> TAG
@@ -115,7 +116,8 @@ class Ignite2Server private constructor(
          * ```
          *
          * @param image          Docker 이미지 이름, blank이면 [IllegalArgumentException]이 발생합니다.
-         * @param tag            Docker 이미지 태그, blank이면 [IllegalArgumentException]이 발생합니다 (기본: [DEFAULT_TAG]; aarch64에서는 [TAG]-arm64).
+         * @param tag            Docker 이미지 태그, blank이면 [IllegalArgumentException]이 발생합니다
+         *                       (기본: [DEFAULT_TAG]; aarch64에서는 [TAG]-arm64).
          * @param useDefaultPort `true`면 10800 포트를 고정 바인딩합니다.
          * @param reuse          컨테이너 재사용 여부입니다.
          */
@@ -163,7 +165,7 @@ class Ignite2Server private constructor(
         // Ignite 2.x 노드가 완전히 초기화될 때까지 로그 메시지로 대기
         waitingFor(
             Wait.forLogMessage(".*Ignite node started OK.*", 1)
-                .withStartupTimeout(Duration.ofMinutes(5))
+                .withStartupTimeout(Duration.ofMinutes(STARTUP_TIMEOUT_MINUTES))
         )
 
         if (useDefaultPort) {

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
@@ -20,9 +20,20 @@ import java.time.Duration
  *
  * **사용 예시:**
  * ```kotlin
- * val ignite2 = Ignite2Server().apply { start() }
- * val clientAddress = ignite2.url
+ * Ignite2Server().use { ignite2 ->
+ *     ignite2.start()
+ *     Ignition.startClient(ClientConfiguration().setAddresses(ignite2.url)).use { client ->
+ *         val cache = client.getOrCreateCache<String, String>("example-cache")
+ *         cache.put("key", "value")
+ *         check(cache.get("key") == "value")
+ *     }
+ * }
  * ```
+ *
+ * canonical 이미지는 `x86_64`/`amd64`에서 `2.18.0`, `aarch64`/`arm64`에서
+ * `2.18.0-arm64`로 지연 해석됩니다. canonical tag를 생략한 상태에서 지원하지
+ * 않는 아키텍처를 만나면 즉시 실패합니다. Custom image는 명시적인 tag가
+ * 필요하며, 명시한 custom tag는 canonical resolver를 우회합니다.
  *
  * @param imageName Docker 이미지 이름 ([DockerImageName])
  * @param useDefaultPort 기본 포트(10800)를 그대로 사용할지 여부. `false`이면 임의 포트가 할당됩니다.
@@ -44,8 +55,18 @@ class Ignite2Server private constructor(
         /**
          * 현재 아키텍처에 맞는 기본 태그.
          * arm64(Apple Silicon 등)에서는 에뮬레이션 없이 실행하기 위해 `2.18.0-arm64` 태그를 사용합니다.
+         * 지원하지 않는 아키텍처에서는 기본 생성자 경로를 조용히 다른 이미지로 완화하지 않습니다.
          */
-        val DEFAULT_TAG: String = if (System.getProperty("os.arch") == "aarch64") "$TAG-arm64" else TAG
+        val DEFAULT_TAG: String
+            get() = defaultTagForArchitecture(System.getProperty("os.arch"))
+
+        private const val DEFAULT_TAG_SENTINEL = "__ignite2_default_tag__"
+
+        private fun defaultTagForArchitecture(architecture: String?): String = when (architecture?.lowercase()) {
+            "x86_64", "amd64" -> TAG
+            "aarch64", "arm64" -> "$TAG-arm64"
+            else -> error("Unsupported Ignite2 default image architecture: $architecture")
+        }
 
         /** 시스템 프로퍼티 등록 시 사용하는 서버 이름 */
         const val NAME = "ignite2"
@@ -71,7 +92,19 @@ class Ignite2Server private constructor(
             imageName: DockerImageName,
             useDefaultPort: Boolean = false,
             reuse: Boolean = false,
-        ): Ignite2Server = Ignite2Server(imageName, useDefaultPort, reuse)
+        ): Ignite2Server {
+            val resolvedImageName = if (
+                imageName.getUnversionedPart() == IMAGE && imageName.getVersionPart() == "latest"
+            ) {
+                imageName.withTag(DEFAULT_TAG)
+            } else {
+                require(imageName.getVersionPart() != "latest" || imageName.getUnversionedPart() == IMAGE) {
+                    "Custom Ignite2 DockerImageName must include an explicit tag"
+                }
+                imageName
+            }
+            return Ignite2Server(resolvedImageName, useDefaultPort, reuse)
+        }
 
         /**
          * 이미지 이름과 태그로 [Ignite2Server]를 생성합니다.
@@ -89,13 +122,21 @@ class Ignite2Server private constructor(
         @JvmStatic
         operator fun invoke(
             image: String = IMAGE,
-            tag: String = DEFAULT_TAG,
+            tag: String = DEFAULT_TAG_SENTINEL,
             useDefaultPort: Boolean = false,
             reuse: Boolean = false,
         ): Ignite2Server {
             image.requireNotBlank("image")
-            tag.requireNotBlank("tag")
-            val imageName = DockerImageName.parse(image).withTag(tag)
+            val resolvedTag = if (tag == DEFAULT_TAG_SENTINEL) {
+                require(image == IMAGE) {
+                    "Custom Ignite2 image requires an explicit tag"
+                }
+                DEFAULT_TAG
+            } else {
+                tag.requireNotBlank("tag")
+                tag
+            }
+            val imageName = DockerImageName.parse(image).withTag(resolvedTag)
             return Ignite2Server(imageName, useDefaultPort, reuse)
         }
     }

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
@@ -116,8 +116,7 @@ class Ignite2Server private constructor(
          * ```
          *
          * @param image          Docker 이미지 이름, blank이면 [IllegalArgumentException]이 발생합니다.
-         * @param tag            Docker 이미지 태그, blank이면 [IllegalArgumentException]이 발생합니다
-         *                       (기본: [DEFAULT_TAG]; aarch64에서는 [TAG]-arm64).
+         * @param tag            Docker 이미지 태그, blank이면 [IllegalArgumentException]이 발생합니다 (기본: [DEFAULT_TAG]; aarch64에서는 [TAG]-arm64).
          * @param useDefaultPort `true`면 10800 포트를 고정 바인딩합니다.
          * @param reuse          컨테이너 재사용 여부입니다.
          */

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt
@@ -4,14 +4,47 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.testcontainers.AbstractContainerTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
-import org.junit.jupiter.api.Disabled
+import org.apache.ignite.Ignition
+import org.apache.ignite.configuration.ClientConfiguration
+import org.testcontainers.utility.DockerImageName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import io.bluetape4k.assertions.assertFailsWith
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 
-@Disabled("사용성이 낮아서 테스트에서 제외합니다")
 class Ignite2ServerTest: AbstractContainerTest() {
 
     companion object: KLogging()
+
+    @Test
+    @Timeout(value = 6, unit = TimeUnit.MINUTES)
+    fun representativeStartupAndWorkload() {
+        Ignite2Server().use { server ->
+            server.start()
+            writeStartupMarker()
+
+            @Suppress("DEPRECATION")
+            val clientConfiguration = ClientConfiguration()
+                .setAddresses(server.url)
+                .setTimeout(30_000)
+                .setRequestTimeout(30_000)
+
+            Ignition.startClient(clientConfiguration).use { client ->
+                val cache = client.getOrCreateCache<String, String>("ignite2-image-gate")
+                cache.put("representative-key", "representative-value")
+                cache.get("representative-key") shouldBeEqualTo "representative-value"
+            }
+        }
+    }
+
+    private fun writeStartupMarker() {
+        val evidenceDir = System.getProperty("testcontainers.image-gate.evidence-dir") ?: return
+        val root = Path.of(evidenceDir).toAbsolutePath().normalize()
+        Files.createDirectories(root)
+        Files.writeString(root.resolve("startup.marker"), "Ignite node started OK\n")
+    }
 
     @Test
     fun `create ignite2 server`() {
@@ -34,5 +67,38 @@ class Ignite2ServerTest: AbstractContainerTest() {
     fun `blank image tag 는 허용하지 않는다`() {
         assertFailsWith<IllegalArgumentException> { Ignite2Server(image = " ") }
         assertFailsWith<IllegalArgumentException> { Ignite2Server(tag = " ") }
+    }
+
+    @Test
+    fun `default tag follows the native architecture and custom images stay explicit`() {
+        val originalArchitecture = System.getProperty("os.arch")
+        try {
+            System.setProperty("os.arch", "x86_64")
+            Ignite2Server.DEFAULT_TAG shouldBeEqualTo Ignite2Server.TAG
+
+            System.setProperty("os.arch", "arm64")
+            Ignite2Server.DEFAULT_TAG shouldBeEqualTo "${Ignite2Server.TAG}-arm64"
+            assertFailsWith<IllegalArgumentException> { Ignite2Server(image = "custom/ignite") }
+            Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom").use { }
+
+            System.setProperty("os.arch", "mips64")
+            assertFailsWith<IllegalStateException> { Ignite2Server() }
+        } finally {
+            if (originalArchitecture == null) {
+                System.clearProperty("os.arch")
+            } else {
+                System.setProperty("os.arch", originalArchitecture)
+            }
+        }
+    }
+
+    @Test
+    fun `DockerImageName tagless canonical image resolves while custom tagless image fails`() {
+        val canonical = Ignite2Server(DockerImageName.parse(Ignite2Server.IMAGE))
+        canonical.dockerImageName shouldBeEqualTo
+            "${Ignite2Server.IMAGE}:${Ignite2Server.DEFAULT_TAG}"
+        assertFailsWith<IllegalArgumentException> {
+            Ignite2Server(DockerImageName.parse("custom/ignite"))
+        }
     }
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt
@@ -19,11 +19,11 @@ class Ignite2ServerTest: AbstractContainerTest() {
     companion object: KLogging()
 
     @Test
-    @Timeout(value = 6, unit = TimeUnit.MINUTES)
+    @Timeout(value = 30, unit = TimeUnit.MINUTES)
     fun representativeStartupAndWorkload() {
         Ignite2Server().use { server ->
             server.start()
-            writeStartupMarker()
+            writeWorkloadEvidence(server)
 
             @Suppress("DEPRECATION")
             val clientConfiguration = ClientConfiguration()
@@ -39,11 +39,12 @@ class Ignite2ServerTest: AbstractContainerTest() {
         }
     }
 
-    private fun writeStartupMarker() {
+    private fun writeWorkloadEvidence(server: Ignite2Server) {
         val evidenceDir = System.getProperty("testcontainers.image-gate.evidence-dir") ?: return
         val root = Path.of(evidenceDir).toAbsolutePath().normalize()
         Files.createDirectories(root)
         Files.writeString(root.resolve("startup.marker"), "Ignite node started OK\n")
+        Files.writeString(root.resolve("workload.image-id"), "${server.containerInfo.imageId}\n")
     }
 
     @Test


### PR DESCRIPTION
## 요약

Issue #1486의 stacked PR child입니다. Ignite2Server의 native architecture 기본 태그를 실제 arm64 image pull·startup·thin-client workload와 연결하고, Java 25+ 테스트 런타임 옵션을 최소 범위로 확정합니다.

## 변경 사항

- `x86_64`/`amd64`는 `2.18.0`, `aarch64`/`arm64`는 `2.18.0-arm64`를 사용하고 알 수 없는 architecture는 fail-fast 처리합니다.
- 비활성화된 Ignite2 대표 테스트를 실제 `start → client connect → cache put/get` workload로 전환합니다.
- `workload.image-id`와 startup marker를 기록하고 strict runner가 pull image ID와 exact match하는지 검증합니다.
- arm64 Nightly/Release gate를 `ubuntu-24.04-arm`에서 30분 계약으로 실행하고 x64/arm64 gate를 publish에 모두 연결합니다.
- Docker pull 이벤트가 JSON 대신 ID 없는 text 형식으로 반환되는 hosted runner에서도 exact ref·timestamp receipt와 post-pull inspect image ID/digest binding을 검증합니다.
- Java 25+ 옵션은 `--add-opens=java.base/java.nio=ALL-UNNAMED`, `--add-opens=java.base/java.util=ALL-UNNAMED` 두 개로 확정해 `bluetape4k-testcontainers` 모듈의 `Test` 태스크에만 적용합니다. README EN/KO에도 동일 계약을 기록했습니다.
- Ignite 2 thin-client 의존성은 `testImplementation`으로만 추가합니다.
- 기존 Bluetape4k `AbstractContainerTest`, `GenericServer`, `PropertyExportingServer`, `ShutdownQueue`, `requireNotBlank`, `KLogging`, assertions를 재사용합니다.

## 검증

- Python runner/contract 통합 테스트: 45/45 PASS
- `:bluetape4k-testcontainers:compileTestKotlin :bluetape4k-testcontainers:detekt`: BUILD SUCCESSFUL
- `actionlint`, `python3 -m py_compile scripts/*.py`, `git diff --check`: PASS
- 로컬 Colima(`aarch64`, Docker `linux`) targeted Ignite2 workload: 1 test, skipped=0, failures=0, errors=0; startup marker와 workload image ID 수집
- 로컬 strict arm64 gate: hosted runner 계약(`Linux`/`ubuntu-24.04-arm`)을 macOS `Darwin`으로 대체하지 않도록 `0/1`, `blocked=1`, `release_gate=false`로 fail-closed
- PR CI run `32806688135` (exact head `d42694b99c7ff3519b99e53486c1ad24a7e43b48`): 21개 job 전체 PASS
- Hosted Nightly full run `32806713052` (exact head `d42694b99c7ff3519b99e53486c1ad24a7e43b48`): 43개 job 전체 SUCCESS; x64 `52/52`, ARM64 Ignite2 `1/1`, 양쪽 `release_gate=true`, `product_failure=0`, `infrastructure_failure=0`, `blocked=0`

## 스택

- parent PR: #1489 (`fix/1486-image-gate-runner` → `develop`), merge commit `14150e6e628273d73aa67f291f1593851d34481c`
- this child base: `develop@ce39a86b21eee42924e40411e1ea6b90ce9669bb` (parent #1489 이후 최신 develop와 후속 core PR 반영)

Closes #1486

## DoD Status

- 상태: Java 25 옵션·Kotlin workload·parser·byte/line overflow fail-closed·정적 검증 및 최신 develop 기준 exact head `d42694b99c7ff3519b99e53486c1ad24a7e43b48` PR CI(`32806688135`)·hosted Nightly full(`32806713052`) PASS 완료; stacked merge preflight 완료
- Java 25 옵션: 최소 2개·`bluetape4k-testcontainers` Test 태스크 한정으로 확정
- CG-14 human-review subgate: N/A (single-developer lane; repository maintainer scope is `debop`, with CI/review-thread/independent evidence retained)
- P1 blocker: 0 (parser와 stdout/stderr byte·line overflow fail-closed 회귀 수정; ARM64 `1/1`·x64 `52/52`, 양쪽 `release_gate=true`; fresh architect/code-review P1=0)
- P2 watch: x64 manifest 6분과 JUnit 공통 30분 표현, manifest client timeout과 Kotlin hardcode parity는 후속 정리 항목이며 현재 arm64 gate correctness blocker가 아님
