### PR TITLE
CI 공통 경로 변경을 전체 도메인 검증으로 연결

### DIFF
--- a/.github/scripts/test-ci-domain-parallelization.py
+++ b/.github/scripts/test-ci-domain-parallelization.py
@@ -26,6 +26,18 @@ BENCHMARK_PROJECTS = (
     "web-framework-benchmark",
 )
 
+SHARED_FILTER_PATHS = (
+    "'buildSrc/**'",
+    "'build.gradle.kts'",
+    "'settings.gradle.kts'",
+    "'gradle/**'",
+    "'gradle.properties'",
+    "'.github/workflows/**'",
+    "'.github/scripts/**'",
+    "'.github/actions/**'",
+    "'scripts/validate-ci-*.rb'",
+)
+
 DOMAIN_JOBS = (
     "test-core",
     "test-io",
@@ -103,6 +115,12 @@ class CiDomainParallelizationTest(unittest.TestCase):
         changes = job_block(self.workflow, "changes")
         self.assertIn("Validate CI domain dependency graph", changes)
         self.assertIn("python3 .github/scripts/test-ci-domain-parallelization.py -v", changes)
+
+    def test_shared_filter_covers_ci_orchestration_inputs(self):
+        shared_filter = path_filter_block(self.workflow, "shared")
+        for path_pattern in SHARED_FILTER_PATHS:
+            with self.subTest(path_pattern=path_pattern):
+                self.assertIn(path_pattern, shared_filter)
 
     def test_ci_and_nightly_exclude_benchmark_tag(self):
         for workflow_path in (CI_WORKFLOW, NIGHTLY_WORKFLOW):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,10 @@ jobs:
               - 'settings.gradle.kts'
               - 'gradle/**'
               - 'gradle.properties'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/**'
+              - '.github/scripts/**'
+              - '.github/actions/**'
+              - 'scripts/validate-ci-*.rb'
             core:
               - 'bluetape4k/annotations/**'
               - 'bluetape4k/core/**'

--- a/docs/lessons/2026-08-24-ci-shared-path-filter.md
+++ b/docs/lessons/2026-08-24-ci-shared-path-filter.md
@@ -1,0 +1,45 @@
+# CI 공통 경로는 도메인 선택 필터의 shared 계약으로 고정한다
+
+## 배경
+
+Daily CI는 `dorny/paths-filter`로 변경된 도메인만 테스트한다. 기존 `shared` 필터는
+Gradle 공통 파일과 `.github/workflows/ci.yml`만 포함했다. 따라서 다른 workflow나 CI
+helper, CSV/Kafka coverage validator가 바뀌어도 도메인 test job이 모두 `skipped`될 수
+있었다. `changes` job 자체가 성공하는 것만으로는 해당 변경이 도메인 테스트에 반영됐다는
+증거가 되지 않는다.
+
+## 결정
+
+- `shared`는 Gradle 공통 입력을 계속 포함한다.
+- `.github/workflows/**`, `.github/scripts/**`, `.github/actions/**`를 공통 CI
+  orchestration 입력으로 포함한다.
+- `scripts/validate-ci-*.rb`를 CI coverage 선택 계약의 공통 입력으로 포함한다.
+- 일반 문서/다이어그램 생성 스크립트 전체를 `shared`에 넣지는 않는다. 해당 파일은
+  도메인 테스트 선택을 바꾸지 않으므로 불필요한 전 도메인 실행을 만들지 않는다.
+- `test-ci-domain-parallelization.py`가 위 목록을 회귀 계약으로 검사하고, `changes` job이
+  계속 이 검증기를 실행한다.
+
+## 결과
+
+CI orchestration 또는 도메인 선택 계약이 바뀌면 모든 도메인 test job이 실행된다. 일반
+모듈 변경은 기존 도메인별 filter만 통과하므로 변경 없는 모듈을 계속 테스트하지 않는다.
+workflow 변경이 Nightly/Release 전용이어도 CI 정의의 영향 범위를 보수적으로 검증하며,
+일반 `scripts/**` 변경까지 전파하지 않아 생성 도구 수정으로 인한 불필요한 비용은 막는다.
+
+## 검증
+
+- RED: 기존 shared 목록에서 workflow/helper/validator wildcard 4개가 누락되어 회귀 테스트
+  12개 중 4개 subtest가 실패했다.
+- GREEN: shared 목록에 `.github/workflows/**`, `.github/scripts/**`,
+  `.github/actions/**`, `scripts/validate-ci-*.rb`를 추가한 뒤 12개 계약 테스트가
+  통과했다.
+- 후속 정적 검증에서 `actionlint`, `git diff --check`, 관련 workflow/test 계약을 다시
+  실행한다.
+
+## 향후 지침
+
+- 새로운 CI helper/action 또는 공통 path-filter 계약을 추가하면 `shared` 목록과 회귀
+  테스트를 같은 변경에서 갱신한다.
+- 모듈 전용 파일은 해당 도메인 filter에만 추가하고 `shared`로 승격하지 않는다.
+- `skipped` job은 coverage 증거가 아니므로, shared 경로 변경의 hosted CI에서는 모든
+  도메인 test job이 실제로 시작했는지 확인한다.


### PR DESCRIPTION
## 변경 내용

CI orchestration과 coverage 선택 계약 변경이 변경 감지에서 누락되지 않도록 `shared` path filter를 `.github/workflows/**`, `.github/scripts/**`, `.github/actions/**`, `scripts/validate-ci-*.rb`까지 확장했습니다. 일반 `scripts/**` 전체는 제외해 불필요한 도메인 검증을 막았습니다.

## 검증

- 기존 계약 테스트는 보강 전 4건 실패(RED), 보강 후 12건 통과(GREEN)
- `python3 .github/scripts/test-ci-domain-parallelization.py -v`
- `python3 .github/scripts/test-aggregate-kover-coverage.py -v`
- `ruby scripts/validate-ci-csv-coverage.rb`
- `ruby scripts/validate-ci-kafka4-coverage.rb`
- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`
- `git diff --check`

## 영향 및 한계

변경 없는 도메인 테스트를 계속 건너뛰면서 CI 계약 변경은 전체 도메인 검증으로 연결합니다. hosted PR head에서 실제 모든 도메인 test job 시작 시각과 전체 절감 시간은 PR 실행 후 확인합니다.

## Hosted CI Evidence

- PR exact head `aef9d2218383c1a2b9df16c79091fd33b233886a`의 hosted checks 21/21이 모두 SUCCESS로 완료되었습니다.
- `CI Status`, `Coverage Report`, 11개 도메인/브리지 테스트, Build, 변경 모듈 감지, Release/JVM/Catalog/CodeQL 정책 검증이 모두 통과했습니다.
- merge는 별도 승인 경계로 유지하며 자동 병합은 사용하지 않습니다.
## DoD Status

- [x] shared path filter 보강
- [x] 회귀 계약 테스트 추가 및 통과
- [x] actionlint·validator·diff 검증 통과
- [x] `develop` 기준 head `aef9d2218383c1a2b9df16c79091fd33b233886a` push 완료
- [x] hosted CI 실행시간·체크 결과 확인 완료 (21/21 SUCCESS)
- [ ] merge는 별도 승인 필요