### PR TITLE
[7-Tier][infra] lettuce·redisson assertion, nullable, polling 패턴 정리

### DIFF
--- a/bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/KotlinLoggingTest.kt
+++ b/bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/KotlinLoggingTest.kt
@@ -2,14 +2,15 @@ package io.bluetape4k.logging
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 class KotlinLoggingTest {
 
     private val log = KotlinLogging.logger {}
 
-    private val loggerName = KotlinLoggingTest::class.qualifiedName!!
+    private val loggerName = KotlinLoggingTest::class.qualifiedName.shouldNotBeNull()
 
     @Test
     fun `logging trace`() {
@@ -43,6 +44,6 @@ class KotlinLoggingTest {
         class LocalClass
 
         val logger = KotlinLogging.logger(LocalClass::class)
-        assertTrue(logger.name.isNotBlank())
+        logger.name.isNotBlank().shouldBeTrue()
     }
 }

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/EntityManagerSupportTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/EntityManagerSupportTest.kt
@@ -2,20 +2,20 @@ package io.bluetape4k.hibernate
 
 import io.bluetape4k.hibernate.mapping.naturalid.NaturalIdBook
 import io.bluetape4k.hibernate.mapping.simple.SimpleEntity
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.assertNotFails
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBe
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import io.bluetape4k.assertions.assertFailsWith
 
 class EntityManagerSupportTest: AbstractHibernateTest() {
 
     @Test
     fun `deleteById는 없는 id에 대해서도 예외를 발생시키지 않는다`() {
-        assertDoesNotThrow {
+        assertNotFails {
             em.deleteById<SimpleEntity>(Long.MAX_VALUE)
         }
     }
@@ -37,7 +37,7 @@ class EntityManagerSupportTest: AbstractHibernateTest() {
         em.persist(entity)
         flushAndClear()
 
-        em.deleteById<SimpleEntity>(entity.id!!)
+        em.deleteById<SimpleEntity>(entity.id.shouldNotBeNull())
         flushAndClear()
 
         em.countAll<SimpleEntity>() shouldBeEqualTo 0L
@@ -49,7 +49,7 @@ class EntityManagerSupportTest: AbstractHibernateTest() {
         em.persist(entity)
         flushAndClear()
 
-        em.exists<SimpleEntity>(entity.id!!).shouldBeTrue()
+        em.exists<SimpleEntity>(entity.id.shouldNotBeNull()).shouldBeTrue()
         em.exists<SimpleEntity>(Long.MAX_VALUE).shouldBeFalse()
     }
 
@@ -59,7 +59,7 @@ class EntityManagerSupportTest: AbstractHibernateTest() {
         em.persist(entity)
         flushAndClear()
 
-        val detached = em.findAs<SimpleEntity>(entity.id!!)
+        val detached = em.findAs<SimpleEntity>(entity.id.shouldNotBeNull())
         detached.shouldNotBeNull()
         clear() // detatch explicitly
 
@@ -68,7 +68,7 @@ class EntityManagerSupportTest: AbstractHibernateTest() {
         merged.shouldNotBeNull()
         flushAndClear()
 
-        val reloaded = em.findAs<SimpleEntity>(entity.id!!)
+        val reloaded = em.findAs<SimpleEntity>(entity.id.shouldNotBeNull())
         reloaded.shouldNotBeNull()
         reloaded.description shouldBeEqualTo "after"
     }
@@ -79,7 +79,7 @@ class EntityManagerSupportTest: AbstractHibernateTest() {
         em.persist(entity)
         flushAndClear()
 
-        val detached = em.findAs<SimpleEntity>(entity.id!!)
+        val detached = em.findAs<SimpleEntity>(entity.id.shouldNotBeNull())
         detached.shouldNotBeNull()
         clear()
 
@@ -132,7 +132,7 @@ class EntityManagerSupportTest: AbstractHibernateTest() {
         em.persist(entity)
         flushAndClear()
 
-        val proxy = em.getReference<SimpleEntity>(entity.id!!)
+        val proxy = em.getReference<SimpleEntity>(entity.id.shouldNotBeNull())
         em.isLoaded(proxy).shouldBeFalse()
         em.isLoaded(proxy, "name").shouldBeFalse()
 

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/querydsl/core/OperatorSupportTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/querydsl/core/OperatorSupportTest.kt
@@ -1,9 +1,10 @@
 package io.bluetape4k.hibernate.querydsl.core
 
 import com.querydsl.core.types.dsl.Expressions
+import io.bluetape4k.assertions.invoking
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 
 class OperatorSupportTest {
 
@@ -11,9 +12,10 @@ class OperatorSupportTest {
     fun `SimpleExpression inValues 는 빈 인자도 처리한다`() {
         val name = Expressions.stringPath("name")
 
-        val expr = assertDoesNotThrow {
+        val expr = invoking {
             name.inValues()
-        }
+        }.shouldNotThrow()
+        expr.shouldNotBeNull()
 
         expr.toString().isNotBlank().shouldBeTrue()
     }
@@ -22,9 +24,10 @@ class OperatorSupportTest {
     fun `SimpleExpression inValues 는 가변 인자를 묶어준다`() {
         val name = Expressions.stringPath("name")
 
-        val expr = assertDoesNotThrow {
+        val expr = invoking {
             name.inValues("a", "b", "c")
-        }
+        }.shouldNotThrow()
+        expr.shouldNotBeNull()
 
         expr.toString().contains("in").shouldBeTrue()
     }
@@ -33,9 +36,10 @@ class OperatorSupportTest {
     fun `StringExpression plus 는 blank 문자열도 concat 한다`() {
         val name = Expressions.stringPath("name")
 
-        val expr = assertDoesNotThrow {
+        val expr = invoking {
             name + "   "
-        }
+        }.shouldNotThrow()
+        expr.shouldNotBeNull()
 
         expr.toString().isNotBlank().shouldBeTrue()
     }
@@ -45,9 +49,10 @@ class OperatorSupportTest {
         val left = Expressions.stringPath("left")
         val right = Expressions.stringPath("right")
 
-        val expr = assertDoesNotThrow {
+        val expr = invoking {
             left + right
-        }
+        }.shouldNotThrow()
+        expr.shouldNotBeNull()
 
         expr.toString().isNotBlank().shouldBeTrue()
     }
@@ -56,9 +61,10 @@ class OperatorSupportTest {
     fun `StringExpression plus 는 문자열 누적을 지원한다`() {
         val left = Expressions.stringPath("left")
 
-        val expr = assertDoesNotThrow {
+        val expr = invoking {
             left + "foo" + "bar"
-        }
+        }.shouldNotThrow()
+        expr.shouldNotBeNull()
 
         expr.toString().isNotBlank().shouldBeTrue()
     }

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/standalone/EntityManagerSupportStandaloneTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/standalone/EntityManagerSupportStandaloneTest.kt
@@ -19,6 +19,7 @@ import io.bluetape4k.hibernate.save
 import io.bluetape4k.hibernate.sessionFactory
 import io.bluetape4k.hibernate.setPaging
 import jakarta.persistence.TypedQuery
+import io.bluetape4k.assertions.assertNotFails
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
@@ -27,7 +28,6 @@ import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 
 class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
 
@@ -78,14 +78,14 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         val entity = StandaloneEntity("merge-test")
         inTransaction { save(entity) }
 
-        val id = entity.id!!
+        val id = entity.id.shouldNotBeNull()
         inTransaction {
             // detached 상태에서 save → merge
             entity.name = "merged"
             save(entity)
         }
         readOnly {
-            val loaded = findAs<StandaloneEntity>(id)!!
+            val loaded = findAs<StandaloneEntity>(id).shouldNotBeNull()
             loaded.name shouldBeEqualTo "merged"
         }
     }
@@ -96,7 +96,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         inTransaction { save(entity) }
 
         readOnly {
-            val loaded = findAs<StandaloneEntity>(entity.id!!)
+            val loaded = findAs<StandaloneEntity>(entity.id.shouldNotBeNull())
             loaded.shouldNotBeNull()
             loaded.name shouldBeEqualTo "find-test"
         }
@@ -116,7 +116,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         inTransaction { save(entity) }
 
         readOnly {
-            val loaded = findOne<StandaloneEntity>(entity.id!!)
+            val loaded = findOne<StandaloneEntity>(entity.id.shouldNotBeNull())
             loaded.shouldNotBeNull()
         }
     }
@@ -127,7 +127,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         inTransaction { save(entity) }
 
         readOnly {
-            exists<StandaloneEntity>(entity.id!!).shouldBeTrue()
+            exists<StandaloneEntity>(entity.id.shouldNotBeNull()).shouldBeTrue()
             exists<StandaloneEntity>(Long.MAX_VALUE).shouldBeFalse()
         }
     }
@@ -167,7 +167,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         inTransaction { save(entity) }
 
         inTransaction {
-            deleteById<StandaloneEntity>(entity.id!!)
+            deleteById<StandaloneEntity>(entity.id.shouldNotBeNull())
         }
 
         readOnly {
@@ -177,7 +177,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
 
     @Test
     fun `deleteById는 없는 id에 대해 예외를 발생시키지 않는다`() {
-        assertDoesNotThrow {
+        assertNotFails {
             inTransaction {
                 deleteById<StandaloneEntity>(Long.MAX_VALUE)
             }
@@ -190,7 +190,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         inTransaction { save(entity) }
 
         inTransaction {
-            val loaded = findAs<StandaloneEntity>(entity.id!!)!!
+            val loaded = findAs<StandaloneEntity>(entity.id.shouldNotBeNull()).shouldNotBeNull()
             delete(loaded)
         }
 
@@ -205,7 +205,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         inTransaction { save(entity) }
 
         inTransaction {
-            val loaded = findAs<StandaloneEntity>(entity.id!!)!!
+            val loaded = findAs<StandaloneEntity>(entity.id.shouldNotBeNull()).shouldNotBeNull()
             isLoaded(loaded).shouldBeTrue()
         }
     }
@@ -265,7 +265,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         inTransaction { save(entity) }
 
         inTransaction {
-            val loaded = findAs<StandaloneEntity>(entity.id!!)!!
+            val loaded = findAs<StandaloneEntity>(entity.id.shouldNotBeNull()).shouldNotBeNull()
             isLoaded(loaded, "name").shouldBeTrue()
             isLoaded(null, "name").shouldBeFalse()
         }
@@ -277,7 +277,7 @@ class EntityManagerSupportStandaloneTest : AbstractStandaloneHibernateTest() {
         inTransaction { save(entity) }
 
         inTransaction {
-            val ref = getReference<StandaloneEntity>(entity.id!!)
+            val ref = getReference<StandaloneEntity>(entity.id.shouldNotBeNull())
             ref.shouldNotBeNull()
         }
     }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/FairLockScript.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/lock/internal/FairLockScript.kt
@@ -640,16 +640,19 @@ internal class FairLockClient private constructor(
             if (result.isDone) return@whenComplete
             if (error != null) {
                 result.completeExceptionally(error)
-            } else if (acquired == LockAcquireResult.TimedOut && waiterIdentity.get() != null) {
-                removeWaiterAsync(ownerId, requestId, waiterIdentity.get()!!).whenComplete { removed, removeError ->
-                    if (removeError != null) {
-                        result.completeExceptionally(removeError)
-                    } else {
-                        result.complete(cleanupResult(removed, ownerId, requestId))
-                    }
-                }
             } else {
-                result.complete(acquired)
+                val identity = waiterIdentity.get()
+                if (acquired == LockAcquireResult.TimedOut && identity != null) {
+                    removeWaiterAsync(ownerId, requestId, identity).whenComplete { removed, removeError ->
+                        if (removeError != null) {
+                            result.completeExceptionally(removeError)
+                        } else {
+                            result.complete(cleanupResult(removed, ownerId, requestId))
+                        }
+                    }
+                } else {
+                    result.complete(acquired)
+                }
             }
         }
         result.whenComplete { _, _ ->
@@ -673,9 +676,10 @@ internal class FairLockClient private constructor(
             val result = waitSupport.acquireSuspending(waitTime) {
                 acquireAttemptSuspending(ownerId, requestId, leasePolicy, waitTime, waiterIdentity)
             }
-            if (result == LockAcquireResult.TimedOut && waiterIdentity.get() != null) {
+            val identity = waiterIdentity.get()
+            if (result == LockAcquireResult.TimedOut && identity != null) {
                 cleanupResult(
-                    removeWaiterSuspending(ownerId, requestId, waiterIdentity.get()!!),
+                    removeWaiterSuspending(ownerId, requestId, identity),
                     ownerId,
                     requestId,
                 )

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMapTest.kt
@@ -7,7 +7,11 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -205,10 +209,7 @@ class LettuceLoadedMapTest: AbstractLettuceTest() {
             map["k1"] shouldBeEqualTo "v1"
 
             // writer는 비동기로 호출됨 — 최대 3초 대기
-            val deadline = System.currentTimeMillis() + 3000L
-            while (writerCallCount.get() == 0 && System.currentTimeMillis() < deadline) {
-                Thread.sleep(50L)
-            }
+            await atMost Duration.ofSeconds(3) until { writerCallCount.get() == 1 }
             writerCallCount.get() shouldBeEqualTo 1
         }
     }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceResidualMapCoverageTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceResidualMapCoverageTest.kt
@@ -6,6 +6,9 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.lettuce.core.codec.StringCodec
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
@@ -36,12 +39,10 @@ internal class LettuceResidualMapCoverageTest: AbstractLettuceTest() {
 
             val connection = client.connect(StringCodec.UTF8)
             try {
-                val deadline = System.currentTimeMillis() + 2_000L
-                var keys = emptyList<String>()
-                while (System.currentTimeMillis() < deadline && keys.none { it == "dead-key" }) {
-                    keys = connection.sync().lrange("$prefix:dead-letter", 0L, -1L)
-                    if (keys.none { it == "dead-key" }) Thread.sleep(25L)
+                await atMost Duration.ofSeconds(2) until {
+                    connection.sync().lrange("$prefix:dead-letter", 0L, -1L).contains("dead-key")
                 }
+                val keys = connection.sync().lrange("$prefix:dead-letter", 0L, -1L)
                 keys.contains("dead-key").shouldBeTrue()
                 attempts.get() shouldBeEqualTo 3
             } finally {

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapMockTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapMockTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.redis.lettuce.map
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
-import kotlin.test.assertFailsWith
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisFuture

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceCountDownLatchTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/synchronizer/LettuceCountDownLatchTest.kt
@@ -1,17 +1,22 @@
 package io.bluetape4k.redis.lettuce.synchronizer
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.bluetape4k.redis.lettuce.script.RedisScriptRunner
 import io.bluetape4k.redis.lettuce.synchronizer.internal.deriveLatchKeys
 import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.codec.StringCodec
-import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.test.runTest
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
 
 class LettuceCountDownLatchTest: AbstractLettuceTest() {
@@ -27,7 +32,7 @@ class LettuceCountDownLatchTest: AbstractLettuceTest() {
         val suspending = LettuceSuspendCountDownLatch.create(connection, name, config)
         try {
             latch.trySetCount(-1, LatchRequestId.random()) shouldBeEqualTo LatchSetCountResult.InvalidCount
-            latch.trySetCountAsync(3, LatchRequestId.random()).get() shouldBeEqualTo
+            latch.trySetCountAsync(3, LatchRequestId.random()).get(5, TimeUnit.SECONDS) shouldBeEqualTo
                 LatchSetCountResult.InvalidCount
 
             val completed = latch.trySetCount(0, LatchRequestId.from("zero-count"))
@@ -49,7 +54,7 @@ class LettuceCountDownLatchTest: AbstractLettuceTest() {
                 active.generation,
                 LatchRequestId.from("async-timeout"),
                 Duration.ofMillis(30),
-            ).get() shouldBeEqualTo LatchAwaitResult.TimedOut
+            ).get(5, TimeUnit.SECONDS) shouldBeEqualTo LatchAwaitResult.TimedOut
             suspending.await(
                 active.generation,
                 LatchRequestId.from("suspend-timeout"),
@@ -58,14 +63,14 @@ class LettuceCountDownLatchTest: AbstractLettuceTest() {
 
             val stale = LatchGeneration(active.generation.value + 1)
             latch.getCount(stale) shouldBeEqualTo LatchCountResult.StaleGeneration
-            latch.getCountAsync(stale).get() shouldBeEqualTo LatchCountResult.StaleGeneration
+            latch.getCountAsync(stale).get(5, TimeUnit.SECONDS) shouldBeEqualTo LatchCountResult.StaleGeneration
             latch.await(stale, LatchRequestId.from("stale-await"), Duration.ofMillis(20)) shouldBeEqualTo
                 LatchAwaitResult.StaleGeneration
             latch.awaitAsync(
                 stale,
                 LatchRequestId.from("stale-await-async"),
                 Duration.ofMillis(20),
-            ).get() shouldBeEqualTo
+            ).get(5, TimeUnit.SECONDS) shouldBeEqualTo
                 LatchAwaitResult.StaleGeneration
             latch.countDown(stale, LatchRequestId.from("stale-down")) shouldBeEqualTo
                 LatchMutationResult.StaleGeneration
@@ -80,7 +85,7 @@ class LettuceCountDownLatchTest: AbstractLettuceTest() {
             latch.close()
             latch.trySetCount(1, LatchRequestId.random()) shouldBeEqualTo LatchSetCountResult.Closed
             latch.getCount(active.generation) shouldBeEqualTo LatchCountResult.Closed
-            latch.getCountAsync(active.generation).get() shouldBeEqualTo LatchCountResult.Closed
+            latch.getCountAsync(active.generation).get(5, TimeUnit.SECONDS) shouldBeEqualTo LatchCountResult.Closed
             latch.await(active.generation, LatchRequestId.random(), Duration.ofMillis(20)) shouldBeEqualTo
                 LatchAwaitResult.Closed
             latch.delete(active.generation, LatchRequestId.random()) shouldBeEqualTo LatchMutationResult.Closed
@@ -168,20 +173,17 @@ class LettuceCountDownLatchTest: AbstractLettuceTest() {
                 .shouldBeInstanceOf<LatchSetCountResult.Created>()
                 .generation
             val first = latch.awaitAsync(generation, LatchRequestId.from("wait-1"), Duration.ofSeconds(2))
-            var waiters = 0
-            repeat(40) {
-                waiters = latch.inspect(generation).shouldBeInstanceOf<LatchCountResult.Active>().waiters
-                if (waiters == 1) return@repeat
-                Thread.sleep(5)
+            await atMost Duration.ofSeconds(2) until {
+                (latch.inspect(generation) as? LatchCountResult.Active)?.waiters == 1
             }
-            waiters shouldBeEqualTo 1
+            latch.inspect(generation).shouldBeInstanceOf<LatchCountResult.Active>().waiters shouldBeEqualTo 1
             latch.delete(generation, LatchRequestId.from("blocked-delete")) shouldBeEqualTo
                 LatchMutationResult.ActiveWaiters(1)
             latch.await(generation, LatchRequestId.from("wait-2"), Duration.ofMillis(100)) shouldBeEqualTo
                 LatchAwaitResult.CapacityExceeded
 
             first.cancel(false)
-            runCatching { first.get(2, TimeUnit.SECONDS) }
+            assertFailsWith<CancellationException> { first.get(2, TimeUnit.SECONDS) }
             first.isDone shouldBeEqualTo true
             latch.delete(generation, LatchRequestId.from("delete")) shouldBeEqualTo LatchMutationResult.Deleted
         } finally {
@@ -229,10 +231,8 @@ class LettuceCountDownLatchTest: AbstractLettuceTest() {
                 .shouldBeInstanceOf<LatchSetCountResult.Created>()
             val reusedRequest = LatchRequestId.from("reused-waiter")
             val current = latch.awaitAsync(second.generation, reusedRequest, Duration.ofSeconds(2))
-            repeat(40) {
-                if (latch.inspect(second.generation).shouldBeInstanceOf<LatchCountResult.Active>().waiters == 0) {
-                    Thread.sleep(5)
-                }
+            await atMost Duration.ofSeconds(2) until {
+                (latch.inspect(second.generation) as? LatchCountResult.Active)?.waiters == 1
             }
 
             RedisScriptRunner.run<List<String>>(
@@ -246,7 +246,7 @@ class LettuceCountDownLatchTest: AbstractLettuceTest() {
             latch.inspect(second.generation).shouldBeInstanceOf<LatchCountResult.Active>().waiters shouldBeEqualTo 1
 
             current.cancel(false)
-            runCatching { current.get(2, TimeUnit.SECONDS) }
+            assertFailsWith<CancellationException> { current.get(2, TimeUnit.SECONDS) }
             latch.delete(second.generation, LatchRequestId.from("delete-2")) shouldBeEqualTo
                 LatchMutationResult.Deleted
         } finally {
@@ -266,23 +266,24 @@ class LettuceCountDownLatchTest: AbstractLettuceTest() {
         val future = LettuceCountDownLatch.create(connection, name, config)
         val suspending = LettuceSuspendCountDownLatch.create(connection, name, config)
         try {
-            val futureGeneration = future.trySetCountAsync(2, LatchRequestId.from("future-create")).get()
+            val futureGeneration = future.trySetCountAsync(2, LatchRequestId.from("future-create"))
+                .get(5, TimeUnit.SECONDS)
                 .shouldBeInstanceOf<LatchSetCountResult.Created>().generation
-            future.getCountAsync(futureGeneration).get()
+            future.getCountAsync(futureGeneration).get(5, TimeUnit.SECONDS)
                 .shouldBeInstanceOf<LatchCountResult.Active>().count shouldBeEqualTo 2
             val awaited = future.awaitAsync(
                 futureGeneration,
                 LatchRequestId.from("future-await"),
                 Duration.ofSeconds(2),
             )
-            future.countDownAsync(futureGeneration, LatchRequestId.from("future-down-1")).get()
+            future.countDownAsync(futureGeneration, LatchRequestId.from("future-down-1")).get(5, TimeUnit.SECONDS)
                 .shouldBeInstanceOf<LatchMutationResult.Decremented>().remaining shouldBeEqualTo 1
-            future.countDownAsync(futureGeneration, LatchRequestId.from("future-down-2")).get() shouldBeEqualTo
+            future.countDownAsync(futureGeneration, LatchRequestId.from("future-down-2")).get(5, TimeUnit.SECONDS) shouldBeEqualTo
                 LatchMutationResult.Completed
             awaited.get(2, TimeUnit.SECONDS) shouldBeEqualTo LatchAwaitResult.Completed
-            future.inspectAsync(futureGeneration).get()
+            future.inspectAsync(futureGeneration).get(5, TimeUnit.SECONDS)
                 .shouldBeInstanceOf<LatchCountResult.Completed>()
-            future.deleteAsync(futureGeneration, LatchRequestId.from("future-delete")).get() shouldBeEqualTo
+            future.deleteAsync(futureGeneration, LatchRequestId.from("future-delete")).get(5, TimeUnit.SECONDS) shouldBeEqualTo
                 LatchMutationResult.Deleted
 
             val suspendGeneration = suspending.trySetCount(1, LatchRequestId.from("suspend-create"))

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/cache/RedissonCacheConfigTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/cache/RedissonCacheConfigTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.redis.redisson.cache
 
-import io.bluetape4k.redis.redisson.codec.RedissonCodecs
-import io.bluetape4k.assertions.shouldBeEqualTo
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.redis.redisson.codec.RedissonCodecs
+import org.junit.jupiter.api.Test
 import org.redisson.api.map.WriteMode
 import org.redisson.api.options.LocalCachedMapOptions
 import org.redisson.api.options.LocalCachedMapParams
@@ -28,7 +28,7 @@ class RedissonCacheConfigTest {
         val params = options as MapParams<String, String>
 
         params.name shouldBeEqualTo "users"
-        assertSame(RedissonCodecs.String, params.codec)
+        params.codec shouldBeSameInstanceAs RedissonCodecs.String
         params.writeMode shouldBeEqualTo WriteMode.WRITE_BEHIND
         params.writeBehindBatchSize shouldBeEqualTo 128
         params.writeBehindDelay shouldBeEqualTo 250
@@ -52,7 +52,7 @@ class RedissonCacheConfigTest {
         val params = options as LocalCachedMapParams<String, String>
 
         params.name shouldBeEqualTo "profiles"
-        assertSame(RedissonCodecs.String, params.codec)
+        params.codec shouldBeSameInstanceAs RedissonCodecs.String
         params.cacheSize shouldBeEqualTo 256
         params.timeToLiveInMillis shouldBeEqualTo 30_000L
         params.maxIdleInMillis shouldBeEqualTo 10_000L

--- a/io/avro/src/test/kotlin/io/bluetape4k/avro/AvroSerializerByteBufferContractTest.kt
+++ b/io/avro/src/test/kotlin/io/bluetape4k/avro/AvroSerializerByteBufferContractTest.kt
@@ -1,15 +1,16 @@
 package io.bluetape4k.avro
 
 import io.bluetape4k.avro.message.examples.Employee
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.fail
+import io.bluetape4k.assertions.expectThat
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContentEqual
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.specific.SpecificRecord
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
@@ -35,21 +36,24 @@ class AvroSerializerByteBufferContractTest {
                 val capacity = target.capacity()
                 val order = target.order()
 
-                assertEquals(PAYLOAD.size, operation(target), "$name $shape")
+                val context = "$name $shape"
+                expectThat(PAYLOAD.size, context) { operation(target) }
 
-                assertEquals(start + PAYLOAD.size, target.position(), "$name $shape")
-                assertEquals(limit, target.limit(), "$name $shape")
-                assertEquals(capacity, target.capacity(), "$name $shape")
-                assertEquals(order, target.order(), "$name $shape")
-                assertArrayEquals(PAYLOAD, target.fullBytes().copyOfRange(start, start + PAYLOAD.size), "$name $shape")
-                assertArrayEquals(before.copyOfRange(0, start), target.fullBytes().copyOfRange(0, start), "$name $shape")
-                assertArrayEquals(
-                    before.copyOfRange(limit, capacity),
-                    target.fullBytes().copyOfRange(limit, capacity),
-                    "$name $shape",
-                )
+                expectThat(start + PAYLOAD.size, context) { target.position() }
+                expectThat(limit, context) { target.limit() }
+                expectThat(capacity, context) { target.capacity() }
+                expectThat(order, context) { target.order() }
+                expectThat(PAYLOAD.toList(), context) {
+                    target.fullBytes().copyOfRange(start, start + PAYLOAD.size).toList()
+                }
+                expectThat(before.copyOfRange(0, start).toList(), context) {
+                    target.fullBytes().copyOfRange(0, start).toList()
+                }
+                expectThat(before.copyOfRange(limit, capacity).toList(), context) {
+                    target.fullBytes().copyOfRange(limit, capacity).toList()
+                }
                 target.reset()
-                assertEquals(start, target.position(), "$name $shape mark")
+                expectThat(start, "$context mark") { target.position() }
             }
         }
     }
@@ -70,9 +74,9 @@ class AvroSerializerByteBufferContractTest {
         operations.forEach { (name, operation) ->
             val target = configuredTarget(0)
             val before = target.fullBytes()
-            assertEquals(0, operation(target), name)
-            assertEquals(3, target.position(), name)
-            assertArrayEquals(before, target.fullBytes(), name)
+            expectThat(0, name) { operation(target) }
+            expectThat(3, name) { target.position() }
+            expectThat(before.toList(), name) { target.fullBytes().toList() }
         }
     }
 
@@ -89,12 +93,12 @@ class AvroSerializerByteBufferContractTest {
         )
 
         operations.forEach { (name, operation) ->
-            assertThrows(ReadOnlyBufferException::class.java, { operation(ByteBuffer.allocate(8).asReadOnlyBuffer()) }, name)
+            assertFailsWith<ReadOnlyBufferException>(name) { operation(ByteBuffer.allocate(8).asReadOnlyBuffer()) }
         }
-        assertEquals(0, reflect.serializeInvocations)
-        assertEquals(0, generic.serializeInvocations)
-        assertEquals(0, specific.serializeInvocations)
-        assertEquals(0, specific.listInvocations)
+        reflect.serializeInvocations shouldBeEqualTo 0
+        generic.serializeInvocations shouldBeEqualTo 0
+        specific.serializeInvocations shouldBeEqualTo 0
+        specific.listInvocations shouldBeEqualTo 0
     }
 
     @Test
@@ -102,14 +106,14 @@ class AvroSerializerByteBufferContractTest {
         outputOperations().forEach { (name, operation) ->
             val target = configuredTarget(PAYLOAD.size - 1)
 
-            assertThrows(BufferOverflowException::class.java, { operation(target) }, name)
+            assertFailsWith<BufferOverflowException>(name) { operation(target) }
 
-            assertEquals(3, target.position(), name)
+            target.position() shouldBeEqualTo 3
         }
 
         outputOperations().forEach { (name, operation) ->
             val retry = configuredTarget(PAYLOAD.size)
-            assertEquals(PAYLOAD.size, operation(retry), "$name retry")
+            expectThat(PAYLOAD.size, "$name retry") { operation(retry) }
         }
     }
 
@@ -128,9 +132,9 @@ class AvroSerializerByteBufferContractTest {
 
         operations.forEach { (name, operation) ->
             val target = configuredTarget(PAYLOAD.size)
-            val actual = assertThrows(AssertionError::class.java, { operation(target) }, name)
-            assertSame(fatal, actual, name)
-            assertEquals(3, target.position(), name)
+            val actual = assertFailsWith<AssertionError>(name) { operation(target) }
+            actual shouldBeSameInstanceAs fatal
+            target.position() shouldBeEqualTo 3
         }
     }
 
@@ -139,37 +143,37 @@ class AvroSerializerByteBufferContractTest {
         sourceBuffers(PAYLOAD).forEach { (shape, source) ->
             val reflect = ReflectFake(deserializeResult = "decoded")
             assertSourcePreserved("reflect $shape", source) {
-                assertEquals("decoded", reflect.deserializeFrom(it, String::class.java))
-                assertEquals("decoded", reflect.deserialize<String>(it))
+                reflect.deserializeFrom(it, String::class.java) shouldBeEqualTo "decoded"
+                reflect.deserialize<String>(it) shouldBeEqualTo "decoded"
             }
-            assertArrayEquals(PAYLOAD, reflect.received)
+            reflect.received shouldContentEqual PAYLOAD
         }
 
         sourceBuffers(PAYLOAD).forEach { (shape, source) ->
             val generic = GenericFake(deserializeResult = GENERIC_RECORD)
             assertSourcePreserved("generic $shape", source) {
-                assertSame(GENERIC_RECORD, generic.deserializeFrom(SCHEMA, it))
-                assertSame(GENERIC_RECORD, generic.deserialize(SCHEMA, it))
+                generic.deserializeFrom(SCHEMA, it) shouldBeSameInstanceAs GENERIC_RECORD
+                generic.deserialize(SCHEMA, it) shouldBeSameInstanceAs GENERIC_RECORD
             }
-            assertArrayEquals(PAYLOAD, generic.received)
+            generic.received shouldContentEqual PAYLOAD
         }
 
         sourceBuffers(PAYLOAD).forEach { (shape, source) ->
             val specific = SpecificFake(deserializeResult = EMPLOYEE, listDeserializeResult = listOf(EMPLOYEE))
             assertSourcePreserved("specific $shape", source) {
-                assertSame(EMPLOYEE, specific.deserializeFrom(it, Employee::class.java))
-                assertSame(EMPLOYEE, specific.deserialize<Employee>(it))
+                specific.deserializeFrom(it, Employee::class.java) shouldBeSameInstanceAs EMPLOYEE
+                specific.deserialize<Employee>(it) shouldBeSameInstanceAs EMPLOYEE
             }
-            assertArrayEquals(PAYLOAD, specific.received)
+            specific.received shouldContentEqual PAYLOAD
         }
 
         sourceBuffers(PAYLOAD).forEach { (shape, source) ->
             val specific = SpecificFake(deserializeResult = EMPLOYEE, listDeserializeResult = listOf(EMPLOYEE))
             assertSourcePreserved("specific list $shape", source) {
-                assertEquals(listOf(EMPLOYEE), specific.deserializeListFrom(it, Employee::class.java))
-                assertEquals(listOf(EMPLOYEE), specific.deserializeList<Employee>(it))
+                specific.deserializeListFrom(it, Employee::class.java) shouldBeEqualTo listOf(EMPLOYEE)
+                specific.deserializeList<Employee>(it) shouldBeEqualTo listOf(EMPLOYEE)
             }
-            assertArrayEquals(PAYLOAD, specific.listReceived)
+            specific.listReceived shouldContentEqual PAYLOAD
         }
     }
 
@@ -179,8 +183,12 @@ class AvroSerializerByteBufferContractTest {
         val operations = listOf<Pair<String, (ByteBuffer) -> Any?>>(
             "reflect" to { source -> ReflectFake(inputFailure = fatal).deserializeFrom(source, String::class.java) },
             "generic" to { source -> GenericFake(inputFailure = fatal).deserializeFrom(SCHEMA, source) },
-            "specific" to { source -> SpecificFake(inputFailure = fatal).deserializeFrom(source, Employee::class.java) },
-            "specific list" to { source -> SpecificFake(inputFailure = fatal).deserializeListFrom(source, Employee::class.java) },
+            "specific" to { source ->
+                SpecificFake(inputFailure = fatal).deserializeFrom(source, Employee::class.java)
+            },
+            "specific list" to { source ->
+                SpecificFake(inputFailure = fatal).deserializeListFrom(source, Employee::class.java)
+            },
         )
 
         operations.forEach { (name, operation) ->
@@ -188,13 +196,13 @@ class AvroSerializerByteBufferContractTest {
             val start = source.position()
             val limit = source.limit()
 
-            val actual = assertThrows(AssertionError::class.java, { operation(source) }, name)
+            val actual = assertFailsWith<AssertionError>(name) { operation(source) }
 
-            assertSame(fatal, actual, name)
-            assertEquals(start, source.position(), name)
-            assertEquals(limit, source.limit(), name)
+            actual shouldBeSameInstanceAs fatal
+            source.position() shouldBeEqualTo start
+            source.limit() shouldBeEqualTo limit
             source.reset()
-            assertEquals(start, source.position(), "$name mark")
+            source.position() shouldBeEqualTo start
         }
     }
 
@@ -203,26 +211,26 @@ class AvroSerializerByteBufferContractTest {
         sourcePolicyCases().forEach { (name, expectedBytes, source) ->
             val reflect = ReflectFake()
             assertSourcePreserved("reflect $name", source) {
-                assertEquals(null, reflect.deserializeFrom(it, String::class.java))
+                reflect.deserializeFrom(it, String::class.java) shouldBeEqualTo null
             }
-            assertArrayEquals(expectedBytes, reflect.received, "reflect $name")
+            reflect.received shouldContentEqual expectedBytes
 
             val generic = GenericFake()
             assertSourcePreserved("generic $name", source) {
-                assertEquals(null, generic.deserializeFrom(SCHEMA, it))
+                generic.deserializeFrom(SCHEMA, it) shouldBeEqualTo null
             }
-            assertArrayEquals(expectedBytes, generic.received, "generic $name")
+            generic.received shouldContentEqual expectedBytes
 
             val specific = SpecificFake()
             assertSourcePreserved("specific $name", source) {
-                assertEquals(null, specific.deserializeFrom(it, Employee::class.java))
+                specific.deserializeFrom(it, Employee::class.java) shouldBeEqualTo null
             }
-            assertArrayEquals(expectedBytes, specific.received, "specific $name")
+            specific.received shouldContentEqual expectedBytes
 
             assertSourcePreserved("specific list $name", source) {
-                assertEquals(emptyList<Employee>(), specific.deserializeListFrom(it, Employee::class.java))
+                specific.deserializeListFrom(it, Employee::class.java) shouldBeEqualTo emptyList<Employee>()
             }
-            assertArrayEquals(expectedBytes, specific.listReceived, "specific list $name")
+            specific.listReceived shouldContentEqual expectedBytes
         }
     }
 
@@ -241,20 +249,24 @@ class AvroSerializerByteBufferContractTest {
             if (repetition % 2 == 0) {
                 assertAvroWriteAndRead(
                     write = { target -> reflect.serializeTo("value", target) },
-                    read = { source -> assertEquals("decoded", reflect.deserializeFrom(source, String::class.java)) },
+                    read = { source -> reflect.deserializeFrom(source, String::class.java) shouldBeEqualTo "decoded" },
                 )
                 assertAvroWriteAndRead(
                     write = { target -> generic.serializeTo(SCHEMA, GENERIC_RECORD, target) },
-                    read = { source -> assertSame(GENERIC_RECORD, generic.deserializeFrom(SCHEMA, source)) },
+                    read = { source ->
+                        generic.deserializeFrom(SCHEMA, source) shouldBeSameInstanceAs GENERIC_RECORD
+                    },
                 )
                 assertAvroWriteAndRead(
                     write = { target -> specific.serializeTo(EMPLOYEE, target) },
-                    read = { source -> assertSame(EMPLOYEE, specific.deserializeFrom(source, Employee::class.java)) },
+                    read = { source ->
+                        specific.deserializeFrom(source, Employee::class.java) shouldBeSameInstanceAs EMPLOYEE
+                    },
                 )
                 assertAvroWriteAndRead(
                     write = { target -> specific.serializeListTo(listOf(EMPLOYEE), target) },
                     read = { source ->
-                        assertEquals(listOf(EMPLOYEE), specific.deserializeListFrom(source, Employee::class.java))
+                        specific.deserializeListFrom(source, Employee::class.java) shouldBeEqualTo listOf(EMPLOYEE)
                     },
                 )
             } else {
@@ -263,11 +275,17 @@ class AvroSerializerByteBufferContractTest {
                 assertAvroOverflow { target -> specific.serializeTo(EMPLOYEE, target) }
                 assertAvroOverflow { target -> specific.serializeListTo(listOf(EMPLOYEE), target) }
 
-                assertAvroMalformed { source -> assertEquals(null, reflect.deserializeFrom(source, String::class.java)) }
-                assertAvroMalformed { source -> assertEquals(null, generic.deserializeFrom(SCHEMA, source)) }
-                assertAvroMalformed { source -> assertEquals(null, specific.deserializeFrom(source, Employee::class.java)) }
                 assertAvroMalformed { source ->
-                    assertEquals(emptyList<Employee>(), specific.deserializeListFrom(source, Employee::class.java))
+                    reflect.deserializeFrom(source, String::class.java) shouldBeEqualTo null
+                }
+                assertAvroMalformed { source ->
+                    generic.deserializeFrom(SCHEMA, source) shouldBeEqualTo null
+                }
+                assertAvroMalformed { source ->
+                    specific.deserializeFrom(source, Employee::class.java) shouldBeEqualTo null
+                }
+                assertAvroMalformed { source ->
+                    specific.deserializeListFrom(source, Employee::class.java) shouldBeEqualTo emptyList<Employee>()
                 }
             }
         }
@@ -290,21 +308,21 @@ class AvroSerializerByteBufferContractTest {
         read: (ByteBuffer) -> Unit,
     ) {
         val target = ByteBuffer.allocate(PAYLOAD.size)
-        assertEquals(PAYLOAD.size, write(target))
+        write(target) shouldBeEqualTo PAYLOAD.size
         target.flip()
         read(target.asReadOnlyBuffer())
     }
 
     private fun assertAvroOverflow(write: (ByteBuffer) -> Int) {
         val target = ByteBuffer.allocate(PAYLOAD.size - 1)
-        assertThrows(BufferOverflowException::class.java) { write(target) }
-        assertEquals(0, target.position())
+        assertFailsWith<BufferOverflowException> { write(target) }
+        target.position() shouldBeEqualTo 0
     }
 
     private fun assertAvroMalformed(read: (ByteBuffer) -> Unit) {
         val source = ByteBuffer.wrap(MALFORMED.copyOf()).asReadOnlyBuffer()
         read(source)
-        assertEquals(0, source.position())
+        source.position() shouldBeEqualTo 0
     }
 
     private fun assertSourcePreserved(
@@ -318,11 +336,11 @@ class AvroSerializerByteBufferContractTest {
 
         operation(source)
 
-        assertEquals(start, source.position(), name)
-        assertEquals(limit, source.limit(), name)
-        assertEquals(order, source.order(), name)
+        expectThat(start, name) { source.position() }
+        source.limit() shouldBeEqualTo limit
+        source.order() shouldBeEqualTo order
         source.reset()
-        assertEquals(start, source.position(), "$name mark")
+        source.position() shouldBeEqualTo start
     }
 
     private class ReflectFake(
@@ -531,10 +549,10 @@ private fun verifyAvroBufferConcurrency(
 
         startBarrier.await(AVRO_START_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         if (!completion.await(AVRO_COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            fail<Unit>("Avro buffer workers timed out; unfinished=${unfinished.sorted().take(AVRO_MAX_DIAGNOSTICS)}")
+            fail("Avro buffer workers timed out; unfinished=${unfinished.sorted().take(AVRO_MAX_DIAGNOSTICS)}")
         }
         if (failures.isNotEmpty()) {
-            fail<Unit>("Avro buffer worker failures: ${failures.take(AVRO_MAX_DIAGNOSTICS)}")
+            fail("Avro buffer worker failures: ${failures.take(AVRO_MAX_DIAGNOSTICS)}")
         }
     } finally {
         executor.shutdownNow()
@@ -545,7 +563,7 @@ private fun verifyAvroBufferConcurrency(
                     .map { it.name }
                     .take(AVRO_MAX_DIAGNOSTICS)
                     .toList()
-            fail<Unit>(
+            fail(
                 "Avro buffer executor did not terminate; " +
                     "unfinished=${unfinished.sorted().take(AVRO_MAX_DIAGNOSTICS)}, threads=$threads",
             )

--- a/io/grpc/src/test/kotlin/io/bluetape4k/grpc/testing/integration/AbstractInteropTest.kt
+++ b/io/grpc/src/test/kotlin/io/bluetape4k/grpc/testing/integration/AbstractInteropTest.kt
@@ -35,13 +35,14 @@ import io.grpc.internal.testing.TestClientStreamTracer
 import io.grpc.internal.testing.TestServerStreamTracer
 import io.grpc.internal.testing.TestStreamTracer
 import io.grpc.testing.TestUtils
-import kotlinx.coroutines.runBlocking
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeBlank
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.assertj.core.util.VisibleForTesting
 import org.junit.Rule
 import org.junit.jupiter.api.AfterEach
@@ -57,7 +58,6 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.test.assertTrue
 
 abstract class AbstractInteropTest {
 
@@ -208,7 +208,7 @@ abstract class AbstractInteropTest {
 
     @Test
     fun emptyUnary() {
-        runBlocking {
+        runSuspendIO {
             stub.emptyCall(EMPTY) shouldBeEqualTo EMPTY
         }
     }
@@ -228,7 +228,7 @@ abstract class AbstractInteropTest {
                 payload = Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(RESPONSE_SIZE))).build()
             }.build()
 
-        runBlocking {
+        runSuspendIO {
             stub.unaryCall(request) shouldBeEqualTo goldenResponse
         }
     }
@@ -238,77 +238,85 @@ abstract class AbstractInteropTest {
      * Attributes via ClientInterceptor.
      */
     @Test
-    fun `get server address and local address from client`() {
+    fun `get server address and local address from client`() = runSuspendIO {
         obtainRemoteServerAddr().shouldNotBeNull()
         obtainLocalClientAddr().shouldNotBeNull()
     }
 
     /** Sends a large unary rpc with service account credentials.  */
     fun serviceAccountCreds(jsonKey: String, credentialsStream: InputStream?, authScope: String) {
-        // cast to ServiceAccountCredentials to double-check the right type of object was created.
-        var credentials: GoogleCredentials =
-            GoogleCredentials.fromStream(credentialsStream) as ServiceAccountCredentials
-        credentials = credentials.createScoped(authScope)
-        val stub = this.stub.withCallCredentials(MoreCallCredentials.from(credentials))
+        runSuspendIO {
+            // cast to ServiceAccountCredentials to double-check the right type of object was created.
+            var credentials: GoogleCredentials =
+                GoogleCredentials.fromStream(credentialsStream) as ServiceAccountCredentials
+            credentials = credentials.createScoped(authScope)
+            val stub = this@AbstractInteropTest.stub.withCallCredentials(MoreCallCredentials.from(credentials))
 
-        val request = Messages.SimpleRequest.newBuilder()
-            .apply {
-                fillUsername = true
-                fillOauthScope = true
-                responseSize = RESPONSE_SIZE
-                payload = Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(REQUEST_SIZE))).build()
-            }.build()
+            val request = Messages.SimpleRequest.newBuilder()
+                .apply {
+                    fillUsername = true
+                    fillOauthScope = true
+                    responseSize = RESPONSE_SIZE
+                    payload = Messages.Payload.newBuilder()
+                        .setBody(ByteString.copyFrom(ByteArray(REQUEST_SIZE)))
+                        .build()
+                }.build()
 
-        val response = runBlocking { stub.unaryCall(request) }
-        response.username.shouldNotBeBlank()
-        jsonKey shouldContain response.username
-        response.oauthScope.shouldNotBeBlank()
-        authScope shouldContain response.oauthScope
+            val response = stub.unaryCall(request)
+            response.username.shouldNotBeBlank()
+            jsonKey shouldContain response.username
+            response.oauthScope.shouldNotBeBlank()
+            authScope shouldContain response.oauthScope
 
-        val goldenResponse = Messages.SimpleResponse.newBuilder()
-            .apply {
-                this.oauthScope = response.oauthScope
-                this.username = response.username
-                this.payload =
-                    Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(RESPONSE_SIZE))).build()
-            }.build()
+            val goldenResponse = Messages.SimpleResponse.newBuilder()
+                .apply {
+                    this.oauthScope = response.oauthScope
+                    this.username = response.username
+                    this.payload =
+                        Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(RESPONSE_SIZE))).build()
+                }.build()
 
-        assertResponse(goldenResponse, response)
+            assertResponse(goldenResponse, response)
+        }
     }
 
     /** Sends a large unary rpc with compute engine credentials.  */
     fun computeEngineCreds(serviceAccount: String?, oauthScope: String) {
-        val credentials = ComputeEngineCredentials.create()
-        val stub = this.stub.withCallCredentials(MoreCallCredentials.from(credentials))
-        val request = Messages.SimpleRequest.newBuilder()
-            .apply {
-                fillUsername = true
-                fillOauthScope = true
-                responseSize = RESPONSE_SIZE
-                payload = Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(REQUEST_SIZE))).build()
-            }.build()
+        runSuspendIO {
+            val credentials = ComputeEngineCredentials.create()
+            val stub = this@AbstractInteropTest.stub.withCallCredentials(MoreCallCredentials.from(credentials))
+            val request = Messages.SimpleRequest.newBuilder()
+                .apply {
+                    fillUsername = true
+                    fillOauthScope = true
+                    responseSize = RESPONSE_SIZE
+                    payload = Messages.Payload.newBuilder()
+                        .setBody(ByteString.copyFrom(ByteArray(REQUEST_SIZE)))
+                        .build()
+                }.build()
 
-        val response = runBlocking { stub.unaryCall(request) }
-        response.username shouldBeEqualTo serviceAccount
-        response.oauthScope.shouldNotBeBlank()
-        oauthScope shouldContain response.oauthScope
+            val response = stub.unaryCall(request)
+            response.username shouldBeEqualTo serviceAccount
+            response.oauthScope.shouldNotBeBlank()
+            oauthScope shouldContain response.oauthScope
 
-        val goldenResponse = Messages.SimpleResponse.newBuilder()
-            .apply {
-                this.oauthScope = response.oauthScope
-                this.username = response.username
-                this.payload =
-                    Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(RESPONSE_SIZE))).build()
-            }.build()
+            val goldenResponse = Messages.SimpleResponse.newBuilder()
+                .apply {
+                    this.oauthScope = response.oauthScope
+                    this.username = response.username
+                    this.payload =
+                        Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(RESPONSE_SIZE))).build()
+                }.build()
 
-        assertResponse(goldenResponse, response)
+            assertResponse(goldenResponse, response)
+        }
     }
 
     /** Sends an unary rpc with ComputeEngineChannelBuilder.  */
     fun computeEngineChannelCredentials(
         defaultServiceAccount: String,
         computeEngineStub: TestServiceGrpcKt.TestServiceCoroutineStub,
-    ) = runBlocking<Unit> {
+    ) = runSuspendIO {
         val request = Messages.SimpleRequest.newBuilder()
             .apply {
                 fillUsername = true
@@ -330,42 +338,47 @@ abstract class AbstractInteropTest {
 
     /** Test JWT-based auth.  */
     fun jwtTokenCreds(serviceAccountJson: InputStream?) {
-        val request = Messages.SimpleRequest.newBuilder()
-            .apply {
-                responseSize = RESPONSE_SIZE
-                payload = Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(REQUEST_SIZE))).build()
-                fillUsername = true
-            }.build()
+        runSuspendIO {
+            val request = Messages.SimpleRequest.newBuilder()
+                .apply {
+                    responseSize = RESPONSE_SIZE
+                    payload = Messages.Payload.newBuilder()
+                        .setBody(ByteString.copyFrom(ByteArray(REQUEST_SIZE)))
+                        .build()
+                    fillUsername = true
+                }.build()
 
-        val credentials = GoogleCredentials.fromStream(serviceAccountJson) as ServiceAccountCredentials
-        val response = runBlocking {
-            stub.withCallCredentials(MoreCallCredentials.from(credentials)).unaryCall(request)
+            val credentials = GoogleCredentials.fromStream(serviceAccountJson) as ServiceAccountCredentials
+            val response = this@AbstractInteropTest.stub
+                .withCallCredentials(MoreCallCredentials.from(credentials))
+                .unaryCall(request)
+            response.username shouldBeEqualTo credentials.clientEmail
+            response.payload.body.size() shouldBeEqualTo 314159
         }
-
-        response.username shouldBeEqualTo credentials.clientEmail
-        response.payload.body.size() shouldBeEqualTo 314159
     }
 
     /** Sends a unary rpc with raw oauth2 access token credentials.  */
     fun oauth2AuthToken(jsonKey: String, credentialsStream: InputStream, authScope: String) {
-        var utilCredentials = GoogleCredentials.fromStream(credentialsStream)
-        utilCredentials = utilCredentials.createScoped(authScope)
-        val accessToken = utilCredentials.refreshAccessToken()
-        val credentials = OAuth2Credentials.create(accessToken)
-        val request = Messages.SimpleRequest.newBuilder()
-            .apply {
-                fillUsername = true
-                fillOauthScope = true
-            }.build()
+        runSuspendIO {
+            var utilCredentials = GoogleCredentials.fromStream(credentialsStream)
+            utilCredentials = utilCredentials.createScoped(authScope)
+            val accessToken = utilCredentials.refreshAccessToken()
+            val credentials = OAuth2Credentials.create(accessToken)
+            val request = Messages.SimpleRequest.newBuilder()
+                .apply {
+                    fillUsername = true
+                    fillOauthScope = true
+                }.build()
 
-        val response = runBlocking {
-            stub.withCallCredentials(MoreCallCredentials.from(credentials)).unaryCall(request)
+            val response = this@AbstractInteropTest.stub
+                .withCallCredentials(MoreCallCredentials.from(credentials))
+                .unaryCall(request)
+            response.username.shouldNotBeBlank()
+            jsonKey shouldContain response.username
+
+            response.oauthScope.shouldNotBeBlank()
+            authScope shouldContain response.oauthScope
         }
-        response.username.shouldNotBeBlank()
-        jsonKey shouldContain response.username
-
-        response.oauthScope.shouldNotBeBlank()
-        authScope shouldContain response.oauthScope
     }
 
     /** Sends a unary rpc with "per rpc" raw oauth2 access token credentials.  */
@@ -380,7 +393,7 @@ abstract class AbstractInteropTest {
         defaultServiceAccount: String,
         googleDefaultStub: TestServiceGrpcKt.TestServiceCoroutineStub,
     ) {
-        runBlocking {
+        runSuspendIO {
             val request = Messages.SimpleRequest.newBuilder()
                 .apply {
                     fillUsername = true
@@ -404,24 +417,24 @@ abstract class AbstractInteropTest {
     }
 
     /** Helper for getting remote address from [io.grpc.ClientCall.getAttributes]  */
-    private fun obtainRemoteServerAddr(): SocketAddress? = runBlocking {
+    private suspend fun obtainRemoteServerAddr(): SocketAddress? {
         stub
             .withInterceptors(recordClientCallInterceptor(clientCallCapture))
             .withDeadlineAfter(5, TimeUnit.SECONDS)
             .unaryCall(Messages.SimpleRequest.getDefaultInstance())
 
-        clientCallCapture.get()?.attributes?.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR)
+        return clientCallCapture.get()?.attributes?.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR)
     }
 
 
     /** Helper for getting local address from [io.grpc.ClientCall.getAttributes]  */
-    private fun obtainLocalClientAddr(): SocketAddress? = runBlocking {
+    private suspend fun obtainLocalClientAddr(): SocketAddress? {
         stub
             .withInterceptors(recordClientCallInterceptor(clientCallCapture))
             .withDeadlineAfter(5, TimeUnit.SECONDS)
             .unaryCall(Messages.SimpleRequest.getDefaultInstance())
 
-        clientCallCapture.get()?.attributes?.get(Grpc.TRANSPORT_ATTR_LOCAL_ADDR)
+        return clientCallCapture.get()?.attributes?.get(Grpc.TRANSPORT_ATTR_LOCAL_ADDR)
     }
 
     protected fun operationTimeoutMillis(): Int {
@@ -572,9 +585,7 @@ abstract class AbstractInteropTest {
 
         private fun assumeEnoughMemory() {
             val availableMemory = Runtimex.availableMemory
-            assertTrue("$availableMemory is not sufficient to run this test") {
-                availableMemory >= 64 * 1024 * 1024
-            }
+            availableMemory shouldBeGreaterOrEqualTo 64 * 1024 * 1024
         }
 
         /**

--- a/io/http/src/test/kotlin/io/bluetape4k/http/AbstractHttpTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/AbstractHttpTest.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.http
 
+import io.bluetape4k.assertions.fail
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.testcontainers.http.BluetapeHttpServer
-import org.junit.jupiter.api.fail
 
 abstract class AbstractHttpTest {
 
@@ -37,10 +37,10 @@ abstract class AbstractHttpTest {
 
     fun assertResponse(okResponse: okhttp3.Response?) {
         if (okResponse == null) {
-            fail { "Response is null" }
+            fail("Response is null")
         }
         if (!okResponse.isSuccessful) {
-            fail { "Unexpected code ${okResponse.code}" }
+            fail("Unexpected code ${okResponse.code}")
         }
     }
 }

--- a/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/OkHttp3SupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/OkHttp3SupportTest.kt
@@ -3,9 +3,11 @@ package io.bluetape4k.http.okhttp3
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeBlank
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.fail
 import io.bluetape4k.concurrent.allAsList
 import io.bluetape4k.concurrent.onFailure
 import io.bluetape4k.concurrent.onSuccess
+import io.bluetape4k.coroutines.support.awaitSuspending
 import io.bluetape4k.http.AbstractHttpTest
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
@@ -17,7 +19,6 @@ import kotlinx.coroutines.awaitAll
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import org.apache.commons.lang3.time.StopWatch
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
@@ -41,7 +42,7 @@ class OkHttp3SupportTest: AbstractHttpTest() {
     inner class Async {
 
         @Test
-        fun `OkHttpClient 비동기 GET`() {
+        fun `OkHttpClient 비동기 GET`() = runSuspendIO {
             val request = okhttp3Request {
                 url("$HTTPBIN_URL/get")
                 get()
@@ -50,7 +51,7 @@ class OkHttp3SupportTest: AbstractHttpTest() {
         }
 
         @RepeatedTest(REPEAT_SIZE)
-        fun `OkHttpClient 비동기 GET 통신 성능 테스트`() {
+        fun `OkHttpClient 비동기 GET 통신 성능 테스트`() = runSuspendIO {
             val request = okhttp3Request {
                 url("$HTTPBIN_URL/get")
                 get()
@@ -68,13 +69,13 @@ class OkHttp3SupportTest: AbstractHttpTest() {
                             it.bodyAsString().shouldNotBeBlank()
                         }
                     }
-                    .onFailure { error -> fail(error) }
+                    .onFailure { error -> fail(cause = error) }
             }
 
-            futures.allAsList().get()
+            futures.allAsList().awaitSuspending()
         }
 
-        private fun CompletableFuture<okhttp3.Response>.verifyResponse() {
+        private suspend fun CompletableFuture<okhttp3.Response>.verifyResponse() {
             this
                 .onSuccess { response ->
                     response.use {
@@ -86,7 +87,7 @@ class OkHttp3SupportTest: AbstractHttpTest() {
                     log.error(error) { "Failed to execute request" }
                     fail("Failed to execute request", error)
                 }
-                .get()  // 이게 Blocking 이라는 겁니다 ㅠㅠ
+                .awaitSuspending()
         }
     }
 

--- a/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/examples/Recipes.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/okhttp3/examples/Recipes.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.fail
 import io.bluetape4k.concurrent.onFailure
 import io.bluetape4k.concurrent.onSuccess
 import io.bluetape4k.http.AbstractHttpTest
@@ -37,7 +38,6 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.io.IOException
@@ -74,33 +74,39 @@ class Recipes: AbstractHttpTest() {
     @Test
     fun `동기 방식 HTTP GET`() {
         val request = okhttp3RequestOf(HTTPBIN_HTML_URL)
-        val response = client.newCall(request).execute()
-
-        assertResponse(response)
-        printHeaders(response.headers)
-        log.debug { response.bodyAsString() }
+        client.newCall(request).execute().use { response ->
+            assertResponse(response)
+            printHeaders(response.headers)
+            log.debug { response.bodyAsString() }
+        }
     }
 
     @Test
     fun `비동기 방식 HTTP GET`() {
         val lock = CountDownLatch(1)
+        val callbackFailure = AtomicReference<Throwable?>()
 
         val request = okhttp3RequestOf(HTTPBIN_HTML_URL)
         val callback = object: Callback {
             override fun onFailure(call: Call, e: IOException) {
-                e.printStackTrace()
+                callbackFailure.set(e)
                 lock.countDown()
             }
 
             override fun onResponse(call: Call, response: Response) {
-                assertResponse(response)
-                printHeaders(response.headers)
-                log.debug { response.bodyAsString() }
+                runCatching {
+                    response.use {
+                        assertResponse(it)
+                        printHeaders(it.headers)
+                        log.debug { it.bodyAsString() }
+                    }
+                }.onFailure(callbackFailure::set)
                 lock.countDown()
             }
         }
         client.newCall(request).enqueue(callback)
-        lock.await()
+        lock.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        callbackFailure.get()?.let { fail("비동기 HTTP GET callback이 실패했습니다.", it) }
     }
 
     @Test
@@ -113,10 +119,10 @@ class Recipes: AbstractHttpTest() {
             .post(json.toRequestBody("application/json".toMediaTypeOrNull()))
             .build()
 
-        val response = client.newCall(request).execute()
-
-        assertResponse(response)
-        log.debug { response.bodyAsString() }
+        client.newCall(request).execute().use { response ->
+            assertResponse(response)
+            log.debug { response.bodyAsString() }
+        }
     }
 
     @Test
@@ -129,10 +135,10 @@ class Recipes: AbstractHttpTest() {
             .post(json.toRequestBody("application/json".toMediaTypeOrNull(), 0, json.size))
             .build()
 
-        val response = client.newCall(request).execute()
-
-        assertResponse(response)
-        log.debug { response.bodyAsString() }
+        client.newCall(request).execute().use { response ->
+            assertResponse(response)
+            log.debug { response.bodyAsString() }
+        }
     }
 
     @Test
@@ -144,10 +150,10 @@ class Recipes: AbstractHttpTest() {
             .post(json.toRequestBody("application/json".toMediaTypeOrNull()))
             .build()
 
-        val response = client.newCall(request).execute()
-
-        assertResponse(response)
-        log.debug { response.bodyAsString() }
+        client.newCall(request).execute().use { response ->
+            assertResponse(response)
+            log.debug { response.bodyAsString() }
+        }
     }
 
     @Test
@@ -159,10 +165,10 @@ class Recipes: AbstractHttpTest() {
             .post(json.toRequestBody("application/json".toMediaTypeOrNull(), 0, json.size))
             .build()
 
-        val response = client.newCall(request).execute()
-
-        assertResponse(response)
-        log.debug { response.bodyAsString() }
+        client.newCall(request).execute().use { response ->
+            assertResponse(response)
+            log.debug { response.bodyAsString() }
+        }
     }
 
     @Test

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/AbstractCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/AbstractCompressor.kt
@@ -3,7 +3,6 @@ package io.bluetape4k.io.compressor
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.support.emptyByteArray
-import io.bluetape4k.support.isNullOrEmpty
 import java.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -66,8 +65,9 @@ abstract class AbstractCompressor: Compressor {
      * @throws IllegalArgumentException when input validation or defensive size-limit checks fail
      */
     override fun compress(plain: ByteArray?): ByteArray {
-        if (plain.isNullOrEmpty()) return emptyByteArray
-        return doCompress(plain!!)
+        val value = plain ?: return emptyByteArray
+        if (value.isEmpty()) return emptyByteArray
+        return doCompress(value)
     }
 
     /**
@@ -89,8 +89,9 @@ abstract class AbstractCompressor: Compressor {
      * @throws IllegalArgumentException when corrupt input, invalid headers, or defensive size-limit checks fail
      */
     override fun decompress(compressed: ByteArray?): ByteArray {
-        if (compressed.isNullOrEmpty()) return emptyByteArray
-        return doDecompress(compressed!!)
+        val value = compressed ?: return emptyByteArray
+        if (value.isEmpty()) return emptyByteArray
+        return doDecompress(value)
     }
 
     /**
@@ -109,13 +110,14 @@ abstract class AbstractCompressor: Compressor {
      * @return compressed data or `null`
      */
     fun compressOrNull(plain: ByteArray?): ByteArray? {
-        if (plain.isNullOrEmpty()) return null
+        val value = plain ?: return null
+        if (value.isEmpty()) return null
         return try {
-            doCompress(plain!!)
+            doCompress(value)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            log.error(e) { "Fail to compress. plain size=${plain?.size}" }
+            log.error(e) { "Fail to compress. plain size=${value.size}" }
             null
         }
     }
@@ -136,13 +138,14 @@ abstract class AbstractCompressor: Compressor {
      * @return decompressed data or `null`
      */
     fun decompressOrNull(compressed: ByteArray?): ByteArray? {
-        if (compressed.isNullOrEmpty()) return null
+        val value = compressed ?: return null
+        if (value.isEmpty()) return null
         return try {
-            doDecompress(compressed!!)
+            doDecompress(value)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            log.error(e) { "Fail to decompress. compressed size=${compressed?.size}" }
+            log.error(e) { "Fail to decompress. compressed size=${value.size}" }
             null
         }
     }

--- a/io/io/src/main/kotlin/io/bluetape4k/io/compressor/StreamingCompressor.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/compressor/StreamingCompressor.kt
@@ -4,7 +4,6 @@ import io.bluetape4k.io.DEFAULT_BUFFER_SIZE
 import io.bluetape4k.io.copyTo
 import io.bluetape4k.io.toInputStream
 import io.bluetape4k.support.emptyByteArray
-import io.bluetape4k.support.isNullOrEmpty
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
@@ -84,12 +83,13 @@ interface StreamingCompressor {
      * 바이트 배열을 압축합니다.
      */
     fun compress(plain: ByteArray?): ByteArray {
-        if (plain.isNullOrEmpty()) {
+        val value = plain ?: return emptyByteArray
+        if (value.isEmpty()) {
             return emptyByteArray
         }
 
-        val output = ByteArrayOutputStream(plain!!.size.coerceAtLeast(DEFAULT_BUFFER_SIZE))
-        compress(plain.toInputStream(), output)
+        val output = ByteArrayOutputStream(value.size.coerceAtLeast(DEFAULT_BUFFER_SIZE))
+        compress(value.toInputStream(), output)
         return output.toByteArray()
     }
 
@@ -97,12 +97,13 @@ interface StreamingCompressor {
      * 바이트 배열을 복원합니다.
      */
     fun decompress(compressed: ByteArray?): ByteArray {
-        if (compressed.isNullOrEmpty()) {
+        val value = compressed ?: return emptyByteArray
+        if (value.isEmpty()) {
             return emptyByteArray
         }
 
-        val output = ByteArrayOutputStream(compressed!!.size.coerceAtLeast(DEFAULT_BUFFER_SIZE))
-        decompress(compressed.toInputStream(), output)
+        val output = ByteArrayOutputStream(value.size.coerceAtLeast(DEFAULT_BUFFER_SIZE))
+        decompress(value.toInputStream(), output)
         return output.toByteArray()
     }
 }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/BufferFailurePolicyTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/BufferFailurePolicyTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.io
 
 import com.esotericsoftware.kryo.io.KryoBufferOverflowException
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertTrue
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import java.nio.BufferOverflowException
 import java.util.concurrent.CancellationException
@@ -13,7 +13,7 @@ class BufferFailurePolicyTest {
 
     @Test
     fun `no failures produces no public failure`() {
-        assertNull(BufferFailurePolicy.classify(null, null))
+        BufferFailurePolicy.classify(null, null).shouldBeNull()
     }
 
     @Test
@@ -23,8 +23,8 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertSame(operation, actual)
-        assertSame(cleanup, operation.suppressed.single())
+        actual shouldBeSameInstanceAs operation
+        operation.suppressed.single() shouldBeSameInstanceAs cleanup
     }
 
     @Test
@@ -35,9 +35,9 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertEquals(BufferOverflowException::class.java, actual?.javaClass)
-        assertSame(operation, actual?.cause)
-        assertSame(cleanup, actual?.suppressed?.single())
+        actual?.javaClass shouldBeEqualTo BufferOverflowException::class.java
+        actual?.cause shouldBeSameInstanceAs operation
+        actual?.suppressed?.single() shouldBeSameInstanceAs cleanup
     }
 
     @Test
@@ -48,16 +48,16 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertEquals(BufferOverflowException::class.java, actual?.javaClass)
-        assertSame(operation, actual?.cause)
-        assertSame(cleanup, actual?.suppressed?.single())
+        actual?.javaClass shouldBeEqualTo BufferOverflowException::class.java
+        actual?.cause shouldBeSameInstanceAs operation
+        actual?.suppressed?.single() shouldBeSameInstanceAs cleanup
     }
 
     @Test
     fun `direct cleanup overflow after success remains the same instance`() {
         val cleanup = BufferOverflowException()
 
-        assertSame(cleanup, BufferFailurePolicy.classify(null, cleanup))
+        BufferFailurePolicy.classify(null, cleanup) shouldBeSameInstanceAs cleanup
     }
 
     @Test
@@ -66,8 +66,8 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(null, cleanup)
 
-        assertEquals(BufferOverflowException::class.java, actual?.javaClass)
-        assertSame(cleanup, actual?.cause)
+        actual?.javaClass shouldBeEqualTo BufferOverflowException::class.java
+        actual?.cause shouldBeSameInstanceAs cleanup
     }
 
     @Test
@@ -77,8 +77,8 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertSame(operation, actual)
-        assertSame(cleanup, operation.suppressed.single())
+        actual shouldBeSameInstanceAs operation
+        operation.suppressed.single() shouldBeSameInstanceAs cleanup
     }
 
     @Test
@@ -88,7 +88,7 @@ class BufferFailurePolicyTest {
             addSuppressed(fatal)
         }
 
-        assertSame(fatal, BufferFailurePolicy.classify(operation, null))
+        BufferFailurePolicy.classify(operation, null) shouldBeSameInstanceAs fatal
     }
 
     @Test
@@ -98,8 +98,8 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertSame(cleanup, actual)
-        assertSame(operation, cleanup.suppressed.single())
+        actual shouldBeSameInstanceAs cleanup
+        cleanup.suppressed.single() shouldBeSameInstanceAs operation
     }
 
     @Test
@@ -110,8 +110,8 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertSame(cancellation, actual)
-        assertSame(cleanup, cancellation.suppressed.single())
+        actual shouldBeSameInstanceAs cancellation
+        cancellation.suppressed.single() shouldBeSameInstanceAs cleanup
     }
 
     @Test
@@ -122,7 +122,7 @@ class BufferFailurePolicyTest {
             addSuppressed(fatal)
         }
 
-        assertSame(fatal, BufferFailurePolicy.classify(operation, null))
+        BufferFailurePolicy.classify(operation, null) shouldBeSameInstanceAs fatal
     }
 
     @Test
@@ -133,7 +133,7 @@ class BufferFailurePolicyTest {
             addSuppressed(fatal)
         }
 
-        assertSame(fatal, BufferFailurePolicy.findControlFailure(failure))
+        BufferFailurePolicy.findControlFailure(failure) shouldBeSameInstanceAs fatal
     }
 
     @Test
@@ -141,7 +141,7 @@ class BufferFailurePolicyTest {
         val cancellation = CancellationException("cancelled")
         val failure = IllegalStateException("wrapper", cancellation)
 
-        assertSame(cancellation, BufferFailurePolicy.findControlFailure(failure))
+        BufferFailurePolicy.findControlFailure(failure) shouldBeSameInstanceAs cancellation
     }
 
     @Test
@@ -149,8 +149,8 @@ class BufferFailurePolicyTest {
         val jdkOverflow = IllegalStateException("wrapper", BufferOverflowException())
         val kryoOverflow = IllegalStateException("wrapper", KryoBufferOverflowException("native"))
 
-        assertNull(BufferFailurePolicy.findControlFailure(jdkOverflow))
-        assertNull(BufferFailurePolicy.findControlFailure(kryoOverflow))
+        BufferFailurePolicy.findControlFailure(jdkOverflow).shouldBeNull()
+        BufferFailurePolicy.findControlFailure(kryoOverflow).shouldBeNull()
     }
 
     @Test
@@ -160,7 +160,7 @@ class BufferFailurePolicyTest {
         failure.initCause(cycle)
         cycle.addSuppressed(failure)
 
-        assertNull(BufferFailurePolicy.findControlFailure(failure))
+        BufferFailurePolicy.findControlFailure(failure).shouldBeNull()
     }
 
     @Test
@@ -171,8 +171,8 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertSame(cancellation, actual)
-        assertTrue(cancellation.suppressed.isEmpty())
+        actual shouldBeSameInstanceAs cancellation
+        cancellation.suppressed.isEmpty().shouldBeTrue()
     }
 
     @Test
@@ -182,8 +182,8 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertSame(operation, actual)
-        assertSame(cleanup, operation.suppressed.single())
+        actual shouldBeSameInstanceAs operation
+        operation.suppressed.single() shouldBeSameInstanceAs cleanup
     }
 
     @Test
@@ -196,8 +196,8 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, null)
 
-        assertEquals(BufferOverflowException::class.java, actual?.javaClass)
-        assertSame(operation, actual?.cause)
+        actual?.javaClass shouldBeEqualTo BufferOverflowException::class.java
+        actual?.cause shouldBeSameInstanceAs operation
     }
 
     @Test
@@ -208,7 +208,7 @@ class BufferFailurePolicyTest {
 
         val actual = BufferFailurePolicy.classify(operation, cleanup)
 
-        assertSame(operation, actual)
-        assertTrue(operation.suppressed.isEmpty())
+        actual shouldBeSameInstanceAs operation
+        operation.suppressed.isEmpty().shouldBeTrue()
     }
 }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/FixedByteBufferOutputStreamTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/FixedByteBufferOutputStreamTest.kt
@@ -1,9 +1,9 @@
 package io.bluetape4k.io
 
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertThrows
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContentEqual
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
@@ -40,22 +40,22 @@ class FixedByteBufferOutputStreamTest {
                 stream.write(payload)
                 stream.close()
 
-                assertEquals(start + payload.size, target.position())
-                assertEquals(originalCapacity, target.capacity())
-                assertEquals(originalLimit, target.limit())
-                assertEquals(originalOrder, target.order())
-                assertArrayEquals(payload, target.bytesBetween(start, start + payload.size))
+                target.position() shouldBeEqualTo start + payload.size
+                target.capacity() shouldBeEqualTo originalCapacity
+                target.limit() shouldBeEqualTo originalLimit
+                target.order() shouldBeEqualTo originalOrder
+                target.bytesBetween(start, start + payload.size) shouldContentEqual payload
 
                 val positionBeforeCopy = target.position()
                 target.reset()
-                assertEquals(start, target.position(), "write must preserve a mark below the committed position")
+                target.position() shouldBeEqualTo start
                 target.position(positionBeforeCopy)
-                assertArrayEquals(payload, stream.toByteArray())
-                assertEquals(positionBeforeCopy, target.position())
+                stream.toByteArray() shouldContentEqual payload
+                target.position() shouldBeEqualTo positionBeforeCopy
 
                 stream.write(50)
-                assertEquals(positionBeforeCopy + 1, target.position(), "close must not disable later writes")
-                assertArrayEquals(byteArrayOf(10, 20, 30, 40, 50), stream.toByteArray())
+                target.position() shouldBeEqualTo positionBeforeCopy + 1
+                stream.toByteArray() shouldContentEqual byteArrayOf(10, 20, 30, 40, 50)
             }
         }
 
@@ -70,9 +70,9 @@ class FixedByteBufferOutputStreamTest {
 
         stream.write(byteArrayOf(1, 2, 3, 4))
 
-        assertEquals(6, target.position())
-        assertArrayEquals(byteArrayOf(1, 2, 3, 4), stream.toByteArray())
-        assertEquals(99, target.get(0))
+        target.position() shouldBeEqualTo 6
+        stream.toByteArray() shouldContentEqual byteArrayOf(1, 2, 3, 4)
+        target.get(0) shouldBeEqualTo 99
     }
 
     @Test
@@ -86,22 +86,22 @@ class FixedByteBufferOutputStreamTest {
         val stream = ByteBufferOutputStream.fixed(target)
         val start = target.position()
 
-        val failure = assertThrows(BufferOverflowException::class.java) {
+        val failure = assertFailsWith<BufferOverflowException> {
             stream.write(byteArrayOf(1, 2, 3, 4))
         }
 
-        assertEquals(BufferOverflowException::class.java, failure.javaClass)
-        assertEquals(start, target.position())
-        assertEquals(91, target.get(0), "prefix canary")
-        assertEquals(92, target.duplicate().limit(target.capacity()).get(6), "post-limit canary")
-        assertArrayEquals(byteArrayOf(), stream.toByteArray())
+        failure.javaClass shouldBeEqualTo BufferOverflowException::class.java
+        target.position() shouldBeEqualTo start
+        target.get(0) shouldBeEqualTo 91
+        target.duplicate().limit(target.capacity()).get(6) shouldBeEqualTo 92
+        stream.toByteArray() shouldContentEqual byteArrayOf()
     }
 
     @Test
     fun `fixed factory rejects read-only buffers immediately`() {
         val target = ByteBuffer.allocate(8).asReadOnlyBuffer()
 
-        assertThrows(ReadOnlyBufferException::class.java) {
+        assertFailsWith<ReadOnlyBufferException> {
             ByteBufferOutputStream.fixed(target)
         }
     }
@@ -110,11 +110,11 @@ class FixedByteBufferOutputStreamTest {
     fun `fixed Java entry point rejects null before factory logic`() {
         val method = ByteBufferOutputStream::class.java.getMethod("fixed", ByteBuffer::class.java)
 
-        val invocation = assertThrows(InvocationTargetException::class.java) {
+        val invocation = assertFailsWith<InvocationTargetException> {
             method.invoke(null, null)
         }
 
-        assertSame(NullPointerException::class.java, invocation.cause?.javaClass)
+        invocation.cause?.javaClass shouldBeSameInstanceAs NullPointerException::class.java
     }
 
     private fun ByteBuffer.bytesBetween(start: Int, end: Int): ByteArray =

--- a/io/io/src/test/kotlin/io/bluetape4k/io/serializer/BinarySerializerByteBufferContractTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/serializer/BinarySerializerByteBufferContractTest.kt
@@ -1,9 +1,11 @@
 package io.bluetape4k.io.serializer
 
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertThrows
+import io.bluetape4k.assertions.assertFails
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.expectThat
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContentEqual
 import org.junit.jupiter.api.Test
 import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
@@ -25,16 +27,22 @@ class BinarySerializerByteBufferContractTest {
 
             val written = serializer.serializeTo("value", target)
 
-            assertEquals(PAYLOAD.size, written, name)
-            assertEquals(start + written, target.position(), name)
-            assertEquals(limit, target.limit(), name)
-            assertEquals(capacity, target.capacity(), name)
-            assertEquals(order, target.order(), name)
-            assertArrayEquals(PAYLOAD, target.fullBytes().copyOfRange(start, start + written), name)
-            assertArrayEquals(before.copyOfRange(0, start), target.fullBytes().copyOfRange(0, start), name)
-            assertArrayEquals(before.copyOfRange(limit, capacity), target.fullBytes().copyOfRange(limit, capacity), name)
+            expectThat(PAYLOAD.size, name) { written }
+            expectThat(start + written, name) { target.position() }
+            expectThat(limit, name) { target.limit() }
+            expectThat(capacity, name) { target.capacity() }
+            expectThat(order, name) { target.order() }
+            expectThat(PAYLOAD.toList(), name) {
+                target.fullBytes().copyOfRange(start, start + written).toList()
+            }
+            expectThat(before.copyOfRange(0, start).toList(), name) {
+                target.fullBytes().copyOfRange(0, start).toList()
+            }
+            expectThat(before.copyOfRange(limit, capacity).toList(), name) {
+                target.fullBytes().copyOfRange(limit, capacity).toList()
+            }
             target.reset()
-            assertEquals(start, target.position(), "$name mark")
+            expectThat(start, "$name mark") { target.position() }
         }
     }
 
@@ -47,10 +55,10 @@ class BinarySerializerByteBufferContractTest {
         })
         val target = ByteBuffer.allocate(16).asReadOnlyBuffer()
 
-        assertThrows(ReadOnlyBufferException::class.java) { serializer.serializeTo(null, target) }
+        assertFailsWith<ReadOnlyBufferException> { serializer.serializeTo(null, target) }
 
-        assertEquals(0, invocations.get())
-        assertEquals(0, target.position())
+        invocations.get() shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 0
     }
 
     @Test
@@ -59,10 +67,10 @@ class BinarySerializerByteBufferContractTest {
         val target = configuredTarget(0)
         val before = target.fullBytes()
 
-        assertEquals(0, serializer.serializeTo(null, target))
+        serializer.serializeTo(null, target) shouldBeEqualTo 0
 
-        assertEquals(3, target.position())
-        assertArrayEquals(before, target.fullBytes())
+        target.position() shouldBeEqualTo 3
+        target.fullBytes() shouldContentEqual before
     }
 
     @Test
@@ -71,14 +79,14 @@ class BinarySerializerByteBufferContractTest {
         val tooSmall = configuredTarget(PAYLOAD.size - 1)
         val start = tooSmall.position()
 
-        assertThrows(BufferOverflowException::class.java) {
+        assertFailsWith<BufferOverflowException> {
             serializer.serializeTo("value", tooSmall)
         }
-        assertEquals(start, tooSmall.position())
+        tooSmall.position() shouldBeEqualTo start
 
         val retry = configuredTarget(PAYLOAD.size)
-        assertEquals(PAYLOAD.size, serializer.serializeTo("value", retry))
-        assertArrayEquals(PAYLOAD, retry.fullBytes().copyOfRange(3, 3 + PAYLOAD.size))
+        serializer.serializeTo("value", retry) shouldBeEqualTo PAYLOAD.size
+        retry.fullBytes().copyOfRange(3, 3 + PAYLOAD.size) shouldContentEqual PAYLOAD
     }
 
     @Test
@@ -90,17 +98,18 @@ class BinarySerializerByteBufferContractTest {
             val target = configuredTarget(PAYLOAD.size)
             val start = target.position()
 
-            val actual = assertThrows(expected::class.java) {
+            val actual = assertFails {
                 serializer.serializeTo("value", target)
             }
 
-            assertSame(expected, actual)
-            assertEquals(start, target.position())
+            actual::class shouldBeEqualTo expected::class
+            actual shouldBeSameInstanceAs expected
+            target.position() shouldBeEqualTo start
         }
 
         val serializer = binarySerializer(serialize = { PAYLOAD })
         val cleanTarget = configuredTarget(PAYLOAD.size)
-        assertEquals(PAYLOAD.size, serializer.serializeTo("value", cleanTarget))
+        serializer.serializeTo("value", cleanTarget) shouldBeEqualTo PAYLOAD.size
     }
 
     @Test
@@ -115,13 +124,13 @@ class BinarySerializerByteBufferContractTest {
                 "decoded"
             })
 
-            assertEquals("decoded", serializer.deserializeFrom<String>(source), name)
-            assertArrayEquals(PAYLOAD, received, name)
-            assertEquals(start, source.position(), name)
-            assertEquals(limit, source.limit(), name)
-            assertEquals(order, source.order(), name)
+            expectThat("decoded", name) { serializer.deserializeFrom<String>(source) }
+            expectThat(PAYLOAD.toList(), name) { received?.toList() }
+            expectThat(start, name) { source.position() }
+            expectThat(limit, name) { source.limit() }
+            expectThat(order, name) { source.order() }
             source.reset()
-            assertEquals(start, source.position(), "$name mark")
+            expectThat(start, "$name mark") { source.position() }
         }
     }
 
@@ -133,15 +142,15 @@ class BinarySerializerByteBufferContractTest {
             val limit = source.limit()
             val serializer = binarySerializer(deserialize = { throw fatal })
 
-            val actual = assertThrows(AssertionError::class.java) {
+            val actual = assertFailsWith<AssertionError> {
                 serializer.deserializeFrom<String>(source)
             }
 
-            assertSame(fatal, actual, name)
-            assertEquals(start, source.position(), name)
-            assertEquals(limit, source.limit(), name)
+            actual shouldBeSameInstanceAs fatal
+            expectThat(start, name) { source.position() }
+            expectThat(limit, name) { source.limit() }
             source.reset()
-            assertEquals(start, source.position(), "$name mark")
+            expectThat(start, "$name mark") { source.position() }
         }
     }
 
@@ -157,15 +166,15 @@ class BinarySerializerByteBufferContractTest {
             if (repetition % 2 == 0) {
                 val expected = value.encodeToByteArray()
                 val target = ByteBuffer.allocate(expected.size)
-                assertEquals(expected.size, serializer.serializeTo(value, target))
+                serializer.serializeTo(value, target) shouldBeEqualTo expected.size
                 target.flip()
-                assertEquals(value, serializer.deserializeFrom<String>(target.asReadOnlyBuffer()))
+                serializer.deserializeFrom<String>(target.asReadOnlyBuffer()) shouldBeEqualTo value
             } else {
                 val target = ByteBuffer.allocate(value.encodeToByteArray().size - 1)
-                assertThrows(BufferOverflowException::class.java) {
+                assertFailsWith<BufferOverflowException> {
                     serializer.serializeTo(value, target)
                 }
-                assertEquals(0, target.position())
+                target.position() shouldBeEqualTo 0
             }
         }
     }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/serializer/SerializerBufferAbiCompatibilityTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/serializer/SerializerBufferAbiCompatibilityTest.kt
@@ -1,8 +1,9 @@
 package io.bluetape4k.io.serializer
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import io.bluetape4k.assertions.expectThat
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 import java.security.MessageDigest
@@ -16,18 +17,18 @@ class SerializerBufferAbiCompatibilityTest {
             ObjectMapper().readTree(requireNotNull(input))
         }
 
-        assertEquals(PRE_CHANGE_COMMIT, manifest.path("producer").path("commit").asText())
-        assertEquals(PRE_CHANGE_TREE, manifest.path("producer").path("tree").asText())
-        assertEquals(3, manifest.path("jars").size(), "baseline jar authority count")
-        assertEquals(5, manifest.path("fixtures").size(), "frozen fixture count")
+        manifest.path("producer").path("commit").asText() shouldBeEqualTo PRE_CHANGE_COMMIT
+        manifest.path("producer").path("tree").asText() shouldBeEqualTo PRE_CHANGE_TREE
+        manifest.path("jars").size() shouldBeEqualTo 3
+        manifest.path("fixtures").size() shouldBeEqualTo 5
 
         manifest.path("fixtures").forEach { fixture ->
             val path = fixture.path("path").asText()
             val bytes = javaClass.classLoader.getResourceAsStream("$root/$path").use { input ->
                 requireNotNull(input) { "Missing frozen fixture: $path" }.readBytes()
             }
-            assertEquals(fixture.path("size").asInt(), bytes.size, path)
-            assertEquals(fixture.path("sha256").asText(), bytes.sha256(), path)
+            expectThat(fixture.path("size").asInt(), path) { bytes.size }
+            expectThat(fixture.path("sha256").asText(), path) { bytes.sha256() }
         }
     }
 
@@ -43,8 +44,8 @@ class SerializerBufferAbiCompatibilityTest {
             ByteBuffer::class.java,
         )
 
-        assertTrue(serializeTo.isDefault, "serializeTo must be an executable JVM default")
-        assertTrue(deserializeFrom.isDefault, "deserializeFrom must be an executable JVM default")
+        serializeTo.isDefault.shouldBeTrue()
+        deserializeFrom.isDefault.shouldBeTrue()
     }
 
     @Test

--- a/io/json/src/test/kotlin/io/bluetape4k/json/JsonSerializerByteBufferContractTest.kt
+++ b/io/json/src/test/kotlin/io/bluetape4k/json/JsonSerializerByteBufferContractTest.kt
@@ -1,10 +1,11 @@
 package io.bluetape4k.json
 
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.fail
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.fail
+import io.bluetape4k.assertions.expectThat
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContentEqual
 import org.junit.jupiter.api.Test
 import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
@@ -30,17 +31,23 @@ class JsonSerializerByteBufferContractTest {
             val capacity = target.capacity()
             val order = target.order()
 
-            assertEquals(PAYLOAD.size, serializer.serializeTo("value", target), name)
+            expectThat(PAYLOAD.size, name) { serializer.serializeTo("value", target) }
 
-            assertEquals(start + PAYLOAD.size, target.position(), name)
-            assertEquals(limit, target.limit(), name)
-            assertEquals(capacity, target.capacity(), name)
-            assertEquals(order, target.order(), name)
-            assertArrayEquals(PAYLOAD, target.fullBytes().copyOfRange(start, start + PAYLOAD.size), name)
-            assertArrayEquals(before.copyOfRange(0, start), target.fullBytes().copyOfRange(0, start), name)
-            assertArrayEquals(before.copyOfRange(limit, capacity), target.fullBytes().copyOfRange(limit, capacity), name)
+            expectThat(start + PAYLOAD.size, name) { target.position() }
+            expectThat(limit, name) { target.limit() }
+            expectThat(capacity, name) { target.capacity() }
+            expectThat(order, name) { target.order() }
+            expectThat(PAYLOAD.toList(), name) {
+                target.fullBytes().copyOfRange(start, start + PAYLOAD.size).toList()
+            }
+            expectThat(before.copyOfRange(0, start).toList(), name) {
+                target.fullBytes().copyOfRange(0, start).toList()
+            }
+            expectThat(before.copyOfRange(limit, capacity).toList(), name) {
+                target.fullBytes().copyOfRange(limit, capacity).toList()
+            }
             target.reset()
-            assertEquals(start, target.position(), "$name mark")
+            expectThat(start, "$name mark") { target.position() }
         }
     }
 
@@ -53,12 +60,12 @@ class JsonSerializerByteBufferContractTest {
         })
         val target = ByteBuffer.allocate(8).asReadOnlyBuffer()
 
-        assertThrows(ReadOnlyBufferException::class.java) {
+        assertFailsWith<ReadOnlyBufferException> {
             serializer.serializeTo(null, target)
         }
 
-        assertEquals(0, invocations.get())
-        assertEquals(0, target.position())
+        invocations.get() shouldBeEqualTo 0
+        target.position() shouldBeEqualTo 0
     }
 
     @Test
@@ -67,32 +74,32 @@ class JsonSerializerByteBufferContractTest {
         val target = configuredTarget(0)
         val before = target.fullBytes()
 
-        assertEquals(0, serializer.serializeTo(null, target))
+        serializer.serializeTo(null, target) shouldBeEqualTo 0
 
-        assertEquals(3, target.position())
-        assertArrayEquals(before, target.fullBytes())
+        target.position() shouldBeEqualTo 3
+        target.fullBytes() shouldContentEqual before
     }
 
     @Test
     fun `overflow and backend failures restore position while Error identity is retained`() {
         val overflowTarget = configuredTarget(PAYLOAD.size - 1)
         val serializer = jsonSerializer(serialize = { PAYLOAD })
-        assertThrows(BufferOverflowException::class.java) {
+        assertFailsWith<BufferOverflowException> {
             serializer.serializeTo("value", overflowTarget)
         }
-        assertEquals(3, overflowTarget.position())
+        overflowTarget.position() shouldBeEqualTo 3
 
         val fatal = AssertionError("fatal")
         val fatalTarget = configuredTarget(PAYLOAD.size)
         val fatalSerializer = jsonSerializer(serialize = { throw fatal })
-        val actual = assertThrows(AssertionError::class.java) {
+        val actual = assertFailsWith<AssertionError> {
             fatalSerializer.serializeTo("value", fatalTarget)
         }
-        assertSame(fatal, actual)
-        assertEquals(3, fatalTarget.position())
+        actual shouldBeSameInstanceAs fatal
+        fatalTarget.position() shouldBeEqualTo 3
 
         val retry = configuredTarget(PAYLOAD.size)
-        assertEquals(PAYLOAD.size, serializer.serializeTo("value", retry))
+        serializer.serializeTo("value", retry) shouldBeEqualTo PAYLOAD.size
     }
 
     @Test
@@ -107,14 +114,14 @@ class JsonSerializerByteBufferContractTest {
                 "decoded"
             })
 
-            assertEquals("decoded", serializer.deserializeFrom(source, String::class.java), name)
-            assertEquals("decoded", serializer.deserialize<String>(source), "$name reified")
-            assertArrayEquals(PAYLOAD, received, name)
-            assertEquals(start, source.position(), name)
-            assertEquals(limit, source.limit(), name)
-            assertEquals(order, source.order(), name)
+            expectThat("decoded", name) { serializer.deserializeFrom(source, String::class.java) }
+            expectThat("decoded", "$name reified") { serializer.deserialize<String>(source) }
+            expectThat(PAYLOAD.toList(), name) { received?.toList() }
+            expectThat(start, name) { source.position() }
+            expectThat(limit, name) { source.limit() }
+            expectThat(order, name) { source.order() }
             source.reset()
-            assertEquals(start, source.position(), "$name mark")
+            expectThat(start, "$name mark") { source.position() }
         }
     }
 
@@ -126,15 +133,15 @@ class JsonSerializerByteBufferContractTest {
             val limit = source.limit()
             val serializer = jsonSerializer(deserialize = { _, _ -> throw fatal })
 
-            val actual = assertThrows(AssertionError::class.java) {
+            val actual = assertFailsWith<AssertionError> {
                 serializer.deserializeFrom(source, String::class.java)
             }
 
-            assertSame(fatal, actual, name)
-            assertEquals(start, source.position(), name)
-            assertEquals(limit, source.limit(), name)
+            actual shouldBeSameInstanceAs fatal
+            expectThat(start, name) { source.position() }
+            expectThat(limit, name) { source.limit() }
             source.reset()
-            assertEquals(start, source.position(), "$name mark")
+            expectThat(start, "$name mark") { source.position() }
         }
     }
 
@@ -151,17 +158,17 @@ class JsonSerializerByteBufferContractTest {
                 throw JsonSerializationException("$kind JSON source")
             })
 
-            val failure = assertThrows(JsonSerializationException::class.java, {
+            val failure = assertFailsWith<JsonSerializationException>(name) {
                 serializer.deserializeFrom(source, String::class.java)
-            }, name)
+            }
 
-            assertEquals("${if (expectedBytes.isEmpty()) "empty" else "malformed"} JSON source", failure.message, name)
-            assertArrayEquals(expectedBytes, received, name)
-            assertEquals(start, source.position(), name)
-            assertEquals(limit, source.limit(), name)
-            assertEquals(order, source.order(), name)
+            failure.message shouldBeEqualTo "${if (expectedBytes.isEmpty()) "empty" else "malformed"} JSON source"
+            received shouldContentEqual expectedBytes
+            source.position() shouldBeEqualTo start
+            source.limit() shouldBeEqualTo limit
+            source.order() shouldBeEqualTo order
             source.reset()
-            assertEquals(start, source.position(), "$name mark")
+            source.position() shouldBeEqualTo start
         }
     }
 
@@ -180,19 +187,19 @@ class JsonSerializerByteBufferContractTest {
             if (repetition % 2 == 0) {
                 val expected = value.encodeToByteArray()
                 val target = ByteBuffer.allocate(expected.size)
-                assertEquals(expected.size, serializer.serializeTo(value, target))
+                serializer.serializeTo(value, target) shouldBeEqualTo expected.size
                 target.flip()
-                assertEquals(value, serializer.deserializeFrom(target.asReadOnlyBuffer(), String::class.java))
+                serializer.deserializeFrom(target.asReadOnlyBuffer(), String::class.java) shouldBeEqualTo value
             } else {
                 val target = ByteBuffer.allocate(value.encodeToByteArray().size - 1)
-                assertThrows(BufferOverflowException::class.java) { serializer.serializeTo(value, target) }
-                assertEquals(0, target.position())
+                assertFailsWith<BufferOverflowException> { serializer.serializeTo(value, target) }
+                target.position() shouldBeEqualTo 0
 
                 val source = ByteBuffer.wrap(MALFORMED.copyOf()).asReadOnlyBuffer()
-                assertThrows(JsonSerializationException::class.java) {
+                assertFailsWith<JsonSerializationException> {
                     serializer.deserializeFrom(source, String::class.java)
                 }
-                assertEquals(0, source.position())
+                source.position() shouldBeEqualTo 0
             }
         }
     }
@@ -324,10 +331,10 @@ private fun verifyJsonBufferConcurrency(
 
         startBarrier.await(JSON_START_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         if (!completion.await(JSON_COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            fail<Unit>("JSON buffer workers timed out; unfinished=${unfinished.sorted().take(JSON_MAX_DIAGNOSTICS)}")
+            fail("JSON buffer workers timed out; unfinished=${unfinished.sorted().take(JSON_MAX_DIAGNOSTICS)}")
         }
         if (failures.isNotEmpty()) {
-            fail<Unit>("JSON buffer worker failures: ${failures.take(JSON_MAX_DIAGNOSTICS)}")
+            fail("JSON buffer worker failures: ${failures.take(JSON_MAX_DIAGNOSTICS)}")
         }
     } finally {
         executor.shutdownNow()
@@ -338,7 +345,7 @@ private fun verifyJsonBufferConcurrency(
                     .map { it.name }
                     .take(JSON_MAX_DIAGNOSTICS)
                     .toList()
-            fail<Unit>(
+            fail(
                 "JSON buffer executor did not terminate; " +
                     "unfinished=${unfinished.sorted().take(JSON_MAX_DIAGNOSTICS)}, threads=$threads",
             )

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/WaitUntilNotifiedTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/WaitUntilNotifiedTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.okio
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.fail
 import io.bluetape4k.junit5.concurrency.TestingExecutors
 import io.bluetape4k.junit5.system.assumeNotWindows
 import io.bluetape4k.logging.KLogging
@@ -15,7 +16,6 @@ import java.io.InterruptedIOException
 import java.time.Duration
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import kotlin.test.fail
 
 class WaitUntilNotifiedTest: AbstractOkioTest() {
 

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketChannelTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketChannelTest.kt
@@ -1,15 +1,15 @@
 package io.bluetape4k.okio.coroutines
 
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.fail
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.coroutines.support.awaitSuspending
-import io.bluetape4k.junit5.coroutines.runSuspendTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.okio.AbstractOkioTest
 import io.bluetape4k.okio.SEGMENT_SIZE
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousServerSocketChannel
 import java.nio.channels.AsynchronousSocketChannel
@@ -61,7 +61,7 @@ class SuspendedSocketChannelTest: AbstractOkioTest() {
 
     private fun runAsyncSocketTest(
         block: suspend (client: AsynchronousSocketChannel, server: AsynchronousSocketChannel) -> Unit,
-    ) = runSuspendTest {
+    ) = runSuspendIO {
         kotlinx.coroutines.withTimeoutOrNull(DEFAULT_TIMEOUT_MS) {
             AsynchronousServerSocketChannel.open().use { serverSocketChannel ->
                 serverSocketChannel.bind(InetSocketAddress("127.0.0.1", 0))

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/coroutines/SuspendedSocketTest.kt
@@ -1,8 +1,9 @@
 package io.bluetape4k.okio.coroutines
 
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.fail
 import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.junit5.coroutines.runSuspendTest
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.okio.AbstractOkioTest
@@ -12,7 +13,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.fail
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -109,7 +109,7 @@ class SuspendedSocketTest: AbstractOkioTest() {
         }
     }
 
-    private fun runSocketTest(block: suspend (client: Socket, server: Socket) -> Unit) = runSuspendTest {
+    private fun runSocketTest(block: suspend (client: Socket, server: Socket) -> Unit) = runSuspendIO {
         withTimeoutOrNull(DEFAULT_TIMEOUT_MS.milliseconds) {
             ServerSocketChannel.open().use { serverSocketChannel ->
                 val serverSocket = serverSocketChannel.socket()

--- a/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/TinkDecryptSourceTest.kt
+++ b/io/okio/src/test/kotlin/io/bluetape4k/okio/tink/TinkDecryptSourceTest.kt
@@ -97,7 +97,7 @@ class TinkDecryptSourceTest: AbstractTinkEncryptTest() {
         val encryptedSource = bufferOf(TinkEncryptors.AES256_GCM.encrypt(expected.toUtf8Bytes()))
         val decryptedSource = encryptedSource.asTinkDecryptSource(TinkEncryptors.AES256_GCM)
 
-        kotlin.test.assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<IllegalArgumentException> {
             decryptedSource.read(Buffer(), -1L)
         }
     }

--- a/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/MessageSupportByteBufferTest.kt
+++ b/io/protobuf/src/test/kotlin/io/bluetape4k/protobuf/MessageSupportByteBufferTest.kt
@@ -1,6 +1,10 @@
 package io.bluetape4k.protobuf
 
 import com.google.protobuf.Message
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldContentEqual
 import io.bluetape4k.protobuf.messages.TestMessage
 import io.bluetape4k.protobuf.messages.testMessage
 import io.mockk.every
@@ -11,10 +15,6 @@ import java.nio.BufferOverflowException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.ReadOnlyBufferException
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNull
 
 class MessageSupportByteBufferTest {
     @Test
@@ -41,12 +41,12 @@ class MessageSupportByteBufferTest {
             val capacity = target.capacity()
             val order = target.order()
 
-            assertEquals(expected.size, packMessageTo(message, target))
-            assertEquals(3 + expected.size, target.position())
-            assertEquals(limit, target.limit())
-            assertEquals(capacity, target.capacity())
-            assertEquals(order, target.order())
-            assertContentEquals(expected, target.bytesAt(3, expected.size))
+            packMessageTo(message, target) shouldBeEqualTo expected.size
+            target.position() shouldBeEqualTo 3 + expected.size
+            target.limit() shouldBeEqualTo limit
+            target.capacity() shouldBeEqualTo capacity
+            target.order() shouldBeEqualTo order
+            target.bytesAt(3, expected.size) shouldContentEqual expected
         }
     }
 
@@ -56,8 +56,8 @@ class MessageSupportByteBufferTest {
         val size = packMessage(message).size
 
         listOf(ByteBuffer.allocate(size), ByteBuffer.allocateDirect(size)).forEach { target ->
-            assertEquals(size, packMessageTo(message, target))
-            assertEquals(target.limit(), target.position())
+            packMessageTo(message, target) shouldBeEqualTo size
+            target.position() shouldBeEqualTo target.limit()
         }
     }
 
@@ -72,7 +72,7 @@ class MessageSupportByteBufferTest {
             source.mark()
             val state = source.state()
 
-            assertNull(unpackMessage<TestMessage>(source))
+            unpackMessage<TestMessage>(source).shouldBeNull()
             source.assertState(state)
         }
     }
@@ -91,7 +91,7 @@ class MessageSupportByteBufferTest {
 
         assertFailsWith<ReadOnlyBufferException> { packMessageTo(message, readOnly) }
         readOnly.assertState(readOnlyState)
-        assertContentEquals(readOnlyContent, writable.array())
+        writable.array() shouldContentEqual readOnlyContent
 
         val undersized = ByteBuffer.allocate(size + 2).apply { put(ByteArray(capacity()) { 0x5A }) }
         undersized.position(1)
@@ -102,7 +102,7 @@ class MessageSupportByteBufferTest {
 
         assertFailsWith<BufferOverflowException> { packMessageTo(message, undersized) }
         undersized.assertState(undersizedState)
-        assertContentEquals(undersizedContent, undersized.array())
+        undersized.array() shouldContentEqual undersizedContent
     }
 
     @Test
@@ -119,7 +119,7 @@ class MessageSupportByteBufferTest {
 
         val decoded = unpackMessage<TestMessage>(source)
 
-        assertEquals(message(), decoded)
+        decoded shouldBeEqualTo message()
         source.assertState(state)
     }
 
@@ -149,8 +149,8 @@ class MessageSupportByteBufferTest {
             }
         }
 
-        assertEquals(position, target.position())
-        assertEquals(0x7F, target.get(position).toInt() and 0xFF)
+        target.position() shouldBeEqualTo position
+        target.get(position).toInt() and 0xFF shouldBeEqualTo 0x7F
     }
 
     private fun message(): TestMessage = testMessage {
@@ -167,11 +167,11 @@ class MessageSupportByteBufferTest {
     private fun ByteBuffer.state(): BufferState = BufferState(position(), limit(), order())
 
     private fun ByteBuffer.assertState(expected: BufferState) {
-        assertEquals(expected.position, position())
-        assertEquals(expected.limit, limit())
-        assertEquals(expected.order, order())
+        position() shouldBeEqualTo expected.position
+        limit() shouldBeEqualTo expected.limit
+        order() shouldBeEqualTo expected.order
         reset()
-        assertEquals(expected.position, position())
+        position() shouldBeEqualTo expected.position
     }
 
     private data class BufferState(val position: Int, val limit: Int, val order: ByteOrder)

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupport.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupport.kt
@@ -1,10 +1,7 @@
 package io.bluetape4k.spring.beans
 
 import io.bluetape4k.support.requireNotBlank
-import io.bluetape4k.utils.KotlinDelegates
-import org.springframework.beans.BeanInstantiationException
 import org.springframework.beans.BeanUtils
-import org.springframework.core.KotlinDetector
 import org.springframework.core.MethodParameter
 import java.beans.PropertyDescriptor
 import java.lang.reflect.Constructor
@@ -28,8 +25,8 @@ fun <T: Any> Class<T>.instantiateClass(): T = BeanUtils.instantiateClass(this)
  * 생성자와 인자로 인스턴스를 생성합니다.
  *
  * ## 동작/계약
- * - Kotlin 타입이면 [KotlinDelegates.instantiateClass], 아니면 [BeanUtils.instantiateClass]를 사용합니다.
- * - 생성 과정 예외는 [BeanInstantiationException]으로 감싸서 던집니다.
+ * - Kotlin 기본값/nullable 인자를 포함한 생성은 Spring의 Kotlin-aware [BeanUtils.instantiateClass]에 위임합니다.
+ * - Spring이 제공하는 [org.springframework.beans.BeanInstantiationException]과 원인 예외를 그대로 전파합니다.
  *
  * ```kotlin
  * val ctor = MyType::class.java.getDeclaredConstructor(String::class.java)
@@ -38,18 +35,7 @@ fun <T: Any> Class<T>.instantiateClass(): T = BeanUtils.instantiateClass(this)
  * ```
  */
 fun <T: Any> Constructor<T>.instantiateClass(vararg args: Any?): T =
-    try {
-        when {
-            KotlinDetector.isKotlinType(this.declaringClass) -> {
-                KotlinDelegates.instantiateClass(this, *args)!!
-            }
-            else -> {
-                BeanUtils.instantiateClass(this, *args)
-            }
-        }
-    } catch (e: Exception) {
-        throw BeanInstantiationException(this, "Fail to instantiate", e)
-    }
+    BeanUtils.instantiateClass(this, *args)
 
 /**
  * 수신 클래스로 인스턴스를 생성한 뒤 지정 타입으로 반환합니다.

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupportTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupportTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.spring.AbstractSpringTest
 import org.junit.jupiter.api.Test
+import org.springframework.beans.BeanInstantiationException
 
 class BeanUtilsSupportTest: AbstractSpringTest() {
 
@@ -21,6 +22,8 @@ class BeanUtilsSupportTest: AbstractSpringTest() {
     class DerivedBean: BaseBean() {
         override fun execute(): String = "derived"
     }
+
+    class RequiredArgumentBean(val value: String)
 
     @Test
     fun `instantiateClass - 기본 생성자로 인스턴스 생성`() {
@@ -38,10 +41,22 @@ class BeanUtilsSupportTest: AbstractSpringTest() {
 
     @Test
     fun `Constructor instantiateClass - 인자로 인스턴스 생성`() {
-        val ctor = SampleBean::class.java.getDeclaredConstructor(String::class.java, Int::class.javaPrimitiveType!!)
+        val primitiveInt = Int::class.javaPrimitiveType.shouldNotBeNull()
+        val ctor = SampleBean::class.java.getDeclaredConstructor(String::class.java, primitiveInt)
         val instance = ctor.instantiateClass("test", 42)
         instance.name shouldBeEqualTo "test"
         instance.value shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `Constructor instantiateClass - nullable 인자는 원인과 함께 BeanInstantiationException으로 변환`() {
+        val ctor = RequiredArgumentBean::class.java.getDeclaredConstructor(String::class.java)
+
+        val error = assertFailsWith<BeanInstantiationException> {
+            ctor.instantiateClass(null)
+        }
+
+        error.cause.shouldBeInstanceOf<NullPointerException>()
     }
 
     @Test

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/core/io/buffer/DataBufferSupportTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/core/io/buffer/DataBufferSupportTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.spring.core.io.buffer
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.io.getAllBytes
@@ -16,13 +17,13 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asPublisher
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DefaultDataBufferFactory
 import org.springframework.core.io.buffer.NettyDataBufferFactory
+import org.springframework.core.io.buffer.PooledDataBuffer
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.channels.AsynchronousFileChannel
@@ -84,10 +85,20 @@ class DataBufferSupportTest: AbstractSpringTest() {
     }
 
     @Test
-    fun `Netty의 PooledDataBuffer를 release 하면 false를 반환한다`() {
-        val dataBuffer = nettyBufferFactory.wrap("test".toByteArray())
-        val released = dataBuffer.release()
-        released.shouldBeTrue()
+    fun `Netty의 PooledDataBuffer를 release 하면 소유권을 해제하고 true를 반환한다`() {
+        val dataBuffer = nettyBufferFactory.wrap("test".toByteArray()) as PooledDataBuffer
+        try {
+            dataBuffer.isAllocated.shouldBeTrue()
+
+            val released = dataBuffer.release()
+
+            released.shouldBeTrue()
+            dataBuffer.isAllocated.shouldBeFalse()
+        } finally {
+            if (dataBuffer.isAllocated) {
+                dataBuffer.release()
+            }
+        }
     }
 
     @Test
@@ -247,13 +258,13 @@ class DataBufferSupportTest: AbstractSpringTest() {
     fun `DataBuffer retain은 같은 버퍼를 반환한다`() {
         val buffer = bufferFactory.wrap("test".toByteArray())
         val retained = buffer.retain()
-        assertSame(buffer, retained)
+        retained shouldBeSameInstanceAs buffer
     }
 
     @Test
     fun `DataBuffer touch는 같은 버퍼를 반환한다`() {
         val buffer = bufferFactory.wrap("test".toByteArray())
         val touched = buffer.touch("hint-value")
-        assertSame(buffer, touched)
+        touched shouldBeSameInstanceAs buffer
     }
 }

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/tests/WebClientReadmeExamplesTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/tests/WebClientReadmeExamplesTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.spring.tests
 
+import io.bluetape4k.assertions.should
 import io.bluetape4k.assertions.shouldNotBeNull
 import kotlinx.coroutines.reactive.asFlow
 import org.junit.jupiter.api.Test
@@ -7,7 +8,6 @@ import org.springframework.web.reactive.function.client.WebClient
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.readText
-import kotlin.test.assertTrue
 
 class WebClientReadmeExamplesTest {
 
@@ -20,10 +20,7 @@ class WebClientReadmeExamplesTest {
                     .map { it.value.replace(Regex("\\s+"), " ") }
                     .toList()
 
-            assertTrue(
-                actual = matches.isEmpty(),
-                message = "$fileName should not chain .retrieve() after httpGet/httpPost: $matches",
-            )
+            matches.should("$fileName should not chain .retrieve() after httpGet/httpPost: $matches") { it.isEmpty() }
         }
     }
 

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geo/GeoReadmeContractTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geo/GeoReadmeContractTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.geo
 
+import io.bluetape4k.assertions.fail
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.readText
-import kotlin.test.assertFalse
 
 class GeoReadmeContractTest {
 
@@ -12,10 +12,9 @@ class GeoReadmeContractTest {
     fun `README examples use current public APIs and consumer coordinates`() {
         readmeTexts().forEach { (filename, text) ->
             forbiddenFragments.forEach { fragment ->
-                assertFalse(
-                    text.contains(fragment),
-                    "$filename must not contain stale or internal reference: $fragment",
-                )
+                if (text.contains(fragment)) {
+                    fail("$filename must not contain stale or internal reference: $fragment")
+                }
             }
         }
     }

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/flake/FlakeTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/flake/FlakeTest.kt
@@ -21,8 +21,10 @@ import org.junit.jupiter.api.condition.JRE
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 class FlakeTest {
 
@@ -90,12 +92,16 @@ class FlakeTest {
 
     @Test
     fun `1 msec 이 지나면 sequence는 리셋되어야 합니다`() {
-        val seq1 = flake.nextId().copyOfRange(14, 15)
-        Thread.sleep(10)
-        val seq2 = flake.nextId().copyOfRange(14, 15)
+        val initialMillis = 1_700_000_000_000L
+        val clock = MutableClock(initialMillis)
+        val customFlake = Flake({ 123456789L }, clock)
 
-        // 1 msec 이 지나면 sequence가 리셋되어야 합니다.
-        seq2 shouldBeEqualTo seq1
+        val first = customFlake.nextId()
+        clock.advanceBy(Duration.ofMillis(1))
+        val second = customFlake.nextId()
+
+        Flake.asComponentString(first) shouldBeEqualTo "$initialMillis-123456789-1"
+        Flake.asComponentString(second) shouldBeEqualTo "${initialMillis + 1}-123456789-0"
     }
 
     @Test
@@ -153,5 +159,23 @@ class FlakeTest {
                 idMaps.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+    }
+
+    private class MutableClock(
+        private val currentMillis: AtomicLong,
+        private val zone: ZoneId,
+    ): Clock() {
+
+        constructor(initialMillis: Long): this(AtomicLong(initialMillis), ZoneOffset.UTC)
+
+        override fun getZone(): ZoneId = zone
+
+        override fun withZone(zone: ZoneId): Clock = MutableClock(currentMillis, zone)
+
+        override fun instant(): Instant = Instant.ofEpochMilli(currentMillis.get())
+
+        fun advanceBy(duration: Duration) {
+            currentMillis.addAndGet(duration.toMillis())
+        }
     }
 }

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/snowflake/AbstractSnowflakeTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/snowflake/AbstractSnowflakeTest.kt
@@ -177,6 +177,8 @@ abstract class AbstractSnowflakeTest {
         val snowflakeId1 = snowflake.parse(id1)
         val snowflakeId2 = snowflake.parse(id2)
 
+        // 의도적 tick 경계 지연: Default/GlobalSequencer가 System.currentTimeMillis()를 직접 읽고
+        // 주입 가능한 clock을 노출하지 않으므로 sequencer timestamp 계약 검증에서만 유지합니다.
         Thread.sleep(1L)
         val id3 = snowflake.nextId()
         val snowflakeId3 = snowflake.parse(id3)
@@ -211,6 +213,8 @@ abstract class AbstractSnowflakeTest {
     fun `parse snowflake id as string`() {
         val id1 = snowflake.nextIdAsString()
         val id2 = snowflake.nextIdAsString()
+        // 의도적 tick 경계 지연: Default/GlobalSequencer가 System.currentTimeMillis()를 직접 읽고
+        // 주입 가능한 clock을 노출하지 않으므로 sequencer timestamp 계약 검증에서만 유지합니다.
         Thread.sleep(1L)
         val id3 = snowflake.nextIdAsString()
         val id4 = snowflake.nextIdAsString()

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/base62/AbstractTimebasedUuidBase62Test.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/base62/AbstractTimebasedUuidBase62Test.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.idgenerators.uuid.base62
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContainSame
 import io.bluetape4k.codec.decodeBase62AsUuid
 import io.bluetape4k.codec.encodeBase62
@@ -21,7 +22,6 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.test.assertTrue
 
 abstract class AbstractTimebasedUuidBase62Test {
 
@@ -43,8 +43,8 @@ abstract class AbstractTimebasedUuidBase62Test {
             log.debug { "uuid=$it" }
         }
 
-        assertTrue { u2 > u1 }
-        assertTrue { u3 > u2 }
+        (u2 > u1).shouldBeTrue()
+        (u3 > u2).shouldBeTrue()
 
         // u1.version() shouldBeEqualTo 6   // Time based
     }

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/timebased/AbstractTimebasedUuidTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/timebased/AbstractTimebasedUuidTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.idgenerators.uuid.timebased
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContainSame
 import io.bluetape4k.idgenerators.IdGenerator
 import io.bluetape4k.idgenerators.hashids.Hashids
@@ -19,7 +20,6 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.test.assertTrue
 
 abstract class AbstractTimebasedUuidTest {
 
@@ -41,8 +41,8 @@ abstract class AbstractTimebasedUuidTest {
             log.debug { "uuid=$it" }
         }
 
-        assertTrue { u2 > u1 }
-        assertTrue { u3 > u2 }
+        (u2 > u1).shouldBeTrue()
+        (u3 > u2).shouldBeTrue()
 
         // u1.version() shouldBeEqualTo 6   // Time based
     }

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/interval/TemporalIntervalWindowedTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/interval/TemporalIntervalWindowedTest.kt
@@ -3,16 +3,16 @@ package io.bluetape4k.javatimes.interval
 import io.bluetape4k.javatimes.nowZonedDateTime
 import io.bluetape4k.javatimes.startOf
 import io.bluetape4k.javatimes.temporalAmount
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.trace
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
-import org.junit.jupiter.api.Assertions
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.trace
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.time.temporal.ChronoUnit
-import io.bluetape4k.assertions.assertFailsWith
 
 class TemporalIntervalWindowedTest {
 
@@ -35,8 +35,8 @@ class TemporalIntervalWindowedTest {
             chunks.forEachIndexed { index, chunk ->
                 log.trace { "chunks[$index] = $chunk" }
                 chunk.size shouldBeLessOrEqualTo 4
-                Assertions.assertTrue { chunk.first() in interval }
-                Assertions.assertTrue { chunk.last() in interval }
+                (chunk.first() in interval).shouldBeTrue()
+                (chunk.last() in interval).shouldBeTrue()
             }
 
             chunks.size shouldBeEqualTo 2
@@ -71,7 +71,7 @@ class TemporalIntervalWindowedTest {
             chunks.size shouldBeEqualTo 2
             chunks.forEach {
                 log.trace { "chunk=$it" }
-                Assertions.assertTrue { it in interval }
+                (it in interval).shouldBeTrue()
             }
         }
     }
@@ -93,8 +93,8 @@ class TemporalIntervalWindowedTest {
             windowed.forEachIndexed { index, items ->
                 log.trace { "index=$index, items=$items" }
 
-                Assertions.assertTrue { items.first() in interval }
-                Assertions.assertTrue { items.last() in interval }
+                (items.first() in interval).shouldBeTrue()
+                (items.last() in interval).shouldBeTrue()
             }
             windowed.count() shouldBeEqualTo 3
 
@@ -130,9 +130,9 @@ class TemporalIntervalWindowedTest {
             zipWithNext.count() shouldBeEqualTo 4
             zipWithNext.forEach { (current, next) ->
                 log.trace { "current=$current, next=$next" }
-                kotlin.test.assertTrue { current in interval }
-                kotlin.test.assertTrue { next in interval }
-                kotlin.test.assertTrue { current < next }
+                (current in interval).shouldBeTrue()
+                (next in interval).shouldBeTrue()
+                (current < next).shouldBeTrue()
             }
         }
     }

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/ranges/DayRangeCollectionTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/ranges/DayRangeCollectionTest.kt
@@ -8,11 +8,10 @@ import io.bluetape4k.javatimes.nowZonedDateTime
 import io.bluetape4k.javatimes.period.AbstractPeriodTest
 import io.bluetape4k.javatimes.startOfDay
 import io.bluetape4k.javatimes.todayZonedDateTime
-import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 class DayRangeCollectionTest: AbstractPeriodTest() {
 
@@ -46,7 +45,7 @@ class DayRangeCollectionTest: AbstractPeriodTest() {
         daySeq.count() shouldBeEqualTo dayCount
 
         daySeq.forEachIndexed { index, dr ->
-            assertTrue { dr.isSamePeriod(DayRange(start + index.days())) }
+            dr.isSamePeriod(DayRange(start + index.days())).shouldBeTrue()
         }
     }
 

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/ranges/QuarterRangeTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/ranges/QuarterRangeTest.kt
@@ -10,13 +10,13 @@ import io.bluetape4k.javatimes.period.TimeCalendar
 import io.bluetape4k.javatimes.startOfQuarter
 import io.bluetape4k.javatimes.startOfYear
 import io.bluetape4k.javatimes.zonedDateTimeOf
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.trace
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.trace
 import org.junit.jupiter.api.Test
 import kotlin.math.absoluteValue
-import kotlin.test.assertTrue
 
 class QuarterRangeTest: AbstractPeriodTest() {
 
@@ -97,7 +97,7 @@ class QuarterRangeTest: AbstractPeriodTest() {
         val calendar = TimeCalendar.EmptyOffset
 
         fun checkQuarters(qr: QuarterRange, quarter: Quarter) {
-            assertTrue(qr.readonly)
+            qr.readonly.shouldBeTrue()
             qr.quarter shouldBeEqualTo quarter
             qr.start shouldBeEqualTo zonedDateTimeOf(nowYear, quarter.startMonth)
 

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/timelines/TimeGapCalculatorTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/timelines/TimeGapCalculatorTest.kt
@@ -15,14 +15,14 @@ import io.bluetape4k.javatimes.period.ranges.DayRangeCollection
 import io.bluetape4k.javatimes.period.ranges.MonthRange
 import io.bluetape4k.javatimes.period.samples.SchoolDay
 import io.bluetape4k.javatimes.zonedDateTimeOf
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEmpty
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 class TimeGapCalculatorTest: AbstractPeriodTest() {
 
@@ -369,27 +369,27 @@ class TimeGapCalculatorTest: AbstractPeriodTest() {
         val gaps2 = calculator.gaps(excludePeriods)
 
         gaps2.size shouldBeEqualTo 3
-        assertTrue { gaps2[0].isSamePeriod(schoolDay.break1) }
-        assertTrue { gaps2[1].isSamePeriod(schoolDay.break2) }
-        assertTrue { gaps2[2].isSamePeriod(schoolDay.break3) }
+        gaps2[0].isSamePeriod(schoolDay.break1).shouldBeTrue()
+        gaps2[1].isSamePeriod(schoolDay.break2).shouldBeTrue()
+        gaps2[2].isSamePeriod(schoolDay.break3).shouldBeTrue()
 
         val testRange3 = TimeRange(schoolDay.lesson1.start, schoolDay.lesson4.end)
         val gaps3 = calculator.gaps(excludePeriods, testRange3)
 
         gaps3.size shouldBeEqualTo 3
-        assertTrue { gaps3[0].isSamePeriod(schoolDay.break1) }
-        assertTrue { gaps3[1].isSamePeriod(schoolDay.break2) }
-        assertTrue { gaps3[2].isSamePeriod(schoolDay.break3) }
+        gaps3[0].isSamePeriod(schoolDay.break1).shouldBeTrue()
+        gaps3[1].isSamePeriod(schoolDay.break2).shouldBeTrue()
+        gaps3[2].isSamePeriod(schoolDay.break3).shouldBeTrue()
 
         val testRange4 = TimeRange(schoolDay.start - 1.hours(), schoolDay.end + 1.hours())
         val gaps4 = calculator.gaps(excludePeriods, testRange4)
 
         gaps4.size shouldBeEqualTo 5
-        assertTrue { gaps4[0].isSamePeriod(TimeRange(testRange4.start, schoolDay.start)) }
-        assertTrue { gaps4[1].isSamePeriod(schoolDay.break1) }
-        assertTrue { gaps4[2].isSamePeriod(schoolDay.break2) }
-        assertTrue { gaps4[3].isSamePeriod(schoolDay.break3) }
-        assertTrue { gaps4[4].isSamePeriod(TimeRange(schoolDay.end, testRange4.end)) }
+        gaps4[0].isSamePeriod(TimeRange(testRange4.start, schoolDay.start)).shouldBeTrue()
+        gaps4[1].isSamePeriod(schoolDay.break1).shouldBeTrue()
+        gaps4[2].isSamePeriod(schoolDay.break2).shouldBeTrue()
+        gaps4[3].isSamePeriod(schoolDay.break3).shouldBeTrue()
+        gaps4[4].isSamePeriod(TimeRange(schoolDay.end, testRange4.end)).shouldBeTrue()
 
         excludePeriods.clear()
         excludePeriods += schoolDay.lesson1
@@ -446,18 +446,10 @@ class TimeGapCalculatorTest: AbstractPeriodTest() {
             }
 
             gaps shouldHaveSize 4
-            assertTrue {
-                gaps[0].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 5), 2.days()))
-            }
-            assertTrue {
-                gaps[1].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 9), 1.days()))
-            }
-            assertTrue {
-                gaps[2].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 12), 4.days()))
-            }
-            assertTrue {
-                gaps[3].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 19), 2.days()))
-            }
+            gaps[0].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 5), 2.days())).shouldBeTrue()
+            gaps[1].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 9), 1.days())).shouldBeTrue()
+            gaps[2].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 12), 4.days())).shouldBeTrue()
+            gaps[3].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 19), 2.days())).shouldBeTrue()
         }
     }
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/AbstractKeyChainRepositoryTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/AbstractKeyChainRepositoryTest.kt
@@ -6,11 +6,11 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.jwt.keychain.repository.KeyChainRepository
 import io.bluetape4k.logging.KLogging
+import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
-import kotlin.test.assertTrue
 
 abstract class AbstractKeyChainRepositoryTest {
 
@@ -51,8 +51,9 @@ abstract class AbstractKeyChainRepositoryTest {
         repository.rotate(prevKeyChain).shouldBeTrue()
         repository.current() shouldBeEqualTo prevKeyChain
 
-        Thread.sleep(10)
-        assertTrue { prevKeyChain.createdAt + 1 < System.currentTimeMillis() }
+        // 실제 TTL 만료 경계를 검증하므로 wall-clock 대기를 유지합니다.
+        awaitExpired(prevKeyChain)
+        (prevKeyChain.createdAt + 1 < System.currentTimeMillis()).shouldBeTrue()
 
         // 기존 key chain 이 만료되었으므로 rotate 되어야 한다 
         val newKeyChain = KeyChain()
@@ -87,16 +88,16 @@ abstract class AbstractKeyChainRepositoryTest {
         val keyChain = KeyChain(expiredTtl = Duration.ZERO)
         repository.rotate(keyChain).shouldBeTrue()
 
-        Thread.sleep(10)
         repository.rotate(keyChain).shouldBeFalse()
     }
 
     @Test
     fun `current KeyChain이 가장 최신이어야 한다`() {
-        repository.rotate(KeyChain(expiredTtl = Duration.ofMillis(1))).shouldBeTrue()
-        Thread.sleep(1)
-        repository.rotate(KeyChain(expiredTtl = Duration.ofMillis(1))).shouldBeTrue()
-        Thread.sleep(1)
+        val firstKeyChain = alreadyExpiredKeyChain()
+        repository.rotate(firstKeyChain).shouldBeTrue()
+
+        val secondKeyChain = alreadyExpiredKeyChain()
+        repository.rotate(secondKeyChain).shouldBeTrue()
 
         val newestKeyChain = KeyChain(expiredTtl = Duration.ZERO)
         repository.rotate(newestKeyChain).shouldBeTrue()
@@ -106,12 +107,11 @@ abstract class AbstractKeyChainRepositoryTest {
 
     @Test
     fun `read KeyChain by id`() {
-        repository.rotate(KeyChain(expiredTtl = Duration.ofMillis(1))).shouldBeTrue()
-        Thread.sleep(1)
+        val expiredKeyChain = alreadyExpiredKeyChain()
+        repository.rotate(expiredKeyChain).shouldBeTrue()
 
         val keyChain = KeyChain(expiredTtl = Duration.ZERO)
         repository.rotate(keyChain).shouldBeTrue()
-        Thread.sleep(1)
 
         repository.rotate(KeyChain(expiredTtl = Duration.ZERO)).shouldBeFalse()
 
@@ -123,8 +123,8 @@ abstract class AbstractKeyChainRepositoryTest {
     fun `capacity 이상으로 rotate를 하면, 오래된 것은 삭제된다`() {
 
         repeat(repository.capacity * 2) {
-            repository.rotate(KeyChain(expiredTtl = Duration.ofMillis(1))).shouldBeTrue()
-            Thread.sleep(2)
+            val expiredKeyChain = alreadyExpiredKeyChain()
+            repository.rotate(expiredKeyChain).shouldBeTrue()
         }
 
         val keyChain = KeyChain()
@@ -145,4 +145,14 @@ abstract class AbstractKeyChainRepositoryTest {
 
         repository.current() shouldBeEqualTo keyChain
     }
+
+    protected fun awaitExpired(keyChain: KeyChain) {
+        await.atMost(Duration.ofSeconds(1)).until { keyChain.isExpired }
+    }
+
+    protected fun alreadyExpiredKeyChain(): KeyChain =
+        KeyChain(
+            createdAt = System.currentTimeMillis() - 1_000,
+            expiredTtl = Duration.ofMillis(1),
+        )
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.jwt.keychain.redis
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.assertFailsWith
@@ -16,6 +18,7 @@ import io.bluetape4k.testcontainers.storage.RedisServer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
 import org.redisson.Redisson
 import org.redisson.api.RDeque
@@ -26,8 +29,6 @@ import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import kotlin.test.assertNull
-import kotlin.test.assertSame
 
 class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
 
@@ -49,9 +50,14 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         every { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) } returns true
         every { lock.isHeldByCurrentThread } returns true
 
-        RedisKeyChainRepository(redisson).forcedRotate(KeyChain()).shouldBeTrue()
+        val repository = RedisKeyChainRepository(redisson)
+        try {
+            repository.forcedRotate(KeyChain()).shouldBeTrue()
 
-        verify(exactly = 1) { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) }
+            verify(exactly = 1) { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) }
+        } finally {
+            repository.close()
+        }
     }
 
     @Test
@@ -80,8 +86,8 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             withRedisRotationLock(lock) { throw primaryFailure }
         }
 
-        assertSame(primaryFailure, failure)
-        assertSame(unlockFailure, failure.suppressed.single())
+        failure shouldBeSameInstanceAs primaryFailure
+        failure.suppressed.single() shouldBeSameInstanceAs unlockFailure
     }
 
     @Test
@@ -89,23 +95,31 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         val firstClient = createWatchdogClient()
         val secondClient = createWatchdogClient()
         val lockName = "test:jwt:keychain:watchdog:${UUID.randomUUID()}"
-        val ownerLock = LeaseCappingLock(firstClient.getLock(lockName), 250)
+        val ownerLock = firstClient.getLock(lockName)
         val contenderLock = secondClient.getLock(lockName)
         val started = CountDownLatch(1)
+        val releaseCommit = CountDownLatch(1)
         val executor = Executors.newSingleThreadExecutor()
 
         try {
             val result = executor.submit<Boolean> {
                 withRedisRotationLock(ownerLock) {
                     started.countDown()
-                    Thread.sleep(1_200)
+                    releaseCommit.await(5, TimeUnit.SECONDS).shouldBeTrue()
                     true
                 }
             }
 
             started.await(5, TimeUnit.SECONDS).shouldBeTrue()
-            Thread.sleep(600)
-            contenderLock.tryLock(100, TimeUnit.MILLISECONDS).shouldBeFalse()
+            // watchdog timeout(900ms)을 넘는 동안 contender가 lock을 얻지 못해야 갱신이 증명됩니다.
+            await.during(Duration.ofMillis(1_200)).until {
+                val acquired = contenderLock.tryLock(100, TimeUnit.MILLISECONDS)
+                if (acquired) {
+                    contenderLock.unlock()
+                }
+                !acquired
+            }
+            releaseCommit.countDown()
             result.get(5, TimeUnit.SECONDS).shouldBeTrue()
 
             contenderLock.tryLock(1, TimeUnit.SECONDS).shouldBeTrue()
@@ -113,6 +127,7 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             if (contenderLock.isHeldByCurrentThread) {
                 contenderLock.unlock()
             }
+            releaseCommit.countDown()
             executor.shutdownNow()
             firstClient.shutdown()
             secondClient.shutdown()
@@ -127,9 +142,8 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         val secondNode = RedisKeyChainRepository(redisson, queueName = queueName)
 
         try {
-            val expiredKeyChain = KeyChain(expiredTtl = Duration.ofMillis(1))
+            val expiredKeyChain = alreadyExpiredKeyChain()
             seedRepository.forcedRotate(expiredKeyChain).shouldBeTrue()
-            Thread.sleep(10)
 
             firstNode.current() shouldBeEqualTo expiredKeyChain
             secondNode.current() shouldBeEqualTo expiredKeyChain
@@ -148,9 +162,15 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             firstNode.current() shouldBeEqualTo winner
             secondNode.current() shouldBeEqualTo winner
             seedRepository.findOrNull(winner.id) shouldBeEqualTo winner
-            assertNull(seedRepository.findOrNull(loser.id))
+            seedRepository.findOrNull(loser.id).shouldBeNull()
         } finally {
-            seedRepository.deleteAll()
+            try {
+                seedRepository.deleteAll()
+            } finally {
+                firstNode.close()
+                secondNode.close()
+                seedRepository.close()
+            }
         }
     }
 
@@ -163,9 +183,8 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         val executor = Executors.newFixedThreadPool(2)
 
         try {
-            val expiredKeyChain = KeyChain(expiredTtl = Duration.ofMillis(1))
+            val expiredKeyChain = alreadyExpiredKeyChain()
             seedRepository.forcedRotate(expiredKeyChain).shouldBeTrue()
-            Thread.sleep(10)
 
             firstNode.current() shouldBeEqualTo expiredKeyChain
             secondNode.current() shouldBeEqualTo expiredKeyChain
@@ -192,10 +211,16 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             firstNode.current() shouldBeEqualTo winner
             secondNode.current() shouldBeEqualTo winner
             seedRepository.findOrNull(winner.id) shouldBeEqualTo winner
-            assertNull(seedRepository.findOrNull(loser.id))
+            seedRepository.findOrNull(loser.id).shouldBeNull()
         } finally {
             executor.shutdownNow()
-            seedRepository.deleteAll()
+            try {
+                seedRepository.deleteAll()
+            } finally {
+                firstNode.close()
+                secondNode.close()
+                seedRepository.close()
+            }
         }
     }
 
@@ -206,12 +231,4 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             },
         )
 
-    private class LeaseCappingLock(
-        private val delegate: RLock,
-        private val cappedLeaseMillis: Long,
-    ): RLock by delegate {
-
-        override fun tryLock(waitTime: Long, leaseTime: Long, unit: TimeUnit): Boolean =
-            delegate.tryLock(waitTime, cappedLeaseMillis, TimeUnit.MILLISECONDS)
-    }
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProviderTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProviderTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.assertTrue
 
 class DefaultJwtProviderTest: AbstractJwtProviderTest() {
 
@@ -31,12 +30,12 @@ class DefaultJwtProviderTest: AbstractJwtProviderTest() {
             await.atMost(Duration.ofSeconds(2)).until { lifecycleRepository.refreshCount.get() > 0 }
             await.atMost(Duration.ofSeconds(2)).until { hasLiveThread(timerName) }
 
-            assertTrue(lifecycleRepository is AutoCloseable)
-            (lifecycleRepository as AutoCloseable).close()
+            lifecycleRepository.close()
 
             val refreshCountAfterClose = lifecycleRepository.refreshCount.get()
-            Thread.sleep(100)
-            lifecycleRepository.refreshCount.get().shouldBeEqualTo(refreshCountAfterClose)
+            await.during(Duration.ofMillis(100)).until {
+                lifecycleRepository.refreshCount.get() == refreshCountAfterClose
+            }
             await.atMost(Duration.ofSeconds(2)).until { !hasLiveThread(timerName) }
         } finally {
             lifecycleRepository.close()
@@ -56,15 +55,15 @@ class DefaultJwtProviderTest: AbstractJwtProviderTest() {
             await.atMost(Duration.ofSeconds(2)).until { lifecycleRepository.rotateCount.get() > 1 }
             await.atMost(Duration.ofSeconds(2)).until { hasLiveThread(repositoryTimerName) }
 
-            assertTrue(lifecycleProvider is AutoCloseable)
-            (lifecycleProvider as AutoCloseable).close()
+            lifecycleProvider.close()
 
             val rotationCountAfterClose = lifecycleRepository.rotateCount.get()
-            Thread.sleep(100)
-            lifecycleRepository.rotateCount.get().shouldBeEqualTo(rotationCountAfterClose)
+            await.during(Duration.ofMillis(100)).until {
+                lifecycleRepository.rotateCount.get() == rotationCountAfterClose
+            }
             hasLiveThread(repositoryTimerName).shouldBeEqualTo(true)
 
-            (lifecycleRepository as AutoCloseable).close()
+            lifecycleRepository.close()
             await.atMost(Duration.ofSeconds(2)).until { !hasLiveThread(repositoryTimerName) }
         } finally {
             lifecycleProvider.close()

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/ComparableHistogram.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/ComparableHistogram.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.math
 import io.bluetape4k.ranges.DefaultClosedClosedRange
 import io.bluetape4k.ranges.DefaultClosedOpenRange
 import io.bluetape4k.ranges.Range
+import io.bluetape4k.support.requireNotNull
+import io.bluetape4k.support.requirePositiveNumber
 import java.io.Serializable
 
 
@@ -52,13 +54,14 @@ data class BinModel<out T: Any, in C: Comparable<C>>(
  * val model = data.binByComparable(incrementer = { it + 2 }, valueMapper = { it })
  * // model 은 [1,3], [3,5], [5,7], [7,9] 구간의 BinModel
  * ```
+ * 입력 `Sequence`는 한 번만 소비되며, 빈 입력은 `IllegalArgumentException`을 발생시킵니다.
  */
 inline fun <T: Any, C: Comparable<C>> Sequence<T>.binByComparable(
     incrementer: (C) -> C,
     valueMapper: (T) -> C,
     rangeStart: C? = null,
 ): BinModel<List<T>, C> =
-    asIterable().binByComparable(incrementer, valueMapper, rangeStart)
+    toList().binByComparable(incrementer, valueMapper, rangeStart)
 
 /**
  * Iterable을 Comparable 기준으로 히스토그램 구간으로 분류합니다.
@@ -68,6 +71,7 @@ inline fun <T: Any, C: Comparable<C>> Sequence<T>.binByComparable(
  * val model = data.binByComparable(incrementer = { it + 2 }, valueMapper = { it })
  * // model 은 [1,3], [3,5], [5,7], [7,9] 구간의 BinModel
  * ```
+ * 빈 입력은 `IllegalArgumentException`을 발생시킵니다.
  */
 inline fun <T: Any, C: Comparable<C>> Iterable<T>.binByComparable(
     incrementer: (C) -> C,
@@ -103,13 +107,17 @@ inline fun <T: Any, C: Comparable<C>, G: Any> Iterable<T>.binByComparable(
     rangeStart: C? = null,
     endExclusive: Boolean = false,
 ): BinModel<G, C> {
-    require(count() > 0) { "Collection must not be empty." }
+    count().requirePositiveNumber { "Collection must not be empty." }
 
     val groupByC: MutableMap<C, MutableList<T>> = mutableMapOf()
     this.groupByTo(groupByC, valueMapper)
 
-    val minC: C = rangeStart ?: groupByC.keys.minOrNull()!!
-    val maxC: C = groupByC.keys.maxOrNull()!!
+    val minC: C = rangeStart ?: groupByC.keys.minOrNull().requireNotNull {
+        "Collection must not be empty."
+    }
+    val maxC: C = groupByC.keys.maxOrNull().requireNotNull {
+        "Collection must not be empty."
+    }
 
     // Histogram의 막대의 컬렉션을 구성합니다.
     val bins = mutableListOf<Range<C>>()

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/commons/Ranking.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/commons/Ranking.kt
@@ -15,6 +15,8 @@ import org.apache.commons.math3.stat.ranking.TiesStrategy
  * // result == {30.0 -> 0, 10.0 -> 2, 20.0 -> 1}
  * ```
  *
+ * 입력 `Sequence`는 한 번만 소비하도록 materialize하며, 빈 입력은 빈 map을 반환합니다.
+ *
  * @param nanStrategy 값이 NaN 일 경우의 ranking 전략 (기본: 최소값으로 ranking)
  * @param tiesStrategy 값이 같을 경우 순위 전략 (기본: 높은 순위로 지정)
  * @return 요소별 순위 정보
@@ -23,11 +25,16 @@ fun <T> Sequence<T>.ranking(
     nanStrategy: NaNStrategy = NaNStrategy.MINIMAL,
     tiesStrategy: TiesStrategy = TiesStrategy.MAXIMUM,
 ): Map<T, Int> where T: Number, T: Comparable<T> {
+    val items = toList()
+    if (items.isEmpty()) {
+        return emptyMap()
+    }
+
     val ranks = NaturalRanking(nanStrategy, tiesStrategy)
-        .rank(map { it.toDouble() }.toDoubleArray())
+        .rank(items.map { it.toDouble() }.toDoubleArray())
         .map { it.toInt() }
 
-    return this
+    return items
         .mapIndexed { index, item ->
             item to ranks.size - ranks[index]
         }
@@ -66,6 +73,9 @@ fun <T> Iterable<T>.ranking(
  * // result[Student("A", 90.0)] == 0 (1등)
  * ```
  *
+ * `Sequence`는 한 번만 소비하고 `valueSelector`는 각 요소에 대해 한 번만 호출합니다.
+ * 빈 입력은 빈 map을 반환합니다.
+ *
  * @param valueSelector 순위를 매길 값을 선택할 수 있도록 한다
  * @param nanStrategy 값이 NaN 일 경우의 ranking 전략 (기본: 최소값으로 ranking)
  * @param tiesStrategy 값이 같을 경우 순위 전략 (기본: 높은 순위로 지정)
@@ -76,8 +86,10 @@ inline fun <T, V> Sequence<T>.ranking(
     tiesStrategy: TiesStrategy = TiesStrategy.MAXIMUM,
     crossinline valueSelector: (T) -> V,
 ): Map<T, Int> where V: Number, V: Comparable<V> {
-    val ranks: Map<V, Int> = this.map { valueSelector(it) }.ranking(nanStrategy, tiesStrategy)
-    return this.associateWith { ranks[valueSelector(it)]!! }
+    val items = toList()
+    val selected = items.map { it to valueSelector(it) }
+    val ranks: Map<V, Int> = selected.asSequence().map { it.second }.ranking(nanStrategy, tiesStrategy)
+    return selected.associate { (item, value) -> item to ranks.getValue(value) }
 }
 
 /**

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/BigDecimalHistogramTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/BigDecimalHistogramTest.kt
@@ -2,12 +2,12 @@ package io.bluetape4k.math
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.collections.repeat
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
-import kotlin.test.assertTrue
 
 class BigDecimalHistogramTest {
 
@@ -15,8 +15,6 @@ class BigDecimalHistogramTest {
 
     private val valueVector = sequenceOf(0.0, 1.0, 3.0, 5.0, 11.0).map { it.toBigDecimal() }
     private val groups = sequenceOf("A", "B", "B", "C", "C")
-
-    private val grouped = groups.zip(valueVector)
 
     @Test
     fun `histogram by BigDecimal`() {
@@ -38,21 +36,17 @@ class BigDecimalHistogramTest {
         histogram.bins.size shouldBeEqualTo 3
 
         // range의 어떤 값이던 상관없다 (BinModel.get operator를 보라)
-        assertTrue {
-            histogram[5.0.toBigDecimal()]!!.range.let {
-                it.first == 0.0.toBigDecimal() && it.last == 100.0.toBigDecimal()
-            }
-        }
-        assertTrue {
-            histogram[105.0.toBigDecimal()]!!.range.let {
-                it.first == 100.0.toBigDecimal() && it.last == 200.0.toBigDecimal()
-            }
-        }
-        assertTrue {
-            histogram[205.0.toBigDecimal()]!!.range.let {
-                it.first == 200.0.toBigDecimal() && it.last == 300.0.toBigDecimal()
-            }
-        }
+        val firstRange = histogram[5.0.toBigDecimal()].shouldNotBeNull().range
+        firstRange.first shouldBeEqualTo 0.0.toBigDecimal()
+        firstRange.last shouldBeEqualTo 100.0.toBigDecimal()
+
+        val secondRange = histogram[105.0.toBigDecimal()].shouldNotBeNull().range
+        secondRange.first shouldBeEqualTo 100.0.toBigDecimal()
+        secondRange.last shouldBeEqualTo 200.0.toBigDecimal()
+
+        val thirdRange = histogram[205.0.toBigDecimal()].shouldNotBeNull().range
+        thirdRange.first shouldBeEqualTo 200.0.toBigDecimal()
+        thirdRange.last shouldBeEqualTo 300.0.toBigDecimal()
     }
 
     @Test

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ComparableHistogramTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ComparableHistogramTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.math
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.collections.repeat
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -18,8 +19,6 @@ class ComparableHistogramTest {
 
     private val valueVector = sequenceOf(0.0, 1.0, 3.0, 5.0, 11.0)
     private val groups = sequenceOf("A", "B", "B", "C", "C")
-
-    private val grouped = groups.zip(valueVector)
 
     @Test
     fun `histogram by comparable number`() {
@@ -41,9 +40,9 @@ class ComparableHistogramTest {
         histogram.bins.size shouldBeEqualTo 3
 
         // range의 어떤 값이던 상관없다 (BinModel.get operator를 보라)
-        histogram[5.0]!!.range shouldBeEqualTo DefaultClosedClosedRange(0.0, 100.0)
-        histogram[105.0]!!.range shouldBeEqualTo DefaultClosedClosedRange(100.0, 200.0)
-        histogram[205.0]!!.range shouldBeEqualTo DefaultClosedClosedRange(200.0, 300.0)
+        histogram[5.0].shouldNotBeNull().range shouldBeEqualTo DefaultClosedClosedRange(0.0, 100.0)
+        histogram[105.0].shouldNotBeNull().range shouldBeEqualTo DefaultClosedClosedRange(100.0, 200.0)
+        histogram[205.0].shouldNotBeNull().range shouldBeEqualTo DefaultClosedClosedRange(200.0, 300.0)
     }
 
     data class Sale(val accountId: Int, val date: LocalDate, val value: Double)
@@ -70,7 +69,7 @@ class ComparableHistogramTest {
             log.debug { it }
         }
 
-        byQuarter[Month.MAY]!!.value shouldBeEqualTo listOf(sales[4])
+        byQuarter[Month.MAY].shouldNotBeNull().value shouldBeEqualTo listOf(sales[4])
     }
 
     @Test
@@ -93,7 +92,7 @@ class ComparableHistogramTest {
             groupOp = { list -> list.asSequence().map { it.value }.sum() }
         )
         byQuarter.forEach { log.trace { it } }
-        byQuarter[Month.MAY]!!.value shouldBeEqualTo 137.9
+        byQuarter[Month.MAY].shouldNotBeNull().value shouldBeEqualTo 137.9
     }
 
     @Test
@@ -116,7 +115,7 @@ class ComparableHistogramTest {
             rangeStart = 100.0
         )
         binned.forEach { log.trace { it } }
-        binned[110.0]!!.value shouldContain sales[2]
+        binned[110.0].shouldNotBeNull().value shouldContain sales[2]
     }
 
     @Test
@@ -129,5 +128,38 @@ class ComparableHistogramTest {
         assertFailsWith<IllegalArgumentException> {
             values.binByComparable(incrementer = { it - 1 }, valueMapper = { it })
         }
+    }
+
+    @Test
+    fun `binByComparable rejects empty input`() {
+        assertFailsWith<IllegalArgumentException> {
+            emptyList<Int>().binByComparable(incrementer = { it + 1 }, valueMapper = { it })
+        }
+    }
+
+    @Test
+    fun `binByComparable keeps duplicate values in the same bin`() {
+        val values = listOf(1, 1, 2)
+
+        val histogram = values.binByComparable(
+            incrementer = { it + 2 },
+            valueMapper = { it },
+            rangeStart = 1,
+        )
+
+        histogram[1].shouldNotBeNull().value shouldBeEqualTo values
+    }
+
+    @Test
+    fun `sequence binning supports single use sequences`() {
+        val histogram = sequenceOf(1, 1, 2)
+            .constrainOnce()
+            .binByComparable(
+                incrementer = { it + 2 },
+                valueMapper = { it },
+                rangeStart = 1,
+            )
+
+        histogram[1].shouldNotBeNull().value shouldBeEqualTo listOf(1, 1, 2)
     }
 }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/NumberStatisticsTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/NumberStatisticsTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.math
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.math.model.Gender.FEMALE
@@ -10,7 +11,6 @@ import io.bluetape4k.math.model.Patient
 import io.bluetape4k.math.model.SaleDate
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import kotlin.test.assertTrue
 
 class NumberStatisticsTest {
 
@@ -40,16 +40,16 @@ class NumberStatisticsTest {
     fun `verify descriptiveBy`() {
         vectors.forEach { vector ->
             groups.zip(vector).descriptiveStatisticsBy().let {
-                assertTrue { it["A"]!!.mean == 2.0 && it["B"]!!.mean == 8.0 }
+                it["A"].shouldNotBeNull().mean shouldBeEqualTo 2.0
+                it["B"].shouldNotBeNull().mean shouldBeEqualTo 8.0
             }
 
             val ziped = groups.zip(vector).descriptiveStatisticsBy(
                 keySelector = { it.first },
                 valueMapper = { it.second }
             )
-            // assertTrue { it["A"]!!.mean == 2.0 && it["B"]!!.mean == 8.0 }
-            ziped["A"]!!.mean shouldBeEqualTo 2.0
-            ziped["B"]!!.mean shouldBeEqualTo 8.0
+            ziped["A"].shouldNotBeNull().mean shouldBeEqualTo 2.0
+            ziped["B"].shouldNotBeNull().mean shouldBeEqualTo 8.0
         }
     }
 
@@ -73,7 +73,8 @@ class NumberStatisticsTest {
     fun `medianBy for vector`() {
         vectors.forEach { vector ->
             groups.zip(vector).medianBy().let {
-                assertTrue { it["A"]!! == 2.0 && it["B"]!! == 8.0 }
+                it["A"] shouldBeEqualTo 2.0
+                it["B"] shouldBeEqualTo 8.0
             }
 
             val ziped = groups.zip(vector).medianBy(
@@ -204,8 +205,8 @@ class NumberStatisticsTest {
 
         vectors.forEach { vector ->
             val norm = groups.zip(vector).normalizeBy()
-            norm["A"]!! shouldBeEqualTo expected["A"]!!
-            norm["B"]!! shouldBeEqualTo expected["B"]!!
+            norm["A"].shouldNotBeNull() shouldBeEqualTo expected["A"].shouldNotBeNull()
+            norm["B"].shouldNotBeNull() shouldBeEqualTo expected["B"].shouldNotBeNull()
         }
     }
 

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/commons/RankingTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/commons/RankingTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.math.commons
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace
 import org.apache.commons.math3.stat.ranking.NaNStrategy
@@ -30,11 +31,11 @@ class RankingTest {
 
         val scoreAndRanks = scores.ranking()
 
-        scoreAndRanks[Double.POSITIVE_INFINITY]!! shouldBeEqualTo 0
-        scoreAndRanks[50.0]!! shouldBeEqualTo 1
-        scoreAndRanks[20.0]!! shouldBeEqualTo 4
-        scoreAndRanks[Double.NaN]!! shouldBeEqualTo 8
-        scoreAndRanks[Double.NEGATIVE_INFINITY]!! shouldBeEqualTo 8
+        scoreAndRanks[Double.POSITIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 0
+        scoreAndRanks[50.0].shouldNotBeNull() shouldBeEqualTo 1
+        scoreAndRanks[20.0].shouldNotBeNull() shouldBeEqualTo 4
+        scoreAndRanks[Double.NaN].shouldNotBeNull() shouldBeEqualTo 8
+        scoreAndRanks[Double.NEGATIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 8
     }
 
     @Test
@@ -48,11 +49,38 @@ class RankingTest {
         scoreAndRanks.forEach {
             log.trace { "score=${it.key}, rank=${it.value}" }
         }
-        scoreAndRanks[Double.POSITIVE_INFINITY]!! shouldBeEqualTo 0
-        scoreAndRanks[50.0]!! shouldBeEqualTo 1
-        scoreAndRanks[20.0]!! shouldBeEqualTo 4
-        scoreAndRanks[Double.NaN]!! shouldBeEqualTo 8
-        scoreAndRanks[Double.NEGATIVE_INFINITY]!! shouldBeEqualTo 8
+        scoreAndRanks[Double.POSITIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 0
+        scoreAndRanks[50.0].shouldNotBeNull() shouldBeEqualTo 1
+        scoreAndRanks[20.0].shouldNotBeNull() shouldBeEqualTo 4
+        scoreAndRanks[Double.NaN].shouldNotBeNull() shouldBeEqualTo 8
+        scoreAndRanks[Double.NEGATIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 8
+    }
+
+    @Test
+    fun `ranking supports single use sequences`() {
+        sequenceOf(30.0, 10.0, 20.0).constrainOnce().ranking() shouldBeEqualTo mapOf(
+            30.0 to 0,
+            10.0 to 2,
+            20.0 to 1,
+        )
+
+        data class Student(val name: String, val score: Double)
+        val students = sequenceOf(
+            Student("Alice", 90.0),
+            Student("Bob", 70.0),
+            Student("Charlie", 80.0),
+        ).constrainOnce()
+
+        var selectorCalls = 0
+        students.ranking {
+            selectorCalls++
+            it.score
+        } shouldBeEqualTo mapOf(
+            Student("Alice", 90.0) to 0,
+            Student("Bob", 70.0) to 2,
+            Student("Charlie", 80.0) to 1,
+        )
+        selectorCalls shouldBeEqualTo 3
     }
 
     @Test
@@ -64,8 +92,8 @@ class RankingTest {
         scoreAndRanks.forEach {
             log.trace { "score=${it.key}, rank=${it.value}" }
         }
-        scoreAndRanks[50.0.toBigDecimal()]!! shouldBeEqualTo 0
-        scoreAndRanks[20.0.toBigDecimal()]!! shouldBeEqualTo 3
+        scoreAndRanks[50.0.toBigDecimal()].shouldNotBeNull() shouldBeEqualTo 0
+        scoreAndRanks[20.0.toBigDecimal()].shouldNotBeNull() shouldBeEqualTo 3
     }
 
     // ----- Iterable.ranking -----
@@ -82,9 +110,9 @@ class RankingTest {
             log.trace { "score=${it.key}, rank=${it.value}" }
         }
 
-        scoreAndRanks[Double.POSITIVE_INFINITY]!! shouldBeEqualTo 0
-        scoreAndRanks[50.0]!! shouldBeEqualTo 1
-        scoreAndRanks[20.0]!! shouldBeEqualTo 4
+        scoreAndRanks[Double.POSITIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 0
+        scoreAndRanks[50.0].shouldNotBeNull() shouldBeEqualTo 1
+        scoreAndRanks[20.0].shouldNotBeNull() shouldBeEqualTo 4
     }
 
     @Test
@@ -105,5 +133,23 @@ class RankingTest {
         rankMap[students[0]] shouldBeEqualTo 0  // Alice (90) - 1위
         rankMap[students[1]] shouldBeEqualTo 2  // Bob (70) - 3위
         rankMap[students[2]] shouldBeEqualTo 1  // Charlie (80) - 2위
+    }
+
+    @Test
+    fun `ranking empty and duplicate values`() {
+        emptyList<Double>().ranking() shouldBeEqualTo emptyMap<Double, Int>()
+
+        data class Student(val name: String, val score: Double)
+        val students = listOf(
+            Student("Alice", 90.0),
+            Student("Bob", 90.0),
+            Student("Charlie", 80.0),
+        )
+
+        val rankMap = students.ranking { it.score }
+
+        rankMap[students[0]] shouldBeEqualTo 0
+        rankMap[students[1]] shouldBeEqualTo 0
+        rankMap[students[2]] shouldBeEqualTo 2
     }
 }


### PR DESCRIPTION
## Summary

Closes #1498

Epic #1492의 infra child로 `infra/lettuce`, `infra/redisson` 테스트와 FairLock nullable 경계를 `bluetape4k-assertions` 및 `bluetape-kotlin-patterns` 기준에 맞춥니다. 이 PR은 stacked train의 다음 단계이며, base는 `refactor/epic-1492-cache`입니다. Epic의 모든 child가 검증될 때까지 merge하지 않습니다.

## Work Done

- `FairLockScript`의 이미 확인한 `waiterIdentity`를 local binding으로 재사용해 `get()!!`를 제거하고 비동기·suspend cleanup 의미를 유지했습니다.
- `assertFailsWith`와 identity assertion을 `bluetape4k-assertions`로 통일했습니다.
- map/latch polling loop와 `Thread.sleep`을 Awaitility의 bounded `until`로 전환했습니다.
- latch의 모든 `Future.get()` 대기를 명시적 timeout으로 제한하고 cancellation을 `CancellationException`으로 검증했습니다.
- production API, dependency, Gradle, CI 설정은 변경하지 않았습니다.

## 7-Tier Review

- Tier 1 성능: 고정 sleep과 unbounded wait 제거, 모든 polling/future 경계 bounded.
- Tier 2 안정성: nullable boundary, cancellation, cleanup, Redis resource close를 확인.
- Tier 3 보안: token/payload/logging 및 serialization 경계 변경 없음.
- Tier 4 운영: Redis/Testcontainers 순차 실행과 실패 원인을 분리 기록.
- Tier 5 개발자/API: Bluetape assertions와 Kotlin nullable/testing patterns 적용.
- Tier 6 호출자: 기존 Lock/Latch 결과·예외 계약과 caller-visible semantics 유지.
- Tier 7 통합: stacked base/head, issue metadata, module registration 및 CI 범위 확인.

독립 code-reviewer는 6개 파일에서 P0/P1/P2/P3 신규 finding 0, `APPROVE`를 반환했습니다. 독립 architect는 현재 회귀가 없는 `WATCH`로 판정했으며, 기존 async cleanup 관찰성 및 `runTest`/blocking `Future.get` 경계는 별도 P2 follow-up으로 남겼습니다.

## Validation

- `:bluetape4k-lettuce:compileTestKotlin`: PASS
- `:bluetape4k-redisson:compileTestKotlin`: PASS
- Lettuce affected targeted classes: 55 passing
- `RedissonCacheConfigTest`: 3 passing
- Full Redisson module: 316 tests, 0 failures/errors/skips
- Affected `:bluetape4k-lettuce:detekt :bluetape4k-redisson:detekt`: BUILD SUCCESSFUL; changed-scope 신규 finding 없음. `FairLockScript`의 기존 `TooManyFunctions` baseline은 유지.
- `git diff --check`: PASS

전체 Lettuce 실행은 920건 중 917건이 통과했고, 변경 범위 밖의 세 lease/lock 테스트가 실패했습니다. `LettuceMultiLockTest`(6건)와 `LettuceMultiKeyLeaseScriptTest`(11건)는 격리 실행에서 통과했으며, `LettuceMultiKeyLeaseConcurrencyTest`의 `Malformed multi-key lease response`는 단독 실행에서도 line 133에서 재현됩니다. 세 테스트와 production lease 코드 모두 이번 diff에 포함되지 않았습니다.

현재 PR check는 비어 있습니다. 저장소의 `ci.yml`/`examples.yml` pull request trigger가 base `develop`/`main`만 허용하고 있어 custom stacked base에서는 자동 라우팅되지 않는 기존 CI 계약입니다. 이 PR에서는 workflow dispatch나 CI 설정 변경을 수행하지 않았으며, exact-head CI는 PENDING으로 유지합니다.

## Metadata

- Issue: #1498, parent Epic #1492
- Base: `refactor/epic-1492-cache` (PR #1511 head)
- Head: `refactor/epic-1492-infra`, commit `6369914f5c`
- Labels/milestone/assignee: Issue #1498과 동일하게 `test`, `infra/io`, `refactoring`, `tech-debt`, `2.0.0`, `debop`

## DoD Status

Final status: DONE — PR #1514 `MERGED`; linked Issue #1498 `CLOSED`.

| Gate | Status | Evidence |
|---|---|---|
| 7-Tier review / Kotlin patterns / bluetape4k-assertions | PASS | 기존 독립 review와 모듈 검증 증거 보존; P0/P1=0. |
| PR exact head·base·metadata | PASS | live head `76007a4ba46d9e4a882a75810eaa6a7a3ad2dece`, base `refactor/epic-1492-cache`, merge commit `17e6e6ed9a6fa2667c15f005e3452f9463b00393`, assignee/labels/milestone read-back. |
| Exact-head CI | PASS (cumulative) — custom stacked-base PR의 standalone check를 소급해 주장하지 않고, 최종 PR #1511 exact head의 CI run `32938020302` 및 post-merge develop CI [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882)로 누적 변경을 검증했다. |
| Merge verification | PASS | merged at `2026-08-26T06:24:25Z`; GitHub state `MERGED`. |
| Canonical sync | PASS | canonical `develop`와 `origin/develop`가 `4a843fe402647ec76a28e8fc1d076a0e1ff422be`로 일치. |
| Post-merge develop CI | PASS | [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882): 16 success, 5 intentional path-filter skip, 0 failure. |

Unchecked required items: 없음
