### PR TITLE
[7-Tier][testing/testcontainers] launcher assertion을 bluetape4k 방식으로 통일

### DIFF
--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/GenericServerSupportTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/GenericServerSupportTest.kt
@@ -1,12 +1,12 @@
 package io.bluetape4k.testcontainers
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import io.bluetape4k.assertions.assertFailsWith
-import kotlin.test.assertNull
 
 class GenericServerSupportTest {
 
@@ -30,11 +30,11 @@ class GenericServerSupportTest {
 
         server.writeToSystemProperties("redis", mapOf("ssl" to true, "nullable" to null))
 
-        assertEquals("127.0.0.1", System.getProperty("testcontainers.redis.host"))
-        assertEquals("6379", System.getProperty("testcontainers.redis.port"))
-        assertEquals("127.0.0.1:6379", System.getProperty("testcontainers.redis.url"))
-        assertEquals("true", System.getProperty("testcontainers.redis.ssl"))
-        assertNull(System.getProperty("testcontainers.redis.nullable"))
+        System.getProperty("testcontainers.redis.host") shouldBeEqualTo "127.0.0.1"
+        System.getProperty("testcontainers.redis.port") shouldBeEqualTo "6379"
+        System.getProperty("testcontainers.redis.url") shouldBeEqualTo "127.0.0.1:6379"
+        System.getProperty("testcontainers.redis.ssl") shouldBeEqualTo "true"
+        System.getProperty("testcontainers.redis.nullable").shouldBeNull()
     }
 
     @Test
@@ -50,10 +50,10 @@ class GenericServerSupportTest {
 
         server.writeToSystemProperties("redis", mapOf("timeoutMs" to 1500))
 
-        assertEquals("10.0.0.15", System.getProperty("testcontainers.redis.host"))
-        assertEquals("16379", System.getProperty("testcontainers.redis.port"))
-        assertEquals("10.0.0.15:16379", System.getProperty("testcontainers.redis.url"))
-        assertEquals("1500", System.getProperty("testcontainers.redis.timeoutMs"))
+        System.getProperty("testcontainers.redis.host") shouldBeEqualTo "10.0.0.15"
+        System.getProperty("testcontainers.redis.port") shouldBeEqualTo "16379"
+        System.getProperty("testcontainers.redis.url") shouldBeEqualTo "10.0.0.15:16379"
+        System.getProperty("testcontainers.redis.timeoutMs") shouldBeEqualTo "1500"
     }
 
     @Test

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/EtcdServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/EtcdServerTest.kt
@@ -10,7 +10,6 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
-import kotlin.test.assertEquals
 
 class EtcdServerTest: AbstractContainerTest() {
 
@@ -46,7 +45,7 @@ class EtcdServerTest: AbstractContainerTest() {
     @Test
     fun `uses provided image`() {
         val server = EtcdServer(image = "gcr.io/etcd-development/etcd", tag = EtcdServer.TAG)
-        assertEquals("gcr.io/etcd-development/etcd:${EtcdServer.TAG}", server.dockerImageName)
+        server.dockerImageName shouldBeEqualTo "gcr.io/etcd-development/etcd:${EtcdServer.TAG}"
     }
 
     companion object {

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ToxiproxyServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ToxiproxyServerTest.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.TestInstance
 import org.testcontainers.containers.Network
 import kotlin.system.measureTimeMillis
 import io.bluetape4k.assertions.assertFailsWith
-import kotlin.test.assertTrue
 
 /**
  * [ToxiproxyServer] 테스트입니다.
@@ -90,20 +89,14 @@ class ToxiproxyServerTest: AbstractContainerTest() {
                                         val delayedElapsed = measureTimeMillis {
                                             commands.get("toxiproxy:key") shouldBeEqualTo "value"
                                         }
-                                        assertTrue(
-                                            delayedElapsed >= 150,
-                                            "latency toxic 이후 GET 응답은 지연되어야 한다. actual=${delayedElapsed}ms"
-                                        )
+                                        (delayedElapsed >= 150).shouldBeTrue()
 
                                         latency.remove()
 
                                         val recoveredElapsed = measureTimeMillis {
                                             commands.get("toxiproxy:key") shouldBeEqualTo "value"
                                         }
-                                        assertTrue(
-                                            recoveredElapsed < delayedElapsed,
-                                            "latency toxic 제거 후 응답 시간은 감소해야 한다. delayed=${delayedElapsed}ms, recovered=${recoveredElapsed}ms"
-                                        )
+                                        (recoveredElapsed < delayedElapsed).shouldBeTrue()
                                     }
                                 } finally {
                                     runCatching { proxy.delete() }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/infra/ZooKeeperServerTest.kt
@@ -8,7 +8,6 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 import io.bluetape4k.assertions.assertFailsWith
 
 class ZooKeeperServerTest: AbstractContainerTest() {
@@ -61,6 +60,6 @@ class ZooKeeperServerTest: AbstractContainerTest() {
     @Test
     fun `전달받은 image 를 사용한다`() {
         val server = ZooKeeperServer(image = "zookeeper", tag = ZooKeeperServer.TAG)
-        assertEquals("zookeeper:${ZooKeeperServer.TAG}", server.dockerImageName)
+        server.dockerImageName shouldBeEqualTo "zookeeper:${ZooKeeperServer.TAG}"
     }
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/PulsarServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/mq/PulsarServerTest.kt
@@ -8,7 +8,6 @@ import org.apache.pulsar.client.api.PulsarClient
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
-import kotlin.test.assertEquals
 import io.bluetape4k.assertions.assertFailsWith
 
 class PulsarServerTest: AbstractContainerTest() {
@@ -90,6 +89,6 @@ class PulsarServerTest: AbstractContainerTest() {
     @Test
     fun `전달받은 image 를 사용한다`() {
         val server = PulsarServer(image = "apachepulsar/pulsar", tag = "3.3.5")
-        assertEquals("apachepulsar/pulsar:3.3.5", server.dockerImageName)
+        server.dockerImageName shouldBeEqualTo "apachepulsar/pulsar:3.3.5"
     }
 }


### PR DESCRIPTION
## Summary

Closes #1494

`testing/testcontainers`의 launcher 계약 테스트가 모듈 표준인 `bluetape4k-assertions`와 일관되지 않아, 다섯 대상 테스트의 값·널·예외 검증을 ecosystem assertion으로 통일한다.

## Background

Epic #1492의 testing/testcontainers child에서 `kotlin.test` raw assertion 잔여 파일을 정리한다. 이번 PR은 assertion·검증 패턴만 다루며 #1486의 image/tag gate와 CI routing은 변경하지 않는다.

## What This Solves

- `GenericServerSupportTest`, `EtcdServerTest`, `ZooKeeperServerTest`, `ToxiproxyServerTest`, `PulsarServerTest`의 raw assertion 의존을 제거한다.
- launcher의 null/value/exception 계약과 Testcontainers lifecycle·cleanup·순차 실행 의미를 유지하면서 Kotlin patterns를 적용한다.

## Work Done

- `assertEquals`를 `shouldBeEqualTo`, `assertNull`을 `shouldBeNull`, timing Boolean 검증을 `shouldBeTrue`, 기존 예외 검증을 `io.bluetape4k.assertions.assertFailsWith`로 통일했다.
- 제공 image 계약은 `dockerImageName shouldBeEqualTo ...`로 유지했고, `use`/`finally` 기반 resource cleanup과 `Launcher` 사용을 변경하지 않았다.
- 변경 범위는 다섯 테스트 파일이며 production API, dependency, image manifest, CI routing, parallelization, module registration은 수정하지 않았다.

## 7-Tier Review

| Tier | 결과 | 근거 |
|---|---|---|
| Tier 1 성능 | PASS | 새 blocking/sleep/retry를 추가하지 않았고 기존 timing threshold와 Testcontainers 순차 실행을 유지했다. |
| Tier 2 안정성 | PASS | launcher의 null/value/exception 계약, `use`/`finally` cleanup, container lifecycle을 targeted runtime test로 확인했다. |
| Tier 3 보안 | PASS | payload, token, serialization, logging surface를 추가하거나 변경하지 않았다. |
| Tier 4 운영 | PASS | Docker/Colima에서 다섯 대상 suite를 한 번에 하나씩 실행했고 resource close 경계를 보존했다. |
| Tier 5 개발자/API | PASS | 다섯 파일의 raw assertion scan이 비었고 bluetape4k assertion과 Kotlin testing pattern을 사용했다. |
| Tier 6 호출자 | PASS | public launcher API와 caller-visible 예외·널·값 의미를 변경하지 않았다. |
| Tier 7 통합 | PASS | Gradle module 등록, docs, image gate, CI routing을 건드리지 않고 issue 범위만 변경했다. |

## Validation

- `git diff --check`: PASS
- `rg -n 'kotlin\\.test\\.assert|\\bassertEquals\\b|\\bassertNull\\b|\\bassertTrue\\b' <five target files>`: PASS (결과 없음)
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.GenericServerSupportTest' --no-daemon --console=plain`: PASS (26s)
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.infra.EtcdServerTest' --no-daemon --console=plain`: PASS (30s)
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.infra.ZooKeeperServerTest' --no-daemon --console=plain`: PASS (43s)
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.infra.ToxiproxyServerTest' --no-daemon --console=plain`: PASS (1m)
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.mq.PulsarServerTest' --no-daemon --console=plain`: PASS (1m46s)
- `./gradlew :bluetape4k-testcontainers:detekt --no-daemon --console=plain`: PASS (`BUILD SUCCESSFUL`; 기존 module-wide findings는 별도 기록)
- `./gradlew :bluetape4k-testcontainers:test --no-daemon --console=plain`: PENDING (변경과 무관한 장시간 Jaeger/RabbitMQ 등 infrastructure case에서 bounded run을 중단했으며 completed report가 생성되지 않음)
- `gh pr checks 1506`: PASS (workflow run `32753498712`의 policy/build/coverage checks와 `:bluetape4k-testcontainers-spring:test`는 green; `:bluetape4k-testcontainers:test` 전용 job은 path-filter로 생성되지 않음)
- `gh run view 32797310719`: PASS on exact head `60b147a7c70d0f46d494ef7290a96616c35550b8` for `Test / Testcontainers (infra)`, `Test / Testcontainers (mq-brokers)`, and `Test / Testcontainers (misc-contract)`; target jobs completed successfully.
- `gh pr merge 1506 --rebase --match-head-commit 60b147a7c70d0f46d494ef7290a96616c35550b8`: PASS; merged at `2026-08-25T01:50:49Z` as `dcd68ad0ca2271e09472b5abcbb55c106d2332f1`.
- `git pull --ff-only origin develop`: PASS; canonical `develop` and `origin/develop` both point to `dcd68ad0ca2271e09472b5abcbb55c106d2332f1`, with clean status.
- Issue #1494: CLOSED through `Closes #1494`; local linked worktree remains clean at source commit `60b147a7c70d0f46d494ef7290a96616c35550b8`.

## Review Notes

- P0/P1: 0
- P2/P3: 기존 `ToxiproxyServerTest`의 `NestedBlockDepth` detekt finding과 raw assertion의 custom failure message 축소는 후속 cleanup 후보로 남긴다. `shouldBeTrue()` API가 custom message overload를 제공하지 않아 assertion contract 통일을 우선했다.
- Testcontainers full-module 결과는 변경 파일 targeted proof와 분리한다. 전체 실행은 다른 장시간 infrastructure case와 Docker 자원을 점유하므로 PR CI의 exact-head 결과를 추가 근거로 사용한다.
- 독립 read-only 7-Tier review는 exact head에서 diff PASS, P0/P1=0으로 확인했다. 기존 P3 timing 진단성 저하는 후속 후보로 남긴다.
- PR CI의 direct `:bluetape4k-testcontainers:test` job은 path-filter로 라우팅되지 않았지만, nightly exact-head `infra`/`mq-brokers`/`misc-contract` shard가 변경 대상 클래스를 원격 실행해 기존 coverage gap을 해소했다.

## Metadata

- Issue: #1494, milestone `2.0.0`, assignee `debop`, labels `test`, `infra/io`, `refactoring`, `tech-debt`
- Parent: Epic #1492
- Branch: `refactor/epic-1492-testcontainers`
- Commit: `60b147a7c70d0f46d494ef7290a96616c35550b8`
- PR: #1506, head `60b147a7c70d0f46d494ef7290a96616c35550b8`, base `develop`
- Merge commit: `dcd68ad0ca2271e09472b5abcbb55c106d2332f1` (rebase merge)
- CI: [PR workflow run 32753498712](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32753498712) green; [exact-head Nightly run 32797310719](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32797310719) target Testcontainers shards green

## DoD Status

Final status: DONE — PR #1506 `MERGED`; linked Issue #1494 `CLOSED`.

| Gate | Status | Evidence |
|---|---|---|
| 7-Tier review / Kotlin patterns / bluetape4k-assertions | PASS | 기존 독립 review와 모듈 검증 증거 보존; P0/P1=0. |
| PR exact head·base·metadata | PASS | live head `60b147a7c70d0f46d494ef7290a96616c35550b8`, base `develop`, merge commit `dcd68ad0ca2271e09472b5abcbb55c106d2332f1`, assignee/labels/milestone read-back. |
| Exact-head CI | PASS (cumulative) — custom stacked-base PR의 standalone check를 소급해 주장하지 않고, 최종 PR #1511 exact head의 CI run `32938020302` 및 post-merge develop CI [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882)로 누적 변경을 검증했다. |
| Merge verification | PASS | merged at `2026-08-25T01:50:49Z`; GitHub state `MERGED`. |
| Canonical sync | PASS | canonical `develop`와 `origin/develop`가 `4a843fe402647ec76a28e8fc1d076a0e1ff422be`로 일치. |
| Post-merge develop CI | PASS | [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882): 16 success, 5 intentional path-filter skip, 0 failure. |

Unchecked required items: 없음
