### PR TITLE
coroutines 테스트를 bluetape4k assertions와 cancellation 패턴으로 정리한다

### DIFF
--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/AbstractCoroutineScopeTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/AbstractCoroutineScopeTest.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.coroutines
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.fail
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.trace
@@ -13,7 +15,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -100,7 +101,7 @@ abstract class AbstractCoroutineScopeTest {
 
             job.join()
             caught?.message shouldBeEqualTo "stop-by-test"
-            scope.coroutineContext[Job]!!.isActive.shouldBeFalse()
+            scope.coroutineContext[Job].shouldNotBeNull().isActive.shouldBeFalse()
         }
     }
 }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/StructuredConcurrencyTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/StructuredConcurrencyTest.kt
@@ -62,6 +62,8 @@ class StructuredConcurrencyTest {
             taskScope<Unit> {
                 fork { throw RuntimeException("빠른 실패") }
                 fork {
+                    // 의도적인 blocking 경계: taskScope가 withVirtualDispatcher와
+                    // virtual-thread factory로 소유한 JDK structured-task lifecycle을 검증한다.
                     Thread.sleep(500)
                     counter.incrementAndGet()
                 }
@@ -146,6 +148,8 @@ class StructuredConcurrencyTest {
     fun `firstSuccessTaskScope - 여러 소스에서 가장 빠른 결과 선택`() = runSuspendIO {
         val result = firstSuccessTaskScope<String> {
             fork {
+                // 실제 blocking 지연으로 first-success winner 경쟁을 검증한다. blocking task의
+                // 실행 경계는 firstSuccessTaskScope의 withVirtualDispatcher가 소유한다.
                 Thread.sleep(200)
                 "느린 소스"
             }
@@ -370,7 +374,8 @@ class StructuredConcurrencyTest {
         assertFailsWith<TimeoutException> {
             taskScope<Unit> {
                 // StructuredTaskScope.close()는 forked thread 완료까지 대기하므로
-                // sleep을 deadline보다 크되 최소화 (200ms > 50ms deadline)
+                // sleep을 deadline보다 크되 최소화 (200ms > 50ms deadline)한다.
+                // forked task의 blocking 경계는 taskScope가 생성한 virtual thread가 담당한다.
                 fork { Thread.sleep(200) }
                 joinUntil(deadline).throwIfFailed()
             }
@@ -382,6 +387,8 @@ class StructuredConcurrencyTest {
         val deadline = java.time.Instant.now().plusMillis(50)
         assertFailsWith<TimeoutException> {
             supervisedTaskScope<Int, List<Result<Int>>> {
+                // 실제 blocking 지연으로 joinUntil deadline 경계를 검증하며 forked task는
+                // supervisedTaskScope의 virtual-thread 실행 경계를 사용한다.
                 fork { Thread.sleep(200); 1 }
                 joinUntil(deadline)
                 results()

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/SuspendLazyTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/SuspendLazyTest.kt
@@ -1,16 +1,25 @@
 package io.bluetape4k.coroutines
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBe
+import io.bluetape4k.assertions.shouldNotBe
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.junit5.coroutines.withSingleThread
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.trace
 import io.bluetape4k.utils.Runtimex
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -67,55 +76,80 @@ class SuspendLazyTest {
     }
 
     @Test
-    fun `get lazy value in blocking mode`() = runTest {
-        val callCounter = AtomicInteger(0)
+    fun `get lazy value in blocking mode`() = runSuspendIO {
+        withSingleThread { callerDispatcher ->
+            withContext(callerDispatcher) {
+                val callerThread = Thread.currentThread()
+                val initializerThread = AtomicReference<Thread?>()
+                val callCounter = AtomicInteger(0)
 
-        val lazyValue = suspendBlockingLazy {
-            Thread.sleep(Random.nextLong(100))
-            log.trace { "Calculate lazy value in blocking mode." }
-            callCounter.incrementAndGet()
-            TEST_NUMBER
+                val lazyValue = suspendBlockingLazy {
+                    // 의도적인 blocking 경계: suspendBlockingLazy는 caller context에서
+                    // initializer를 실행하고 그 thread를 보존해야 한다.
+                    initializerThread.set(Thread.currentThread())
+                    Thread.sleep(Random.nextLong(100))
+                    log.trace { "Calculate lazy value in blocking mode." }
+                    callCounter.incrementAndGet()
+                    TEST_NUMBER
+                }
+                callCounter.get() shouldBeEqualTo 0
+
+                yield()
+
+                lazyValue() shouldBeEqualTo TEST_NUMBER
+                lazyValue() shouldBeEqualTo TEST_NUMBER
+
+                callCounter.get() shouldBeEqualTo 1
+                initializerThread.get().shouldBe(callerThread)
+            }
         }
-        callCounter.get() shouldBeEqualTo 0
-
-        yield()
-
-        lazyValue() shouldBeEqualTo TEST_NUMBER
-        lazyValue() shouldBeEqualTo TEST_NUMBER
-
-        callCounter.get() shouldBeEqualTo 1
     }
 
     @Test
-    fun `get lazy value in blocking mode with IO dispatchers`() = runTest {
-        val callCounter = AtomicInteger(0)
+    fun `get lazy value in blocking mode with IO dispatchers`() = runSuspendIO {
+        withSingleThread { callerDispatcher ->
+            withContext(callerDispatcher) {
+                val callerThread = Thread.currentThread()
+                val initializerThread = AtomicReference<Thread?>()
+                val callCounter = AtomicInteger(0)
 
-        val lazyValue = suspendBlockingLazyIO {
-            Thread.sleep(Random.nextLong(100))
-            log.trace { "Calculate lazy value in blocking mode with IO dispatchers" }
-            callCounter.incrementAndGet()
-            TEST_NUMBER
+                val lazyValue = suspendBlockingLazyIO {
+                    // 의도적인 blocking 경계: suspendBlockingLazyIO가 caller와 다른
+                    // Dispatchers.IO thread에서 initializer를 실행하는지 관찰한다.
+                    initializerThread.set(Thread.currentThread())
+                    Thread.sleep(Random.nextLong(100))
+                    log.trace { "Calculate lazy value in blocking mode with IO dispatchers" }
+                    callCounter.incrementAndGet()
+                    TEST_NUMBER
+                }
+                callCounter.get() shouldBeEqualTo 0
+
+                yield()
+
+                val lazy1 = async { lazyValue() }
+                val lazy2 = async { lazyValue() }
+
+                yield()
+
+                lazy1.await() shouldBeEqualTo TEST_NUMBER
+                lazy2.await() shouldBeEqualTo TEST_NUMBER
+
+                callCounter.get() shouldBeEqualTo 1
+                initializerThread.get().shouldNotBeNull().shouldNotBe(callerThread)
+            }
         }
-        callCounter.get() shouldBeEqualTo 0
-
-        yield()
-
-        val lazy1 = async { lazyValue() }
-        val lazy2 = async { lazyValue() }
-
-        yield()
-
-        lazy1.await() shouldBeEqualTo TEST_NUMBER
-        lazy2.await() shouldBeEqualTo TEST_NUMBER
-
-        callCounter.get() shouldBeEqualTo 1
     }
 
     @Test
-    fun `get lazy value in blocking mode with Multijob`() {
+    fun `get lazy value in blocking mode with Multijob`() = runSuspendIO {
+        val callerThreads = ConcurrentHashMap.newKeySet<Thread>()
+        val initializerThread = AtomicReference<Thread?>()
         val callCounter = AtomicInteger(0)
 
         val lazyValue = suspendBlockingLazyIO {
+            // 실제 blocking 경계: SuspendedJobTester의 고정 worker와
+            // suspendBlockingLazyIO의 Dispatchers.IO initializer thread를 구분한다.
+            initializerThread.set(Thread.currentThread())
             Thread.sleep(Random.nextLong(1000))
             log.trace { "Calculate lazy value in blocking mode with IO dispatchers" }
             callCounter.incrementAndGet()
@@ -123,15 +157,16 @@ class SuspendLazyTest {
         }
         callCounter.get() shouldBeEqualTo 0
 
-        runTest {
-            SuspendedJobTester()
-                .workers(Runtimex.availableProcessors)
-                .rounds(16)
-                .add {
-                    lazyValue() shouldBeEqualTo TEST_NUMBER
-                }
-                .run()
-        }
+        SuspendedJobTester()
+            .workers(Runtimex.availableProcessors)
+            .rounds(16)
+            .add {
+                callerThreads += Thread.currentThread()
+                lazyValue() shouldBeEqualTo TEST_NUMBER
+            }
+            .run()
         callCounter.get() shouldBeEqualTo 1
+        val initializedOn = initializerThread.get().shouldNotBeNull()
+        callerThreads.any { it === initializedOn }.shouldBeFalse()
     }
 }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/exceptions/FlowExceptionsTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/exceptions/FlowExceptionsTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.coroutines.flow.exceptions
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
@@ -143,7 +144,7 @@ class FlowExceptionsTest {
         val owner2 = kotlinx.coroutines.flow.FlowCollector<Int> { }
         val exception = StopException(owner1)
 
-        kotlin.test.assertFailsWith<StopException> {
+        assertFailsWith<StopException> {
             exception.checkOwnership(owner2)
         }
     }

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ResultsTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ResultsTest.kt
@@ -1,16 +1,20 @@
 package io.bluetape4k.coroutines.flow.extensions
 
 import app.cash.turbine.test
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.fail
+import io.bluetape4k.assertions.shouldBe
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 
 class ResultsTest: AbstractFlowTest() {
@@ -103,6 +107,15 @@ class ResultsTest: AbstractFlowTest() {
 
         receivedFirst.await()
         job.cancelAndJoin()
+        job.isCancelled.shouldBeTrue()
+
+        val cancellation = CancellationException("transform cancelled")
+        val propagated = assertFailsWith<CancellationException> {
+            flowOf(Result.success(1))
+                .mapResultCatching<Int, Int> { throw cancellation }
+                .collect { }
+        }
+        propagated shouldBe cancellation
     }
 
     @Test

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ScanWithTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/ScanWithTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.coroutines.flow.extensions
 
 import app.cash.turbine.test
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.fail
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import kotlinx.coroutines.delay
@@ -11,7 +12,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/support/DeferredSupportTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/support/DeferredSupportTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CancellationException
-import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
 class DeferredSupportTest {
@@ -95,7 +94,7 @@ class DeferredSupportTest {
 
         second.isCancelled.shouldBeTrue()
         third.isCancelled.shouldBeTrue()
-        assertTrue(first.isCompleted)
+        first.isCompleted.shouldBeTrue()
     }
 
     @Test

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/support/FutureSupportTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/support/FutureSupportTest.kt
@@ -38,6 +38,8 @@ class FutureSupportTest {
             .rounds(ITEM_COUNT / 4)
             .add {
                 val task: FutureTask<Int> = FutureTask {
+                    // MultithreadingTester가 제공하는 worker에서 실제 blocking FutureTask를
+                    // 실행해 Future.get 계약을 검증한다. runTest 가상 시간은 이 경계를 우회한다.
                     Thread.sleep(Random.nextLong(10))
                     log.trace { "counter=${counter.get()}" }
                     counter.incrementAndGet()


### PR DESCRIPTION
## Summary

Closes #1496

Epic #1492의 coroutines child 이슈에서 지적한 assertion·runner·cancellation 패턴을 bluetape4k 생태계 계약에 맞춰 정리합니다. 테스트 코드만 변경하며 production/API/dependency는 건드리지 않습니다.

## Background

Issue #1496은 `bluetape4k/coroutines`의 raw JUnit/Kotlin assertion, blocking 테스트 runner, `CancellationException` 전파, `Thread.sleep` 경계 문서화를 7-Tier 기준으로 고정합니다.

## What This Solves

- raw `org.junit.jupiter.api.Assertions`/`kotlin.test` assertion drift를 `bluetape4k-assertions` helper로 통일합니다.
- virtual-time과 실제 blocking/dispatcher 경계를 구분하고, cancellation이 failure 값으로 흡수되지 않는지 직접 검증합니다.
- structured-task의 blocking 책임을 `runSuspendIO`가 아니라 `withVirtualDispatcher`/virtual-thread 실행 경계로 정확히 기록합니다.

## Work Done

- `AbstractCoroutineScopeTest.kt`, `ScanWithTest.kt`, `ResultsTest.kt`, `FlowExceptionsTest.kt`, `DeferredSupportTest.kt`의 지정 raw assertion을 `fail`, `assertFailsWith`, `shouldBeTrue`, `shouldNotBeNull` 등 bluetape4k assertion으로 교체했습니다.
- `SuspendLazyTest.kt`의 실제 blocking 테스트를 `runSuspendIO`와 `withSingleThread`로 분리하고, caller/IO initializer를 실제 `Thread` identity로 검증했습니다. multijob 경계도 worker와 IO thread identity를 `===`로 확인합니다.
- `ResultsTest.kt`에서 특정 `CancellationException` 동일 인스턴스가 `mapResultCatching`에서 재전파되는지 검증하고, `StructuredConcurrencyTest.kt`/`FutureSupportTest.kt`의 `Thread.sleep` 경계 의도를 문서화했습니다.
- `runTest`는 virtual-time coroutine 테스트에 유지했으며 production/API/Gradle/dependency 변경은 없습니다.

## Validation

- `./gradlew :bluetape4k-coroutines:compileTestKotlin --no-daemon`: PASS
- 대상 테스트 (`SuspendLazyTest`, `ResultsTest`, `StructuredConcurrencyTest`): PASS, 47 tests
- `./gradlew :bluetape4k-coroutines:test --no-daemon --no-build-cache`: PASS, 630 passing; skipped/failures/errors 0
- `./gradlew :bluetape4k-coroutines:detekt --no-daemon --no-build-cache`: PASS (기존 테스트 baseline 경고 출력은 있으나 task 성공)
- `git diff --check`: PASS
- 지정 5개 raw assertion 검색: 0건

## Review Notes

- 독립 code-review: P0/P1/P2/P3 모두 0, COMMENT (환경에 `lsp_diagnostics`가 없어 별도 검증 공백을 명시)
- 독립 architecture review: CLEAR; dispatcher/cancellation/blocking 책임 WATCH 3건과 thread-name P2를 모두 보강 후 해소
- 최종 scope: 기준 `84a17fd09be120211582c24542d4c7bac29bbde9` 대비 테스트 파일 8개만 변경

## Metadata

- Issue: #1496, milestone `2.0.0`, assignee `debop`
- PR: #1508, `https://github.com/bluetape4k/bluetape4k-projects/pull/1508`, head `d9aa59561fa1095603aab6e2bfbb082e2c17da48`
- Head branch: `refactor/epic-1492-coroutines`, commit `d9aa59561fa1095603aab6e2bfbb082e2c17da48`
- CI: exact-head GitHub run `32849434989` 성공 (head `d9aa59561fa1095603aab6e2bfbb082e2c17da48`)
- Merge: rebase merge commit `32b0888035968ffd487240691efdbb847f89f954`; Issue #1496 CLOSED

## DoD Status

Final status: DONE — PR #1508 `MERGED`; linked Issue #1496 `CLOSED`.

| Gate | Status | Evidence |
|---|---|---|
| 7-Tier review / Kotlin patterns / bluetape4k-assertions | PASS | 기존 독립 review와 모듈 검증 증거 보존; P0/P1=0. |
| PR exact head·base·metadata | PASS | live head `d9aa59561fa1095603aab6e2bfbb082e2c17da48`, base `develop`, merge commit `32b0888035968ffd487240691efdbb847f89f954`, assignee/labels/milestone read-back. |
| Exact-head CI | PASS (cumulative) — custom stacked-base PR의 standalone check를 소급해 주장하지 않고, 최종 PR #1511 exact head의 CI run `32938020302` 및 post-merge develop CI [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882)로 누적 변경을 검증했다. |
| Merge verification | PASS | merged at `2026-08-25T12:58:50Z`; GitHub state `MERGED`. |
| Canonical sync | PASS | canonical `develop`와 `origin/develop`가 `4a843fe402647ec76a28e8fc1d076a0e1ff422be`로 일치. |
| Post-merge develop CI | PASS | [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882): 16 success, 5 intentional path-filter skip, 0 failure. |

Unchecked required items: 없음
