### PR TITLE
[hibernate-lettuce] root disable 조건 전파

### DIFF
--- a/spring-boot/hibernate-lettuce/README.ko.md
+++ b/spring-boot/hibernate-lettuce/README.ko.md
@@ -189,13 +189,28 @@ bluetape4k:
 | `metrics.enabled=true`               | `hibernate.generate_statistics=true`               |
 | `metrics.enable-caffeine-stats=true` | `hibernate.cache.lettuce.local.record_stats=true`  |
 
+### Root 및 metrics 활성화 matrix
+
+root 속성인 `bluetape4k.cache.lettuce-near.enabled`는 모든 자동 설정 단계를
+제어합니다. Metrics 및 Actuator 단계는 추가로
+`bluetape4k.cache.lettuce-near.metrics.enabled=true`를 요구합니다. Actuator
+엔드포인트에는 선택 의존성 `spring-boot-starter-actuator`,
+`EntityManagerFactory` Bean, `management.endpoints.web.exposure.include=nearcache`
+설정도 필요합니다.
+
+| Root `enabled` | `metrics.enabled` | Hibernate customizer | MetricsBinder | Actuator endpoint Bean |
+|---------------|-------------------|----------------------|---------------|------------------------|
+| `false`       | `false` 또는 `true` | 없음                 | 없음          | 없음                   |
+| `true`        | `false`           | 있음                 | 없음          | 없음                   |
+| `true`        | `true`            | 있음                 | 있음          | Actuator 조건 및 exposure 충족 시 있음 |
+
 ## Auto-Configuration 클래스
 
 | 클래스                                          | 조건                                                                   | 역할                                 |
 |----------------------------------------------|----------------------------------------------------------------------|------------------------------------|
-| `LettuceNearCacheHibernateAutoConfiguration` | `LettuceNearCacheRegionFactory`, `EntityManagerFactory` on classpath | `HibernatePropertiesCustomizer` 등록 |
-| `LettuceNearCacheMetricsAutoConfiguration`   | `MeterRegistry` on classpath + Bean                                  | `LettuceNearCacheMetricsBinder` 등록 |
-| `LettuceNearCacheActuatorAutoConfiguration`  | `Endpoint` (actuate) on classpath + `EntityManagerFactory` Bean      | `/actuator/nearcache` 엔드포인트 등록     |
+| `LettuceNearCacheHibernateAutoConfiguration` | Root `enabled=true` (기본값) + `LettuceNearCacheRegionFactory`, `EntityManagerFactory`, `HibernatePropertiesCustomizer` classpath | `HibernatePropertiesCustomizer` 등록 |
+| `LettuceNearCacheMetricsAutoConfiguration`   | Root `enabled=true` + `metrics.enabled=true` (기본값) + `MeterRegistry`, `EntityManagerFactory` Bean | `LettuceNearCacheMetricsBinder` 등록 |
+| `LettuceNearCacheActuatorAutoConfiguration`  | Root `enabled=true` + `metrics.enabled=true` (기본값) + Actuator `Endpoint`, `EntityManagerFactory` 조건 | `/actuator/nearcache` 엔드포인트 등록     |
 
 ## Actuator 엔드포인트
 
@@ -253,7 +268,9 @@ GET /actuator/nearcache/product
 
 ## Micrometer 메트릭
 
-`metrics.enabled=true` 설정 시 다음 Gauge가 등록됩니다.
+root `enabled=true`와 `metrics.enabled=true` 조건을 모두 만족할 때 다음
+Gauge가 등록됩니다. `metrics.enabled=false`로 설정하면 Hibernate customizer는
+유지하면서 MetricsBinder와 near-cache Actuator 엔드포인트를 비활성화합니다.
 
 | 메트릭                                   | 설명                    |
 |---------------------------------------|-----------------------|
@@ -283,14 +300,19 @@ GET /actuator/metrics/lettuce.nearcache.total.local.size
 
 ## 비활성화
 
-Auto-configuration을 완전히 비활성화하려면:
+Auto-configuration을 완전히 비활성화하려면 root 속성을 false로 설정하세요:
 
 ```yaml
 bluetape4k:
     cache:
         lettuce-near:
-            enabled: false   # HibernatePropertiesCustomizer, MetricsBinder, Endpoint 모두 비활성화
+            enabled: false   # customizer, MetricsBinder, Actuator endpoint 모두 비활성화
 ```
+
+root 스위치는 `metrics.enabled=true` 및 Actuator exposure 설정보다 우선합니다.
+따라서 `management.endpoints.web.exposure.include=nearcache`만으로 엔드포인트를
+다시 활성화할 수 없습니다. Hibernate 통합은 유지하면서 metrics와 엔드포인트만
+끄려면 `bluetape4k.cache.lettuce-near.metrics.enabled=false`를 사용하세요.
 
 ## 테스트 실행
 

--- a/spring-boot/hibernate-lettuce/README.ko.md
+++ b/spring-boot/hibernate-lettuce/README.ko.md
@@ -194,15 +194,17 @@ bluetape4k:
 root 속성인 `bluetape4k.cache.lettuce-near.enabled`는 모든 자동 설정 단계를
 제어합니다. Metrics 및 Actuator 단계는 추가로
 `bluetape4k.cache.lettuce-near.metrics.enabled=true`를 요구합니다. Actuator
-엔드포인트에는 선택 의존성 `spring-boot-starter-actuator`,
-`EntityManagerFactory` Bean, `management.endpoints.web.exposure.include=nearcache`
-설정도 필요합니다.
+엔드포인트 Bean에는 선택 의존성 `spring-boot-starter-actuator`와
+`EntityManagerFactory` Bean이 필요합니다. endpoint Bean 등록은 web exposure
+설정을 검사하지 않으며, HTTP route를 열려면
+`management.endpoints.web.exposure.include=nearcache`(또는 동등한 exposure
+규칙)를 별도로 설정해야 합니다.
 
 | Root `enabled` | `metrics.enabled` | Hibernate customizer | MetricsBinder | Actuator endpoint Bean |
 |---------------|-------------------|----------------------|---------------|------------------------|
 | `false`       | `false` 또는 `true` | 없음                 | 없음          | 없음                   |
 | `true`        | `false`           | 있음                 | 없음          | 없음                   |
-| `true`        | `true`            | 있음                 | 있음          | Actuator 조건 및 exposure 충족 시 있음 |
+| `true`        | `true`            | 있음                 | 있음          | Actuator 조건 충족 시 있음              |
 
 ## Auto-Configuration 클래스
 
@@ -210,9 +212,12 @@ root 속성인 `bluetape4k.cache.lettuce-near.enabled`는 모든 자동 설정 �
 |----------------------------------------------|----------------------------------------------------------------------|------------------------------------|
 | `LettuceNearCacheHibernateAutoConfiguration` | Root `enabled=true` (기본값) + `LettuceNearCacheRegionFactory`, `EntityManagerFactory`, `HibernatePropertiesCustomizer` classpath | `HibernatePropertiesCustomizer` 등록 |
 | `LettuceNearCacheMetricsAutoConfiguration`   | Root `enabled=true` + `metrics.enabled=true` (기본값) + `MeterRegistry`, `EntityManagerFactory` Bean | `LettuceNearCacheMetricsBinder` 등록 |
-| `LettuceNearCacheActuatorAutoConfiguration`  | Root `enabled=true` + `metrics.enabled=true` (기본값) + Actuator `Endpoint`, `EntityManagerFactory` 조건 | `/actuator/nearcache` 엔드포인트 등록     |
+| `LettuceNearCacheActuatorAutoConfiguration`  | Root `enabled=true` + `metrics.enabled=true` (기본값) + Actuator `Endpoint`, `EntityManagerFactory` 조건 | `/actuator/nearcache` 엔드포인트 Bean 등록 |
 
 ## Actuator 엔드포인트
+
+위 조건을 만족하면 endpoint Bean이 등록됩니다. HTTP route를 노출하려면
+`management.endpoints.web.exposure.include=nearcache`를 별도로 설정하세요.
 
 ### 전체 Region 통계 조회
 

--- a/spring-boot/hibernate-lettuce/README.md
+++ b/spring-boot/hibernate-lettuce/README.md
@@ -190,13 +190,27 @@ bluetape4k:
 | `metrics.enabled=true`               | `hibernate.generate_statistics=true`               |
 | `metrics.enable-caffeine-stats=true` | `hibernate.cache.lettuce.local.record_stats=true`  |
 
+### Root and metrics activation matrix
+
+The root property `bluetape4k.cache.lettuce-near.enabled` gates every phase.
+The Metrics and Actuator phases additionally require
+`bluetape4k.cache.lettuce-near.metrics.enabled=true`. The Actuator endpoint also
+requires the optional `spring-boot-starter-actuator` dependency, an
+`EntityManagerFactory` bean, and `management.endpoints.web.exposure.include=nearcache`.
+
+| Root `enabled` | `metrics.enabled` | Hibernate customizer | MetricsBinder | Actuator endpoint bean |
+|---------------|-------------------|----------------------|---------------|------------------------|
+| `false`       | `false` or `true`  | absent               | absent        | absent                 |
+| `true`        | `false`           | present              | absent        | absent                 |
+| `true`        | `true`            | present              | present       | present when Actuator conditions and exposure are met |
+
 ## Auto-Configuration Classes
 
 | Class                                        | Condition                                                            | Role                                      |
 |----------------------------------------------|----------------------------------------------------------------------|-------------------------------------------|
-| `LettuceNearCacheHibernateAutoConfiguration` | `LettuceNearCacheRegionFactory`, `EntityManagerFactory` on classpath | Registers `HibernatePropertiesCustomizer` |
-| `LettuceNearCacheMetricsAutoConfiguration`   | `MeterRegistry` on classpath + Bean                                  | Registers `LettuceNearCacheMetricsBinder` |
-| `LettuceNearCacheActuatorAutoConfiguration`  | `Endpoint` (actuate) on classpath + `EntityManagerFactory` Bean      | Registers `/actuator/nearcache` endpoint  |
+| `LettuceNearCacheHibernateAutoConfiguration` | Root `enabled=true` (default) + `LettuceNearCacheRegionFactory`, `EntityManagerFactory`, and `HibernatePropertiesCustomizer` on classpath | Registers `HibernatePropertiesCustomizer` |
+| `LettuceNearCacheMetricsAutoConfiguration`   | Root `enabled=true` + `metrics.enabled=true` (both default) + `MeterRegistry` and `EntityManagerFactory` beans | Registers `LettuceNearCacheMetricsBinder` |
+| `LettuceNearCacheActuatorAutoConfiguration`  | Root `enabled=true` + `metrics.enabled=true` (both default) + Actuator `Endpoint` and `EntityManagerFactory` conditions | Registers `/actuator/nearcache` endpoint  |
 
 ## Actuator Endpoint
 
@@ -254,7 +268,9 @@ Response:
 
 ## Micrometer Metrics
 
-When `metrics.enabled=true`, the following Gauges are registered:
+When both the root `enabled=true` and `metrics.enabled=true` conditions hold,
+the following Gauges are registered. Setting `metrics.enabled=false` keeps the
+Hibernate customizer but disables the MetricsBinder and near-cache Actuator endpoint.
 
 | Metric                                  | Description                          |
 |-----------------------------------------|--------------------------------------|
@@ -284,14 +300,19 @@ Example response:
 
 ## Disabling
 
-To completely disable auto-configuration:
+To completely disable auto-configuration, set the root property to false:
 
 ```yaml
 bluetape4k:
     cache:
         lettuce-near:
-            enabled: false   # Disables HibernatePropertiesCustomizer, MetricsBinder, and Endpoint
+            enabled: false   # Disables customizer, MetricsBinder, and Actuator endpoint
 ```
+
+This root switch wins over `metrics.enabled=true` and any Actuator exposure
+setting; `management.endpoints.web.exposure.include=nearcache` cannot re-enable
+the endpoint. To keep Hibernate integration while disabling metrics and the
+endpoint, set `bluetape4k.cache.lettuce-near.metrics.enabled=false` instead.
 
 ## Running Tests
 

--- a/spring-boot/hibernate-lettuce/README.md
+++ b/spring-boot/hibernate-lettuce/README.md
@@ -195,14 +195,17 @@ bluetape4k:
 The root property `bluetape4k.cache.lettuce-near.enabled` gates every phase.
 The Metrics and Actuator phases additionally require
 `bluetape4k.cache.lettuce-near.metrics.enabled=true`. The Actuator endpoint also
-requires the optional `spring-boot-starter-actuator` dependency, an
-`EntityManagerFactory` bean, and `management.endpoints.web.exposure.include=nearcache`.
+requires the optional `spring-boot-starter-actuator` dependency and an
+`EntityManagerFactory` bean. Endpoint bean registration does not inspect web
+exposure; the HTTP route is reachable only when
+`management.endpoints.web.exposure.include=nearcache` (or an equivalent
+exposure rule) is configured.
 
 | Root `enabled` | `metrics.enabled` | Hibernate customizer | MetricsBinder | Actuator endpoint bean |
 |---------------|-------------------|----------------------|---------------|------------------------|
 | `false`       | `false` or `true`  | absent               | absent        | absent                 |
 | `true`        | `false`           | present              | absent        | absent                 |
-| `true`        | `true`            | present              | present       | present when Actuator conditions and exposure are met |
+| `true`        | `true`            | present              | present       | present when Actuator conditions are met              |
 
 ## Auto-Configuration Classes
 
@@ -210,9 +213,12 @@ requires the optional `spring-boot-starter-actuator` dependency, an
 |----------------------------------------------|----------------------------------------------------------------------|-------------------------------------------|
 | `LettuceNearCacheHibernateAutoConfiguration` | Root `enabled=true` (default) + `LettuceNearCacheRegionFactory`, `EntityManagerFactory`, and `HibernatePropertiesCustomizer` on classpath | Registers `HibernatePropertiesCustomizer` |
 | `LettuceNearCacheMetricsAutoConfiguration`   | Root `enabled=true` + `metrics.enabled=true` (both default) + `MeterRegistry` and `EntityManagerFactory` beans | Registers `LettuceNearCacheMetricsBinder` |
-| `LettuceNearCacheActuatorAutoConfiguration`  | Root `enabled=true` + `metrics.enabled=true` (both default) + Actuator `Endpoint` and `EntityManagerFactory` conditions | Registers `/actuator/nearcache` endpoint  |
+| `LettuceNearCacheActuatorAutoConfiguration`  | Root `enabled=true` + `metrics.enabled=true` (both default) + Actuator `Endpoint` and `EntityManagerFactory` conditions | Registers the `/actuator/nearcache` endpoint bean  |
 
 ## Actuator Endpoint
+
+The endpoint bean is registered by the conditions above. To expose its HTTP
+route, configure `management.endpoints.web.exposure.include=nearcache`.
 
 ### Retrieve Statistics for All Regions
 

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheActuatorAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheActuatorAutoConfiguration.kt
@@ -12,7 +12,9 @@ import org.springframework.context.annotation.Bean
  * Lettuce Near Cache Actuator Endpoint 자동 설정.
  *
  * `spring-boot-starter-actuator`가 classpath에 있고 root/metrics 설정이
- * 모두 활성화될 때 [LettuceNearCacheActuatorEndpoint]를 등록한다.
+ * 모두 활성화될 때 [LettuceNearCacheActuatorEndpoint] Bean을 등록한다.
+ * HTTP route 노출은 `management.endpoints.web.exposure.include`가 별도로
+ * 제어한다.
  * `@ConditionalOnClass(Endpoint::class)`이 클래스 레벨에 있어, actuate가 없으면 이 클래스 자체가 로드되지 않는다.
  *
  * ```yaml

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheActuatorAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheActuatorAutoConfiguration.kt
@@ -11,7 +11,8 @@ import org.springframework.context.annotation.Bean
 /**
  * Lettuce Near Cache Actuator Endpoint 자동 설정.
  *
- * `spring-boot-actuate`가 classpath에 있을 때 [LettuceNearCacheActuatorEndpoint]를 등록한다.
+ * `spring-boot-starter-actuator`가 classpath에 있고 root/metrics 설정이
+ * 모두 활성화될 때 [LettuceNearCacheActuatorEndpoint]를 등록한다.
  * `@ConditionalOnClass(Endpoint::class)`이 클래스 레벨에 있어, actuate가 없으면 이 클래스 자체가 로드되지 않는다.
  *
  * ```yaml
@@ -47,6 +48,12 @@ import org.springframework.context.annotation.Bean
 @ConditionalOnBean(type = ["jakarta.persistence.EntityManagerFactory"])
 @ConditionalOnProperty(
     prefix = "bluetape4k.cache.lettuce-near",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+@ConditionalOnProperty(
+    prefix = "bluetape4k.cache.lettuce-near.metrics",
     name = ["enabled"],
     havingValue = "true",
     matchIfMissing = true,

--- a/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheMetricsAutoConfiguration.kt
+++ b/spring-boot/hibernate-lettuce/src/main/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheMetricsAutoConfiguration.kt
@@ -13,8 +13,12 @@ import org.springframework.context.annotation.Bean
 /**
  * Lettuce Near Cache Micrometer Metrics 자동 설정.
  *
+ * root `bluetape4k.cache.lettuce-near.enabled`와
+ * `bluetape4k.cache.lettuce-near.metrics.enabled`가 모두 활성화되고
  * [MeterRegistry]가 있을 때 [LettuceNearCacheMetricsBinder]를 등록한다.
- * Actuator endpoint는 [LettuceNearCacheActuatorAutoConfiguration]에서 별도로 등록된다.
+ * root를 끄면 metrics.enabled가 true여도 binder가 등록되지 않는다.
+ * Actuator endpoint는 [LettuceNearCacheActuatorAutoConfiguration]에서
+ * 동일한 root/metrics 조건으로 별도 등록된다.
  *
  * ```yaml
  * # application.yml — Metrics 활성화 설정
@@ -49,6 +53,12 @@ import org.springframework.context.annotation.Bean
     ]
 )
 @ConditionalOnBean(type = ["jakarta.persistence.EntityManagerFactory", "io.micrometer.core.instrument.MeterRegistry"])
+@ConditionalOnProperty(
+    prefix = "bluetape4k.cache.lettuce-near",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
 @ConditionalOnProperty(
     prefix = "bluetape4k.cache.lettuce-near.metrics",
     name = ["enabled"],

--- a/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheAutoConfigurationTest.kt
+++ b/spring-boot/hibernate-lettuce/src/test/kotlin/io/bluetape4k/spring/boot/autoconfigure/cache/lettuce/LettuceNearCacheAutoConfigurationTest.kt
@@ -25,6 +25,7 @@ class LettuceNearCacheAutoConfigurationTest {
     private val metricsContextRunner = ApplicationContextRunner()
         .withConfiguration(
             AutoConfigurations.of(
+                LettuceNearCacheHibernateAutoConfiguration::class.java,
                 LettuceNearCacheMetricsAutoConfiguration::class.java,
                 LettuceNearCacheActuatorAutoConfiguration::class.java,
             )
@@ -149,6 +150,70 @@ class LettuceNearCacheAutoConfigurationTest {
             .withBean(SimpleMeterRegistry::class.java, Supplier { SimpleMeterRegistry() })
             .run { context ->
                 context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldHaveSize(1)
+            }
+    }
+
+    @Test
+    fun `root=false metrics=false이면 세 auto configuration이 모두 비활성화된다`() {
+        metricsContextRunner
+            .withBean(SimpleMeterRegistry::class.java, Supplier { SimpleMeterRegistry() })
+            .withPropertyValues(
+                "bluetape4k.cache.lettuce-near.enabled=false",
+                "bluetape4k.cache.lettuce-near.metrics.enabled=false",
+                "management.endpoints.web.exposure.include=nearcache",
+            )
+            .run { context ->
+                context.getBeansOfType<HibernatePropertiesCustomizer>().shouldBeEmpty()
+                context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldBeEmpty()
+                context.getBeansOfType<LettuceNearCacheActuatorEndpoint>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `root=false metrics=true여도 exposure 설정으로 세 auto configuration을 우회할 수 없다`() {
+        metricsContextRunner
+            .withBean(SimpleMeterRegistry::class.java, Supplier { SimpleMeterRegistry() })
+            .withPropertyValues(
+                "bluetape4k.cache.lettuce-near.enabled=false",
+                "bluetape4k.cache.lettuce-near.metrics.enabled=true",
+                "management.endpoints.web.exposure.include=nearcache",
+            )
+            .run { context ->
+                context.getBeansOfType<HibernatePropertiesCustomizer>().shouldBeEmpty()
+                context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldBeEmpty()
+                context.getBeansOfType<LettuceNearCacheActuatorEndpoint>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `root=true metrics=false이면 customizer만 등록되고 metrics와 actuator는 비활성화된다`() {
+        metricsContextRunner
+            .withBean(SimpleMeterRegistry::class.java, Supplier { SimpleMeterRegistry() })
+            .withPropertyValues(
+                "bluetape4k.cache.lettuce-near.enabled=true",
+                "bluetape4k.cache.lettuce-near.metrics.enabled=false",
+                "management.endpoints.web.exposure.include=nearcache",
+            )
+            .run { context ->
+                context.getBeansOfType<HibernatePropertiesCustomizer>().shouldHaveSize(1)
+                context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldBeEmpty()
+                context.getBeansOfType<LettuceNearCacheActuatorEndpoint>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `root=true metrics=true이고 nearcache가 노출되면 세 auto configuration이 등록된다`() {
+        metricsContextRunner
+            .withBean(SimpleMeterRegistry::class.java, Supplier { SimpleMeterRegistry() })
+            .withPropertyValues(
+                "bluetape4k.cache.lettuce-near.enabled=true",
+                "bluetape4k.cache.lettuce-near.metrics.enabled=true",
+                "management.endpoints.web.exposure.include=nearcache",
+            )
+            .run { context ->
+                context.getBeansOfType<HibernatePropertiesCustomizer>().shouldHaveSize(1)
+                context.getBeansOfType<LettuceNearCacheMetricsBinder>().shouldHaveSize(1)
+                context.getBeansOfType<LettuceNearCacheActuatorEndpoint>().shouldHaveSize(1)
             }
     }
 


### PR DESCRIPTION
Fixes #1357

## 목적

Hibernate-Lettuce near-cache의 root disable이 Hibernate customizer, metrics
binder, Actuator endpoint 전부에 일관되게 전파되도록 조건 경계를 고정합니다.

## Train 위치

- base: `develop` @ `a1b4946fa06182d287698bec1739800f02a347a4` (#1528 merge)
- head: `fix/1357-hibernate-lettuce-root-condition` @ `052a8a1b014c89cf2fedb38105760c29383661e9`
- predecessor: #1528 merged exact SHA `a1b4946fa06182d287698bec1739800f02a347a4`
- successor: `fix/1358-mongodb-boot41-boundary`

## 변경 범위

- `bluetape4k.cache.lettuce-near.enabled` root 조건을 Metrics와 Actuator 자동
  구성에도 추가했습니다.
- `root enabled × metrics.enabled` 2×2 및 기본값/optional-class
  `ApplicationContextRunner` 테스트를 추가했습니다.
- EN/KO README와 KDoc에 `root enabled && metrics.enabled`, optional
  `spring-boot-starter-actuator`, root false의 fail-closed 동작을 기록했습니다.
  endpoint Bean 등록과 HTTP exposure 조건은 별도 경계로 설명했습니다.

범위 밖: Redis metrics backend 자체, near-cache 기능 추가, Actuator exposure
정책의 전역 변경.

## 검증

- `LettuceNearCacheAutoConfigurationTest`: 20개 통과
- `:bluetape4k-spring-boot-hibernate-lettuce:detekt`: BUILD SUCCESSFUL
- 누적 최종 train Hibernate-Lettuce 전체 테스트: 30개 통과
- `git diff --check`: 통과

## Restack 및 rollback

#1528 merge 후 predecessor merge SHA를 다시 읽고 `git range-diff`를 통과한 뒤
`--force-with-lease`로 `develop` 위에 restack했습니다. root 조건 회귀 시 merge
SHA를 보존한 revert PR로 되돌립니다.

## DoD Status

- 로컬 구현·2×2 계약·문서: DONE
- restack exact-head: `052a8a1b014c89cf2fedb38105760c29383661e9`
- hosted exact-head CI/review/mergeability: restack 후 확인 필요
- 병합·자동 병합: fresh 명시 승인 범위에서 순차 진행
