### PR TITLE
stacked train 이슈 자동 종료 경계를 PR 템플릿에 명시한다

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,13 @@
 - [ ] **Code review 에이전트 실행 완료** (`oh-my-claudecode:code-reviewer` 또는 `pr-review-toolkit:code-reviewer`) — HIGH/CRITICAL 이슈 모두 해소
 - [ ] OMC Code Review 확인 후 머지
 
+## Issue 연결 및 자동 종료
+
+- [ ] 단일 PR 또는 default branch 대상 PR은 실제로 해결하는 issue마다 `Closes #<issue-number>`를 한 줄씩 명시한다.
+- [ ] stacked child PR(base가 `develop`/`main`이 아닌 경우)은 `Part of #<epic-number>` 또는 `Refs #<issue-number>`를 사용하며 issue 자동 종료를 기대하지 않는다.
+- [ ] stacked train의 최종 PR(base가 `develop` 또는 `main`)은 모든 child issue에 대해 `Closes #<issue-number>`를 한 줄씩 명시한다. GitHub는 이 PR이 default branch에 merge될 때 해당 issue를 자동 종료한다.
+- [ ] merge 후 `closingIssuesReferences`와 issue state를 live read-back한다. 자동 종료가 의도되지 않은 PR에는 `Closes` 대신 `Part of`/`Refs`를 사용한다.
+
 ## 체크리스트
 
 - [ ] 변경된 모듈의 `README.md` + `README.ko.md` 업데이트


### PR DESCRIPTION
## 변경 요약

stacked train에서 intermediate PR과 최종 default branch PR의 issue 자동 종료 경계를 PR 템플릿에 명시했습니다.

## 문제와 해결

- GitHub의 closing keyword는 PR이 default branch에 merge될 때 적용됩니다.
- custom-base를 사용하는 stacked child PR은 `Part of #<epic-number>` 또는 `Refs #<issue-number>`로 연결하고 자동 종료를 기대하지 않습니다.
- 최종 `develop`/`main` 대상 PR은 모든 child issue를 `Closes #<issue-number>`로 열거하며, merge 후 `closingIssuesReferences`와 issue state를 확인합니다.

## 검증

- `git diff --check`: PASS
- PR template rule scan: PASS
- `./gradlew :bluetape4k-cache-core:test --tests 'io.bluetape4k.cache.nearcache.jcache.NearJCacheConfigBinaryCompatibilityTest' --no-daemon --console=plain`: PASS (1 test)
- [PR CI run 32942330930](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32942330930): PASS (실패 0)
- [post-merge develop CI run 32943414117](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32943414117): PASS (실패 0, path-filtered tests 11개 의도적 skip)
- [Dependency Submission run 32943414102](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32943414102): PASS

## 범위

- Base: `develop`
- Head: `chore/stacked-pr-auto-close`
- Exact head: `1bd5950cbdfe33ab3ea8462921771c59ba81a7d5`
- Merge commit: `a907d144f39bfb94cba783cf65a5412e0714e9d5`
- 변경 파일: `.github/pull_request_template.md`
- Issue: workflow hygiene (단일 issue 미연결; `closingIssuesReferences` 비어 있음이 의도됨)

## DoD Status

| Gate | Status | Evidence |
|---|---|---|
| 자동 종료 규칙·stacked child 연결 방식 | PASS | PR template의 `Closes`/`Part of`/`Refs` 경계와 merge 후 read-back 절차 |
| 로컬 검증 | PASS | `git diff --check`, template rule scan, compatibility test 1개 |
| Hosted CI | PASS | [run 32942330930](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32942330930) |
| Merge verification | PASS | 2026-08-26 merge commit `a907d144f39bfb94cba783cf65a5412e0714e9d5` |
| Post-merge develop CI | PASS | [run 32943414117](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32943414117) |
| Dependency Submission | PASS | [run 32943414102](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32943414102) |

Final status: DONE — PR #1526 `MERGED`; default branch template 반영과 post-merge 검증 완료.
Unchecked required items: 없음
