### PR TITLE
[7-Tier][spring-boot/core] assertion·nullable·DataBuffer 계약 정리

### DIFF
--- a/bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/KotlinLoggingTest.kt
+++ b/bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/KotlinLoggingTest.kt
@@ -2,14 +2,15 @@ package io.bluetape4k.logging
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 class KotlinLoggingTest {
 
     private val log = KotlinLogging.logger {}
 
-    private val loggerName = KotlinLoggingTest::class.qualifiedName!!
+    private val loggerName = KotlinLoggingTest::class.qualifiedName.shouldNotBeNull()
 
     @Test
     fun `logging trace`() {
@@ -43,6 +44,6 @@ class KotlinLoggingTest {
         class LocalClass
 
         val logger = KotlinLogging.logger(LocalClass::class)
-        assertTrue(logger.name.isNotBlank())
+        logger.name.isNotBlank().shouldBeTrue()
     }
 }

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupport.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupport.kt
@@ -1,10 +1,7 @@
 package io.bluetape4k.spring.beans
 
 import io.bluetape4k.support.requireNotBlank
-import io.bluetape4k.utils.KotlinDelegates
-import org.springframework.beans.BeanInstantiationException
 import org.springframework.beans.BeanUtils
-import org.springframework.core.KotlinDetector
 import org.springframework.core.MethodParameter
 import java.beans.PropertyDescriptor
 import java.lang.reflect.Constructor
@@ -28,8 +25,8 @@ fun <T: Any> Class<T>.instantiateClass(): T = BeanUtils.instantiateClass(this)
  * 생성자와 인자로 인스턴스를 생성합니다.
  *
  * ## 동작/계약
- * - Kotlin 타입이면 [KotlinDelegates.instantiateClass], 아니면 [BeanUtils.instantiateClass]를 사용합니다.
- * - 생성 과정 예외는 [BeanInstantiationException]으로 감싸서 던집니다.
+ * - Kotlin 기본값/nullable 인자를 포함한 생성은 Spring의 Kotlin-aware [BeanUtils.instantiateClass]에 위임합니다.
+ * - Spring이 제공하는 [org.springframework.beans.BeanInstantiationException]과 원인 예외를 그대로 전파합니다.
  *
  * ```kotlin
  * val ctor = MyType::class.java.getDeclaredConstructor(String::class.java)
@@ -38,18 +35,7 @@ fun <T: Any> Class<T>.instantiateClass(): T = BeanUtils.instantiateClass(this)
  * ```
  */
 fun <T: Any> Constructor<T>.instantiateClass(vararg args: Any?): T =
-    try {
-        when {
-            KotlinDetector.isKotlinType(this.declaringClass) -> {
-                KotlinDelegates.instantiateClass(this, *args)!!
-            }
-            else -> {
-                BeanUtils.instantiateClass(this, *args)
-            }
-        }
-    } catch (e: Exception) {
-        throw BeanInstantiationException(this, "Fail to instantiate", e)
-    }
+    BeanUtils.instantiateClass(this, *args)
 
 /**
  * 수신 클래스로 인스턴스를 생성한 뒤 지정 타입으로 반환합니다.

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupportTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/beans/BeanUtilsSupportTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.spring.AbstractSpringTest
 import org.junit.jupiter.api.Test
+import org.springframework.beans.BeanInstantiationException
 
 class BeanUtilsSupportTest: AbstractSpringTest() {
 
@@ -21,6 +22,8 @@ class BeanUtilsSupportTest: AbstractSpringTest() {
     class DerivedBean: BaseBean() {
         override fun execute(): String = "derived"
     }
+
+    class RequiredArgumentBean(val value: String)
 
     @Test
     fun `instantiateClass - 기본 생성자로 인스턴스 생성`() {
@@ -38,10 +41,22 @@ class BeanUtilsSupportTest: AbstractSpringTest() {
 
     @Test
     fun `Constructor instantiateClass - 인자로 인스턴스 생성`() {
-        val ctor = SampleBean::class.java.getDeclaredConstructor(String::class.java, Int::class.javaPrimitiveType!!)
+        val primitiveInt = Int::class.javaPrimitiveType.shouldNotBeNull()
+        val ctor = SampleBean::class.java.getDeclaredConstructor(String::class.java, primitiveInt)
         val instance = ctor.instantiateClass("test", 42)
         instance.name shouldBeEqualTo "test"
         instance.value shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `Constructor instantiateClass - nullable 인자는 원인과 함께 BeanInstantiationException으로 변환`() {
+        val ctor = RequiredArgumentBean::class.java.getDeclaredConstructor(String::class.java)
+
+        val error = assertFailsWith<BeanInstantiationException> {
+            ctor.instantiateClass(null)
+        }
+
+        error.cause.shouldBeInstanceOf<NullPointerException>()
     }
 
     @Test

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/core/io/buffer/DataBufferSupportTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/core/io/buffer/DataBufferSupportTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.spring.core.io.buffer
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.io.getAllBytes
@@ -16,13 +17,13 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asPublisher
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DefaultDataBufferFactory
 import org.springframework.core.io.buffer.NettyDataBufferFactory
+import org.springframework.core.io.buffer.PooledDataBuffer
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.channels.AsynchronousFileChannel
@@ -84,10 +85,20 @@ class DataBufferSupportTest: AbstractSpringTest() {
     }
 
     @Test
-    fun `Netty의 PooledDataBuffer를 release 하면 false를 반환한다`() {
-        val dataBuffer = nettyBufferFactory.wrap("test".toByteArray())
-        val released = dataBuffer.release()
-        released.shouldBeTrue()
+    fun `Netty의 PooledDataBuffer를 release 하면 소유권을 해제하고 true를 반환한다`() {
+        val dataBuffer = nettyBufferFactory.wrap("test".toByteArray()) as PooledDataBuffer
+        try {
+            dataBuffer.isAllocated.shouldBeTrue()
+
+            val released = dataBuffer.release()
+
+            released.shouldBeTrue()
+            dataBuffer.isAllocated.shouldBeFalse()
+        } finally {
+            if (dataBuffer.isAllocated) {
+                dataBuffer.release()
+            }
+        }
     }
 
     @Test
@@ -247,13 +258,13 @@ class DataBufferSupportTest: AbstractSpringTest() {
     fun `DataBuffer retain은 같은 버퍼를 반환한다`() {
         val buffer = bufferFactory.wrap("test".toByteArray())
         val retained = buffer.retain()
-        assertSame(buffer, retained)
+        retained shouldBeSameInstanceAs buffer
     }
 
     @Test
     fun `DataBuffer touch는 같은 버퍼를 반환한다`() {
         val buffer = bufferFactory.wrap("test".toByteArray())
         val touched = buffer.touch("hint-value")
-        assertSame(buffer, touched)
+        touched shouldBeSameInstanceAs buffer
     }
 }

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/tests/WebClientReadmeExamplesTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/tests/WebClientReadmeExamplesTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.spring.tests
 
+import io.bluetape4k.assertions.should
 import io.bluetape4k.assertions.shouldNotBeNull
 import kotlinx.coroutines.reactive.asFlow
 import org.junit.jupiter.api.Test
@@ -7,7 +8,6 @@ import org.springframework.web.reactive.function.client.WebClient
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.readText
-import kotlin.test.assertTrue
 
 class WebClientReadmeExamplesTest {
 
@@ -20,10 +20,7 @@ class WebClientReadmeExamplesTest {
                     .map { it.value.replace(Regex("\\s+"), " ") }
                     .toList()
 
-            assertTrue(
-                actual = matches.isEmpty(),
-                message = "$fileName should not chain .retrieve() after httpGet/httpPost: $matches",
-            )
+            matches.should("$fileName should not chain .retrieve() after httpGet/httpPost: $matches") { it.isEmpty() }
         }
     }
 

--- a/utils/geo/src/test/kotlin/io/bluetape4k/geo/GeoReadmeContractTest.kt
+++ b/utils/geo/src/test/kotlin/io/bluetape4k/geo/GeoReadmeContractTest.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.geo
 
+import io.bluetape4k.assertions.fail
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.readText
-import kotlin.test.assertFalse
 
 class GeoReadmeContractTest {
 
@@ -12,10 +12,9 @@ class GeoReadmeContractTest {
     fun `README examples use current public APIs and consumer coordinates`() {
         readmeTexts().forEach { (filename, text) ->
             forbiddenFragments.forEach { fragment ->
-                assertFalse(
-                    text.contains(fragment),
-                    "$filename must not contain stale or internal reference: $fragment",
-                )
+                if (text.contains(fragment)) {
+                    fail("$filename must not contain stale or internal reference: $fragment")
+                }
             }
         }
     }

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/flake/FlakeTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/flake/FlakeTest.kt
@@ -21,8 +21,10 @@ import org.junit.jupiter.api.condition.JRE
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 class FlakeTest {
 
@@ -90,12 +92,16 @@ class FlakeTest {
 
     @Test
     fun `1 msec 이 지나면 sequence는 리셋되어야 합니다`() {
-        val seq1 = flake.nextId().copyOfRange(14, 15)
-        Thread.sleep(10)
-        val seq2 = flake.nextId().copyOfRange(14, 15)
+        val initialMillis = 1_700_000_000_000L
+        val clock = MutableClock(initialMillis)
+        val customFlake = Flake({ 123456789L }, clock)
 
-        // 1 msec 이 지나면 sequence가 리셋되어야 합니다.
-        seq2 shouldBeEqualTo seq1
+        val first = customFlake.nextId()
+        clock.advanceBy(Duration.ofMillis(1))
+        val second = customFlake.nextId()
+
+        Flake.asComponentString(first) shouldBeEqualTo "$initialMillis-123456789-1"
+        Flake.asComponentString(second) shouldBeEqualTo "${initialMillis + 1}-123456789-0"
     }
 
     @Test
@@ -153,5 +159,23 @@ class FlakeTest {
                 idMaps.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+    }
+
+    private class MutableClock(
+        private val currentMillis: AtomicLong,
+        private val zone: ZoneId,
+    ): Clock() {
+
+        constructor(initialMillis: Long): this(AtomicLong(initialMillis), ZoneOffset.UTC)
+
+        override fun getZone(): ZoneId = zone
+
+        override fun withZone(zone: ZoneId): Clock = MutableClock(currentMillis, zone)
+
+        override fun instant(): Instant = Instant.ofEpochMilli(currentMillis.get())
+
+        fun advanceBy(duration: Duration) {
+            currentMillis.addAndGet(duration.toMillis())
+        }
     }
 }

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/snowflake/AbstractSnowflakeTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/snowflake/AbstractSnowflakeTest.kt
@@ -177,6 +177,8 @@ abstract class AbstractSnowflakeTest {
         val snowflakeId1 = snowflake.parse(id1)
         val snowflakeId2 = snowflake.parse(id2)
 
+        // 의도적 tick 경계 지연: Default/GlobalSequencer가 System.currentTimeMillis()를 직접 읽고
+        // 주입 가능한 clock을 노출하지 않으므로 sequencer timestamp 계약 검증에서만 유지합니다.
         Thread.sleep(1L)
         val id3 = snowflake.nextId()
         val snowflakeId3 = snowflake.parse(id3)
@@ -211,6 +213,8 @@ abstract class AbstractSnowflakeTest {
     fun `parse snowflake id as string`() {
         val id1 = snowflake.nextIdAsString()
         val id2 = snowflake.nextIdAsString()
+        // 의도적 tick 경계 지연: Default/GlobalSequencer가 System.currentTimeMillis()를 직접 읽고
+        // 주입 가능한 clock을 노출하지 않으므로 sequencer timestamp 계약 검증에서만 유지합니다.
         Thread.sleep(1L)
         val id3 = snowflake.nextIdAsString()
         val id4 = snowflake.nextIdAsString()

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/base62/AbstractTimebasedUuidBase62Test.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/base62/AbstractTimebasedUuidBase62Test.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.idgenerators.uuid.base62
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContainSame
 import io.bluetape4k.codec.decodeBase62AsUuid
 import io.bluetape4k.codec.encodeBase62
@@ -21,7 +22,6 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.test.assertTrue
 
 abstract class AbstractTimebasedUuidBase62Test {
 
@@ -43,8 +43,8 @@ abstract class AbstractTimebasedUuidBase62Test {
             log.debug { "uuid=$it" }
         }
 
-        assertTrue { u2 > u1 }
-        assertTrue { u3 > u2 }
+        (u2 > u1).shouldBeTrue()
+        (u3 > u2).shouldBeTrue()
 
         // u1.version() shouldBeEqualTo 6   // Time based
     }

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/timebased/AbstractTimebasedUuidTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/timebased/AbstractTimebasedUuidTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.idgenerators.uuid.timebased
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContainSame
 import io.bluetape4k.idgenerators.IdGenerator
 import io.bluetape4k.idgenerators.hashids.Hashids
@@ -19,7 +20,6 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.test.assertTrue
 
 abstract class AbstractTimebasedUuidTest {
 
@@ -41,8 +41,8 @@ abstract class AbstractTimebasedUuidTest {
             log.debug { "uuid=$it" }
         }
 
-        assertTrue { u2 > u1 }
-        assertTrue { u3 > u2 }
+        (u2 > u1).shouldBeTrue()
+        (u3 > u2).shouldBeTrue()
 
         // u1.version() shouldBeEqualTo 6   // Time based
     }

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/interval/TemporalIntervalWindowedTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/interval/TemporalIntervalWindowedTest.kt
@@ -3,16 +3,16 @@ package io.bluetape4k.javatimes.interval
 import io.bluetape4k.javatimes.nowZonedDateTime
 import io.bluetape4k.javatimes.startOf
 import io.bluetape4k.javatimes.temporalAmount
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.trace
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
-import org.junit.jupiter.api.Assertions
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.trace
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.time.temporal.ChronoUnit
-import io.bluetape4k.assertions.assertFailsWith
 
 class TemporalIntervalWindowedTest {
 
@@ -35,8 +35,8 @@ class TemporalIntervalWindowedTest {
             chunks.forEachIndexed { index, chunk ->
                 log.trace { "chunks[$index] = $chunk" }
                 chunk.size shouldBeLessOrEqualTo 4
-                Assertions.assertTrue { chunk.first() in interval }
-                Assertions.assertTrue { chunk.last() in interval }
+                (chunk.first() in interval).shouldBeTrue()
+                (chunk.last() in interval).shouldBeTrue()
             }
 
             chunks.size shouldBeEqualTo 2
@@ -71,7 +71,7 @@ class TemporalIntervalWindowedTest {
             chunks.size shouldBeEqualTo 2
             chunks.forEach {
                 log.trace { "chunk=$it" }
-                Assertions.assertTrue { it in interval }
+                (it in interval).shouldBeTrue()
             }
         }
     }
@@ -93,8 +93,8 @@ class TemporalIntervalWindowedTest {
             windowed.forEachIndexed { index, items ->
                 log.trace { "index=$index, items=$items" }
 
-                Assertions.assertTrue { items.first() in interval }
-                Assertions.assertTrue { items.last() in interval }
+                (items.first() in interval).shouldBeTrue()
+                (items.last() in interval).shouldBeTrue()
             }
             windowed.count() shouldBeEqualTo 3
 
@@ -130,9 +130,9 @@ class TemporalIntervalWindowedTest {
             zipWithNext.count() shouldBeEqualTo 4
             zipWithNext.forEach { (current, next) ->
                 log.trace { "current=$current, next=$next" }
-                kotlin.test.assertTrue { current in interval }
-                kotlin.test.assertTrue { next in interval }
-                kotlin.test.assertTrue { current < next }
+                (current in interval).shouldBeTrue()
+                (next in interval).shouldBeTrue()
+                (current < next).shouldBeTrue()
             }
         }
     }

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/ranges/DayRangeCollectionTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/ranges/DayRangeCollectionTest.kt
@@ -8,11 +8,10 @@ import io.bluetape4k.javatimes.nowZonedDateTime
 import io.bluetape4k.javatimes.period.AbstractPeriodTest
 import io.bluetape4k.javatimes.startOfDay
 import io.bluetape4k.javatimes.todayZonedDateTime
-import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 class DayRangeCollectionTest: AbstractPeriodTest() {
 
@@ -46,7 +45,7 @@ class DayRangeCollectionTest: AbstractPeriodTest() {
         daySeq.count() shouldBeEqualTo dayCount
 
         daySeq.forEachIndexed { index, dr ->
-            assertTrue { dr.isSamePeriod(DayRange(start + index.days())) }
+            dr.isSamePeriod(DayRange(start + index.days())).shouldBeTrue()
         }
     }
 

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/ranges/QuarterRangeTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/ranges/QuarterRangeTest.kt
@@ -10,13 +10,13 @@ import io.bluetape4k.javatimes.period.TimeCalendar
 import io.bluetape4k.javatimes.startOfQuarter
 import io.bluetape4k.javatimes.startOfYear
 import io.bluetape4k.javatimes.zonedDateTimeOf
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.trace
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.trace
 import org.junit.jupiter.api.Test
 import kotlin.math.absoluteValue
-import kotlin.test.assertTrue
 
 class QuarterRangeTest: AbstractPeriodTest() {
 
@@ -97,7 +97,7 @@ class QuarterRangeTest: AbstractPeriodTest() {
         val calendar = TimeCalendar.EmptyOffset
 
         fun checkQuarters(qr: QuarterRange, quarter: Quarter) {
-            assertTrue(qr.readonly)
+            qr.readonly.shouldBeTrue()
             qr.quarter shouldBeEqualTo quarter
             qr.start shouldBeEqualTo zonedDateTimeOf(nowYear, quarter.startMonth)
 

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/timelines/TimeGapCalculatorTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/timelines/TimeGapCalculatorTest.kt
@@ -15,14 +15,14 @@ import io.bluetape4k.javatimes.period.ranges.DayRangeCollection
 import io.bluetape4k.javatimes.period.ranges.MonthRange
 import io.bluetape4k.javatimes.period.samples.SchoolDay
 import io.bluetape4k.javatimes.zonedDateTimeOf
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEmpty
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
 
 class TimeGapCalculatorTest: AbstractPeriodTest() {
 
@@ -369,27 +369,27 @@ class TimeGapCalculatorTest: AbstractPeriodTest() {
         val gaps2 = calculator.gaps(excludePeriods)
 
         gaps2.size shouldBeEqualTo 3
-        assertTrue { gaps2[0].isSamePeriod(schoolDay.break1) }
-        assertTrue { gaps2[1].isSamePeriod(schoolDay.break2) }
-        assertTrue { gaps2[2].isSamePeriod(schoolDay.break3) }
+        gaps2[0].isSamePeriod(schoolDay.break1).shouldBeTrue()
+        gaps2[1].isSamePeriod(schoolDay.break2).shouldBeTrue()
+        gaps2[2].isSamePeriod(schoolDay.break3).shouldBeTrue()
 
         val testRange3 = TimeRange(schoolDay.lesson1.start, schoolDay.lesson4.end)
         val gaps3 = calculator.gaps(excludePeriods, testRange3)
 
         gaps3.size shouldBeEqualTo 3
-        assertTrue { gaps3[0].isSamePeriod(schoolDay.break1) }
-        assertTrue { gaps3[1].isSamePeriod(schoolDay.break2) }
-        assertTrue { gaps3[2].isSamePeriod(schoolDay.break3) }
+        gaps3[0].isSamePeriod(schoolDay.break1).shouldBeTrue()
+        gaps3[1].isSamePeriod(schoolDay.break2).shouldBeTrue()
+        gaps3[2].isSamePeriod(schoolDay.break3).shouldBeTrue()
 
         val testRange4 = TimeRange(schoolDay.start - 1.hours(), schoolDay.end + 1.hours())
         val gaps4 = calculator.gaps(excludePeriods, testRange4)
 
         gaps4.size shouldBeEqualTo 5
-        assertTrue { gaps4[0].isSamePeriod(TimeRange(testRange4.start, schoolDay.start)) }
-        assertTrue { gaps4[1].isSamePeriod(schoolDay.break1) }
-        assertTrue { gaps4[2].isSamePeriod(schoolDay.break2) }
-        assertTrue { gaps4[3].isSamePeriod(schoolDay.break3) }
-        assertTrue { gaps4[4].isSamePeriod(TimeRange(schoolDay.end, testRange4.end)) }
+        gaps4[0].isSamePeriod(TimeRange(testRange4.start, schoolDay.start)).shouldBeTrue()
+        gaps4[1].isSamePeriod(schoolDay.break1).shouldBeTrue()
+        gaps4[2].isSamePeriod(schoolDay.break2).shouldBeTrue()
+        gaps4[3].isSamePeriod(schoolDay.break3).shouldBeTrue()
+        gaps4[4].isSamePeriod(TimeRange(schoolDay.end, testRange4.end)).shouldBeTrue()
 
         excludePeriods.clear()
         excludePeriods += schoolDay.lesson1
@@ -446,18 +446,10 @@ class TimeGapCalculatorTest: AbstractPeriodTest() {
             }
 
             gaps shouldHaveSize 4
-            assertTrue {
-                gaps[0].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 5), 2.days()))
-            }
-            assertTrue {
-                gaps[1].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 9), 1.days()))
-            }
-            assertTrue {
-                gaps[2].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 12), 4.days()))
-            }
-            assertTrue {
-                gaps[3].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 19), 2.days()))
-            }
+            gaps[0].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 5), 2.days())).shouldBeTrue()
+            gaps[1].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 9), 1.days())).shouldBeTrue()
+            gaps[2].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 12), 4.days())).shouldBeTrue()
+            gaps[3].isSamePeriod(TimeRange(zonedDateTimeOf(2018, 3, 19), 2.days())).shouldBeTrue()
         }
     }
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/AbstractKeyChainRepositoryTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/AbstractKeyChainRepositoryTest.kt
@@ -6,11 +6,11 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.jwt.keychain.repository.KeyChainRepository
 import io.bluetape4k.logging.KLogging
+import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
-import kotlin.test.assertTrue
 
 abstract class AbstractKeyChainRepositoryTest {
 
@@ -51,8 +51,9 @@ abstract class AbstractKeyChainRepositoryTest {
         repository.rotate(prevKeyChain).shouldBeTrue()
         repository.current() shouldBeEqualTo prevKeyChain
 
-        Thread.sleep(10)
-        assertTrue { prevKeyChain.createdAt + 1 < System.currentTimeMillis() }
+        // 실제 TTL 만료 경계를 검증하므로 wall-clock 대기를 유지합니다.
+        awaitExpired(prevKeyChain)
+        (prevKeyChain.createdAt + 1 < System.currentTimeMillis()).shouldBeTrue()
 
         // 기존 key chain 이 만료되었으므로 rotate 되어야 한다 
         val newKeyChain = KeyChain()
@@ -87,16 +88,16 @@ abstract class AbstractKeyChainRepositoryTest {
         val keyChain = KeyChain(expiredTtl = Duration.ZERO)
         repository.rotate(keyChain).shouldBeTrue()
 
-        Thread.sleep(10)
         repository.rotate(keyChain).shouldBeFalse()
     }
 
     @Test
     fun `current KeyChain이 가장 최신이어야 한다`() {
-        repository.rotate(KeyChain(expiredTtl = Duration.ofMillis(1))).shouldBeTrue()
-        Thread.sleep(1)
-        repository.rotate(KeyChain(expiredTtl = Duration.ofMillis(1))).shouldBeTrue()
-        Thread.sleep(1)
+        val firstKeyChain = alreadyExpiredKeyChain()
+        repository.rotate(firstKeyChain).shouldBeTrue()
+
+        val secondKeyChain = alreadyExpiredKeyChain()
+        repository.rotate(secondKeyChain).shouldBeTrue()
 
         val newestKeyChain = KeyChain(expiredTtl = Duration.ZERO)
         repository.rotate(newestKeyChain).shouldBeTrue()
@@ -106,12 +107,11 @@ abstract class AbstractKeyChainRepositoryTest {
 
     @Test
     fun `read KeyChain by id`() {
-        repository.rotate(KeyChain(expiredTtl = Duration.ofMillis(1))).shouldBeTrue()
-        Thread.sleep(1)
+        val expiredKeyChain = alreadyExpiredKeyChain()
+        repository.rotate(expiredKeyChain).shouldBeTrue()
 
         val keyChain = KeyChain(expiredTtl = Duration.ZERO)
         repository.rotate(keyChain).shouldBeTrue()
-        Thread.sleep(1)
 
         repository.rotate(KeyChain(expiredTtl = Duration.ZERO)).shouldBeFalse()
 
@@ -123,8 +123,8 @@ abstract class AbstractKeyChainRepositoryTest {
     fun `capacity 이상으로 rotate를 하면, 오래된 것은 삭제된다`() {
 
         repeat(repository.capacity * 2) {
-            repository.rotate(KeyChain(expiredTtl = Duration.ofMillis(1))).shouldBeTrue()
-            Thread.sleep(2)
+            val expiredKeyChain = alreadyExpiredKeyChain()
+            repository.rotate(expiredKeyChain).shouldBeTrue()
         }
 
         val keyChain = KeyChain()
@@ -145,4 +145,14 @@ abstract class AbstractKeyChainRepositoryTest {
 
         repository.current() shouldBeEqualTo keyChain
     }
+
+    protected fun awaitExpired(keyChain: KeyChain) {
+        await.atMost(Duration.ofSeconds(1)).until { keyChain.isExpired }
+    }
+
+    protected fun alreadyExpiredKeyChain(): KeyChain =
+        KeyChain(
+            createdAt = System.currentTimeMillis() - 1_000,
+            expiredTtl = Duration.ofMillis(1),
+        )
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/keychain/redis/RedisKeyChainRepositoryTest.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.jwt.keychain.redis
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.assertFailsWith
@@ -16,6 +18,7 @@ import io.bluetape4k.testcontainers.storage.RedisServer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
 import org.redisson.Redisson
 import org.redisson.api.RDeque
@@ -26,8 +29,6 @@ import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import kotlin.test.assertNull
-import kotlin.test.assertSame
 
 class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
 
@@ -49,9 +50,14 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         every { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) } returns true
         every { lock.isHeldByCurrentThread } returns true
 
-        RedisKeyChainRepository(redisson).forcedRotate(KeyChain()).shouldBeTrue()
+        val repository = RedisKeyChainRepository(redisson)
+        try {
+            repository.forcedRotate(KeyChain()).shouldBeTrue()
 
-        verify(exactly = 1) { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) }
+            verify(exactly = 1) { lock.tryLock(REDIS_ROTATION_LOCK_WAIT_SECONDS, TimeUnit.SECONDS) }
+        } finally {
+            repository.close()
+        }
     }
 
     @Test
@@ -80,8 +86,8 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             withRedisRotationLock(lock) { throw primaryFailure }
         }
 
-        assertSame(primaryFailure, failure)
-        assertSame(unlockFailure, failure.suppressed.single())
+        failure shouldBeSameInstanceAs primaryFailure
+        failure.suppressed.single() shouldBeSameInstanceAs unlockFailure
     }
 
     @Test
@@ -89,23 +95,31 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         val firstClient = createWatchdogClient()
         val secondClient = createWatchdogClient()
         val lockName = "test:jwt:keychain:watchdog:${UUID.randomUUID()}"
-        val ownerLock = LeaseCappingLock(firstClient.getLock(lockName), 250)
+        val ownerLock = firstClient.getLock(lockName)
         val contenderLock = secondClient.getLock(lockName)
         val started = CountDownLatch(1)
+        val releaseCommit = CountDownLatch(1)
         val executor = Executors.newSingleThreadExecutor()
 
         try {
             val result = executor.submit<Boolean> {
                 withRedisRotationLock(ownerLock) {
                     started.countDown()
-                    Thread.sleep(1_200)
+                    releaseCommit.await(5, TimeUnit.SECONDS).shouldBeTrue()
                     true
                 }
             }
 
             started.await(5, TimeUnit.SECONDS).shouldBeTrue()
-            Thread.sleep(600)
-            contenderLock.tryLock(100, TimeUnit.MILLISECONDS).shouldBeFalse()
+            // watchdog timeout(900ms)을 넘는 동안 contender가 lock을 얻지 못해야 갱신이 증명됩니다.
+            await.during(Duration.ofMillis(1_200)).until {
+                val acquired = contenderLock.tryLock(100, TimeUnit.MILLISECONDS)
+                if (acquired) {
+                    contenderLock.unlock()
+                }
+                !acquired
+            }
+            releaseCommit.countDown()
             result.get(5, TimeUnit.SECONDS).shouldBeTrue()
 
             contenderLock.tryLock(1, TimeUnit.SECONDS).shouldBeTrue()
@@ -113,6 +127,7 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             if (contenderLock.isHeldByCurrentThread) {
                 contenderLock.unlock()
             }
+            releaseCommit.countDown()
             executor.shutdownNow()
             firstClient.shutdown()
             secondClient.shutdown()
@@ -127,9 +142,8 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         val secondNode = RedisKeyChainRepository(redisson, queueName = queueName)
 
         try {
-            val expiredKeyChain = KeyChain(expiredTtl = Duration.ofMillis(1))
+            val expiredKeyChain = alreadyExpiredKeyChain()
             seedRepository.forcedRotate(expiredKeyChain).shouldBeTrue()
-            Thread.sleep(10)
 
             firstNode.current() shouldBeEqualTo expiredKeyChain
             secondNode.current() shouldBeEqualTo expiredKeyChain
@@ -148,9 +162,15 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             firstNode.current() shouldBeEqualTo winner
             secondNode.current() shouldBeEqualTo winner
             seedRepository.findOrNull(winner.id) shouldBeEqualTo winner
-            assertNull(seedRepository.findOrNull(loser.id))
+            seedRepository.findOrNull(loser.id).shouldBeNull()
         } finally {
-            seedRepository.deleteAll()
+            try {
+                seedRepository.deleteAll()
+            } finally {
+                firstNode.close()
+                secondNode.close()
+                seedRepository.close()
+            }
         }
     }
 
@@ -163,9 +183,8 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
         val executor = Executors.newFixedThreadPool(2)
 
         try {
-            val expiredKeyChain = KeyChain(expiredTtl = Duration.ofMillis(1))
+            val expiredKeyChain = alreadyExpiredKeyChain()
             seedRepository.forcedRotate(expiredKeyChain).shouldBeTrue()
-            Thread.sleep(10)
 
             firstNode.current() shouldBeEqualTo expiredKeyChain
             secondNode.current() shouldBeEqualTo expiredKeyChain
@@ -192,10 +211,16 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             firstNode.current() shouldBeEqualTo winner
             secondNode.current() shouldBeEqualTo winner
             seedRepository.findOrNull(winner.id) shouldBeEqualTo winner
-            assertNull(seedRepository.findOrNull(loser.id))
+            seedRepository.findOrNull(loser.id).shouldBeNull()
         } finally {
             executor.shutdownNow()
-            seedRepository.deleteAll()
+            try {
+                seedRepository.deleteAll()
+            } finally {
+                firstNode.close()
+                secondNode.close()
+                seedRepository.close()
+            }
         }
     }
 
@@ -206,12 +231,4 @@ class RedisKeyChainRepositoryTest: AbstractKeyChainRepositoryTest() {
             },
         )
 
-    private class LeaseCappingLock(
-        private val delegate: RLock,
-        private val cappedLeaseMillis: Long,
-    ): RLock by delegate {
-
-        override fun tryLock(waitTime: Long, leaseTime: Long, unit: TimeUnit): Boolean =
-            delegate.tryLock(waitTime, cappedLeaseMillis, TimeUnit.MILLISECONDS)
-    }
 }

--- a/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProviderTest.kt
+++ b/utils/jwt/src/test/kotlin/io/bluetape4k/jwt/provider/DefaultJwtProviderTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.assertTrue
 
 class DefaultJwtProviderTest: AbstractJwtProviderTest() {
 
@@ -31,12 +30,12 @@ class DefaultJwtProviderTest: AbstractJwtProviderTest() {
             await.atMost(Duration.ofSeconds(2)).until { lifecycleRepository.refreshCount.get() > 0 }
             await.atMost(Duration.ofSeconds(2)).until { hasLiveThread(timerName) }
 
-            assertTrue(lifecycleRepository is AutoCloseable)
-            (lifecycleRepository as AutoCloseable).close()
+            lifecycleRepository.close()
 
             val refreshCountAfterClose = lifecycleRepository.refreshCount.get()
-            Thread.sleep(100)
-            lifecycleRepository.refreshCount.get().shouldBeEqualTo(refreshCountAfterClose)
+            await.during(Duration.ofMillis(100)).until {
+                lifecycleRepository.refreshCount.get() == refreshCountAfterClose
+            }
             await.atMost(Duration.ofSeconds(2)).until { !hasLiveThread(timerName) }
         } finally {
             lifecycleRepository.close()
@@ -56,15 +55,15 @@ class DefaultJwtProviderTest: AbstractJwtProviderTest() {
             await.atMost(Duration.ofSeconds(2)).until { lifecycleRepository.rotateCount.get() > 1 }
             await.atMost(Duration.ofSeconds(2)).until { hasLiveThread(repositoryTimerName) }
 
-            assertTrue(lifecycleProvider is AutoCloseable)
-            (lifecycleProvider as AutoCloseable).close()
+            lifecycleProvider.close()
 
             val rotationCountAfterClose = lifecycleRepository.rotateCount.get()
-            Thread.sleep(100)
-            lifecycleRepository.rotateCount.get().shouldBeEqualTo(rotationCountAfterClose)
+            await.during(Duration.ofMillis(100)).until {
+                lifecycleRepository.rotateCount.get() == rotationCountAfterClose
+            }
             hasLiveThread(repositoryTimerName).shouldBeEqualTo(true)
 
-            (lifecycleRepository as AutoCloseable).close()
+            lifecycleRepository.close()
             await.atMost(Duration.ofSeconds(2)).until { !hasLiveThread(repositoryTimerName) }
         } finally {
             lifecycleProvider.close()

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/ComparableHistogram.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/ComparableHistogram.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.math
 import io.bluetape4k.ranges.DefaultClosedClosedRange
 import io.bluetape4k.ranges.DefaultClosedOpenRange
 import io.bluetape4k.ranges.Range
+import io.bluetape4k.support.requireNotNull
+import io.bluetape4k.support.requirePositiveNumber
 import java.io.Serializable
 
 
@@ -52,13 +54,14 @@ data class BinModel<out T: Any, in C: Comparable<C>>(
  * val model = data.binByComparable(incrementer = { it + 2 }, valueMapper = { it })
  * // model 은 [1,3], [3,5], [5,7], [7,9] 구간의 BinModel
  * ```
+ * 입력 `Sequence`는 한 번만 소비되며, 빈 입력은 `IllegalArgumentException`을 발생시킵니다.
  */
 inline fun <T: Any, C: Comparable<C>> Sequence<T>.binByComparable(
     incrementer: (C) -> C,
     valueMapper: (T) -> C,
     rangeStart: C? = null,
 ): BinModel<List<T>, C> =
-    asIterable().binByComparable(incrementer, valueMapper, rangeStart)
+    toList().binByComparable(incrementer, valueMapper, rangeStart)
 
 /**
  * Iterable을 Comparable 기준으로 히스토그램 구간으로 분류합니다.
@@ -68,6 +71,7 @@ inline fun <T: Any, C: Comparable<C>> Sequence<T>.binByComparable(
  * val model = data.binByComparable(incrementer = { it + 2 }, valueMapper = { it })
  * // model 은 [1,3], [3,5], [5,7], [7,9] 구간의 BinModel
  * ```
+ * 빈 입력은 `IllegalArgumentException`을 발생시킵니다.
  */
 inline fun <T: Any, C: Comparable<C>> Iterable<T>.binByComparable(
     incrementer: (C) -> C,
@@ -103,13 +107,17 @@ inline fun <T: Any, C: Comparable<C>, G: Any> Iterable<T>.binByComparable(
     rangeStart: C? = null,
     endExclusive: Boolean = false,
 ): BinModel<G, C> {
-    require(count() > 0) { "Collection must not be empty." }
+    count().requirePositiveNumber { "Collection must not be empty." }
 
     val groupByC: MutableMap<C, MutableList<T>> = mutableMapOf()
     this.groupByTo(groupByC, valueMapper)
 
-    val minC: C = rangeStart ?: groupByC.keys.minOrNull()!!
-    val maxC: C = groupByC.keys.maxOrNull()!!
+    val minC: C = rangeStart ?: groupByC.keys.minOrNull().requireNotNull {
+        "Collection must not be empty."
+    }
+    val maxC: C = groupByC.keys.maxOrNull().requireNotNull {
+        "Collection must not be empty."
+    }
 
     // Histogram의 막대의 컬렉션을 구성합니다.
     val bins = mutableListOf<Range<C>>()

--- a/utils/math/src/main/kotlin/io/bluetape4k/math/commons/Ranking.kt
+++ b/utils/math/src/main/kotlin/io/bluetape4k/math/commons/Ranking.kt
@@ -15,6 +15,8 @@ import org.apache.commons.math3.stat.ranking.TiesStrategy
  * // result == {30.0 -> 0, 10.0 -> 2, 20.0 -> 1}
  * ```
  *
+ * 입력 `Sequence`는 한 번만 소비하도록 materialize하며, 빈 입력은 빈 map을 반환합니다.
+ *
  * @param nanStrategy 값이 NaN 일 경우의 ranking 전략 (기본: 최소값으로 ranking)
  * @param tiesStrategy 값이 같을 경우 순위 전략 (기본: 높은 순위로 지정)
  * @return 요소별 순위 정보
@@ -23,11 +25,16 @@ fun <T> Sequence<T>.ranking(
     nanStrategy: NaNStrategy = NaNStrategy.MINIMAL,
     tiesStrategy: TiesStrategy = TiesStrategy.MAXIMUM,
 ): Map<T, Int> where T: Number, T: Comparable<T> {
+    val items = toList()
+    if (items.isEmpty()) {
+        return emptyMap()
+    }
+
     val ranks = NaturalRanking(nanStrategy, tiesStrategy)
-        .rank(map { it.toDouble() }.toDoubleArray())
+        .rank(items.map { it.toDouble() }.toDoubleArray())
         .map { it.toInt() }
 
-    return this
+    return items
         .mapIndexed { index, item ->
             item to ranks.size - ranks[index]
         }
@@ -66,6 +73,9 @@ fun <T> Iterable<T>.ranking(
  * // result[Student("A", 90.0)] == 0 (1등)
  * ```
  *
+ * `Sequence`는 한 번만 소비하고 `valueSelector`는 각 요소에 대해 한 번만 호출합니다.
+ * 빈 입력은 빈 map을 반환합니다.
+ *
  * @param valueSelector 순위를 매길 값을 선택할 수 있도록 한다
  * @param nanStrategy 값이 NaN 일 경우의 ranking 전략 (기본: 최소값으로 ranking)
  * @param tiesStrategy 값이 같을 경우 순위 전략 (기본: 높은 순위로 지정)
@@ -76,8 +86,10 @@ inline fun <T, V> Sequence<T>.ranking(
     tiesStrategy: TiesStrategy = TiesStrategy.MAXIMUM,
     crossinline valueSelector: (T) -> V,
 ): Map<T, Int> where V: Number, V: Comparable<V> {
-    val ranks: Map<V, Int> = this.map { valueSelector(it) }.ranking(nanStrategy, tiesStrategy)
-    return this.associateWith { ranks[valueSelector(it)]!! }
+    val items = toList()
+    val selected = items.map { it to valueSelector(it) }
+    val ranks: Map<V, Int> = selected.asSequence().map { it.second }.ranking(nanStrategy, tiesStrategy)
+    return selected.associate { (item, value) -> item to ranks.getValue(value) }
 }
 
 /**

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/BigDecimalHistogramTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/BigDecimalHistogramTest.kt
@@ -2,12 +2,12 @@ package io.bluetape4k.math
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.collections.repeat
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
-import kotlin.test.assertTrue
 
 class BigDecimalHistogramTest {
 
@@ -15,8 +15,6 @@ class BigDecimalHistogramTest {
 
     private val valueVector = sequenceOf(0.0, 1.0, 3.0, 5.0, 11.0).map { it.toBigDecimal() }
     private val groups = sequenceOf("A", "B", "B", "C", "C")
-
-    private val grouped = groups.zip(valueVector)
 
     @Test
     fun `histogram by BigDecimal`() {
@@ -38,21 +36,17 @@ class BigDecimalHistogramTest {
         histogram.bins.size shouldBeEqualTo 3
 
         // range의 어떤 값이던 상관없다 (BinModel.get operator를 보라)
-        assertTrue {
-            histogram[5.0.toBigDecimal()]!!.range.let {
-                it.first == 0.0.toBigDecimal() && it.last == 100.0.toBigDecimal()
-            }
-        }
-        assertTrue {
-            histogram[105.0.toBigDecimal()]!!.range.let {
-                it.first == 100.0.toBigDecimal() && it.last == 200.0.toBigDecimal()
-            }
-        }
-        assertTrue {
-            histogram[205.0.toBigDecimal()]!!.range.let {
-                it.first == 200.0.toBigDecimal() && it.last == 300.0.toBigDecimal()
-            }
-        }
+        val firstRange = histogram[5.0.toBigDecimal()].shouldNotBeNull().range
+        firstRange.first shouldBeEqualTo 0.0.toBigDecimal()
+        firstRange.last shouldBeEqualTo 100.0.toBigDecimal()
+
+        val secondRange = histogram[105.0.toBigDecimal()].shouldNotBeNull().range
+        secondRange.first shouldBeEqualTo 100.0.toBigDecimal()
+        secondRange.last shouldBeEqualTo 200.0.toBigDecimal()
+
+        val thirdRange = histogram[205.0.toBigDecimal()].shouldNotBeNull().range
+        thirdRange.first shouldBeEqualTo 200.0.toBigDecimal()
+        thirdRange.last shouldBeEqualTo 300.0.toBigDecimal()
     }
 
     @Test

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/ComparableHistogramTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/ComparableHistogramTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.math
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.collections.repeat
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -18,8 +19,6 @@ class ComparableHistogramTest {
 
     private val valueVector = sequenceOf(0.0, 1.0, 3.0, 5.0, 11.0)
     private val groups = sequenceOf("A", "B", "B", "C", "C")
-
-    private val grouped = groups.zip(valueVector)
 
     @Test
     fun `histogram by comparable number`() {
@@ -41,9 +40,9 @@ class ComparableHistogramTest {
         histogram.bins.size shouldBeEqualTo 3
 
         // range의 어떤 값이던 상관없다 (BinModel.get operator를 보라)
-        histogram[5.0]!!.range shouldBeEqualTo DefaultClosedClosedRange(0.0, 100.0)
-        histogram[105.0]!!.range shouldBeEqualTo DefaultClosedClosedRange(100.0, 200.0)
-        histogram[205.0]!!.range shouldBeEqualTo DefaultClosedClosedRange(200.0, 300.0)
+        histogram[5.0].shouldNotBeNull().range shouldBeEqualTo DefaultClosedClosedRange(0.0, 100.0)
+        histogram[105.0].shouldNotBeNull().range shouldBeEqualTo DefaultClosedClosedRange(100.0, 200.0)
+        histogram[205.0].shouldNotBeNull().range shouldBeEqualTo DefaultClosedClosedRange(200.0, 300.0)
     }
 
     data class Sale(val accountId: Int, val date: LocalDate, val value: Double)
@@ -70,7 +69,7 @@ class ComparableHistogramTest {
             log.debug { it }
         }
 
-        byQuarter[Month.MAY]!!.value shouldBeEqualTo listOf(sales[4])
+        byQuarter[Month.MAY].shouldNotBeNull().value shouldBeEqualTo listOf(sales[4])
     }
 
     @Test
@@ -93,7 +92,7 @@ class ComparableHistogramTest {
             groupOp = { list -> list.asSequence().map { it.value }.sum() }
         )
         byQuarter.forEach { log.trace { it } }
-        byQuarter[Month.MAY]!!.value shouldBeEqualTo 137.9
+        byQuarter[Month.MAY].shouldNotBeNull().value shouldBeEqualTo 137.9
     }
 
     @Test
@@ -116,7 +115,7 @@ class ComparableHistogramTest {
             rangeStart = 100.0
         )
         binned.forEach { log.trace { it } }
-        binned[110.0]!!.value shouldContain sales[2]
+        binned[110.0].shouldNotBeNull().value shouldContain sales[2]
     }
 
     @Test
@@ -129,5 +128,38 @@ class ComparableHistogramTest {
         assertFailsWith<IllegalArgumentException> {
             values.binByComparable(incrementer = { it - 1 }, valueMapper = { it })
         }
+    }
+
+    @Test
+    fun `binByComparable rejects empty input`() {
+        assertFailsWith<IllegalArgumentException> {
+            emptyList<Int>().binByComparable(incrementer = { it + 1 }, valueMapper = { it })
+        }
+    }
+
+    @Test
+    fun `binByComparable keeps duplicate values in the same bin`() {
+        val values = listOf(1, 1, 2)
+
+        val histogram = values.binByComparable(
+            incrementer = { it + 2 },
+            valueMapper = { it },
+            rangeStart = 1,
+        )
+
+        histogram[1].shouldNotBeNull().value shouldBeEqualTo values
+    }
+
+    @Test
+    fun `sequence binning supports single use sequences`() {
+        val histogram = sequenceOf(1, 1, 2)
+            .constrainOnce()
+            .binByComparable(
+                incrementer = { it + 2 },
+                valueMapper = { it },
+                rangeStart = 1,
+            )
+
+        histogram[1].shouldNotBeNull().value shouldBeEqualTo listOf(1, 1, 2)
     }
 }

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/NumberStatisticsTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/NumberStatisticsTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.math
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.math.model.Gender.FEMALE
@@ -10,7 +11,6 @@ import io.bluetape4k.math.model.Patient
 import io.bluetape4k.math.model.SaleDate
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import kotlin.test.assertTrue
 
 class NumberStatisticsTest {
 
@@ -40,16 +40,16 @@ class NumberStatisticsTest {
     fun `verify descriptiveBy`() {
         vectors.forEach { vector ->
             groups.zip(vector).descriptiveStatisticsBy().let {
-                assertTrue { it["A"]!!.mean == 2.0 && it["B"]!!.mean == 8.0 }
+                it["A"].shouldNotBeNull().mean shouldBeEqualTo 2.0
+                it["B"].shouldNotBeNull().mean shouldBeEqualTo 8.0
             }
 
             val ziped = groups.zip(vector).descriptiveStatisticsBy(
                 keySelector = { it.first },
                 valueMapper = { it.second }
             )
-            // assertTrue { it["A"]!!.mean == 2.0 && it["B"]!!.mean == 8.0 }
-            ziped["A"]!!.mean shouldBeEqualTo 2.0
-            ziped["B"]!!.mean shouldBeEqualTo 8.0
+            ziped["A"].shouldNotBeNull().mean shouldBeEqualTo 2.0
+            ziped["B"].shouldNotBeNull().mean shouldBeEqualTo 8.0
         }
     }
 
@@ -73,7 +73,8 @@ class NumberStatisticsTest {
     fun `medianBy for vector`() {
         vectors.forEach { vector ->
             groups.zip(vector).medianBy().let {
-                assertTrue { it["A"]!! == 2.0 && it["B"]!! == 8.0 }
+                it["A"] shouldBeEqualTo 2.0
+                it["B"] shouldBeEqualTo 8.0
             }
 
             val ziped = groups.zip(vector).medianBy(
@@ -204,8 +205,8 @@ class NumberStatisticsTest {
 
         vectors.forEach { vector ->
             val norm = groups.zip(vector).normalizeBy()
-            norm["A"]!! shouldBeEqualTo expected["A"]!!
-            norm["B"]!! shouldBeEqualTo expected["B"]!!
+            norm["A"].shouldNotBeNull() shouldBeEqualTo expected["A"].shouldNotBeNull()
+            norm["B"].shouldNotBeNull() shouldBeEqualTo expected["B"].shouldNotBeNull()
         }
     }
 

--- a/utils/math/src/test/kotlin/io/bluetape4k/math/commons/RankingTest.kt
+++ b/utils/math/src/test/kotlin/io/bluetape4k/math/commons/RankingTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.math.commons
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace
 import org.apache.commons.math3.stat.ranking.NaNStrategy
@@ -30,11 +31,11 @@ class RankingTest {
 
         val scoreAndRanks = scores.ranking()
 
-        scoreAndRanks[Double.POSITIVE_INFINITY]!! shouldBeEqualTo 0
-        scoreAndRanks[50.0]!! shouldBeEqualTo 1
-        scoreAndRanks[20.0]!! shouldBeEqualTo 4
-        scoreAndRanks[Double.NaN]!! shouldBeEqualTo 8
-        scoreAndRanks[Double.NEGATIVE_INFINITY]!! shouldBeEqualTo 8
+        scoreAndRanks[Double.POSITIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 0
+        scoreAndRanks[50.0].shouldNotBeNull() shouldBeEqualTo 1
+        scoreAndRanks[20.0].shouldNotBeNull() shouldBeEqualTo 4
+        scoreAndRanks[Double.NaN].shouldNotBeNull() shouldBeEqualTo 8
+        scoreAndRanks[Double.NEGATIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 8
     }
 
     @Test
@@ -48,11 +49,38 @@ class RankingTest {
         scoreAndRanks.forEach {
             log.trace { "score=${it.key}, rank=${it.value}" }
         }
-        scoreAndRanks[Double.POSITIVE_INFINITY]!! shouldBeEqualTo 0
-        scoreAndRanks[50.0]!! shouldBeEqualTo 1
-        scoreAndRanks[20.0]!! shouldBeEqualTo 4
-        scoreAndRanks[Double.NaN]!! shouldBeEqualTo 8
-        scoreAndRanks[Double.NEGATIVE_INFINITY]!! shouldBeEqualTo 8
+        scoreAndRanks[Double.POSITIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 0
+        scoreAndRanks[50.0].shouldNotBeNull() shouldBeEqualTo 1
+        scoreAndRanks[20.0].shouldNotBeNull() shouldBeEqualTo 4
+        scoreAndRanks[Double.NaN].shouldNotBeNull() shouldBeEqualTo 8
+        scoreAndRanks[Double.NEGATIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 8
+    }
+
+    @Test
+    fun `ranking supports single use sequences`() {
+        sequenceOf(30.0, 10.0, 20.0).constrainOnce().ranking() shouldBeEqualTo mapOf(
+            30.0 to 0,
+            10.0 to 2,
+            20.0 to 1,
+        )
+
+        data class Student(val name: String, val score: Double)
+        val students = sequenceOf(
+            Student("Alice", 90.0),
+            Student("Bob", 70.0),
+            Student("Charlie", 80.0),
+        ).constrainOnce()
+
+        var selectorCalls = 0
+        students.ranking {
+            selectorCalls++
+            it.score
+        } shouldBeEqualTo mapOf(
+            Student("Alice", 90.0) to 0,
+            Student("Bob", 70.0) to 2,
+            Student("Charlie", 80.0) to 1,
+        )
+        selectorCalls shouldBeEqualTo 3
     }
 
     @Test
@@ -64,8 +92,8 @@ class RankingTest {
         scoreAndRanks.forEach {
             log.trace { "score=${it.key}, rank=${it.value}" }
         }
-        scoreAndRanks[50.0.toBigDecimal()]!! shouldBeEqualTo 0
-        scoreAndRanks[20.0.toBigDecimal()]!! shouldBeEqualTo 3
+        scoreAndRanks[50.0.toBigDecimal()].shouldNotBeNull() shouldBeEqualTo 0
+        scoreAndRanks[20.0.toBigDecimal()].shouldNotBeNull() shouldBeEqualTo 3
     }
 
     // ----- Iterable.ranking -----
@@ -82,9 +110,9 @@ class RankingTest {
             log.trace { "score=${it.key}, rank=${it.value}" }
         }
 
-        scoreAndRanks[Double.POSITIVE_INFINITY]!! shouldBeEqualTo 0
-        scoreAndRanks[50.0]!! shouldBeEqualTo 1
-        scoreAndRanks[20.0]!! shouldBeEqualTo 4
+        scoreAndRanks[Double.POSITIVE_INFINITY].shouldNotBeNull() shouldBeEqualTo 0
+        scoreAndRanks[50.0].shouldNotBeNull() shouldBeEqualTo 1
+        scoreAndRanks[20.0].shouldNotBeNull() shouldBeEqualTo 4
     }
 
     @Test
@@ -105,5 +133,23 @@ class RankingTest {
         rankMap[students[0]] shouldBeEqualTo 0  // Alice (90) - 1위
         rankMap[students[1]] shouldBeEqualTo 2  // Bob (70) - 3위
         rankMap[students[2]] shouldBeEqualTo 1  // Charlie (80) - 2위
+    }
+
+    @Test
+    fun `ranking empty and duplicate values`() {
+        emptyList<Double>().ranking() shouldBeEqualTo emptyMap<Double, Int>()
+
+        data class Student(val name: String, val score: Double)
+        val students = listOf(
+            Student("Alice", 90.0),
+            Student("Bob", 90.0),
+            Student("Charlie", 80.0),
+        )
+
+        val rankMap = students.ranking { it.score }
+
+        rankMap[students[0]] shouldBeEqualTo 0
+        rankMap[students[1]] shouldBeEqualTo 0
+        rankMap[students[2]] shouldBeEqualTo 2
     }
 }


### PR DESCRIPTION
## Summary

Closes #1502

Epic #1492의 dependency-aware stacked PR train에서 `spring-boot/core`의 assertion·nullable·DataBuffer 계약을 정리합니다. 이 child PR은 PR #1521의 exact head `dd27b0c0694cdd04e19d3b3c7f7cea9941025a32` 위에 쌓이며, Epic의 모든 child가 검증될 때까지 merge하지 않습니다.

## Background

Issue #1502는 `spring-boot/core`에 남은 raw assertion과 constructor force-unwrap, pooled `DataBuffer` 소유권 검증 공백, EN/KO README WebClient 예제 계약을 7-Tier 기준으로 정리하기 위해 등록됐습니다. 독립 검토에서 Kotlin constructor helper가 실제 생성 원인을 synthetic cause로 대체하는 P1이 발견되어 Spring의 Kotlin-aware 경로로 보정했습니다.

## What This Solves

- `bluetape4k-assertions`를 사용해 assertion 표현을 모듈 기준으로 통일합니다.
- Spring `BeanUtils.instantiateClass`의 Kotlin-aware constructor 경로를 재사용해 nullable/default 인자와 `BeanInstantiationException`의 실제 원인을 보존합니다.
- Netty pooled `DataBuffer` release 소유권과 README 두 locale의 WebClient 계약을 실행 가능한 테스트로 고정합니다.

## Work Done

- `BeanUtilsSupport`의 constructor extension에서 `KotlinDelegates` null fallback, broad catch, `!!`를 제거하고 Spring `BeanUtils.instantiateClass(this, *args)`에 직접 위임했습니다.
- `BeanUtilsSupportTest`에 nullable 필수 인자 실패가 원래 `NullPointerException` cause와 함께 전달되는 회귀 검증을 추가하고 primitive type force-unwrap을 bluetape assertion으로 바꿨습니다.
- `DataBufferSupportTest`의 identity assertion을 `bluetape4k-assertions`로 전환하고 `PooledDataBuffer.isAllocated`/`release` 및 `finally` cleanup을 검증했습니다.
- `WebClientReadmeExamplesTest`의 raw assertion을 Bluetape predicate assertion으로 전환해 `README.md`와 `README.ko.md` 계약을 계속 검사합니다.

## Validation

- `repo-test-summary -- ./gradlew :bluetape4k-spring-boot-core:compileKotlin :bluetape4k-spring-boot-core:compileTestKotlin :bluetape4k-spring-boot-core:test --tests ...`: PASS (45 tests)
- `repo-test-summary -- ./gradlew :bluetape4k-spring-boot-core:test --max-workers=1 --no-daemon --no-build-cache`: PASS (250 tests)
- `./gradlew :bluetape4k-spring-boot-core:detekt --rerun-tasks --no-daemon --no-build-cache`: PASS (`BUILD SUCCESSFUL`; 기존 baseline finding은 변경 범위 밖 또는 기존 파일 구조)
- `git diff --check` 및 변경 네 파일의 raw JUnit/assertion/force-unwrap/blocking scan: PASS

## Review Notes

- 7-Tier 독립 재검토: P0=0, P1=0, P2=0, P3=0.
- P1 remediation: synthetic `IllegalStateException` fallback을 제거하고 Spring이 전달하는 실제 `NullPointerException` cause를 테스트로 고정했습니다.
- LSP 도구는 런타임에 없어 Kotlin compiler·targeted/full Gradle test·Detekt로 대체 검증했습니다.
- Review evidence: 내부 workflow receipt run `20260826T021152Z-f3edf755`, sequence 13; live human review와 hosted exact-head CI는 custom stacked base에서 PENDING입니다.

## Metadata

- Issue: #1502, milestone `2.0.0`, assignee `debop`, labels `test`, `refactoring`, `tech-debt`
- PR: #1522, base `refactor/epic-1492-hibernate`, head `refactor/epic-1492-spring-boot-core`, head SHA `1da3aa161639b16588a1c3933d013cc10466d761`
- CI: custom stacked base에 대한 hosted exact-head check는 현재 dispatch하지 않아 PENDING; 로컬 full module/Detekt 증거만 사용했습니다.

## DoD Status

Final status: DONE — PR #1522 `MERGED`; linked Issue #1502 `CLOSED`.

| Gate | Status | Evidence |
|---|---|---|
| 7-Tier review / Kotlin patterns / bluetape4k-assertions | PASS | 기존 독립 review와 모듈 검증 증거 보존; P0/P1=0. |
| PR exact head·base·metadata | PASS | live head `101df405ccde523dfcabd87d6ead81ba242b6cf8`, base `refactor/epic-1492-hibernate`, merge commit `2f83919229d9cfd07002cc719d6fff6d9356e1f0`, assignee/labels/milestone read-back. |
| Exact-head CI | PASS (cumulative) — custom stacked-base PR의 standalone check를 소급해 주장하지 않고, 최종 PR #1511 exact head의 CI run `32938020302` 및 post-merge develop CI [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882)로 누적 변경을 검증했다. |
| Merge verification | PASS | merged at `2026-08-26T06:20:30Z`; GitHub state `MERGED`. |
| Canonical sync | PASS | canonical `develop`와 `origin/develop`가 `4a843fe402647ec76a28e8fc1d076a0e1ff422be`로 일치. |
| Post-merge develop CI | PASS | [32938793882](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32938793882): 16 success, 5 intentional path-filter skip, 0 failure. |

Unchecked required items: 없음
