### PR TITLE
[7-Tier][bluetape4k/core] assertion 표준화와 CompletableFuture blocking 경계 정리

### DIFF
--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/CompletableFutureSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/CompletableFutureSupportTest.kt
@@ -1,18 +1,18 @@
 package io.bluetape4k.concurrent
 
+import io.bluetape4k.assertions.assertFails
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.junit.jupiter.api.Assertions
+import io.bluetape4k.assertions.fail
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.assertFails
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -90,7 +90,7 @@ class CompletableFutureSupportTest {
     @Test
     fun `onFailure callback fires only on failure`() {
         success.onFailure(DirectExecutor) { e ->
-            Assertions.fail("성공한 future에 대해 onFailure가 호출되면 안됩니다.", e)
+            fail("성공한 future에 대해 onFailure가 호출되면 안됩니다.", e)
         }.get() shouldBeEqualTo 1
 
         var capturedThrowable: Throwable? = null
@@ -167,6 +167,8 @@ class CompletableFutureSupportTest {
 
     @Test
     fun `futureWithTimeout completes within limit or throws TimeoutException`() {
+        // 의도적인 blocking 경계: worker의 실제 지연과 Future.get 결과로 timeout 계약을 검증한다.
+        // runTest나 가상 시간 tester로 치환하면 CompletableFuture scheduler 의미가 달라진다.
         futureWithTimeout(500L) { Thread.sleep(50); 42 }.get() shouldBeEqualTo 42
         futureWithTimeout(50L) { Thread.sleep(3000); 42 }.shouldCauseBe<TimeoutException>()
         futureWithTimeout(500.milliseconds) { Thread.sleep(50); "hello" }.get() shouldBeEqualTo "hello"

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/CompletableFutureSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/CompletableFutureSupportTest.kt
@@ -199,7 +199,7 @@ class CompletableFutureSupportTest {
     fun `join with defaultValue propagates non-timeout exceptions`() {
         // H2 수정 검증: TimeoutException 이외의 예외는 rethrow
         val future = failedCompletableFutureOf<Int>(IllegalStateException("비즈니스 오류"))
-        assertFails { future.join(500.milliseconds, 0) }
+        assertFailsWith<IllegalStateException> { future.join(500.milliseconds, 0) }
     }
 
     @Test
@@ -220,6 +220,7 @@ class CompletableFutureSupportTest {
     fun `joinOrNull propagates non-timeout exceptions`() {
         // H2 수정 검증: TimeoutException 이외의 예외는 rethrow
         val future = failedCompletableFutureOf<Int>(IllegalStateException("비즈니스 오류"))
-        assertFails { future.joinOrNull(500.milliseconds) }
+        assertFailsWith<ExecutionException> { future.joinOrNull(500.milliseconds) }
+            .cause shouldBeInstanceOf IllegalStateException::class
     }
 }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/javatimes/TemporalSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/javatimes/TemporalSupportTest.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.javatimes
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
 import java.time.Instant
@@ -15,8 +17,6 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.time.temporal.Temporal
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class TemporalSupportTest {
 
@@ -130,35 +130,35 @@ class TemporalSupportTest {
 
     @Test
     fun `Temporal supports operator`() {
-        assertFalse { nowInstant() supports ChronoUnit.ERAS }
-        assertFalse { nowInstant() supports ChronoUnit.CENTURIES }
-        assertFalse { nowInstant() supports ChronoUnit.YEARS }
-        assertFalse { nowInstant() supports ChronoUnit.MONTHS }
+        (nowInstant() supports ChronoUnit.ERAS).shouldBeFalse()
+        (nowInstant() supports ChronoUnit.CENTURIES).shouldBeFalse()
+        (nowInstant() supports ChronoUnit.YEARS).shouldBeFalse()
+        (nowInstant() supports ChronoUnit.MONTHS).shouldBeFalse()
 
-        assertTrue { nowInstant() supports ChronoUnit.DAYS }
-        assertTrue { nowInstant() supports ChronoUnit.HALF_DAYS }
-        assertTrue { nowInstant() supports ChronoUnit.HOURS }
+        (nowInstant() supports ChronoUnit.DAYS).shouldBeTrue()
+        (nowInstant() supports ChronoUnit.HALF_DAYS).shouldBeTrue()
+        (nowInstant() supports ChronoUnit.HOURS).shouldBeTrue()
 
-        assertTrue { nowZonedDateTime() supports ChronoUnit.ERAS }
-        assertTrue { nowZonedDateTime() supports ChronoUnit.CENTURIES }
-        assertTrue { nowZonedDateTime() supports ChronoUnit.YEARS }
-        assertTrue { nowZonedDateTime() supports ChronoUnit.DAYS }
-        assertTrue { nowZonedDateTime() supports ChronoUnit.HALF_DAYS }
-        assertTrue { nowZonedDateTime() supports ChronoUnit.HOURS }
+        (nowZonedDateTime() supports ChronoUnit.ERAS).shouldBeTrue()
+        (nowZonedDateTime() supports ChronoUnit.CENTURIES).shouldBeTrue()
+        (nowZonedDateTime() supports ChronoUnit.YEARS).shouldBeTrue()
+        (nowZonedDateTime() supports ChronoUnit.DAYS).shouldBeTrue()
+        (nowZonedDateTime() supports ChronoUnit.HALF_DAYS).shouldBeTrue()
+        (nowZonedDateTime() supports ChronoUnit.HOURS).shouldBeTrue()
 
-        assertTrue { nowLocalDate() supports ChronoUnit.ERAS }
-        assertTrue { nowLocalDate() supports ChronoUnit.CENTURIES }
-        assertTrue { nowLocalDate() supports ChronoUnit.YEARS }
-        assertTrue { nowLocalDate() supports ChronoUnit.DAYS }
-        assertFalse { nowLocalDate() supports ChronoUnit.HALF_DAYS }
-        assertFalse { nowLocalDate() supports ChronoUnit.HOURS }
+        (nowLocalDate() supports ChronoUnit.ERAS).shouldBeTrue()
+        (nowLocalDate() supports ChronoUnit.CENTURIES).shouldBeTrue()
+        (nowLocalDate() supports ChronoUnit.YEARS).shouldBeTrue()
+        (nowLocalDate() supports ChronoUnit.DAYS).shouldBeTrue()
+        (nowLocalDate() supports ChronoUnit.HALF_DAYS).shouldBeFalse()
+        (nowLocalDate() supports ChronoUnit.HOURS).shouldBeFalse()
 
-        assertTrue { nowLocalDateTime() supports ChronoUnit.ERAS }
-        assertTrue { nowLocalDateTime() supports ChronoUnit.CENTURIES }
-        assertTrue { nowLocalDateTime() supports ChronoUnit.YEARS }
-        assertTrue { nowLocalDateTime() supports ChronoUnit.DAYS }
-        assertTrue { nowLocalDateTime() supports ChronoUnit.HALF_DAYS }
-        assertTrue { nowLocalDateTime() supports ChronoUnit.HOURS }
+        (nowLocalDateTime() supports ChronoUnit.ERAS).shouldBeTrue()
+        (nowLocalDateTime() supports ChronoUnit.CENTURIES).shouldBeTrue()
+        (nowLocalDateTime() supports ChronoUnit.YEARS).shouldBeTrue()
+        (nowLocalDateTime() supports ChronoUnit.DAYS).shouldBeTrue()
+        (nowLocalDateTime() supports ChronoUnit.HALF_DAYS).shouldBeTrue()
+        (nowLocalDateTime() supports ChronoUnit.HOURS).shouldBeTrue()
     }
 
     @Test

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/ranges/RangeSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/ranges/RangeSupportTest.kt
@@ -4,8 +4,6 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class RangeSupportTest {
 
@@ -49,8 +47,8 @@ class RangeSupportTest {
     fun `create closed range by BigDecimal`() {
         val range = 5.toBigDecimal()..10.toBigDecimal()
 
-        assertTrue { 6.toBigDecimal() in range }
-        assertFalse { 3.toBigDecimal() in range }
+        (6.toBigDecimal() in range).shouldBeTrue()
+        (3.toBigDecimal() in range).shouldBeFalse()
 
         range.contains(7.toBigDecimal()..10.toBigDecimal()).shouldBeTrue()
         range.contains(7.toBigDecimal()..11.toBigDecimal()).shouldBeFalse()
@@ -61,8 +59,8 @@ class RangeSupportTest {
     fun `create closed range by BigInteger`() {
         val range = 5.toBigInteger()..10.toBigInteger()
 
-        assertTrue { 6.toBigInteger() in range }
-        assertFalse { 3.toBigInteger() in range }
+        (6.toBigInteger() in range).shouldBeTrue()
+        (3.toBigInteger() in range).shouldBeFalse()
 
         range.contains(7.toBigInteger()..10.toBigInteger()).shouldBeTrue()
         range.contains(7.toBigInteger()..11.toBigInteger()).shouldBeFalse()

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/ArraySupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/ArraySupportTest.kt
@@ -5,12 +5,12 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldContainSame
 import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
 import kotlin.byteArrayOf
 import kotlin.longArrayOf
-import kotlin.test.assertTrue
 
 class ArraySupportTest {
 
@@ -165,27 +165,27 @@ class ArraySupportTest {
     @Test
     fun `padTo - 크기가 같거나 작으면 배열을 변경하지 않는다`() {
         val arr = arrayOf(1, 2, 3)
-        assertTrue { arr.padTo(3, 0) === arr }; assertTrue { arr.padTo(2, 0) === arr }
+        arr.padTo(3, 0).shouldBeSameInstanceAs(arr); arr.padTo(2, 0).shouldBeSameInstanceAs(arr)
 
         val ints = intArrayOf(1, 2, 3)
-        assertTrue { ints.padTo(3, 0) === ints }; assertTrue { ints.padTo(2, 0) === ints }
+        ints.padTo(3, 0).shouldBeSameInstanceAs(ints); ints.padTo(2, 0).shouldBeSameInstanceAs(ints)
 
         val bytes = byteArrayOf(1, 2, 3)
-        assertTrue { bytes.padTo(3, 0) === bytes }; assertTrue { bytes.padTo(2, 0) === bytes }
+        bytes.padTo(3, 0).shouldBeSameInstanceAs(bytes); bytes.padTo(2, 0).shouldBeSameInstanceAs(bytes)
 
         val longs = longArrayOf(1L, 2L, 3L)
-        assertTrue { longs.padTo(3, 0L) === longs }; assertTrue { longs.padTo(2, 0L) === longs }
+        longs.padTo(3, 0L).shouldBeSameInstanceAs(longs); longs.padTo(2, 0L).shouldBeSameInstanceAs(longs)
 
         val floats = floatArrayOf(1.0f, 2.0f, 3.0f)
-        assertTrue { floats.padTo(3, 0.0f) === floats }; assertTrue { floats.padTo(2, 0.0f) === floats }
+        floats.padTo(3, 0.0f).shouldBeSameInstanceAs(floats); floats.padTo(2, 0.0f).shouldBeSameInstanceAs(floats)
 
         val doubles = doubleArrayOf(1.0, 2.0, 3.0)
-        assertTrue { doubles.padTo(3, 0.0) === doubles }; assertTrue { doubles.padTo(2, 0.0) === doubles }
+        doubles.padTo(3, 0.0).shouldBeSameInstanceAs(doubles); doubles.padTo(2, 0.0).shouldBeSameInstanceAs(doubles)
 
         val chars = charArrayOf('a', 'b', 'c')
-        assertTrue { chars.padTo(3, 'x') === chars }; assertTrue { chars.padTo(2, 'x') === chars }
+        chars.padTo(3, 'x').shouldBeSameInstanceAs(chars); chars.padTo(2, 'x').shouldBeSameInstanceAs(chars)
 
         val shorts = shortArrayOf(1, 2, 3)
-        assertTrue { shorts.padTo(3, 0) === shorts }; assertTrue { shorts.padTo(2, 0) === shorts }
+        shorts.padTo(3, 0).shouldBeSameInstanceAs(shorts); shorts.padTo(2, 0).shouldBeSameInstanceAs(shorts)
     }
 }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/BigDecimalSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/BigDecimalSupportTest.kt
@@ -2,23 +2,23 @@ package io.bluetape4k.support
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import kotlin.minus
 import kotlin.plus
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import kotlin.toBigDecimal
 
 class BigDecimalSupportTest {
 
     @Test
     fun `compare BigDecimal and Number`() {
-        assertTrue { BigDecimal.ONE > 0L }
-        assertTrue { BigDecimal.ONE > 0.5 }
+        (BigDecimal.ONE > 0L).shouldBeTrue()
+        (BigDecimal.ONE > 0.5).shouldBeTrue()
 
-        assertFalse { BigDecimal.ZERO > 0L }
-        assertFalse { BigDecimal.ZERO > 0.5 }
+        (BigDecimal.ZERO > 0L).shouldBeFalse()
+        (BigDecimal.ZERO > 0.5).shouldBeFalse()
     }
 
     @Test

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/BigIntegerSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/support/BigIntegerSupportTest.kt
@@ -2,23 +2,23 @@ package io.bluetape4k.support
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import java.math.BigInteger
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class BigIntegerSupportTest {
 
     @Test
     fun `compare BigInteger with Number`() {
-        assertTrue { BigInteger.ZERO < 1L }
-        assertFalse { BigInteger.ZERO > 1L }
+        (BigInteger.ZERO < 1L).shouldBeTrue()
+        (BigInteger.ZERO > 1L).shouldBeFalse()
 
-        assertTrue { BigInteger.ONE > 0L }
-        assertTrue { BigInteger.TEN > 5 }
+        (BigInteger.ONE > 0L).shouldBeTrue()
+        (BigInteger.TEN > 5).shouldBeTrue()
 
-        assertFalse { BigInteger.ZERO > 1L }
-        assertFalse { BigInteger.ZERO > 1.0 }
+        (BigInteger.ZERO > 1L).shouldBeFalse()
+        (BigInteger.ZERO > 1.0).shouldBeFalse()
     }
 
     @Test


### PR DESCRIPTION
## 목적

Epic #1492의 다음 stacked PR slice로 Issue #1495의 `bluetape4k/core` 테스트 잔여 assertion을 `bluetape4k-assertions` 표준으로 통일한다. production API와 CompletableFuture timeout semantics는 변경하지 않았다.

## 변경 범위

- `BigDecimalSupportTest`, `BigIntegerSupportTest`, `TemporalSupportTest`, `RangeSupportTest`의 raw `assertTrue`/`assertFalse`를 `shouldBeTrue`/`shouldBeFalse`로 전환했다.
- `ArraySupportTest`의 배열 identity 검증을 `shouldBeSameInstanceAs`로 전환했다.
- `CompletableFutureSupportTest`의 `kotlin.test.assertFails`와 JUnit `Assertions.fail`을 `bluetape4k-assertions.assertFails`/`fail`로 전환했다. `join`은 `IllegalStateException`을, `joinOrNull`은 `ExecutionException.cause`를 `assertFailsWith`로 고정해 non-timeout wrapping 계약을 정확히 보존했다.
- `Thread.sleep`와 `Future.get`은 CompletableFuture worker 지연·timeout·예외 전파 계약을 검증하는 의도적 blocking boundary로 분류했다. `runTest`/가상 시간 tester로 바꾸면 실제 scheduler 의미가 달라지므로 blanket 제거하지 않았다.
- production source, public API, Gradle module registration, dependency closure는 변경하지 않았다.

## 7-Tier 결과

| Tier | 결과 |
| --- | --- |
| 1 성능 | 고정 delay와 `Future.get`은 API-under-test의 timeout 측정 경계로 유지했고 새 반복 비용은 없다. |
| 2 안정성 | timeout, cancellation state, `ExecutionException.cause`, 실패 전파 테스트를 유지·재실행했다. `orTimeout` 이후 worker 취소·interrupt는 검증하거나 보장하지 않는다. |
| 3 보안 | payload, token, logging, serialization surface 변경 없음. |
| 4 운영 | executor/worker lifecycle과 기존 cleanup 경계를 변경하지 않았고, timeout 이후 worker cleanup을 새 계약으로 주장하지 않는다. |
| 5 개발자/API | 여섯 파일의 raw assertion을 bluetape4k assertion으로 통일하고 Kotlin pattern을 적용했다. |
| 6 호출자 | assertion 표현만 변경했으며 결과·예외 타입·원인은 동일하다. |
| 7 통합 | core 등록·dependency·문서 변경 없이 모듈 전체 테스트와 detekt를 확인했다. |

## 검증

- `./gradlew :bluetape4k-core:test --tests ...` — 대상 6개 클래스, 74 tests PASS; CompletableFuture 예외 타입/cause 검증 포함.
- `./gradlew :bluetape4k-core:test --no-daemon --console=plain` — 1,645 tests PASS, `BUILD SUCCESSFUL`.
- `./gradlew :bluetape4k-core:detekt --no-daemon --console=plain` — exit 0; 변경 6개 파일에 findings 없음. 기존 module-wide findings는 범위 밖이다.
- raw `kotlin.test`/JUnit `Assertions` assertion scan — no matches.
- `git diff --check` — PASS.

## 부모 이슈

- Parent: #1492
- Closes: #1495

## DoD Status

Final status: DONE — PR #1507 `MERGED`; linked Issue #1495 `CLOSED`.

| Gate | Status | Evidence |
|---|---|---|
| 7-Tier review / Kotlin patterns / bluetape4k-assertions | PASS | 기존 독립 review와 모듈 검증 증거 보존; P0/P1=0. |
| PR exact head·base·metadata | PASS | live head `34fa5b28ed9c864de84ff79f0457f7fbe4b6b239`, base `develop`, merge commit `ce39a86b21eee42924e40411e1ea6b90ce9669bb`, assignee/labels/milestone read-back. |
| Exact-head CI | PASS (cumulative) — custom stacked-base PR의 standalone check를 소급해 주장하지 않고, 최종 PR #1511 exact head의 CI run `32938020302` 및 post-merge develop CI [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882)로 누적 변경을 검증했다. |
| Merge verification | PASS | merged at `2026-08-25T03:33:46Z`; GitHub state `MERGED`. |
| Canonical sync | PASS | canonical `develop`와 `origin/develop`가 `4a843fe402647ec76a28e8fc1d076a0e1ff422be`로 일치. |
| Post-merge develop CI | PASS | [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882): 16 success, 5 intentional path-filter skip, 0 failure. |

Unchecked required items: 없음
