### PR TITLE
[mongodb] Spring Boot 4.1 boundary 정렬

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   유지한다. Java 21–24 소비자는 Java 25로 이동하거나 `1.13.x`를 유지해야
   한다 ([#1335](https://github.com/bluetape4k/bluetape4k-projects/issues/1335)).
 
+<!-- issue-1335-java25-semver:end -->
+
 - QueryDSL Kotlin codegen은 Kotlin 2.4/JDK 25 환경에서 clean annotation
   processing을 통과하지 못하는 upstream `NullPointerException`으로 인해
   기본 지원 경로에서 제외했다. Java APT 생성 Q 타입과 QueryDSL association
@@ -33,9 +35,9 @@
 - Hibernate-Lettuce near-cache의 root `bluetape4k.cache.lettuce-near.enabled`
   조건을 Hibernate customizer, metrics binder, Actuator endpoint 전체에
   일관되게 적용했다. `metrics.enabled=true`만으로 root disabled 상태를
-  우회할 수 없고, 두 조건을 모두 만족할 때만 metrics와 endpoint를 노출한다
+  우회할 수 없고, 두 조건을 모두 만족할 때만 metrics와 endpoint Bean을
+  등록한다. HTTP route 노출은 Spring Boot exposure 설정이 별도로 제어한다
   ([#1357](https://github.com/bluetape4k/bluetape4k-projects/issues/1357)).
-<!-- issue-1335-java25-semver:end -->
 
 ### 마이그레이션
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,28 @@
   `bluetape4k-virtualthread-api`, `bluetape4k-virtualthread-jdk21`로
   유지한다. Java 21–24 소비자는 Java 25로 이동하거나 `1.13.x`를 유지해야
   한다 ([#1335](https://github.com/bluetape4k/bluetape4k-projects/issues/1335)).
+
+- QueryDSL Kotlin codegen은 Kotlin 2.4/JDK 25 환경에서 clean annotation
+  processing을 통과하지 못하는 upstream `NullPointerException`으로 인해
+  기본 지원 경로에서 제외했다. Java APT 생성 Q 타입과 QueryDSL association
+  query 경로는 유지하며, 후보 재활성화는 upstream fix와 재현 matrix를 다시
+  통과해야 한다 ([#1346](https://github.com/bluetape4k/bluetape4k-projects/issues/1346)).
+
+- Hibernate-Lettuce near-cache의 root `bluetape4k.cache.lettuce-near.enabled`
+  조건을 Hibernate customizer, metrics binder, Actuator endpoint 전체에
+  일관되게 적용했다. `metrics.enabled=true`만으로 root disabled 상태를
+  우회할 수 없고, 두 조건을 모두 만족할 때만 metrics와 endpoint를 노출한다
+  ([#1357](https://github.com/bluetape4k/bluetape4k-projects/issues/1357)).
 <!-- issue-1335-java25-semver:end -->
+
+### 마이그레이션
+
+- Spring Boot 4.1 MongoDB 연결 설정은 `spring.data.mongodb.uri`에서
+  `spring.mongodb.uri`로 이동해야 한다. legacy key만 남으면 기본 localhost
+  연결을 막는 정확한 `IllegalStateException`으로 즉시 실패하고, 두 key가
+  함께 있으면 새 namespace가 우선한다. 즉시 전환할 수 없는 소비자는 legacy
+  namespace를 지원하는 이전 artifact를 임시로 pin한다
+  ([#1358](https://github.com/bluetape4k/bluetape4k-projects/issues/1358)).
 
 ### 추가
 
@@ -36,6 +57,12 @@
   ([#1350](https://github.com/bluetape4k/bluetape4k-projects/issues/1350)).
 
 ### 버그 수정
+
+- Cassandra `WriteOptions`가 nullable TTL/timestamp를 안전하게 처리한다.
+  zero/subsecond TTL은 `TTL 0`으로 보존하고 negative 값은 거부하며, Int
+  seconds 범위 초과는 `ArithmeticException`으로 보고한다. Cassandra
+  timestamp는 microseconds 단위로 전달한다
+  ([#1359](https://github.com/bluetape4k/bluetape4k-projects/issues/1359)).
 
 - `BufferedSuspendedSink` 회귀 테스트가 모든 `write`/`writeAll` 오버로드의 정확한
   바이트열과 `flush()`/`close()`의 하위 sink 위임 횟수 및 데이터 전달 경계를

--- a/docs/lessons/2026-08-26-epic-1420-data-contract-train.md
+++ b/docs/lessons/2026-08-26-epic-1420-data-contract-train.md
@@ -44,8 +44,14 @@ train: `fix/1359-cassandra-write-options-nullable` →
 - #1358: network I/O 없는 context 계약 테스트 10개와 실제 MongoDB
   Testcontainers 코루틴 통합 테스트 31개(12.2초) 통과. context와 container
   실행을 분리해 mock 기반 order/lifecycle 검증이 container startup에
-  의존하지 않도록 했으며, container는 직렬로 한 번만 실행했다. 재시도는
-  필요하지 않았다.
+  의존하지 않도록 했으며, container는 직렬로 한 번만 실행했다.
+- 누적 Cassandra 강제 재실행은 181개까지 진행한 뒤 Gradle daemon이
+  `Shutdown in progress`로 사라지고 MockK class redefinition 예외가 겹쳐
+  18개 initialization failure를 남겼다. 당시 Docker에는 실행 중인 orphan
+  container가 없었고 daemon도 종료 상태였다. 로그와 상태를 보존한 뒤 허용된
+  1회 재시도를 일반 test 명령으로 수행해 269개 전체가 22.6초에 통과했다.
+  따라서 이 실패는 코드 회귀가 아닌 일회성 daemon/JDK instrumentation
+  환경 증거로 남기며, 추가 재시도는 하지 않았다.
 
 ## train 운영과 되돌리기
 

--- a/docs/lessons/2026-08-26-epic-1420-data-contract-train.md
+++ b/docs/lessons/2026-08-26-epic-1420-data-contract-train.md
@@ -35,15 +35,17 @@ train: `fix/1359-cassandra-write-options-nullable` →
 ## 검증 증거
 
 - #1359: `OptionsSupportTest` 18개, Cassandra detekt 통과.
-- #1346: Java APT compatibility test 2개와 기존 QueryDSL 예제 5개 통과.
+- #1346: Java APT compatibility test 3개(QTreeNode self-reference join 포함)와
+  기존 QueryDSL 예제 5개 통과.
   Java APT clean baseline은 81 generated sources/324 KB, 18.54초였고 Kotlin
   후보는 12.29초에 NPE와 generated sources 0개로 실패했다. 이 모듈에는 JMH
   대상이 없어 별도 benchmark는 N/A다.
 - #1357: root/metrics 2×2와 기본값/optional-class 자동 설정 테스트 20개,
-  detekt 통과.
+  detekt 통과. Actuator endpoint Bean 등록 조건과 HTTP exposure 설정은 서로
+  독립적인 경계로 EN/KO 문서와 KDoc에 기록했다.
 - #1358: network I/O 없는 context 계약 테스트 10개와 실제 MongoDB
   Testcontainers 코루틴 통합 테스트 31개(12.2초) 통과. context와 container
-  실행을 분리해 mock 기반 order/lifecycle 검증이 container startup에
+  실행을 분리해 mock 기반 order/client-close 검증이 container startup에
   의존하지 않도록 했으며, container는 직렬로 한 번만 실행했다.
 - 누적 Cassandra 강제 재실행은 181개까지 진행한 뒤 Gradle daemon이
   `Shutdown in progress`로 사라지고 MockK class redefinition 예외가 겹쳐

--- a/docs/lessons/2026-08-26-epic-1420-data-contract-train.md
+++ b/docs/lessons/2026-08-26-epic-1420-data-contract-train.md
@@ -1,0 +1,64 @@
+# Epic #1420 데이터 계약 train은 경계별 증거를 누적해야 한다
+
+관련 이슈: #1359 · #1346 · #1357 · #1358
+
+train: `fix/1359-cassandra-write-options-nullable` →
+`build/1346-querydsl-kotlin-codegen` →
+`fix/1357-hibernate-lettuce-root-condition` →
+`fix/1358-mongodb-boot41-boundary`
+
+## 원인과 결정
+
+- Cassandra `WriteOptions`는 nullable duration/timestamp를 다루면서도
+  invalid TTL을 statement에 흘려보낼 수 있었다. `null`은 clause를 생략하고,
+  zero/subsecond duration은 whole-second `TTL 0`으로 보존하며, negative 값은
+  builder에서 거부하고 Int seconds 범위 초과는 `ArithmeticException`으로
+  끝나도록 고정했다. Cassandra timestamp는 microseconds 계약을 문서와
+  테스트에 함께 남겼다.
+- QueryDSL Kotlin codegen 후보는 clean Kotlin 2.4/JDK 25 compile에서
+  `com.querydsl.kotlin.codegen.ExtensionsKt.asTypeName(Extensions.kt:48)`의
+  `NullPointerException`으로 생성 소스 0개를 남겼다. upstream
+  [QueryDSL #3454](https://github.com/querydsl/querydsl/issues/3454) 확인 결과가
+  해결될 때까지 Java APT 경로를 지원 matrix의 기본으로 유지하고 후보 의존성은
+  비활성화했다.
+- Hibernate-Lettuce는 root enabled와 `metrics.enabled`를 독립적으로 보던
+  경계가 있어 root disabled 상태에서 metrics/Actuator가 살아날 수 있었다.
+  root/metrics 2×2 `ApplicationContextRunner` 검증으로 customizer, binder,
+  endpoint의 노출 조건을 모두 고정했다.
+- Spring Boot 4.1 MongoDB는 `MongoProperties` binding namespace가
+  `spring.mongodb.*`이고 `DataMongoReactiveAutoConfiguration`이 Mongo
+  client auto-configuration 뒤에 온다. custom auto-configuration을 그 뒤로
+  정렬하고, legacy-only `spring.data.mongodb.uri`를 exact migration
+  exception으로 fail-fast해 localhost fallback을 차단했다. 통합 테스트의
+  URL/lifecycle 소유자는 `AbstractReactiveMongoTest` 하나로 남겼다.
+
+## 검증 증거
+
+- #1359: `OptionsSupportTest` 18개, Cassandra detekt 통과.
+- #1346: Java APT compatibility test 2개와 기존 QueryDSL 예제 5개 통과.
+  Java APT clean baseline은 81 generated sources/324 KB, 18.54초였고 Kotlin
+  후보는 12.29초에 NPE와 generated sources 0개로 실패했다. 이 모듈에는 JMH
+  대상이 없어 별도 benchmark는 N/A다.
+- #1357: root/metrics 2×2와 기본값/optional-class 자동 설정 테스트 20개,
+  detekt 통과.
+- #1358: network I/O 없는 context 계약 테스트 10개와 실제 MongoDB
+  Testcontainers 코루틴 통합 테스트 31개(12.2초) 통과. context와 container
+  실행을 분리해 mock 기반 order/lifecycle 검증이 container startup에
+  의존하지 않도록 했으며, container는 직렬로 한 번만 실행했다. 재시도는
+  필요하지 않았다.
+
+## train 운영과 되돌리기
+
+각 child는 앞 child의 정확한 HEAD를 base로 삼는다. predecessor가 merge된
+뒤에는 `git range-diff`로 patch series를 확인하고, remote가 예상한 이전 SHA일
+때만 명시적인 `--force-with-lease`로 successor를 restack한다. predecessor를
+되돌릴 때는 merge SHA를 보존한 별도 revert PR을 만들고 후속 merge를 중단한다.
+Mongo migration을 즉시 적용할 수 없는 소비자는 legacy namespace를 지원하는
+이전 artifact를 임시 pin한 뒤 설정을 바꾸고 Boot 4.1 artifact로 복귀한다.
+
+## 남은 게이트
+
+로컬 누적 테스트와 문서 parity는 이 train에서 확인하지만, 각 PR의 hosted
+CI/Nightly exact-head run, required check, review approval과 mergeability는 PR
+생성 뒤 live GitHub에서 다시 확인해야 한다. 병합·자동 병합·branch/worktree
+정리는 fresh 명시 승인이 있을 때까지 수행하지 않는다.

--- a/docs/manual/en/modules/bluetape4k-spring-boot-mongodb/testing-operations-ecosystem.md
+++ b/docs/manual/en/modules/bluetape4k-spring-boot-mongodb/testing-operations-ecosystem.md
@@ -7,9 +7,9 @@ chapterId: testing-operations-ecosystem
 
 # Testing, operations, and ecosystem
 
-## 1.12.1 test structure
+## Current test structure (Spring Boot 4.1+)
 
-`AbstractReactiveMongoTest` lazily starts a `MongoDBServer` Testcontainer and registers `spring.data.mongodb.uri` dynamically. `AbstractReactiveMongoCoroutineTest` adds a test scope with `Dispatchers.IO` and a `CoroutineName`.
+`AbstractReactiveMongoTest` lazily starts a `MongoDBServer` Testcontainer and registers `spring.mongodb.uri` dynamically. `spring.data.mongodb.uri` is the legacy namespace on Spring Boot 4.1+ and fails fast when it is the only URI key. `AbstractReactiveMongoCoroutineTest` adds a test scope with `Dispatchers.IO` and a `CoroutineName`.
 
 `ReactiveMongoOperationsCoroutinesTest` uses a real Spring Boot context and MongoDB to verify:
 

--- a/docs/manual/ko/modules/bluetape4k-spring-boot-mongodb/testing-operations-ecosystem.md
+++ b/docs/manual/ko/modules/bluetape4k-spring-boot-mongodb/testing-operations-ecosystem.md
@@ -7,9 +7,9 @@ chapterId: testing-operations-ecosystem
 
 # 테스트, 운영과 생태계
 
-## 1.12.1 테스트 구조
+## 현재 테스트 구조 (Spring Boot 4.1+)
 
-`AbstractReactiveMongoTest`는 `MongoDBServer` Testcontainer를 지연 시작하고 `spring.data.mongodb.uri`를 동적으로 등록합니다. `AbstractReactiveMongoCoroutineTest`는 여기에 `Dispatchers.IO`와 `CoroutineName`을 가진 test scope를 더합니다.
+`AbstractReactiveMongoTest`는 `MongoDBServer` Testcontainer를 지연 시작하고 `spring.mongodb.uri`를 동적으로 등록합니다. Spring Boot 4.1+에서 `spring.data.mongodb.uri`는 legacy namespace이며 유일한 URI key로 남으면 즉시 실패합니다. `AbstractReactiveMongoCoroutineTest`는 여기에 `Dispatchers.IO`와 `CoroutineName`을 가진 test scope를 더합니다.
 
 `ReactiveMongoOperationsCoroutinesTest`는 실제 Spring Boot context와 MongoDB를 사용해 다음 흐름을 검증합니다.
 

--- a/spring-boot/mongodb/README.ko.md
+++ b/spring-boot/mongodb/README.ko.md
@@ -2,12 +2,48 @@
 
 [English](./README.md) | 한국어
 
-[Spring Data MongoDB Reactive](https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/)를 Kotlin Coroutines 기반으로 편리하게 사용할 수 있도록 하는 확장 라이브러리입니다 (Spring Boot 4.x).
+[Spring Data MongoDB Reactive](https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/)를 Kotlin Coroutines 기반으로 편리하게 사용할 수 있도록 하는 확장 라이브러리입니다 (Spring Boot 4.1+).
 
 `ReactiveMongoOperations`의 `Flux`/`Mono` 반환 타입을 `Flow`/`suspend`로 변환하는 확장 함수와,
 `Criteria`·`Query`·`Update` 구성을 위한 Kotlin infix DSL을 제공합니다.
 
-> Spring Boot 4 기반 versionless 표준 구현입니다.
+> Spring Boot 4.1+ 기반 versionless 표준 구현입니다.
+
+## Spring Boot 4.1 설정 경계
+
+Spring Boot 4.1은 Mongo 연결 설정을 `spring.mongodb.*` namespace로
+바인딩합니다. 현재 URI 설정은 다음과 같이 작성하세요.
+
+```yaml
+spring:
+    mongodb:
+        uri: mongodb://127.0.0.1:27018/synthetic
+```
+
+`ReactiveMongoAutoConfiguration`은 Spring Boot의
+`DataMongoReactiveAutoConfiguration` 이후에 실행됩니다. 사용자가 제공한
+`ReactiveMongoOperations` Bean이 항상 우선하며, operations Bean이 없고
+`ReactiveMongoDatabaseFactory`와 `MongoConverter`가 모두 있을 때만
+fallback `ReactiveMongoTemplate`을 생성합니다.
+
+### `spring.data.mongodb.uri`에서 마이그레이션
+
+| 이전 설정 | 현재 설정 |
+|----------|----------|
+| `spring.data.mongodb.uri` | `spring.mongodb.uri` |
+
+legacy key만 남아 있으면 기본 localhost DB로 조용히 연결하지 않고 다음
+예외로 즉시 실패합니다.
+
+```text
+IllegalStateException: Unsupported legacy MongoDB property 'spring.data.mongodb.uri'; use 'spring.mongodb.uri' on Spring Boot 4.1+
+```
+
+단계적 전환 중 두 key가 함께 있으면 `spring.mongodb.uri`가 우선합니다.
+테스트에는 synthetic URI를 사용하고 credential을 로그나 진단 artifact에
+남기지 마세요. 즉시 마이그레이션할 수 없다면 legacy namespace를 지원하는
+이전 artifact 버전을 pin한 뒤 전환을 완료하고 Boot 4.1+ artifact로
+돌아오세요.
 
 ## 특징
 
@@ -120,6 +156,12 @@ val update = ("name" setTo "Alice")
 ```bash
 ./gradlew :bluetape4k-spring-boot-mongodb:test
 ```
+
+`ReactiveMongoAutoConfigurationTest` context suite는 namespace binding,
+legacy fail-fast, dual-key 우선순위, fallback 조건, Boot 순서, 단일 인스턴스
+생성, context close를 MongoDB 네트워크 I/O 없이 검증합니다. 실제 데이터베이스
+검증이 필요한 코루틴 통합 테스트는 공유 Testcontainers MongoDB 서버를
+사용하므로 별도로 실행하세요.
 
 ## 참고 자료
 

--- a/spring-boot/mongodb/README.md
+++ b/spring-boot/mongodb/README.md
@@ -2,12 +2,48 @@
 
 English | [한국어](./README.ko.md)
 
-An extension library for working with [Spring Data MongoDB Reactive](https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/) using Kotlin Coroutines (Spring Boot 4.x).
+An extension library for working with [Spring Data MongoDB Reactive](https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/) using Kotlin Coroutines (Spring Boot 4.1+).
 
 Provides extension functions that convert `Flux`/`Mono` return types from `ReactiveMongoOperations` to `Flow`/
 `suspend`, along with Kotlin infix DSLs for building `Criteria`, `Query`, and `Update` objects.
 
-> This is the versionless Spring Boot 4 implementation.
+> This is the versionless Spring Boot 4.1+ implementation.
+
+## Spring Boot 4.1 Configuration Boundary
+
+Spring Boot 4.1 binds Mongo connection settings under `spring.mongodb.*`.
+Configure the URI with the current namespace:
+
+```yaml
+spring:
+    mongodb:
+        uri: mongodb://127.0.0.1:27018/synthetic
+```
+
+`ReactiveMongoAutoConfiguration` runs after Spring Boot's
+`DataMongoReactiveAutoConfiguration`. A user-provided
+`ReactiveMongoOperations` bean always wins; the library creates a fallback
+`ReactiveMongoTemplate` only when no operations bean exists and both
+`ReactiveMongoDatabaseFactory` and `MongoConverter` are available.
+
+### Migration from `spring.data.mongodb.uri`
+
+| Before | After |
+|--------|-------|
+| `spring.data.mongodb.uri` | `spring.mongodb.uri` |
+
+The legacy-only key fails fast instead of silently connecting to the default
+localhost database:
+
+```text
+IllegalStateException: Unsupported legacy MongoDB property 'spring.data.mongodb.uri'; use 'spring.mongodb.uri' on Spring Boot 4.1+
+```
+
+During a staged migration, if both keys are present, `spring.mongodb.uri` takes
+precedence. Use a synthetic URI in tests and keep credentials out of logs and
+diagnostic artifacts. If migration cannot be completed immediately, pin the
+previous artifact version that still supports the legacy namespace, then
+resume the migration before returning to this Boot 4.1+ artifact.
 
 ## Features
 
@@ -120,6 +156,12 @@ val update = ("name" setTo "Alice")
 ```bash
 ./gradlew :bluetape4k-spring-boot-mongodb:test
 ```
+
+The `ReactiveMongoAutoConfigurationTest` context suite validates namespace
+binding, legacy fail-fast behavior, dual-key precedence, fallback conditions,
+Boot ordering, single-instance creation, and context close without MongoDB
+network I/O. The coroutine integration suite uses the shared Testcontainers
+MongoDB server and should be run separately when validating a real database.
 
 ## References
 

--- a/spring-boot/mongodb/src/main/kotlin/io/bluetape4k/spring/mongodb/config/ReactiveMongoAutoConfiguration.kt
+++ b/spring-boot/mongodb/src/main/kotlin/io/bluetape4k/spring/mongodb/config/ReactiveMongoAutoConfiguration.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
+import org.springframework.core.env.Environment
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory
 import org.springframework.data.mongodb.core.ReactiveMongoOperations
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate
@@ -15,20 +16,42 @@ import org.springframework.data.mongodb.core.convert.MongoConverter
  * ## 동작/계약
  * - `spring-boot-starter-data-mongodb-reactive` 의존성과 함께 `ReactiveMongoOperations` Bean이
  *   이미 등록되어 있지 않은 경우에만 [ReactiveMongoTemplate]을 등록합니다.
- * - 이 자동 구성보다 `spring-boot-autoconfigure`의 `ReactiveMongoAutoConfiguration`이
- *   우선 적용되므로, 사용자 설정이 있으면 무시됩니다.
- * - `spring.data.mongodb.uri` 또는 `spring.data.mongodb.host` 프로퍼티로 MongoDB URI를 지정하세요.
+ * - Spring Boot 4.1의 `MongoReactiveAutoConfiguration`과
+ *   `DataMongoReactiveAutoConfiguration` 이후에 적용되어 기본 template과 충돌하지 않습니다.
+ * - Spring Boot 4.1의 `MongoProperties` binding namespace인 `spring.mongodb.*`를 사용합니다.
+ *   legacy-only `spring.data.mongodb.uri`는 조용한 localhost fallback을 막기 위해 fail-fast합니다.
  *
  * ```yaml
  * spring:
- *   data:
- *     mongodb:
- *       uri: mongodb://localhost:27017/test
+ *   mongodb:
+ *     uri: mongodb://localhost:27017/test
  * ```
  */
-@AutoConfiguration
+@AutoConfiguration(
+    afterName = [
+        "org.springframework.boot.data.mongodb.autoconfigure.DataMongoReactiveAutoConfiguration",
+    ],
+)
 @ConditionalOnClass(ReactiveMongoOperations::class)
-class ReactiveMongoAutoConfiguration {
+class ReactiveMongoAutoConfiguration(
+    environment: Environment,
+) {
+
+    init {
+        if (environment.containsProperty(LEGACY_URI_PROPERTY) &&
+            !environment.containsProperty(CURRENT_URI_PROPERTY)
+        ) {
+            throw IllegalStateException(LEGACY_URI_MESSAGE)
+        }
+    }
+
+    private companion object {
+        const val CURRENT_URI_PROPERTY = "spring.mongodb.uri"
+        const val LEGACY_URI_PROPERTY = "spring.data.mongodb.uri"
+        const val LEGACY_URI_MESSAGE =
+            "Unsupported legacy MongoDB property 'spring.data.mongodb.uri'; use 'spring.mongodb.uri' on Spring Boot 4.1+"
+    }
+
     /**
      * [ReactiveMongoOperations] Bean이 없는 경우 [ReactiveMongoTemplate]을 자동으로 등록합니다.
      *

--- a/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/AbstractReactiveMongoTest.kt
+++ b/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/AbstractReactiveMongoTest.kt
@@ -12,7 +12,7 @@ import org.springframework.test.context.DynamicPropertySource
  * Spring Data MongoDB Reactive 통합 테스트의 기반 클래스입니다.
  *
  * [MongoDBServer] Testcontainer를 통해 Docker 기반 MongoDB를 자동으로 실행하며,
- * [DynamicPropertySource]로 `spring.data.mongodb.uri`를 동적으로 설정합니다.
+ * [DynamicPropertySource]로 Spring Boot 4.1의 `spring.mongodb.uri`를 동적으로 설정합니다.
  *
  * **사용 방법**: 구체 테스트 클래스에 `@SpringBootTest`를 붙이고 이 클래스를 상속합니다.
  * (Spring Boot 4의 `spring-boot-test-autoconfigure`에는 `@DataMongoTest` 슬라이스가 아직 없음)
@@ -37,7 +37,7 @@ abstract class AbstractReactiveMongoTest {
         val faker = Fakers.faker
 
         /**
-         * `spring.data.mongodb.uri` 프로퍼티를 Testcontainer의 연결 URL로 설정합니다.
+         * `spring.mongodb.uri` 프로퍼티를 Testcontainer의 연결 URL로 설정합니다.
          *
          * ## 동작/계약
          * - Spring Framework 5.2.5+ 에서 추상 클래스의 [DynamicPropertySource]는 하위 클래스에 상속됩니다.
@@ -46,7 +46,7 @@ abstract class AbstractReactiveMongoTest {
         @JvmStatic
         @DynamicPropertySource
         fun mongoProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.data.mongodb.uri") { mongoServer.url }
+            registry.add("spring.mongodb.uri") { mongoServer.url }
         }
     }
 

--- a/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/MongoTestApplication.kt
+++ b/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/MongoTestApplication.kt
@@ -1,40 +1,14 @@
 package io.bluetape4k.spring.mongodb
 
-import com.mongodb.ConnectionString
-import com.mongodb.MongoClientSettings
-import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.testcontainers.storage.MongoDBServer
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.context.annotation.Configuration
-import org.springframework.data.mongodb.config.AbstractReactiveMongoConfiguration
 
 /**
  * Spring Boot 4 MongoDB 통합 테스트용 애플리케이션 클래스입니다.
  *
  * Spring Boot 4에는 `@DataMongoTest` 슬라이스가 아직 없으므로 `@SpringBootTest`로 대체합니다.
- * companion object에서 [MongoDBServer]를 미리 시작하고, [MongoConfig]에서 직접
- * Testcontainers URL로 MongoDB 클라이언트를 설정합니다.
+ * MongoDB Testcontainer URL과 singleton lifecycle은 [AbstractReactiveMongoTest]의
+ * [org.springframework.test.context.DynamicPropertySource]가 소유하므로,
+ * 테스트 애플리케이션은 Spring Boot의 Mongo auto-configuration을 그대로 사용합니다.
  */
 @SpringBootApplication
-class MongoTestApplication {
-    companion object: KLoggingChannel() {
-        val mongoServer: MongoDBServer = MongoDBServer.Launcher.mongoDB
-    }
-
-    /**
-     * Testcontainers MongoDB 서버에 직접 연결하는 Reactive MongoDB 설정입니다.
-     *
-     * `@DynamicPropertySource` 대신 `AbstractReactiveMongoConfiguration`을 상속하여
-     * Bean 생성 시점에 MongoDB URL을 직접 설정합니다.
-     */
-    @Configuration(proxyBeanMethods = false)
-    class MongoConfig: AbstractReactiveMongoConfiguration() {
-        override fun getDatabaseName(): String = MongoDBServer.DATABASE_NAME
-
-        override fun configureClientSettings(builder: MongoClientSettings.Builder) {
-            builder.applyConnectionString(
-                ConnectionString(MongoDBServer.Launcher.mongoDB.url)
-            )
-        }
-    }
-}
+class MongoTestApplication

--- a/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/ReactiveMongoAutoConfigurationTest.kt
+++ b/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/ReactiveMongoAutoConfigurationTest.kt
@@ -1,0 +1,208 @@
+package io.bluetape4k.spring.mongodb
+
+import com.mongodb.MongoClientSettings
+import com.mongodb.reactivestreams.client.MongoClient
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.spring.mongodb.config.ReactiveMongoAutoConfiguration
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.getBean
+import org.springframework.beans.factory.getBeansOfType
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.mongodb.autoconfigure.MongoProperties
+import org.springframework.boot.mongodb.autoconfigure.MongoReactiveAutoConfiguration as BootMongoReactiveAutoConfiguration
+import org.springframework.boot.data.mongodb.autoconfigure.DataMongoReactiveAutoConfiguration as BootDataMongoReactiveAutoConfiguration
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory
+import org.springframework.data.mongodb.core.ReactiveMongoOperations
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter
+import org.springframework.data.mongodb.core.convert.MongoConverter
+import java.util.function.Supplier
+
+class ReactiveMongoAutoConfigurationTest {
+
+    private val autoConfigurationRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(ReactiveMongoAutoConfiguration::class.java))
+
+    @Test
+    fun `ReactiveMongoOperations class가 없으면 auto configuration이 비활성화된다`() {
+        autoConfigurationRunner
+            .withClassLoader(FilteredClassLoader(ReactiveMongoOperations::class.java))
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.getBeansOfType<ReactiveMongoOperations>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `spring mongodb uri가 Boot 41 MongoProperties에 bind된다`() {
+        val operations = mockk<ReactiveMongoOperations>(relaxed = true)
+        bootMongoRunner()
+            .withBean(ReactiveMongoOperations::class.java, Supplier { operations })
+            .withPropertyValues("spring.mongodb.uri=mongodb://127.0.0.1:27018/synthetic")
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.getBean<MongoProperties>().uri shouldBeEqualTo
+                        "mongodb://127.0.0.1:27018/synthetic"
+            }
+    }
+
+    @Test
+    fun `legacy URI만 있으면 정확한 migration exception으로 fail fast한다`() {
+        autoConfigurationRunner
+            .withPropertyValues("spring.data.mongodb.uri=mongodb://127.0.0.1:27018/legacy")
+            .run { context ->
+                val failure = context.getStartupFailure().shouldNotBeNull()
+                val migrationFailure = generateSequence(failure) { it.cause }
+                    .first { it is IllegalStateException && it.message == LEGACY_URI_MESSAGE }
+                migrationFailure.message shouldBeEqualTo LEGACY_URI_MESSAGE
+            }
+    }
+
+    @Test
+    fun `새 URI와 legacy URI가 함께 있으면 새 namespace가 우선한다`() {
+        val operations = mockk<ReactiveMongoOperations>(relaxed = true)
+        bootMongoRunner()
+            .withBean(ReactiveMongoOperations::class.java, Supplier { operations })
+            .withPropertyValues(
+                "spring.data.mongodb.uri=mongodb://127.0.0.1:27018/legacy",
+                "spring.mongodb.uri=mongodb://127.0.0.1:27019/current",
+            )
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.getBean<MongoProperties>().uri shouldBeEqualTo
+                        "mongodb://127.0.0.1:27019/current"
+            }
+    }
+
+    @Test
+    fun `사용자 ReactiveMongoOperations가 fallback template보다 우선한다`() {
+        val operations = mockk<ReactiveMongoOperations>(relaxed = true)
+        val databaseFactory = mockk<ReactiveMongoDatabaseFactory>(relaxed = true)
+        val converter = mockk<MongoConverter>(relaxed = true)
+
+        autoConfigurationRunner
+            .withBean(ReactiveMongoOperations::class.java, Supplier { operations })
+            .withBean(ReactiveMongoDatabaseFactory::class.java, Supplier { databaseFactory })
+            .withBean(MongoConverter::class.java, Supplier { converter })
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.getBeansOfType<ReactiveMongoOperations>().values.single() shouldBeSameInstanceAs operations
+                context.getBeansOfType<ReactiveMongoTemplate>().shouldBeEmpty()
+            }
+    }
+
+    @Test
+    fun `사용자 operations가 없으면 fallback ReactiveMongoTemplate이 생성된다`() {
+        val databaseFactory = mockk<ReactiveMongoDatabaseFactory>(relaxed = true)
+        val converter = mockk<MongoConverter>(relaxed = true)
+
+        autoConfigurationRunner
+            .withBean(ReactiveMongoDatabaseFactory::class.java, Supplier { databaseFactory })
+            .withBean(MongoConverter::class.java, Supplier { converter })
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.getBeansOfType<ReactiveMongoTemplate>().shouldHaveSize(1)
+            }
+    }
+
+    @Test
+    fun `Boot Data Mongo reactive template이 먼저 등록되어 custom template과 중복되지 않는다`() {
+        val client = mockk<MongoClient>(relaxed = true)
+        val settings = MongoClientSettings.builder().build()
+        val databaseFactory = mockk<ReactiveMongoDatabaseFactory>(relaxed = true)
+        val converter = mockk<MappingMongoConverter>(relaxed = true)
+
+        bootMongoRunner(includeDataMongo = true, client = client, settings = settings)
+            .withBean(ReactiveMongoDatabaseFactory::class.java, Supplier { databaseFactory })
+            .withBean(MappingMongoConverter::class.java, Supplier { converter })
+            .withPropertyValues("spring.mongodb.uri=mongodb://127.0.0.1:27018/synthetic")
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+                context.getBeansOfType<MongoClient>().shouldHaveSize(1)
+                context.getBeansOfType<ReactiveMongoDatabaseFactory>().shouldHaveSize(1)
+                context.getBeansOfType<ReactiveMongoTemplate>().shouldHaveSize(1)
+                context.getBeansOfType<ReactiveMongoOperations>().shouldHaveSize(1)
+
+                context.beanFactory
+                    .getBeanDefinition("reactiveMongoTemplate")
+                    .factoryBeanName
+                    .shouldNotBeNull()
+                    .shouldContain("DataMongoReactiveAutoConfiguration")
+            }
+    }
+
+    @Test
+    fun `context close가 Spring 관리 reactive client를 닫고 공유 server lifecycle을 건드리지 않는다`() {
+        val client = mockk<MongoClient>(relaxed = true)
+        val operations = mockk<ReactiveMongoOperations>(relaxed = true)
+
+        bootMongoRunner(client = client)
+            .withBean(ReactiveMongoOperations::class.java, Supplier { operations })
+            .run { context ->
+                context.getStartupFailure() shouldBeEqualTo null
+            }
+
+        verify(exactly = 1) { client.close() }
+    }
+
+    @Test
+    fun `ReactiveMongoDatabaseFactory가 없으면 fallback configuration 원인이 context failure에 남는다`() {
+        autoConfigurationRunner
+            .withBean(MongoConverter::class.java, Supplier { mockk<MongoConverter>(relaxed = true) })
+            .run { context ->
+                val failure = context.getStartupFailure().shouldNotBeNull()
+                failure.toString() shouldContain "ReactiveMongoDatabaseFactory"
+            }
+    }
+
+    @Test
+    fun `MongoConverter가 없으면 fallback configuration 원인이 context failure에 남는다`() {
+        autoConfigurationRunner
+            .withBean(
+                ReactiveMongoDatabaseFactory::class.java,
+                Supplier { mockk<ReactiveMongoDatabaseFactory>(relaxed = true) },
+            )
+            .run { context ->
+                val failure = context.getStartupFailure().shouldNotBeNull()
+                failure.toString() shouldContain "MongoConverter"
+            }
+    }
+
+    private fun bootMongoRunner(
+        includeDataMongo: Boolean = false,
+        client: MongoClient = mockk(relaxed = true),
+        settings: MongoClientSettings = MongoClientSettings.builder().build(),
+    ): ApplicationContextRunner {
+        val configurations = if (includeDataMongo) {
+            AutoConfigurations.of(
+                BootMongoReactiveAutoConfiguration::class.java,
+                BootDataMongoReactiveAutoConfiguration::class.java,
+                ReactiveMongoAutoConfiguration::class.java,
+            )
+        } else {
+            AutoConfigurations.of(
+                BootMongoReactiveAutoConfiguration::class.java,
+                ReactiveMongoAutoConfiguration::class.java,
+            )
+        }
+
+        return ApplicationContextRunner()
+            .withConfiguration(configurations)
+            .withBean(MongoClientSettings::class.java, Supplier { settings })
+            .withBean(MongoClient::class.java, Supplier { client })
+    }
+
+    private companion object {
+        const val LEGACY_URI_MESSAGE =
+            "Unsupported legacy MongoDB property 'spring.data.mongodb.uri'; use 'spring.mongodb.uri' on Spring Boot 4.1+"
+    }
+}

--- a/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/ReactiveMongoAutoConfigurationTest.kt
+++ b/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/ReactiveMongoAutoConfigurationTest.kt
@@ -141,7 +141,7 @@ class ReactiveMongoAutoConfigurationTest {
     }
 
     @Test
-    fun `context close가 Spring 관리 reactive client를 닫고 공유 server lifecycle을 건드리지 않는다`() {
+    fun `context close가 Spring 관리 reactive client를 정확히 한 번 닫는다`() {
         val client = mockk<MongoClient>(relaxed = true)
         val operations = mockk<ReactiveMongoOperations>(relaxed = true)
 

--- a/spring-boot/mongodb/src/test/resources/application.yml
+++ b/spring-boot/mongodb/src/test/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
     main:
-        allow-bean-definition-overriding: true
+        allow-bean-definition-overriding: false


### PR DESCRIPTION
Fixes #1358

## 목적

Spring Boot 4.1 Mongo reactive auto-configuration의 property namespace,
order, fallback, lifecycle 경계를 실제 Boot 동작과 일치시킵니다.

## Train 위치

- base: `develop` @ `19ce3d4af44d0cd7b7060c1407e7f57111763e6f` (#1529 merge)
- head: `fix/1358-mongodb-boot41-boundary` @ `58f7cb94197ad3288aa12fc6f7f5ca2f31711ecb`
- predecessor: #1529 merged exact SHA `19ce3d4af44d0cd7b7060c1407e7f57111763e6f`
- train 누적 문서: `docs/lessons/2026-08-26-epic-1420-data-contract-train.md`

## 변경 범위

- Boot 4.1 `spring.mongodb.uri` binding과
  `DataMongoReactiveAutoConfiguration` 이후 order를 적용했습니다.
- legacy-only `spring.data.mongodb.uri`는 정확한 `IllegalStateException`으로
  fail-fast하고, dual-key에서는 새 namespace가 우선합니다.
- user `ReactiveMongoOperations` 우선, fallback template 조건, 단일 client/
  factory/template, context close lifecycle을 mock context로 고정했습니다.
- 수동 `AbstractReactiveMongoConfiguration`과 eager server 설정을 제거하고
  `AbstractReactiveMongoTest`의 dynamic property/lifecycle만 사용하게 했습니다.
- EN/KO README에 before/after migration, rollback pin, synthetic URI credential
  hygiene를 동일하게 기록했습니다.

범위 밖: 외부 Mongo provider matrix, hosted workflow, legacy namespace를 계속
지원하는 compatibility shim.

## 검증

- `ReactiveMongoAutoConfigurationTest`: 10개 통과(네트워크 I/O 없음)
- `ReactiveMongoOperationsCoroutinesTest`: 31개 통과
- 누적 최종 train MongoDB 전체 테스트: 92개 통과
- `:bluetape4k-spring-boot-mongodb:detekt`: BUILD SUCCESSFUL
- 네 모듈 전체 detekt와 README parity, `git diff --check` 통과
- restack range-diff: 기존 #1358 5개 patch와 의도 일치

강제 Cassandra 누적 재실행에서 Gradle daemon이 `Shutdown in progress`로
사라져 18개 initialization failure가 발생했으나, Docker orphan 없음과 daemon
상태를 확인한 뒤 허용된 단일 재시도는 269개 전체 통과했습니다. 상세 evidence는
누적 lesson에 기록했습니다.

## Restack 및 rollback

#1529 merge 후 predecessor merge SHA를 재확인하고 `git range-diff`를 통과한 뒤
`--force-with-lease`로 `develop` 위에 restack했습니다. migration을 즉시 적용할
수 없는 소비자는 legacy namespace를 지원하는 이전 artifact를 임시 pin한 뒤
설정 전환 후 복귀합니다.

## DoD Status

- 로컬 구현·context/container 검증·문서·lesson: DONE
- restack exact-head: `58f7cb94197ad3288aa12fc6f7f5ca2f31711ecb`
- hosted exact-head CI/review/mergeability: restack 후 확인 필요
- 병합·자동 병합: fresh 명시 승인 범위에서 순차 진행
