### PR TITLE
[test] CassandraTypeMappingTest를 실제 type round-trip 검증으로 완성한다

### DIFF
--- a/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/convert/CassandraTypeMappingTest.kt
+++ b/spring-boot/cassandra/src/test/kotlin/io/bluetape4k/spring/cassandra/convert/CassandraTypeMappingTest.kt
@@ -1,35 +1,174 @@
 package io.bluetape4k.spring.cassandra.convert
 
-import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.logging.info
-import kotlinx.atomicfu.atomic
+import com.datastax.oss.driver.api.core.cql.SimpleStatement
+import com.datastax.oss.driver.api.core.data.TupleValue
+import com.datastax.oss.driver.api.core.type.DataTypes
+import com.datastax.oss.driver.api.core.type.TupleType
+import com.datastax.oss.driver.api.core.uuid.Uuids
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
-import org.junit.jupiter.api.BeforeEach
+import io.bluetape4k.spring.cassandra.convert.model.CounterEntity
+import io.bluetape4k.spring.cassandra.convert.model.TimeEntity
+import io.bluetape4k.spring.cassandra.domain.model.AllPossibleTypes
+import io.bluetape4k.spring.cassandra.domain.model.Condition
+import io.bluetape4k.spring.cassandra.schema.SchemaGenerator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.cassandra.core.CassandraOperations
+import org.springframework.data.cassandra.core.selectOneById
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.net.InetAddress
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.Date
 
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 @SpringBootTest(classes = [ConvertTestConfiguration::class])
+@Execution(ExecutionMode.SAME_THREAD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class CassandraTypeMappingTest(
     @param:Autowired private val operations: CassandraOperations,
 ): io.bluetape4k.spring.cassandra.AbstractCassandraTest() {
 
-    companion object: KLoggingChannel() {
-        private val initialized = atomic(false)
+    private val cleanupActions = mutableListOf<() -> Unit>()
+
+    /**
+     * 매핑 대상 테이블을 이 클래스에서 명시적으로 보장합니다.
+     * 테스트는 고유한 time-based id를 사용하고 JUnit same-thread 계약으로 실행해
+     * 공유 keyspace를 truncate하지 않아 다른 Cassandra 테스트와 상태를 섞지 않습니다.
+     */
+    @BeforeAll
+    fun createSchema() {
+        SchemaGenerator.potentiallyCreateTableFor<CounterEntity>(operations)
+        SchemaGenerator.potentiallyCreateTableFor<TimeEntity>(operations)
+        SchemaGenerator.potentiallyCreateTableFor<AllPossibleTypes>(operations)
     }
 
-    @BeforeEach
-    fun beforeEach() {
-        if (initialized.compareAndSet(expect = false, update = true)) {
-            // TODO: 초기화                                  
-        }
+    @AfterEach
+    fun cleanupRows() {
+        cleanupActions.asReversed().forEach { it() }
+        cleanupActions.clear()
     }
 
     @Test
+    @Order(1)
     fun `context loading`() {
         operations.shouldNotBeNull()
         session.shouldNotBeNull()
-        log.info { "Current keyspace=${session.keyspace}" }
+    }
+
+    @Test
+    @Order(2)
+    fun `time values round trip through Cassandra`() {
+        val expected = TimeEntity(
+            id = Uuids.timeBased().toString(),
+            time = 42_000_000_000L,
+        )
+
+        trackCleanup(expected.id, TimeEntity::class.java)
+        operations.insert(expected)
+
+        val actual = operations.selectOneById<TimeEntity>(expected.id)
+        actual shouldBeEqualTo expected
+    }
+
+    @Test
+    @Order(3)
+    fun `all supported scalar collection tuple and temporal values round trip`() {
+        val instant = Instant.parse("2026-08-25T05:00:00Z")
+        val expected = AllPossibleTypes(
+            id = Uuids.timeBased().toString(),
+            inet = InetAddress.getByName("127.0.0.1"),
+            uuid = Uuids.timeBased(),
+            justNumber = 123 as java.lang.Number?,
+            boxedByte = 7.toByte() as java.lang.Byte?,
+            primitiveByte = 8,
+            boxedLong = 9_000L as java.lang.Long?,
+            primitiveLong = 10_000L,
+            boxedInteger = 11 as java.lang.Integer?,
+            primitiveInteger = 12,
+            boxedFloat = 13.5F as java.lang.Float?,
+            primitiveFloat = 14.5F,
+            boxedDouble = 15.5 as java.lang.Double?,
+            primitiveDouble = 16.5,
+            boxedBoolean = true as java.lang.Boolean?,
+            primitiveBoolean = false,
+            instant = instant,
+            date = LocalDate.of(2026, 8, 25),
+            time = LocalTime.of(5, 6, 7, 8_000_000),
+            timestamp = Date.from(instant),
+            bigDecimal = BigDecimal("12345.6789"),
+            bigInteger = BigInteger("9876543210"),
+            blob = ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4)),
+            setOfString = mutableSetOf("alpha", "beta"),
+            listOfString = mutableListOf("first", "second"),
+            onEnum = Condition.MINT,
+            setOfEnum = mutableSetOf(Condition.MINT),
+            listOfEnum = mutableListOf(Condition.MINT),
+            tupleValue = tupleValue("tuple", 17L),
+            localDateTime = LocalDateTime.of(2026, 8, 25, 5, 6, 7, 8_000_000),
+            zoneId = ZoneId.of("UTC"),
+        )
+
+        trackCleanup(expected.id, AllPossibleTypes::class.java)
+        operations.insert(expected)
+
+        val actual = operations.selectOneById<AllPossibleTypes>(expected.id)
+        actual shouldBeEqualTo expected
+    }
+
+    @Test
+    @Order(4)
+    fun `counter values round trip after a real counter update`() {
+        val expected = CounterEntity(
+            id = Uuids.timeBased().toString(),
+            coount = 7L,
+        )
+        val tableName = operations.getTableName(CounterEntity::class.java).asCql(false)
+
+        trackCleanup(expected.id, CounterEntity::class.java)
+        session.execute(
+            SimpleStatement.newInstance(
+                "UPDATE $tableName SET coount = coount + ? WHERE id = ?",
+                expected.coount,
+                expected.id,
+            )
+        )
+
+        val raw = session.execute(
+            SimpleStatement.newInstance(
+                "SELECT coount FROM $tableName WHERE id = ?",
+                expected.id,
+            )
+        ).one()
+        raw.shouldNotBeNull()
+        raw.getLong("coount") shouldBeEqualTo expected.coount
+
+        val actual = operations.selectOneById<CounterEntity>(expected.id)
+        actual shouldBeEqualTo expected
+    }
+
+    private fun tupleValue(text: String, number: Long): TupleValue {
+        val tupleType: TupleType = DataTypes.tupleOf(DataTypes.TEXT, DataTypes.BIGINT)
+        return tupleType.newValue()
+            .setString(0, text)
+            .setLong(1, number)
+    }
+
+    private fun trackCleanup(id: String, entityClass: Class<*>) {
+        cleanupActions += { operations.deleteById(id, entityClass) }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1345

`CassandraTypeMappingTest`가 Spring context와 session 존재만 확인해 잘못된 converter도 green이 될 수 있던 문제를 실제 Cassandra provider 왕복 검증으로 고정합니다.

## Background

Epic #1420의 #1340 위임/영속성 검증이 PR #1487로 `develop`에 통합된 뒤, 다음 Cassandra type mapping 단계로 진행했습니다. 기존 테스트의 `@BeforeEach` 초기화는 TODO no-op이었고 실제 write/read assertion이 없었습니다.

## What This Solves

- `TimeEntity`, `AllPossibleTypes`, `CounterEntity`의 실제 Cassandra 저장·조회 계약을 독립적으로 검증합니다.
- scalar/boxed/collection/TUPLE/시간 타입과 counter update를 Testcontainers Cassandra에서 검증하고 테스트 상태 누수를 정리합니다.

## Work Done

- 기존 `CassandraTypeMappingTest`를 확장해 `SchemaGenerator.potentiallyCreateTableFor`로 세 테이블을 보장하고 실제 `insert`/`selectOneById` 왕복 assertion을 추가했습니다.
- `CounterEntity`는 Cassandra counter CQL update와 raw/mapped read를 함께 검증하고, 각 테스트는 고유 ID와 `@AfterEach` 정리로 공유 keyspace 오염을 막습니다.
- `@Execution(SAME_THREAD)`와 method order로 Testcontainers-backed shared state 실행 계약을 명시했습니다.

## Validation

- `./gradlew :bluetape4k-spring-boot-cassandra:test --tests 'io.bluetape4k.spring.cassandra.convert.CassandraTypeMappingTest' --no-configuration-cache --console=plain`: PASS (4/4)
- `./gradlew :bluetape4k-spring-boot-cassandra:test --no-configuration-cache --console=plain`: PASS (262/262)
- `./gradlew :bluetape4k-spring-boot-cassandra:detekt --no-configuration-cache --console=plain`: PASS (기존 baseline findings 보고, 변경 파일 신규 finding 없음)
- `git diff --check`: PASS
- mutation RED/GREEN: PASS (insert 제거 시 의도한 null-vs-entity assertion failure, 복원 후 4/4)

## Review Notes

- P0/P1: 0
- P2/P3: 없음; detekt의 기존 모듈 baseline findings는 범위 밖으로 유지했습니다.
- Review evidence: 대상 파일 `code_quality_checker.py --json` findings 0, workflow receipt `completion-check complete=true`, live review 0건/미해결 thread 0건

## Metadata

- Issue: #1345, milestone `2.0.0`, assignee `debop`
- PR: #1513, head `e9db9a65edc9b5c4d58190ae4fd9fcd23086b666`, milestone `2.0.0`, assignee `debop`
- Base/head: `develop` <- `test/1345-cassandra-type-roundtrip`
- CI: [run 32861411962](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32861411962)에서 Build/Coverage Report/CI Status 및 정책 checks SUCCESS; `Test / Data`는 `dorny/paths-filter`의 `data: data/**` 범위 밖인 `spring-boot/cassandra/**` 변경이라 N/A이며 local Cassandra module 262/262로 보완
- Stack context: 선행 #1340 / PR #1487 merged; 후속 #1359는 별도 단계

## DoD Status

Required checks: 15/17; N/A: 2; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|---|---|---|---|---|
| CG-01 — Re-read authority | applicable AGENTS hierarchy, selected Type C/Kotlin skills, current status/diff, approved issue plan을 재확인 | PASS | current workspace/worktree guidance and issue #1345 metadata | none |
| CG-02 — Historical/current evidence | GNO 검색 후 live #1345/#1420/#1340/#1359/#1487를 확인 | PASS | live issue/epic/predecessor PR metadata and checks | none |
| CG-03 — Protect boundaries | isolated worktree와 semantic `test/1345-cassandra-type-roundtrip` branch에서 단일 파일만 변경 | PASS | worktree status, receipt write scope, one-file commit | none |
| CG-04 — Policy/audience | Korean GitHub prose, Kotlin patterns, one-person developer/review gate 정책 적용 | PASS | current AGENTS and leaf skill read-back | none |
| CG-05 — Reuse ecosystem patterns | 기존 Cassandra launcher, `SchemaGenerator`, Spring Data operations, Bluetape assertions 재사용 | PASS | source inspection and final diff | none |
| CG-06 — Public/docs contracts | public API/docs/registration 변경 여부 확인 | N/A | test-only one-file scope; public API, docs, catalog, registration surface unchanged | scope N/A |
| CG-07 — Targeted proof | RED/GREEN, compile, targeted/full module tests, static analysis 실행 | PASS | fresh commands in Validation | none |
| CG-08 — Heavy checks serialized | Cassandra Testcontainers를 단일 worktree에서 순차 실행 | PASS | Colima/Docker preflight; targeted 4/4 then module 262/262 | none |
| CG-09 — Lesson gate | reusable lesson 필요 여부를 diff와 기존 Testcontainers rule로 검토 | N/A | 기존 sequential Testcontainers/cleanup rule 재사용; novel failure/recovery/design/ops guidance 없음 | scope N/A |
| CG-10 — Final pre-PR proof | final diff, code review, detekt, receipt, commit을 수렴 | PASS | findings 0, `git diff --check`, receipt complete, commit `e9db9a65e` | none |
| CG-11 — PR delivery authority | 사용자 요청의 순차 issue 작업과 승인된 workflow에 따라 repo/base/head를 확정 | PASS | `bluetape4k/bluetape4k-projects`, `develop`, `test/1345-cassandra-type-roundtrip` | none |
| CG-12 — Publish exact head | force 없이 branch push 후 remote SHA를 재확인 | PASS | local/remote `e9db9a65edc9b5c4d58190ae4fd9fcd23086b666` match | none |
| CG-12A — Guidance refresh | PR 직전 AGENTS, Type C/Kotlin skill, common gates, PR template, linked issue를 재독 | PASS | current paths/scopes and no-drift live metadata read-back | none |
| CG-13 — Create/verify PR | PR 생성 후 body, final heading, metadata, exact head를 live read-back | PASS | PR #1513, final heading `## DoD Status`, labels `test`/`tech-debt`, milestone `2.0.0`, assignee `debop`, exact head `e9db9a65e` | none |
| CG-14 — Exact-head CI/review | required CI와 최신 review/thread를 exact head에서 확인 | PASS | exact head `e9db9a65e`; run `32861411962` Build/Coverage/CI Status/policy checks SUCCESS; Test/Data path-filter N/A with local 262/262; reviews 0, unresolved threads 0, mergeable CLEAN | none; CI routing follow-up remains outside this PR |
| CG-15 — Merge-ready report | CI/review 이후 counts와 exact PR/head를 사용자에게 보고 | PASS | PR #1513 exact head `e9db9a65edc9b5c4d58190ae4fd9fcd23086b666`, `Required checks: 15/17; N/A: 2; Blocked: 0` | stop for fresh CG-16 approval |
| CG-16 — Fresh merge approval | CG-15 이후 exact PR/head에 대한 새 merge approval | PASS | 사용자가 현재 turn에서 PR #1513/head `e9db9a65edc9b5c4d58190ae4fd9fcd23086b666` merge를 승인 | none |
| CG-17 — Merge/verify | 승인된 strategy로 merge하고 live merged state와 merge SHA를 확인 | PASS | `gh pr merge 1513 --rebase --match-head-commit e9db9a65edc9b5c4d58190ae4fd9fcd23086b666`; state MERGED; merge SHA `b26e6f2113a1b920bec2796aa1c74f4e409f2918` | none |
| CG-18 — Sync/cleanup | canonical develop을 동기화하고 proven-safe 작업 트리/브랜치를 정리 | PASS | local `develop`와 `origin/develop` 모두 `b26e6f2113a1b920bec2796aa1c74f4e409f2918`; #1345 worktree 제거; 원격 브랜치 자동 삭제; 기존 flow 증거 3개 보존 | none |

Final status: DONE — PR #1513 merged, issue #1345 closed, canonical develop synchronized, and proven-safe cleanup complete

Unchecked required items: none

