### PR TITLE
[hibernate] QueryDSL codegen 호환성 계약 고정

### DIFF
--- a/data/hibernate/README.ko.md
+++ b/data/hibernate/README.ko.md
@@ -30,7 +30,7 @@ dependencies {
     implementation("org.hibernate.orm:hibernate-core:7.2.7.Final")
 
     // Querydsl (선택)
-    implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:7.5")
 }
 ```
 
@@ -348,6 +348,65 @@ val predicate = qUser.active.eq(true)
 val users = queryFactory
     .selectFrom(qUser)
     .where(predicate)
+    .fetch()
+```
+
+#### QueryDSL codegen 호환성
+
+이 모듈이 지원하는 QueryDSL 생성 경로는 Java APT입니다.
+`querydsl-kotlin-codegen` 후보는 clean matrix를 통과할 때까지 의도적으로
+비활성화합니다. 로컬 후보 실행은 fixture별 원인을 분리하기 전에
+`ExtensionsKt.asTypeName(Extensions.kt:48)` 및
+`KotlinEntitySerializer.introClassHeader(KotlinEntitySerializer.kt:109)`의
+`NullPointerException`을 포함한 `AnnotationProcessingError`로 실패했습니다.
+[QueryDSL issue #3454](https://github.com/querydsl/querydsl/issues/3454)를 참고하세요.
+
+| Fixture | Java APT | Kotlin codegen 후보 | 근거 |
+| --- | --- | --- | --- |
+| DTO (`ExampleDto`) | 지원 및 테스트 완료 | 후보가 전역 실패하므로 평가하지 않음 | `SimpleQuerydslExamples` constructor 및 `@QueryProjection` 테스트 |
+| 일반 엔티티 (`AddressEntity`, `JoinUser`) | 지원 및 테스트 완료 | 후보가 전역 실패하므로 평가하지 않음 | `QuerydslCodegenCompatibilityTest` generated-source 검사 |
+| Tree 엔티티 (`ExampleEntity`, `TreeNode`) | 지원 및 테스트 완료 | 후보가 전역 실패하므로 평가하지 않음 | `QExampleEntity`/`QTreeNode` 생성 및 self-reference query |
+| Association/join (`JoinUser.addresses`) | 런타임 지원 및 테스트 완료 | 후보가 전역 실패하므로 평가하지 않음 | `QJoinUser` + `QAddressEntity` repository-path query |
+
+2026-08-26 clean 로컬 측정값은 다음과 같습니다.
+
+- Java APT baseline: wall time 18.54초, generated Java source 81개, `build/generated/source/kapt` 아래 324 KB.
+- Kotlin codegen 후보: wall time 12.29초, `kaptKotlin` 실패, generated source 0개. 실패 시점 관찰값이므로 성능 비교로 해석하지 않습니다.
+
+후보를 사용할 수 없을 때는 Java APT fallback을 명시적으로 구성하세요.
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    kotlin("kapt")
+}
+
+dependencies {
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:7.5")
+    kapt("io.github.openfeign.querydsl:querydsl-apt:7.5:jakarta")
+    kaptTest("io.github.openfeign.querydsl:querydsl-apt:7.5:jakarta")
+}
+
+kapt {
+    correctErrorTypes = true
+    arguments {
+        arg("querydsl.entityAccessors", "true")
+    }
+}
+```
+
+generated source는 `build/generated/source/kapt/main`과
+`build/generated/source/kapt/test`에 생성됩니다. repository path query는
+생성된 타입을 직접 사용할 수 있습니다.
+
+```kotlin
+val user = QJoinUser.joinUser
+val address = QAddressEntity("address")
+val users = JPAQuery<JoinUser>(entityManager)
+    .select(user)
+    .from(user)
+    .innerJoin(user.addresses, address)
+    .where(user.name.eq("querydsl-user"), address.city.eq("Seoul"))
     .fetch()
 ```
 

--- a/data/hibernate/README.md
+++ b/data/hibernate/README.md
@@ -30,7 +30,7 @@ dependencies {
     implementation("org.hibernate.orm:hibernate-core:7.2.7.Final")
 
     // Querydsl (optional)
-    implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:7.5")
 }
 ```
 
@@ -349,6 +349,65 @@ val predicate = qUser.active.eq(true)
 val users = queryFactory
     .selectFrom(qUser)
     .where(predicate)
+    .fetch()
+```
+
+#### QueryDSL Code Generation Compatibility
+
+This module keeps Java APT as the supported QueryDSL generation path. The
+`querydsl-kotlin-codegen` candidate is intentionally disabled until a clean
+matrix passes; the local candidate run failed before fixture isolation with
+`AnnotationProcessingError` caused by `NullPointerException` in
+`ExtensionsKt.asTypeName(Extensions.kt:48)` and
+`KotlinEntitySerializer.introClassHeader(KotlinEntitySerializer.kt:109)`.
+See [QueryDSL issue #3454](https://github.com/querydsl/querydsl/issues/3454).
+
+| Fixture | Java APT | Kotlin codegen candidate | Evidence |
+| --- | --- | --- | --- |
+| DTO (`ExampleDto`) | Supported and tested | Not evaluated; candidate fails globally | `SimpleQuerydslExamples` constructor and `@QueryProjection` tests |
+| General entities (`AddressEntity`, `JoinUser`) | Supported and tested | Not evaluated; candidate fails globally | `QuerydslCodegenCompatibilityTest` generated-source checks |
+| Tree entity (`ExampleEntity`, `TreeNode`) | Supported and tested | Not evaluated; candidate fails globally | `QExampleEntity`/`QTreeNode` generation and self-reference query |
+| Association/join (`JoinUser.addresses`) | Supported and tested at runtime | Not evaluated; candidate fails globally | `QJoinUser` + `QAddressEntity` repository-path query |
+
+The clean local measurements on 2026-08-26 were:
+
+- Java APT baseline: 18.54s wall time, 81 generated Java sources, 324 KB under `build/generated/source/kapt`.
+- Kotlin codegen candidate: 12.29s wall time, `kaptKotlin` failed, and 0 generated sources. This is a failure-time observation, not a performance comparison.
+
+If the candidate remains unavailable, use the Java APT fallback explicitly:
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    kotlin("kapt")
+}
+
+dependencies {
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:7.5")
+    kapt("io.github.openfeign.querydsl:querydsl-apt:7.5:jakarta")
+    kaptTest("io.github.openfeign.querydsl:querydsl-apt:7.5:jakarta")
+}
+
+kapt {
+    correctErrorTypes = true
+    arguments {
+        arg("querydsl.entityAccessors", "true")
+    }
+}
+```
+
+Generated sources are written to `build/generated/source/kapt/main` and
+`build/generated/source/kapt/test`. A repository-path query can use the
+generated types directly:
+
+```kotlin
+val user = QJoinUser.joinUser
+val address = QAddressEntity("address")
+val users = JPAQuery<JoinUser>(entityManager)
+    .select(user)
+    .from(user)
+    .innerJoin(user.addresses, address)
+    .where(user.name.eq("querydsl-user"), address.city.eq("Seoul"))
     .fetch()
 ```
 

--- a/data/hibernate/build.gradle.kts
+++ b/data/hibernate/build.gradle.kts
@@ -148,7 +148,10 @@ dependencies {
     api(project(":bluetape4k-idgenerators"))
     api(bt4k.java.uuid.generator)
 
-    // TODO: querydsl-kotlin-codegen 은 tree entity 도 못 만들고, spring-data-jpa 의 repository에서 문제가 생긴다.
+    // querydsl-kotlin-codegen 후보는 clean :bluetape4k-hibernate:compileKotlin에서
+    // AnnotationProcessingError caused by NPE
+    // (ExtensionsKt.asTypeName -> KotlinEntitySerializer.introClassHeader)로 실패한다.
+    // 따라서 Java APT 경로만 유지하고, 후보 설정은 재현 가능한 대체 경로로 남긴다.
     // https://github.com/querydsl/querydsl/issues/3454
     // kapt(libs.querydsl.kotlin.codegen)
     // kaptTest(libs.querydsl.kotlin.codegen)

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/associations/join/models.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/associations/join/models.kt
@@ -43,7 +43,9 @@ data class Address(
     var zipcode: String? = null,
 ): Serializable
 
-// FIXME: QueryDSL 에서 data class 는 제대로 kapt 가 되는데, 일반 클래스에서는 안된다 -> equals 를 재정의하지 않았기 때문이다 !!!
+// Java APT는 일반 클래스인 AddressEntity와 JoinUser의 Q 타입을 생성하며,
+// association path는 QuerydslCodegenCompatibilityTest에서 실행 경계를 검증한다.
+// Kotlin codegen 후보는 fixture별 equals 원인을 확인하기 전에 전역 NPE로 실패해 활성화하지 않는다.
 @Entity(name = "join_address_entity")
 @Access(AccessType.FIELD)
 class AddressEntity(

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/tree/TreeNode.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/mapping/tree/TreeNode.kt
@@ -14,8 +14,8 @@ import org.hibernate.annotations.DynamicUpdate
 /**
  * 트리 구조를 가지는 Self-Referencing Entity
  *
- * [AbstractJpaTreeEntity]를 직접 상속해서 써야 QueryDSL에서 문제가 생기지 않는다.
- * `LongJpaTreeEntity`에서 상속받게 되면 kapt 작업 시 예외가 발생한다.
+ * Java APT 경로는 [LongJpaTreeEntity] 상속 구조의 Q 타입을 생성한다.
+ * Kotlin codegen 후보는 fixture별 상속 원인을 확인하기 전에 전역 NPE로 실패해 활성화하지 않는다.
  */
 @Entity(name = "tree_treenode")
 @Table(indexes = [Index(name = "ix_treenode_parent", columnList = "parent_id")])
@@ -36,7 +36,7 @@ class TreeNode private constructor(
 
     var description: String? = null
 
-    // NOTE: equals 를 재정의하지 않으면, Querydsl kapt 작업이 실패하는 경우가 있습니다.
+    // equals 계약은 엔티티 동등성 테스트의 대상이며, Q 타입 생성 성공 여부의 원인으로 단정하지 않는다.
     override fun equals(other: Any?): Boolean {
         return other != null && super.equals(other)
     }

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/querydsl/codegen/QuerydslCodegenCompatibilityTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/querydsl/codegen/QuerydslCodegenCompatibilityTest.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.hibernate.querydsl.codegen
+
+import com.querydsl.jpa.impl.JPAQuery
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.hibernate.AbstractHibernateTest
+import io.bluetape4k.hibernate.mapping.associations.join.AddressEntity
+import io.bluetape4k.hibernate.mapping.associations.join.JoinUser
+import io.bluetape4k.hibernate.mapping.associations.join.JoinUserRepository
+import io.bluetape4k.hibernate.mapping.associations.join.QAddressEntity
+import io.bluetape4k.hibernate.mapping.associations.join.QJoinUser
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.nio.file.Path
+
+class QuerydslCodegenCompatibilityTest(
+    @param:Autowired private val userRepository: JoinUserRepository,
+): AbstractHibernateTest() {
+
+    @Test
+    fun `Java APT generates Q types for association and tree fixtures`() {
+        val generatedSourceRoot = Path.of("build/generated/source/kapt/test")
+        listOf(
+            "io/bluetape4k/hibernate/mapping/associations/join/QJoinUser.java",
+            "io/bluetape4k/hibernate/mapping/associations/join/QAddressEntity.java",
+            "io/bluetape4k/hibernate/querydsl/simple/QExampleEntity.java",
+            "io/bluetape4k/hibernate/querydsl/simple/QExampleDto.java",
+        ).forEach { relativePath ->
+            generatedSourceRoot.resolve(relativePath).toFile().exists().shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `generated Q paths resolve repository entity and association query`() {
+        val saved = userRepository.saveAndFlush(
+            JoinUser("querydsl-user").apply {
+                addresses["home"] = AddressEntity(
+                    street = "Main Street",
+                    city = "Seoul",
+                    zipcode = "04524"
+                )
+            }
+        )
+        flushAndClear()
+
+        val user = QJoinUser.joinUser
+        val address = QAddressEntity("address")
+        val result = JPAQuery<JoinUser>(em)
+            .select(user)
+            .from(user)
+            .innerJoin(user.addresses, address)
+            .where(
+                user.name.eq("querydsl-user"),
+                address.city.eq("Seoul")
+            )
+            .fetch()
+
+        result shouldHaveSize 1
+        result.first().name shouldBeEqualTo "querydsl-user"
+
+        val loaded = userRepository.findById(saved.id!!).orElseThrow()
+        loaded.name shouldBeEqualTo "querydsl-user"
+    }
+}

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/querydsl/codegen/QuerydslCodegenCompatibilityTest.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/querydsl/codegen/QuerydslCodegenCompatibilityTest.kt
@@ -10,12 +10,16 @@ import io.bluetape4k.hibernate.mapping.associations.join.JoinUser
 import io.bluetape4k.hibernate.mapping.associations.join.JoinUserRepository
 import io.bluetape4k.hibernate.mapping.associations.join.QAddressEntity
 import io.bluetape4k.hibernate.mapping.associations.join.QJoinUser
+import io.bluetape4k.hibernate.mapping.tree.QTreeNode
+import io.bluetape4k.hibernate.mapping.tree.TreeNode
+import io.bluetape4k.hibernate.mapping.tree.TreeNodeRepository
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.nio.file.Path
 
 class QuerydslCodegenCompatibilityTest(
     @param:Autowired private val userRepository: JoinUserRepository,
+    @param:Autowired private val treeNodeRepository: TreeNodeRepository,
 ): AbstractHibernateTest() {
 
     @Test
@@ -24,11 +28,35 @@ class QuerydslCodegenCompatibilityTest(
         listOf(
             "io/bluetape4k/hibernate/mapping/associations/join/QJoinUser.java",
             "io/bluetape4k/hibernate/mapping/associations/join/QAddressEntity.java",
+            "io/bluetape4k/hibernate/mapping/tree/QTreeNode.java",
             "io/bluetape4k/hibernate/querydsl/simple/QExampleEntity.java",
             "io/bluetape4k/hibernate/querydsl/simple/QExampleDto.java",
         ).forEach { relativePath ->
             generatedSourceRoot.resolve(relativePath).toFile().exists().shouldBeTrue()
         }
+    }
+
+    @Test
+    fun `generated tree Q type resolves self-reference query`() {
+        val root = TreeNode("querydsl-tree-root")
+        root.addChildren(TreeNode("querydsl-tree-child"))
+        treeNodeRepository.saveAndFlush(root)
+        flushAndClear()
+
+        val node = QTreeNode.treeNode
+        val parent = QTreeNode("parent")
+        val result = JPAQuery<TreeNode>(em)
+            .select(node)
+            .from(node)
+            .innerJoin(node.parent(), parent)
+            .where(
+                node.title.eq("querydsl-tree-child"),
+                parent.title.eq("querydsl-tree-root"),
+            )
+            .fetch()
+
+        result shouldHaveSize 1
+        result.first().title shouldBeEqualTo "querydsl-tree-child"
     }
 
     @Test

--- a/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/querydsl/simple/ExampleEntity.kt
+++ b/data/hibernate/src/test/kotlin/io/bluetape4k/hibernate/querydsl/simple/ExampleEntity.kt
@@ -12,8 +12,10 @@ import jakarta.validation.constraints.NotBlank
 /**
  * 트리 구조를 가지는 Self-Referencing Entity
  *
- * [AbstractJpaTreeEntity]를 직접 상속해서 써야 QueryDSL에서 문제가 생기지 않는다.
- * `LongJpaTreeEntity`에서 상속받게 되면 kapt 작업 시 예외가 발생한다.
+ * 현재 Java APT 경로는 [LongJpaTreeEntity] 상속 구조의 Q 타입을 생성하고
+ * `SimpleQuerydslExamples`에서 self-reference query를 실행한다.
+ * `querydsl-kotlin-codegen` 후보는 fixture별 원인을 분리하기 전에
+ * `KotlinEntitySerializer` 단계의 전역 NPE로 실패하므로 활성화하지 않는다.
  */
 @Entity(name = "querydsl_example_entity")
 @Access(AccessType.FIELD)


### PR DESCRIPTION
Fixes #1346

## 목적

Kotlin 2.4/JDK 25에서 QueryDSL Kotlin codegen 후보를 재현 평가하고,
불안정한 후보 대신 Java APT Q 타입 경로와 일반 Entity association query
계약을 지원 matrix로 고정합니다.

## Train 위치

- base: `develop` @ `1181ca1e4a472a993c2d72314ed38306252b8d5a` (#1527 merge)
- head: `build/1346-querydsl-kotlin-codegen` @ `9cec44a037857853e65a18f6f38f0fae28fad1ac`
- predecessor: #1527 merged exact SHA `1181ca1e4a472a993c2d72314ed38306252b8d5a`
- successor: `fix/1357-hibernate-lettuce-root-condition`

## 변경 범위

- Java APT 생성 Q 타입과 association path/repository query compatibility test를
  추가했습니다.
- `querydsl-kotlin-codegen` clean candidate는
  `ExtensionsKt.asTypeName(Extensions.kt:48)`의 `NullPointerException`으로
  generated source 0개를 남겨 기본 경로에서 비활성화했습니다.
- EN/KO README에 Java APT 지원 matrix, 후보 fallback, upstream
  [QueryDSL #3454](https://github.com/querydsl/querydsl/issues/3454)를 기록했습니다.

범위 밖: Kotlin codegen upstream 수정, runtime query API 변경, 새 dependency 추가.

## 검증

- `QuerydslCodegenCompatibilityTest`: 3개 통과 (QTreeNode self-reference join 포함)
- 기존 `SimpleQuerydslExamples`: 5개 통과
- Java APT clean baseline: 81 generated sources, 324 KB, 18.54초
- candidate: 12.29초에 NPE, generated source 0개; 이 모듈의 JMH benchmark는 N/A
- `:bluetape4k-hibernate:detekt`: BUILD SUCCESSFUL
- 누적 최종 train Hibernate 전체 테스트: 507개 통과

## Restack 및 rollback

#1527 merge 후 predecessor merge SHA를 다시 읽고 `git range-diff`를 통과한 뒤
`--force-with-lease`로 `develop` 위에 restack했습니다. 후보 codegen이 필요해지면
upstream fix와 동일 clean matrix를 통과시킨 별도 후속 PR로 재활성화하며, 현재는
Java APT 경로를 사용해 되돌립니다.

## DoD Status

- 로컬 구현·matrix·문서: DONE
- restack exact-head: `9cec44a037857853e65a18f6f38f0fae28fad1ac`
- hosted exact-head CI/review/mergeability: restack 후 확인 필요
- 병합·자동 병합: fresh 명시 승인 범위에서 순차 진행
