### PR TITLE
docs: #1320 TenantContext bridge 승격 평가 기록

### DIFF
--- a/docs/superpowers/research/2026-08-25-issue-1070-event-sourcing-primitive-evaluation.md
+++ b/docs/superpowers/research/2026-08-25-issue-1070-event-sourcing-primitive-evaluation.md
@@ -1,0 +1,183 @@
+# Issue #1070 — Event Sourcing 및 projection primitive 평가 기록
+
+## 결정
+
+**결정: 추출 보류(`defer pending another consumer`). 현재 구현은 애플리케이션 로컬에 유지한다.**
+
+두 개의 독립 도메인에서 비슷한 Event Sourcing과 projection 개념을 확인했지만,
+지금 public module로 추출하면 PostgreSQL 트랜잭션, stream ordering, projection
+복구 의미를 감춘 generic repository가 될 가능성이 높다. 직접 Exposed DSL 구현과
+비교한 append/replay/rebuild/storage benchmark도 아직 없다.
+
+따라서 이 이슈에서는 production code나 public primitive를 추가하지 않는다. 다음
+독립 도메인이 같은 semantic contract를 다시 요구하고, 공통 compatibility suite와
+정량 benchmark를 확보한 뒤에만 별도 추출 이슈를 만든다.
+
+## 평가 범위와 현재 근거
+
+평가 대상은 다음 workshop 구현과 live GitHub 이슈다.
+
+| 소비자/비교 대상 | 역할 | 현재 상태 | 판단에 사용한 근거 |
+| --- | --- | --- | --- |
+| [#552 정규화 usage billing ledger](https://github.com/bluetape4k/bluetape4k-workshop/issues/552) | normalized PostgreSQL state와 append-only ledger를 사용하는 baseline | CLOSED | [`usage-metering-billing-ledger/README.md`](https://github.com/bluetape4k/bluetape4k-workshop/blob/develop/commerce/usage-metering-billing-ledger/README.md), `BillingCloseService`, immutable ledger/invoice 계약 |
+| [#553 Event-sourced usage billing](https://github.com/bluetape4k/bluetape4k-workshop/issues/553) | event store, expected-version append, upcast, snapshot, projection generation을 사용하는 billing consumer | CLOSED | [`usage-metering-billing-event-sourcing/README.md`](https://github.com/bluetape4k/bluetape4k-workshop/blob/develop/commerce/usage-metering-billing-event-sourcing/README.md), `eventstore/`, `projection/`, PostgreSQL integration tests |
+| [#555 usage billing microservices](https://github.com/bluetape4k/bluetape4k-workshop/issues/555) | 다섯 서비스의 local outbox/inbox, ordering, deferred/quarantine, restart를 검증하는 동일 billing series의 분리 변형 | CLOSED | [`usage-billing-microservices-composition-tests/README.md`](https://github.com/bluetape4k/bluetape4k-workshop/blob/develop/commerce/usage-billing-microservices-composition-tests/README.md), composition integration tests |
+| [#538 Event-sourced promotion/voucher campaign](https://github.com/bluetape4k/bluetape4k-workshop/issues/538) | billing과 무관한 campaign/voucher 도메인의 event store와 rebuildable projection consumer | CLOSED | [`event-sourced-promotion-voucher-campaign/README.md`](https://github.com/bluetape4k/bluetape4k-workshop/blob/develop/commerce/event-sourced-promotion-voucher-campaign/README.md), event-store/projection/operations source와 integration tests |
+
+#538은 #1070의 원래 의존성 목록에는 없지만, “billing 외부에서도 유용한가”를
+검증하는 독립 소비자 근거로 함께 읽었다. 반대로 #555는 운영 경계가 늘어난
+중요한 사례지만 같은 usage billing 의미를 유지하므로 독립 business consumer 두
+곳으로 중복 계산하지 않는다.
+
+## 반복 개념과 애플리케이션 전용 개념
+
+### 공통 후보
+
+| 후보 | #553과 #538에서 확인한 반복 | 추출 판단 |
+| --- | --- | --- |
+| Event envelope와 schema discriminator | tenant, stream identity, event type/version, occurred/recorded time, bounded payload, checksum 또는 hash | **보류**. actor/metadata 개인정보 경계와 hash 입력 규칙이 다르며, 한쪽의 envelope를 공통 DTO로 만들면 schema evolution 책임을 숨긴다. |
+| Expected-version append와 stream head CAS | stream version, optimistic conflict, append-only history, transaction 안의 head/event write | **보류**. 두 구현 모두 PostgreSQL row/unique constraint와 transaction 순서를 공개해야 한다. `ExposedJdbcRepository`의 일반 CRUD로 감싸면 correctness 경계를 잃는다. |
+| Pure reducer와 deterministic replay | event sequence를 순서대로 fold하고 동일 state/digest를 재현 | **보류**. 가장 작은 공통 후보지만 event decoding, tenant policy, reducer version을 호출자가 소유한다는 contract와 migration cost를 먼저 검증해야 한다. |
+| Snapshot validity와 genesis fallback | reducer version, stream version, last hash/position 검증 후 invalid snapshot을 폐기하고 full replay | **보류**. snapshot metadata와 invalidation/retention 정책이 두 도메인에서 다르다. |
+| Upcaster chain | 명시적 event type/version registry와 contiguous one-step conversion | **보류**. upcast depth, unknown schema, payload size/security 정책을 통합하기 전에 compatibility fixture가 필요하다. |
+| Projection checkpoint/generation | durable checkpoint, lease/fence, duplicate suppression, BUILDING/ACTIVE 전환, rebuild | **보류**. checkpoint는 저장소를 숨길 수 없고, generation switch와 poison handling은 read-model 운영 정책에 종속된다. |
+| Inbox/outbox/quarantine | #555에서 local transaction과 메시지 delivery 경계를, #538에서 projection poison/recovery를 확인 | **애플리케이션 로컬 유지**. outbox와 projection poison은 이름은 비슷하지만 retry, ownership, redrive authority가 다르다. |
+
+### 애플리케이션 전용
+
+가격 version과 billing close, immutable invoice/ledger, voucher allocation/redeem,
+campaign capacity, operator 권한, actor erasure mapping, HTTP idempotency response,
+Kafka topic/consumer routing은 공통 primitive에 넣지 않는다. 이들은 각 도메인의
+financial 또는 business authority이며 generic event store가 결정할 수 없다.
+
+## Candidate API sketch
+
+아래는 구현 제안이 아니라, 추출을 다시 검토할 때 지켜야 할 경계의 스케치다.
+현재 repository나 public API에는 추가하지 않았다.
+
+```kotlin
+interface EventStreamStore<E : Any> {
+    fun append(
+        transaction: PostgresTransaction,
+        stream: StreamId,
+        expectedVersion: Long,
+        events: List<NewEvent<E>>,
+    ): AppendResult
+
+    fun load(
+        transaction: PostgresTransaction,
+        stream: StreamId,
+        afterVersion: Long,
+        limit: Int,
+    ): EventPage<E>
+}
+
+interface EventReducer<S : Any, E : Any> {
+    val initialState: S
+    fun evolve(state: S, event: E): S
+}
+
+interface SnapshotPolicy<S : Any> {
+    fun validate(snapshot: Snapshot<S>, streamHead: StreamHead): SnapshotValidity
+}
+
+interface ProjectionCheckpointStore {
+    fun claim(request: CheckpointClaim): CheckpointLease
+    fun advance(lease: CheckpointLease, position: GlobalPosition): AdvanceResult
+}
+```
+
+이 스케치는 다음을 전제로 한다.
+
+- `PostgresTransaction`과 `GlobalPosition`은 의도적으로 저장소 의미를 드러낸다.
+  transaction을 숨긴 `Repository<E, ID>`나 in-memory exactly-once 추상화는 만들지 않는다.
+- tenant predicate, event serialization, hash input, expected-version conflict,
+  checkpoint fencing, retry/quarantine 정책은 각 application이 명시적으로 소유한다.
+- API가 의미 있는 중복을 제거한다는 것을 두 consumer의 contract test와 migration
+  diff로 증명하지 못하면 이 스케치를 구현으로 승격하지 않는다.
+
+## Module 위치 선택지
+
+| 선택지 | 결론 | 이유 |
+| --- | --- | --- |
+| `bluetape4k-exposed-jdbc`에 추가 | 거부 | Exposed 공통 저장소 계층은 transaction/SQL dialect/tenant/append semantics의 권위자가 아니다. 추가하면 모든 consumer가 불필요한 dependency와 generic CRUD surface를 얻게 된다. |
+| `bluetape4k-event-sourcing` 단일 public module | 보류 | 두 도메인의 공통 의미, ownership, versioning, migration path와 benchmark가 정해지지 않았다. 지금 만들면 workshop 구현을 library 요구사항으로 오인하게 된다. |
+| workshop test-support contract | 현재 선택 | production class를 공유하지 않고 JSON fixture와 black-box assertion만 먼저 비교할 수 있다. 이 contract가 반복되면 별도 projects module을 다시 제안한다. |
+| 각 application의 local primitive | 현재 유지 | 각 구현이 PostgreSQL transaction, recovery, security, projection authority를 직접 드러내며 현재 acceptance를 충족한다. |
+
+## 도입 게이트 판정
+
+| 게이트 | 판정 | 증거와 남은 조건 |
+| --- | --- | --- |
+| 독립 production-shaped consumer 두 곳이 같은 semantic contract를 요구 | **부분 충족** | #553 usage billing과 #538 promotion/voucher는 독립 도메인이다. 다만 두 구현이 동일한 transaction/failure contract를 요구한다고 말할 만큼의 shared test는 아직 없다. #555는 같은 billing series라 별도 consumer로 세지 않았다. |
+| transaction/ordering/failure를 숨기지 않는 API가 중복을 줄임 | **미충족** | 두 구현의 event store와 projection API를 side-by-side로 비교한 migration proof가 없고, transaction context를 노출할 public boundary도 합의하지 않았다. |
+| PostgreSQL contention/replay/snapshot/checkpoint/schema/tenant compatibility suite | **부분 충족** | 각 workshop은 PostgreSQL integration/architecture test를 보유하지만 공통 black-box suite는 없다. 우선 test-support contract로 중복 시나리오를 고정해야 한다. |
+| ownership/dependency direction/migration/versioning | **미충족** | projects module owner, 공개 패키지, compatibility policy, 기존 consumer migration 순서가 정해지지 않았다. |
+| append/replay/rebuild/allocation/storage benchmark | **미충족** | 현재 `stressTest`는 10,000 event/command의 correctness와 recovery를 확인하는 회귀 테스트이며 직접 Exposed DSL 대비 비용을 측정하지 않는다. allocation, row/storage overhead, p95 latency 비교도 없다. |
+
+모든 게이트가 충족되지 않았으므로 지금은 library 구현이나 release 가능한
+implementation issue를 만들지 않는다. #1070은 “추출 보류” 상태로 남기고, 다음
+독립 consumer가 생길 때 이 기록의 gate matrix를 갱신한다.
+
+## 최소 reusable test contract 제안
+
+추출 전에 workshop test-support에서 다음 시나리오를 두 구현에 각각 실행할 수
+있어야 한다. 공통 fixture는 production repository나 entity를 공유하지 않고,
+command/HTTP 또는 명시적인 adapter 경계만 사용한다.
+
+1. **Append CAS** — 같은 stream과 expected version으로 경쟁한 append 중 하나만
+   commit되고, conflict가 안정된 결과로 분류된다.
+2. **Atomicity** — event와 stream head가 함께 commit되거나 함께 rollback된다.
+   receipt/outbox/checkpoint를 포함하는 transaction 경계를 테스트에서 확인한다.
+3. **Replay and snapshot** — genesis replay와 valid snapshot replay가 같은 state,
+   version, digest를 만들고 invalid snapshot은 원본 history를 수정하지 않고
+   genesis로 돌아간다.
+4. **Schema evolution** — contiguous upcast chain, unknown mandatory version,
+   payload/metadata bound, checksum/hash 검증을 각각 확인한다.
+5. **Projection recovery** — duplicate, stale owner, checkpoint gap, poison event,
+   rebuild generation switch, active generation 보존을 확인한다.
+6. **Tenant and security** — 모든 stream/event/snapshot/checkpoint 조회가 tenant를
+   조건에 포함하고, payload·credential·raw identity가 로그/metric/response로
+   새지 않음을 확인한다.
+7. **Observable recovery** — lag, retry, quarantine, rebuild state가 bounded
+   low-cardinality signal로 노출되고 operator action이 audit trail을 남긴다.
+8. **Cost profile** — 동일 workload에서 직접 Exposed DSL과 후보 adapter의 append,
+   replay, rebuild latency, allocation, row/storage overhead를 같은 JDK/DB/fixture
+   조건으로 기록한다. 이 수치는 capacity 보장이 아니라 extraction decision 근거다.
+
+## 보안·운영·성능 위험
+
+- **보안:** 공통 envelope가 actor, credential, request body, tenant boundary를
+  무심코 직렬화하면 두 consumer의 개인정보 삭제/보존 정책을 위반할 수 있다.
+- **트랜잭션:** transaction을 감춘 generic repository는 append와 head CAS,
+  projection mutation과 checkpoint, local state와 outbox의 atomicity를 보장하지
+  못한다.
+- **복구:** checkpoint, lease, generation, poison 상태를 하나의 “retry” API로
+  합치면 stale worker나 재처리 중복을 숨긴다.
+- **호환성:** event type/version registry를 library가 소유하면 각 consumer의
+  schema evolution을 동시에 version 관리해야 한다. 독립 release 정책이 없다.
+- **성능:** serialization, wrapper allocation, extra metadata/hash와 generic
+  dispatch 비용을 현재 자료로 정량화할 수 없다. stress test 통과를 overhead
+  허용 증거로 해석하지 않는다.
+- **운영:** #555의 outbox/inbox와 #538의 projection poison은 복구 authority와
+  redrive 경로가 다르다. 공통 운영 API는 오히려 잘못된 조치를 유도할 수 있다.
+
+## DoD와 후속 조건
+
+- [x] #552, #553, #555와 독립 consumer #538의 live 상태와 source를 확인했다.
+- [x] 반복 개념과 application-specific 개념을 분리했다.
+- [x] 후보 API와 module 위치 선택지를 제시했지만 production code는 추가하지 않았다.
+- [x] compatibility/security/transaction/performance/operation 위험과 최소 test
+  contract를 기록했다.
+- [x] `extract now / defer pending another consumer / keep application-local` 중
+  `defer pending another consumer`를 선택했다.
+- [ ] 공통 compatibility suite와 직접 구현 대비 benchmark — 다음 독립 consumer가
+  생긴 뒤 후속 작업.
+- [ ] public module 구현/PR — 모든 도입 게이트 통과 전에는 생성하지 않음.
+
+### 작성·검증 메모
+
+- 문서 언어: 한국어 기술 문서. API 이름, 경로, 명령, URL, issue 번호는 원문을 보존했다.
+- 범위: Type E 문서 변경이며 production behavior와 public API를 변경하지 않는다.
+- 1인 개발자 lane에서는 CG-14 human-review를 N/A로 두되, source/read-back,
+  diff, link, stale-token 검증과 live issue read-back은 별도로 수행한다.

--- a/docs/superpowers/research/2026-08-25-issue-1320-tenant-context-bridge-evaluation.md
+++ b/docs/superpowers/research/2026-08-25-issue-1320-tenant-context-bridge-evaluation.md
@@ -1,0 +1,159 @@
+# Issue #1320 — TenantContext 전파·정리 bridge 평가 기록
+
+## 결정
+
+**결정: 공통 bridge 승격을 보류한다. 현재 framework별 context carrier와 tenant routing/auth 경계를 애플리케이션 로컬에 유지한다.**
+
+이슈 본문은 `ThreadLocal`과 `ThreadContextElement`가 여러 예제에 반복된다고
+설명하지만, 현재 `exposed-r2dbc-workshop`의 최신 `develop` 소스는 이미 서로
+다른 경계를 사용한다. Ktor는 `ApplicationCall.attributes`, schema-per-tenant
+WebFlux는 `ReactorContext`와 `CoroutineContext`, connection-factory/security/
+onboarding 예제는 명시적인 Reactor key와 별도의 `TenantId` 검증 계약을 사용한다.
+
+따라서 지금 하나의 `TenantContext`를 공개하면 다음 의미를 섞게 된다.
+
+- request carrier의 수명과 cleanup 방식
+- tenant ID의 정규화·검증과 인증/인가 책임
+- schema 전환 또는 `ConnectionFactory` 선택 같은 저장소 책임
+- context가 없을 때 fail-closed 할지 default tenant를 허용할지에 대한 정책
+
+이번 이슈에서는 production code, public module, 기존 workshop migration을
+추가하지 않는다. 먼저 carrier 중립적인 최소 contract를 독립 fixture로 고정하고,
+Servlet/virtual-thread 소비자까지 포함한 두 개 이상의 production-shaped consumer가
+같은 의미를 실제로 요구하는지 확인한 뒤 별도 구현 이슈를 만든다.
+
+## 평가 범위와 최신 상태
+
+라이브 이슈는 [#1320](https://github.com/bluetape4k/bluetape4k-projects/issues/1320)
+이며 `enhancement`, `design`, `examples`, `coroutines` 라벨과 `2.0.0` milestone,
+`debop` assignee를 유지한다. 이슈 본문에 적힌 일부 경로와 구현 설명은 현재
+workshop 구조와 달라졌으므로, 판단에는 최신 `develop` source와 README/spec/test를
+우선 사용했다.
+
+| 소비자/경계 | 현재 carrier와 책임 | source/test 근거 | 판단 |
+| --- | --- | --- | --- |
+| Ktor schema-per-tenant | `TenantPlugin`이 검증된 `Tenants.Tenant`를 `ApplicationCall.attributes`에 저장하고 `call.currentTenant()`가 없으면 오류 | [`TenantPlugin.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/07-multitenant-ktor/src/main/kotlin/exposed/r2dbc/multitenant/ktor/tenant/TenantPlugin.kt#L6-L40), [`KtorMultitenantApplicationTest.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/07-multitenant-ktor/src/test/kotlin/exposed/r2dbc/multitenant/ktor/KtorMultitenantApplicationTest.kt#L198-L218) | call 수명으로 격리되므로 `ThreadLocal` cleanup bridge를 도입할 이유가 없다. |
+| WebFlux schema-per-tenant | `TenantFilter`가 헤더를 검증하고 Reactor key에 `TenantId`를 저장한다. `currentReactorTenant()`는 직접 호출 경로에서 default tenant로 fallback한다. | [`TenantFilter.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/03-multitenant-spring-webflux/src/main/kotlin/exposed/r2dbc/multitenant/webflux/tenant/TenantFilter.kt#L15-L69), [`TenantId.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/03-multitenant-spring-webflux/src/main/kotlin/exposed/r2dbc/multitenant/webflux/tenant/TenantId.kt#L15-L70), [`ActorControllerTest.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/03-multitenant-spring-webflux/src/test/kotlin/exposed/r2dbc/multitenant/webflux/controller/ActorControllerTest.kt#L94-L148) | Reactor context는 immutable subscriber scope다. Ktor와 같은 `current`/cleanup API로 합치면 fallback 정책이 바뀐다. |
+| Connection-factory routing | `TenantContextKeys.TENANT_ID`를 Reactor context에 기록하고, `TenantTransactionExecutor`가 `Mono.deferContextual`에서 coroutine `ReactorContext`로 bridge한 뒤 routing DB를 연다. | [`TenantContextKeys.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/04-connection-factory-per-tenant-spring-webflux/src/main/kotlin/exposed/r2dbc/multitenant/connectionfactory/tenant/TenantContextKeys.kt#L3-L10), [`TenantTransactionExecutor.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/04-connection-factory-per-tenant-spring-webflux/src/main/kotlin/exposed/r2dbc/multitenant/connectionfactory/tenant/TenantTransactionExecutor.kt#L24-L43), [`TenantRoutingConnectionFactoryTest.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/04-connection-factory-per-tenant-spring-webflux/src/test/kotlin/exposed/r2dbc/multitenant/connectionfactory/tenant/TenantRoutingConnectionFactoryTest.kt#L24-L60) | context key와 connection selection은 저장소 어댑터 책임이다. 공통 core가 DB 정책을 소유하면 안 된다. |
+| Security WebFlux | 인증된 tenant와 요청 tenant가 일치한 뒤에만 `TenantContextKeys.TENANT_ID`를 쓴다. 헤더를 먼저 context에 넣지 않는다. | [`AuthorizedTenantContextWebFilter.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/05-spring-security-tenant-authorization-spring-webflux/src/main/kotlin/exposed/r2dbc/multitenant/security/security/AuthorizedTenantContextWebFilter.kt#L18-L49), [`AuthorizedTenantContextWebFilterTest.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/05-spring-security-tenant-authorization-spring-webflux/src/test/kotlin/exposed/r2dbc/multitenant/security/security/AuthorizedTenantContextWebFilterTest.kt#L1-L180) | routing context와 authorization context를 같은 API로 제공하면 confused-deputy 위험이 생긴다. |
+| Onboarding WebFlux | `[a-z][a-z0-9-]{1,30}` 규칙의 `@JvmInline value class TenantId`와 Reactor key를 사용하며, 명시 tenant 실행 경로도 별도로 제공한다. | [`TenantTypes.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/06-tenant-onboarding-spring-webflux/src/main/kotlin/exposed/r2dbc/multitenant/onboarding/tenant/TenantTypes.kt#L1-L40), [`TenantTransactionExecutor.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/06-tenant-onboarding-spring-webflux/src/main/kotlin/exposed/r2dbc/multitenant/onboarding/tenant/TenantTransactionExecutor.kt#L24-L55), [`TenantIdTest.kt`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/10-multi-tenant/06-tenant-onboarding-spring-webflux/src/test/kotlin/exposed/r2dbc/multitenant/onboarding/tenant/TenantIdTest.kt#L1-L28) | 동적 tenant lifecycle과 request routing을 하나의 mutable context에 넣지 않는다. |
+| Servlet/virtual-thread | 이 issue train의 최신 workshop source에서 공통 `TenantContext` 또는 Servlet/virtual-thread contract를 확인하지 못했다. | projects/workshop/exposed-r2dbc source bounded scan과 현재 issue body 대조 | 수용 기준의 핵심 소비자가 아직 비어 있으므로 public bridge gate를 충족하지 못한다. |
+
+Ktor 예제의 설계 문서도 두 carrier를 의도적으로 분리한다. [`Issue 33 설계`](https://github.com/bluetape4k/exposed-r2dbc-workshop/blob/develop/docs/superpowers/specs/2026-05-23-issue-33-ktor-multitenant-r2dbc-design.md#L90-L115)는 Ktor call attribute와 WebFlux `ReactorContext`를 각각 유지하고, `ThreadLocal`을 Ktor request path에서 금지한다. 이 결정을 거꾸로 되돌릴 공통 consumer proof는 아직 없다.
+
+## 반복되는 최소 의미와 분리해야 할 의미
+
+| 의미 | 공통 후보 | 현재 판정 |
+| --- | --- | --- |
+| tenant 식별자 | 비어 있지 않고 정규화된 opaque value 또는 value class | **후속 검토**. 정규화 규칙과 허용 문자/길이는 consumer별로 다르다. |
+| 현재 값 조회 | `currentOrNull`과 명시적 `requireCurrent` | **후속 검토**. 현재 WebFlux의 default fallback은 fail-closed 계약과 충돌한다. |
+| 중첩 범위 | `withTenant(tenant) { ... }`에서 이전 값을 복원 | **어댑터별 검증**. ThreadLocal adapter에만 필요한 cleanup이며 Reactor/Ktor carrier에는 동일한 복원 모델이 없다. |
+| coroutine 전파 | `ThreadContextElement` 또는 `ReactorContext` bridge | **분리 유지**. blocking/Servlet과 WebFlux의 thread/context 수명이 다르다. |
+| request 종료 정리 | ThreadLocal remove/restore, Reactor subscriber scope, Ktor call discard | **공통 API 금지**. 하나의 `clear()`가 모든 carrier에서 같은 의미를 갖지 않는다. |
+| tenant routing | schema, connection factory, keyspace, cache prefix 선택 | **application 책임**. context core가 저장소나 인증 정책을 결정하지 않는다. |
+
+## 후보 API 스케치
+
+아래는 구현 제안이 아니라, 별도 consumer proof가 생겼을 때 검토할 최소 경계다.
+현재 repository와 public API에는 추가하지 않았다.
+
+```kotlin
+@JvmInline
+value class TenantId(val value: String)
+
+interface TenantContextReader {
+    fun currentOrNull(): TenantId?
+    fun requireCurrent(): TenantId
+}
+
+suspend fun <T> withTenant(
+    tenantId: TenantId,
+    block: suspend () -> T,
+): T
+```
+
+이 스케치는 다음을 전제로 한다.
+
+- core는 tenant 값의 형식과 scope contract만 소유하고, HTTP header 해석·인증/인가·DB
+  schema/connection 선택은 소유하지 않는다.
+- 기본 tenant fallback을 public core의 기본 동작으로 만들지 않는다. fallback이
+  필요한 direct example은 adapter가 명시적으로 선택한다.
+- `withTenant`는 carrier별 adapter 계약을 별도로 갖는다. ThreadLocal adapter는
+  `updateThreadContext`/`restoreThreadContext`와 예외 경로를 검증하고, Reactor
+  adapter는 `contextWrite`/`ReactorContext` 전파와 subscriber scope를 검증한다.
+- Ktor adapter는 call attribute를 사용하며 global mutable state를 만들지 않는다.
+
+## 도입 게이트 판정
+
+| 게이트 | 판정 | 증거와 남은 조건 |
+| --- | --- | --- |
+| 독립 production-shaped consumer 두 곳이 동일 semantic contract를 요구 | **미충족** | 현재 근거는 같은 R2DBC chapter의 teaching modules와 Ktor example이다. Servlet/virtual-thread consumer와 서로 다른 production domain의 공통 contract가 없다. |
+| Ktor, Servlet/virtual-thread, WebFlux에서 동일 contract를 검증 | **미충족** | Ktor와 WebFlux만 확인했다. Servlet/virtual-thread fixture가 없다. |
+| 동시 격리와 중첩/예외 cleanup을 carrier별로 증명 | **부분 충족** | Ktor overlapping request와 WebFlux tenant isolation은 green source/test contract가 있으나, ThreadLocal nested restore/leak test와 cross-carrier black-box suite가 없다. |
+| routing과 authorization 경계를 보존 | **부분 충족** | security filter가 인증 후 context를 쓰는 현재 규칙은 확인했지만, 공통 API migration proof는 없다. |
+| API ownership/dependency/migration/versioning | **미충족** | projects의 public module 위치, adapter dependency 방향, 기존 예제 migration 순서가 합의되지 않았다. |
+| dispatcher/thread hop, Reactor cleanup, 성능·누수 비용 | **미충족** | context switch/restore overhead, ThreadLocal leak soak, adapter 간 allocation benchmark가 없다. |
+
+모든 필수 게이트가 충족되지 않았으므로 library 구현이나 release 가능한 public
+bridge PR을 만들지 않는다. #1320은 설계·평가 이슈로 열어 두고, 다음 단계에서
+공통 fixture와 누락된 Servlet/virtual-thread proof를 먼저 추가한다.
+
+## 최소 reusable test contract
+
+추출을 다시 제안하기 전에, production repository나 framework entity를 공유하지 않는
+black-box fixture를 각 adapter에 실행할 수 있어야 한다.
+
+1. **현재 값과 빈 상태** — `currentOrNull()`은 carrier가 없을 때 `null`이고,
+   `requireCurrent()`는 안정된 오류를 낸다. 암묵적인 default tenant는 fixture의
+   기본값이 아니다.
+2. **중첩 복원** — `A` 안에서 `B`를 설정한 뒤 `A`가 복원되고, 정상·예외 경로 모두
+   request 종료 후 빈 상태가 된다.
+3. **dispatcher/thread hop** — `Dispatchers.IO`, virtual thread, coroutine
+   resumption을 섞어도 각 작업이 자기 tenant만 읽는다.
+4. **동시 격리** — 최소 두 tenant의 병렬 작업에서 값 교차가 없고, 반복 교대 후
+   이전 작업의 값이 남지 않는다.
+5. **Reactor bridge** — `contextWrite`에서 시작한 값이 suspend controller와
+   Exposed transaction까지 전달되고, subscriber 종료 뒤 다른 subscriber에 보이지
+   않는다.
+6. **Ktor lifecycle** — call attribute가 request 사이에 공유되지 않고, 인증/인가
+   검증 전에는 routing tenant가 노출되지 않는다.
+7. **보안/정규화** — raw header가 schema/connection 선택으로 직접 들어가지 않고,
+   malformed/unknown/unauthorized tenant가 fail-closed 된다.
+8. **비용 측정** — ThreadLocal, Reactor, Ktor adapter의 context switch와 allocation,
+   leak soak 결과를 같은 JDK/fixture 조건에서 비교한다.
+
+## 보안·운영·호환성 위험
+
+- **보안:** 요청 header를 인증된 identity와 분리하면 tenant confusion이 발생한다.
+  공통 core는 인증을 우회하는 `setCurrent` API를 공개하지 않아야 한다.
+- **정리:** ThreadLocal을 coroutine context에 연결하면서 `remove()`/이전 값 복원을
+  빠뜨리면 pooled thread와 virtual thread 모두에 잔존 값이 남을 수 있다.
+- **Reactor:** subscriber context를 ThreadLocal처럼 지우려 하면 immutable context
+  semantics와 충돌하고, 반대로 default fallback을 허용하면 누락 요청이 다른 tenant로
+  라우팅될 수 있다.
+- **저장소:** schema switch, connection-factory routing, keyspace/prefix 선택은
+  transaction/resource boundary다. tenant core에 넣으면 dependency 방향과 migration
+  책임이 뒤섞인다.
+- **호환성:** 서로 다른 `TenantId` 검증 규칙을 하나로 통합하면 기존 API가 허용하거나
+  거부하던 값이 바뀐다. value class 도입 전 serialization/logging/Java 호출 경계를
+  별도로 확인해야 한다.
+- **성능:** 모든 호출을 `ThreadContextElement`로 감싸는 비용과 Reactor bridge의
+  context 재구성 비용은 현재 자료로 정량화하지 않았다.
+
+## DoD와 후속 조건
+
+- [x] 라이브 #1320, milestone/labels/assignee와 Epic #1423 train dependency를 확인했다.
+- [x] 최신 `exposed-r2dbc-workshop`의 Ktor/WebFlux/connection-factory/security/onboarding carrier와 test/spec 근거를 대조했다.
+- [x] 이슈 본문과 현재 source의 경로·구현 차이를 기록했다.
+- [x] 공통 후보 API, adapter 경계, routing/auth 분리, cleanup 정책을 제시했다.
+- [x] `extract now / defer pending proof / keep application-local` 중 `defer pending proof + keep application-local`을 선택했다.
+- [ ] Servlet/virtual-thread consumer proof와 ThreadLocal nested/leak fixture — 후속 작업.
+- [ ] cross-carrier compatibility suite와 adapter benchmark — 후속 작업.
+- [ ] public module 구현/기존 예제 migration — 모든 도입 게이트 통과 전에는 생성하지 않음.
+
+### 작성·검증 메모
+
+- 문서 언어: 한국어 기술 문서. API 이름, 경로, 명령, URL, issue 번호는 원문을 보존했다.
+- 범위: Type E 문서 변경이며 production behavior와 public API를 변경하지 않는다.
+- 1인 개발자 lane에서는 CG-14 human-review를 N/A로 두되, source/read-back, diff,
+  link, stale-token 검증과 live issue read-back은 별도로 수행한다.


### PR DESCRIPTION
## 요약

- #1320 최신 소스를 기준으로 Ktor `ApplicationCall.attributes`, WebFlux `ReactorContext`, connection-factory/security/onboarding의 명시적 Reactor key/value class 경계를 대조했습니다.
- carrier 수명, cleanup, default fallback, tenant routing, 인증/인가 책임이 서로 달라 즉시 공통 public bridge로 승격하지 않기로 했습니다.
- Servlet/virtual-thread consumer와 cross-carrier compatibility fixture를 먼저 확보하는 후속 조건을 기록했습니다.

## 결정

`defer pending proof + keep application-local`을 선택합니다. 이번 PR은 문서만 변경하며 production code, public API, 기존 workshop migration을 추가하지 않습니다.

## 검증

- `git diff --check`
- `node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs --json docs/superpowers/research/2026-08-25-issue-1320-tenant-context-bridge-evaluation.md`
- GitHub API로 문서의 source/spec 경로 6개 확인
- Bluetape Type E workflow receipt: run `20260825T132554Z-e366ee57`, sequence 16, completed

## 선행·후속

- 선행 PR #1509 (`docs/1070-event-sourcing-evaluation`)가 merge되었고, 현재 PR base는 최신 `develop` (`9446c860248d7af53a00561b0b3764d7f465fee2`)으로 갱신되었습니다.
- #1320 이슈는 닫지 않고 평가 결과와 후속 조건을 유지합니다.

Refs #1320

## DoD Status

- [x] 최신 consumer/source/spec/test 대조와 carrier 경계 기록
- [x] 공통 API 스케치와 adapter별 최소 test contract 기록
- [x] public bridge 추출 보류 결정과 Servlet/virtual-thread 후속 조건 기록
- [x] 문서·용어·링크·diff 검증
- [x] 선행 #1509 merge 및 최신 develop base 반영 — PR base `develop@9446c860248d7af53a00561b0b3764d7f465fee2` 확인
- [ ] 공통 compatibility fixture/benchmark 및 production code — 모든 도입 게이트 통과 후 후속 이슈


