### PR TITLE
[examples] Kafka callbackFlow bridge 실행 계약 추가

### DIFF
--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -21,6 +21,7 @@ ALLOWLIST = {
 SHA40 = re.compile(r"^[0-9a-fA-F]{40}$")
 USES = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
 URI = re.compile(r"\b(?:https?|amqps?|redis|kafka|postgres(?:ql)?|file)://[^\s<>\"']+")
+AUTHORIZATION_LINE = re.compile(r"(?im)^(\s*[\"']?authorization[\"']?\s*[:=]\s*).*$")
 SECRET_KEY_QUOTED = re.compile(
     r"(?i)([\"']?\b(?:authorization|token|password|secret|api[_-]?key)\b[\"']?\s*[:=]\s*)(\"|')([^\"']*)(\2)"
 )
@@ -33,7 +34,7 @@ INLINE_SENSITIVE = re.compile(
 XML_SENSITIVE = re.compile(
     r"(?is)(<\s*(?:payload|message|body|value)\b[^>]*>).*?(</\s*(?:payload|message|body|value)\s*>)"
 )
-UPPER_ENV_LINE = re.compile(r"(?im)^\s*[A-Z][A-Z0-9_]*\s*[:=].*$")
+UPPER_ENV_LINE = re.compile(r"(?m)^\s*[A-Z][A-Z0-9_]*\s*[:=].*$")
 LOWER_SENSITIVE_ENV_LINE = re.compile(
     r"(?im)^\s*[a-z][a-z0-9_]*(?:secret|token|password|api[_-]?key)[a-z0-9_]*\s*[:=].*$"
 )
@@ -44,6 +45,7 @@ EXCEPTION_MESSAGE = re.compile(r"(?im)^([^\r\n]*(?:Exception|Error))\s*:\s*[^\r\
 def sanitize(value: str) -> str:
     """Redact credentials, endpoints, payloads, and exception messages."""
 
+    value = AUTHORIZATION_LINE.sub(r"\1[REDACTED]", value)
     value = SECRET_KEY_QUOTED.sub(r"\1\2[REDACTED]\4", value)
     value = SECRET_KEY_UNQUOTED.sub(r"\1[REDACTED]", value)
     value = URI.sub("[REDACTED]", value)

--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -28,7 +28,7 @@ URI = re.compile(
 )
 AUTHORIZATION_LINE = re.compile(r"(?im)^(\s*[\"']?authorization[\"']?\s*[:=]\s*).*$")
 SENSITIVE_KEY = (
-    r"(?:payload|message|body|value|authorization|access[_-]?token|access[_-]?key(?:[_-]?id)?|token|password|secret|"
+    r"(?:payload|message|body|value|authorization|access[_-]?token|access[_-]?key(?:[_-]?id)?|token|password|secret[_-]?key|secret|"
     r"private[_-]?key|api[_-]?key|"
     r"[a-z][a-z0-9_.-]*(?:authorization|access[_-]?token|access[_-]?key(?:[_-]?id)?|token|password|secret|"
     r"private[_-]?key|api[_-]?key)[a-z0-9_.-]*)"

--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -239,6 +239,17 @@ def inspect_container(task_name: str, container_id: str) -> dict[str, Any]:
     image = str(config.get("Image") or payload.get("Image") or "")
     repo_digests = payload.get("RepoDigests") or []
     if not repo_digests:
+        if not image:
+            raise RuntimeError(f"{task_name}: container image is missing")
+        image_inspected = run_docker(task_name, ["image", "inspect", image])
+        if image_inspected.returncode != 0:
+            raise RuntimeError(f"{task_name}: docker image inspect failed")
+        try:
+            image_payload = json.loads(image_inspected.stdout)[0]
+        except (IndexError, json.JSONDecodeError, TypeError) as error:
+            raise RuntimeError(f"{task_name}: invalid docker image inspect response") from error
+        repo_digests = image_payload.get("RepoDigests") or []
+    if not repo_digests:
         raise RuntimeError(f"{task_name}: container image has no immutable repo digest")
     resolved = next((item for item in repo_digests if item in ALLOWLIST), None)
     if resolved is None:

--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Collect bounded, redacted Testcontainers diagnostics and test reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+DEFAULT_MAX_BYTES = 2_000_000
+DEFAULT_MAX_REPORT_FILES = 200
+ALLOWLIST = {
+    "confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130",
+    "redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a",
+}
+SHA40 = re.compile(r"^[0-9a-fA-F]{40}$")
+USES = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
+URI = re.compile(r"\b(?:https?|amqps?|redis|kafka|postgres(?:ql)?|file)://[^\s<>\"']+")
+SECRET_KEY_QUOTED = re.compile(
+    r"(?i)([\"']?\b(?:authorization|token|password|secret|api[_-]?key)\b[\"']?\s*[:=]\s*)(\"|')([^\"']*)(\2)"
+)
+SECRET_KEY_UNQUOTED = re.compile(
+    r"(?i)([\"']?\b(?:authorization|token|password|secret|api[_-]?key)\b[\"']?\s*[:=]\s*)(?!\[REDACTED\])([^\"'\s,;&}\]\r\n]+)"
+)
+INLINE_SENSITIVE = re.compile(
+    r'''(?is)([\"']?(?:payload|message|body|value)[\"']?\s*[:=]\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\{.*?\}|\[.*?\]|[^\s,;&}\]\r\n]+)'''
+)
+XML_SENSITIVE = re.compile(
+    r"(?is)(<\s*(?:payload|message|body|value)\b[^>]*>).*?(</\s*(?:payload|message|body|value)\s*>)"
+)
+UPPER_ENV_LINE = re.compile(r"(?im)^\s*[A-Z][A-Z0-9_]*\s*[:=].*$")
+LOWER_SENSITIVE_ENV_LINE = re.compile(
+    r"(?im)^\s*[a-z][a-z0-9_]*(?:secret|token|password|api[_-]?key)[a-z0-9_]*\s*[:=].*$"
+)
+SENSITIVE_LINE = re.compile(r"(?im)^\s*(?:payload|message|body|value)\s*[:=].*$")
+EXCEPTION_MESSAGE = re.compile(r"(?im)^([^\r\n]*(?:Exception|Error))\s*:\s*[^\r\n]*$")
+
+
+def sanitize(value: str) -> str:
+    """Redact credentials, endpoints, payloads, and exception messages."""
+
+    value = SECRET_KEY_QUOTED.sub(r"\1\2[REDACTED]\4", value)
+    value = SECRET_KEY_UNQUOTED.sub(r"\1[REDACTED]", value)
+    value = URI.sub("[REDACTED]", value)
+    value = INLINE_SENSITIVE.sub(r"\1[REDACTED]", value)
+    value = XML_SENSITIVE.sub(r"\1[REDACTED]\2", value)
+    value = UPPER_ENV_LINE.sub("[REDACTED]", value)
+    value = LOWER_SENSITIVE_ENV_LINE.sub("[REDACTED]", value)
+    value = SENSITIVE_LINE.sub("[REDACTED]", value)
+    value = EXCEPTION_MESSAGE.sub(r"\1: [REDACTED]", value)
+    return value
+
+
+def bounded_bytes(value: str, limit: int) -> tuple[bytes, bool]:
+    encoded = value.encode("utf-8", errors="replace")
+    if len(encoded) <= limit:
+        return encoded, False
+    return encoded[:limit], True
+
+
+def run_docker(task_name: str, args: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["docker", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except OSError as error:
+        raise RuntimeError(f"{task_name}: docker command unavailable") from error
+
+
+def workflow_action_refs(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    refs: list[str] = []
+    for reference in USES.findall(text):
+        if "@" not in reference:
+            raise ValueError(f"{path}: mutable workflow action reference")
+        action, ref = reference.rsplit("@", 1)
+        if not SHA40.fullmatch(ref):
+            raise ValueError(f"{path}: workflow action is not pinned to a commit SHA")
+        normalized = f"{action}@{ref.lower()}"
+        if normalized not in refs:
+            refs.append(normalized)
+    return refs
+
+
+def inspect_container(task_name: str, container_id: str) -> tuple[dict[str, Any], str | None]:
+    inspected = run_docker(task_name, ["inspect", container_id])
+    if inspected.returncode != 0:
+        raise RuntimeError(f"{task_name}: docker inspect failed")
+    try:
+        payload = json.loads(inspected.stdout)[0]
+    except (IndexError, json.JSONDecodeError, TypeError) as error:
+        raise RuntimeError(f"{task_name}: invalid docker inspect response") from error
+
+    config = payload.get("Config") or {}
+    image = str(config.get("Image") or payload.get("Config", {}).get("Image") or "")
+    repo_digests = payload.get("RepoDigests") or []
+    if not repo_digests:
+        image_reference = image or str(payload.get("Image") or "")
+        image_inspected = run_docker(task_name, ["image", "inspect", image_reference])
+        if image_inspected.returncode != 0:
+            raise RuntimeError(f"{task_name}: docker image inspect failed")
+        try:
+            image_payload = json.loads(image_inspected.stdout)[0]
+            repo_digests = image_payload.get("RepoDigests") or []
+        except (IndexError, json.JSONDecodeError, TypeError) as error:
+            raise RuntimeError(f"{task_name}: invalid docker image inspect response") from error
+    resolved = next((item for item in repo_digests if item in ALLOWLIST), None)
+    if resolved is None:
+        raise RuntimeError(f"{task_name}: container image is outside the diagnostics allowlist")
+
+    name = str(payload.get("Name") or container_id).lstrip("/")
+    record = {
+        "id": container_id,
+        "name": name,
+        "image": image,
+        "image_id": payload.get("Image"),
+        "image_digest": resolved,
+        "created": payload.get("Created"),
+    }
+    logs_result = run_docker(task_name, ["logs", "--tail", "200", container_id])
+    if logs_result.returncode != 0:
+        return record, None
+    return record, sanitize(logs_result.stdout + logs_result.stderr)
+
+
+def matching_report_files(root: Path) -> list[Path]:
+    if root.is_symlink():
+        raise ValueError(f"report path is a symlink: {root}")
+    if not root.is_dir():
+        raise ValueError(f"report path does not exist: {root}")
+    allowed_suffixes = {".xml", ".html", ".css", ".js"}
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"report path contains a symlink: {path}")
+        if path.is_file() and path.suffix.lower() in allowed_suffixes:
+            files.append(path)
+    return sorted(files)
+
+
+def sanitize_reports(
+    report_paths: Iterable[Path],
+    destination: Path,
+    repo_root: Path,
+    max_files: int,
+    max_total_bytes: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    all_files: list[tuple[Path, Path]] = []
+    for root in report_paths:
+        files = matching_report_files(root)
+        if not files:
+            raise ValueError(f"report path has no supported files: {root}")
+        try:
+            relative_root = root.relative_to(repo_root)
+        except ValueError as error:
+            raise ValueError(f"report path is outside repository: {root}") from error
+        all_files.extend((path, destination / relative_root / path.relative_to(root)) for path in files)
+
+    truncated = len(all_files) > max_files
+    selected = all_files[:max_files]
+    written: list[dict[str, Any]] = []
+    used = 0
+    for source, target in selected:
+        raw = source.read_text(encoding="utf-8", errors="replace")
+        sanitized = sanitize(raw)
+        remaining = max_total_bytes - used
+        if remaining <= 0:
+            truncated = True
+            break
+        data, was_truncated = bounded_bytes(sanitized, min(2_000_000, remaining))
+        if was_truncated:
+            truncated = True
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        used += len(data)
+        written.append(
+            {
+                "source": str(source.relative_to(repo_root)),
+                "destination": str(target.relative_to(destination)),
+                "bytes": len(data),
+            }
+        )
+        if was_truncated:
+            break
+    if len(written) < len(all_files):
+        truncated = True
+    return written, truncated
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task-name", required=True)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--workflow-file", required=True, type=Path)
+    parser.add_argument("--max-total-bytes", type=int, default=DEFAULT_MAX_BYTES)
+    parser.add_argument("--container-id", action="append", default=[])
+    parser.add_argument("--sanitized-report-dir", type=Path)
+    parser.add_argument("--report-path", action="append", default=[], type=Path)
+    parser.add_argument("--max-report-files", type=int, default=DEFAULT_MAX_REPORT_FILES)
+    parser.add_argument("--max-report-total-bytes", type=int, default=DEFAULT_MAX_BYTES)
+    return parser.parse_args()
+
+
+def write_manifest(path: Path, manifest: dict[str, Any], max_bytes: int) -> None:
+    encoded = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    if len(encoded) > max_bytes:
+        # The manifest is deliberately small; if a caller supplies an unusable cap, fail closed.
+        raise ValueError("manifest exceeds max-total-bytes")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(encoded)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.max_total_bytes <= 0 or args.max_report_files <= 0 or args.max_report_total_bytes <= 0:
+        print(f"{args.task_name}: diagnostic limits must be positive", file=sys.stderr)
+        return 1
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, Any] = {
+        "task_name": args.task_name,
+        "workflow_action_refs": [],
+        "containers": [],
+        "truncated": False,
+        "sanitized_reports": [],
+        "report_truncated": False,
+    }
+    try:
+        manifest["workflow_action_refs"] = workflow_action_refs(args.workflow_file)
+        container_logs: list[tuple[str, str]] = []
+        for container_id in sorted(set(args.container_id)):
+            record, logs = inspect_container(args.task_name, container_id)
+            manifest["containers"].append(record)
+            if logs:
+                container_logs.append((container_id, logs))
+
+        # Reserve space for the manifest before writing bounded log files.
+        provisional = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+        log_budget = max(0, args.max_total_bytes - len(provisional))
+        log_used = 0
+        for container_id, logs in container_logs:
+            remaining = log_budget - log_used
+            data, was_truncated = bounded_bytes(logs, remaining)
+            if was_truncated:
+                manifest["truncated"] = True
+            log_path = args.output_dir / f"{container_id}.log"
+            log_path.write_bytes(data)
+            log_used += len(data)
+            if was_truncated:
+                break
+
+        if args.report_path:
+            if args.sanitized_report_dir is None:
+                raise ValueError("sanitized-report-dir is required with report-path")
+            repo_root = args.workflow_file.resolve().parents[2]
+            reports, report_truncated = sanitize_reports(
+                [path.resolve() for path in args.report_path],
+                args.sanitized_report_dir.resolve(),
+                repo_root,
+                args.max_report_files,
+                args.max_report_total_bytes,
+            )
+            manifest["sanitized_reports"] = reports
+            manifest["report_truncated"] = report_truncated
+
+        write_manifest(args.output_dir / "manifest.json", manifest, args.max_total_bytes)
+    except (OSError, RuntimeError, ValueError) as error:
+        # Do not echo Docker output or report contents; the task name is the only diagnostic detail.
+        print(str(error) if str(error).startswith(args.task_name) else f"{args.task_name}: diagnostics failed", file=sys.stderr)
+        try:
+            write_manifest(args.output_dir / "manifest.json", manifest, args.max_total_bytes)
+        except (OSError, ValueError):
+            pass
+        return 1
+    return 1 if manifest["report_truncated"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -237,12 +237,14 @@ def inspect_container(task_name: str, container_id: str) -> dict[str, Any]:
 
     config = payload.get("Config") or {}
     container_image_id = str(payload.get("Image") or "")
+    if not container_image_id:
+        raise RuntimeError(f"{task_name}: container image id is missing")
     image = str(config.get("Image") or container_image_id)
     repo_digests = payload.get("RepoDigests") or []
     if not repo_digests:
         if not image:
             raise RuntimeError(f"{task_name}: container image is missing")
-        image_reference = container_image_id or image
+        image_reference = container_image_id
         image_inspected = run_docker(task_name, ["image", "inspect", image_reference])
         if image_inspected.returncode != 0:
             raise RuntimeError(f"{task_name}: docker image inspect failed")

--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -236,18 +236,23 @@ def inspect_container(task_name: str, container_id: str) -> dict[str, Any]:
         raise RuntimeError(f"{task_name}: invalid docker inspect response") from error
 
     config = payload.get("Config") or {}
-    image = str(config.get("Image") or payload.get("Image") or "")
+    container_image_id = str(payload.get("Image") or "")
+    image = str(config.get("Image") or container_image_id)
     repo_digests = payload.get("RepoDigests") or []
     if not repo_digests:
         if not image:
             raise RuntimeError(f"{task_name}: container image is missing")
-        image_inspected = run_docker(task_name, ["image", "inspect", image])
+        image_reference = container_image_id or image
+        image_inspected = run_docker(task_name, ["image", "inspect", image_reference])
         if image_inspected.returncode != 0:
             raise RuntimeError(f"{task_name}: docker image inspect failed")
         try:
             image_payload = json.loads(image_inspected.stdout)[0]
         except (IndexError, json.JSONDecodeError, TypeError) as error:
             raise RuntimeError(f"{task_name}: invalid docker image inspect response") from error
+        inspected_image_id = str(image_payload.get("Id") or "")
+        if container_image_id and inspected_image_id != container_image_id:
+            raise RuntimeError(f"{task_name}: container image identity mismatch")
         repo_digests = image_payload.get("RepoDigests") or []
     if not repo_digests:
         raise RuntimeError(f"{task_name}: container image has no immutable repo digest")

--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -16,6 +16,9 @@ from typing import Any, NamedTuple
 DEFAULT_MAX_BYTES = 2_000_000
 DEFAULT_MAX_REPORT_FILES = 200
 MAX_REPORT_FILE_BYTES = 2_000_000
+# Read reports with a bounded source budget before compacting unbounded test output.
+# The sanitized artifact remains capped by MAX_REPORT_FILE_BYTES.
+MAX_REPORT_SOURCE_BYTES = 32_000_000
 MAX_REPORT_ENTRIES = 50_000
 ALLOWLIST = {
     "confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130",
@@ -38,6 +41,12 @@ SENSITIVE_ASSIGNMENT_KEY = re.compile(
 )
 XML_SENSITIVE = re.compile(
     rf"(?is)(<\s*(?P<tag>{SENSITIVE_KEY}|failure|error)\b[^>]*>).*?(</\s*(?P=tag)\s*>)"
+)
+XML_REPORT_OUTPUT = re.compile(
+    r"(?is)(<\s*(?P<tag>system-out|system-err)\b[^>]*>).*?(</\s*(?P=tag)\s*>)"
+)
+HTML_REPORT_OUTPUT = re.compile(
+    r'(?is)(<pre\b(?=[^>]*\bid\s*=\s*["\'][^"\']*-(?:stdout|stderr)-[^"\']*["\'])[^>]*>).*?(</pre\s*>)'
 )
 SENSITIVE_ENV_LINE = re.compile(
     r"(?im)^\s*[A-Z][A-Z0-9_]*(?:AUTHORIZATION|ACCESS[_-]?TOKEN|ACCESS[_-]?KEY(?:[_-]?ID)?|"
@@ -145,6 +154,14 @@ def sanitize(value: str) -> str:
     value = SENSITIVE_LINE.sub("[REDACTED]", value)
     value = EXCEPTION_MESSAGE.sub(r"\1: [REDACTED]", value)
     return value
+
+
+def sanitize_report(value: str) -> str:
+    """Compact verbose test output before applying the generic redaction rules."""
+
+    value = XML_REPORT_OUTPUT.sub(r"\1[REDACTED]\3", value)
+    value = HTML_REPORT_OUTPUT.sub(r"\1[REDACTED]\2", value)
+    return sanitize(value)
 
 
 def bounded_bytes(value: str, limit: int) -> tuple[bytes, bool]:
@@ -386,10 +403,10 @@ def sanitize_reports(
             break
         per_file_limit = min(MAX_REPORT_FILE_BYTES, remaining)
         with source.open("rb") as handle:
-            raw_bytes = handle.read(per_file_limit + 1)
+            raw_bytes = handle.read(MAX_REPORT_SOURCE_BYTES + 1)
         raw = raw_bytes.decode("utf-8", errors="replace")
-        raw_truncated = len(raw_bytes) > per_file_limit
-        sanitized = sanitize(raw)
+        raw_truncated = len(raw_bytes) > MAX_REPORT_SOURCE_BYTES
+        sanitized = sanitize_report(raw)
         data, was_truncated = bounded_bytes(sanitized, per_file_limit)
         was_truncated = was_truncated or raw_truncated
         if was_truncated:

--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -5,54 +5,137 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
-
+from typing import Any
 
 DEFAULT_MAX_BYTES = 2_000_000
 DEFAULT_MAX_REPORT_FILES = 200
+MAX_REPORT_FILE_BYTES = 2_000_000
+MAX_REPORT_ENTRIES = 50_000
 ALLOWLIST = {
     "confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130",
     "redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a",
 }
 SHA40 = re.compile(r"^[0-9a-fA-F]{40}$")
-USES = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
-URI = re.compile(r"\b(?:https?|amqps?|redis|kafka|postgres(?:ql)?|file)://[^\s<>\"']+")
+USES_KEY = re.compile(r"(?i)(?:^|[,{])\s*(?:-\s*)?(?:[\"']uses[\"']|uses)\s*:")
+URI = re.compile(
+    r"\b(?:https?|amqps?|redis|kafka|postgres(?:ql)?|mongodb(?:\+srv)?|mysql|file|jdbc:[a-z0-9+.-]+)://[^\s<>\"']+"
+)
 AUTHORIZATION_LINE = re.compile(r"(?im)^(\s*[\"']?authorization[\"']?\s*[:=]\s*).*$")
-SECRET_KEY_QUOTED = re.compile(
-    r"(?i)([\"']?\b(?:authorization|token|password|secret|api[_-]?key)\b[\"']?\s*[:=]\s*)(\"|')([^\"']*)(\2)"
+SENSITIVE_KEY = (
+    r"(?:payload|message|body|value|authorization|access[_-]?token|access[_-]?key(?:[_-]?id)?|token|password|secret|"
+    r"private[_-]?key|api[_-]?key|"
+    r"[a-z][a-z0-9_.-]*(?:authorization|access[_-]?token|access[_-]?key(?:[_-]?id)?|token|password|secret|"
+    r"private[_-]?key|api[_-]?key)[a-z0-9_.-]*)"
 )
-SECRET_KEY_UNQUOTED = re.compile(
-    r"(?i)([\"']?\b(?:authorization|token|password|secret|api[_-]?key)\b[\"']?\s*[:=]\s*)(?!\[REDACTED\])([^\"'\s,;&}\]\r\n]+)"
-)
-INLINE_SENSITIVE = re.compile(
-    r'''(?is)([\"']?(?:payload|message|body|value)[\"']?\s*[:=]\s*)(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|\{.*?\}|\[.*?\]|[^\s,;&}\]\r\n]+)'''
+SENSITIVE_ASSIGNMENT_KEY = re.compile(
+    rf'''(?is)(?<![a-z0-9_.-])([\"']?{SENSITIVE_KEY}[\"']?\s*[:=]\s*)'''
 )
 XML_SENSITIVE = re.compile(
-    r"(?is)(<\s*(?:payload|message|body|value)\b[^>]*>).*?(</\s*(?:payload|message|body|value)\s*>)"
+    rf"(?is)(<\s*(?P<tag>{SENSITIVE_KEY}|failure|error)\b[^>]*>).*?(</\s*(?P=tag)\s*>)"
 )
-UPPER_ENV_LINE = re.compile(r"(?m)^\s*[A-Z][A-Z0-9_]*\s*[:=].*$")
-LOWER_SENSITIVE_ENV_LINE = re.compile(
-    r"(?im)^\s*[a-z][a-z0-9_]*(?:secret|token|password|api[_-]?key)[a-z0-9_]*\s*[:=].*$"
+SENSITIVE_ENV_LINE = re.compile(
+    r"(?im)^\s*[A-Z][A-Z0-9_]*(?:AUTHORIZATION|ACCESS[_-]?TOKEN|ACCESS[_-]?KEY(?:[_-]?ID)?|"
+    r"TOKEN|PASSWORD|SECRET|PRIVATE[_-]?KEY|API[_-]?KEY|CREDENTIALS?)[A-Z0-9_-]*\s*[:=].*$"
 )
 SENSITIVE_LINE = re.compile(r"(?im)^\s*(?:payload|message|body|value)\s*[:=].*$")
 EXCEPTION_MESSAGE = re.compile(r"(?im)^([^\r\n]*(?:Exception|Error))\s*:\s*[^\r\n]*$")
+
+
+def _assignment_value_end(value: str, start: int) -> int:
+    """Find the end of a scalar, quoted, or balanced object assignment."""
+
+    index = start
+    while index < len(value) and value[index].isspace():
+        index += 1
+    if index >= len(value):
+        return index
+
+    opening = value[index]
+    if opening in "\"'":
+        quote = opening
+        index += 1
+        escaped = False
+        while index < len(value):
+            character = value[index]
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                return index + 1
+            index += 1
+        return index
+
+    if opening in "[{":
+        closing = {"[": "]", "{": "}"}
+        stack = [opening]
+        index += 1
+        quote: str | None = None
+        escaped = False
+        while index < len(value) and stack:
+            character = value[index]
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = None
+            elif character in "\"'":
+                quote = character
+            elif character in "[{":
+                stack.append(character)
+            elif character in "]}" and character == closing[stack[-1]]:
+                stack.pop()
+            index += 1
+        return index
+
+    while index < len(value) and value[index] not in " \t,;&}]\r\n":
+        index += 1
+    return index
+
+
+def redact_sensitive_assignments(value: str) -> str:
+    """Replace complete sensitive assignment values, including nested objects."""
+
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    while match := SENSITIVE_ASSIGNMENT_KEY.search(value, cursor):
+        start = match.end()
+        end = _assignment_value_end(value, start)
+        value_start = start
+        while value_start < end and value[value_start].isspace():
+            value_start += 1
+        spans.append((value_start, end))
+        cursor = max(end, match.end() + 1)
+
+    if not spans:
+        return value
+    output: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        if start < cursor:
+            continue
+        output.extend((value[cursor:start], "[REDACTED]"))
+        cursor = end
+    output.append(value[cursor:])
+    return "".join(output)
 
 
 def sanitize(value: str) -> str:
     """Redact credentials, endpoints, payloads, and exception messages."""
 
     value = AUTHORIZATION_LINE.sub(r"\1[REDACTED]", value)
-    value = SECRET_KEY_QUOTED.sub(r"\1\2[REDACTED]\4", value)
-    value = SECRET_KEY_UNQUOTED.sub(r"\1[REDACTED]", value)
+    value = redact_sensitive_assignments(value)
     value = URI.sub("[REDACTED]", value)
-    value = INLINE_SENSITIVE.sub(r"\1[REDACTED]", value)
-    value = XML_SENSITIVE.sub(r"\1[REDACTED]\2", value)
-    value = UPPER_ENV_LINE.sub("[REDACTED]", value)
-    value = LOWER_SENSITIVE_ENV_LINE.sub("[REDACTED]", value)
+    value = XML_SENSITIVE.sub(r"\1[REDACTED]\3", value)
+    value = SENSITIVE_ENV_LINE.sub("[REDACTED]", value)
     value = SENSITIVE_LINE.sub("[REDACTED]", value)
     value = EXCEPTION_MESSAGE.sub(r"\1: [REDACTED]", value)
     return value
@@ -79,22 +162,61 @@ def run_docker(task_name: str, args: list[str]) -> subprocess.CompletedProcess[s
         raise RuntimeError(f"{task_name}: docker command unavailable") from error
 
 
+def run_docker_logs(task_name: str, container_id: str, max_bytes: int) -> subprocess.CompletedProcess[str]:
+    command = ["docker", "logs", "--tail", "200", container_id]
+    try:
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except OSError as error:
+        raise RuntimeError(f"{task_name}: docker command unavailable") from error
+    output = process.stdout.read(max_bytes + 1) if process.stdout is not None else b""
+    output_truncated = len(output) > max_bytes
+    if output_truncated:
+        process.kill()
+    process.wait()
+    return subprocess.CompletedProcess(
+        command,
+        0 if output_truncated else process.returncode,
+        output.decode("utf-8", errors="replace"),
+        "",
+    )
+
+
 def workflow_action_refs(path: Path) -> list[str]:
-    text = path.read_text(encoding="utf-8")
     refs: list[str] = []
-    for reference in USES.findall(text):
-        if "@" not in reference:
-            raise ValueError(f"{path}: mutable workflow action reference")
-        action, ref = reference.rsplit("@", 1)
-        if not SHA40.fullmatch(ref):
-            raise ValueError(f"{path}: workflow action is not pinned to a commit SHA")
-        normalized = f"{action}@{ref.lower()}"
-        if normalized not in refs:
-            refs.append(normalized)
+    with path.open("rb") as handle:
+        workflow_bytes = handle.read(MAX_REPORT_FILE_BYTES + 1)
+    if len(workflow_bytes) > MAX_REPORT_FILE_BYTES:
+        raise ValueError(f"{path}: workflow file exceeds size limit")
+    for line_number, original_line in enumerate(
+        workflow_bytes.decode("utf-8", errors="replace").splitlines(), start=1
+    ):
+        if original_line.lstrip().startswith("#"):
+            continue
+        line = original_line.split("#", 1)[0]
+        for match in USES_KEY.finditer(line):
+            tail = line[match.end():].lstrip()
+            if not tail:
+                raise ValueError(f"{path}:{line_number}: missing workflow action reference")
+            if tail[0] in "\"'":
+                quote = tail[0]
+                end = tail.find(quote, 1)
+                if end < 0:
+                    raise ValueError(f"{path}:{line_number}: malformed workflow action reference")
+                reference = tail[1:end]
+            else:
+                reference = re.split(r"[\s,}]+", tail, maxsplit=1)[0]
+            if "@" not in reference:
+                raise ValueError(f"{path}:{line_number}: mutable workflow action reference")
+            action, ref = reference.rsplit("@", 1)
+            if not action or not SHA40.fullmatch(ref):
+                raise ValueError(f"{path}:{line_number}: workflow action is not pinned to a commit SHA")
+            normalized = f"{action}@{ref.lower()}"
+            if normalized not in refs:
+                refs.append(normalized)
     return refs
 
 
-def inspect_container(task_name: str, container_id: str) -> tuple[dict[str, Any], str | None]:
+def inspect_container(task_name: str, container_id: str) -> dict[str, Any]:
     inspected = run_docker(task_name, ["inspect", container_id])
     if inspected.returncode != 0:
         raise RuntimeError(f"{task_name}: docker inspect failed")
@@ -104,7 +226,7 @@ def inspect_container(task_name: str, container_id: str) -> tuple[dict[str, Any]
         raise RuntimeError(f"{task_name}: invalid docker inspect response") from error
 
     config = payload.get("Config") or {}
-    image = str(config.get("Image") or payload.get("Config", {}).get("Image") or "")
+    image = str(config.get("Image") or payload.get("Image") or "")
     repo_digests = payload.get("RepoDigests") or []
     if not repo_digests:
         image_reference = image or str(payload.get("Image") or "")
@@ -129,25 +251,83 @@ def inspect_container(task_name: str, container_id: str) -> tuple[dict[str, Any]
         "image_digest": resolved,
         "created": payload.get("Created"),
     }
-    logs_result = run_docker(task_name, ["logs", "--tail", "200", container_id])
+    return record
+
+
+def collect_container_logs(task_name: str, container_id: str, max_log_bytes: int) -> str | None:
+    """Read and sanitize one container's bounded log stream."""
+
+    logs_result = run_docker_logs(task_name, container_id, max_log_bytes)
     if logs_result.returncode != 0:
-        return record, None
-    return record, sanitize(logs_result.stdout + logs_result.stderr)
+        return None
+    return sanitize(logs_result.stdout + logs_result.stderr)
 
 
-def matching_report_files(root: Path) -> list[Path]:
+CONTAINER_ID = re.compile(r"^[0-9a-fA-F]{12,64}$")
+
+
+def normalized_path(path: Path) -> Path:
+    """Normalize lexical dot segments without following symlinks."""
+
+    return Path(os.path.abspath(path))
+
+
+def reject_symlink_components(path: Path, stop_at: Path | None = None) -> None:
+    """Reject a path or any existing parent component that is a symlink."""
+
+    current = path.absolute()
+    boundary = stop_at.absolute() if stop_at is not None else None
+    while True:
+        if boundary is not None and current == boundary:
+            return
+        if current.is_symlink():
+            raise ValueError(f"path contains a symlink: {path}")
+        if current.parent == current:
+            return
+        current = current.parent
+
+
+def require_relative(path: Path, root: Path, description: str) -> None:
+    try:
+        path.relative_to(root)
+    except ValueError as error:
+        raise ValueError(f"{description} is outside repository: {path}") from error
+
+
+def matching_report_files(root: Path, max_files: int, repo_root: Path) -> tuple[list[Path], bool]:
+    reject_symlink_components(root, repo_root)
     if root.is_symlink():
         raise ValueError(f"report path is a symlink: {root}")
     if not root.is_dir():
         raise ValueError(f"report path does not exist: {root}")
     allowed_suffixes = {".xml", ".html", ".css", ".js"}
     files: list[Path] = []
-    for path in root.rglob("*"):
-        if path.is_symlink():
-            raise ValueError(f"report path contains a symlink: {path}")
-        if path.is_file() and path.suffix.lower() in allowed_suffixes:
-            files.append(path)
-    return sorted(files)
+    directories = [root]
+    entries_seen = 0
+    while directories:
+        directory = directories.pop()
+        entries: list[os.DirEntry[str]] = []
+        try:
+            with os.scandir(directory) as scanner:
+                for entry in scanner:
+                    entries_seen += 1
+                    if entries_seen > MAX_REPORT_ENTRIES:
+                        return sorted(files), True
+                    entries.append(entry)
+        except OSError as error:
+            raise ValueError(f"report path cannot be read: {directory}") from error
+        entries.sort(key=lambda entry: entry.name)
+        for entry in entries:
+            path = Path(entry.path)
+            if entry.is_symlink():
+                raise ValueError(f"report path contains a symlink: {path}")
+            if entry.is_dir(follow_symlinks=False):
+                directories.append(path)
+            elif entry.is_file(follow_symlinks=False) and path.suffix.lower() in allowed_suffixes:
+                files.append(path)
+                if len(files) > max_files:
+                    return sorted(files), True
+    return sorted(files), False
 
 
 def sanitize_reports(
@@ -158,31 +338,47 @@ def sanitize_reports(
     max_total_bytes: int,
 ) -> tuple[list[dict[str, Any]], bool]:
     all_files: list[tuple[Path, Path]] = []
+    truncated = False
     for root in report_paths:
-        files = matching_report_files(root)
+        remaining_files = max_files - len(all_files)
+        if remaining_files <= 0:
+            truncated = True
+            break
+        files, files_truncated = matching_report_files(root, remaining_files + 1, repo_root)
+        truncated = truncated or files_truncated
         if not files:
             raise ValueError(f"report path has no supported files: {root}")
         try:
             relative_root = root.relative_to(repo_root)
         except ValueError as error:
             raise ValueError(f"report path is outside repository: {root}") from error
+        if len(files) > remaining_files:
+            truncated = True
+            files = files[:remaining_files]
         all_files.extend((path, destination / relative_root / path.relative_to(root)) for path in files)
 
-    truncated = len(all_files) > max_files
-    selected = all_files[:max_files]
     written: list[dict[str, Any]] = []
     used = 0
-    for source, target in selected:
-        raw = source.read_text(encoding="utf-8", errors="replace")
-        sanitized = sanitize(raw)
+    for source, target in all_files:
         remaining = max_total_bytes - used
         if remaining <= 0:
             truncated = True
             break
-        data, was_truncated = bounded_bytes(sanitized, min(2_000_000, remaining))
+        per_file_limit = min(MAX_REPORT_FILE_BYTES, remaining)
+        with source.open("rb") as handle:
+            raw_bytes = handle.read(per_file_limit + 1)
+        raw = raw_bytes.decode("utf-8", errors="replace")
+        raw_truncated = len(raw_bytes) > per_file_limit
+        sanitized = sanitize(raw)
+        data, was_truncated = bounded_bytes(sanitized, per_file_limit)
+        was_truncated = was_truncated or raw_truncated
         if was_truncated:
             truncated = True
+        reject_symlink_components(target.parent, repo_root)
         target.parent.mkdir(parents=True, exist_ok=True)
+        reject_symlink_components(target.parent, repo_root)
+        if target.is_symlink():
+            raise ValueError(f"sanitized report target is a symlink: {target}")
         target.write_bytes(data)
         used += len(data)
         written.append(
@@ -218,6 +414,8 @@ def write_manifest(path: Path, manifest: dict[str, Any], max_bytes: int) -> None
     if len(encoded) > max_bytes:
         # The manifest is deliberately small; if a caller supplies an unusable cap, fail closed.
         raise ValueError("manifest exceeds max-total-bytes")
+    if path.is_symlink():
+        raise ValueError(f"manifest target is a symlink: {path}")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(encoded)
 
@@ -228,7 +426,28 @@ def main() -> int:
         print(f"{args.task_name}: diagnostic limits must be positive", file=sys.stderr)
         return 1
 
-    args.output_dir.mkdir(parents=True, exist_ok=True)
+    args.workflow_file = normalized_path(args.workflow_file)
+    args.output_dir = normalized_path(args.output_dir)
+    args.report_path = [normalized_path(path) for path in args.report_path]
+    if args.sanitized_report_dir is not None:
+        args.sanitized_report_dir = normalized_path(args.sanitized_report_dir)
+    try:
+        repo_root = args.workflow_file.parents[2]
+        reject_symlink_components(args.workflow_file, repo_root)
+        reject_symlink_components(args.output_dir, repo_root)
+        require_relative(args.workflow_file, repo_root, "workflow file")
+        require_relative(args.output_dir, repo_root, "output directory")
+        if args.sanitized_report_dir is not None:
+            reject_symlink_components(args.sanitized_report_dir, repo_root)
+            require_relative(args.sanitized_report_dir, repo_root, "sanitized report directory")
+        for report_path in args.report_path:
+            reject_symlink_components(report_path, repo_root)
+            require_relative(report_path, repo_root, "report path")
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+    except (OSError, ValueError) as error:
+        print(str(error) if str(error).startswith(args.task_name) else f"{args.task_name}: diagnostics failed", file=sys.stderr)
+        return 1
+
     manifest: dict[str, Any] = {
         "task_name": args.task_name,
         "workflow_action_refs": [],
@@ -239,23 +458,27 @@ def main() -> int:
     }
     try:
         manifest["workflow_action_refs"] = workflow_action_refs(args.workflow_file)
-        container_logs: list[tuple[str, str]] = []
-        for container_id in sorted(set(args.container_id)):
-            record, logs = inspect_container(args.task_name, container_id)
-            manifest["containers"].append(record)
-            if logs:
-                container_logs.append((container_id, logs))
+        container_ids = sorted(set(args.container_id))
+        for container_id in container_ids:
+            if not CONTAINER_ID.fullmatch(container_id):
+                raise ValueError(f"{args.task_name}: invalid container id")
+            manifest["containers"].append(inspect_container(args.task_name, container_id))
 
         # Reserve space for the manifest before writing bounded log files.
         provisional = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8") + b"\n"
         log_budget = max(0, args.max_total_bytes - len(provisional))
         log_used = 0
-        for container_id, logs in container_logs:
+        for container_id in container_ids:
+            logs = collect_container_logs(args.task_name, container_id, args.max_total_bytes)
+            if logs is None:
+                continue
             remaining = log_budget - log_used
             data, was_truncated = bounded_bytes(logs, remaining)
             if was_truncated:
                 manifest["truncated"] = True
             log_path = args.output_dir / f"{container_id}.log"
+            if log_path.is_symlink():
+                raise ValueError(f"{args.task_name}: log target is a symlink")
             log_path.write_bytes(data)
             log_used += len(data)
             if was_truncated:
@@ -264,10 +487,9 @@ def main() -> int:
         if args.report_path:
             if args.sanitized_report_dir is None:
                 raise ValueError("sanitized-report-dir is required with report-path")
-            repo_root = args.workflow_file.resolve().parents[2]
             reports, report_truncated = sanitize_reports(
-                [path.resolve() for path in args.report_path],
-                args.sanitized_report_dir.resolve(),
+                args.report_path,
+                args.sanitized_report_dir,
                 repo_root,
                 args.max_report_files,
                 args.max_report_total_bytes,

--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 DEFAULT_MAX_BYTES = 2_000_000
 DEFAULT_MAX_REPORT_FILES = 200
@@ -45,6 +45,12 @@ SENSITIVE_ENV_LINE = re.compile(
 )
 SENSITIVE_LINE = re.compile(r"(?im)^\s*(?:payload|message|body|value)\s*[:=].*$")
 EXCEPTION_MESSAGE = re.compile(r"(?im)^([^\r\n]*(?:Exception|Error))\s*:\s*[^\r\n]*$")
+
+
+class DockerLogsResult(NamedTuple):
+    returncode: int
+    stdout: str
+    truncated: bool
 
 
 def _assignment_value_end(value: str, start: int) -> int:
@@ -145,7 +151,9 @@ def bounded_bytes(value: str, limit: int) -> tuple[bytes, bool]:
     encoded = value.encode("utf-8", errors="replace")
     if len(encoded) <= limit:
         return encoded, False
-    return encoded[:limit], True
+    # Drop an incomplete trailing code point rather than emitting invalid UTF-8.
+    bounded = encoded[:limit].decode("utf-8", errors="ignore").encode("utf-8")
+    return bounded, True
 
 
 def run_docker(task_name: str, args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -162,7 +170,7 @@ def run_docker(task_name: str, args: list[str]) -> subprocess.CompletedProcess[s
         raise RuntimeError(f"{task_name}: docker command unavailable") from error
 
 
-def run_docker_logs(task_name: str, container_id: str, max_bytes: int) -> subprocess.CompletedProcess[str]:
+def run_docker_logs(task_name: str, container_id: str, max_bytes: int) -> DockerLogsResult:
     command = ["docker", "logs", "--tail", "200", container_id]
     try:
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -171,13 +179,15 @@ def run_docker_logs(task_name: str, container_id: str, max_bytes: int) -> subpro
     output = process.stdout.read(max_bytes + 1) if process.stdout is not None else b""
     output_truncated = len(output) > max_bytes
     if output_truncated:
-        process.kill()
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
     process.wait()
-    return subprocess.CompletedProcess(
-        command,
-        0 if output_truncated else process.returncode,
-        output.decode("utf-8", errors="replace"),
-        "",
+    return DockerLogsResult(
+        returncode=0 if output_truncated else process.returncode,
+        stdout=output.decode("utf-8", errors="replace"),
+        truncated=output_truncated,
     )
 
 
@@ -229,15 +239,7 @@ def inspect_container(task_name: str, container_id: str) -> dict[str, Any]:
     image = str(config.get("Image") or payload.get("Image") or "")
     repo_digests = payload.get("RepoDigests") or []
     if not repo_digests:
-        image_reference = image or str(payload.get("Image") or "")
-        image_inspected = run_docker(task_name, ["image", "inspect", image_reference])
-        if image_inspected.returncode != 0:
-            raise RuntimeError(f"{task_name}: docker image inspect failed")
-        try:
-            image_payload = json.loads(image_inspected.stdout)[0]
-            repo_digests = image_payload.get("RepoDigests") or []
-        except (IndexError, json.JSONDecodeError, TypeError) as error:
-            raise RuntimeError(f"{task_name}: invalid docker image inspect response") from error
+        raise RuntimeError(f"{task_name}: container image has no immutable repo digest")
     resolved = next((item for item in repo_digests if item in ALLOWLIST), None)
     if resolved is None:
         raise RuntimeError(f"{task_name}: container image is outside the diagnostics allowlist")
@@ -254,13 +256,13 @@ def inspect_container(task_name: str, container_id: str) -> dict[str, Any]:
     return record
 
 
-def collect_container_logs(task_name: str, container_id: str, max_log_bytes: int) -> str | None:
+def collect_container_logs(task_name: str, container_id: str, max_log_bytes: int) -> tuple[str, bool]:
     """Read and sanitize one container's bounded log stream."""
 
     logs_result = run_docker_logs(task_name, container_id, max_log_bytes)
     if logs_result.returncode != 0:
-        return None
-    return sanitize(logs_result.stdout + logs_result.stderr)
+        raise RuntimeError(f"{task_name}: docker logs failed")
+    return sanitize(logs_result.stdout), logs_result.truncated
 
 
 CONTAINER_ID = re.compile(r"^[0-9a-fA-F]{12,64}$")
@@ -409,11 +411,13 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def write_manifest(path: Path, manifest: dict[str, Any], max_bytes: int) -> None:
+def write_manifest(path: Path, manifest: dict[str, Any], max_bytes: int, repo_root: Path | None = None) -> None:
     encoded = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8") + b"\n"
     if len(encoded) > max_bytes:
         # The manifest is deliberately small; if a caller supplies an unusable cap, fail closed.
         raise ValueError("manifest exceeds max-total-bytes")
+    if repo_root is not None:
+        reject_symlink_components(path.parent, repo_root)
     if path.is_symlink():
         raise ValueError(f"manifest target is a symlink: {path}")
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -469,9 +473,10 @@ def main() -> int:
         log_budget = max(0, args.max_total_bytes - len(provisional))
         log_used = 0
         for container_id in container_ids:
-            logs = collect_container_logs(args.task_name, container_id, args.max_total_bytes)
-            if logs is None:
-                continue
+            logs, logs_truncated = collect_container_logs(
+                args.task_name, container_id, args.max_total_bytes
+            )
+            manifest["truncated"] = manifest["truncated"] or logs_truncated
             remaining = log_budget - log_used
             data, was_truncated = bounded_bytes(logs, remaining)
             if was_truncated:
@@ -497,12 +502,12 @@ def main() -> int:
             manifest["sanitized_reports"] = reports
             manifest["report_truncated"] = report_truncated
 
-        write_manifest(args.output_dir / "manifest.json", manifest, args.max_total_bytes)
+        write_manifest(args.output_dir / "manifest.json", manifest, args.max_total_bytes, repo_root)
     except (OSError, RuntimeError, ValueError) as error:
         # Do not echo Docker output or report contents; the task name is the only diagnostic detail.
         print(str(error) if str(error).startswith(args.task_name) else f"{args.task_name}: diagnostics failed", file=sys.stderr)
         try:
-            write_manifest(args.output_dir / "manifest.json", manifest, args.max_total_bytes)
+            write_manifest(args.output_dir / "manifest.json", manifest, args.max_total_bytes, repo_root)
         except (OSError, ValueError):
             pass
         return 1

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -9,7 +9,6 @@ from contextlib import redirect_stderr
 from pathlib import Path
 from unittest.mock import patch
 
-
 SCRIPT = Path(__file__).with_name("collect-testcontainers-diagnostics.py")
 SPEC = importlib.util.spec_from_file_location("collect_testcontainers_diagnostics", SCRIPT)
 assert SPEC and SPEC.loader
@@ -22,6 +21,7 @@ name: fixture
 steps:
   - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
 """
+CONTAINER_ID = "a" * 12
 
 
 class DiagnosticsCollectorTest(unittest.TestCase):
@@ -42,7 +42,14 @@ class DiagnosticsCollectorTest(unittest.TestCase):
             if docker_run is None:
                 result = diagnostics.main()
             else:
-                with patch.object(diagnostics.subprocess, "run", side_effect=docker_run):
+                def fake_logs(task_name, container_id, max_bytes):
+                    del task_name, max_bytes
+                    return docker_run(["docker", "logs", "--tail", "200", container_id])
+
+                with (
+                    patch.object(diagnostics.subprocess, "run", side_effect=docker_run),
+                    patch.object(diagnostics, "run_docker_logs", side_effect=fake_logs),
+                ):
                     result = diagnostics.main()
         return result, stderr.getvalue()
 
@@ -54,6 +61,14 @@ Authorization: Bearer authorization-secret
 <body>xml-secret</body>
 AWS_SECRET_ACCESS_KEY=upper-secret
 aws_secret_access_key=lower-secret
+clientSecret=client-secret access_token=access-secret
+mongodb://user:password@mongo.example/db
+aws_access_key_id=AKIA-SECRET
+private_key=private-key-secret
+client.privateKey=client-key-secret
+<failure message="failure-attribute-secret">failure-body-secret</failure>
+<error>error-body-secret</error>
+PLAINTEXT://broker:9092
 IllegalStateException: exception-secret
 """
 
@@ -68,9 +83,19 @@ IllegalStateException: exception-secret
             "xml-secret",
             "upper-secret",
             "lower-secret",
+            "client-secret",
+            "access-secret",
+            "password@mongo.example",
+            "AKIA-SECRET",
+            "private-key-secret",
+            "client-key-secret",
+            "failure-attribute-secret",
+            "failure-body-secret",
+            "error-body-secret",
             "exception-secret",
         ):
             self.assertNotIn(secret, sanitized)
+        self.assertIn("PLAINTEXT://broker:9092", sanitized)
         self.assertGreaterEqual(sanitized.count("[REDACTED]"), 7)
 
     def test_empty_container_set_writes_manifest(self):
@@ -99,7 +124,7 @@ IllegalStateException: exception-secret
         )
 
         def docker_run(command, **_kwargs):
-            if command[1:3] == ["inspect", "container-1"]:
+            if command[1:3] == ["inspect", CONTAINER_ID]:
                 payload = [{
                     "Name": "/kafka",
                     "Config": {"Image": "confluentinc/cp-kafka:local"},
@@ -125,7 +150,7 @@ IllegalStateException: exception-secret
             "--workflow-file",
             self.workflow,
             "--container-id",
-            "container-1",
+            CONTAINER_ID,
             docker_run=docker_run,
         )
 
@@ -133,7 +158,7 @@ IllegalStateException: exception-secret
         self.assertEqual(stderr, "")
         manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
         self.assertEqual(manifest["containers"][0]["image_digest"], image_digest)
-        log = (output_dir / "container-1.log").read_text(encoding="utf-8")
+        log = (output_dir / f"{CONTAINER_ID}.log").read_text(encoding="utf-8")
         self.assertNotIn("secret", log)
         self.assertNotIn("sensitive", log)
 
@@ -141,7 +166,7 @@ IllegalStateException: exception-secret
         output_dir = self.root / "diagnostics" / "rejected"
 
         def docker_run(command, **_kwargs):
-            if command[1:3] == ["inspect", "container-1"]:
+            if command[1:3] == ["inspect", CONTAINER_ID]:
                 payload = [{
                     "Name": "/unknown",
                     "Config": {"Image": "private/image:latest"},
@@ -159,7 +184,7 @@ IllegalStateException: exception-secret
             "--workflow-file",
             self.workflow,
             "--container-id",
-            "container-1",
+            CONTAINER_ID,
             docker_run=docker_run,
         )
 
@@ -167,11 +192,32 @@ IllegalStateException: exception-secret
         self.assertIn("rejected-task", stderr)
         self.assertNotIn("private-secret", stderr)
 
+    def test_docker_logs_are_bounded_before_decoding(self):
+        class FakeProcess:
+            def __init__(self):
+                self.stdout = io.BytesIO(b"0123456789")
+                self.returncode = 0
+                self.killed = False
+
+            def kill(self):
+                self.killed = True
+
+            def wait(self):
+                return self.returncode
+
+        process = FakeProcess()
+        with patch.object(diagnostics.subprocess, "Popen", return_value=process):
+            result = diagnostics.run_docker_logs("bounded-task", CONTAINER_ID, 4)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "01234")
+        self.assertTrue(process.killed)
+
     def test_local_image_id_without_allowlisted_repo_digest_fails(self):
         output_dir = self.root / "diagnostics" / "local-id"
 
         def docker_run(command, **_kwargs):
-            if command[1:3] == ["inspect", "container-1"]:
+            if command[1:3] == ["inspect", CONTAINER_ID]:
                 payload = [{
                     "Name": "/unknown",
                     "Config": {"Image": "private/image:local"},
@@ -195,7 +241,7 @@ IllegalStateException: exception-secret
             "--workflow-file",
             self.workflow,
             "--container-id",
-            "container-1",
+            CONTAINER_ID,
             docker_run=docker_run,
         )
 
@@ -268,6 +314,103 @@ IllegalStateException: exception-secret
         manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
         self.assertTrue(manifest["report_truncated"])
         self.assertEqual(len(manifest["sanitized_reports"]), 1)
+
+    def test_report_byte_cap_is_fail_closed(self):
+        reports = self.root / "examples" / "coroutines-demo" / "build" / "test-results" / "test"
+        reports.mkdir(parents=True)
+        (reports / "TEST-large.xml").write_text("<testsuite>" + ("x" * 128) + "</testsuite>", encoding="utf-8")
+        output_dir = self.root / "examples" / "build" / "testcontainers-diagnostics" / "byte-cap"
+        destination = self.root / "examples" / "build" / "sanitized-test-reports"
+
+        result, _ = self.run_main(
+            "--task-name",
+            "byte-cap-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--sanitized-report-dir",
+            destination,
+            "--report-path",
+            reports,
+            "--max-report-total-bytes",
+            "16",
+        )
+
+        self.assertEqual(result, 1)
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertTrue(manifest["report_truncated"])
+        copied = destination / "examples" / "coroutines-demo" / "build" / "test-results" / "test" / "TEST-large.xml"
+        self.assertLessEqual(copied.stat().st_size, 16)
+
+    def test_nested_and_quoted_workflow_action_references_are_checked(self):
+        upload_sha = "abcdef0123456789abcdef0123456789abcdef01"
+        setup_sha = "1234567890abcdef1234567890abcdef12345678"
+        self.workflow.write_text(
+            f'''\
+steps:
+  - "uses": "actions/upload-artifact@{upload_sha}"
+  - {{uses: actions/setup-java@{setup_sha}}}
+''',
+            encoding="utf-8",
+        )
+
+        refs = diagnostics.workflow_action_refs(self.workflow)
+
+        self.assertEqual(
+            refs,
+            [
+                f"actions/upload-artifact@{upload_sha}",
+                f"actions/setup-java@{setup_sha}",
+            ],
+        )
+
+    def test_invalid_container_id_is_rejected_before_docker(self):
+        output_dir = self.root / "diagnostics" / "invalid-id"
+
+        def docker_run(command, **_kwargs):
+            self.fail(f"docker must not run for invalid id: {command}")
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "invalid-id-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            "../outside",
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("invalid-id-task", stderr)
+
+    def test_symlink_report_root_is_rejected(self):
+        reports = self.root / "real-reports"
+        reports.mkdir()
+        (reports / "TEST-example.xml").write_text("<testsuite/>", encoding="utf-8")
+        symlink = self.root / "examples" / "coroutines-demo" / "build" / "test-results" / "test"
+        symlink.parent.mkdir(parents=True)
+        symlink.symlink_to(reports, target_is_directory=True)
+        output_dir = self.root / "examples" / "build" / "testcontainers-diagnostics" / "symlink"
+        destination = self.root / "examples" / "build" / "sanitized-test-reports"
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "symlink-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--sanitized-report-dir",
+            destination,
+            "--report-path",
+            symlink,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("symlink-task", stderr)
 
     def test_mutable_workflow_reference_is_rejected(self):
         self.workflow.write_text("- uses: actions/checkout@v7\n", encoding="utf-8")

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -244,6 +244,37 @@ IllegalStateException: exception-secret
         self.assertEqual(result, 1)
         self.assertIn("image-id-mismatch-task", stderr)
 
+    def test_missing_running_image_id_rejects_mutable_config_image(self):
+        output_dir = self.root / "diagnostics" / "missing-image-id"
+
+        def docker_run(command, **_kwargs):
+            if command[1:3] == ["inspect", CONTAINER_ID]:
+                payload = [{
+                    "Name": "/kafka",
+                    "Config": {"Image": "confluentinc/cp-kafka:mutable"},
+                }]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:3] == ["image", "inspect"]:
+                self.fail("mutable Config.Image must not be used without a running image ID")
+            if command[1:4] == ["logs", "--tail", "200"]:
+                return subprocess.CompletedProcess(command, 0, "", "")
+            self.fail(f"unexpected docker command: {command}")
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "missing-image-id-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            CONTAINER_ID,
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("missing-image-id-task", stderr)
+
     def test_image_outside_allowlist_fails_without_leaking_docker_output(self):
         output_dir = self.root / "diagnostics" / "rejected"
 

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -447,7 +447,9 @@ IllegalStateException: exception-secret
             '<testsuite><system-out>token="xml-secret"</system-out></testsuite>', encoding="utf-8"
         )
         (html_reports / "index.html").write_text(
-            '<html><body>https://user:pass@example.test</body></html>', encoding="utf-8"
+            '<html><body>https://user:pass@example.test'
+            '<pre id="root-0-test-stdout-example">verbose-output</pre></body></html>',
+            encoding="utf-8",
         )
         output_dir = self.root / "examples" / "build" / "testcontainers-diagnostics" / "reports"
         destination = self.root / "examples" / "build" / "sanitized-test-reports"
@@ -475,8 +477,51 @@ IllegalStateException: exception-secret
         content = "\n".join(path.read_text(encoding="utf-8") for path in files)
         self.assertNotIn("xml-secret", content)
         self.assertNotIn("user:pass@example.test", content)
+        self.assertNotIn("verbose-output", content)
+        self.assertIn("[REDACTED]", content)
         manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
         self.assertEqual(len(manifest["sanitized_reports"]), 2)
+
+    def test_report_standard_output_is_compacted_before_file_cap(self):
+        test_results = self.root / "examples" / "virtualthreads-demo" / "build" / "test-results" / "test"
+        html_reports = self.root / "examples" / "virtualthreads-demo" / "build" / "reports" / "tests" / "test"
+        test_results.mkdir(parents=True)
+        html_reports.mkdir(parents=True)
+        verbose_output = "debug output\n" * 300_000
+        (test_results / "TEST-verbose.xml").write_text(
+            f"<testsuite><system-out>{verbose_output}</system-out></testsuite>", encoding="utf-8"
+        )
+        (html_reports / "verbose.html").write_text(
+            f'<html><pre id="root-0-test-stdout-verbose">{verbose_output}</pre></html>',
+            encoding="utf-8",
+        )
+        output_dir = self.root / "examples" / "build" / "testcontainers-diagnostics" / "verbose"
+        destination = self.root / "examples" / "build" / "sanitized-test-reports"
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "verbose-report-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--sanitized-report-dir",
+            destination,
+            "--report-path",
+            test_results,
+            "--report-path",
+            html_reports,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertFalse(manifest["report_truncated"])
+        self.assertEqual(len(manifest["sanitized_reports"]), 2)
+        self.assertTrue(all(item["bytes"] < 1_000 for item in manifest["sanitized_reports"]))
+        content = "\n".join(path.read_text(encoding="utf-8") for path in destination.rglob("*") if path.is_file())
+        self.assertNotIn("debug output", content)
+        self.assertEqual(content.count("[REDACTED]"), 2)
 
     def test_report_file_cap_is_fail_closed(self):
         reports = self.root / "examples" / "coroutines-demo" / "build" / "test-results" / "test"

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -49,6 +49,7 @@ class DiagnosticsCollectorTest(unittest.TestCase):
     def test_sanitize_redacts_credentials_uris_payloads_xml_and_exception_messages(self):
         raw = """\
 https://user:password@example.test/path?token=secret
+Authorization: Bearer authorization-secret
 {"payload":{"nested":"payload-secret","token":"deep-secret"},"message":"message-secret"}
 <body>xml-secret</body>
 AWS_SECRET_ACCESS_KEY=upper-secret
@@ -60,6 +61,7 @@ IllegalStateException: exception-secret
 
         for secret in (
             "password@example.test",
+            "authorization-secret",
             "payload-secret",
             "deep-secret",
             "message-secret",

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -184,8 +184,8 @@ IllegalStateException: exception-secret
                     "Image": "sha256:image-id",
                 }]
                 return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
-            if command[1:4] == ["image", "inspect", "confluentinc/cp-kafka@sha256:" + "a" * 64]:
-                payload = [{"RepoDigests": [image_digest]}]
+            if command[1:4] == ["image", "inspect", "sha256:image-id"]:
+                payload = [{"Id": "sha256:image-id", "RepoDigests": [image_digest]}]
                 return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
             if command[1:4] == ["logs", "--tail", "200"]:
                 return subprocess.CompletedProcess(command, 0, "", "")
@@ -207,6 +207,42 @@ IllegalStateException: exception-secret
         self.assertEqual(stderr, "")
         manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
         self.assertEqual(manifest["containers"][0]["image_digest"], image_digest)
+
+    def test_allowlisted_digest_rejects_image_id_mismatch(self):
+        output_dir = self.root / "diagnostics" / "image-id-mismatch"
+        image_digest = next(
+            digest for digest in diagnostics.ALLOWLIST if digest.startswith("confluentinc/cp-kafka@")
+        )
+
+        def docker_run(command, **_kwargs):
+            if command[1:3] == ["inspect", CONTAINER_ID]:
+                payload = [{
+                    "Name": "/kafka",
+                    "Config": {"Image": "confluentinc/cp-kafka:mutable"},
+                    "Image": "sha256:running-image",
+                }]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["image", "inspect", "sha256:running-image"]:
+                payload = [{"Id": "sha256:current-image", "RepoDigests": [image_digest]}]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["logs", "--tail", "200"]:
+                return subprocess.CompletedProcess(command, 0, "", "")
+            self.fail(f"unexpected docker command: {command}")
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "image-id-mismatch-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            CONTAINER_ID,
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("image-id-mismatch-task", stderr)
 
     def test_image_outside_allowlist_fails_without_leaking_docker_output(self):
         output_dir = self.root / "diagnostics" / "rejected"
@@ -346,8 +382,8 @@ IllegalStateException: exception-secret
                     "Image": "sha256:image-id",
                 }]
                 return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
-            if command[1:4] == ["image", "inspect", "private/image:local"]:
-                return subprocess.CompletedProcess(command, 0, json.dumps([{}]), "")
+            if command[1:4] == ["image", "inspect", "sha256:image-id"]:
+                return subprocess.CompletedProcess(command, 0, json.dumps([{"Id": "sha256:image-id"}]), "")
             self.fail(f"unexpected docker command: {command}")
 
         result, _ = self.run_main(

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -170,6 +170,44 @@ IllegalStateException: exception-secret
         self.assertNotIn("secret", log)
         self.assertNotIn("sensitive", log)
 
+    def test_allowlisted_digest_is_resolved_from_image_inspect(self):
+        output_dir = self.root / "diagnostics" / "image-inspect"
+        image_digest = next(
+            digest for digest in diagnostics.ALLOWLIST if digest.startswith("confluentinc/cp-kafka@")
+        )
+
+        def docker_run(command, **_kwargs):
+            if command[1:3] == ["inspect", CONTAINER_ID]:
+                payload = [{
+                    "Name": "/kafka",
+                    "Config": {"Image": "confluentinc/cp-kafka@sha256:" + "a" * 64},
+                    "Image": "sha256:image-id",
+                }]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["image", "inspect", "confluentinc/cp-kafka@sha256:" + "a" * 64]:
+                payload = [{"RepoDigests": [image_digest]}]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["logs", "--tail", "200"]:
+                return subprocess.CompletedProcess(command, 0, "", "")
+            self.fail(f"unexpected docker command: {command}")
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "image-inspect-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            CONTAINER_ID,
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["containers"][0]["image_digest"], image_digest)
+
     def test_image_outside_allowlist_fails_without_leaking_docker_output(self):
         output_dir = self.root / "diagnostics" / "rejected"
 
@@ -308,6 +346,8 @@ IllegalStateException: exception-secret
                     "Image": "sha256:image-id",
                 }]
                 return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["image", "inspect", "private/image:local"]:
+                return subprocess.CompletedProcess(command, 0, json.dumps([{}]), "")
             self.fail(f"unexpected docker command: {command}")
 
         result, _ = self.run_main(

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -44,7 +44,12 @@ class DiagnosticsCollectorTest(unittest.TestCase):
             else:
                 def fake_logs(task_name, container_id, max_bytes):
                     del task_name, max_bytes
-                    return docker_run(["docker", "logs", "--tail", "200", container_id])
+                    result = docker_run(["docker", "logs", "--tail", "200", container_id])
+                    return diagnostics.DockerLogsResult(
+                        returncode=result.returncode,
+                        stdout=result.stdout,
+                        truncated=getattr(result, "truncated", False),
+                    )
 
                 with (
                     patch.object(diagnostics.subprocess, "run", side_effect=docker_run),
@@ -192,6 +197,81 @@ IllegalStateException: exception-secret
         self.assertIn("rejected-task", stderr)
         self.assertNotIn("private-secret", stderr)
 
+    def test_docker_log_failure_is_fail_closed_without_leaking_output(self):
+        output_dir = self.root / "diagnostics" / "log-failure"
+        image_digest = next(
+            digest for digest in diagnostics.ALLOWLIST if digest.startswith("confluentinc/cp-kafka@")
+        )
+
+        def docker_run(command, **_kwargs):
+            if command[1:3] == ["inspect", CONTAINER_ID]:
+                payload = [{
+                    "Name": "/kafka",
+                    "Config": {"Image": "confluentinc/cp-kafka:local"},
+                    "Image": "sha256:image-id",
+                    "RepoDigests": [image_digest],
+                }]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["logs", "--tail", "200"]:
+                return subprocess.CompletedProcess(command, 1, "token=secret", "private-docker-error")
+            self.fail(f"unexpected docker command: {command}")
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "log-failure-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            CONTAINER_ID,
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("log-failure-task", stderr)
+        self.assertNotIn("private-docker-error", stderr)
+        self.assertNotIn("secret", stderr)
+
+    def test_docker_log_truncation_is_preserved_in_manifest(self):
+        output_dir = self.root / "diagnostics" / "log-truncated"
+        image_digest = next(
+            digest for digest in diagnostics.ALLOWLIST if digest.startswith("confluentinc/cp-kafka@")
+        )
+
+        def docker_run(command, **_kwargs):
+            if command[1:3] == ["inspect", CONTAINER_ID]:
+                payload = [{
+                    "Name": "/kafka",
+                    "Config": {"Image": "confluentinc/cp-kafka:local"},
+                    "Image": "sha256:image-id",
+                    "RepoDigests": [image_digest],
+                }]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["logs", "--tail", "200"]:
+                result = subprocess.CompletedProcess(command, 0, "token=secret", "")
+                result.truncated = True
+                return result
+            self.fail(f"unexpected docker command: {command}")
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "log-truncated-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            CONTAINER_ID,
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertTrue(manifest["truncated"])
+        self.assertNotIn("secret", (output_dir / f"{CONTAINER_ID}.log").read_text(encoding="utf-8"))
+
     def test_docker_logs_are_bounded_before_decoding(self):
         class FakeProcess:
             def __init__(self):
@@ -211,6 +291,7 @@ IllegalStateException: exception-secret
 
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout, "01234")
+        self.assertTrue(result.truncated)
         self.assertTrue(process.killed)
 
     def test_local_image_id_without_allowlisted_repo_digest_fails(self):
@@ -224,13 +305,6 @@ IllegalStateException: exception-secret
                     "Image": "sha256:image-id",
                 }]
                 return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
-            if command[1:4] == ["image", "inspect", "private/image:local"]:
-                return subprocess.CompletedProcess(
-                    command,
-                    0,
-                    json.dumps([{"RepoDigests": []}]),
-                    "",
-                )
             self.fail(f"unexpected docker command: {command}")
 
         result, _ = self.run_main(
@@ -246,6 +320,13 @@ IllegalStateException: exception-secret
         )
 
         self.assertEqual(result, 1)
+
+    def test_bounded_bytes_keeps_utf8_valid(self):
+        data, truncated = diagnostics.bounded_bytes("가나다", 4)
+
+        self.assertTrue(truncated)
+        self.assertEqual(data.decode("utf-8"), "가")
+        self.assertLessEqual(len(data), 4)
 
     def test_report_sanitization_preserves_relative_paths(self):
         test_results = self.root / "examples" / "coroutines-demo" / "build" / "test-results" / "test"

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -1,0 +1,288 @@
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).with_name("collect-testcontainers-diagnostics.py")
+SPEC = importlib.util.spec_from_file_location("collect_testcontainers_diagnostics", SCRIPT)
+assert SPEC and SPEC.loader
+diagnostics = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(diagnostics)
+
+
+PINNED_WORKFLOW = """\
+name: fixture
+steps:
+  - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
+"""
+
+
+class DiagnosticsCollectorTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.workflow = self.root / ".github" / "workflows" / "examples.yml"
+        self.workflow.parent.mkdir(parents=True)
+        self.workflow.write_text(PINNED_WORKFLOW, encoding="utf-8")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def run_main(self, *args, docker_run=None):
+        argv = ["collect-testcontainers-diagnostics.py", *map(str, args)]
+        stderr = io.StringIO()
+        with patch.object(sys, "argv", argv), redirect_stderr(stderr):
+            if docker_run is None:
+                result = diagnostics.main()
+            else:
+                with patch.object(diagnostics.subprocess, "run", side_effect=docker_run):
+                    result = diagnostics.main()
+        return result, stderr.getvalue()
+
+    def test_sanitize_redacts_credentials_uris_payloads_xml_and_exception_messages(self):
+        raw = """\
+https://user:password@example.test/path?token=secret
+{"payload":{"nested":"payload-secret","token":"deep-secret"},"message":"message-secret"}
+<body>xml-secret</body>
+AWS_SECRET_ACCESS_KEY=upper-secret
+aws_secret_access_key=lower-secret
+IllegalStateException: exception-secret
+"""
+
+        sanitized = diagnostics.sanitize(raw)
+
+        for secret in (
+            "password@example.test",
+            "payload-secret",
+            "deep-secret",
+            "message-secret",
+            "xml-secret",
+            "upper-secret",
+            "lower-secret",
+            "exception-secret",
+        ):
+            self.assertNotIn(secret, sanitized)
+        self.assertGreaterEqual(sanitized.count("[REDACTED]"), 7)
+
+    def test_empty_container_set_writes_manifest(self):
+        output_dir = self.root / "diagnostics" / "empty"
+        result, stderr = self.run_main(
+            "--task-name",
+            "empty-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["containers"], [])
+        self.assertEqual(manifest["workflow_action_refs"], [
+            "actions/checkout@0123456789abcdef0123456789abcdef01234567"
+        ])
+
+    def test_allowlisted_container_writes_sanitized_log_and_digest(self):
+        output_dir = self.root / "diagnostics" / "kafka"
+        image_digest = next(
+            digest for digest in diagnostics.ALLOWLIST if digest.startswith("confluentinc/cp-kafka@")
+        )
+
+        def docker_run(command, **_kwargs):
+            if command[1:3] == ["inspect", "container-1"]:
+                payload = [{
+                    "Name": "/kafka",
+                    "Config": {"Image": "confluentinc/cp-kafka:local"},
+                    "Image": "sha256:image-id",
+                    "RepoDigests": [image_digest],
+                    "Created": "2026-08-26T00:00:00Z",
+                }]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["logs", "--tail", "200"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    "token=secret\nIllegalStateException: sensitive\n",
+                    "",
+                )
+            self.fail(f"unexpected docker command: {command}")
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "kafka-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            "container-1",
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["containers"][0]["image_digest"], image_digest)
+        log = (output_dir / "container-1.log").read_text(encoding="utf-8")
+        self.assertNotIn("secret", log)
+        self.assertNotIn("sensitive", log)
+
+    def test_image_outside_allowlist_fails_without_leaking_docker_output(self):
+        output_dir = self.root / "diagnostics" / "rejected"
+
+        def docker_run(command, **_kwargs):
+            if command[1:3] == ["inspect", "container-1"]:
+                payload = [{
+                    "Name": "/unknown",
+                    "Config": {"Image": "private/image:latest"},
+                    "Image": "sha256:image-id",
+                    "RepoDigests": ["private/image@sha256:" + "f" * 64],
+                }]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "private-secret")
+            self.fail(f"unexpected docker command: {command}")
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "rejected-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            "container-1",
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("rejected-task", stderr)
+        self.assertNotIn("private-secret", stderr)
+
+    def test_local_image_id_without_allowlisted_repo_digest_fails(self):
+        output_dir = self.root / "diagnostics" / "local-id"
+
+        def docker_run(command, **_kwargs):
+            if command[1:3] == ["inspect", "container-1"]:
+                payload = [{
+                    "Name": "/unknown",
+                    "Config": {"Image": "private/image:local"},
+                    "Image": "sha256:image-id",
+                }]
+                return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+            if command[1:4] == ["image", "inspect", "private/image:local"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    json.dumps([{"RepoDigests": []}]),
+                    "",
+                )
+            self.fail(f"unexpected docker command: {command}")
+
+        result, _ = self.run_main(
+            "--task-name",
+            "local-id-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--container-id",
+            "container-1",
+            docker_run=docker_run,
+        )
+
+        self.assertEqual(result, 1)
+
+    def test_report_sanitization_preserves_relative_paths(self):
+        test_results = self.root / "examples" / "coroutines-demo" / "build" / "test-results" / "test"
+        html_reports = self.root / "examples" / "coroutines-demo" / "build" / "reports" / "tests" / "test"
+        test_results.mkdir(parents=True)
+        html_reports.mkdir(parents=True)
+        (test_results / "TEST-example.xml").write_text(
+            '<testsuite><system-out>token="xml-secret"</system-out></testsuite>', encoding="utf-8"
+        )
+        (html_reports / "index.html").write_text(
+            '<html><body>https://user:pass@example.test</body></html>', encoding="utf-8"
+        )
+        output_dir = self.root / "examples" / "build" / "testcontainers-diagnostics" / "reports"
+        destination = self.root / "examples" / "build" / "sanitized-test-reports"
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "report-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--sanitized-report-dir",
+            destination,
+            "--report-path",
+            test_results,
+            "--report-path",
+            html_reports,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        copied = list(destination.rglob("*"))
+        files = [path for path in copied if path.is_file()]
+        self.assertEqual(len(files), 2)
+        content = "\n".join(path.read_text(encoding="utf-8") for path in files)
+        self.assertNotIn("xml-secret", content)
+        self.assertNotIn("user:pass@example.test", content)
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(len(manifest["sanitized_reports"]), 2)
+
+    def test_report_file_cap_is_fail_closed(self):
+        reports = self.root / "examples" / "coroutines-demo" / "build" / "test-results" / "test"
+        reports.mkdir(parents=True)
+        for index in range(2):
+            (reports / f"TEST-{index}.xml").write_text("<testsuite/>", encoding="utf-8")
+        output_dir = self.root / "examples" / "build" / "testcontainers-diagnostics" / "cap"
+        destination = self.root / "examples" / "build" / "sanitized-test-reports"
+
+        result, _ = self.run_main(
+            "--task-name",
+            "cap-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--sanitized-report-dir",
+            destination,
+            "--report-path",
+            reports,
+            "--max-report-files",
+            "1",
+        )
+
+        self.assertEqual(result, 1)
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertTrue(manifest["report_truncated"])
+        self.assertEqual(len(manifest["sanitized_reports"]), 1)
+
+    def test_mutable_workflow_reference_is_rejected(self):
+        self.workflow.write_text("- uses: actions/checkout@v7\n", encoding="utf-8")
+        output_dir = self.root / "diagnostics" / "mutable"
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "mutable-task",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("mutable-task", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -67,6 +67,7 @@ Authorization: Bearer authorization-secret
 AWS_SECRET_ACCESS_KEY=upper-secret
 aws_secret_access_key=lower-secret
 clientSecret=client-secret access_token=access-secret
+secretKey=secret-key-secret secret_key=snake-secret-key
 mongodb://user:password@mongo.example/db
 aws_access_key_id=AKIA-SECRET
 private_key=private-key-secret
@@ -90,6 +91,8 @@ IllegalStateException: exception-secret
             "lower-secret",
             "client-secret",
             "access-secret",
+            "secret-key-secret",
+            "snake-secret-key",
             "password@mongo.example",
             "AKIA-SECRET",
             "private-key-secret",

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -182,7 +182,7 @@ jobs:
             --output-dir examples/build/testcontainers-diagnostics/report-scan \
             --workflow-file .github/workflows/examples.yml \
             --sanitized-report-dir examples/build/sanitized-test-reports \
-            --max-report-files 200 \
+            --max-report-files 400 \
             --max-report-total-bytes 2000000 \
             "${report_paths[@]}" || status=1
           test -d examples/build/sanitized-test-reports || status=1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -182,7 +182,7 @@ jobs:
             --output-dir examples/build/testcontainers-diagnostics/report-scan \
             --workflow-file .github/workflows/examples.yml \
             --sanitized-report-dir examples/build/sanitized-test-reports \
-            --max-report-files 400 \
+            --max-report-files 600 \
             --max-report-total-bytes 8000000 \
             "${report_paths[@]}" || status=1
           test -d examples/build/sanitized-test-reports || status=1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -158,9 +158,17 @@ jobs:
           for task in "${test_tasks[@]}"; do
             before_ids_file=$(mktemp)
             after_ids_file=$(mktemp)
-            docker ps -aq --filter label=org.testcontainers=true | sort -u >"$before_ids_file" || status=1
+            # Snapshot only test-session containers; Ryuk itself also carries
+            # org.testcontainers=true but is not a test image we collect.
+            docker ps -aq \
+              --filter label=org.testcontainers=true \
+              --filter label=org.testcontainers.sessionId \
+              | sort -u >"$before_ids_file" || status=1
             ./gradlew "$task" --max-workers=1 || status=1
-            docker ps -aq --filter label=org.testcontainers=true | sort -u >"$after_ids_file" || status=1
+            docker ps -aq \
+              --filter label=org.testcontainers=true \
+              --filter label=org.testcontainers.sessionId \
+              | sort -u >"$after_ids_file" || status=1
             new_ids=$(comm -13 "$before_ids_file" "$after_ids_file")
             container_args=()
             while IFS= read -r container_id; do

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -5,11 +5,13 @@ on:
     branches: [develop, main]
     paths:
       - 'examples/**'
+      - '.github/scripts/**'
       - '.github/workflows/examples.yml'
   push:
     branches: [develop]
     paths:
       - 'examples/**'
+      - '.github/scripts/**'
       - '.github/workflows/examples.yml'
   workflow_dispatch:
 
@@ -185,7 +187,7 @@ jobs:
             "${report_paths[@]}" || status=1
           test -d examples/build/sanitized-test-reports || status=1
           phase_elapsed=$(( $(date +%s) - phase_started ))
-          printf 'serial_test_phase_seconds=%s\n' "$phase_elapsed" > examples/build/testcontainers-diagnostics/test-phase-timing.txt
+          printf 'serial_test_phase_seconds=%s\n' "$phase_elapsed" > examples/build/testcontainers-diagnostics/test-phase-timing.txt || status=1
           (( phase_elapsed <= 2700 )) || status=1
           set -e
           exit "$status"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -31,79 +31,172 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
-      - uses: gradle/actions/setup-gradle@v6.3.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           gradle-version: wrapper
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
-      - name: Compile and test examples
+      - name: Compile examples
         shell: bash
         run: |
           set -euo pipefail
 
-          tasks=(
+          compile_tasks=(
             :bluetape4k-examples-coroutines-demo:compileKotlin
-            :bluetape4k-examples-coroutines-demo:test
             :bluetape4k-examples-jpa-blazepersistence-demo:compileKotlin
-            :bluetape4k-examples-jpa-blazepersistence-demo:test
             :bluetape4k-examples-jpa-querydsl-demo:compileKotlin
-            :bluetape4k-examples-jpa-querydsl-demo:test
             :bluetape4k-examples-redisson-demo:compileKotlin
-            :bluetape4k-examples-redisson-demo:test
             :bluetape4k-examples-virtualthreads-demo:compileKotlin
-            :bluetape4k-examples-virtualthreads-demo:test
           )
 
           if [[ -f examples/ktor/idgenerator-ktor-demo/build.gradle.kts ]]; then
-            tasks+=(
+            compile_tasks+=(
               :idgenerator-ktor-demo:compileKotlin
-              :idgenerator-ktor-demo:test
             )
           fi
 
           if [[ -f examples/ktor/observability-ktor-demo/build.gradle.kts ]]; then
-            tasks+=(
+            compile_tasks+=(
               :observability-ktor-demo:compileKotlin
-              :observability-ktor-demo:test
             )
           fi
 
           if [[ -f examples/spring-boot/idgenerator-spring-boot-demo/build.gradle.kts ]]; then
-            tasks+=(
+            compile_tasks+=(
               :idgenerator-spring-boot-demo:compileKotlin
-              :idgenerator-spring-boot-demo:test
             )
           fi
 
           if [[ -f examples/spring-boot/observability-spring-boot-demo/build.gradle.kts ]]; then
-            tasks+=(
+            compile_tasks+=(
               :observability-spring-boot-demo:compileKotlin
-              :observability-spring-boot-demo:test
             )
           fi
 
-          ./gradlew "${tasks[@]}" --parallel
+          ./gradlew "${compile_tasks[@]}" --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
-      - name: Upload example test results
+      - name: Test examples sequentially and collect diagnostics
         if: always()
-        uses: actions/upload-artifact@v7
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test_tasks=(
+            :bluetape4k-examples-coroutines-demo:test
+            :bluetape4k-examples-jpa-blazepersistence-demo:test
+            :bluetape4k-examples-jpa-querydsl-demo:test
+            :bluetape4k-examples-redisson-demo:test
+            :bluetape4k-examples-virtualthreads-demo:test
+          )
+
+          if [[ -f examples/ktor/idgenerator-ktor-demo/build.gradle.kts ]]; then
+            test_tasks+=( :idgenerator-ktor-demo:test )
+          fi
+          if [[ -f examples/ktor/observability-ktor-demo/build.gradle.kts ]]; then
+            test_tasks+=( :observability-ktor-demo:test )
+          fi
+          if [[ -f examples/spring-boot/idgenerator-spring-boot-demo/build.gradle.kts ]]; then
+            test_tasks+=( :idgenerator-spring-boot-demo:test )
+          fi
+          if [[ -f examples/spring-boot/observability-spring-boot-demo/build.gradle.kts ]]; then
+            test_tasks+=( :observability-spring-boot-demo:test )
+          fi
+
+          report_paths=(
+            --report-path examples/coroutines-demo/build/test-results/test
+            --report-path examples/coroutines-demo/build/reports/tests/test
+            --report-path examples/jpa-blazepersistence-demo/build/test-results/test
+            --report-path examples/jpa-blazepersistence-demo/build/reports/tests/test
+            --report-path examples/jpa-querydsl-demo/build/test-results/test
+            --report-path examples/jpa-querydsl-demo/build/reports/tests/test
+            --report-path examples/redisson-demo/build/test-results/test
+            --report-path examples/redisson-demo/build/reports/tests/test
+            --report-path examples/virtualthreads-demo/build/test-results/test
+            --report-path examples/virtualthreads-demo/build/reports/tests/test
+          )
+          if [[ -f examples/ktor/idgenerator-ktor-demo/build.gradle.kts ]]; then
+            report_paths+=(
+              --report-path examples/ktor/idgenerator-ktor-demo/build/test-results/test
+              --report-path examples/ktor/idgenerator-ktor-demo/build/reports/tests/test
+            )
+          fi
+          if [[ -f examples/ktor/observability-ktor-demo/build.gradle.kts ]]; then
+            report_paths+=(
+              --report-path examples/ktor/observability-ktor-demo/build/test-results/test
+              --report-path examples/ktor/observability-ktor-demo/build/reports/tests/test
+            )
+          fi
+          if [[ -f examples/spring-boot/idgenerator-spring-boot-demo/build.gradle.kts ]]; then
+            report_paths+=(
+              --report-path examples/spring-boot/idgenerator-spring-boot-demo/build/test-results/test
+              --report-path examples/spring-boot/idgenerator-spring-boot-demo/build/reports/tests/test
+            )
+          fi
+          if [[ -f examples/spring-boot/observability-spring-boot-demo/build.gradle.kts ]]; then
+            report_paths+=(
+              --report-path examples/spring-boot/observability-spring-boot-demo/build/test-results/test
+              --report-path examples/spring-boot/observability-spring-boot-demo/build/reports/tests/test
+            )
+          fi
+
+          set +e
+          status=0
+          phase_started=$(date +%s)
+          for task in "${test_tasks[@]}"; do
+            before_ids_file=$(mktemp)
+            after_ids_file=$(mktemp)
+            docker ps -aq --filter label=org.testcontainers=true | sort -u >"$before_ids_file" || status=1
+            ./gradlew "$task" --max-workers=1 || status=1
+            docker ps -aq --filter label=org.testcontainers=true | sort -u >"$after_ids_file" || status=1
+            new_ids=$(comm -13 "$before_ids_file" "$after_ids_file")
+            container_args=()
+            while IFS= read -r container_id; do
+              [[ -n "$container_id" ]] && container_args+=(--container-id "$container_id")
+            done <<<"$new_ids"
+            task_output_dir="examples/build/testcontainers-diagnostics/${task//:/_}"
+            python3 .github/scripts/collect-testcontainers-diagnostics.py \
+              --task-name "$task" \
+              --output-dir "$task_output_dir" \
+              --workflow-file .github/workflows/examples.yml \
+              --max-total-bytes 2000000 \
+              "${container_args[@]}" || status=1
+            test -f "$task_output_dir/manifest.json" || status=1
+            rm -f "$before_ids_file" "$after_ids_file"
+          done
+
+          python3 .github/scripts/collect-testcontainers-diagnostics.py \
+            --task-name examples-test-phase-reports \
+            --output-dir examples/build/testcontainers-diagnostics/report-scan \
+            --workflow-file .github/workflows/examples.yml \
+            --sanitized-report-dir examples/build/sanitized-test-reports \
+            --max-report-files 200 \
+            --max-report-total-bytes 2000000 \
+            "${report_paths[@]}" || status=1
+          test -d examples/build/sanitized-test-reports || status=1
+          phase_elapsed=$(( $(date +%s) - phase_started ))
+          printf 'serial_test_phase_seconds=%s\n' "$phase_elapsed" > examples/build/testcontainers-diagnostics/test-phase-timing.txt
+          (( phase_elapsed <= 2700 )) || status=1
+          set -e
+          exit "$status"
+
+      - name: Upload sanitized example diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: examples-test-results
+          name: examples-test-diagnostics
           path: |
-            examples/**/build/test-results/test/**
-            examples/**/build/reports/tests/test/**
-            examples/spring-boot/idgenerator-spring-boot-demo/build/test-results/test/**
-            examples/spring-boot/idgenerator-spring-boot-demo/build/reports/tests/test/**
-            examples/spring-boot/observability-spring-boot-demo/build/test-results/test/**
-            examples/spring-boot/observability-spring-boot-demo/build/reports/tests/test/**
-          if-no-files-found: ignore
+            examples/build/sanitized-test-reports/**
+            examples/build/testcontainers-diagnostics/**
+          if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -183,7 +183,7 @@ jobs:
             --workflow-file .github/workflows/examples.yml \
             --sanitized-report-dir examples/build/sanitized-test-reports \
             --max-report-files 400 \
-            --max-report-total-bytes 2000000 \
+            --max-report-total-bytes 8000000 \
             "${report_paths[@]}" || status=1
           test -d examples/build/sanitized-test-reports || status=1
           phase_elapsed=$(( $(date +%s) - phase_started ))

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -808,7 +808,7 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --report-path examples/coroutines-demo/build/test-results/test \
   --report-path examples/coroutines-demo/build/reports/tests/test \
   --max-report-files 400 \
-  --max-report-total-bytes 2000000
+  --max-report-total-bytes 8000000
 ```
 
 스크립트는 `--container-id`를 반복 인자로 받아 현재 Gradle invocation에서 새로 생성된
@@ -827,7 +827,7 @@ Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한
 `report-path`가 존재하지 않거나 report 파일이 없으면 해당 단계는 실패시키고, 원본
 report를 sanitized 디렉터리에 절대 링크하지 않는다. collector는 report path를
 재귀적으로 무제한 탐색하지 않고 정렬된 path 목록만 방문하며, 전체 sanitized report는
-`--max-report-files`(기본 200, Examples workflow 400)와 `--max-report-total-bytes`(기본 2,000,000 bytes)를
+`--max-report-files`(기본 200, Examples workflow 400)와 `--max-report-total-bytes`(기본 2,000,000 bytes, Examples workflow 8,000,000 bytes)를
 동시에 적용한다. 상한 초과 시 추가 파일을 저장하지 않고 manifest에
 `report_truncated=true`를 기록하며 exit 1로 종료한다.
 
@@ -959,7 +959,7 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --workflow-file .github/workflows/examples.yml \
   --sanitized-report-dir examples/build/sanitized-test-reports \
   --max-report-files 400 \
-  --max-report-total-bytes 2000000 \
+  --max-report-total-bytes 8000000 \
   "${report_paths[@]}" || status=1
 test -d examples/build/sanitized-test-reports || status=1
 phase_elapsed=$(( $(date +%s) - phase_started ))
@@ -977,7 +977,7 @@ exit "$status"
 aggregate status를 1로 유지하되 collector는 빈 manifest를 남겨 `if: always()`에서
 진단 artifact를 확인할 수 있게 한다. 모든 test task가 끝난 뒤 collector를 정확히
 한 번 더 호출해 `report_paths`에 열거한 report 디렉터리만 sanitization하고, 이 호출은
-`--max-report-files=400`과 `--max-report-total-bytes=2000000`을 적용한다.
+`--max-report-files=400`과 `--max-report-total-bytes=8000000`을 적용한다.
 Ktor/Spring Boot 조건부 task는 현재
 `build.gradle.kts`가 존재하는 경우에만 compile/test 배열 각각에 추가한다. compile
 task와 test task를 같은 `--parallel` 배열에 넣지 않는다. ID 목록은 정렬·중복 제거해

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -175,6 +175,27 @@ fun `collector cancellation rethrows CancellationException and closes producer o
 }
 
 @Test
+fun `cancellation immediately after producer creation closes it once`() = runSuspendIO {
+    val producer = TrackingProducer(holdCallbacks = true)
+    val factoryStarted = CompletableDeferred<Unit>()
+    val task = async {
+        producerResults(
+            flowOf(record("immediate-cancel")),
+            {
+                factoryStarted.complete(Unit)
+                producer.producer
+            },
+        ).toList()
+    }
+
+    withTimeout(5.seconds) { factoryStarted.await() }
+    task.cancel()
+    assertFailsWith<CancellationException> { task.await() }
+
+    producer.closeCount shouldBeEqualTo 1
+}
+
+@Test
 fun `factory and synchronous send failures are terminal causes`() = runSuspendIO {
     val factoryFailure = IllegalArgumentException("factory failure")
     val factoryError = assertFailsWith<IllegalArgumentException> {
@@ -439,12 +460,14 @@ Step 2–3에서 이 signature의 함수 body를 완성한다. `channelCapacity`
 필요한 coroutine import는 `CancellationException`, `CoroutineStart`, `Dispatchers`,
 `Job`, `NonCancellable`, `TimeoutCancellationException`, `delay`, `launch`,
 `runInterruptible`, `withContext`, `withTimeout`이며, callback state에는
-`AtomicBoolean`, `AtomicReference`, `ConcurrentHashMap`, `Semaphore`를 사용한다.
+`AtomicBoolean`, `AtomicReference`, `ConcurrentHashMap`,
+`kotlinx.coroutines.sync.Semaphore`를 사용한다. producer 생성은 LAZY worker 내부의
+`try/finally` 소유 범위에서 수행해 worker가 시작되기 전에 downstream이 취소되면
+producer를 만들지 않고, 생성된 뒤에는 worker가 반드시 close한다.
 `callbackFlow` 내부는 다음 이름과 수명 순서를 그대로 사용한다.
 
 ```kotlin
 return callbackFlow {
-    val producer = producerFactory()
     val terminalCause = AtomicReference<Throwable?>(null)
     val downstreamCancelled = AtomicBoolean()
     val permits = Semaphore(maxInFlight)
@@ -498,6 +521,7 @@ return callbackFlow {
     }
 
     val upstreamJob = launch(context = Dispatchers.IO, start = CoroutineStart.LAZY) {
+        val producer = producerFactory()
         try {
             records.collect { record ->
                 permits.acquire()
@@ -602,8 +626,8 @@ channel에서 도착한 late callback은 새 terminal cause나 permit release를
 `terminalCause`를 CAS한 뒤 `upstreamJobRef`가 가리키는 Job을 취소하고 channel close를
 수행한다. Job은 `CoroutineStart.LAZY`로 만든 뒤 ref를 저장하고 시작하므로 callback이
 동기 실행되어도 초기화되지 않은 Job을 참조하지 않는다. 각 collection마다
-`producerFactory()`는 한 번만
-호출한다. 두 helper는 `upstreamJob`을 생성하기 전에 같은 `callbackFlow` block의
+`producerFactory()`는 LAZY worker가 실제로 시작할 때 한 번만 호출하며 worker의
+`try/finally`가 생성된 producer의 소유자가 된다. 두 helper는 `upstreamJob`을 생성하기 전에 같은 `callbackFlow` block의
 local function으로 선언하며, callback thread에서 suspend하지 않는다.
 각 `send`의 반환 Future는 state에 저장하고, cancellation 또는 drain deadline에서
 모든 in-flight state의 Future를 `cancel(false)`한다. deterministic probe는 send마다

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -103,7 +103,7 @@ fun `backpressure fails without dropping callback and closes producer once`() = 
             records = flowOf(record("one"), record("two"), record("three")),
             producerFactory = { producer.producer },
             channelCapacity = 1,
-            maxInFlight = 3,
+            maxInFlight = 2,
         ).collect {
             val index = received
             received += 1
@@ -114,10 +114,12 @@ fun `backpressure fails without dropping callback and closes producer once`() = 
         }
     }
 
-    withTimeout(5.seconds) { producer.allSendsStarted.await() }
-    producer.pendingSends.distinct().size shouldBeEqualTo 3
+    withTimeout(5.seconds) { producer.twoSendsStarted.await() }
+    producer.pendingSends.distinct().size shouldBeEqualTo 2
     producer.fireCallback()
     withTimeout(5.seconds) { firstItemReceived.await() }
+    withTimeout(5.seconds) { producer.allSendsStarted.await() }
+    producer.pendingSends.distinct().size shouldBeEqualTo 3
     producer.fireCallback()
     producer.fireCallback()
     collectorGate.complete(Unit)
@@ -195,6 +197,25 @@ fun `normal completion drains callbacks flushes and closes once`() = runSuspendI
 }
 
 @Test
+fun `mixed synchronous and asynchronous callbacks drain before close`() = runSuspendIO {
+    val producer = TrackingProducer(heldSendIndexes = setOf(2))
+    val collection = async {
+        producerResults(
+            flowOf(record("sync"), record("async")),
+            { producer.producer },
+        ).toList()
+    }
+
+    withTimeout(5.seconds) { producer.twoSendsStarted.await() }
+    producer.fireCallback()
+    collection.await()
+
+    producer.callbackCount shouldBeEqualTo 2
+    producer.flushCount shouldBeEqualTo 1
+    producer.closeCount shouldBeEqualTo 1
+}
+
+@Test
 fun `flush failure becomes the terminal cause after callback drain`() = runSuspendIO {
     val flushFailure = IllegalStateException("flush failure")
     val producer = TrackingProducer(flushError = flushFailure)
@@ -253,13 +274,22 @@ fun `callback drain timeout cancels pending sends and preserves timeout cause`()
 ```
 
 `record(value)`는 다음 private helper로 unique topic을 만들고 topic/key/value/header 길이 계약을 검사한다.
+`org.apache.kafka.common.header.internals.RecordHeaders`를 import해 고정된 비밀정보 없는
+header를 하나만 부착한다.
 
 ```kotlin
 private fun record(value: String): ProducerRecord<String, String> {
     val topic = "epic-1422-${Base58.randomString(8)}"
+    val key = "key"
+    val headerName = "x-epic-1422"
+    val headerValue = "example"
     require(topic.length <= 128)
+    require(key.length <= 128)
     require(value.toByteArray(Charsets.UTF_8).size <= 1024)
-    return ProducerRecord(topic, "key", value)
+    require(headerName.toByteArray(Charsets.UTF_8).size <= 256)
+    require(headerValue.toByteArray(Charsets.UTF_8).size <= 256)
+    val headers = RecordHeaders().add(headerName, headerValue.toByteArray(Charsets.UTF_8))
+    return ProducerRecord(topic, null, null, key, value, headers)
 }
 ```
 
@@ -273,6 +303,7 @@ private class TrackingProducer(
     private val flushError: Exception? = null,
     val closeError: Exception? = null,
     private val holdCallbacks: Boolean = false,
+    private val heldSendIndexes: Set<Int> = emptySet(),
 ) {
     val producer: Producer<String, String> = mockk(relaxed = true)
     val callbackCount = AtomicInteger()
@@ -280,6 +311,7 @@ private class TrackingProducer(
     val flushCount = AtomicInteger()
     val lateCallbackCount = AtomicInteger()
     val sendStarted = CompletableDeferred<Unit>()
+    val twoSendsStarted = CompletableDeferred<Unit>()
     val allSendsStarted = CompletableDeferred<Unit>()
     val sendCount = AtomicInteger()
     data class Pending(val callback: Callback, val future: CompletableFuture<RecordMetadata>)
@@ -294,7 +326,9 @@ private class TrackingProducer(
         every { producer.send(any<ProducerRecord<String, String>>(), any()) } answers {
             if (sendError != null) throw sendError
             val callback = secondArg<Callback>()
-            val resultFuture = if (holdCallbacks) {
+            val index = sendCount.incrementAndGet()
+            val hold = holdCallbacks || index in heldSendIndexes
+            val resultFuture = if (hold) {
                 val future = CompletableFuture<RecordMetadata>()
                 pendingSends += future
                 pendingCallbacks += Pending(callback, future)
@@ -306,7 +340,10 @@ private class TrackingProducer(
                 sendStarted.complete(Unit)
                 CompletableFuture.completedFuture(metadata)
             }
-            if (sendCount.incrementAndGet() == 3) allSendsStarted.complete(Unit)
+            when (index) {
+                2 -> twoSendsStarted.complete(Unit)
+                3 -> allSendsStarted.complete(Unit)
+            }
             resultFuture
         }
         every { producer.flush() } answers {
@@ -342,12 +379,16 @@ private class TrackingProducer(
 
 기본 성공 fixture는 callback을 즉시 호출하고, held fixture는 callback과 매번 새로
 생성한 `CompletableFuture`를 `Pending` 쌍으로 보관해 drain timeout과 cancellation을
-결정적으로 만든다. backpressure 테스트는
-세 `send` 완료를 `allSendsStarted`로 확인한 뒤 `fireCallback()`을 1→2→3 순서로
-수동 발화한다. 첫 callback 수신 후 collector가 gate에서 멈추므로 두 번째 결과가
-1-slot buffer를 채우고 세 번째 callback이 full을 재현한다. `maxInFlight=1`에서
+결정적으로 만든다. backpressure 테스트는 `maxInFlight=2`에서 처음 두 `send`를
+`twoSendsStarted`로 확인한 뒤 첫 callback을 발화한다. 첫 callback 수신 후 collector가
+gate에서 멈추고 permit이 반환되면 세 번째 send가 시작된다. `allSendsStarted`를
+확인한 뒤 두 번째·세 번째 callback을 순서대로 발화하면 두 번째 결과가 1-slot
+buffer를 채우고 세 번째 callback이 full을 재현한다. `maxInFlight=1`에서
 두 record가 모두 완료되는 테스트가 callback 공통 `finally`의 permit release를
 간접적으로 증명한다. close 이후 callback은 `lateCallbackCount`만 증가시킨다.
+`heldSendIndexes`를 사용하는 mixed 테스트는 첫 send의 synchronous callback과 두 번째
+send의 asynchronous callback을 함께 실행해 마지막 callback 처리 전에 flush/close가
+시작되지 않음을 검증한다.
 취소 테스트는 late callback 뒤에도 동일한 `CancellationException`이 다시 관찰되고
 추가 결과가 발행되지 않음을 확인해 terminal state 불변성을 검증한다.
 각 held send는 서로 다른 Future를 반환하며 `cancelledPendingSends()`로 다중 in-flight
@@ -402,13 +443,12 @@ return callbackFlow {
         val completed = AtomicBoolean()
     }
     val inFlight = ConcurrentHashMap.newKeySet<SendState>()
-    val drained = CompletableDeferred<Unit>()
-    lateinit var upstreamJob: Job
+    val upstreamJobRef = AtomicReference<Job?>()
 
     fun failOnce(cause: Throwable) {
         if (downstreamCancelled.get()) return
         if (terminalCause.compareAndSet(null, cause)) {
-            upstreamJob.cancel(CancellationException("producer terminal failure", cause))
+            upstreamJobRef.get()?.cancel(CancellationException("producer terminal failure", cause))
             close(cause)
         } else {
             log.debug { "late Kafka callback ignored; failureKind=${cause::class.simpleName}" }
@@ -421,16 +461,14 @@ return callbackFlow {
             if (cause != null) {
                 failOnce(cause)
             } else if (metadata != null) {
-                trySend(metadata).onFailure {
-                    if (!downstreamCancelled.get()) {
-                        failOnce(IllegalStateException("callback buffer is full"))
-                    }
+                val result = trySend(metadata)
+                if (result.isFailure && !result.isClosed && !downstreamCancelled.get()) {
+                    failOnce(IllegalStateException("callback buffer is full"))
                 }
             }
         } finally {
             inFlight.remove(state)
             permits.release()
-            if (inFlight.isEmpty()) drained.complete(Unit)
         }
     }
 
@@ -438,7 +476,7 @@ return callbackFlow {
         complete(state, metadata, cause)
     }
 
-    upstreamJob = launch(Dispatchers.IO) {
+    val upstreamJob = launch(context = Dispatchers.IO, start = CoroutineStart.LAZY) {
         try {
             records.collect { record ->
                 permits.acquire()
@@ -447,7 +485,7 @@ return callbackFlow {
                 try {
                     val future = producer.send(record, callbackFor(state))
                     state.future.set(future)
-                    if (state.completed.get() && terminalCause.get() != null) {
+                    if (state.completed.get() && (terminalCause.get() != null || downstreamCancelled.get())) {
                         future.cancel(false)
                     }
                 } catch (cause: Throwable) {
@@ -456,15 +494,47 @@ return callbackFlow {
                         permits.release()
                     }
                     failOnce(cause)
-                    if (inFlight.isEmpty()) drained.complete(Unit)
                     throw cause
                 }
             }
         } catch (cause: Throwable) {
             failOnce(cause)
             throw cause
+        } finally {
+            withContext(NonCancellable + Dispatchers.IO) {
+                var cleanupFailure: Throwable? = null
+                try {
+                    withTimeout(30.seconds) {
+                        while (inFlight.isNotEmpty()) delay(10)
+                        runInterruptible { producer.flush() }
+                    }
+                } catch (cause: Throwable) {
+                    cleanupFailure = cause
+                    inFlight.forEach { it.future.get()?.cancel(false) }
+                    if (!downstreamCancelled.get()) failOnce(cause)
+                }
+
+                val closeFailure = runCatching {
+                    withTimeout(5.seconds) {
+                        runInterruptible { producer.close(Duration.ofSeconds(5)) }
+                    }
+                }.exceptionOrNull()
+                val first = terminalCause.get()
+                if (first != null && cleanupFailure != null && first !== cleanupFailure) {
+                    first.addSuppressed(cleanupFailure)
+                }
+                if (first != null && closeFailure != null && first !== closeFailure) {
+                    first.addSuppressed(closeFailure)
+                }
+                if (first == null && closeFailure != null && !downstreamCancelled.get()) {
+                    failOnce(closeFailure)
+                }
+                if (terminalCause.get() == null && !downstreamCancelled.get()) close()
+            }
         }
     }
+    upstreamJobRef.set(upstreamJob)
+    upstreamJob.start()
     awaitClose {
         downstreamCancelled.set(true)
         upstreamJob.cancel(CancellationException("collector cancelled"))
@@ -475,21 +545,24 @@ return callbackFlow {
 각 send는 `SendState`를 먼저 `inFlight`에 등록하고 callback에 전달한다. callback이
 동기 실행되어도 state가 이미 존재하므로 stale Future가 생기지 않는다. callback은
 결과 전달 또는 `failOnce` 처리가 끝난 뒤 `finally`에서 state를 `inFlight`에서 제거하고
-permit을 정확히 한 번 해제한다. 마지막 callback의 처리까지 끝난 뒤에만 `drained`를
-완료하므로 worker cleanup이 결과 전달보다 앞서지 않는다. 반환 Future는 state에
+permit을 정확히 한 번 해제한다. worker cleanup은 one-shot signal에 의존하지 않고
+bounded loop에서 `inFlight.isEmpty()`를 다시 확인하므로 mixed sync/async callback이
+남아 있으면 flush/close로 진행하지 않는다. 반환 Future는 state에
 저장한 뒤 이미 완료된 callback이면 registry에 남기지 않는다. `awaitClose`는 먼저
 `downstreamCancelled` sentinel을 세우고 cancellation
 signal만 전달한다. 따라서 닫힌 channel에서 도착한 late callback은 새 terminal cause를
 기록하지 않는다. `failOnce(cause)`는 downstream sentinel이 없을 때만
-`terminalCause`를 CAS한 뒤
-`upstreamJob.cancel(CancellationException("producer terminal failure", cause))`과
-channel close를 수행한다. 각 collection마다 `producerFactory()`는 한 번만
+`terminalCause`를 CAS한 뒤 `upstreamJobRef`가 가리키는 Job을 취소하고 channel close를
+수행한다. Job은 `CoroutineStart.LAZY`로 만든 뒤 ref를 저장하고 시작하므로 callback이
+동기 실행되어도 초기화되지 않은 Job을 참조하지 않는다. 각 collection마다
+`producerFactory()`는 한 번만
 호출한다. 두 helper는 `upstreamJob`을 생성하기 전에 같은 `callbackFlow` block의
 local function으로 선언하며, callback thread에서 suspend하지 않는다.
 각 `send`의 반환 Future는 state에 저장하고, cancellation 또는 drain deadline에서
 모든 in-flight state의 Future를 `cancel(false)`한다. deterministic probe는 send마다
 서로 다른 pending Future를 반환하고 `pendingSend`와 `cancelledPendingSends()`로 그
-결과를 검증한다.
+결과를 검증한다. Future를 state에 저장한 직후 `downstreamCancelled`도 확인하므로
+`sendStarted`와 Future 등록 사이에 collector가 취소되는 경합도 놓치지 않는다.
 
 - [ ] **Step 2: callback failure와 full-buffer terminal path를 구현한다**
 
@@ -504,7 +577,11 @@ if (!downstreamCancelled.get() && terminalCause.compareAndSet(null, cause)) {
 }
 ```
 
-`trySend`가 full이면 `IllegalStateException("callback buffer is full")`을 위 CAS에 넣고 worker/upstream을 취소한다. 이미 닫힌 channel은 downstream cancellation이면 새 cause로 덮지 않는다. callbackFlow channel과 producer close는 각각 한 번만 실행하며, cleanup 예외는 first cause의 `suppressed`에 붙인다.
+`trySend`가 full이면서 channel이 아직 닫히지 않은 경우에만
+`IllegalStateException("callback buffer is full")`을 위 CAS에 넣고 worker/upstream을
+취소한다. `ChannelResult.isClosed` 또는 `downstreamCancelled`인 경우는 정상적인
+종료/취소로 분류해 새 cause를 만들지 않는다. callbackFlow channel과 producer close는
+각각 한 번만 실행하며, cleanup 예외는 first cause의 `suppressed`에 붙인다.
 
 - [ ] **Step 3: awaitClose와 bounded cleanup을 구현한다**
 
@@ -513,8 +590,9 @@ if (!downstreamCancelled.get() && terminalCause.compareAndSet(null, cause)) {
 
 1. `withContext(NonCancellable + Dispatchers.IO)`로 진입한다.
 2. callback drain과 `flush()`를 30초 `withTimeout`으로 기다린다.
-   `inFlight`가 이미 비어 있으면 즉시 진행하고, 아니면 callback이 완료할 때
-   `drained`를 깨워 대기한다. 모든 send가 callback 완료 후에만 정상 close로 간다.
+   `while (inFlight.isNotEmpty()) delay(10)` bounded loop를 사용해 모든 callback
+   처리가 끝난 뒤에만 flush/close로 진행한다. 모든 send가 callback 완료 후에만
+   정상 close로 간다.
 3. deadline을 넘기면 `TimeoutCancellationException`을 first cause로 CAS하고 pending send를 취소한다.
 4. `producer.close(Duration.ofSeconds(5))`를 한 번 실행하고 예외를 suppressed로 연결한다.
 5. `CancellationException`을 broad catch에서 삼키지 않고 재전파한다.
@@ -545,9 +623,28 @@ Expected: Task 2의 failure/lifecycle tests가 PASS하고, close count=1, first 
 
 - Modify: `examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt`
 
-- [ ] **Step 1: Testcontainers precondition과 실제 fixture를 사용한다**
+- [ ] **Step 1: digest-pinned Testcontainers precondition과 실제 fixture를 사용한다**
 
-`runSuspendIO(timeout = 120.seconds)`에서 `KafkaServer.Launcher.kafka`를 참조하고, `createStringProducer()`와 `createStringConsumer()`를 각각 한 번 생성한다. topic은 `"epic-1422-callback-" + Base58.randomString(8)`로 만들고, record 수는 128개 이하, value는 1 KiB 이하로 제한한다. producer와 consumer가 broker 자체를 종료하지 않고 collection-scoped/test-owned resource만 닫도록 `use`와 bounded close를 적용한다.
+`runSuspendIO(timeout = 120.seconds)`에서 다음 immutable image reference로 test-owned
+broker를 하나 시작하고 `ShutdownQueue`에 등록한다. `DockerImageName`과 기존
+`KafkaServer.Launcher.createStringProducer(broker)`/`createStringConsumer(broker)`를
+그대로 재사용해 새 client factory를 만들지 않는다.
+필요한 import는 `org.testcontainers.utility.DockerImageName`와
+`io.bluetape4k.utils.ShutdownQueue`다.
+
+```kotlin
+private const val KAFKA_IMAGE_REF =
+    "confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130"
+
+val broker = KafkaServer(DockerImageName.parse(KAFKA_IMAGE_REF)).apply {
+    start()
+    ShutdownQueue.register(this)
+}
+```
+
+topic은 `"epic-1422-callback-" + Base58.randomString(8)`로 만들고, record 수는 128개
+이하, value는 1 KiB 이하로 제한한다. producer와 consumer가 broker 자체를 종료하지
+않고 collection-scoped/test-owned resource만 닫도록 `use`와 bounded close를 적용한다.
 
 - [ ] **Step 2: success cardinality와 eventual broker result를 검증한다**
 
@@ -559,12 +656,16 @@ fun `real Kafka producer callbacks become metadata flow`() = runSuspendIO(timeou
         ProducerRecord(topic, "key-$index", "value-$index")
     }
 
-    val consumer = KafkaServer.Launcher.createStringConsumer()
+    val broker = KafkaServer(DockerImageName.parse(KAFKA_IMAGE_REF)).apply {
+        start()
+        ShutdownQueue.register(this)
+    }
+    val consumer = KafkaServer.Launcher.createStringConsumer(broker)
     try {
         consumer.subscribe(listOf(topic))
         val metadata = producerResults(
             records = records.asFlow(),
-            producerFactory = { KafkaServer.Launcher.createStringProducer() },
+            producerFactory = { KafkaServer.Launcher.createStringProducer(broker) },
         ).toList()
 
         metadata shouldHaveSize records.size
@@ -615,6 +716,7 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --task-name :bluetape4k-examples-coroutines-demo:test \
   --output-dir examples/build/testcontainers-diagnostics/_bluetape4k-examples-coroutines-demo_test \
   --workflow-file .github/workflows/examples.yml \
+  --report-root examples \
   --max-total-bytes 2000000
 ```
 
@@ -627,6 +729,11 @@ manifest의 총 산출량은 `--max-total-bytes`(기본 2,000,000 bytes)를 넘�
 초과분은 잘라내고 manifest에 `truncated=true`를 기록한다. container log가 없으면
 해당 container의 로그를 생략하고, 전체 ID가 비어 있으면 빈 manifest를 만든다.
 Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한다.
+`--report-root`가 지정되면 `**/build/test-results/**/*.xml`과
+`**/build/reports/tests/test/**/*.{html,css,js}`를 순회해 같은 redaction을 적용한
+파일을 `--sanitized-report-dir` 아래 상대 경로로 복사한다. report-root 자체가
+존재하지 않거나 report 파일이 없으면 해당 단계는 실패시키고, 원본 report를
+sanitized 디렉터리에 절대 링크하지 않는다.
 
 `sanitize`는 다음 순서의 stdlib 정규식만 사용한다: (1) `authorization`,
 `token`, `password`, `secret`, `api[_-]?key` 등의 key/value를 치환하고,
@@ -635,6 +742,15 @@ Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한
 뒤의 message를 치환한다. 원문 로그는 저장하지 않는다. `--workflow-file`의
 `uses: owner/action@ref`를 파싱해 `workflow_action_refs`에 기록하고,
 `docker inspect`의 `RepoDigests` 또는 image ID를 `image_digest`에 기록한다.
+허용 image allowlist는 `confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130`과
+`redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a`로
+고정한다. 해당 image는 `RepoDigests`가 allowlist와 정확히 일치해야 하며, local
+image ID만 있거나 예상하지 않은 image면 collector를 실패시킨다.
+같은 `sanitize` 규칙을 `--report-root` 아래의 JUnit XML/HTML에도 적용해
+`examples/build/sanitized-test-reports/`에 복사하고, workflow는 원본 report가 아닌
+이 경로만 artifact로 업로드한다. 각 파일은 2MB를 넘기지 않으며, 원본 경로는
+artifact 대상에서 제외한다. 테스트 source의 logging은 module·recordCount·failureKind
+같은 구조화 필드만 남기고 payload/message/result/URI를 기록하지 않는다.
 
 - [ ] **Step 2: compile과 test 배열을 분리한다**
 
@@ -677,14 +793,33 @@ fi
 
 set +e
 status=0
+phase_started=$(date +%s)
 for task in "${test_tasks[@]}"; do
+  before_ids_file=$(mktemp)
+  after_ids_file=$(mktemp)
+  docker ps -aq --filter label=org.testcontainers=true | sort -u >"$before_ids_file" || status=1
   ./gradlew "$task" --max-workers=1 || status=1
+  docker ps -aq --filter label=org.testcontainers=true | sort -u >"$after_ids_file" || status=1
+  new_ids=$(comm -13 "$before_ids_file" "$after_ids_file")
+  container_args=()
+  while IFS= read -r container_id; do
+    [[ -n "$container_id" ]] && container_args+=(--container-id "$container_id")
+  done <<<"$new_ids"
   python3 .github/scripts/collect-testcontainers-diagnostics.py \
     --task-name "$task" \
     --output-dir "examples/build/testcontainers-diagnostics/${task//:/_}" \
-    --workflow-file .github/workflows/examples.yml || status=1
+    --workflow-file .github/workflows/examples.yml \
+    --report-root examples \
+    --sanitized-report-dir examples/build/sanitized-test-reports \
+    --max-total-bytes 2000000 \
+    "${container_args[@]}" || status=1
   test -f "examples/build/testcontainers-diagnostics/${task//:/_}/manifest.json" || status=1
+  test -d examples/build/sanitized-test-reports || status=1
+  rm -f "$before_ids_file" "$after_ids_file"
 done
+phase_elapsed=$(( $(date +%s) - phase_started ))
+printf 'serial_test_phase_seconds=%s\n' "$phase_elapsed" > examples/build/testcontainers-diagnostics/test-phase-timing.txt
+(( phase_elapsed <= 2700 )) || status=1
 set -e
 exit "$status"
 ```
@@ -706,10 +841,22 @@ task와 test task를 같은 `--parallel` 배열에 넣지 않는다. ID 목록�
 
 ```yaml
 path: |
-  examples/**/build/test-results/**
-  examples/**/build/reports/tests/test/**
+  examples/build/sanitized-test-reports/**
   examples/build/testcontainers-diagnostics/**
 if-no-files-found: error
+```
+
+workflow action은 live tag를 직접 사용하지 않고 2026-08-26에 확인한 immutable
+commit SHA로 고정한다. `.github/workflows/examples.yml`의 action 줄은 다음 ref와
+`# vN` 주석을 사용하고, checkout에는 `persist-credentials: false`를 설정한다.
+
+```yaml
+- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+  with:
+    persist-credentials: false
+- uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+- uses: gradle/actions/setup-gradle@67621b124fd2e251c5e8a0e6e3b91318f2287669 # v6.3.0
+- uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
 ```
 
 각 test invocation 뒤 manifest가 존재하는지 shell에서 검사하고, collector 또는

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -521,14 +521,16 @@ return callbackFlow {
     }
 
     val upstreamJob = launch(context = Dispatchers.IO, start = CoroutineStart.LAZY) {
-        val producer = producerFactory()
+        var producer: Producer<String, String>? = null
         try {
+            val activeProducer = producerFactory()
+            producer = activeProducer
             records.collect { record ->
                 permits.acquire()
                 val state = SendState()
                 inFlight += state
                 try {
-                    val future = producer.send(record, callbackFor(state))
+                    val future = activeProducer.send(record, callbackFor(state))
                     state.future.set(future)
                     if (terminalCause.get() != null || downstreamCancelled.get()) {
                         future.cancel(false)
@@ -556,47 +558,49 @@ return callbackFlow {
             failOnce(cause)
             throw cause
         } finally {
-            withContext(NonCancellable + Dispatchers.IO) {
-                var cleanupFailure: Throwable? = null
-                var cleanupCancellation: CancellationException? = null
-                try {
-                    withTimeout(30.seconds) {
-                        while (inFlight.isNotEmpty()) delay(10)
-                        runInterruptible { producer.flush() }
+            producer?.let { activeProducer ->
+                withContext(NonCancellable + Dispatchers.IO) {
+                    var cleanupFailure: Throwable? = null
+                    var cleanupCancellation: CancellationException? = null
+                    try {
+                        withTimeout(30.seconds) {
+                            while (inFlight.isNotEmpty()) delay(10)
+                            runInterruptible { activeProducer.flush() }
+                        }
+                    } catch (cause: TimeoutCancellationException) {
+                        cleanupFailure = cause
+                        cancelInFlight()
+                        if (!downstreamCancelled.get()) failOnce(cause)
+                    } catch (cause: CancellationException) {
+                        cleanupFailure = cause
+                        cleanupCancellation = cause
+                        cancelInFlight()
+                        if (!downstreamCancelled.get()) failOnce(cause)
+                    } catch (cause: Throwable) {
+                        cleanupFailure = cause
+                        cancelInFlight()
+                        if (!downstreamCancelled.get()) failOnce(cause)
                     }
-                } catch (cause: TimeoutCancellationException) {
-                    cleanupFailure = cause
-                    cancelInFlight()
-                    if (!downstreamCancelled.get()) failOnce(cause)
-                } catch (cause: CancellationException) {
-                    cleanupFailure = cause
-                    cleanupCancellation = cause
-                    cancelInFlight()
-                    if (!downstreamCancelled.get()) failOnce(cause)
-                } catch (cause: Throwable) {
-                    cleanupFailure = cause
-                    cancelInFlight()
-                    if (!downstreamCancelled.get()) failOnce(cause)
-                }
 
-                val closeFailure = runCatching {
-                    withTimeout(5.seconds) {
-                        runInterruptible { producer.close(Duration.ofSeconds(5)) }
+                    val closeFailure = runCatching {
+                        withTimeout(5.seconds) {
+                            runInterruptible { activeProducer.close(Duration.ofSeconds(5)) }
+                        }
+                    }.exceptionOrNull()
+                    val first = terminalCause.get()
+                    if (first != null && cleanupFailure != null && first !== cleanupFailure) {
+                        first.addSuppressed(cleanupFailure)
                     }
-                }.exceptionOrNull()
-                val first = terminalCause.get()
-                if (first != null && cleanupFailure != null && first !== cleanupFailure) {
-                    first.addSuppressed(cleanupFailure)
-                }
-                if (first != null && closeFailure != null && first !== closeFailure) {
-                    first.addSuppressed(closeFailure)
-                }
-                if (first == null && closeFailure != null && !downstreamCancelled.get()) {
-                    failOnce(closeFailure)
-                }
-                if (terminalCause.get() == null && !downstreamCancelled.get()) close()
-                if (cleanupCancellation != null && terminalCause.get() == null) {
-                    throw cleanupCancellation
+                    if (first != null && closeFailure != null && first !== closeFailure) {
+                        first.addSuppressed(closeFailure)
+                    }
+                    if (first == null && closeFailure != null && !downstreamCancelled.get()) {
+                        failOnce(closeFailure)
+                    }
+                    if (terminalCause.get() == null && !downstreamCancelled.get()) close()
+                    if (cleanupCancellation != null && terminalCause.get() == null) {
+                        throw cleanupCancellation
+                    }
                 }
             }
         }

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Kotlin 2.4/JVM 25, kotlinx.coroutines `callbackFlow`/`awaitClose`, Apache Kafka 4 client, Testcontainers Kafka, JUnit 5, `runSuspendIO`, `bluetape4k-assertions`, existing Gradle version catalog.
 
+**Approved basis:** `docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md` at commit `7d22431a975e12a237083c93d6e2e6749f966b9d`, based on `origin/develop` `a907d144f39bfb94cba783cf65a5412e0714e9d5`.
+
 ---
 
 ## 계획 범위와 파일 소유권
@@ -93,19 +95,30 @@ fun `callback failure preserves first cause and closes producer once`() = runSus
 @Test
 fun `backpressure fails without dropping callback and closes producer once`() = runSuspendIO {
     val producer = TrackingProducer()
-
-    val error = assertFailsWith<IllegalStateException> {
+    val collectorGate = CompletableDeferred<Unit>()
+    val collection = async {
+        var received = 0
         producerResults(
-            records = flowOf(record("one"), record("two")),
+            records = flowOf(record("one"), record("two"), record("three")),
             producerFactory = { producer.producer },
             channelCapacity = 1,
-            maxInFlight = 2,
-        ).take(1).toList()
+            maxInFlight = 3,
+        ).collect {
+            val index = received
+            received += 1
+            if (index == 0) collectorGate.await()
+        }
+    }
+
+    producer.thirdCallback.await()
+    collectorGate.complete(Unit)
+    val error = assertFailsWith<IllegalStateException> {
+        collection.await()
     }
 
     error.message shouldBeEqualTo "callback buffer is full"
     producer.closeCount shouldBeEqualTo 1
-    producer.callbackCount shouldBeEqualTo 2
+    producer.callbackCount shouldBeEqualTo 3
 }
 
 @Test
@@ -128,13 +141,15 @@ fun `collector cancellation rethrows CancellationException and closes producer o
     val task = async {
         producerResults(flowOf(record("cancel")), { producer.producer }).toList()
     }
-    yield()
 
+    producer.sendStarted.await()
     task.cancel()
     assertFailsWith<CancellationException> { task.await() }
 
     producer.closeCount shouldBeEqualTo 1
-    producer.lateCallbackCount shouldBeEqualTo 0
+    producer.pendingSend.isCancelled shouldBeEqualTo true
+    producer.fireLateCallback()
+    producer.lateCallbackCount shouldBeEqualTo 1
 }
 
 @Test
@@ -146,10 +161,12 @@ fun `factory and synchronous send failures are terminal causes`() = runSuspendIO
     factoryError shouldBeEqualTo factoryFailure
 
     val sendFailure = IllegalStateException("send failure")
+    val sendProducer = TrackingProducer(sendError = sendFailure)
     val sendError = assertFailsWith<IllegalStateException> {
-        producerResults(flowOf(record("send")), { TrackingProducer(sendError = sendFailure).producer }).toList()
+        producerResults(flowOf(record("send")), { sendProducer.producer }).toList()
     }
     sendError shouldBeEqualTo sendFailure
+    sendProducer.closeCount shouldBeEqualTo 1
 }
 
 @Test
@@ -186,10 +203,10 @@ fun `upstream exception remains primary and cleanup failure is suppressed`() = r
 @Test
 fun `channel and in flight bounds reject invalid values`() = runSuspendIO {
     assertFailsWith<IllegalArgumentException> {
-        producerResults(flowOf(record("invalid-capacity")), { TrackingProducer().producer }, channelCapacity = 0)
+        producerResults(flowOf(record("invalid-capacity")), { TrackingProducer().producer }, channelCapacity = 0).toList()
     }
     assertFailsWith<IllegalArgumentException> {
-        producerResults(flowOf(record("invalid-in-flight")), { TrackingProducer().producer }, maxInFlight = 17)
+        producerResults(flowOf(record("invalid-in-flight")), { TrackingProducer().producer }, maxInFlight = 17).toList()
     }
 }
 
@@ -203,6 +220,7 @@ fun `callback drain timeout cancels pending sends and preserves timeout cause`()
 
     error::class shouldBeEqualTo TimeoutCancellationException::class
     producer.closeCount shouldBeEqualTo 1
+    producer.pendingSend.isCancelled shouldBeEqualTo true
 }
 ```
 
@@ -232,24 +250,39 @@ private class TrackingProducer(
     val closeCount = AtomicInteger()
     val flushCount = AtomicInteger()
     val lateCallbackCount = AtomicInteger()
+    val sendStarted = CompletableDeferred<Unit>()
+    val thirdCallback = CompletableDeferred<Unit>()
     val pendingCallbacks = ConcurrentLinkedQueue<Callback>()
+    val pendingSend = CompletableFuture<RecordMetadata>()
+    private val closed = AtomicBoolean()
+    private val metadata = mockk<RecordMetadata>(relaxed = true)
 
     init {
         every { producer.send(any<ProducerRecord<String, String>>(), any()) } answers {
             if (sendError != null) throw sendError
             val callback = secondArg<Callback>()
-            val metadata = RecordMetadata(TopicPartition("probe", 0), 0, 0, 0L, 0, 0)
-            if (holdCallbacks) pendingCallbacks += callback
-            else {
+            if (holdCallbacks) {
+                pendingCallbacks += callback
+            } else {
                 callbackCount.incrementAndGet()
                 callback.onCompletion(metadata, callbackError)
+                if (callbackCount.get() == 3) thirdCallback.complete(Unit)
             }
-            CompletableFuture.completedFuture(metadata)
+            sendStarted.complete(Unit)
+            if (holdCallbacks) pendingSend else CompletableFuture.completedFuture(metadata)
         }
         every { producer.flush() } answers { flushCount.incrementAndGet() }
         every { producer.close(any<Duration>()) } answers {
             closeCount.incrementAndGet()
+            closed.set(true)
             closeError?.let { throw it }
+        }
+    }
+
+    fun fireLateCallback() {
+        pendingCallbacks.poll()?.let { callback ->
+            if (closed.get()) lateCallbackCount.incrementAndGet()
+            callback.onCompletion(metadata, null)
         }
     }
 }
@@ -299,6 +332,9 @@ Step 2–3에서 이 signature의 함수 body를 완성한다. Flow collection�
 `AtomicReference<Throwable?>`를 collection-local 상태로 만든다. callback 성공은
 `channel.trySend(metadata)`로 전달하고, callback 성공·실패·동기 `send` 예외 모두에서
 공통 `finally`로 permit/in-flight를 정확히 한 번만 해제한다.
+각 `send`의 반환 Future를 in-flight 항목과 함께 보관해 cancellation 또는 drain
+deadline에서 `cancel(false)`하고, deterministic probe의 `pendingSend`로 그 결과를
+검증한다.
 
 - [ ] **Step 2: callback failure와 full-buffer terminal path를 구현한다**
 
@@ -360,7 +396,8 @@ fun `real Kafka producer callbacks become metadata flow`() = runSuspendIO(timeou
         ProducerRecord(topic, "key-$index", "value-$index")
     }
 
-    KafkaServer.Launcher.createStringConsumer().use { consumer ->
+    val consumer = KafkaServer.Launcher.createStringConsumer()
+    try {
         consumer.subscribe(listOf(topic))
         val metadata = producerResults(
             records = records.asFlow(),
@@ -375,6 +412,12 @@ fun `real Kafka producer callbacks become metadata flow`() = runSuspendIO(timeou
                 .toList()
         }
         polled shouldHaveSize records.size
+    } finally {
+        withContext(NonCancellable + Dispatchers.IO) {
+            withTimeout(5.seconds) {
+                consumer.close(Duration.ofSeconds(5))
+            }
+        }
     }
 }
 ```
@@ -522,10 +565,14 @@ Expected: actionlint와 Python syntax가 PASS한다. 실제 CI에서는 중간 t
 
 ```bash
 ./gradlew :bluetape4k-examples-coroutines-demo:test \
-  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples'
+  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples' \
+  --no-configuration-cache --max-workers=1
 ```
 
-Docker daemon/Testcontainers dynamic port가 필요하고, topic은 매 test마다 unique하며 poll·producer close는 bounded timeout이라는 설명을 두 locale에 같은 의미로 넣는다.
+Docker daemon/Testcontainers dynamic port가 필요하고, topic은 매 test마다 unique하며
+poll·producer close는 bounded timeout이라는 설명을 두 locale에 같은 의미로 넣는다.
+metadata 순서는 보장하지 않고 adapter는 retry하지 않으며, failure/cancellation 시
+부분 결과가 발생할 수 있다는 caller 계약도 두 locale에 기록한다.
 
 - [ ] **Step 2: README locale parity를 검사한다**
 
@@ -572,7 +619,7 @@ Expected: 세 명령이 모두 PASS하고, Testcontainers 종료 후 다음 chil
 
 - [ ] **Step 3: parent child를 merge-ready 상태로 고정한다**
 
-PR 생성 전 child issue #1347의 `## DoD Status`와 parent PR body에 exact head, required check count, 6-R artifact, known gaps를 기록한다. #1353 branch는 이 parent head를 base로 만들며, parent merge 전 temporary base 절차는 승인된 설계 명세를 그대로 따른다.
+PR 생성 전 child issue #1347의 `## DoD Status`와 parent PR body에 exact head, required check count, 6-R artifact, known gaps를 기록한다. child PR body에는 `Closes #1347`을 사용해 child merge 시 이슈가 자동 종료되도록 하고, 최종 child #1353 PR에만 `Closes #1422`를 둔다. #1353 branch는 이 parent head를 base로 만들며, parent merge 전 temporary base 절차는 승인된 설계 명세를 그대로 따른다. 최종 merge 후 live GitHub에서 두 child issue와 Epic #1422의 closed/DoD 상태를 재확인한다.
 
 ## Kafka plan traceability
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -456,7 +456,13 @@ return callbackFlow {
     val upstreamJobRef = AtomicReference<Job?>()
 
     fun cancelInFlight() {
-        inFlight.forEach { it.future.get()?.cancel(false) }
+        inFlight.toList().forEach { state ->
+            state.future.get()?.cancel(false)
+            if (state.completed.compareAndSet(false, true)) {
+                inFlight.remove(state)
+                permits.release()
+            }
+        }
     }
 
     fun failOnce(cause: Throwable) {
@@ -503,6 +509,13 @@ return callbackFlow {
                     if (terminalCause.get() != null || downstreamCancelled.get()) {
                         future.cancel(false)
                     }
+                } catch (cause: CancellationException) {
+                    if (state.completed.compareAndSet(false, true)) {
+                        inFlight.remove(state)
+                        permits.release()
+                    }
+                    if (!downstreamCancelled.get()) failOnce(cause)
+                    throw cause
                 } catch (cause: Throwable) {
                     if (state.completed.compareAndSet(false, true)) {
                         inFlight.remove(state)
@@ -512,12 +525,16 @@ return callbackFlow {
                     throw cause
                 }
             }
+        } catch (cause: CancellationException) {
+            if (!downstreamCancelled.get()) failOnce(cause)
+            throw cause
         } catch (cause: Throwable) {
             failOnce(cause)
             throw cause
         } finally {
             withContext(NonCancellable + Dispatchers.IO) {
                 var cleanupFailure: Throwable? = null
+                var cleanupCancellation: CancellationException? = null
                 try {
                     withTimeout(30.seconds) {
                         while (inFlight.isNotEmpty()) delay(10)
@@ -529,9 +546,9 @@ return callbackFlow {
                     if (!downstreamCancelled.get()) failOnce(cause)
                 } catch (cause: CancellationException) {
                     cleanupFailure = cause
+                    cleanupCancellation = cause
                     cancelInFlight()
                     if (!downstreamCancelled.get()) failOnce(cause)
-                    throw cause
                 } catch (cause: Throwable) {
                     cleanupFailure = cause
                     cancelInFlight()
@@ -554,6 +571,9 @@ return callbackFlow {
                     failOnce(closeFailure)
                 }
                 if (terminalCause.get() == null && !downstreamCancelled.get()) close()
+                if (cleanupCancellation != null && terminalCause.get() == null) {
+                    throw cleanupCancellation
+                }
             }
         }
     }
@@ -570,13 +590,15 @@ return callbackFlow {
 각 send는 `SendState`를 먼저 `inFlight`에 등록하고 callback에 전달한다. callback이
 동기 실행되어도 state가 이미 존재하므로 stale Future가 생기지 않는다. callback은
 결과 전달 또는 `failOnce` 처리가 끝난 뒤 `finally`에서 state를 `inFlight`에서 제거하고
-permit을 정확히 한 번 해제한다. worker cleanup은 one-shot signal에 의존하지 않고
+permit을 정확히 한 번 해제한다. `cancelInFlight()`도 state의 completed CAS를 통해
+같은 제거·permit release를 한 번만 수행한다. worker cleanup은 one-shot signal에 의존하지 않고
 bounded loop에서 `inFlight.isEmpty()`를 다시 확인하므로 mixed sync/async callback이
 남아 있으면 flush/close로 진행하지 않는다. 반환 Future는 state에
 저장한 뒤 이미 완료된 callback이면 registry에 남기지 않는다. `awaitClose`는 먼저
-`downstreamCancelled` sentinel을 세우고 cancellation
-signal만 전달한다. 따라서 닫힌 channel에서 도착한 late callback은 새 terminal cause를
-기록하지 않는다. `failOnce(cause)`는 downstream sentinel이 없을 때만
+`downstreamCancelled` sentinel을 세우고 in-flight state를 완료·제거하면서
+non-blocking Future cancellation과 cancellation signal을 전달한다. 따라서 닫힌
+channel에서 도착한 late callback은 새 terminal cause나 permit release를 만들지 않는다.
+`failOnce(cause)`는 downstream sentinel이 없을 때만
 `terminalCause`를 CAS한 뒤 `upstreamJobRef`가 가리키는 Job을 취소하고 channel close를
 수행한다. Job은 `CoroutineStart.LAZY`로 만든 뒤 ref를 저장하고 시작하므로 callback이
 동기 실행되어도 초기화되지 않은 Job을 참조하지 않는다. 각 collection마다

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -614,10 +614,19 @@ Python 표준 라이브러리만 사용해 다음 CLI 계약을 구현한다.
 python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --task-name :bluetape4k-examples-coroutines-demo:test \
   --output-dir examples/build/testcontainers-diagnostics/_bluetape4k-examples-coroutines-demo_test \
-  --workflow-file .github/workflows/examples.yml
+  --workflow-file .github/workflows/examples.yml \
+  --max-total-bytes 2000000
 ```
 
-스크립트는 `docker ps -a --filter label=org.testcontainers=true`로 container id를 읽고, 각 container에 대해 `docker inspect`의 image/name/created와 `docker logs --tail 200`만 수집한다. 출력은 task 이름으로 정규화한 JSON manifest와 `*.log`로 저장하며, token·URI·환경 변수·payload·exception message는 `[REDACTED]`로 치환한다. container log가 없으면 빈 manifest를 만들고 exit 0으로 종료한다. Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한다.
+스크립트는 `--container-id`를 반복 인자로 받아 현재 Gradle invocation에서 새로 생성된
+container만 대상으로 삼는다. ID가 없으면 빈 manifest를 만들고 exit 0으로 종료한다.
+각 container에 대해 `docker inspect`의 image/name/created와 `docker logs --tail 200`만
+수집한다. 출력은 task 이름으로 정규화한 JSON manifest와 `*.log`로 저장하며,
+token·URI·환경 변수·payload·exception message는 `[REDACTED]`로 치환한다. 로그와
+manifest의 총 산출량은 `--max-total-bytes`(기본 2,000,000 bytes)를 넘지 않으며,
+초과분은 잘라내고 manifest에 `truncated=true`를 기록한다. container log가 없으면
+해당 container의 로그를 생략하고, 전체 ID가 비어 있으면 빈 manifest를 만든다.
+Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한다.
 
 `sanitize`는 다음 순서의 stdlib 정규식만 사용한다: (1) `authorization`,
 `token`, `password`, `secret`, `api[_-]?key` 등의 key/value를 치환하고,
@@ -681,9 +690,15 @@ exit "$status"
 ```
 
 실제 step에서는 위 배열을 만든 뒤 `./gradlew "${compile_tasks[@]}" --parallel`을
-실행한다. Ktor/Spring Boot 조건부 task는 현재 `build.gradle.kts`가 존재하는
-경우에만 compile/test 배열 각각에 추가한다. compile task와 test task를 같은
-`--parallel` 배열에 넣지 않는다.
+실행한다. 각 test task 직전에
+`docker ps -aq --filter label=org.testcontainers=true | sort`를 실행 전 기준 목록으로
+저장하고, task 종료 직후 실행 후 기준 목록과 `comm -13`으로 새 ID만 계산해 collector의
+반복 `--container-id` 인자로 전달한다. 기준 목록 명령이 Docker 오류를 반환하면
+aggregate status를 1로 유지하되 collector는 빈 manifest를 남겨 `if: always()`에서
+진단 artifact를 확인할 수 있게 한다. Ktor/Spring Boot 조건부 task는 현재
+`build.gradle.kts`가 존재하는 경우에만 compile/test 배열 각각에 추가한다. compile
+task와 test task를 같은 `--parallel` 배열에 넣지 않는다. ID 목록은 정렬·중복 제거해
+같은 container의 log/manifest를 여러 번 수집하지 않는다.
 
 - [ ] **Step 3: always artifact와 provenance completeness를 고정한다**
 
@@ -700,8 +715,13 @@ if-no-files-found: error
 각 test invocation 뒤 manifest가 존재하는지 shell에서 검사하고, collector 또는
 manifest 누락이면 aggregate status를 1로 만든다. manifest에는 resolved image
 digest와 workflow action ref를 기록하되, 이 Epic에서는 mutable image/action을
-변경하거나 pinning하지 않는다. `actionlint`, path filter, artifact path와
-순서를 정적 검사한다.
+변경하거나 pinning하지 않는다. 진단 파일은 task별로 새 container ID를 deduplicate하고
+총 2,000,000 bytes 상한을 적용한다. `actionlint`, path filter, artifact path와
+순서를 정적 검사한다. 기존 workflow timeout 60분에서 15분 headroom을 확보하기
+위해 전체 직렬 test phase의 elapsed를 `date +%s`로 측정해
+`examples/build/testcontainers-diagnostics/test-phase-timing.txt`에 기록하고, 45분을 초과하면
+aggregate status를 1로 만든다. 6-R evidence에는 baseline 병렬 elapsed와 계획된
+직렬 elapsed를 함께 남긴다.
 
 - [ ] **Step 4: workflow 정적 검증과 실패 누적을 확인한다**
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -19,7 +19,7 @@
 - Modify: `examples/coroutines-demo/README.md` — 정확한 Gradle task, Docker/Testcontainers precondition, callback contract를 영어로 갱신한다.
 - Modify: `examples/coroutines-demo/README.ko.md` — 같은 명령과 계약을 한국어로 갱신한다.
 - Create: `.github/scripts/collect-testcontainers-diagnostics.py` — task별 bounded/sanitized Docker log와 provenance manifest를 표준 출력 경로에 만든다.
-- Create: `.github/scripts/test_collect-testcontainers-diagnostics.py` — redaction·allowlist·report cap 회귀 fixture를 검증한다.
+- Create: `.github/scripts/test_collect_testcontainers_diagnostics.py` — redaction·allowlist·report cap 회귀 fixture를 검증한다.
 - Modify: `.github/workflows/examples.yml` — compile 병렬 phase와 Testcontainers test 순차 phase를 분리하고 aggregate failure/artifact를 고정한다.
 
 이 계획은 production Kafka API, 새 library module, catalog version, 공용 Kafka image/tag를
@@ -984,6 +984,8 @@ allowlist 밖 image와 local image ID를 거부하는지, report 파일 수·전
 `report_truncated=true`를 검증한다. Expected: actionlint, Python syntax, redaction
 fixture가 PASS한다. 실제 CI에서는 중간 test failure가 있어도 뒤의 task와 artifact
 수집이 실행되고 마지막에 aggregate non-zero가 된다.
+fixture는 하이픈이 있는 collector 파일을 `importlib.util.spec_from_file_location`으로
+불러오며 실제 Docker 호출은 mock subprocess로 대체해 secret 원문을 남기지 않는다.
 
 ## Task 6: coroutines README locale parity를 맞춘다
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -153,7 +153,7 @@ fun `collector cancellation rethrows CancellationException and closes producer o
 
     withTimeout(5.seconds) { producer.sendStarted.await() }
     task.cancel()
-    assertFailsWith<CancellationException> { task.await() }
+    val cancellation = assertFailsWith<CancellationException> { task.await() }
 
     producer.closeCount shouldBeEqualTo 1
     producer.pendingSend.isCancelled shouldBeEqualTo true
@@ -161,6 +161,9 @@ fun `collector cancellation rethrows CancellationException and closes producer o
     producer.fireLateCallback()
     producer.callbackCount shouldBeEqualTo 0
     producer.lateCallbackCount shouldBeEqualTo 1
+    val afterLate = assertFailsWith<CancellationException> { task.await() }
+    afterLate::class shouldBeEqualTo cancellation::class
+    afterLate.message shouldBeEqualTo cancellation.message
 }
 
 @Test
@@ -345,6 +348,8 @@ private class TrackingProducer(
 1-slot buffer를 채우고 세 번째 callback이 full을 재현한다. `maxInFlight=1`에서
 두 record가 모두 완료되는 테스트가 callback 공통 `finally`의 permit release를
 간접적으로 증명한다. close 이후 callback은 `lateCallbackCount`만 증가시킨다.
+취소 테스트는 late callback 뒤에도 동일한 `CancellationException`이 다시 관찰되고
+추가 결과가 발행되지 않음을 확인해 terminal state 불변성을 검증한다.
 각 held send는 서로 다른 Future를 반환하며 `cancelledPendingSends()`로 다중 in-flight
 취소를 검증할 수 있다. `Producer`의 다른 메서드는 MockK relaxed
 기본값으로 두되 `send`, `flush`, `close(Duration)`만 위 계약으로 검증한다. 모든
@@ -390,15 +395,18 @@ Step 2–3에서 이 signature의 함수 body를 완성한다. `channelCapacity`
 return callbackFlow {
     val producer = producerFactory()
     val terminalCause = AtomicReference<Throwable?>(null)
+    val downstreamCancelled = AtomicBoolean()
     val permits = Semaphore(maxInFlight)
     class SendState {
         val future = AtomicReference<Future<RecordMetadata>?>(null)
         val completed = AtomicBoolean()
     }
     val inFlight = ConcurrentHashMap.newKeySet<SendState>()
+    val drained = CompletableDeferred<Unit>()
     lateinit var upstreamJob: Job
 
     fun failOnce(cause: Throwable) {
+        if (downstreamCancelled.get()) return
         if (terminalCause.compareAndSet(null, cause)) {
             upstreamJob.cancel(CancellationException("producer terminal failure", cause))
             close(cause)
@@ -411,11 +419,14 @@ return callbackFlow {
         if (!state.completed.compareAndSet(false, true)) return
         inFlight.remove(state)
         permits.release()
+        if (inFlight.isEmpty()) drained.complete(Unit)
         if (cause != null) {
             failOnce(cause)
         } else if (metadata != null) {
             trySend(metadata).onFailure {
-                failOnce(IllegalStateException("callback buffer is full"))
+                if (!downstreamCancelled.get()) {
+                    failOnce(IllegalStateException("callback buffer is full"))
+                }
             }
         }
     }
@@ -440,6 +451,7 @@ return callbackFlow {
                     if (state.completed.compareAndSet(false, true)) {
                         inFlight.remove(state)
                         permits.release()
+                        if (inFlight.isEmpty()) drained.complete(Unit)
                     }
                     failOnce(cause)
                     throw cause
@@ -450,7 +462,10 @@ return callbackFlow {
             throw cause
         }
     }
-    awaitClose { upstreamJob.cancel(CancellationException("collector cancelled")) }
+    awaitClose {
+        downstreamCancelled.set(true)
+        upstreamJob.cancel(CancellationException("collector cancelled"))
+    }
 }.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)
 ```
 
@@ -458,7 +473,10 @@ return callbackFlow {
 동기 실행되어도 state가 이미 존재하므로 stale Future가 생기지 않는다. callback은
 state의 `completed` CAS를 통과할 때만 `inFlight`에서 제거하고 permit을 정확히 한 번
 해제하며, 반환 Future는 state에 저장한 뒤 이미 완료된 callback이면 registry에 남기지
-않는다. `failOnce(cause)`는 `terminalCause`를 CAS한 뒤
+않는다. `awaitClose`는 먼저 `downstreamCancelled` sentinel을 세우고 cancellation
+signal만 전달한다. 따라서 닫힌 channel에서 도착한 late callback은 새 terminal cause를
+기록하지 않는다. `failOnce(cause)`는 downstream sentinel이 없을 때만
+`terminalCause`를 CAS한 뒤
 `upstreamJob.cancel(CancellationException("producer terminal failure", cause))`과
 channel close를 수행한다. 각 collection마다 `producerFactory()`는 한 번만
 호출한다. 두 helper는 `upstreamJob`을 생성하기 전에 같은 `callbackFlow` block의
@@ -473,7 +491,7 @@ local function으로 선언하며, callback thread에서 suspend하지 않는다
 첫 terminal cause는 다음 규칙을 사용한다.
 
 ```kotlin
-if (terminalCause.compareAndSet(null, cause)) {
+if (!downstreamCancelled.get() && terminalCause.compareAndSet(null, cause)) {
     upstreamJob.cancel(CancellationException("producer terminal failure", cause))
     channel.close(cause)
 } else {
@@ -485,13 +503,22 @@ if (terminalCause.compareAndSet(null, cause)) {
 
 - [ ] **Step 3: awaitClose와 bounded cleanup을 구현한다**
 
-`awaitClose`에서는 cancellation signal만 전달하고 blocking Kafka API를 호출하지 않는다. worker의 `finally` 안에서 다음 순서를 지킨다.
+`awaitClose`에서는 sentinel 설정과 cancellation signal만 수행하고 blocking Kafka API를
+호출하지 않는다. worker의 `finally` 안에서 다음 순서를 지킨다.
 
 1. `withContext(NonCancellable + Dispatchers.IO)`로 진입한다.
 2. callback drain과 `flush()`를 30초 `withTimeout`으로 기다린다.
+   `inFlight`가 이미 비어 있으면 즉시 진행하고, 아니면 callback이 완료할 때
+   `drained`를 깨워 대기한다. 모든 send가 callback 완료 후에만 정상 close로 간다.
 3. deadline을 넘기면 `TimeoutCancellationException`을 first cause로 CAS하고 pending send를 취소한다.
 4. `producer.close(Duration.ofSeconds(5))`를 한 번 실행하고 예외를 suppressed로 연결한다.
 5. `CancellationException`을 broad catch에서 삼키지 않고 재전파한다.
+
+정상적인 `records.collect` 완료에서는 drain과 flush가 끝난 뒤 channel을 성공적으로
+닫고, terminal cause가 있으면 해당 cause로 이미 닫힌 channel을 유지한다. drain 또는
+flush/close 중 발생한 후속 예외는 first cause에만 `suppressed`로 연결한다. pending
+state의 Future는 close 호출 전에 모두 `cancel(false)`해 callback이 뒤늦게 도착해도
+새 결과를 발행하지 않도록 한다.
 
 `runBlocking`이나 IO dispatcher 밖의 blocking Kafka call을 추가하지 않는다.
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -91,8 +91,8 @@ fun `callback failure preserves first cause and closes producer once`() = runSus
     }
 
     error shouldBeEqualTo failure
-    producer.closeCount shouldBeEqualTo 1
-    producer.callbackCount shouldBeEqualTo 1
+    producer.closeCount.get() shouldBeEqualTo 1
+    producer.callbackCount.get() shouldBeEqualTo 1
 }
 
 @Test
@@ -131,8 +131,8 @@ fun `backpressure fails without dropping callback and closes producer once`() = 
     }
 
     error.message shouldBeEqualTo "callback buffer is full"
-    producer.closeCount shouldBeEqualTo 1
-    producer.callbackCount shouldBeEqualTo 3
+    producer.closeCount.get() shouldBeEqualTo 1
+    producer.callbackCount.get() shouldBeEqualTo 3
 }
 
 @Test
@@ -146,7 +146,7 @@ fun `in-flight permit is released after callback`() = runSuspendIO {
         maxInFlight = 1,
     ).toList()
 
-    producer.callbackCount shouldBeEqualTo 2
+    producer.callbackCount.get() shouldBeEqualTo 2
 }
 
 @Test
@@ -163,12 +163,12 @@ fun `collector cancellation rethrows CancellationException and closes producer o
     }
     val cancellation = assertFailsWith<CancellationException> { task.await() }
 
-    producer.closeCount shouldBeEqualTo 1
+    producer.closeCount.get() shouldBeEqualTo 1
     producer.pendingSend.isCancelled shouldBeEqualTo true
     producer.cancelledPendingSends() shouldBeEqualTo 1
     producer.fireLateCallback()
-    producer.callbackCount shouldBeEqualTo 0
-    producer.lateCallbackCount shouldBeEqualTo 1
+    producer.callbackCount.get() shouldBeEqualTo 0
+    producer.lateCallbackCount.get() shouldBeEqualTo 1
     val afterLate = assertFailsWith<CancellationException> { task.await() }
     afterLate::class shouldBeEqualTo cancellation::class
     afterLate.message shouldBeEqualTo cancellation.message
@@ -192,7 +192,7 @@ fun `cancellation immediately after producer creation closes it once`() = runSus
     task.cancel()
     assertFailsWith<CancellationException> { task.await() }
 
-    producer.closeCount shouldBeEqualTo 1
+    producer.closeCount.get() shouldBeEqualTo 1
 }
 
 @Test
@@ -218,9 +218,9 @@ fun `normal completion drains callbacks flushes and closes once`() = runSuspendI
 
     producerResults(flowOf(record("normal")), { producer.producer }).toList()
 
-    producer.flushCount shouldBeEqualTo 1
-    producer.closeCount shouldBeEqualTo 1
-    producer.callbackCount shouldBeEqualTo 1
+    producer.flushCount.get() shouldBeEqualTo 1
+    producer.closeCount.get() shouldBeEqualTo 1
+    producer.callbackCount.get() shouldBeEqualTo 1
 }
 
 @Test
@@ -237,9 +237,9 @@ fun `mixed synchronous and asynchronous callbacks drain before close`() = runSus
     producer.fireCallback()
     collection.await()
 
-    producer.callbackCount shouldBeEqualTo 2
-    producer.flushCount shouldBeEqualTo 1
-    producer.closeCount shouldBeEqualTo 1
+    producer.callbackCount.get() shouldBeEqualTo 2
+    producer.flushCount.get() shouldBeEqualTo 1
+    producer.closeCount.get() shouldBeEqualTo 1
 }
 
 @Test
@@ -252,7 +252,7 @@ fun `flush failure becomes the terminal cause after callback drain`() = runSuspe
     }
 
     error shouldBeEqualTo flushFailure
-    producer.closeCount shouldBeEqualTo 1
+    producer.closeCount.get() shouldBeEqualTo 1
 }
 
 @Test
@@ -272,7 +272,7 @@ fun `upstream exception remains primary and cleanup failure is suppressed`() = r
 
     error shouldBeEqualTo upstreamFailure
     error.suppressed.single() shouldBeEqualTo producer.closeError!!
-    producer.closeCount shouldBeEqualTo 1
+    producer.closeCount.get() shouldBeEqualTo 1
 }
 
 @Test
@@ -294,7 +294,7 @@ fun `callback drain timeout cancels pending sends and preserves timeout cause`()
     }
 
     error::class shouldBeEqualTo TimeoutCancellationException::class
-    producer.closeCount shouldBeEqualTo 1
+    producer.closeCount.get() shouldBeEqualTo 1
     producer.pendingSend.isCancelled shouldBeEqualTo true
     producer.cancelledPendingSends() shouldBeEqualTo 1
 }

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -417,17 +417,20 @@ return callbackFlow {
 
     fun complete(state: SendState, metadata: RecordMetadata?, cause: Exception?) {
         if (!state.completed.compareAndSet(false, true)) return
-        inFlight.remove(state)
-        permits.release()
-        if (inFlight.isEmpty()) drained.complete(Unit)
-        if (cause != null) {
-            failOnce(cause)
-        } else if (metadata != null) {
-            trySend(metadata).onFailure {
-                if (!downstreamCancelled.get()) {
-                    failOnce(IllegalStateException("callback buffer is full"))
+        try {
+            if (cause != null) {
+                failOnce(cause)
+            } else if (metadata != null) {
+                trySend(metadata).onFailure {
+                    if (!downstreamCancelled.get()) {
+                        failOnce(IllegalStateException("callback buffer is full"))
+                    }
                 }
             }
+        } finally {
+            inFlight.remove(state)
+            permits.release()
+            if (inFlight.isEmpty()) drained.complete(Unit)
         }
     }
 
@@ -451,9 +454,9 @@ return callbackFlow {
                     if (state.completed.compareAndSet(false, true)) {
                         inFlight.remove(state)
                         permits.release()
-                        if (inFlight.isEmpty()) drained.complete(Unit)
                     }
                     failOnce(cause)
+                    if (inFlight.isEmpty()) drained.complete(Unit)
                     throw cause
                 }
             }
@@ -471,9 +474,11 @@ return callbackFlow {
 
 각 send는 `SendState`를 먼저 `inFlight`에 등록하고 callback에 전달한다. callback이
 동기 실행되어도 state가 이미 존재하므로 stale Future가 생기지 않는다. callback은
-state의 `completed` CAS를 통과할 때만 `inFlight`에서 제거하고 permit을 정확히 한 번
-해제하며, 반환 Future는 state에 저장한 뒤 이미 완료된 callback이면 registry에 남기지
-않는다. `awaitClose`는 먼저 `downstreamCancelled` sentinel을 세우고 cancellation
+결과 전달 또는 `failOnce` 처리가 끝난 뒤 `finally`에서 state를 `inFlight`에서 제거하고
+permit을 정확히 한 번 해제한다. 마지막 callback의 처리까지 끝난 뒤에만 `drained`를
+완료하므로 worker cleanup이 결과 전달보다 앞서지 않는다. 반환 Future는 state에
+저장한 뒤 이미 완료된 callback이면 registry에 남기지 않는다. `awaitClose`는 먼저
+`downstreamCancelled` sentinel을 세우고 cancellation
 signal만 전달한다. 따라서 닫힌 channel에서 도착한 late callback은 새 terminal cause를
 기록하지 않는다. `failOnce(cause)`는 downstream sentinel이 없을 때만
 `terminalCause`를 CAS한 뒤

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -115,6 +115,7 @@ fun `backpressure fails without dropping callback and closes producer once`() = 
     }
 
     withTimeout(5.seconds) { producer.allSendsStarted.await() }
+    producer.pendingSends.distinct().size shouldBeEqualTo 3
     producer.fireCallback()
     withTimeout(5.seconds) { firstItemReceived.await() }
     producer.fireCallback()
@@ -156,7 +157,9 @@ fun `collector cancellation rethrows CancellationException and closes producer o
 
     producer.closeCount shouldBeEqualTo 1
     producer.pendingSend.isCancelled shouldBeEqualTo true
+    producer.cancelledPendingSends() shouldBeEqualTo 1
     producer.fireLateCallback()
+    producer.callbackCount shouldBeEqualTo 0
     producer.lateCallbackCount shouldBeEqualTo 1
 }
 
@@ -242,6 +245,7 @@ fun `callback drain timeout cancels pending sends and preserves timeout cause`()
     error::class shouldBeEqualTo TimeoutCancellationException::class
     producer.closeCount shouldBeEqualTo 1
     producer.pendingSend.isCancelled shouldBeEqualTo true
+    producer.cancelledPendingSends() shouldBeEqualTo 1
 }
 ```
 
@@ -275,8 +279,11 @@ private class TrackingProducer(
     val sendStarted = CompletableDeferred<Unit>()
     val allSendsStarted = CompletableDeferred<Unit>()
     val sendCount = AtomicInteger()
-    val pendingCallbacks = ConcurrentLinkedQueue<Callback>()
-    val pendingSend = CompletableFuture<RecordMetadata>()
+    data class Pending(val callback: Callback, val future: CompletableFuture<RecordMetadata>)
+    val pendingCallbacks = ConcurrentLinkedQueue<Pending>()
+    val pendingSends = ConcurrentLinkedQueue<CompletableFuture<RecordMetadata>>()
+    val pendingSend: CompletableFuture<RecordMetadata>
+        get() = pendingSends.peek() ?: error("no pending Kafka send")
     private val closed = AtomicBoolean()
     private val metadata = mockk<RecordMetadata>(relaxed = true)
 
@@ -284,15 +291,20 @@ private class TrackingProducer(
         every { producer.send(any<ProducerRecord<String, String>>(), any()) } answers {
             if (sendError != null) throw sendError
             val callback = secondArg<Callback>()
-            if (holdCallbacks) {
-                pendingCallbacks += callback
+            val resultFuture = if (holdCallbacks) {
+                val future = CompletableFuture<RecordMetadata>()
+                pendingSends += future
+                pendingCallbacks += Pending(callback, future)
+                sendStarted.complete(Unit)
+                future
             } else {
                 callbackCount.incrementAndGet()
                 callback.onCompletion(metadata, callbackError)
+                sendStarted.complete(Unit)
+                CompletableFuture.completedFuture(metadata)
             }
-            sendStarted.complete(Unit)
             if (sendCount.incrementAndGet() == 3) allSendsStarted.complete(Unit)
-            if (holdCallbacks) pendingSend else CompletableFuture.completedFuture(metadata)
+            resultFuture
         }
         every { producer.flush() } answers {
             flushCount.incrementAndGet()
@@ -306,29 +318,35 @@ private class TrackingProducer(
     }
 
     fun fireLateCallback() {
-        pendingCallbacks.poll()?.let { callback ->
+        pendingCallbacks.poll()?.let { pending ->
             if (closed.get()) lateCallbackCount.incrementAndGet()
-            callback.onCompletion(metadata, null)
+            pending.callback.onCompletion(metadata, null)
+            pending.future.complete(metadata)
         }
     }
 
     fun fireCallback() {
-        pendingCallbacks.poll()?.let { callback ->
+        pendingCallbacks.poll()?.let { pending ->
             callbackCount.incrementAndGet()
-            callback.onCompletion(metadata, null)
+            pending.callback.onCompletion(metadata, null)
+            pending.future.complete(metadata)
         }
     }
+
+    fun cancelledPendingSends(): Int = pendingSends.count { it.isCancelled }
 }
 ```
 
-기본 성공 fixture는 callback을 즉시 호출하고, held fixture는 `pendingCallbacks`를
-보관해 drain timeout과 cancellation을 결정적으로 만든다. backpressure 테스트는
+기본 성공 fixture는 callback을 즉시 호출하고, held fixture는 callback과 매번 새로
+생성한 `CompletableFuture`를 `Pending` 쌍으로 보관해 drain timeout과 cancellation을
+결정적으로 만든다. backpressure 테스트는
 세 `send` 완료를 `allSendsStarted`로 확인한 뒤 `fireCallback()`을 1→2→3 순서로
 수동 발화한다. 첫 callback 수신 후 collector가 gate에서 멈추므로 두 번째 결과가
 1-slot buffer를 채우고 세 번째 callback이 full을 재현한다. `maxInFlight=1`에서
 두 record가 모두 완료되는 테스트가 callback 공통 `finally`의 permit release를
 간접적으로 증명한다. close 이후 callback은 `lateCallbackCount`만 증가시킨다.
-`Producer`의 다른 메서드는 MockK relaxed
+각 held send는 서로 다른 Future를 반환하며 `cancelledPendingSends()`로 다중 in-flight
+취소를 검증할 수 있다. `Producer`의 다른 메서드는 MockK relaxed
 기본값으로 두되 `send`, `flush`, `close(Duration)`만 위 계약으로 검증한다. 모든
 assertion은 `assertFailsWith`, `shouldBeEqualTo` 또는 기존 `bluetape4k` matcher를
 사용한다. Timeout 테스트는 adapter의 30초 drain deadline을 그대로 검증하므로
@@ -373,16 +391,56 @@ return callbackFlow {
     val producer = producerFactory()
     val terminalCause = AtomicReference<Throwable?>(null)
     val permits = Semaphore(maxInFlight)
-    val inFlight = ConcurrentHashMap.newKeySet<Future<RecordMetadata>>()
-    val upstreamJob = launch(Dispatchers.IO) {
+    class SendState {
+        val future = AtomicReference<Future<RecordMetadata>?>(null)
+        val completed = AtomicBoolean()
+    }
+    val inFlight = ConcurrentHashMap.newKeySet<SendState>()
+    lateinit var upstreamJob: Job
+
+    fun failOnce(cause: Throwable) {
+        if (terminalCause.compareAndSet(null, cause)) {
+            upstreamJob.cancel(CancellationException("producer terminal failure", cause))
+            close(cause)
+        } else {
+            log.debug { "late Kafka callback ignored; failureKind=${cause::class.simpleName}" }
+        }
+    }
+
+    fun complete(state: SendState, metadata: RecordMetadata?, cause: Exception?) {
+        if (!state.completed.compareAndSet(false, true)) return
+        inFlight.remove(state)
+        permits.release()
+        if (cause != null) {
+            failOnce(cause)
+        } else if (metadata != null) {
+            trySend(metadata).onFailure {
+                failOnce(IllegalStateException("callback buffer is full"))
+            }
+        }
+    }
+
+    fun callbackFor(state: SendState): Callback = Callback { metadata, cause ->
+        complete(state, metadata, cause)
+    }
+
+    upstreamJob = launch(Dispatchers.IO) {
         try {
             records.collect { record ->
                 permits.acquire()
+                val state = SendState()
+                inFlight += state
                 try {
-                    val future = producer.send(record, callbackFor(record))
-                    inFlight += future
+                    val future = producer.send(record, callbackFor(state))
+                    state.future.set(future)
+                    if (state.completed.get() && terminalCause.get() != null) {
+                        future.cancel(false)
+                    }
                 } catch (cause: Throwable) {
-                    permits.release()
+                    if (state.completed.compareAndSet(false, true)) {
+                        inFlight.remove(state)
+                        permits.release()
+                    }
                     failOnce(cause)
                     throw cause
                 }
@@ -396,16 +454,19 @@ return callbackFlow {
 }.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)
 ```
 
-`callbackFor(record)`는 callback 성공·실패와 동기 `send` 예외 모두에서 공통
-`finally`로 해당 Future를 `inFlight`에서 제거하고 permit을 정확히 한 번만
-해제한다. `failOnce(cause)`는 `terminalCause`를 CAS한 뒤
+각 send는 `SendState`를 먼저 `inFlight`에 등록하고 callback에 전달한다. callback이
+동기 실행되어도 state가 이미 존재하므로 stale Future가 생기지 않는다. callback은
+state의 `completed` CAS를 통과할 때만 `inFlight`에서 제거하고 permit을 정확히 한 번
+해제하며, 반환 Future는 state에 저장한 뒤 이미 완료된 callback이면 registry에 남기지
+않는다. `failOnce(cause)`는 `terminalCause`를 CAS한 뒤
 `upstreamJob.cancel(CancellationException("producer terminal failure", cause))`과
 channel close를 수행한다. 각 collection마다 `producerFactory()`는 한 번만
 호출한다. 두 helper는 `upstreamJob`을 생성하기 전에 같은 `callbackFlow` block의
 local function으로 선언하며, callback thread에서 suspend하지 않는다.
-각 `send`의 반환 Future를 in-flight 항목과 함께 보관해 cancellation 또는 drain
-deadline에서 `cancel(false)`하고, deterministic probe의 `pendingSend`로 그 결과를
-검증한다.
+각 `send`의 반환 Future는 state에 저장하고, cancellation 또는 drain deadline에서
+모든 in-flight state의 Future를 `cancel(false)`한다. deterministic probe는 send마다
+서로 다른 pending Future를 반환하고 `pendingSend`와 `cancelledPendingSends()`로 그
+결과를 검증한다.
 
 - [ ] **Step 2: callback failure와 full-buffer terminal path를 구현한다**
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -945,9 +945,11 @@ phase_started=$(date +%s)
 for task in "${test_tasks[@]}"; do
   before_ids_file=$(mktemp)
   after_ids_file=$(mktemp)
-  docker ps -aq --filter label=org.testcontainers=true | sort -u >"$before_ids_file" || status=1
+  docker ps -aq --filter label=org.testcontainers=true \
+    --filter label=org.testcontainers.sessionId | sort -u >"$before_ids_file" || status=1
   ./gradlew "$task" --max-workers=1 || status=1
-  docker ps -aq --filter label=org.testcontainers=true | sort -u >"$after_ids_file" || status=1
+  docker ps -aq --filter label=org.testcontainers=true \
+    --filter label=org.testcontainers.sessionId | sort -u >"$after_ids_file" || status=1
   new_ids=$(comm -13 "$before_ids_file" "$after_ids_file")
   container_args=()
   while IFS= read -r container_id; do
@@ -980,13 +982,16 @@ exit "$status"
 
 실제 step에서는 위 배열을 만든 뒤 `./gradlew "${compile_tasks[@]}" --parallel`을
 실행한다. 각 test task 직전에
-`docker ps -aq --filter label=org.testcontainers=true | sort`를 실행 전 기준 목록으로
+`docker ps -aq --filter label=org.testcontainers=true --filter label=org.testcontainers.sessionId | sort`를 실행 전 기준 목록으로
 저장하고, task 종료 직후 실행 후 기준 목록과 `comm -13`으로 새 ID만 계산해 collector의
 반복 `--container-id` 인자로 전달한다. 기준 목록 명령이 Docker 오류를 반환하면
 aggregate status를 1로 유지하되 collector는 빈 manifest를 남겨 `if: always()`에서
 진단 artifact를 확인할 수 있게 한다. 모든 test task가 끝난 뒤 collector를 정확히
 한 번 더 호출해 `report_paths`에 열거한 report 디렉터리만 sanitization하고, 이 호출은
 `--max-report-files=600`과 `--max-report-total-bytes=8000000`을 적용한다.
+두 label filter를 함께 사용해 현재 Testcontainers session에 속한 실제 테스트
+컨테이너만 snapshot하며, session ID가 없는 Ryuk cleanup helper는 image allowlist
+검사의 대상에서 제외한다.
 Ktor/Spring Boot 조건부 task는 현재
 `build.gradle.kts`가 존재하는 경우에만 compile/test 배열 각각에 추가한다. compile
 task와 test task를 같은 `--parallel` 배열에 넣지 않는다. ID 목록은 정렬·중복 제거해
@@ -1002,6 +1007,18 @@ bounded report를 보장한다. source는 32MB까지만 읽고 최종 파일별 
 상한을 유지한다. 보정 후 실제 15,341,646-byte JUnit XML local scan은
 `report_truncated=false`, 12개 report, 19,510 bytes, 최대 9,362 bytes였으며,
 다음 exact-head hosted run에서 전체 report manifest를 재검증한다.
+
+`82c28a6a6f719b1c2471e84d07bc5300342dfc60`에서는 직전 hosted 실패의 잔여
+원인을 확인했다. `coroutines` Kafka와 `redisson` Redis 테스트는 모두
+`BUILD SUCCESSFUL`이었지만, session ID가 없는 Ryuk helper까지
+`org.testcontainers=true` snapshot에 포함되어 image allowlist 검사에서
+`container image is outside the diagnostics allowlist`로 종료됐다. workflow의
+before/after snapshot을 `org.testcontainers.sessionId`까지 필터링해 실제 테스트
+컨테이너만 수집하도록 좁혔고, exact-head Examples run `32994262529`는 9분 38초에
+compile·9개 순차 test·진단 수집·artifact 업로드를 모두 성공했다. report-scan
+manifest는 507개 report, 399,325 bytes, `truncated=false`,
+`report_truncated=false`였고, exact-head CI run `32994262718`도 전체 required
+job과 aggregate coverage를 성공했다.
 
 - [ ] **Step 3: always artifact와 provenance completeness를 고정한다**
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -807,7 +807,7 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --sanitized-report-dir examples/build/sanitized-test-reports \
   --report-path examples/coroutines-demo/build/test-results/test \
   --report-path examples/coroutines-demo/build/reports/tests/test \
-  --max-report-files 400 \
+  --max-report-files 600 \
   --max-report-total-bytes 8000000
 ```
 
@@ -827,7 +827,7 @@ Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한
 `report-path`가 존재하지 않거나 report 파일이 없으면 해당 단계는 실패시키고, 원본
 report를 sanitized 디렉터리에 절대 링크하지 않는다. collector는 report path를
 재귀적으로 무제한 탐색하지 않고 정렬된 path 목록만 방문하며, 전체 sanitized report는
-`--max-report-files`(기본 200, Examples workflow 400)와 `--max-report-total-bytes`(기본 2,000,000 bytes, Examples workflow 8,000,000 bytes)를
+`--max-report-files`(기본 200, Examples workflow 600)와 `--max-report-total-bytes`(기본 2,000,000 bytes, Examples workflow 8,000,000 bytes)를
 동시에 적용한다. 상한 초과 시 추가 파일을 저장하지 않고 manifest에
 `report_truncated=true`를 기록하며 exit 1로 종료한다.
 
@@ -959,7 +959,7 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --output-dir examples/build/testcontainers-diagnostics/report-scan \
   --workflow-file .github/workflows/examples.yml \
   --sanitized-report-dir examples/build/sanitized-test-reports \
-  --max-report-files 400 \
+  --max-report-files 600 \
   --max-report-total-bytes 8000000 \
   "${report_paths[@]}" || status=1
 test -d examples/build/sanitized-test-reports || status=1
@@ -978,7 +978,7 @@ exit "$status"
 aggregate status를 1로 유지하되 collector는 빈 manifest를 남겨 `if: always()`에서
 진단 artifact를 확인할 수 있게 한다. 모든 test task가 끝난 뒤 collector를 정확히
 한 번 더 호출해 `report_paths`에 열거한 report 디렉터리만 sanitization하고, 이 호출은
-`--max-report-files=400`과 `--max-report-total-bytes=8000000`을 적용한다.
+`--max-report-files=600`과 `--max-report-total-bytes=8000000`을 적용한다.
 Ktor/Spring Boot 조건부 task는 현재
 `build.gradle.kts`가 존재하는 경우에만 compile/test 배열 각각에 추가한다. compile
 task와 test task를 같은 `--parallel` 배열에 넣지 않는다. ID 목록은 정렬·중복 제거해

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -814,7 +814,7 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
 스크립트는 `--container-id`를 반복 인자로 받아 현재 Gradle invocation에서 새로 생성된
 container만 대상으로 삼는다. ID가 없으면 container 섹션이 빈 manifest가 되며 exit 0으로
 처리하되, `--report-path`가 함께 지정된 경우 report sanitization은 계속 수행한다.
-각 container에 대해 `docker inspect`의 image/name/created와 `docker logs --tail 200`만
+각 container에 대해 `docker inspect`의 image/image ID/name/created와 `docker logs --tail 200`만
 수집한다. 출력은 task 이름으로 정규화한 JSON manifest와 `*.log`로 저장하며,
 token·URI·환경 변수·payload·exception message는 `[REDACTED]`로 치환한다. 로그와
 manifest의 총 산출량은 `--max-total-bytes`(기본 2,000,000 bytes)를 넘지 않으며,
@@ -838,11 +838,12 @@ report를 sanitized 디렉터리에 절대 링크하지 않는다. collector는 
 뒤의 message를 치환한다. 원문 로그는 저장하지 않는다. `--workflow-file`의
 `uses: owner/action@ref`를 파싱해 `workflow_action_refs`에 기록하되 ref가 40자리
 immutable commit SHA가 아니면 실패시킨다. `docker container inspect`의
-`RepoDigests`가 제공되면 이를 우선 사용하고, Docker 엔진이 해당 필드를 생략하는
-경우에는 container의 image reference로 `docker image inspect`를 수행해 allowlist와
-정확히 일치하는 값을 `image_digest`에 기록한다. image ID는 보조 진단 필드로만
-기록하며, 두 inspect 결과 모두에 immutable `RepoDigests`가 없으면 provenance를
-완성할 수 없으므로 실패시킨다.
+`Image` ID가 없으면 mutable `Config.Image`를 provenance 근거로 사용하지 않고
+실패시킨다. `RepoDigests`가 제공되면 이를 우선 사용하고, Docker 엔진이 해당
+필드를 생략하는 경우에는 실제 container `Image` ID로 `docker image inspect`를
+수행한다. image inspect 반환 `Id`가 container `Image` ID와 정확히 일치할 때만
+allowlist와 일치하는 `image_digest`를 기록하며, 두 inspect 결과 모두에 immutable
+`RepoDigests`가 없으면 provenance를 완성할 수 없으므로 실패시킨다.
 허용 image allowlist는 `confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130`과
 `redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a`로
 고정한다. 해당 image는 `RepoDigests`가 allowlist와 정확히 일치해야 하며, local

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -1,0 +1,598 @@
+# Epic #1422 #1347 Kafka CallbackFlow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 실제 Kafka producer callback을 `Flow<RecordMetadata>`로 변환하고 성공·실패·취소·backpressure·cleanup 계약을 실행 가능한 coroutines example로 증명한다.
+
+**Architecture:** `CallbackFlowExamples.kt` 안의 private adapter만 Kafka callback lifecycle을 소유한다. 성공 경로는 기존 `KafkaServer.Launcher` broker helper를 사용하고, failure/lifecycle 경로는 producer factory seam을 사용하는 deterministic fixture로 분리한다. 이 parent child는 examples 공통 CI의 compile/test phase 분리와 diagnostics 수집도 소유하며, child #1353은 이 branch를 base로 쌓는다.
+
+**Tech Stack:** Kotlin 2.4/JVM 25, kotlinx.coroutines `callbackFlow`/`awaitClose`, Apache Kafka 4 client, Testcontainers Kafka, JUnit 5, `runSuspendIO`, `bluetape4k-assertions`, existing Gradle version catalog.
+
+---
+
+## 계획 범위와 파일 소유권
+
+- Modify: `examples/coroutines-demo/build.gradle.kts` — 기존 catalog/project를 재사용하는 test dependency만 추가한다.
+- Modify: `examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt` — private adapter, deterministic fixture, actual broker test를 한 example class에 둔다.
+- Modify: `examples/coroutines-demo/README.md` — 정확한 Gradle task, Docker/Testcontainers precondition, callback contract를 영어로 갱신한다.
+- Modify: `examples/coroutines-demo/README.ko.md` — 같은 명령과 계약을 한국어로 갱신한다.
+- Create: `.github/scripts/collect-testcontainers-diagnostics.py` — task별 bounded/sanitized Docker log와 provenance manifest를 표준 출력 경로에 만든다.
+- Modify: `.github/workflows/examples.yml` — compile 병렬 phase와 Testcontainers test 순차 phase를 분리하고 aggregate failure/artifact를 고정한다.
+
+이 계획은 production Kafka API, 새 library module, catalog version, Kafka image/tag를 변경하지 않는다. #1353 소유 파일은 이 계획에서 수정하지 않는다.
+
+## Task 1: Kafka example dependency와 baseline 고정
+
+**Files:**
+
+- Modify: `examples/coroutines-demo/build.gradle.kts`
+- Test: `examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt`
+
+- [ ] **Step 1: 기존 dependency 블록에 명시적 test project를 추가한다**
+
+`dependencies` 안의 `testImplementation(project(":bluetape4k-junit5"))` 앞에 다음 세 줄을 추가한다. catalog의 기존 alias와 project path만 사용한다.
+
+```kotlin
+    testImplementation(project(":bluetape4k-kafka4"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+    testImplementation(libs.testcontainers.kafka)
+```
+
+- [ ] **Step 2: dependency와 기존 test source가 함께 컴파일되는지 확인한다**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-examples-coroutines-demo:testClasses --no-configuration-cache
+```
+
+Expected: `BUILD SUCCESSFUL`; Kafka client와 `KafkaServer.Launcher`를 resolve하고 기존 `CallbackFlowExamples` test source를 컴파일한다.
+
+- [ ] **Step 3: 변경을 독립 commit으로 기록한다**
+
+```bash
+git add examples/coroutines-demo/build.gradle.kts
+git commit -F - <<'EOF'
+Kafka callback 예제의 기존 broker·client helper 연결을 보장한다
+
+Constraint: 새로운 version coordinate나 production dependency를 추가하지 않는다.
+Rejected: compileOnly Kafka dependency | test runtime에서 실제 producer를 만들 수 없다.
+Confidence: high
+Scope-risk: narrow
+Directive: 다음 Kafka example은 KafkaServer.Launcher와 중앙 catalog만 재사용한다.
+Tested: ./gradlew :bluetape4k-examples-coroutines-demo:testClasses --no-configuration-cache
+Not-tested: callback lifecycle, broker runtime, hosted CI
+EOF
+```
+
+## Task 2: deterministic lifecycle RED 테스트 작성
+
+**Files:**
+
+- Modify: `examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt`
+
+- [ ] **Step 1: test fixture와 결과 assertion을 추가한다**
+
+`CallbackFlowExamples` 안에 `runSuspendIO`와 `bluetape4k-assertions`를 사용해 다음 행동을 각각 검증한다. 테스트 이름과 기대 예외를 그대로 유지한다.
+
+```kotlin
+@Test
+fun `callback failure preserves first cause and closes producer once`() = runSuspendIO {
+    val failure = IllegalStateException("callback failure")
+    val producer = TrackingProducer(callbackError = failure)
+
+    val error = assertFailsWith<IllegalStateException> {
+        producerResults(flowOf(record("failure")), { producer.producer }).toList()
+    }
+
+    error shouldBeEqualTo failure
+    producer.closeCount shouldBeEqualTo 1
+    producer.callbackCount shouldBeEqualTo 1
+}
+
+@Test
+fun `backpressure fails without dropping callback and closes producer once`() = runSuspendIO {
+    val producer = TrackingProducer()
+
+    val error = assertFailsWith<IllegalStateException> {
+        producerResults(
+            records = flowOf(record("one"), record("two")),
+            producerFactory = { producer.producer },
+            channelCapacity = 1,
+            maxInFlight = 2,
+        ).take(1).toList()
+    }
+
+    error.message shouldBeEqualTo "callback buffer is full"
+    producer.closeCount shouldBeEqualTo 1
+    producer.callbackCount shouldBeEqualTo 2
+}
+
+@Test
+fun `in-flight permit is released after callback`() = runSuspendIO {
+    val producer = TrackingProducer()
+
+    producerResults(
+        records = flowOf(record("permit-one"), record("permit-two")),
+        producerFactory = { producer.producer },
+        channelCapacity = 1,
+        maxInFlight = 1,
+    ).toList()
+
+    producer.callbackCount shouldBeEqualTo 2
+}
+
+@Test
+fun `collector cancellation rethrows CancellationException and closes producer once`() = runSuspendIO {
+    val producer = TrackingProducer(holdCallbacks = true)
+    val task = async {
+        producerResults(flowOf(record("cancel")), { producer.producer }).toList()
+    }
+    yield()
+
+    task.cancel()
+    assertFailsWith<CancellationException> { task.await() }
+
+    producer.closeCount shouldBeEqualTo 1
+    producer.lateCallbackCount shouldBeEqualTo 0
+}
+
+@Test
+fun `factory and synchronous send failures are terminal causes`() = runSuspendIO {
+    val factoryFailure = IllegalArgumentException("factory failure")
+    val factoryError = assertFailsWith<IllegalArgumentException> {
+        producerResults(flowOf(record("factory")), { throw factoryFailure }).toList()
+    }
+    factoryError shouldBeEqualTo factoryFailure
+
+    val sendFailure = IllegalStateException("send failure")
+    val sendError = assertFailsWith<IllegalStateException> {
+        producerResults(flowOf(record("send")), { TrackingProducer(sendError = sendFailure).producer }).toList()
+    }
+    sendError shouldBeEqualTo sendFailure
+}
+
+@Test
+fun `normal completion drains callbacks flushes and closes once`() = runSuspendIO {
+    val producer = TrackingProducer()
+
+    producerResults(flowOf(record("normal")), { producer.producer }).toList()
+
+    producer.flushCount shouldBeEqualTo 1
+    producer.closeCount shouldBeEqualTo 1
+    producer.callbackCount shouldBeEqualTo 1
+}
+
+@Test
+fun `upstream exception remains primary and cleanup failure is suppressed`() = runSuspendIO {
+    val upstreamFailure = IllegalArgumentException("upstream failure")
+    val producer = TrackingProducer(closeError = IllegalStateException("close failure"))
+
+    val error = assertFailsWith<IllegalArgumentException> {
+        producerResults(
+            flow {
+                emit(record("before-upstream-failure"))
+                throw upstreamFailure
+            },
+            { producer.producer },
+        ).toList()
+    }
+
+    error shouldBeEqualTo upstreamFailure
+    error.suppressed.single() shouldBeEqualTo producer.closeError!!
+    producer.closeCount shouldBeEqualTo 1
+}
+
+@Test
+fun `channel and in flight bounds reject invalid values`() = runSuspendIO {
+    assertFailsWith<IllegalArgumentException> {
+        producerResults(flowOf(record("invalid-capacity")), { TrackingProducer().producer }, channelCapacity = 0)
+    }
+    assertFailsWith<IllegalArgumentException> {
+        producerResults(flowOf(record("invalid-in-flight")), { TrackingProducer().producer }, maxInFlight = 17)
+    }
+}
+
+@Test
+fun `callback drain timeout cancels pending sends and preserves timeout cause`() = runSuspendIO(timeout = 40.seconds) {
+    val producer = TrackingProducer(holdCallbacks = true)
+
+    val error = assertFailsWith<TimeoutCancellationException> {
+        producerResults(flowOf(record("timeout")), { producer.producer }).toList()
+    }
+
+    error::class shouldBeEqualTo TimeoutCancellationException::class
+    producer.closeCount shouldBeEqualTo 1
+}
+```
+
+`record(value)`는 다음 private helper로 unique topic을 만들고 topic/key/value/header 길이 계약을 검사한다.
+
+```kotlin
+private fun record(value: String): ProducerRecord<String, String> {
+    val topic = "epic-1422-${Base58.randomString(8)}"
+    require(topic.length <= 128)
+    require(value.toByteArray(Charsets.UTF_8).size <= 1024)
+    return ProducerRecord(topic, "key", value)
+}
+```
+
+`TrackingProducer`는 MockK로 감싼 test-only `Producer<String, String>` probe다. 다음
+설정을 생성자에서 받고, 테스트 factory가 `producer`를 반환하도록 고정한다.
+
+```kotlin
+private class TrackingProducer(
+    private val callbackError: Exception? = null,
+    private val sendError: Exception? = null,
+    val closeError: Exception? = null,
+    private val holdCallbacks: Boolean = false,
+) {
+    val producer: Producer<String, String> = mockk(relaxed = true)
+    val callbackCount = AtomicInteger()
+    val closeCount = AtomicInteger()
+    val flushCount = AtomicInteger()
+    val lateCallbackCount = AtomicInteger()
+    val pendingCallbacks = ConcurrentLinkedQueue<Callback>()
+
+    init {
+        every { producer.send(any<ProducerRecord<String, String>>(), any()) } answers {
+            if (sendError != null) throw sendError
+            val callback = secondArg<Callback>()
+            val metadata = RecordMetadata(TopicPartition("probe", 0), 0, 0, 0L, 0, 0)
+            if (holdCallbacks) pendingCallbacks += callback
+            else {
+                callbackCount.incrementAndGet()
+                callback.onCompletion(metadata, callbackError)
+            }
+            CompletableFuture.completedFuture(metadata)
+        }
+        every { producer.flush() } answers { flushCount.incrementAndGet() }
+        every { producer.close(any<Duration>()) } answers {
+            closeCount.incrementAndGet()
+            closeError?.let { throw it }
+        }
+    }
+}
+```
+
+기본 성공 fixture는 callback을 즉시 호출하고, held fixture는 `pendingCallbacks`를
+보관해 drain timeout과 cancellation을 결정적으로 만든다. `maxInFlight=1`에서
+두 record가 모두 완료되는 테스트가 callback 공통 `finally`의 permit release를
+간접적으로 증명한다. close 이후 callback은 `lateCallbackCount`만 증가시킨다.
+`Producer`의 다른 메서드는 MockK relaxed
+기본값으로 두되 `send`, `flush`, `close(Duration)`만 위 계약으로 검증한다. 모든
+assertion은 `assertFailsWith`, `shouldBeEqualTo` 또는 기존 `bluetape4k` matcher를
+사용한다. Timeout 테스트는 adapter의 30초 drain deadline을 그대로 검증하므로
+바깥 `runSuspendIO`는 40초로 제한한다.
+
+- [ ] **Step 2: RED 상태를 확인한다**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-examples-coroutines-demo:test \
+  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples' \
+  --no-configuration-cache
+```
+
+Expected: 새 `producerResults`와 `TrackingProducer`가 아직 없으므로 compile/test가 실패한다. failure가 test discovery 또는 missing symbol인지 확인하고 lifecycle 실패가 아닌 다른 환경 오류는 기록한다.
+
+## Task 3: private callbackFlow adapter를 구현한다
+
+**Files:**
+
+- Modify: `examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt`
+
+- [ ] **Step 1: public surface 없이 adapter의 정확한 signature를 정의한다**
+
+```kotlin
+private fun producerResults(
+    records: Flow<ProducerRecord<String, String>>,
+    producerFactory: () -> Producer<String, String>,
+    channelCapacity: Int = 16,
+    maxInFlight: Int = 16,
+): Flow<RecordMetadata>
+```
+
+Step 2–3에서 이 signature의 함수 body를 완성한다. Flow collection마다
+`producerFactory()`를 한 번 호출하고, `Semaphore(maxInFlight)`와
+`AtomicReference<Throwable?>`를 collection-local 상태로 만든다. callback 성공은
+`channel.trySend(metadata)`로 전달하고, callback 성공·실패·동기 `send` 예외 모두에서
+공통 `finally`로 permit/in-flight를 정확히 한 번만 해제한다.
+
+- [ ] **Step 2: callback failure와 full-buffer terminal path를 구현한다**
+
+첫 terminal cause는 다음 규칙을 사용한다.
+
+```kotlin
+if (terminalCause.compareAndSet(null, cause)) {
+    worker.cancel(CancellationException("producer terminal failure", cause))
+    upstream.cancel(CancellationException("producer terminal failure", cause))
+    channel.close(cause)
+} else {
+    log.debug { "late Kafka callback ignored; failureKind=$failureKind" }
+}
+```
+
+`trySend`가 full이면 `IllegalStateException("callback buffer is full")`을 위 CAS에 넣고 worker/upstream을 취소한다. 이미 닫힌 channel은 downstream cancellation이면 새 cause로 덮지 않는다. callbackFlow channel과 producer close는 각각 한 번만 실행하며, cleanup 예외는 first cause의 `suppressed`에 붙인다.
+
+- [ ] **Step 3: awaitClose와 bounded cleanup을 구현한다**
+
+`awaitClose`에서는 cancellation signal만 전달하고 blocking Kafka API를 호출하지 않는다. worker의 `finally` 안에서 다음 순서를 지킨다.
+
+1. `withContext(NonCancellable + Dispatchers.IO)`로 진입한다.
+2. callback drain과 `flush()`를 30초 `withTimeout`으로 기다린다.
+3. deadline을 넘기면 `TimeoutCancellationException`을 first cause로 CAS하고 pending send를 취소한다.
+4. `producer.close(Duration.ofSeconds(5))`를 한 번 실행하고 예외를 suppressed로 연결한다.
+5. `CancellationException`을 broad catch에서 삼키지 않고 재전파한다.
+
+`runBlocking`이나 IO dispatcher 밖의 blocking Kafka call을 추가하지 않는다.
+
+- [ ] **Step 4: RED 테스트를 GREEN으로 전환한다**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-examples-coroutines-demo:test \
+  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples' \
+  --no-configuration-cache
+```
+
+Expected: Task 2의 failure/lifecycle tests가 PASS하고, close count=1, first cause identity, callback/permit count가 assertion된다.
+
+## Task 4: 실제 Kafka broker 성공 경로와 consumer 검증을 추가한다
+
+**Files:**
+
+- Modify: `examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt`
+
+- [ ] **Step 1: Testcontainers precondition과 실제 fixture를 사용한다**
+
+`runSuspendIO(timeout = 120.seconds)`에서 `KafkaServer.Launcher.kafka`를 참조하고, `createStringProducer()`와 `createStringConsumer()`를 각각 한 번 생성한다. topic은 `"epic-1422-callback-" + Base58.randomString(8)`로 만들고, record 수는 128개 이하, value는 1 KiB 이하로 제한한다. producer와 consumer가 broker 자체를 종료하지 않고 collection-scoped/test-owned resource만 닫도록 `use`와 bounded close를 적용한다.
+
+- [ ] **Step 2: success cardinality와 eventual broker result를 검증한다**
+
+```kotlin
+@Test
+fun `real Kafka producer callbacks become metadata flow`() = runSuspendIO(timeout = 120.seconds) {
+    val topic = "epic-1422-callback-${Base58.randomString(8)}"
+    val records = (0 until 8).map { index ->
+        ProducerRecord(topic, "key-$index", "value-$index")
+    }
+
+    KafkaServer.Launcher.createStringConsumer().use { consumer ->
+        consumer.subscribe(listOf(topic))
+        val metadata = producerResults(
+            records = records.asFlow(),
+            producerFactory = { KafkaServer.Launcher.createStringProducer() },
+        ).toList()
+
+        metadata shouldHaveSize records.size
+        val polled = withTimeout(10.seconds) {
+            generateSequence { consumer.poll(Duration.ofMillis(250)).toList() }
+                .flatten()
+                .take(records.size)
+                .toList()
+        }
+        polled shouldHaveSize records.size
+    }
+}
+```
+
+metadata 순서는 `maxInFlight` 때문에 비교하지 않고 cardinality와 실제 consumer record count만 비교한다. consumer poll은 10초를 넘기지 않는다.
+
+- [ ] **Step 3: actual broker test를 순차적으로 실행한다**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-examples-coroutines-demo:test \
+  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples' \
+  --no-configuration-cache --max-workers=1
+```
+
+Expected: Docker/Testcontainers가 동작하는 환경에서 deterministic tests와 broker success test가 모두 PASS한다. Docker daemon이 없으면 코드 실패로 분류하지 않고 container startup evidence를 기록한다.
+
+## Task 5: bounded diagnostics와 examples CI test phase를 분리한다
+
+**Files:**
+
+- Create: `.github/scripts/collect-testcontainers-diagnostics.py`
+- Modify: `.github/workflows/examples.yml`
+
+- [ ] **Step 1: diagnostics collector를 추가한다**
+
+Python 표준 라이브러리만 사용해 다음 CLI 계약을 구현한다.
+
+```text
+python3 .github/scripts/collect-testcontainers-diagnostics.py \
+  --task-name :bluetape4k-examples-coroutines-demo:test \
+  --output-dir examples/build/testcontainers-diagnostics/_bluetape4k-examples-coroutines-demo_test \
+  --workflow-file .github/workflows/examples.yml
+```
+
+스크립트는 `docker ps -a --filter label=org.testcontainers=true`로 container id를 읽고, 각 container에 대해 `docker inspect`의 image/name/created와 `docker logs --tail 200`만 수집한다. 출력은 task 이름으로 정규화한 JSON manifest와 `*.log`로 저장하며, token·URI·환경 변수·payload·exception message는 `[REDACTED]`로 치환한다. container log가 없으면 빈 manifest를 만들고 exit 0으로 종료한다. Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한다.
+
+`sanitize`는 다음 순서의 stdlib 정규식만 사용한다: (1) `authorization`,
+`token`, `password`, `secret`, `api[_-]?key` 등의 key/value를 치환하고,
+(2) `scheme://host/path` 형태의 URI를 치환하며, (3) 대문자 환경 변수 assignment와
+`payload|message|body|value` 라인 전체를 치환하고, (4) `*Exception`/`*Error`
+뒤의 message를 치환한다. 원문 로그는 저장하지 않는다. `--workflow-file`의
+`uses: owner/action@ref`를 파싱해 `workflow_action_refs`에 기록하고,
+`docker inspect`의 `RepoDigests` 또는 image ID를 `image_digest`에 기록한다.
+
+- [ ] **Step 2: compile과 test 배열을 분리한다**
+
+workflow의 compile step은 기존 compile task만 `--parallel`로 실행한다. test step은 다음 순서를 정확히 유지한다.
+
+```bash
+compile_tasks=(
+  :bluetape4k-examples-coroutines-demo:compileKotlin
+  :bluetape4k-examples-jpa-blazepersistence-demo:compileKotlin
+  :bluetape4k-examples-jpa-querydsl-demo:compileKotlin
+  :bluetape4k-examples-redisson-demo:compileKotlin
+  :bluetape4k-examples-virtualthreads-demo:compileKotlin
+)
+test_tasks=(
+  :bluetape4k-examples-coroutines-demo:test
+  :bluetape4k-examples-jpa-blazepersistence-demo:test
+  :bluetape4k-examples-jpa-querydsl-demo:test
+  :bluetape4k-examples-redisson-demo:test
+  :bluetape4k-examples-virtualthreads-demo:test
+)
+
+if [[ -f examples/ktor/idgenerator-ktor-demo/build.gradle.kts ]]; then
+  compile_tasks+=( :idgenerator-ktor-demo:compileKotlin )
+  test_tasks+=( :idgenerator-ktor-demo:test )
+fi
+if [[ -f examples/ktor/observability-ktor-demo/build.gradle.kts ]]; then
+  compile_tasks+=( :observability-ktor-demo:compileKotlin )
+  test_tasks+=( :observability-ktor-demo:test )
+fi
+if [[ -f examples/spring-boot/idgenerator-spring-boot-demo/build.gradle.kts ]]; then
+  compile_tasks+=( :idgenerator-spring-boot-demo:compileKotlin )
+  test_tasks+=( :idgenerator-spring-boot-demo:test )
+fi
+if [[ -f examples/spring-boot/observability-spring-boot-demo/build.gradle.kts ]]; then
+  compile_tasks+=( :observability-spring-boot-demo:compileKotlin )
+  test_tasks+=( :observability-spring-boot-demo:test )
+fi
+
+./gradlew "${compile_tasks[@]}" --parallel
+
+set +e
+status=0
+for task in "${test_tasks[@]}"; do
+  ./gradlew "$task" --max-workers=1 || status=1
+  python3 .github/scripts/collect-testcontainers-diagnostics.py \
+    --task-name "$task" \
+    --output-dir "examples/build/testcontainers-diagnostics/${task//:/_}" \
+    --workflow-file .github/workflows/examples.yml || status=1
+  test -f "examples/build/testcontainers-diagnostics/${task//:/_}/manifest.json" || status=1
+done
+set -e
+exit "$status"
+```
+
+실제 step에서는 위 배열을 만든 뒤 `./gradlew "${compile_tasks[@]}" --parallel`을
+실행한다. Ktor/Spring Boot 조건부 task는 현재 `build.gradle.kts`가 존재하는
+경우에만 compile/test 배열 각각에 추가한다. compile task와 test task를 같은
+`--parallel` 배열에 넣지 않는다.
+
+- [ ] **Step 3: always artifact와 provenance completeness를 고정한다**
+
+`if: always()` upload step은 다음 glob을 포함한다.
+
+```yaml
+path: |
+  examples/**/build/test-results/**
+  examples/**/build/reports/tests/test/**
+  examples/build/testcontainers-diagnostics/**
+if-no-files-found: error
+```
+
+각 test invocation 뒤 manifest가 존재하는지 shell에서 검사하고, collector 또는
+manifest 누락이면 aggregate status를 1로 만든다. manifest에는 resolved image
+digest와 workflow action ref를 기록하되, 이 Epic에서는 mutable image/action을
+변경하거나 pinning하지 않는다. `actionlint`, path filter, artifact path와
+순서를 정적 검사한다.
+
+- [ ] **Step 4: workflow 정적 검증과 실패 누적을 확인한다**
+
+Run:
+
+```bash
+actionlint .github/workflows/examples.yml
+python3 -m py_compile .github/scripts/collect-testcontainers-diagnostics.py
+git diff --check
+```
+
+Expected: actionlint와 Python syntax가 PASS한다. 실제 CI에서는 중간 test failure가 있어도 뒤의 task와 artifact 수집이 실행되고 마지막에 aggregate non-zero가 된다.
+
+## Task 6: coroutines README locale parity를 맞춘다
+
+**Files:**
+
+- Modify: `examples/coroutines-demo/README.md`
+- Modify: `examples/coroutines-demo/README.ko.md`
+
+- [ ] **Step 1: example table과 실행 명령을 같은 순서로 갱신한다**
+
+두 README의 `CallbackFlowExamples.kt` 행에 실제 Kafka producer callback, bounded backpressure, cancellation, cleanup 설명을 추가한다. 실행 섹션에는 다음 명령을 그대로 넣는다.
+
+```bash
+./gradlew :bluetape4k-examples-coroutines-demo:test \
+  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples'
+```
+
+Docker daemon/Testcontainers dynamic port가 필요하고, topic은 매 test마다 unique하며 poll·producer close는 bounded timeout이라는 설명을 두 locale에 같은 의미로 넣는다.
+
+- [ ] **Step 2: README locale parity를 검사한다**
+
+Run:
+
+```bash
+git diff --check
+rg -n "bluetape4k-examples-coroutines-demo:test|CallbackFlowExamples|Testcontainers|Docker|timeout" \
+  examples/coroutines-demo/README.md examples/coroutines-demo/README.ko.md
+```
+
+Expected: 두 파일의 task name과 example name이 일치하고 한국어 문서에는 독자용 설명이 자연스럽게 남는다.
+
+## Task 7: child-level verification과 6-R module review evidence를 만든다
+
+**Files:**
+
+- Create: `docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md`
+- Modify: `examples/coroutines-demo/build.gradle.kts` only when verification finds a dependency defect
+- Modify: `examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt` only when verification finds a behavior defect
+- Modify: `examples/coroutines-demo/README.md` only when verification finds an English parity defect
+- Modify: `examples/coroutines-demo/README.ko.md` only when verification finds a Korean parity defect
+- Modify: `.github/scripts/collect-testcontainers-diagnostics.py` only when verification finds a diagnostics defect
+- Modify: `.github/workflows/examples.yml` only when verification finds a CI ordering or artifact defect
+
+- [ ] **Step 1: targeted와 full module test를 순차 실행한다**
+
+```bash
+./gradlew :bluetape4k-examples-coroutines-demo:test \
+  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples' \
+  --no-configuration-cache --max-workers=1
+./gradlew :bluetape4k-examples-coroutines-demo:test \
+  --no-configuration-cache --max-workers=1
+./gradlew :bluetape4k-examples-coroutines-demo:detekt \
+  --no-configuration-cache --max-workers=1
+git diff --check
+```
+
+Expected: 세 명령이 모두 PASS하고, Testcontainers 종료 후 다음 child로 넘어갈 수 있도록 남은 container와 dynamic topic을 확인한다.
+
+- [ ] **Step 2: 6-R evidence를 기록한다**
+
+검토 문서에는 touched file, 실제 command/output, bluetape assertions 사용 위치, `runSuspendIO`/IO dispatcher, callback first-cause/cleanup, Docker precondition, known gaps를 기록한다. six perspective 결과가 P0=0/P1=0이 될 때까지 수정하고 `audit-korean-terms.mjs`를 실행한다.
+
+- [ ] **Step 3: parent child를 merge-ready 상태로 고정한다**
+
+PR 생성 전 child issue #1347의 `## DoD Status`와 parent PR body에 exact head, required check count, 6-R artifact, known gaps를 기록한다. #1353 branch는 이 parent head를 base로 만들며, parent merge 전 temporary base 절차는 승인된 설계 명세를 그대로 따른다.
+
+## Kafka plan traceability
+
+| 명세 acceptance | 계획 task | 증거 |
+|---|---|---|
+| 실제 broker callbackFlow | 1, 3, 4 | targeted Kafka test와 consumer poll |
+| success/failure/cancellation/backpressure/shutdown | 2, 3, 4 | deterministic fixture counters와 failure matrix |
+| bluetape assertions | 2, 4, 7 | `assertFailsWith`, `shouldBeEqualTo`, collection matchers |
+| README parity | 6 | 두 locale diff/readback |
+| Testcontainers 순차 실행 | 5, 7 | actionlint와 CI task output |
+| diagnostics/provenance follow-up | 5 | manifest 존재·redaction 검사 |
+| exact-head/stacked delivery | 7 | child SHA, parent merge commit, base retarget evidence |
+
+## Rollback과 stop condition
+
+Kafka adapter/test만 실패하면 Task 3–4 commit을 되돌리고 기존 example test를 복구한다. workflow 변경이 60분 budget을 넘기거나 diagnostics completeness가 실패하면 workflow commit만 revert하고 child code evidence를 유지한다. exact-head CI failure, unresolved P1, producer/consumer cleanup timeout이면 merge-ready를 중단하고 해당 task와 `## DoD Status`를 다시 검증한다. production API, dependency version, image/tag 변경이 발견되면 이 계획 범위를 벗어나므로 별도 승인 전에는 진행하지 않는다.
+
+## 계획 완료 조건
+
+- 모든 checkbox가 실제 commit과 fresh command evidence로 완료된다.
+- Kafka child 6-R의 최신 P0/P1이 0이다.
+- `README.md`와 `README.ko.md`가 명령·lifecycle·timeout 계약에서 일치한다.
+- code, workflow, docs, test 결과가 parent PR의 마지막 `## DoD Status`에 연결된다.

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -401,7 +401,8 @@ return callbackFlow {
 해제한다. `failOnce(cause)`는 `terminalCause`를 CAS한 뒤
 `upstreamJob.cancel(CancellationException("producer terminal failure", cause))`과
 channel close를 수행한다. 각 collection마다 `producerFactory()`는 한 번만
-호출한다.
+호출한다. 두 helper는 `upstreamJob`을 생성하기 전에 같은 `callbackFlow` block의
+local function으로 선언하며, callback thread에서 suspend하지 않는다.
 각 `send`의 반환 Future를 in-flight 항목과 함께 보관해 cancellation 또는 drain
 deadline에서 `cancel(false)`하고, deterministic probe의 `pendingSend`로 그 결과를
 검증한다.

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -19,9 +19,12 @@
 - Modify: `examples/coroutines-demo/README.md` — 정확한 Gradle task, Docker/Testcontainers precondition, callback contract를 영어로 갱신한다.
 - Modify: `examples/coroutines-demo/README.ko.md` — 같은 명령과 계약을 한국어로 갱신한다.
 - Create: `.github/scripts/collect-testcontainers-diagnostics.py` — task별 bounded/sanitized Docker log와 provenance manifest를 표준 출력 경로에 만든다.
+- Create: `.github/scripts/test_collect-testcontainers-diagnostics.py` — redaction·allowlist·report cap 회귀 fixture를 검증한다.
 - Modify: `.github/workflows/examples.yml` — compile 병렬 phase와 Testcontainers test 순차 phase를 분리하고 aggregate failure/artifact를 고정한다.
 
-이 계획은 production Kafka API, 새 library module, catalog version, Kafka image/tag를 변경하지 않는다. #1353 소유 파일은 이 계획에서 수정하지 않는다.
+이 계획은 production Kafka API, 새 library module, catalog version, 공용 Kafka image/tag를
+변경하지 않는다. CI/test-only broker image는 immutable digest로 고정한다. #1353 소유
+파일은 이 계획에서 수정하지 않는다.
 
 ## Task 1: Kafka example dependency와 baseline 고정
 
@@ -155,6 +158,9 @@ fun `collector cancellation rethrows CancellationException and closes producer o
 
     withTimeout(5.seconds) { producer.sendStarted.await() }
     task.cancel()
+    withTimeout(5.seconds) {
+        while (producer.cancelledPendingSends() == 0) delay(10)
+    }
     val cancellation = assertFailsWith<CancellationException> { task.await() }
 
     producer.closeCount shouldBeEqualTo 1
@@ -430,6 +436,10 @@ private fun producerResults(
 Step 2–3에서 이 signature의 함수 body를 완성한다. `channelCapacity`와
 `maxInFlight`를 각각 `1..16`으로 검증하고, 마지막에
 `.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)`를 적용한다.
+필요한 coroutine import는 `CancellationException`, `CoroutineStart`, `Dispatchers`,
+`Job`, `NonCancellable`, `TimeoutCancellationException`, `delay`, `launch`,
+`runInterruptible`, `withContext`, `withTimeout`이며, callback state에는
+`AtomicBoolean`, `AtomicReference`, `ConcurrentHashMap`, `Semaphore`를 사용한다.
 `callbackFlow` 내부는 다음 이름과 수명 순서를 그대로 사용한다.
 
 ```kotlin
@@ -445,9 +455,14 @@ return callbackFlow {
     val inFlight = ConcurrentHashMap.newKeySet<SendState>()
     val upstreamJobRef = AtomicReference<Job?>()
 
+    fun cancelInFlight() {
+        inFlight.forEach { it.future.get()?.cancel(false) }
+    }
+
     fun failOnce(cause: Throwable) {
         if (downstreamCancelled.get()) return
         if (terminalCause.compareAndSet(null, cause)) {
+            cancelInFlight()
             upstreamJobRef.get()?.cancel(CancellationException("producer terminal failure", cause))
             close(cause)
         } else {
@@ -485,7 +500,7 @@ return callbackFlow {
                 try {
                     val future = producer.send(record, callbackFor(state))
                     state.future.set(future)
-                    if (state.completed.get() && (terminalCause.get() != null || downstreamCancelled.get())) {
+                    if (terminalCause.get() != null || downstreamCancelled.get()) {
                         future.cancel(false)
                     }
                 } catch (cause: Throwable) {
@@ -508,9 +523,18 @@ return callbackFlow {
                         while (inFlight.isNotEmpty()) delay(10)
                         runInterruptible { producer.flush() }
                     }
+                } catch (cause: TimeoutCancellationException) {
+                    cleanupFailure = cause
+                    cancelInFlight()
+                    if (!downstreamCancelled.get()) failOnce(cause)
+                } catch (cause: CancellationException) {
+                    cleanupFailure = cause
+                    cancelInFlight()
+                    if (!downstreamCancelled.get()) failOnce(cause)
+                    throw cause
                 } catch (cause: Throwable) {
                     cleanupFailure = cause
-                    inFlight.forEach { it.future.get()?.cancel(false) }
+                    cancelInFlight()
                     if (!downstreamCancelled.get()) failOnce(cause)
                 }
 
@@ -537,6 +561,7 @@ return callbackFlow {
     upstreamJob.start()
     awaitClose {
         downstreamCancelled.set(true)
+        cancelInFlight()
         upstreamJob.cancel(CancellationException("collector cancelled"))
     }
 }.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)
@@ -566,12 +591,14 @@ local function으로 선언하며, callback thread에서 suspend하지 않는다
 
 - [ ] **Step 2: callback failure와 full-buffer terminal path를 구현한다**
 
-첫 terminal cause는 다음 규칙을 사용한다.
+첫 terminal cause는 다음 규칙을 사용한다. Step 1의 local helper와 동일하게
+`upstreamJobRef`를 사용해 초기화 전 Job 참조를 막고, downstream cancellation 뒤에는
+late callback이 새 원인을 만들지 않는다.
 
 ```kotlin
 if (!downstreamCancelled.get() && terminalCause.compareAndSet(null, cause)) {
-    upstreamJob.cancel(CancellationException("producer terminal failure", cause))
-    channel.close(cause)
+    upstreamJobRef.get()?.cancel(CancellationException("producer terminal failure", cause))
+    close(cause)
 } else {
     log.debug { "late Kafka callback ignored; failureKind=$failureKind" }
 }
@@ -585,8 +612,9 @@ if (!downstreamCancelled.get() && terminalCause.compareAndSet(null, cause)) {
 
 - [ ] **Step 3: awaitClose와 bounded cleanup을 구현한다**
 
-`awaitClose`에서는 sentinel 설정과 cancellation signal만 수행하고 blocking Kafka API를
-호출하지 않는다. worker의 `finally` 안에서 다음 순서를 지킨다.
+`awaitClose`에서는 sentinel 설정, in-flight Future의 non-blocking `cancel(false)`,
+cancellation signal만 수행하고 blocking Kafka API를 호출하지 않는다. worker의
+`finally` 안에서 다음 순서를 지킨다.
 
 1. `withContext(NonCancellable + Dispatchers.IO)`로 진입한다.
 2. callback drain과 `flush()`를 30초 `withTimeout`으로 기다린다.
@@ -594,8 +622,11 @@ if (!downstreamCancelled.get() && terminalCause.compareAndSet(null, cause)) {
    처리가 끝난 뒤에만 flush/close로 진행한다. 모든 send가 callback 완료 후에만
    정상 close로 간다.
 3. deadline을 넘기면 `TimeoutCancellationException`을 first cause로 CAS하고 pending send를 취소한다.
+   cleanup 중 발생한 `CancellationException`은 broad `Throwable` catch로 흡수하지 않고
+   cleanup 후 재전파하며, 기존 upstream/downstream cancellation 원인은 그대로 보존한다.
 4. `producer.close(Duration.ofSeconds(5))`를 한 번 실행하고 예외를 suppressed로 연결한다.
-5. `CancellationException`을 broad catch에서 삼키지 않고 재전파한다.
+5. `CancellationException`을 broad catch에서 삼키지 않고 재전파한다. close 자체의
+   후속 예외는 기존 cancellation 또는 first cause에 `suppressed`로만 연결한다.
 
 정상적인 `records.collect` 완료에서는 drain과 flush가 끝난 뒤 channel을 성공적으로
 닫고, terminal cause가 있으면 해당 cause로 이미 닫힌 channel을 유지한다. drain 또는
@@ -716,12 +747,23 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --task-name :bluetape4k-examples-coroutines-demo:test \
   --output-dir examples/build/testcontainers-diagnostics/_bluetape4k-examples-coroutines-demo_test \
   --workflow-file .github/workflows/examples.yml \
-  --report-root examples \
-  --max-total-bytes 2000000
+  --max-total-bytes 2000000 \
+  --container-id <new-container-id>
+
+python3 .github/scripts/collect-testcontainers-diagnostics.py \
+  --task-name examples-test-phase-reports \
+  --output-dir examples/build/testcontainers-diagnostics/report-scan \
+  --workflow-file .github/workflows/examples.yml \
+  --sanitized-report-dir examples/build/sanitized-test-reports \
+  --report-path examples/coroutines-demo/build/test-results/test \
+  --report-path examples/coroutines-demo/build/reports/tests/test \
+  --max-report-files 200 \
+  --max-report-total-bytes 2000000
 ```
 
 스크립트는 `--container-id`를 반복 인자로 받아 현재 Gradle invocation에서 새로 생성된
-container만 대상으로 삼는다. ID가 없으면 빈 manifest를 만들고 exit 0으로 종료한다.
+container만 대상으로 삼는다. ID가 없으면 container 섹션이 빈 manifest가 되며 exit 0으로
+처리하되, `--report-path`가 함께 지정된 경우 report sanitization은 계속 수행한다.
 각 container에 대해 `docker inspect`의 image/name/created와 `docker logs --tail 200`만
 수집한다. 출력은 task 이름으로 정규화한 JSON manifest와 `*.log`로 저장하며,
 token·URI·환경 변수·payload·exception message는 `[REDACTED]`로 치환한다. 로그와
@@ -729,27 +771,35 @@ manifest의 총 산출량은 `--max-total-bytes`(기본 2,000,000 bytes)를 넘�
 초과분은 잘라내고 manifest에 `truncated=true`를 기록한다. container log가 없으면
 해당 container의 로그를 생략하고, 전체 ID가 비어 있으면 빈 manifest를 만든다.
 Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한다.
-`--report-root`가 지정되면 `**/build/test-results/**/*.xml`과
-`**/build/reports/tests/test/**/*.{html,css,js}`를 순회해 같은 redaction을 적용한
-파일을 `--sanitized-report-dir` 아래 상대 경로로 복사한다. report-root 자체가
-존재하지 않거나 report 파일이 없으면 해당 단계는 실패시키고, 원본 report를
-sanitized 디렉터리에 절대 링크하지 않는다.
+`--report-path`를 반복 인자로 받으면 전달된 정확한 디렉터리만 순회해
+`**/build/test-results/**/*.xml`과 `**/build/reports/tests/test/**/*.{html,css,js}`에
+같은 redaction을 적용한 파일을 `--sanitized-report-dir` 아래 상대 경로로 복사한다.
+`report-path`가 존재하지 않거나 report 파일이 없으면 해당 단계는 실패시키고, 원본
+report를 sanitized 디렉터리에 절대 링크하지 않는다. collector는 report path를
+재귀적으로 무제한 탐색하지 않고 정렬된 path 목록만 방문하며, 전체 sanitized report는
+`--max-report-files`(기본 200)와 `--max-report-total-bytes`(기본 2,000,000 bytes)를
+동시에 적용한다. 상한 초과 시 추가 파일을 저장하지 않고 manifest에
+`report_truncated=true`를 기록하며 exit 1로 종료한다.
 
 `sanitize`는 다음 순서의 stdlib 정규식만 사용한다: (1) `authorization`,
 `token`, `password`, `secret`, `api[_-]?key` 등의 key/value를 치환하고,
 (2) `scheme://host/path` 형태의 URI를 치환하며, (3) 대문자 환경 변수 assignment와
 `payload|message|body|value` 라인 전체를 치환하고, (4) `*Exception`/`*Error`
 뒤의 message를 치환한다. 원문 로그는 저장하지 않는다. `--workflow-file`의
-`uses: owner/action@ref`를 파싱해 `workflow_action_refs`에 기록하고,
-`docker inspect`의 `RepoDigests` 또는 image ID를 `image_digest`에 기록한다.
+`uses: owner/action@ref`를 파싱해 `workflow_action_refs`에 기록하되 ref가 40자리
+immutable commit SHA가 아니면 실패시킨다. `docker inspect`의 `RepoDigests`에서
+allowlist와 정확히 일치하는 값을 `image_digest`에 기록한다. image ID는 보조 진단
+필드로만 기록할 수 있고, `RepoDigests`가 없으면 provenance를 완성할 수 없으므로
+실패시킨다.
 허용 image allowlist는 `confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130`과
 `redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a`로
 고정한다. 해당 image는 `RepoDigests`가 allowlist와 정확히 일치해야 하며, local
 image ID만 있거나 예상하지 않은 image면 collector를 실패시킨다.
-같은 `sanitize` 규칙을 `--report-root` 아래의 JUnit XML/HTML에도 적용해
+같은 `sanitize` 규칙을 지정된 `--report-path` 아래의 JUnit XML/HTML에도 적용해
 `examples/build/sanitized-test-reports/`에 복사하고, workflow는 원본 report가 아닌
-이 경로만 artifact로 업로드한다. 각 파일은 2MB를 넘기지 않으며, 원본 경로는
-artifact 대상에서 제외한다. 테스트 source의 logging은 module·recordCount·failureKind
+이 경로만 artifact로 업로드한다. 각 파일은 2MB를 넘기지 않으며 전체 합계·파일 수
+상한도 적용하고, 원본 경로는 artifact 대상에서 제외한다. 테스트 source의 logging은
+module·recordCount·failureKind
 같은 구조화 필드만 남기고 payload/message/result/URI를 기록하지 않는다.
 
 - [ ] **Step 2: compile과 test 배열을 분리한다**
@@ -789,6 +839,43 @@ if [[ -f examples/spring-boot/observability-spring-boot-demo/build.gradle.kts ]]
   test_tasks+=( :observability-spring-boot-demo:test )
 fi
 
+report_paths=(
+  --report-path examples/coroutines-demo/build/test-results/test
+  --report-path examples/coroutines-demo/build/reports/tests/test
+  --report-path examples/jpa-blazepersistence-demo/build/test-results/test
+  --report-path examples/jpa-blazepersistence-demo/build/reports/tests/test
+  --report-path examples/jpa-querydsl-demo/build/test-results/test
+  --report-path examples/jpa-querydsl-demo/build/reports/tests/test
+  --report-path examples/redisson-demo/build/test-results/test
+  --report-path examples/redisson-demo/build/reports/tests/test
+  --report-path examples/virtualthreads-demo/build/test-results/test
+  --report-path examples/virtualthreads-demo/build/reports/tests/test
+)
+if [[ -f examples/ktor/idgenerator-ktor-demo/build.gradle.kts ]]; then
+  report_paths+=(
+    --report-path examples/ktor/idgenerator-ktor-demo/build/test-results/test
+    --report-path examples/ktor/idgenerator-ktor-demo/build/reports/tests/test
+  )
+fi
+if [[ -f examples/ktor/observability-ktor-demo/build.gradle.kts ]]; then
+  report_paths+=(
+    --report-path examples/ktor/observability-ktor-demo/build/test-results/test
+    --report-path examples/ktor/observability-ktor-demo/build/reports/tests/test
+  )
+fi
+if [[ -f examples/spring-boot/idgenerator-spring-boot-demo/build.gradle.kts ]]; then
+  report_paths+=(
+    --report-path examples/spring-boot/idgenerator-spring-boot-demo/build/test-results/test
+    --report-path examples/spring-boot/idgenerator-spring-boot-demo/build/reports/tests/test
+  )
+fi
+if [[ -f examples/spring-boot/observability-spring-boot-demo/build.gradle.kts ]]; then
+  report_paths+=(
+    --report-path examples/spring-boot/observability-spring-boot-demo/build/test-results/test
+    --report-path examples/spring-boot/observability-spring-boot-demo/build/reports/tests/test
+  )
+fi
+
 ./gradlew "${compile_tasks[@]}" --parallel
 
 set +e
@@ -809,14 +896,20 @@ for task in "${test_tasks[@]}"; do
     --task-name "$task" \
     --output-dir "examples/build/testcontainers-diagnostics/${task//:/_}" \
     --workflow-file .github/workflows/examples.yml \
-    --report-root examples \
-    --sanitized-report-dir examples/build/sanitized-test-reports \
     --max-total-bytes 2000000 \
     "${container_args[@]}" || status=1
   test -f "examples/build/testcontainers-diagnostics/${task//:/_}/manifest.json" || status=1
-  test -d examples/build/sanitized-test-reports || status=1
   rm -f "$before_ids_file" "$after_ids_file"
 done
+python3 .github/scripts/collect-testcontainers-diagnostics.py \
+  --task-name examples-test-phase-reports \
+  --output-dir examples/build/testcontainers-diagnostics/report-scan \
+  --workflow-file .github/workflows/examples.yml \
+  --sanitized-report-dir examples/build/sanitized-test-reports \
+  --max-report-files 200 \
+  --max-report-total-bytes 2000000 \
+  "${report_paths[@]}" || status=1
+test -d examples/build/sanitized-test-reports || status=1
 phase_elapsed=$(( $(date +%s) - phase_started ))
 printf 'serial_test_phase_seconds=%s\n' "$phase_elapsed" > examples/build/testcontainers-diagnostics/test-phase-timing.txt
 (( phase_elapsed <= 2700 )) || status=1
@@ -830,7 +923,10 @@ exit "$status"
 저장하고, task 종료 직후 실행 후 기준 목록과 `comm -13`으로 새 ID만 계산해 collector의
 반복 `--container-id` 인자로 전달한다. 기준 목록 명령이 Docker 오류를 반환하면
 aggregate status를 1로 유지하되 collector는 빈 manifest를 남겨 `if: always()`에서
-진단 artifact를 확인할 수 있게 한다. Ktor/Spring Boot 조건부 task는 현재
+진단 artifact를 확인할 수 있게 한다. 모든 test task가 끝난 뒤 collector를 정확히
+한 번 더 호출해 `report_paths`에 열거한 report 디렉터리만 sanitization하고, 이 호출은
+`--max-report-files=200`과 `--max-report-total-bytes=2000000`을 적용한다.
+Ktor/Spring Boot 조건부 task는 현재
 `build.gradle.kts`가 존재하는 경우에만 compile/test 배열 각각에 추가한다. compile
 task와 test task를 같은 `--parallel` 배열에 넣지 않는다. ID 목록은 정렬·중복 제거해
 같은 container의 log/manifest를 여러 번 수집하지 않는다.
@@ -855,15 +951,16 @@ commit SHA로 고정한다. `.github/workflows/examples.yml`의 action 줄은 �
   with:
     persist-credentials: false
 - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-- uses: gradle/actions/setup-gradle@67621b124fd2e251c5e8a0e6e3b91318f2287669 # v6.3.0
+- uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
 ```
 
 각 test invocation 뒤 manifest가 존재하는지 shell에서 검사하고, collector 또는
-manifest 누락이면 aggregate status를 1로 만든다. manifest에는 resolved image
-digest와 workflow action ref를 기록하되, 이 Epic에서는 mutable image/action을
-변경하거나 pinning하지 않는다. 진단 파일은 task별로 새 container ID를 deduplicate하고
-총 2,000,000 bytes 상한을 적용한다. `actionlint`, path filter, artifact path와
+manifest 누락이면 aggregate status를 1로 만든다. manifest에는 allowlist와 정확히
+일치하는 resolved image digest와 immutable workflow action commit ref를 기록한다.
+mutable image/action ref는 허용하지 않으며, 이 Epic에서는 공용 image/tag를 변경하지
+않는다. 진단 파일은 task별로 새 container ID를 deduplicate하고 총 2,000,000 bytes
+상한을 적용한다. `actionlint`, path filter, artifact path와
 순서를 정적 검사한다. 기존 workflow timeout 60분에서 15분 headroom을 확보하기
 위해 전체 직렬 test phase의 elapsed를 `date +%s`로 측정해
 `examples/build/testcontainers-diagnostics/test-phase-timing.txt`에 기록하고, 45분을 초과하면
@@ -877,10 +974,16 @@ Run:
 ```bash
 actionlint .github/workflows/examples.yml
 python3 -m py_compile .github/scripts/collect-testcontainers-diagnostics.py
+python3 -m unittest discover -s .github/scripts -p 'test_*.py'
 git diff --check
 ```
 
-Expected: actionlint와 Python syntax가 PASS한다. 실제 CI에서는 중간 test failure가 있어도 뒤의 task와 artifact 수집이 실행되고 마지막에 aggregate non-zero가 된다.
+fixture 테스트는 URI userinfo/query, 중첩 JSON/XML payload, 소문자 환경 변수,
+multiline `Exception`/`Error` stack trace의 비밀값이 sanitized output에 남지 않는지,
+allowlist 밖 image와 local image ID를 거부하는지, report 파일 수·전체 바이트 상한과
+`report_truncated=true`를 검증한다. Expected: actionlint, Python syntax, redaction
+fixture가 PASS한다. 실제 CI에서는 중간 test failure가 있어도 뒤의 task와 artifact
+수집이 실행되고 마지막에 aggregate non-zero가 된다.
 
 ## Task 6: coroutines README locale parity를 맞춘다
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -209,7 +209,7 @@ fun `factory and synchronous send failures are terminal causes`() = runSuspendIO
         producerResults(flowOf(record("send")), { sendProducer.producer }).toList()
     }
     sendError shouldBeEqualTo sendFailure
-    sendProducer.closeCount shouldBeEqualTo 1
+    sendProducer.closeCount.get() shouldBeEqualTo 1
 }
 
 @Test

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -807,7 +807,7 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --sanitized-report-dir examples/build/sanitized-test-reports \
   --report-path examples/coroutines-demo/build/test-results/test \
   --report-path examples/coroutines-demo/build/reports/tests/test \
-  --max-report-files 200 \
+  --max-report-files 400 \
   --max-report-total-bytes 2000000
 ```
 
@@ -827,7 +827,7 @@ Docker CLI 자체 오류는 stderr에 task name만 남기고 exit 1로 반환한
 `report-path`가 존재하지 않거나 report 파일이 없으면 해당 단계는 실패시키고, 원본
 report를 sanitized 디렉터리에 절대 링크하지 않는다. collector는 report path를
 재귀적으로 무제한 탐색하지 않고 정렬된 path 목록만 방문하며, 전체 sanitized report는
-`--max-report-files`(기본 200)와 `--max-report-total-bytes`(기본 2,000,000 bytes)를
+`--max-report-files`(기본 200, Examples workflow 400)와 `--max-report-total-bytes`(기본 2,000,000 bytes)를
 동시에 적용한다. 상한 초과 시 추가 파일을 저장하지 않고 manifest에
 `report_truncated=true`를 기록하며 exit 1로 종료한다.
 
@@ -837,10 +837,12 @@ report를 sanitized 디렉터리에 절대 링크하지 않는다. collector는 
 `payload|message|body|value` 라인 전체를 치환하고, (4) `*Exception`/`*Error`
 뒤의 message를 치환한다. 원문 로그는 저장하지 않는다. `--workflow-file`의
 `uses: owner/action@ref`를 파싱해 `workflow_action_refs`에 기록하되 ref가 40자리
-immutable commit SHA가 아니면 실패시킨다. `docker inspect`의 `RepoDigests`에서
-allowlist와 정확히 일치하는 값을 `image_digest`에 기록한다. image ID는 보조 진단
-필드로만 기록할 수 있고, `RepoDigests`가 없으면 provenance를 완성할 수 없으므로
-실패시킨다.
+immutable commit SHA가 아니면 실패시킨다. `docker container inspect`의
+`RepoDigests`가 제공되면 이를 우선 사용하고, Docker 엔진이 해당 필드를 생략하는
+경우에는 container의 image reference로 `docker image inspect`를 수행해 allowlist와
+정확히 일치하는 값을 `image_digest`에 기록한다. image ID는 보조 진단 필드로만
+기록하며, 두 inspect 결과 모두에 immutable `RepoDigests`가 없으면 provenance를
+완성할 수 없으므로 실패시킨다.
 허용 image allowlist는 `confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130`과
 `redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a`로
 고정한다. 해당 image는 `RepoDigests`가 allowlist와 정확히 일치해야 하며, local
@@ -956,7 +958,7 @@ python3 .github/scripts/collect-testcontainers-diagnostics.py \
   --output-dir examples/build/testcontainers-diagnostics/report-scan \
   --workflow-file .github/workflows/examples.yml \
   --sanitized-report-dir examples/build/sanitized-test-reports \
-  --max-report-files 200 \
+  --max-report-files 400 \
   --max-report-total-bytes 2000000 \
   "${report_paths[@]}" || status=1
 test -d examples/build/sanitized-test-reports || status=1
@@ -975,7 +977,7 @@ exit "$status"
 aggregate status를 1로 유지하되 collector는 빈 manifest를 남겨 `if: always()`에서
 진단 artifact를 확인할 수 있게 한다. 모든 test task가 끝난 뒤 collector를 정확히
 한 번 더 호출해 `report_paths`에 열거한 report 디렉터리만 sanitization하고, 이 호출은
-`--max-report-files=200`과 `--max-report-total-bytes=2000000`을 적용한다.
+`--max-report-files=400`과 `--max-report-total-bytes=2000000`을 적용한다.
 Ktor/Spring Boot 조건부 task는 현재
 `build.gradle.kts`가 존재하는 경우에만 compile/test 배열 각각에 추가한다. compile
 task와 test task를 같은 `--parallel` 배열에 넣지 않는다. ID 목록은 정렬·중복 제거해

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -831,6 +831,14 @@ report를 sanitized 디렉터리에 절대 링크하지 않는다. collector는 
 동시에 적용한다. 상한 초과 시 추가 파일을 저장하지 않고 manifest에
 `report_truncated=true`를 기록하며 exit 1로 종료한다.
 
+표준 출력이 과도한 JUnit/Gradle report는 원본을 무제한으로 보존하지 않는다.
+collector는 32,000,000 bytes의 bounded source window 안에서 JUnit XML의
+`system-out`/`system-err`와 Gradle HTML test report의 `stdout`/`stderr` `<pre>`를
+`[REDACTED]` marker로 compact한 뒤 기존 민감정보 redaction을 적용한다. compact 후에도
+각 sanitized 파일은 2MB, 전체 report는 위의 파일 수·바이트 상한을 넘지 않으며,
+32MB source window를 초과하거나 compact 후 파일 상한을 넘으면
+`report_truncated=true`로 fail-closed 한다.
+
 `sanitize`는 다음 순서의 stdlib 정규식만 사용한다: (1) `authorization`,
 `token`, `password`, `secret`, `api[_-]?key` 등의 key/value를 치환하고,
 (2) `scheme://host/path` 형태의 URI를 치환하며, (3) 대문자 환경 변수 assignment와
@@ -983,6 +991,17 @@ Ktor/Spring Boot 조건부 task는 현재
 `build.gradle.kts`가 존재하는 경우에만 compile/test 배열 각각에 추가한다. compile
 task와 test task를 같은 `--parallel` 배열에 넣지 않는다. ID 목록은 정렬·중복 제거해
 같은 container의 log/manifest를 여러 번 수집하지 않는다.
+
+`9eccc43d8e4f32559781d6541bc77f694963eae6`의 hosted Examples run
+`32990410732`에서 9개 Gradle test task는 모두 성공했지만, virtualthreads 예제의
+`Example1_PlatformAndVirtualThread.xml`이 15,341,647 bytes의 per-test logging으로
+개별 2MB report 상한을 넘어 `report_truncated=true`가 되었다. source test의
+100,000개 virtual thread 실행은 유지하고 collector가 JUnit XML의 `system-out`/
+`system-err`와 Gradle HTML stdout/stderr를 placeholder로 compact하도록 보정해
+bounded report를 보장한다. source는 32MB까지만 읽고 최종 파일별 2MB·전체 8MB
+상한을 유지한다. 보정 후 실제 15,341,646-byte JUnit XML local scan은
+`report_truncated=false`, 12개 report, 19,510 bytes, 최대 9,362 bytes였으며,
+다음 exact-head hosted run에서 전체 report manifest를 재검증한다.
 
 - [ ] **Step 3: always artifact와 provenance completeness를 고정한다**
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md
@@ -94,8 +94,9 @@ fun `callback failure preserves first cause and closes producer once`() = runSus
 
 @Test
 fun `backpressure fails without dropping callback and closes producer once`() = runSuspendIO {
-    val producer = TrackingProducer()
+    val producer = TrackingProducer(holdCallbacks = true)
     val collectorGate = CompletableDeferred<Unit>()
+    val firstItemReceived = CompletableDeferred<Unit>()
     val collection = async {
         var received = 0
         producerResults(
@@ -106,14 +107,21 @@ fun `backpressure fails without dropping callback and closes producer once`() = 
         ).collect {
             val index = received
             received += 1
-            if (index == 0) collectorGate.await()
+            if (index == 0) {
+                firstItemReceived.complete(Unit)
+                collectorGate.await()
+            }
         }
     }
 
-    producer.thirdCallback.await()
+    withTimeout(5.seconds) { producer.allSendsStarted.await() }
+    producer.fireCallback()
+    withTimeout(5.seconds) { firstItemReceived.await() }
+    producer.fireCallback()
+    producer.fireCallback()
     collectorGate.complete(Unit)
     val error = assertFailsWith<IllegalStateException> {
-        collection.await()
+        withTimeout(10.seconds) { collection.await() }
     }
 
     error.message shouldBeEqualTo "callback buffer is full"
@@ -128,7 +136,7 @@ fun `in-flight permit is released after callback`() = runSuspendIO {
     producerResults(
         records = flowOf(record("permit-one"), record("permit-two")),
         producerFactory = { producer.producer },
-        channelCapacity = 1,
+        channelCapacity = 2,
         maxInFlight = 1,
     ).toList()
 
@@ -142,7 +150,7 @@ fun `collector cancellation rethrows CancellationException and closes producer o
         producerResults(flowOf(record("cancel")), { producer.producer }).toList()
     }
 
-    producer.sendStarted.await()
+    withTimeout(5.seconds) { producer.sendStarted.await() }
     task.cancel()
     assertFailsWith<CancellationException> { task.await() }
 
@@ -178,6 +186,19 @@ fun `normal completion drains callbacks flushes and closes once`() = runSuspendI
     producer.flushCount shouldBeEqualTo 1
     producer.closeCount shouldBeEqualTo 1
     producer.callbackCount shouldBeEqualTo 1
+}
+
+@Test
+fun `flush failure becomes the terminal cause after callback drain`() = runSuspendIO {
+    val flushFailure = IllegalStateException("flush failure")
+    val producer = TrackingProducer(flushError = flushFailure)
+
+    val error = assertFailsWith<IllegalStateException> {
+        producerResults(flowOf(record("flush-failure")), { producer.producer }).toList()
+    }
+
+    error shouldBeEqualTo flushFailure
+    producer.closeCount shouldBeEqualTo 1
 }
 
 @Test
@@ -242,6 +263,7 @@ private fun record(value: String): ProducerRecord<String, String> {
 private class TrackingProducer(
     private val callbackError: Exception? = null,
     private val sendError: Exception? = null,
+    private val flushError: Exception? = null,
     val closeError: Exception? = null,
     private val holdCallbacks: Boolean = false,
 ) {
@@ -251,7 +273,8 @@ private class TrackingProducer(
     val flushCount = AtomicInteger()
     val lateCallbackCount = AtomicInteger()
     val sendStarted = CompletableDeferred<Unit>()
-    val thirdCallback = CompletableDeferred<Unit>()
+    val allSendsStarted = CompletableDeferred<Unit>()
+    val sendCount = AtomicInteger()
     val pendingCallbacks = ConcurrentLinkedQueue<Callback>()
     val pendingSend = CompletableFuture<RecordMetadata>()
     private val closed = AtomicBoolean()
@@ -266,12 +289,15 @@ private class TrackingProducer(
             } else {
                 callbackCount.incrementAndGet()
                 callback.onCompletion(metadata, callbackError)
-                if (callbackCount.get() == 3) thirdCallback.complete(Unit)
             }
             sendStarted.complete(Unit)
+            if (sendCount.incrementAndGet() == 3) allSendsStarted.complete(Unit)
             if (holdCallbacks) pendingSend else CompletableFuture.completedFuture(metadata)
         }
-        every { producer.flush() } answers { flushCount.incrementAndGet() }
+        every { producer.flush() } answers {
+            flushCount.incrementAndGet()
+            flushError?.let { throw it }
+        }
         every { producer.close(any<Duration>()) } answers {
             closeCount.incrementAndGet()
             closed.set(true)
@@ -285,11 +311,21 @@ private class TrackingProducer(
             callback.onCompletion(metadata, null)
         }
     }
+
+    fun fireCallback() {
+        pendingCallbacks.poll()?.let { callback ->
+            callbackCount.incrementAndGet()
+            callback.onCompletion(metadata, null)
+        }
+    }
 }
 ```
 
 기본 성공 fixture는 callback을 즉시 호출하고, held fixture는 `pendingCallbacks`를
-보관해 drain timeout과 cancellation을 결정적으로 만든다. `maxInFlight=1`에서
+보관해 drain timeout과 cancellation을 결정적으로 만든다. backpressure 테스트는
+세 `send` 완료를 `allSendsStarted`로 확인한 뒤 `fireCallback()`을 1→2→3 순서로
+수동 발화한다. 첫 callback 수신 후 collector가 gate에서 멈추므로 두 번째 결과가
+1-slot buffer를 채우고 세 번째 callback이 full을 재현한다. `maxInFlight=1`에서
 두 record가 모두 완료되는 테스트가 callback 공통 `finally`의 permit release를
 간접적으로 증명한다. close 이후 callback은 `lateCallbackCount`만 증가시킨다.
 `Producer`의 다른 메서드는 MockK relaxed
@@ -327,11 +363,45 @@ private fun producerResults(
 ): Flow<RecordMetadata>
 ```
 
-Step 2–3에서 이 signature의 함수 body를 완성한다. Flow collection마다
-`producerFactory()`를 한 번 호출하고, `Semaphore(maxInFlight)`와
-`AtomicReference<Throwable?>`를 collection-local 상태로 만든다. callback 성공은
-`channel.trySend(metadata)`로 전달하고, callback 성공·실패·동기 `send` 예외 모두에서
-공통 `finally`로 permit/in-flight를 정확히 한 번만 해제한다.
+Step 2–3에서 이 signature의 함수 body를 완성한다. `channelCapacity`와
+`maxInFlight`를 각각 `1..16`으로 검증하고, 마지막에
+`.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)`를 적용한다.
+`callbackFlow` 내부는 다음 이름과 수명 순서를 그대로 사용한다.
+
+```kotlin
+return callbackFlow {
+    val producer = producerFactory()
+    val terminalCause = AtomicReference<Throwable?>(null)
+    val permits = Semaphore(maxInFlight)
+    val inFlight = ConcurrentHashMap.newKeySet<Future<RecordMetadata>>()
+    val upstreamJob = launch(Dispatchers.IO) {
+        try {
+            records.collect { record ->
+                permits.acquire()
+                try {
+                    val future = producer.send(record, callbackFor(record))
+                    inFlight += future
+                } catch (cause: Throwable) {
+                    permits.release()
+                    failOnce(cause)
+                    throw cause
+                }
+            }
+        } catch (cause: Throwable) {
+            failOnce(cause)
+            throw cause
+        }
+    }
+    awaitClose { upstreamJob.cancel(CancellationException("collector cancelled")) }
+}.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)
+```
+
+`callbackFor(record)`는 callback 성공·실패와 동기 `send` 예외 모두에서 공통
+`finally`로 해당 Future를 `inFlight`에서 제거하고 permit을 정확히 한 번만
+해제한다. `failOnce(cause)`는 `terminalCause`를 CAS한 뒤
+`upstreamJob.cancel(CancellationException("producer terminal failure", cause))`과
+channel close를 수행한다. 각 collection마다 `producerFactory()`는 한 번만
+호출한다.
 각 `send`의 반환 Future를 in-flight 항목과 함께 보관해 cancellation 또는 drain
 deadline에서 `cancel(false)`하고, deterministic probe의 `pendingSend`로 그 결과를
 검증한다.
@@ -342,8 +412,7 @@ deadline에서 `cancel(false)`하고, deterministic probe의 `pendingSend`로 �
 
 ```kotlin
 if (terminalCause.compareAndSet(null, cause)) {
-    worker.cancel(CancellationException("producer terminal failure", cause))
-    upstream.cancel(CancellationException("producer terminal failure", cause))
+    upstreamJob.cancel(CancellationException("producer terminal failure", cause))
     channel.close(cause)
 } else {
     log.debug { "late Kafka callback ignored; failureKind=$failureKind" }
@@ -580,8 +649,31 @@ Run:
 
 ```bash
 git diff --check
-rg -n "bluetape4k-examples-coroutines-demo:test|CallbackFlowExamples|Testcontainers|Docker|timeout" \
-  examples/coroutines-demo/README.md examples/coroutines-demo/README.ko.md
+for file in examples/coroutines-demo/README.md examples/coroutines-demo/README.ko.md; do
+  rg -F -- "bluetape4k-examples-coroutines-demo:test" "$file"
+  rg -F -- "CallbackFlowExamples" "$file"
+  rg -F -- "--no-configuration-cache" "$file"
+  rg -F -- "--max-workers=1" "$file"
+  rg -F -- "Testcontainers" "$file"
+  rg -F -- "Docker" "$file"
+  rg -F -- "timeout" "$file"
+done
+python3 - <<'PY'
+from pathlib import Path
+
+english = Path("examples/coroutines-demo/README.md").read_text()
+korean = Path("examples/coroutines-demo/README.ko.md").read_text()
+required = (
+    ":bluetape4k-examples-coroutines-demo:test",
+    "CallbackFlowExamples",
+    "--no-configuration-cache",
+    "--max-workers=1",
+    "Testcontainers",
+    "Docker",
+    "timeout",
+)
+assert all(token in english and token in korean for token in required)
+PY
 ```
 
 Expected: 두 파일의 task name과 example name이 일치하고 한국어 문서에는 독자용 설명이 자연스럽게 남는다.
@@ -636,6 +728,10 @@ PR 생성 전 child issue #1347의 `## DoD Status`와 parent PR body에 exact he
 ## Rollback과 stop condition
 
 Kafka adapter/test만 실패하면 Task 3–4 commit을 되돌리고 기존 example test를 복구한다. workflow 변경이 60분 budget을 넘기거나 diagnostics completeness가 실패하면 workflow commit만 revert하고 child code evidence를 유지한다. exact-head CI failure, unresolved P1, producer/consumer cleanup timeout이면 merge-ready를 중단하고 해당 task와 `## DoD Status`를 다시 검증한다. production API, dependency version, image/tag 변경이 발견되면 이 계획 범위를 벗어나므로 별도 승인 전에는 진행하지 않는다.
+
+unique topic은 Testcontainers broker 수명과 함께 폐기되므로 정상 경로에서 별도
+삭제 명령을 추가하지 않는다. 장시간 shared broker에서 잔여 topic을 수집해야 하는
+요구가 생기면 별도 운영 이슈로 다루며 이 child의 cleanup 계약을 확장하지 않는다.
 
 ## 계획 완료 조건
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -38,7 +38,27 @@ production module에 테스트 전용 helper를 추출하지 않는 것이 이 e
 
 - [ ] **Step 1: `newRedisson`에 shutdown registration 경계를 추가한다**
 
-기존 함수의 signature를 다음으로 바꾸고, `ShutdownQueue.register`는 조건부로 실행한다. 기본값은 기존 shared client 동작을 보존한다.
+기존 `redis` lazy property가 사용하는 mutable tag 대신 다음 immutable image reference를
+사용한다. `RedisServer`의 기존 `DockerImageName` 생성자와 `ShutdownQueue` ownership을
+그대로 재사용하며, production testcontainers module은 변경하지 않는다.
+
+```kotlin
+@JvmStatic
+val redis: RedisServer by lazy {
+    RedisServer(
+        DockerImageName.parse(
+            "redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a"
+        )
+    ).apply {
+        start()
+        ShutdownQueue.register(this)
+    }
+}
+```
+
+필요한 import는 `org.testcontainers.utility.DockerImageName`다. 기존 함수의
+signature는 다음으로 바꾸고, `ShutdownQueue.register`는 조건부로 실행한다. 기본값은
+기존 shared client 동작을 보존한다.
 
 ```kotlin
 @JvmStatic
@@ -70,6 +90,29 @@ protected fun newRedisson(registerShutdown: Boolean = true): RedissonClient {
 ```
 
 반환 타입은 기존 호출자 호환성을 위해 `RedissonClient`를 유지한다. `redissonClient` lazy property는 인자를 생략해 shared client로 남긴다.
+
+같은 base file에 다음 bounded await helper도 Task 1에서 먼저 추가한다. 필요한
+import는 `org.redisson.api.RFuture`, `kotlinx.coroutines.CancellationException`,
+`kotlinx.coroutines.TimeoutCancellationException`, `kotlinx.coroutines.future.await`,
+`kotlinx.coroutines.withTimeout`, `kotlin.time.Duration.Companion.seconds`다.
+
+```kotlin
+protected suspend fun <T> awaitRedis(
+    future: RFuture<T>,
+    timeout: kotlin.time.Duration = 5.seconds,
+): T = try {
+    withTimeout(timeout) { future.await() }
+} catch (cause: TimeoutCancellationException) {
+    future.cancel(false)
+    throw cause
+} catch (cause: CancellationException) {
+    future.cancel(false)
+    throw cause
+}
+```
+
+Task 2부터 이 helper를 사용할 수 있도록 Task 1의 compile gate가 helper까지
+포함하는지 확인한다.
 
 - [ ] **Step 2: 기존 Redisson example 전체 compile을 확인한다**
 
@@ -269,30 +312,10 @@ firstFailure?.let { throw it }
 }
 ```
 
-모든 Redisson `RFuture`는 base의 다음 bounded helper를 통해 await한다.
-
-필요한 import는 `org.redisson.api.RFuture`, `kotlinx.coroutines.CancellationException`,
-`kotlinx.coroutines.TimeoutCancellationException`, `kotlinx.coroutines.future.await`,
-`kotlinx.coroutines.withTimeout`, `kotlin.time.Duration.Companion.seconds`다.
-
-```kotlin
-protected suspend fun <T> awaitRedis(
-    future: RFuture<T>,
-    timeout: kotlin.time.Duration = 5.seconds,
-): T = try {
-    withTimeout(timeout) { future.await() }
-} catch (cause: TimeoutCancellationException) {
-    future.cancel(false)
-    throw cause
-} catch (cause: CancellationException) {
-    future.cancel(false)
-    throw cause
-}
-```
-
-Task 2–4의 `withTimeout(5.seconds) { future.await() }` 표기는 구현 시
-`awaitRedis(future)`로 치환해 timeout/cancellation 때 underlying future도
-취소한다. helper 자체는 `runSuspendIO`의 IO dispatcher에서 호출하며, 테스트
+모든 Redisson `RFuture`는 Task 1에서 추가한 bounded helper를 통해 await한다.
+Task 2–4의 raw future await 표기는 구현 시 `awaitRedis(future)`로 치환해
+timeout/cancellation 때 underlying future도 취소한다. helper 자체는 `runSuspendIO`의
+IO dispatcher에서 호출하며, 테스트
 종료 시점의 client shutdown과 별개로 pending operation을 남기지 않는다.
 
 두 options와 `backCache`는 같은 concrete codec과 unique `cacheName`을 공유하고,
@@ -301,14 +324,21 @@ shared `redisson`는 base의 `ShutdownQueue` 소유권을 유지한다. Redisson
 5초 bounded shutdown을 갖고, 첫 번째 shutdown 예외가 발생하면 두 번째 client도
 정리한 뒤 테스트 lifecycle failure로 보고한다.
 
-기존 `options1`, `options2`, `backCache` 선언도 다음처럼 value codec을 명시한다.
+기존 `options1`, `options2`의 LFU·maxIdle·timeToLive 동작은 보존하고 value codec만
+명시한다. `backCache`에도 같은 codec을 전달한다.
 
 ```kotlin
 private val options1 = LocalCachedMapOptions.name<String, Int>(cacheName)
     .cacheSize(100)
+    .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.LFU)
+    .maxIdle(10.seconds.toJavaDuration())
+    .timeToLive(5.seconds.toJavaDuration())
     .codec(intCodec)
 private val options2 = LocalCachedMapOptions.name<String, Int>(cacheName)
     .cacheSize(100)
+    .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.LFU)
+    .maxIdle(10.seconds.toJavaDuration())
+    .timeToLive(5.seconds.toJavaDuration())
     .codec(intCodec)
 private val backCache: RMap<String, Int> by lazy { redisson.getMap(cacheName, intCodec) }
 ```

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -40,7 +40,9 @@ production module에 테스트 전용 helper를 추출하지 않는 것이 이 e
 
 기존 `redis` lazy property가 사용하는 mutable tag 대신 다음 immutable image reference를
 사용한다. `RedisServer`의 기존 `DockerImageName` 생성자와 `ShutdownQueue` ownership을
-그대로 재사용하며, production testcontainers module은 변경하지 않는다.
+그대로 재사용하며, production testcontainers module은 변경하지 않는다. 현재
+`RedisServer.Launcher.redis`가 Redisson classpath에서 수행하는 `warmupPubSubChannel`
+호출도 반드시 보존해 첫 연결 시 `StacklessClosedChannelException`을 예방한다.
 
 ```kotlin
 @JvmStatic
@@ -52,11 +54,23 @@ val redis: RedisServer by lazy {
     ).apply {
         start()
         ShutdownQueue.register(this)
+
+        if (classIsPresent("org.redisson.Redisson")) {
+            val warmupClient = Redisson.create(
+                RedisServer.Launcher.RedissonLib.getRedissonConfig(url)
+            )
+            try {
+                RedisServer.Launcher.RedissonLib.warmupPubSubChannel(warmupClient)
+            } finally {
+                warmupClient.shutdown()
+            }
+        }
     }
 }
 ```
 
-필요한 import는 `org.testcontainers.utility.DockerImageName`다. 기존 함수의
+필요한 import는 `io.bluetape4k.support.classIsPresent`, `org.redisson.Redisson`와
+`org.testcontainers.utility.DockerImageName`다. 기존 함수의
 signature는 다음으로 바꾸고, `ShutdownQueue.register`는 조건부로 실행한다. 기본값은
 기존 shared client 동작을 보존한다.
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -157,7 +157,9 @@ fun `empty Double key is initialized by HINCRBYFLOAT`() = runSuspendIO {
 }
 ```
 
-모든 future await는 `withTimeout(5.seconds)` 안에서 실행하고, assertion은 `bluetape4k-assertions`의 `shouldBeEqualTo`를 사용한다.
+모든 future await는 기본 5초 deadline과 cancellation 전파를 제공하는
+`awaitRedis`로 실행하고, assertion은 `bluetape4k-assertions`의 `shouldBeEqualTo`를
+사용한다.
 
 - [ ] **Step 3: RED 상태를 확인한다**
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Kotlin 2.4/JVM 25, Redisson 4.7.0, `RLocalCachedMap`, `CompositeCodec`, `RedissonCodecs.Int`/`Double`, JUnit 5, `runSuspendIO`, `SuspendedJobTester`, Awaitility Kotlin, `bluetape4k-assertions`, Testcontainers Redis.
 
+**Approved basis:** `docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md` at commit `7d22431a975e12a237083c93d6e2e6749f966b9d`, based on `origin/develop` `a907d144f39bfb94cba783cf65a5412e0714e9d5`.
+
 ---
 
 ## 계획 범위와 파일 소유권
@@ -19,6 +21,14 @@
 - Modify: `examples/redisson-demo/README.ko.md` — 같은 명령과 계약을 한국어로 갱신한다.
 
 `examples/redisson-demo/build.gradle.kts`는 이미 `:bluetape4k-testcontainers`, `:bluetape4k-junit5`, `:bluetape4k-redisson`과 Redisson dependency를 선언하므로 변경하지 않는다. Kafka child가 소유하는 `.github/workflows/examples.yml`도 변경하지 않는다.
+
+## Codec 재사용 결정
+
+두 test source가 각각 `Int`/`Double` 제네릭 타입을 추론해야 하므로 file-local
+`CompositeCodec` 상수는 각 파일에 둔다. 값은 새 serializer나 wrapper를 만들지
+않고 공통 `RedissonCodecs.String`, `.Int`, `.Double`을 동일한 순서로 조합한다.
+production module에 테스트 전용 helper를 추출하지 않는 것이 이 examples 범위의
+중복·의존성 경계를 지키는 선택이다.
 
 ## Task 1: test-owned Redisson client lifecycle을 먼저 고정한다
 
@@ -229,6 +239,8 @@ Expected: Redis Testcontainers가 실행 가능한 환경에서 Int/Double round
 `@BeforeAll`의 기존 `newRedisson()` 호출을 다음으로 바꾸고, `@AfterAll`에서 초기화된
 client만 한 번 닫는다.
 
+이 코드 블록에는 `java.util.concurrent.TimeUnit` import를 추가한다.
+
 ```kotlin
 @BeforeAll
 fun setup() {
@@ -238,13 +250,27 @@ fun setup() {
 
 @AfterAll
 fun cleanup() {
-    if (this::redisson1.isInitialized) redisson1.shutdown()
-    if (this::redisson2.isInitialized) redisson2.shutdown()
+    var firstFailure: Throwable? = null
+    if (this::redisson1.isInitialized) {
+        runCatching { redisson1.shutdown(0, 5, TimeUnit.SECONDS) }
+            .onFailure { firstFailure = it }
+    }
+    if (this::redisson2.isInitialized) {
+        runCatching { redisson2.shutdown(0, 5, TimeUnit.SECONDS) }
+            .onFailure { failure ->
+                if (firstFailure == null) firstFailure = failure
+                else firstFailure!!.addSuppressed(failure)
+            }
+    }
+    firstFailure?.let { throw it }
 }
 ```
 
 두 options와 `backCache`는 같은 concrete codec과 unique `cacheName`을 공유하고,
-shared `redisson`는 base의 `ShutdownQueue` 소유권을 유지한다.
+shared `redisson`는 base의 `ShutdownQueue` 소유권을 유지한다. Redisson의
+`shutdown(0, 5, TimeUnit.SECONDS)` overload를 사용해 각 test-owned client가
+5초 bounded shutdown을 갖고, 첫 번째 shutdown 예외가 발생하면 두 번째 client도
+정리한 뒤 테스트 lifecycle failure로 보고한다.
 
 - [ ] **Step 2: concurrent Int/Double increment를 `SuspendedJobTester`로 검증한다**
 
@@ -255,7 +281,7 @@ fun `concurrent numeric increments match independent remote final value`() = run
     val map = redisson1.getLocalCachedMap(
         LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
     )
-    val calls = 4 * 32 * 8
+    val calls = 32 * 8 // rounds는 전체 호출 수이고 workers는 동시 실행 수다.
 
     SuspendedJobTester()
         .workers(4)
@@ -265,10 +291,23 @@ fun `concurrent numeric increments match independent remote final value`() = run
 
     val remote = redisson.getMap<String, Int>(name, intCodec)
     withTimeout(5.seconds) { remote.getAsync("count").await() } shouldBeEqualTo calls
+
+    val map2 = redisson2.getLocalCachedMap(
+        LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
+    )
+    withTimeout(5.seconds) { map.getAsync("count").await() } shouldBeEqualTo calls
+    withTimeout(5.seconds) { map2.getAsync("count").await() } shouldBeEqualTo calls
 }
 ```
 
-같은 구조로 Double은 `0.25` delta와 `Double` codec을 사용하고, expected 값은 `calls * 0.25`로 assertion한다. worker는 ad hoc thread를 만들지 않는다.
+같은 구조로 Double은 `0.25` delta와 `Double` codec을 사용하고, expected 값은
+`calls * 0.25`로 assertion한다. Double도 `redisson2.getLocalCachedMap`으로
+동일한 `name`과 `doubleCodec`을 사용한 두 번째 local view를 만들고,
+`withTimeout(5.seconds) { map2.getAsync("ratio").await() }`가
+`calls * 0.25`와 일치하는지 확인한다. Int와 Double 모두 `redisson2` local
+view를 같은 5초 deadline으로 reread해 remote final value와 일치하는지
+확인한다. worker는 ad hoc thread를 만들지 않는다.
+worker는 ad hoc thread를 만들지 않는다.
 
 - [ ] **Step 3: remote put/remove invalidation을 bounded Awaitility로 검증한다**
 
@@ -277,13 +316,13 @@ fun `concurrent numeric increments match independent remote final value`() = run
 ```kotlin
 await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
     .until { frontCache1.containsKey(key) && frontCache2.containsKey(key) }
-frontCache1.getAsync(key).await() shouldBeEqualTo 42
-frontCache2.getAsync(key).await() shouldBeEqualTo 42
+withTimeout(5.seconds) { frontCache1.getAsync(key).await() } shouldBeEqualTo 42
+withTimeout(5.seconds) { frontCache2.getAsync(key).await() } shouldBeEqualTo 42
 
 await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
     .until { !frontCache1.containsKey(key) && !frontCache2.containsKey(key) }
-frontCache1.getAsync(key).await().shouldBeNull()
-frontCache2.getAsync(key).await().shouldBeNull()
+withTimeout(5.seconds) { frontCache1.getAsync(key).await() }.shouldBeNull()
+withTimeout(5.seconds) { frontCache2.getAsync(key).await() }.shouldBeNull()
 ```
 
 remote 변경 직후 stale read를 허용하되 bounded await 뒤 두 local view가 갱신/삭제된
@@ -340,8 +379,10 @@ negative `RedisException` test가 PASS한다. Redis/Testcontainers startup failu
 ```bash
 ./gradlew :bluetape4k-examples-redisson-demo:test \
   --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapExamples' \
-  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest'
-./gradlew :bluetape4k-examples-redisson-demo:test
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest' \
+  --no-configuration-cache --max-workers=1
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --no-configuration-cache --max-workers=1
 ```
 
 Docker daemon/Testcontainers가 필요하고 dynamic port를 사용한다는 점, invalidation 직후 stale read는 허용되지만 5초 bounded await 뒤 local reread가 갱신값 또는 `null`을 확인한다는 점을 두 locale에 같은 의미로 기록한다.

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -62,15 +62,18 @@ val redis: RedisServer by lazy {
             try {
                 RedisServer.Launcher.RedissonLib.warmupPubSubChannel(warmupClient)
             } finally {
-                warmupClient.shutdown()
+                warmupClient.shutdown(0, 5, TimeUnit.SECONDS)
             }
         }
     }
 }
 ```
 
-필요한 import는 `io.bluetape4k.support.classIsPresent`, `org.redisson.Redisson`와
-`org.testcontainers.utility.DockerImageName`다. 기존 함수의
+필요한 import는 `io.bluetape4k.support.classIsPresent`, `org.redisson.Redisson`,
+`org.testcontainers.utility.DockerImageName`, `java.util.concurrent.TimeUnit`다. lazy
+초기화 블록은 suspend 경계가 아니므로 `runInterruptible`을 끼워 넣지 않고, Redisson의
+bounded `shutdown(0, 5, TimeUnit.SECONDS)` overload로 warm-up client 종료 상한을
+명시한다. 기존 함수의
 signature는 다음으로 바꾸고, `ShutdownQueue.register`는 조건부로 실행한다. 기본값은
 기존 shared client 동작을 보존한다.
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -199,7 +199,8 @@ withTimeout(5.seconds) { backendMap.getAsync("count").await() } shouldBeEqualTo 
 ```
 
 `fastPutAsync`로 같은 numeric key를 먼저 직렬화하지 않는다. key가 없을 때 Redis
-`HINCRBY` 경로가 초기값을 만든다는 점을 KDoc와 assertion으로 설명한다.
+`HINCRBY` 경로가 초기값을 만들고, Double은 `HINCRBYFLOAT` 경로를 사용한다는 점을
+KDoc와 assertion으로 설명한다.
 
 - [ ] **Step 2: Double 예제와 제약 KDoc을 추가한다**
 
@@ -262,15 +263,64 @@ fun cleanup() {
                 else firstFailure!!.addSuppressed(failure)
             }
     }
-    firstFailure?.let { throw it }
+firstFailure?.let { throw it }
 }
 ```
+
+모든 Redisson `RFuture`는 base의 다음 bounded helper를 통해 await한다.
+
+필요한 import는 `org.redisson.api.RFuture`, `kotlinx.coroutines.CancellationException`,
+`kotlinx.coroutines.TimeoutCancellationException`, `kotlinx.coroutines.future.await`,
+`kotlinx.coroutines.withTimeout`, `kotlin.time.Duration.Companion.seconds`다.
+
+```kotlin
+protected suspend fun <T> awaitRedis(
+    future: RFuture<T>,
+    timeout: kotlin.time.Duration = 5.seconds,
+): T = try {
+    withTimeout(timeout) { future.await() }
+} catch (cause: TimeoutCancellationException) {
+    future.cancel(false)
+    throw cause
+} catch (cause: CancellationException) {
+    future.cancel(false)
+    throw cause
+}
+```
+
+Task 2–4의 `withTimeout(5.seconds) { future.await() }` 표기는 구현 시
+`awaitRedis(future)`로 치환해 timeout/cancellation 때 underlying future도
+취소한다. helper 자체는 `runSuspendIO`의 IO dispatcher에서 호출하며, 테스트
+종료 시점의 client shutdown과 별개로 pending operation을 남기지 않는다.
 
 두 options와 `backCache`는 같은 concrete codec과 unique `cacheName`을 공유하고,
 shared `redisson`는 base의 `ShutdownQueue` 소유권을 유지한다. Redisson의
 `shutdown(0, 5, TimeUnit.SECONDS)` overload를 사용해 각 test-owned client가
 5초 bounded shutdown을 갖고, 첫 번째 shutdown 예외가 발생하면 두 번째 client도
 정리한 뒤 테스트 lifecycle failure로 보고한다.
+
+기존 `options1`, `options2`, `backCache` 선언도 다음처럼 value codec을 명시한다.
+
+```kotlin
+private val options1 = LocalCachedMapOptions.name<String, Int>(cacheName)
+    .cacheSize(100)
+    .codec(intCodec)
+private val options2 = LocalCachedMapOptions.name<String, Int>(cacheName)
+    .cacheSize(100)
+    .codec(intCodec)
+private val backCache: RMap<String, Int> by lazy { redisson.getMap(cacheName, intCodec) }
+```
+
+이 클래스의 기존 Redis/Testcontainers 세 테스트 wrapper는 모두
+`runSuspendIO`로 바꾸고, `io.bluetape4k.junit5.awaitility.untilSuspending`을
+import해 suspend Redis future를 IO 경계 안에서 평가한다. `runTest`와 동기
+`containsKey`를 남기지 않는다.
+
+각 기존 테스트 선언의 정확한 변경은 `runTest` wrapper를
+`runSuspendIO(timeout = 60.seconds)`로 교체하고,
+`fastPutAsync`·`fastRemoveAsync`·`getAsync`·`containsKeyAsync`의 반환
+`RFuture`를 `awaitRedis(future)` 또는 `untilSuspending` 내부의 bounded await로
+소비하는 것이다.
 
 - [ ] **Step 2: concurrent Int/Double increment를 `SuspendedJobTester`로 검증한다**
 
@@ -283,20 +333,22 @@ fun `concurrent numeric increments match independent remote final value`() = run
     )
     val calls = 32 * 8 // rounds는 전체 호출 수이고 workers는 동시 실행 수다.
 
-    SuspendedJobTester()
-        .workers(4)
-        .rounds(32 * 8)
-        .add { withTimeout(5.seconds) { map.addAndGetAsync("count", 1).await() } }
-        .run()
+    withTimeout(30.seconds) {
+        SuspendedJobTester()
+            .workers(4)
+            .rounds(32 * 8)
+            .add { awaitRedis(map.addAndGetAsync("count", 1)) }
+            .run()
+    }
 
     val remote = redisson.getMap<String, Int>(name, intCodec)
-    withTimeout(5.seconds) { remote.getAsync("count").await() } shouldBeEqualTo calls
+    awaitRedis(remote.getAsync("count")) shouldBeEqualTo calls
 
     val map2 = redisson2.getLocalCachedMap(
         LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
     )
-    withTimeout(5.seconds) { map.getAsync("count").await() } shouldBeEqualTo calls
-    withTimeout(5.seconds) { map2.getAsync("count").await() } shouldBeEqualTo calls
+    awaitRedis(map.getAsync("count")) shouldBeEqualTo calls
+    awaitRedis(map2.getAsync("count")) shouldBeEqualTo calls
 }
 ```
 
@@ -307,22 +359,54 @@ fun `concurrent numeric increments match independent remote final value`() = run
 `calls * 0.25`와 일치하는지 확인한다. Int와 Double 모두 `redisson2` local
 view를 같은 5초 deadline으로 reread해 remote final value와 일치하는지
 확인한다. worker는 ad hoc thread를 만들지 않는다.
+
+Double 경로의 핵심은 다음처럼 Int와 분리된 map과 동일한 front/back codec을
+사용하는 것이다.
+
+```kotlin
+val name = randomName()
+val calls = 32 * 8
+val doubleMap1 = redisson1.getLocalCachedMap(
+    LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
+)
+val doubleMap2 = redisson2.getLocalCachedMap(
+    LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
+)
+withTimeout(30.seconds) {
+    SuspendedJobTester()
+        .workers(4)
+        .rounds(32 * 8)
+        .add { awaitRedis(doubleMap1.addAndGetAsync("ratio", 0.25)) }
+        .run()
+}
+val remoteDouble = redisson.getMap<String, Double>(name, doubleCodec)
+awaitRedis(remoteDouble.getAsync("ratio")) shouldBeEqualTo calls * 0.25
+awaitRedis(doubleMap2.getAsync("ratio")) shouldBeEqualTo calls * 0.25
+```
 worker는 ad hoc thread를 만들지 않는다.
 
-- [ ] **Step 3: remote put/remove invalidation을 bounded Awaitility로 검증한다**
+- [ ] **Step 3: remote put/remove invalidation을 bounded suspend Awaitility로 검증한다**
 
-기존 세 invalidation 테스트를 보존하면서 매 future await를 `withTimeout(5.seconds)`로 감싼다. remote `fastPutAsync`/`fastRemoveAsync` 뒤에는 다음 조건을 `atMost(5.seconds)`, 100ms poll로 기다린다.
+기존 세 invalidation 테스트를 보존하면서 각 wrapper를 `runSuspendIO`로 바꾸고,
+모든 future를 `awaitRedis(future)`로 감싼다. remote `fastPutAsync`/`fastRemoveAsync`
+뒤에는 blocking `containsKey` 대신 `untilSuspending`에서
+`containsKeyAsync(key).await()`를 IO 경계로 평가한다. 다음 조건을
+`atMost(5.seconds)`, 100ms poll로 기다린다.
 
 ```kotlin
 await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
-    .until { frontCache1.containsKey(key) && frontCache2.containsKey(key) }
-withTimeout(5.seconds) { frontCache1.getAsync(key).await() } shouldBeEqualTo 42
-withTimeout(5.seconds) { frontCache2.getAsync(key).await() } shouldBeEqualTo 42
+    .untilSuspending {
+        awaitRedis(frontCache1.containsKeyAsync(key)) && awaitRedis(frontCache2.containsKeyAsync(key))
+    }
+awaitRedis(frontCache1.getAsync(key)) shouldBeEqualTo 42
+awaitRedis(frontCache2.getAsync(key)) shouldBeEqualTo 42
 
 await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
-    .until { !frontCache1.containsKey(key) && !frontCache2.containsKey(key) }
-withTimeout(5.seconds) { frontCache1.getAsync(key).await() }.shouldBeNull()
-withTimeout(5.seconds) { frontCache2.getAsync(key).await() }.shouldBeNull()
+    .untilSuspending {
+        !awaitRedis(frontCache1.containsKeyAsync(key)) && !awaitRedis(frontCache2.containsKeyAsync(key))
+    }
+awaitRedis(frontCache1.getAsync(key)).shouldBeNull()
+awaitRedis(frontCache2.getAsync(key)).shouldBeNull()
 ```
 
 remote 변경 직후 stale read를 허용하되 bounded await 뒤 두 local view가 갱신/삭제된
@@ -391,8 +475,31 @@ Docker daemon/Testcontainers가 필요하고 dynamic port를 사용한다는 점
 
 ```bash
 git diff --check
-rg -n "bluetape4k-examples-redisson-demo:test|LocalCachedMapExamples|LocalCachedMapTest|CompositeCodec|HINCRBYFLOAT|5초|5 seconds" \
-  examples/redisson-demo/README.md examples/redisson-demo/README.ko.md
+for file in examples/redisson-demo/README.md examples/redisson-demo/README.ko.md; do
+  rg -F -- "bluetape4k-examples-redisson-demo:test" "$file"
+  rg -F -- "LocalCachedMapExamples" "$file"
+  rg -F -- "LocalCachedMapTest" "$file"
+  rg -F -- "--no-configuration-cache" "$file"
+  rg -F -- "--max-workers=1" "$file"
+  rg -F -- "CompositeCodec" "$file"
+  rg -F -- "HINCRBYFLOAT" "$file"
+done
+python3 - <<'PY'
+from pathlib import Path
+
+english = Path("examples/redisson-demo/README.md").read_text()
+korean = Path("examples/redisson-demo/README.ko.md").read_text()
+required = (
+    ":bluetape4k-examples-redisson-demo:test",
+    "LocalCachedMapExamples",
+    "LocalCachedMapTest",
+    "--no-configuration-cache",
+    "--max-workers=1",
+    "CompositeCodec",
+    "HINCRBYFLOAT",
+)
+assert all(token in english and token in korean for token in required)
+PY
 ```
 
 Expected: 두 locale의 task name, test class와 numeric/invalidation 설명이 일치한다.
@@ -443,6 +550,11 @@ parent #1347 merge 전 #1353 child의 base/head SHA와 temporary base ref를 기
 ## Rollback과 stop condition
 
 numeric example/test가 실패하면 Task 2–4 commit을 되돌리고 기존 `fastPutAsync` map example을 유지한다. `newRedisson(registerShutdown = false)`가 기존 test에 영향을 주면 signature 변경만 revert하고 shared default 동작을 복구한다. Redis future timeout, test-owned client leak, invalidation timeout, exact-head CI failure 또는 unresolved P1이면 merge-ready를 중단하고 해당 test·ownership·`## DoD Status`를 다시 검증한다. Redisson codec version, production API, 새 dependency를 추가하지 않는다.
+
+unique map은 Testcontainers Redis 수명과 함께 폐기되며, 테스트 중간에 별도
+delete를 호출하지 않아 invalidation 관찰을 오염시키지 않는다. 장시간 shared Redis의
+잔여 key 정리가 필요해지면 별도 운영 이슈로 다루고 이 child의 numeric 계약에는
+추가하지 않는다.
 
 ## 계획 완료 조건
 

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -1,0 +1,411 @@
+# Epic #1422 #1353 Redisson LocalCachedMap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `RLocalCachedMap`의 Int/Double `addAndGetAsync`와 두 client remote invalidation을 실행 가능한 Redisson coroutine example과 회귀 테스트로 증명한다.
+
+**Architecture:** numeric map은 value type과 map 이름을 분리하고 String key + numeric value의 concrete `CompositeCodec`를 front/back view에 동일하게 전달한다. shared Redis server/client는 기존 base와 `ShutdownQueue`가 소유하며, invalidation용 test-owned client만 명시적으로 만들고 `@AfterAll`에서 한 번 닫는다. 모든 실제 Redis 호출은 `runSuspendIO`와 bounded future await를 사용한다.
+
+**Tech Stack:** Kotlin 2.4/JVM 25, Redisson 4.7.0, `RLocalCachedMap`, `CompositeCodec`, `RedissonCodecs.Int`/`Double`, JUnit 5, `runSuspendIO`, `SuspendedJobTester`, Awaitility Kotlin, `bluetape4k-assertions`, Testcontainers Redis.
+
+---
+
+## 계획 범위와 파일 소유권
+
+- Modify: `examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AbstractRedissonCoroutineTest.kt` — `registerShutdown` 선택 인자로 test-owned client lifecycle을 허용한다.
+- Modify: `examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapExamples.kt` — Int/Double numeric example과 concrete codec을 추가한다.
+- Modify: `examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt` — concurrent increment, invalidation, timeout, negative contract를 추가한다.
+- Modify: `examples/redisson-demo/README.md` — 정확한 task, Redis/Testcontainers precondition과 eventual consistency를 영어로 갱신한다.
+- Modify: `examples/redisson-demo/README.ko.md` — 같은 명령과 계약을 한국어로 갱신한다.
+
+`examples/redisson-demo/build.gradle.kts`는 이미 `:bluetape4k-testcontainers`, `:bluetape4k-junit5`, `:bluetape4k-redisson`과 Redisson dependency를 선언하므로 변경하지 않는다. Kafka child가 소유하는 `.github/workflows/examples.yml`도 변경하지 않는다.
+
+## Task 1: test-owned Redisson client lifecycle을 먼저 고정한다
+
+**Files:**
+
+- Modify: `examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AbstractRedissonCoroutineTest.kt`
+
+- [ ] **Step 1: `newRedisson`에 shutdown registration 경계를 추가한다**
+
+기존 함수의 signature를 다음으로 바꾸고, `ShutdownQueue.register`는 조건부로 실행한다. 기본값은 기존 shared client 동작을 보존한다.
+
+```kotlin
+@JvmStatic
+protected fun newRedisson(registerShutdown: Boolean = true): RedissonClient {
+    val config = Config().apply {
+        useSingleServer()
+            .setAddress(redis.url)
+            .setConnectionPoolSize(128)
+            .setConnectionMinimumIdleSize(32)
+            .setIdleConnectionTimeout(100_000)
+            .setTimeout(5000)
+            .setRetryAttempts(3)
+            .setRetryDelay { attempt -> Duration.ofMillis((attempt + 1) * 100L) }
+            .setDnsMonitoringInterval(5000)
+        executor = VirtualThreadExecutor
+        threads = 256
+        nettyThreads = 128
+        codec = RedissonCodecs.LZ4ForyComposite
+        setTcpNoDelay(true)
+        setTcpUserTimeout(5000)
+    }
+
+    return Redisson.create(config).also { client ->
+        if (registerShutdown) {
+            ShutdownQueue.register { client.shutdown() }
+        }
+    }
+}
+```
+
+반환 타입은 기존 호출자 호환성을 위해 `RedissonClient`를 유지한다. `redissonClient` lazy property는 인자를 생략해 shared client로 남긴다.
+
+- [ ] **Step 2: 기존 Redisson example 전체 compile을 확인한다**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-examples-redisson-demo:testClasses --no-configuration-cache
+```
+
+Expected: 기존 호출부가 default `registerShutdown=true`로 컴파일되고 `BUILD SUCCESSFUL`이다.
+
+- [ ] **Step 3: lifecycle 변경을 독립 commit으로 기록한다**
+
+```bash
+git add examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AbstractRedissonCoroutineTest.kt
+git commit -F - <<'EOF'
+Redisson 예제의 shared와 test-owned client 종료 경계를 분리한다
+
+Constraint: 기존 shared redissonClient와 ShutdownQueue 등록 동작은 기본값으로 보존한다.
+Rejected: 모든 client를 전역 ShutdownQueue에 등록 | @AfterAll 단일 종료와 setup 실패 cleanup을 증명할 수 없다.
+Confidence: high
+Scope-risk: narrow
+Directive: local-cache invalidation test만 registerShutdown=false를 명시한다.
+Tested: ./gradlew :bluetape4k-examples-redisson-demo:testClasses --no-configuration-cache
+Not-tested: numeric codec round-trip, invalidation, hosted CI
+EOF
+```
+
+## Task 2: numeric codec와 atomic update RED 테스트를 작성한다
+
+**Files:**
+
+- Modify: `examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapExamples.kt`
+- Modify: `examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt`
+
+- [ ] **Step 1: concrete codec와 map construction을 선언한다**
+
+두 파일에서 다음 import와 value를 사용한다.
+
+```kotlin
+import io.bluetape4k.redis.redisson.codec.RedissonCodecs
+import org.redisson.codec.CompositeCodec
+
+private val intCodec = CompositeCodec(
+    RedissonCodecs.String,
+    RedissonCodecs.Int,
+    RedissonCodecs.Int,
+)
+private val doubleCodec = CompositeCodec(
+    RedissonCodecs.String,
+    RedissonCodecs.Double,
+    RedissonCodecs.Double,
+)
+```
+
+`LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)`와 `LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)`를 사용하고, remote view도 `redisson.getMap(name, intCodec)` 또는 `redisson.getMap(name, doubleCodec)`로 같은 codec을 전달한다.
+
+- [ ] **Step 2: RED assertion을 추가한다**
+
+```kotlin
+@Test
+fun `empty Int key is initialized by addAndGetAsync`() = runSuspendIO {
+    val name = randomName()
+    val map = redisson.getLocalCachedMap(
+        LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
+    )
+
+    val result = withTimeout(5.seconds) { map.addAndGetAsync("count", 32).await() }
+
+    result shouldBeEqualTo 32
+    withTimeout(5.seconds) { map.getAsync("count").await() } shouldBeEqualTo 32
+}
+
+@Test
+fun `empty Double key is initialized by HINCRBYFLOAT`() = runSuspendIO {
+    val name = randomName()
+    val map = redisson.getLocalCachedMap(
+        LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
+    )
+
+    val result = withTimeout(5.seconds) { map.addAndGetAsync("ratio", 0.25).await() }
+
+    result shouldBeEqualTo 0.25
+    withTimeout(5.seconds) { map.getAsync("ratio").await() } shouldBeEqualTo 0.25
+}
+```
+
+모든 future await는 `withTimeout(5.seconds)` 안에서 실행하고, assertion은 `bluetape4k-assertions`의 `shouldBeEqualTo`를 사용한다.
+
+- [ ] **Step 3: RED 상태를 확인한다**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapExamples' \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest' \
+  --no-configuration-cache --max-workers=1
+```
+
+Expected: concrete codec map과 numeric implementation이 아직 없거나 기존 임시 구현 경로를 사용하므로 새 test가 실패한다. Docker startup failure는 별도 환경 evidence로 분리한다.
+
+## Task 3: LocalCachedMapExamples에 Int/Double 실행 예제를 구현한다
+
+**Files:**
+
+- Modify: `examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapExamples.kt`
+
+- [ ] **Step 1: Int 예제를 빈 key atomic increment로 교체한다**
+
+기존 `fastPutAsync` numeric map은 일반 직렬화 동작 설명으로 유지하되 기존 임시 주석은 제거한다. 별도 unique map에서 다음 순서를 사용한다.
+
+```kotlin
+val name = randomName()
+val options = LocalCachedMapOptions.name<String, Int>(name)
+    .cacheSize(100)
+    .codec(intCodec)
+val cachedMap: RLocalCachedMap<String, Int> = redisson.getLocalCachedMap(options)
+val backendMap: RMap<String, Int> = redisson.getMap(name, intCodec)
+
+val first = withTimeout(5.seconds) { cachedMap.addAndGetAsync("count", 32).await() }
+val second = withTimeout(5.seconds) { cachedMap.addAndGetAsync("count", 10).await() }
+
+first shouldBeEqualTo 32
+second shouldBeEqualTo 42
+withTimeout(5.seconds) { backendMap.getAsync("count").await() } shouldBeEqualTo 42
+```
+
+`fastPutAsync`로 같은 numeric key를 먼저 직렬화하지 않는다. key가 없을 때 Redis
+`HINCRBY` 경로가 초기값을 만든다는 점을 KDoc와 assertion으로 설명한다.
+
+- [ ] **Step 2: Double 예제와 제약 KDoc을 추가한다**
+
+```kotlin
+val name = randomName()
+val options = LocalCachedMapOptions.name<String, Double>(name)
+    .cacheSize(100)
+    .codec(doubleCodec)
+val cachedMap: RLocalCachedMap<String, Double> = redisson.getLocalCachedMap(options)
+val backendMap: RMap<String, Double> = redisson.getMap(name, doubleCodec)
+
+val result = withTimeout(5.seconds) { cachedMap.addAndGetAsync("ratio", 0.25).await() }
+result shouldBeEqualTo 0.25
+withTimeout(5.seconds) { backendMap.getAsync("ratio").await() } shouldBeEqualTo 0.25
+```
+
+KDoc에는 Int/Double map을 섞지 않고 finite Double delta만 사용하며, `HINCRBYFLOAT`가 숫자 hash field를 요구한다는 제약을 한국어로 기록한다.
+
+- [ ] **Step 3: example tests를 GREEN으로 확인한다**
+
+```bash
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapExamples' \
+  --no-configuration-cache --max-workers=1
+```
+
+Expected: Redis Testcontainers가 실행 가능한 환경에서 Int/Double round-trip이 PASS하고, 각 future가 5초 deadline 안에 완료된다.
+
+## Task 4: 두 client 동시성·remote invalidation·negative contract를 구현한다
+
+**Files:**
+
+- Modify: `examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt`
+
+- [ ] **Step 1: setup에서 test-owned clients를 만든다**
+
+`@BeforeAll`의 기존 `newRedisson()` 호출을 다음으로 바꾸고, `@AfterAll`에서 초기화된
+client만 한 번 닫는다.
+
+```kotlin
+@BeforeAll
+fun setup() {
+    redisson1 = newRedisson(registerShutdown = false)
+    redisson2 = newRedisson(registerShutdown = false)
+}
+
+@AfterAll
+fun cleanup() {
+    if (this::redisson1.isInitialized) redisson1.shutdown()
+    if (this::redisson2.isInitialized) redisson2.shutdown()
+}
+```
+
+두 options와 `backCache`는 같은 concrete codec과 unique `cacheName`을 공유하고,
+shared `redisson`는 base의 `ShutdownQueue` 소유권을 유지한다.
+
+- [ ] **Step 2: concurrent Int/Double increment를 `SuspendedJobTester`로 검증한다**
+
+```kotlin
+@Test
+fun `concurrent numeric increments match independent remote final value`() = runSuspendIO {
+    val name = randomName()
+    val map = redisson1.getLocalCachedMap(
+        LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
+    )
+    val calls = 4 * 32 * 8
+
+    SuspendedJobTester()
+        .workers(4)
+        .rounds(32 * 8)
+        .add { withTimeout(5.seconds) { map.addAndGetAsync("count", 1).await() } }
+        .run()
+
+    val remote = redisson.getMap<String, Int>(name, intCodec)
+    withTimeout(5.seconds) { remote.getAsync("count").await() } shouldBeEqualTo calls
+}
+```
+
+같은 구조로 Double은 `0.25` delta와 `Double` codec을 사용하고, expected 값은 `calls * 0.25`로 assertion한다. worker는 ad hoc thread를 만들지 않는다.
+
+- [ ] **Step 3: remote put/remove invalidation을 bounded Awaitility로 검증한다**
+
+기존 세 invalidation 테스트를 보존하면서 매 future await를 `withTimeout(5.seconds)`로 감싼다. remote `fastPutAsync`/`fastRemoveAsync` 뒤에는 다음 조건을 `atMost(5.seconds)`, 100ms poll로 기다린다.
+
+```kotlin
+await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
+    .until { frontCache1.containsKey(key) && frontCache2.containsKey(key) }
+frontCache1.getAsync(key).await() shouldBeEqualTo 42
+frontCache2.getAsync(key).await() shouldBeEqualTo 42
+
+await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
+    .until { !frontCache1.containsKey(key) && !frontCache2.containsKey(key) }
+frontCache1.getAsync(key).await().shouldBeNull()
+frontCache2.getAsync(key).await().shouldBeNull()
+```
+
+remote 변경 직후 stale read를 허용하되 bounded await 뒤 두 local view가 갱신/삭제된
+값을 읽는지 확인한다.
+
+- [ ] **Step 4: unsupported numeric value의 명시적 negative test를 추가한다**
+
+unique map에 String codec으로 `"not-a-number"`를 저장한 뒤 Double composite codec
+view에서 `addAndGetAsync`를 호출하고 Redisson의 `RedisException`을 기대한다. 예외
+message는 비교하지 않아 환경별 Redis endpoint를 노출하지 않는다.
+
+```kotlin
+@Test
+fun `non numeric stored value is rejected by numeric increment`() = runSuspendIO {
+    val name = randomName()
+    val raw = redisson.getMap<String, String>(name, RedissonCodecs.String)
+    withTimeout(5.seconds) { raw.fastPutAsync("ratio", "not-a-number").await() }
+
+    val numeric = redisson1.getLocalCachedMap(
+        LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
+    )
+    assertFailsWith<RedisException> {
+        withTimeout(5.seconds) { numeric.addAndGetAsync("ratio", 0.25).await() }
+    }
+}
+```
+
+예외 타입이 현재 Redisson client 계약과 다르면 실제 failure cause를 확인하고
+`RedisException`의 정확한 subtype으로 test와 KDoc를 함께 갱신한다.
+
+- [ ] **Step 5: RED 테스트를 GREEN으로 확인한다**
+
+```bash
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest' \
+  --no-configuration-cache --max-workers=1
+```
+
+Expected: concurrent final value, both-client invalidation, 5초 future/await deadline,
+negative `RedisException` test가 PASS한다. Redis/Testcontainers startup failure는
+코드 결함과 분리해 evidence로 기록한다.
+
+## Task 5: Redisson README locale parity를 맞춘다
+
+**Files:**
+
+- Modify: `examples/redisson-demo/README.md`
+- Modify: `examples/redisson-demo/README.ko.md`
+
+- [ ] **Step 1: LocalCachedMap 행과 numeric contract를 갱신한다**
+
+두 README의 `LocalCachedMapExamples.kt` 설명에 Int/Double map 분리, 동일 `CompositeCodec`, `HINCRBYFLOAT`, 두 client eventual invalidation을 추가한다. 실행 섹션에는 다음 두 명령을 그대로 넣는다.
+
+```bash
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapExamples' \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest'
+./gradlew :bluetape4k-examples-redisson-demo:test
+```
+
+Docker daemon/Testcontainers가 필요하고 dynamic port를 사용한다는 점, invalidation 직후 stale read는 허용되지만 5초 bounded await 뒤 local reread가 갱신값 또는 `null`을 확인한다는 점을 두 locale에 같은 의미로 기록한다.
+
+- [ ] **Step 2: README parity를 검사한다**
+
+```bash
+git diff --check
+rg -n "bluetape4k-examples-redisson-demo:test|LocalCachedMapExamples|LocalCachedMapTest|CompositeCodec|HINCRBYFLOAT|5초|5 seconds" \
+  examples/redisson-demo/README.md examples/redisson-demo/README.ko.md
+```
+
+Expected: 두 locale의 task name, test class와 numeric/invalidation 설명이 일치한다.
+
+## Task 6: child-level verification과 module 6-R review를 만든다
+
+**Files:**
+
+- Create: `docs/superpowers/reviews/2026-08-26-epic-1422-1353-module-6r.md`
+
+- [ ] **Step 1: targeted와 full module test를 순차 실행한다**
+
+```bash
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapExamples' \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest' \
+  --no-configuration-cache --max-workers=1
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --no-configuration-cache --max-workers=1
+./gradlew :bluetape4k-examples-redisson-demo:detekt \
+  --no-configuration-cache --max-workers=1
+git diff --check
+```
+
+Expected: 세 명령이 모두 PASS하고 Testcontainers 종료·test-owned client shutdown이 확인된다. failure가 발생하면 전체 suite를 재실행하기 전에 해당 test를 동일 조건으로 재현한다.
+
+- [ ] **Step 2: 6-R evidence를 기록한다**
+
+검토 문서에는 touched file, 실제 command/output, `CompositeCodec` front/back 동일성, `runSuspendIO`·future timeout, `SuspendedJobTester`, Awaitility bounded polling, test-owned/shared ownership, negative `RedisException`, known gaps를 기록한다. six perspective 결과가 P0=0/P1=0이 될 때까지 수정하고 한국어 용어 audit를 실행한다.
+
+- [ ] **Step 3: child PR merge-ready evidence를 parent head에 연결한다**
+
+parent #1347 merge 전 #1353 child의 base/head SHA와 temporary base ref를 기록한다. parent merge 후 child base를 `develop` branch로 retarget하고 exact diff, fresh CI, reviews/threads를 다시 확인한다. child PR body의 마지막은 한국어 `## DoD Status`로 끝내며 `Closes #1353`와 최종 child에서만 `Closes #1422`를 사용한다.
+
+## Redisson plan traceability
+
+| 명세 acceptance | 계획 task | 증거 |
+|---|---|---|
+| Int/Double atomic increment | 2, 3 | empty-key `addAndGetAsync` round-trip |
+| `HINCRBYFLOAT` numeric codec | 2, 3, 4 | concrete composite codec와 remote read |
+| concurrent remote final value | 4 | `SuspendedJobTester(workers=4, rounds=32*8)` |
+| two-client invalidation | 4 | Awaitility 5초/100ms와 local reread |
+| bounded cancellation/cleanup | 1, 4, 6 | Future 5초, `@AfterAll`, ownership evidence |
+| unsupported/mismatched input | 4 | `RedisException` negative test |
+| README locale parity | 5 | exact task/name diff |
+| child module 6-R | 6 | review artifact와 P0/P1 table |
+
+## Rollback과 stop condition
+
+numeric example/test가 실패하면 Task 2–4 commit을 되돌리고 기존 `fastPutAsync` map example을 유지한다. `newRedisson(registerShutdown = false)`가 기존 test에 영향을 주면 signature 변경만 revert하고 shared default 동작을 복구한다. Redis future timeout, test-owned client leak, invalidation timeout, exact-head CI failure 또는 unresolved P1이면 merge-ready를 중단하고 해당 test·ownership·`## DoD Status`를 다시 검증한다. Redisson codec version, production API, 새 dependency를 추가하지 않는다.
+
+## 계획 완료 조건
+
+- 모든 checkbox가 실제 commit과 fresh command evidence로 완료된다.
+- Redisson child 6-R의 최신 P0/P1이 0이다.
+- Int/Double map의 front/back codec이 동일하고 invalidation이 bounded reread로 증명된다.
+- README locale, child issue, PR `## DoD Status`가 실제 test behavior와 일치한다.

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -137,10 +137,10 @@ fun `empty Int key is initialized by addAndGetAsync`() = runSuspendIO {
         LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
     )
 
-    val result = withTimeout(5.seconds) { map.addAndGetAsync("count", 32).await() }
+    val result = awaitRedis(map.addAndGetAsync("count", 32))
 
     result shouldBeEqualTo 32
-    withTimeout(5.seconds) { map.getAsync("count").await() } shouldBeEqualTo 32
+    awaitRedis(map.getAsync("count")) shouldBeEqualTo 32
 }
 
 @Test
@@ -150,10 +150,10 @@ fun `empty Double key is initialized by HINCRBYFLOAT`() = runSuspendIO {
         LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
     )
 
-    val result = withTimeout(5.seconds) { map.addAndGetAsync("ratio", 0.25).await() }
+    val result = awaitRedis(map.addAndGetAsync("ratio", 0.25))
 
     result shouldBeEqualTo 0.25
-    withTimeout(5.seconds) { map.getAsync("ratio").await() } shouldBeEqualTo 0.25
+    awaitRedis(map.getAsync("ratio")) shouldBeEqualTo 0.25
 }
 ```
 
@@ -190,12 +190,12 @@ val options = LocalCachedMapOptions.name<String, Int>(name)
 val cachedMap: RLocalCachedMap<String, Int> = redisson.getLocalCachedMap(options)
 val backendMap: RMap<String, Int> = redisson.getMap(name, intCodec)
 
-val first = withTimeout(5.seconds) { cachedMap.addAndGetAsync("count", 32).await() }
-val second = withTimeout(5.seconds) { cachedMap.addAndGetAsync("count", 10).await() }
+val first = awaitRedis(cachedMap.addAndGetAsync("count", 32))
+val second = awaitRedis(cachedMap.addAndGetAsync("count", 10))
 
 first shouldBeEqualTo 32
 second shouldBeEqualTo 42
-withTimeout(5.seconds) { backendMap.getAsync("count").await() } shouldBeEqualTo 42
+awaitRedis(backendMap.getAsync("count")) shouldBeEqualTo 42
 ```
 
 `fastPutAsync`로 같은 numeric key를 먼저 직렬화하지 않는다. key가 없을 때 Redis
@@ -212,9 +212,9 @@ val options = LocalCachedMapOptions.name<String, Double>(name)
 val cachedMap: RLocalCachedMap<String, Double> = redisson.getLocalCachedMap(options)
 val backendMap: RMap<String, Double> = redisson.getMap(name, doubleCodec)
 
-val result = withTimeout(5.seconds) { cachedMap.addAndGetAsync("ratio", 0.25).await() }
+val result = awaitRedis(cachedMap.addAndGetAsync("ratio", 0.25))
 result shouldBeEqualTo 0.25
-withTimeout(5.seconds) { backendMap.getAsync("ratio").await() } shouldBeEqualTo 0.25
+awaitRedis(backendMap.getAsync("ratio")) shouldBeEqualTo 0.25
 ```
 
 KDoc에는 Int/Double map을 섞지 않고 finite Double delta만 사용하며, `HINCRBYFLOAT`가 숫자 hash field를 요구한다는 제약을 한국어로 기록한다.
@@ -355,7 +355,7 @@ fun `concurrent numeric increments match independent remote final value`() = run
 같은 구조로 Double은 `0.25` delta와 `Double` codec을 사용하고, expected 값은
 `calls * 0.25`로 assertion한다. Double도 `redisson2.getLocalCachedMap`으로
 동일한 `name`과 `doubleCodec`을 사용한 두 번째 local view를 만들고,
-`withTimeout(5.seconds) { map2.getAsync("ratio").await() }`가
+`awaitRedis(map2.getAsync("ratio"))`가
 `calls * 0.25`와 일치하는지 확인한다. Int와 Double 모두 `redisson2` local
 view를 같은 5초 deadline으로 reread해 remote final value와 일치하는지
 확인한다. worker는 ad hoc thread를 만들지 않는다.
@@ -390,7 +390,7 @@ worker는 ad hoc thread를 만들지 않는다.
 기존 세 invalidation 테스트를 보존하면서 각 wrapper를 `runSuspendIO`로 바꾸고,
 모든 future를 `awaitRedis(future)`로 감싼다. remote `fastPutAsync`/`fastRemoveAsync`
 뒤에는 blocking `containsKey` 대신 `untilSuspending`에서
-`containsKeyAsync(key).await()`를 IO 경계로 평가한다. 다음 조건을
+`awaitRedis(containsKeyAsync(key))`를 IO 경계로 평가한다. 다음 조건을
 `atMost(5.seconds)`, 100ms poll로 기다린다.
 
 ```kotlin
@@ -423,13 +423,13 @@ message는 비교하지 않아 환경별 Redis endpoint를 노출하지 않는�
 fun `non numeric stored value is rejected by numeric increment`() = runSuspendIO {
     val name = randomName()
     val raw = redisson.getMap<String, String>(name, RedissonCodecs.String)
-    withTimeout(5.seconds) { raw.fastPutAsync("ratio", "not-a-number").await() }
+    awaitRedis(raw.fastPutAsync("ratio", "not-a-number"))
 
     val numeric = redisson1.getLocalCachedMap(
         LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
     )
     assertFailsWith<RedisException> {
-        withTimeout(5.seconds) { numeric.addAndGetAsync("ratio", 0.25).await() }
+        awaitRedis(numeric.addAndGetAsync("ratio", 0.25))
     }
 }
 ```

--- a/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
+++ b/docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md
@@ -260,9 +260,9 @@ second shouldBeEqualTo 42
 awaitRedis(backendMap.getAsync("count")) shouldBeEqualTo 42
 ```
 
-`fastPutAsync`로 같은 numeric key를 먼저 직렬화하지 않는다. key가 없을 때 Redis
-`HINCRBY` 경로가 초기값을 만들고, Double은 `HINCRBYFLOAT` 경로를 사용한다는 점을
-KDoc와 assertion으로 설명한다.
+`fastPutAsync`로 같은 numeric key를 먼저 직렬화하지 않는다. key가 없을 때 Redisson의
+`addAndGetAsync`가 Redis `HINCRBYFLOAT` 경로로 초기값을 만들고, Int/Double 모두
+동일한 atomic hash increment 계약을 사용한다는 점을 KDoc와 assertion으로 설명한다.
 
 - [ ] **Step 2: Double 예제와 제약 KDoc을 추가한다**
 
@@ -380,6 +380,9 @@ fun `concurrent numeric increments match independent remote final value`() = run
     val map = redisson1.getLocalCachedMap(
         LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
     )
+    val map2 = redisson2.getLocalCachedMap(
+        LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
+    )
     val calls = 32 * 8 // rounds는 전체 호출 수이고 workers는 동시 실행 수다.
 
     withTimeout(30.seconds) {
@@ -393,9 +396,11 @@ fun `concurrent numeric increments match independent remote final value`() = run
     val remote = redisson.getMap<String, Int>(name, intCodec)
     awaitRedis(remote.getAsync("count")) shouldBeEqualTo calls
 
-    val map2 = redisson2.getLocalCachedMap(
-        LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
-    )
+    await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
+        .untilSuspending {
+            awaitRedis(map.getAsync("count")) == calls &&
+                awaitRedis(map2.getAsync("count")) == calls
+        }
     awaitRedis(map.getAsync("count")) shouldBeEqualTo calls
     awaitRedis(map2.getAsync("count")) shouldBeEqualTo calls
 }
@@ -430,6 +435,12 @@ withTimeout(30.seconds) {
 }
 val remoteDouble = redisson.getMap<String, Double>(name, doubleCodec)
 awaitRedis(remoteDouble.getAsync("ratio")) shouldBeEqualTo calls * 0.25
+await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
+    .untilSuspending {
+        awaitRedis(doubleMap1.getAsync("ratio")) == calls * 0.25 &&
+            awaitRedis(doubleMap2.getAsync("ratio")) == calls * 0.25
+    }
+awaitRedis(doubleMap1.getAsync("ratio")) shouldBeEqualTo calls * 0.25
 awaitRedis(doubleMap2.getAsync("ratio")) shouldBeEqualTo calls * 0.25
 ```
 worker는 ad hoc thread를 만들지 않는다.

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -7,7 +7,7 @@
 - 브랜치: `feat/epic-1422-kafka-callback-flow`
 - 기준 base: `origin/develop`
   (`552d9921520492033ad650743e8696e6352402c2`)
-- 검토 head: `c5620044c55c5e75768c05cd15c793ebef4ddf13`
+- 검토 head: `45e8e3d23501defbbb0d2b45e9cfbb1fa006f64f`
 - 변경 범위: `examples/coroutines-demo` Kafka `callbackFlow` 예제·테스트,
   해당 Testcontainers 의존성, Examples workflow의 compile/test 경계,
   fail-closed 진단 수집기·회귀 테스트, 한·영 README와 승인된 설계·계획 문서
@@ -61,7 +61,7 @@ container의 실제 `Image` ID를 inspect 대상으로 우선하고 반환 `Id`�
 그 후 exact-head `21c5ffee990a2884dc25d596c3eea72dad29eb41`의 Examples run은
 모든 Gradle test task와 image provenance 검사를 통과했지만, report 산출물이
 211개로 기존 workflow 상한 200개를 초과해 `report_truncated=true`로 종료됐다.
-현재 head에서 바이트 상한 2,000,000 bytes와 fail-closed collector 동작은
+당시 head에서 바이트 상한 2,000,000 bytes와 fail-closed collector 동작은
 유지하면서 Examples workflow report file 상한을 400개로 올려 suite 전체를
 수용하도록 정합화했다.
 
@@ -75,6 +75,14 @@ report budget만 8,000,000 bytes로 확장해 현재 suite의 전체 증거를 �
 mutable `Config.Image` tag로 보완하지 않고 즉시 거부하도록 보강했다. 해당 P2
 경계의 RED/GREEN 회귀와 전체 diagnostics 19개 테스트가 통과했으며,
 `review_ops` 후속 검토에서 P0=0/P1=0으로 확인했다.
+
+그 뒤 exact-head `2f2f05bd0d2825dcd0cc9dd7ea752dd8418bc328`의 Examples run은
+9개 Gradle test task를 모두 `BUILD SUCCESSFUL`로 완료했고 artifact에 411개
+파일을 올렸지만, report-scan manifest가 `report_truncated=true`와 400개
+파일로 종료됐다. 8,000,000 bytes 예산 자체는 2,938,789 bytes만 사용했으므로
+바이트 부족이 아니라 file cap이 원인이었다. 따라서 다음 exact-head에서는
+개별 container log의 2MB 및 전체 report 8MB 상한은 유지하고, suite 산출량에
+여유를 둔 Examples report file 상한을 600개로 올린다.
 
 ## Bluetape4k 적용 근거
 

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -7,7 +7,7 @@
 - 브랜치: `feat/epic-1422-kafka-callback-flow`
 - 기준 base: `origin/develop`
   (`552d9921520492033ad650743e8696e6352402c2`)
-- 검토 head: `dc16db4d993b0d8afaa6267fa1add5cec42b3879`
+- 검토 head: `c5620044c55c5e75768c05cd15c793ebef4ddf13`
 - 변경 범위: `examples/coroutines-demo` Kafka `callbackFlow` 예제·테스트,
   해당 Testcontainers 의존성, Examples workflow의 compile/test 경계,
   fail-closed 진단 수집기·회귀 테스트, 한·영 README와 승인된 설계·계획 문서
@@ -71,6 +71,11 @@ container의 실제 `Image` ID를 inspect 대상으로 우선하고 반환 `Id`�
 report budget만 8,000,000 bytes로 확장해 현재 suite의 전체 증거를 보존하도록
 조정했다.
 
+최신 head `c5620044c5`에서는 실행 중인 container `Image` ID가 없는 응답을
+mutable `Config.Image` tag로 보완하지 않고 즉시 거부하도록 보강했다. 해당 P2
+경계의 RED/GREEN 회귀와 전체 diagnostics 19개 테스트가 통과했으며,
+`review_ops` 후속 검토에서 P0=0/P1=0으로 확인했다.
+
 ## Bluetape4k 적용 근거
 
 - `io.bluetape4k.assertions`: `assertFailsWith`, `shouldBeEqualTo`,
@@ -91,7 +96,7 @@ report budget만 8,000,000 bytes로 확장해 현재 suite의 전체 증거를 �
 | TDD RED | 구현 전 targeted test가 `unresolved reference: producerResults`로 실패함을 확인했다. |
 | Targeted Kotlin | `CallbackFlowExamples`: `SUCCESS: Executed 21 tests in 1m 7s`, XML `21 tests / 0 skipped / 0 failures / 0 errors`, `BUILD SUCCESSFUL`. |
 | Module Kotlin | `:bluetape4k-examples-coroutines-demo:test --no-daemon --rerun-tasks --no-configuration-cache --max-workers=1`: XML 39 files, `148 total / 147 executed / 3 skipped / 0 failures / 0 errors`, `SUCCESS: Executed 147 tests (2 skipped)`, `BUILD SUCCESSFUL`. Testcontainers는 Colima Docker socket으로 순차 실행했다. |
-| Diagnostics Python | `py_compile` 및 `unittest discover`: 18 tests, `OK`; container inspect에 `RepoDigests`가 없는 실제 Docker smoke와 mutable tag/image-ID 불일치 거부 회귀가 통과했다. |
+| Diagnostics Python | `py_compile` 및 `unittest discover`: 19 tests, `OK`; container inspect에 `RepoDigests`가 없는 실제 Docker smoke, mutable tag/image-ID 불일치 거부, 실행 image ID 누락 거부 회귀가 통과했다. |
 | Static | `ruff check --ignore EXE001`, `actionlint .github/workflows/examples.yml`, workflow `shellcheck -s bash`, PyYAML parse 통과. raw Ruff의 EXE001은 100644 script mode 경고만 남아 의도적으로 mode를 바꾸지 않았다. |
 | Documentation | README 한·영 parity와 한국어 용어 검사 통과; `git diff --check` 통과. |
 | Provenance | local manifest의 action ref 4개가 모두 40자리 commit SHA이며 Kafka image digest가 고정됐다. |

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -7,7 +7,7 @@
 - 브랜치: `feat/epic-1422-kafka-callback-flow`
 - 기준 base: `origin/develop`
   (`552d9921520492033ad650743e8696e6352402c2`)
-- 검토 head: `45e8e3d23501defbbb0d2b45e9cfbb1fa006f64f`
+- 검토 head: `28d599863ea9a3a563ce0061c441ca72e415e879`
 - 변경 범위: `examples/coroutines-demo` Kafka `callbackFlow` 예제·테스트,
   해당 Testcontainers 의존성, Examples workflow의 compile/test 경계,
   fail-closed 진단 수집기·회귀 테스트, 한·영 README와 승인된 설계·계획 문서

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -7,7 +7,7 @@
 - 브랜치: `feat/epic-1422-kafka-callback-flow`
 - 기준 base: `origin/develop`
   (`552d9921520492033ad650743e8696e6352402c2`)
-- 검토 head: `28d599863ea9a3a563ce0061c441ca72e415e879`
+- 검토 head: `82c28a6a6f719b1c2471e84d07bc5300342dfc60`
 - 변경 범위: `examples/coroutines-demo` Kafka `callbackFlow` 예제·테스트,
   해당 Testcontainers 의존성, Examples workflow의 compile/test 경계,
   fail-closed 진단 수집기·회귀 테스트, 한·영 README와 승인된 설계·계획 문서
@@ -100,6 +100,18 @@ stdout/stderr 블록을 `[REDACTED]` placeholder로 compact하도록 보정한�
 반영된 다음 exact-head hosted Examples run에서 report manifest와 aggregate
 status를 다시 확인한다.
 
+최신 exact-head `82c28a6a6f719b1c2471e84d07bc5300342dfc60`의 Examples run
+`32994262529`에서는 직전 `outside the diagnostics allowlist` 원인을 닫았다.
+앞선 run에서 `coroutines` Kafka와 `redisson` Redis의 Gradle test task는 모두
+`BUILD SUCCESSFUL`이었지만, `org.testcontainers=true`만 사용한 before/after
+snapshot에 session ID가 없는 Ryuk cleanup helper가 포함됐다. 이를 allowlist에
+추가하지 않고 workflow snapshot을 `org.testcontainers.sessionId`까지 함께
+필터링해 현재 test session의 실제 컨테이너만 수집하도록 보정했다. 결과는
+compile·9개 순차 test·diagnostics·artifact upload 모두 성공(9분 38초)이며,
+report-scan manifest는 507개 report / 399,325 bytes,
+`truncated=false`, `report_truncated=false`였다. 같은 head의 CI run
+`32994262718`도 required jobs와 aggregate coverage를 모두 성공했다.
+
 ## Bluetape4k 적용 근거
 
 - `io.bluetape4k.assertions`: `assertFailsWith`, `shouldBeEqualTo`,
@@ -124,7 +136,8 @@ status를 다시 확인한다.
 | Static | `ruff check --ignore EXE001`, `actionlint .github/workflows/examples.yml`, workflow `shellcheck -s bash`, PyYAML parse 통과. raw Ruff의 EXE001은 100644 script mode 경고만 남아 의도적으로 mode를 바꾸지 않았다. |
 | Documentation | README 한·영 parity와 한국어 용어 검사 통과; `git diff --check` 통과. |
 | Provenance | local manifest의 action ref 4개가 모두 40자리 commit SHA이며 Kafka image digest가 고정됐다. |
-| Sanitized report | callback module 8 reports / 38,059 bytes, `report_truncated=false`, `secretKey`·`secret_key` 포함 민감정보 scan clean. |
+| Sanitized report | callback module 8 reports / 38,059 bytes, `report_truncated=false`, `secretKey`·`secret_key` 포함 민감정보 scan clean. Hosted exact-head report-scan은 507 reports / 399,325 bytes, `truncated=false`, `report_truncated=false`였다. |
+| Hosted exact-head | `82c28a6a6` / Examples `32994262529`: 9개 test task·diagnostics·artifact 성공. CI `32994262718`: 전체 required job 및 aggregate coverage 성공. |
 | Detekt | `:bluetape4k-examples-coroutines-demo:detekt` task가 없어 N/A; root detekt는 examples를 포함하지 않는다. |
 
 ## 잔여 P2/P3
@@ -138,6 +151,9 @@ status를 다시 확인한다.
 - P2: `ShutdownQueue`가 Testcontainers 종료 뒤 상태 자료에서 `containerId=null`
   로 보이는 것은 정상 cleanup 결과지만, 운영 진단 문서에 lifecycle 의미를
   계속 명시해야 한다.
+- P2: `org.testcontainers.sessionId` filter는 재사용 컨테이너처럼 session label이
+  없는 대상을 수집하지 않는다. 현재 Examples에는 `withReuse` 설정이 없으므로
+  범위 밖이며, 재사용 컨테이너를 도입할 때는 별도 provenance 경계를 설계해야 한다.
 - P3: 일부 테스트의 raw `require` 메시지는 Bluetape assertion helper로
   통일할 수 있으나 현재 동작·계약 결함은 아니다.
 
@@ -152,7 +168,7 @@ thread, 승인, mergeability는 이 head를 원격에 publish한 뒤 fresh rerea
 ## DoD Status
 
 - 상태: `PASS WITH FOLLOW-UP`
-- P0: `0`, P1: `0`, P2: `4`, P3: `1`
+- P0: `0`, P1: `0`, P2: `5`, P3: `1`
 - 로컬 module test·diagnostics·static·문서·provenance 증거와 hosted failure
   원인/보정 증거를 최신 구현 head에 맞춰 갱신했다.
 - 다음 게이트: 최신 head push 후 PR hosted CI·reviews·threads·linked issue·

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -7,7 +7,7 @@
 - 브랜치: `feat/epic-1422-kafka-callback-flow`
 - 기준 base: `origin/develop`
   (`552d9921520492033ad650743e8696e6352402c2`)
-- 검토 head: `f500e547a2c9e63e4ac917c2c621e8b4e722225a`
+- 검토 head: `21c5ffee990a2884dc25d596c3eea72dad29eb41`
 - 변경 범위: `examples/coroutines-demo` Kafka `callbackFlow` 예제·테스트,
   해당 Testcontainers 의존성, Examples workflow의 compile/test 경계,
   fail-closed 진단 수집기·회귀 테스트, 한·영 README와 승인된 설계·계획 문서
@@ -44,6 +44,16 @@ P1도 이 head에 반영했다. P2/P3는 현재 동작을 막지는 않지만 �
 4. diagnostics redaction이 `secretKey`와 `secret_key` 변형도 제거하도록
    sanitizer와 회귀 fixture를 보강했다.
 
+### Hosted exact-head 후속 보정
+
+이전 exact-head `432df634fd9147bf6c341bf2dbc4944e46dc7c0c`의 Examples run은
+9개 Gradle 예제 테스트 task를 모두 `BUILD SUCCESSFUL`로 끝냈지만, 실제
+Docker container inspect 응답에 `RepoDigests`가 없어 진단 수집기가
+fail-closed로 종료됐다. 이는 container inspect와 image inspect의 필드 경계를
+혼동한 구현 결함으로, `21c5ffee990a2884dc25d596c3eea72dad29eb41`에서
+`docker image inspect`로 immutable allowlist digest를 해석하도록 보정하고
+실제 Docker 응답 형태를 모사한 회귀 테스트를 추가했다.
+
 ## Bluetape4k 적용 근거
 
 - `io.bluetape4k.assertions`: `assertFailsWith`, `shouldBeEqualTo`,
@@ -64,7 +74,7 @@ P1도 이 head에 반영했다. P2/P3는 현재 동작을 막지는 않지만 �
 | TDD RED | 구현 전 targeted test가 `unresolved reference: producerResults`로 실패함을 확인했다. |
 | Targeted Kotlin | `CallbackFlowExamples`: `SUCCESS: Executed 21 tests in 1m 7s`, XML `21 tests / 0 skipped / 0 failures / 0 errors`, `BUILD SUCCESSFUL`. |
 | Module Kotlin | `:bluetape4k-examples-coroutines-demo:test --no-daemon --rerun-tasks --no-configuration-cache --max-workers=1`: XML 39 files, `148 total / 147 executed / 3 skipped / 0 failures / 0 errors`, `SUCCESS: Executed 147 tests (2 skipped)`, `BUILD SUCCESSFUL`. Testcontainers는 Colima Docker socket으로 순차 실행했다. |
-| Diagnostics Python | `py_compile` 및 `unittest discover`: 16 tests, `OK`. |
+| Diagnostics Python | `py_compile` 및 `unittest discover`: 17 tests, `OK`; container inspect에 `RepoDigests`가 없는 실제 Docker smoke도 통과했다. |
 | Static | `ruff check --ignore EXE001`, `actionlint .github/workflows/examples.yml`, workflow `shellcheck -s bash`, PyYAML parse 통과. raw Ruff의 EXE001은 100644 script mode 경고만 남아 의도적으로 mode를 바꾸지 않았다. |
 | Documentation | README 한·영 parity와 한국어 용어 검사 통과; `git diff --check` 통과. |
 | Provenance | local manifest의 action ref 4개가 모두 40자리 commit SHA이며 Kafka image digest가 고정됐다. |
@@ -97,7 +107,7 @@ thread, 승인, mergeability는 이 head를 원격에 publish한 뒤 fresh rerea
 
 - 상태: `PASS WITH FOLLOW-UP`
 - P0: `0`, P1: `0`, P2: `4`, P3: `1`
-- 로컬 module test·diagnostics·static·문서·provenance 증거를 최신 head에
-  맞춰 갱신했다.
+- 로컬 module test·diagnostics·static·문서·provenance 증거와 hosted failure
+  원인/보정 증거를 최신 구현 head에 맞춰 갱신했다.
 - 다음 게이트: 최신 head push 후 PR hosted CI·reviews·threads·linked issue·
   mergeability를 fresh 확인하고 `CG-16` 병합 승인을 별도로 받는다.

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -7,7 +7,7 @@
 - 브랜치: `feat/epic-1422-kafka-callback-flow`
 - 기준 base: `origin/develop`
   (`552d9921520492033ad650743e8696e6352402c2`)
-- 검토 head: `21c5ffee990a2884dc25d596c3eea72dad29eb41`
+- 검토 head: `dc16db4d993b0d8afaa6267fa1add5cec42b3879`
 - 변경 범위: `examples/coroutines-demo` Kafka `callbackFlow` 예제·테스트,
   해당 Testcontainers 의존성, Examples workflow의 compile/test 경계,
   fail-closed 진단 수집기·회귀 테스트, 한·영 README와 승인된 설계·계획 문서
@@ -51,8 +51,19 @@ P1도 이 head에 반영했다. P2/P3는 현재 동작을 막지는 않지만 �
 Docker container inspect 응답에 `RepoDigests`가 없어 진단 수집기가
 fail-closed로 종료됐다. 이는 container inspect와 image inspect의 필드 경계를
 혼동한 구현 결함으로, `21c5ffee990a2884dc25d596c3eea72dad29eb41`에서
-`docker image inspect`로 immutable allowlist digest를 해석하도록 보정하고
-실제 Docker 응답 형태를 모사한 회귀 테스트를 추가했다.
+`docker image inspect`로 immutable allowlist digest를 해석하도록 보정했다.
+후속 검토에서 `Config.Image` 태그가 재지정될 때 실행 image provenance가
+어긋날 수 있는 P1을 확인했고, `dc16db4d993b0d8afaa6267fa1add5cec42b3879`에서
+container의 실제 `Image` ID를 inspect 대상으로 우선하고 반환 `Id`가 정확히
+일치할 때만 allowlist digest를 신뢰하도록 보강했다. 두 경계를 실제 Docker
+응답 형태를 모사한 회귀 테스트로 고정했다.
+
+그 후 exact-head `21c5ffee990a2884dc25d596c3eea72dad29eb41`의 Examples run은
+모든 Gradle test task와 image provenance 검사를 통과했지만, report 산출물이
+211개로 기존 workflow 상한 200개를 초과해 `report_truncated=true`로 종료됐다.
+현재 head에서 바이트 상한 2,000,000 bytes와 fail-closed collector 동작은
+유지하면서 Examples workflow report file 상한을 400개로 올려 suite 전체를
+수용하도록 정합화했다.
 
 ## Bluetape4k 적용 근거
 
@@ -74,7 +85,7 @@ fail-closed로 종료됐다. 이는 container inspect와 image inspect의 필드
 | TDD RED | 구현 전 targeted test가 `unresolved reference: producerResults`로 실패함을 확인했다. |
 | Targeted Kotlin | `CallbackFlowExamples`: `SUCCESS: Executed 21 tests in 1m 7s`, XML `21 tests / 0 skipped / 0 failures / 0 errors`, `BUILD SUCCESSFUL`. |
 | Module Kotlin | `:bluetape4k-examples-coroutines-demo:test --no-daemon --rerun-tasks --no-configuration-cache --max-workers=1`: XML 39 files, `148 total / 147 executed / 3 skipped / 0 failures / 0 errors`, `SUCCESS: Executed 147 tests (2 skipped)`, `BUILD SUCCESSFUL`. Testcontainers는 Colima Docker socket으로 순차 실행했다. |
-| Diagnostics Python | `py_compile` 및 `unittest discover`: 17 tests, `OK`; container inspect에 `RepoDigests`가 없는 실제 Docker smoke도 통과했다. |
+| Diagnostics Python | `py_compile` 및 `unittest discover`: 18 tests, `OK`; container inspect에 `RepoDigests`가 없는 실제 Docker smoke와 mutable tag/image-ID 불일치 거부 회귀가 통과했다. |
 | Static | `ruff check --ignore EXE001`, `actionlint .github/workflows/examples.yml`, workflow `shellcheck -s bash`, PyYAML parse 통과. raw Ruff의 EXE001은 100644 script mode 경고만 남아 의도적으로 mode를 바꾸지 않았다. |
 | Documentation | README 한·영 parity와 한국어 용어 검사 통과; `git diff --check` 통과. |
 | Provenance | local manifest의 action ref 4개가 모두 40자리 commit SHA이며 Kafka image digest가 고정됐다. |

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -65,6 +65,12 @@ container의 실제 `Image` ID를 inspect 대상으로 우선하고 반환 `Id`�
 유지하면서 Examples workflow report file 상한을 400개로 올려 suite 전체를
 수용하도록 정합화했다.
 
+후속 exact-head `61489437d5` run에서는 report file 상한을 통과하고 265개 파일을
+수집했지만, 실제 sanitized 결과가 2,000,000 bytes에 도달해 같은 fail-closed
+경계로 종료됐다. 개별 container log의 2MB budget은 유지하고, Examples 전체
+report budget만 8,000,000 bytes로 확장해 현재 suite의 전체 증거를 보존하도록
+조정했다.
+
 ## Bluetape4k 적용 근거
 
 - `io.bluetape4k.assertions`: `assertFailsWith`, `shouldBeEqualTo`,

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -1,86 +1,103 @@
 # Epic #1422 / #1347 Kafka callbackFlow 6-R 검토
 
-## DoD Status
+## 검토 범위
 
-- 상태: `PASS WITH FOLLOW-UP`
-- 범위: Epic #1422의 선행 child #1347만 검토한다. #1353 Redisson child는
-  이번 train에 포함하지 않는다.
+- 대상: Epic #1422의 선행 child #1347만 검토한다. #1353 Redisson child는
+  이번 train의 다음 child로 유지한다.
+- 브랜치: `feat/epic-1422-kafka-callback-flow`
 - 기준 base: `origin/develop`
   (`552d9921520492033ad650743e8696e6352402c2`)
-- 검토 head: `9869759575c0676bb42bb7d3b4b6a2aa18395732`
-- 브랜치: `feat/epic-1422-kafka-callback-flow`
-- P0: `0`
-- P1: `0`
-- P2: `4` (후속 개선으로 추적)
-- P3: `0`
-- 다음 게이트: PR hosted CI 및 exact-head merge 재검토 (`CG-16`)
-
-## 변경 범위
-
-- `examples/coroutines-demo`의 Kafka `callbackFlow` 실행 예제와 테스트
-- 해당 예제의 testcontainers 의존성
-- Examples workflow의 compile/test 직렬화와 fail-closed 진단 수집
-- 진단 수집기·회귀 테스트, 두 언어 README, 승인된 Epic 설계/실행 계획 문서
-- public production API, Kafka adapter, Redisson 구현, 새 module은 변경하지 않음
+- 검토 head: `b295222363c3f0cc527c641aedce6905f8ae14e1c`
+- 변경 범위: `examples/coroutines-demo` Kafka `callbackFlow` 예제·테스트,
+  해당 Testcontainers 의존성, Examples workflow의 compile/test 경계,
+  fail-closed 진단 수집기·회귀 테스트, 한·영 README와 승인된 설계·계획 문서
+- 비범위: public production API, Kafka adapter, Redisson 구현, 새 module
 
 ## 6-R 검토 결과
 
-모든 lane은 현재 OMX capability table의 `gpt-5.6-luna` / `max` 설정으로
-독립 검토했다. 아래 P2는 현재 동작을 막는 결함이 아니지만 다음 수정자가
+초기 6개 독립 lane은 현재 OMX capability table의
+`gpt-5.6-luna` / `max` 설정으로 수행했고, 후속 native review에서 발견된
+P1도 이 head에 반영했다. P2/P3는 현재 동작을 막지는 않지만 다음 수정자가
 재검토해야 할 경계다.
 
 | Lens | Lane | 결과 | 핵심 근거 |
 |---|---|---|---|
-| Requirements / User-Caller | `review_user` (Euclid) | PASS WITH FOLLOW-UP | README 명령·Docker 전제·partial result 및 취소 의미가 실제 코드와 일치한다. P3 문구 모호성은 수정했다. |
-| Ops / CI diagnostics | `review_ops` (Harvey) | PASS WITH FOLLOW-UP | 비정상 Docker logs와 log truncation provenance를 fail-closed로 처리하고, action SHA·artifact 경계를 고정했다. `run_docker` inspect stdout/stderr 캡처 상한은 P2다. |
-| Developer API / failure contract | `review_api` (Ampere) | PASS WITH FOLLOW-UP | 첫 원인, cancellation sentinel, bounded flush/close, `hasCause` identity 검증이 보존된다. `Future.cancel(false)`의 underlying Kafka send 중단 보장과 null/null callback 정책은 P2다. |
+| Requirements / User-Caller | `review_user` (Euclid) | PASS WITH FOLLOW-UP | README 명령·Docker 전제·partial result·취소 의미가 실제 코드와 일치한다. KDoc 위치와 cancellation 문구를 보정했다. |
+| Ops / CI diagnostics | `review_ops` (Harvey) | PASS WITH FOLLOW-UP | 비정상 Docker logs와 log truncation provenance를 fail-closed로 처리하고 action SHA·artifact 경계를 고정했다. `run_docker` inspect stdout/stderr 캡처 상한은 P2다. |
+| Developer API / failure contract | `review_api` (Ampere) | PASS WITH FOLLOW-UP | 첫 원인, cancellation sentinel, bounded flush/close, wrapper identity, malformed callback 계약을 보존한다. `Future.cancel(false)`가 이미 Kafka에 제출된 send 중단을 보장하지 않는 점은 P2다. |
 | Performance | `Nietzsche` | PASS WITH FOLLOW-UP | `maxInFlight` semaphore와 단일 IO worker, bounded drain/close로 범위를 제한한다. Kafka future 취소 후 최대 30초 flush 대기는 P2이며 benchmark 주장은 하지 않는다. |
 | Security / Supply chain | `Bernoulli` | PASS WITH FOLLOW-UP | URI·assignment·XML/exception 민감정보 redaction, bounded report walk/read, symlink·path traversal 차단, immutable action/image provenance를 확인했다. inspect 출력 상한은 P2다. |
-| Stability / Lifecycle | `Galileo` | PASS WITH FOLLOW-UP | late callback 무시, in-flight 취소, producer 단일 close, cancellation 중 close failure suppression, 실제 Kafka fixture 종료 경계를 검증했다. malformed callback의 null metadata/null cause는 P2다. |
+| Stability / Lifecycle | `Galileo` | PASS WITH FOLLOW-UP | late callback 무시, in-flight 취소, producer 단일 close, cancellation 중 close failure suppression, 실제 Kafka fixture 종료 경계를 검증했다. post-task Docker snapshot이 비어 있을 수 있는 lifecycle은 P2다. |
 
-## 적용한 보정
+### 후속 검토에서 반영한 P1 수정
 
-1. `callbackFlow` producer 생성은 lazy worker 안에서 수행하고, collection별
-   producer 소유권과 `awaitClose` cancellation을 연결했다.
-2. callback·동기 send·upstream·flush·close 예외를 하나의 terminal 상태로
-   수렴시키고, cleanup 예외는 첫 원인에 suppressed cause로 보존한다.
-3. `kotlinx.coroutines`가 suspend 경계에서 복사한 예외만 boundary 표식과
-   동일 type/message 조건으로 제한적으로 unwrap하며, 원인 identity를
-   `hasCause`로 검증한다.
-4. callback drain, in-flight semaphore, producer flush/close, consumer poll/close에
-   bounded timeout을 적용하고 `NonCancellable + Dispatchers.IO` 정리를 사용한다.
-5. Testcontainers Kafka image digest, dynamic port, unique topic, `ShutdownQueue`,
-   action commit SHA를 고정했다.
-6. 진단 수집은 bounded scanner/read와 symlink/path 검증을 사용하고, Docker
-   logs non-zero 및 truncation을 manifest와 exit status에 반영한다. 원본
-   report는 artifact에 올리지 않고 sanitized 사본만 업로드한다.
-7. README 한·영 parity와 한국어 용어 검사를 통과하도록 cancellation 및
-   broker polling 설명을 실제 동작에 맞췄다.
+1. callback registration handoff 중 collector cancellation이 발생해도
+   `SendState`가 `cancelState`를 통해 in-flight 집합과 semaphore에서 반드시
+   해제되도록 registration 전·후 terminal check와 결정적 회귀 테스트를
+   추가했다.
+2. 같은 타입의 예외를 임의의 cause로 unwrap하지 않도록 coroutine boundary
+   표식·동일 type/message 조건을 유지하고, 원본 wrapper와 cleanup cause의
+   identity를 `shouldBeSameInstanceAs`로 검증했다.
+3. Kafka callback이 metadata와 failure를 모두 주지 않는 malformed callback은
+   성공으로 끝내지 않고 명시적인 `IllegalStateException` terminal cause로
+   수렴시켰다.
+4. diagnostics redaction이 `secretKey`와 `secret_key` 변형도 제거하도록
+   sanitizer와 회귀 fixture를 보강했다.
+
+## Bluetape4k 적용 근거
+
+- `io.bluetape4k.assertions`: `assertFailsWith`, `shouldBeEqualTo`,
+  `shouldBeSameInstanceAs`, `shouldHaveSize`, `shouldBeTrue`, coroutine
+  `assertResult`를 사용해 예외·identity·컬렉션 계약을 검증했다.
+- `io.bluetape4k.junit5.coroutines.runSuspendIO`와
+  `io.bluetape4k.junit5.awaitility.untilSuspending`으로 blocking Kafka
+  handoff를 IO 경계 안에서 검증했다.
+- `KafkaServer.Launcher`, `ShutdownQueue`, `Base58`, Flow `log` 확장을
+  사용하고, Kafka image는 digest로 고정했다.
+- 기존 version catalog/BOM alias를 사용했으며 개별 Bluetape BOM/version을
+  새로 pin하지 않았다.
 
 ## 검증 증거
 
 | Check | Evidence |
 |---|---|
 | TDD RED | 구현 전 targeted test가 `unresolved reference: producerResults`로 실패함을 확인했다. |
-| Targeted Kotlin | `CallbackFlowExamples`: 18 tests, 0 skipped, 0 failures, 0 errors; `BUILD SUCCESSFUL`. |
-| Module Kotlin | `:bluetape4k-examples-coroutines-demo:test`: 145 total, 3 skipped, 0 failures, 0 errors; `BUILD SUCCESSFUL`. 실행 기준 통과 수는 142다. |
+| Targeted Kotlin | callback cancellation·wrapper identity·malformed callback을 포함한 영향 9 tests: `SUCCESS: Executed 9 tests in 1.9s`, `BUILD SUCCESSFUL`. 추가 upstream/close/wrapper 3 tests도 `SUCCESS: Executed 3 tests in 1.3s`. |
+| Module Kotlin | `:bluetape4k-examples-coroutines-demo:test --no-daemon --no-build-cache --no-configuration-cache --rerun-tasks --max-workers=1`: `SUCCESS: Executed 147 tests in 1m 9s (2 skipped)`, `BUILD SUCCESSFUL in 3m 10s`. Testcontainers는 Colima Docker socket으로 순차 실행했다. |
 | Diagnostics Python | `py_compile` 및 `unittest discover`: 16 tests, `OK`. |
-| Static | `ruff check --ignore EXE001` 및 `actionlint .github/workflows/examples.yml` 통과. |
-| Shell/YAML | workflow test block `shellcheck -s bash`, PyYAML parse 통과. |
-| Documentation | README parity 통과; `audit-korean-terms.mjs` 2 files, findings 0. |
-| Provenance | local manifest action refs 4개 모두 40자리 commit SHA, container 0, `truncated=false`. |
-| Sanitized report | callback module 10 reports / 51,789 bytes, `report_truncated=false`, 민감정보 패턴 scan clean. |
-| Diff hygiene | `git diff --check` 통과. |
-| Detekt | `:bluetape4k-examples-coroutines-demo:detekt` task가 없어 N/A; root detekt는 examples를 포함하지 않음. |
+| Static | `ruff check --ignore EXE001`, `actionlint .github/workflows/examples.yml`, workflow `shellcheck -s bash`, PyYAML parse 통과. raw Ruff의 EXE001은 100644 script mode 경고만 남아 의도적으로 mode를 바꾸지 않았다. |
+| Documentation | README 한·영 parity와 한국어 용어 검사 통과; `git diff --check` 통과. |
+| Provenance | local manifest의 action ref 4개가 모두 40자리 commit SHA이며 Kafka image digest가 고정됐다. |
+| Sanitized report | callback module 10 reports / 51,789 bytes, `report_truncated=false`, `secretKey`·`secret_key` 포함 민감정보 scan clean. |
+| Detekt | `:bluetape4k-examples-coroutines-demo:detekt` task가 없어 N/A; root detekt는 examples를 포함하지 않는다. |
 
-## 문서 품질
+## 잔여 P2/P3
 
-SPW-01(독자·목적), SPW-02(명령 재현성), SPW-03(실패/취소 의미),
-SPW-04(한·영 parity), SPW-05(민감정보·운영 경계)를 모두 PASS로 판정했다.
+- P2: `Future.cancel(false)`는 이미 broker client에 제출된 Kafka send의
+  중단을 보장하지 않으므로 bounded flush/close가 최종 경계다.
+- P2: diagnostics의 Docker inspect stdout/stderr 캡처는 별도 상한을 두는
+  후속 hardening이 필요하다.
+- P2: compile parallel 대비 test serial의 개선폭을 정량 비교하는 baseline은
+  아직 없다.
+- P2: `ShutdownQueue`가 Testcontainers 종료 뒤 snapshot에서 `containerId=null`
+  로 보이는 것은 정상 cleanup 결과지만, 운영 진단 문서에 lifecycle 의미를
+  계속 명시해야 한다.
+- P3: 일부 테스트의 raw `require` 메시지는 Bluetape assertion helper로
+  통일할 수 있으나 현재 동작·계약 결함은 아니다.
 
 ## Merge gate
 
-로컬 검증과 6-R review는 완료했지만 hosted CI, PR thread/review, exact-head
-mergeability는 아직 증거가 없다. 따라서 `CG-16`은 보류한다. fresh head/base,
-checks, reviews, threads, linked issue와 mergeability를 다시 읽고 별도 승인을
-받기 전에는 merge·auto-merge·#1353 착수를 수행하지 않는다.
+로컬 6-R review와 exact-head module 검증은 완료했다. PR hosted CI, review
+thread, 승인, mergeability는 이 head를 원격에 publish한 뒤 fresh reread해야
+한다. `CG-16`은 그때까지 보류하며, PR merge·auto-merge·#1353 착수는 수행하지
+않는다. 두 child를 모두 검증한 뒤 한 번에 병합하는 stacked train 정책을
+유지한다.
+
+## DoD Status
+
+- 상태: `PASS WITH FOLLOW-UP`
+- P0: `0`, P1: `0`, P2: `4`, P3: `1`
+- 로컬 module test·diagnostics·static·문서·provenance 증거를 최신 head에
+  맞춰 갱신했다.
+- 다음 게이트: 최신 head push 후 PR hosted CI·reviews·threads·linked issue·
+  mergeability를 fresh 확인하고 `CG-16` 병합 승인을 별도로 받는다.

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -1,0 +1,86 @@
+# Epic #1422 / #1347 Kafka callbackFlow 6-R 검토
+
+## DoD Status
+
+- 상태: `PASS WITH FOLLOW-UP`
+- 범위: Epic #1422의 선행 child #1347만 검토한다. #1353 Redisson child는
+  이번 train에 포함하지 않는다.
+- 기준 base: `origin/develop`
+  (`552d9921520492033ad650743e8696e6352402c2`)
+- 검토 head: `9869759575c0676bb42bb7d3b4b6a2aa18395732`
+- 브랜치: `feat/epic-1422-kafka-callback-flow`
+- P0: `0`
+- P1: `0`
+- P2: `4` (후속 개선으로 추적)
+- P3: `0`
+- 다음 게이트: PR hosted CI 및 exact-head merge 재검토 (`CG-16`)
+
+## 변경 범위
+
+- `examples/coroutines-demo`의 Kafka `callbackFlow` 실행 예제와 테스트
+- 해당 예제의 testcontainers 의존성
+- Examples workflow의 compile/test 직렬화와 fail-closed 진단 수집
+- 진단 수집기·회귀 테스트, 두 언어 README, 승인된 Epic 설계/실행 계획 문서
+- public production API, Kafka adapter, Redisson 구현, 새 module은 변경하지 않음
+
+## 6-R 검토 결과
+
+모든 lane은 현재 OMX capability table의 `gpt-5.6-luna` / `max` 설정으로
+독립 검토했다. 아래 P2는 현재 동작을 막는 결함이 아니지만 다음 수정자가
+재검토해야 할 경계다.
+
+| Lens | Lane | 결과 | 핵심 근거 |
+|---|---|---|---|
+| Requirements / User-Caller | `review_user` (Euclid) | PASS WITH FOLLOW-UP | README 명령·Docker 전제·partial result 및 취소 의미가 실제 코드와 일치한다. P3 문구 모호성은 수정했다. |
+| Ops / CI diagnostics | `review_ops` (Harvey) | PASS WITH FOLLOW-UP | 비정상 Docker logs와 log truncation provenance를 fail-closed로 처리하고, action SHA·artifact 경계를 고정했다. `run_docker` inspect stdout/stderr 캡처 상한은 P2다. |
+| Developer API / failure contract | `review_api` (Ampere) | PASS WITH FOLLOW-UP | 첫 원인, cancellation sentinel, bounded flush/close, `hasCause` identity 검증이 보존된다. `Future.cancel(false)`의 underlying Kafka send 중단 보장과 null/null callback 정책은 P2다. |
+| Performance | `Nietzsche` | PASS WITH FOLLOW-UP | `maxInFlight` semaphore와 단일 IO worker, bounded drain/close로 범위를 제한한다. Kafka future 취소 후 최대 30초 flush 대기는 P2이며 benchmark 주장은 하지 않는다. |
+| Security / Supply chain | `Bernoulli` | PASS WITH FOLLOW-UP | URI·assignment·XML/exception 민감정보 redaction, bounded report walk/read, symlink·path traversal 차단, immutable action/image provenance를 확인했다. inspect 출력 상한은 P2다. |
+| Stability / Lifecycle | `Galileo` | PASS WITH FOLLOW-UP | late callback 무시, in-flight 취소, producer 단일 close, cancellation 중 close failure suppression, 실제 Kafka fixture 종료 경계를 검증했다. malformed callback의 null metadata/null cause는 P2다. |
+
+## 적용한 보정
+
+1. `callbackFlow` producer 생성은 lazy worker 안에서 수행하고, collection별
+   producer 소유권과 `awaitClose` cancellation을 연결했다.
+2. callback·동기 send·upstream·flush·close 예외를 하나의 terminal 상태로
+   수렴시키고, cleanup 예외는 첫 원인에 suppressed cause로 보존한다.
+3. `kotlinx.coroutines`가 suspend 경계에서 복사한 예외만 boundary 표식과
+   동일 type/message 조건으로 제한적으로 unwrap하며, 원인 identity를
+   `hasCause`로 검증한다.
+4. callback drain, in-flight semaphore, producer flush/close, consumer poll/close에
+   bounded timeout을 적용하고 `NonCancellable + Dispatchers.IO` 정리를 사용한다.
+5. Testcontainers Kafka image digest, dynamic port, unique topic, `ShutdownQueue`,
+   action commit SHA를 고정했다.
+6. 진단 수집은 bounded scanner/read와 symlink/path 검증을 사용하고, Docker
+   logs non-zero 및 truncation을 manifest와 exit status에 반영한다. 원본
+   report는 artifact에 올리지 않고 sanitized 사본만 업로드한다.
+7. README 한·영 parity와 한국어 용어 검사를 통과하도록 cancellation 및
+   broker polling 설명을 실제 동작에 맞췄다.
+
+## 검증 증거
+
+| Check | Evidence |
+|---|---|
+| TDD RED | 구현 전 targeted test가 `unresolved reference: producerResults`로 실패함을 확인했다. |
+| Targeted Kotlin | `CallbackFlowExamples`: 18 tests, 0 skipped, 0 failures, 0 errors; `BUILD SUCCESSFUL`. |
+| Module Kotlin | `:bluetape4k-examples-coroutines-demo:test`: 145 total, 3 skipped, 0 failures, 0 errors; `BUILD SUCCESSFUL`. 실행 기준 통과 수는 142다. |
+| Diagnostics Python | `py_compile` 및 `unittest discover`: 16 tests, `OK`. |
+| Static | `ruff check --ignore EXE001` 및 `actionlint .github/workflows/examples.yml` 통과. |
+| Shell/YAML | workflow test block `shellcheck -s bash`, PyYAML parse 통과. |
+| Documentation | README parity 통과; `audit-korean-terms.mjs` 2 files, findings 0. |
+| Provenance | local manifest action refs 4개 모두 40자리 commit SHA, container 0, `truncated=false`. |
+| Sanitized report | callback module 10 reports / 51,789 bytes, `report_truncated=false`, 민감정보 패턴 scan clean. |
+| Diff hygiene | `git diff --check` 통과. |
+| Detekt | `:bluetape4k-examples-coroutines-demo:detekt` task가 없어 N/A; root detekt는 examples를 포함하지 않음. |
+
+## 문서 품질
+
+SPW-01(독자·목적), SPW-02(명령 재현성), SPW-03(실패/취소 의미),
+SPW-04(한·영 parity), SPW-05(민감정보·운영 경계)를 모두 PASS로 판정했다.
+
+## Merge gate
+
+로컬 검증과 6-R review는 완료했지만 hosted CI, PR thread/review, exact-head
+mergeability는 아직 증거가 없다. 따라서 `CG-16`은 보류한다. fresh head/base,
+checks, reviews, threads, linked issue와 mergeability를 다시 읽고 별도 승인을
+받기 전에는 merge·auto-merge·#1353 착수를 수행하지 않는다.

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -73,7 +73,7 @@ report budget만 8,000,000 bytes로 확장해 현재 suite의 전체 증거를 �
 
 최신 head `c5620044c5`에서는 실행 중인 container `Image` ID가 없는 응답을
 mutable `Config.Image` tag로 보완하지 않고 즉시 거부하도록 보강했다. 해당 P2
-경계의 RED/GREEN 회귀와 전체 diagnostics 19개 테스트가 통과했으며,
+경계의 RED/GREEN 회귀와 전체 diagnostics 20개 테스트가 통과했으며,
 `review_ops` 후속 검토에서 P0=0/P1=0으로 확인했다.
 
 그 뒤 exact-head `2f2f05bd0d2825dcd0cc9dd7ea752dd8418bc328`의 Examples run은
@@ -83,6 +83,22 @@ mutable `Config.Image` tag로 보완하지 않고 즉시 거부하도록 보강�
 바이트 부족이 아니라 file cap이 원인이었다. 따라서 다음 exact-head에서는
 개별 container log의 2MB 및 전체 report 8MB 상한은 유지하고, suite 산출량에
 여유를 둔 Examples report file 상한을 600개로 올린다.
+
+그 후 exact-head `9eccc43d8e4f32559781d6541bc77f694963eae6`의 Examples run
+`32990410732`는 9개 Gradle test task를 모두 `BUILD SUCCESSFUL`로 완료했지만,
+`report-scan` 단계가 `report_truncated=true`로 종료됐다. artifact manifest에서
+원인은 `Example1_PlatformAndVirtualThread.xml` 한 파일이 기존 개별 2MB
+상한보다 큰 15,341,647 bytes의 logging output을 생성한 것이며, collector가
+2,000,000 bytes로 잘라낸 뒤 fail-closed로 종료한 것으로 확인했다. 기능 코드의
+실패가 아니라 산출물 bounded-report 계약 위반이므로, source test의 동작은
+변경하지 않고 collector가 JUnit XML의 `system-out`/`system-err`와 Gradle HTML
+stdout/stderr 블록을 `[REDACTED]` placeholder로 compact하도록 보정한다. source
+파일은 32MB bounded read 후 sanitization하며, 최종 파일별 2MB·전체 report 8MB
+상한은 유지한다. 보정 후 실제 15,341,646-byte JUnit XML을 local collector에
+통과시켜 `report_truncated=false`, 12개 report, 19,510 bytes, 최대 9,362 bytes를
+확인했고, virtualthreads module은 32 tests `BUILD SUCCESSFUL`이었다. 이 보정이
+반영된 다음 exact-head hosted Examples run에서 report manifest와 aggregate
+status를 다시 확인한다.
 
 ## Bluetape4k 적용 근거
 
@@ -104,7 +120,7 @@ mutable `Config.Image` tag로 보완하지 않고 즉시 거부하도록 보강�
 | TDD RED | 구현 전 targeted test가 `unresolved reference: producerResults`로 실패함을 확인했다. |
 | Targeted Kotlin | `CallbackFlowExamples`: `SUCCESS: Executed 21 tests in 1m 7s`, XML `21 tests / 0 skipped / 0 failures / 0 errors`, `BUILD SUCCESSFUL`. |
 | Module Kotlin | `:bluetape4k-examples-coroutines-demo:test --no-daemon --rerun-tasks --no-configuration-cache --max-workers=1`: XML 39 files, `148 total / 147 executed / 3 skipped / 0 failures / 0 errors`, `SUCCESS: Executed 147 tests (2 skipped)`, `BUILD SUCCESSFUL`. Testcontainers는 Colima Docker socket으로 순차 실행했다. |
-| Diagnostics Python | `py_compile` 및 `unittest discover`: 19 tests, `OK`; container inspect에 `RepoDigests`가 없는 실제 Docker smoke, mutable tag/image-ID 불일치 거부, 실행 image ID 누락 거부 회귀가 통과했다. |
+| Diagnostics Python | `py_compile` 및 `unittest discover`: 20 tests, `OK`; container inspect에 `RepoDigests`가 없는 실제 Docker smoke, mutable tag/image-ID 불일치 거부, 실행 image ID 누락 거부, verbose JUnit/HTML report compact 회귀가 통과했다. |
 | Static | `ruff check --ignore EXE001`, `actionlint .github/workflows/examples.yml`, workflow `shellcheck -s bash`, PyYAML parse 통과. raw Ruff의 EXE001은 100644 script mode 경고만 남아 의도적으로 mode를 바꾸지 않았다. |
 | Documentation | README 한·영 parity와 한국어 용어 검사 통과; `git diff --check` 통과. |
 | Provenance | local manifest의 action ref 4개가 모두 40자리 commit SHA이며 Kafka image digest가 고정됐다. |

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md
@@ -7,7 +7,7 @@
 - 브랜치: `feat/epic-1422-kafka-callback-flow`
 - 기준 base: `origin/develop`
   (`552d9921520492033ad650743e8696e6352402c2`)
-- 검토 head: `b295222363c3f0cc527c641aedce6905f8ae14e1c`
+- 검토 head: `f500e547a2c9e63e4ac917c2c621e8b4e722225a`
 - 변경 범위: `examples/coroutines-demo` Kafka `callbackFlow` 예제·테스트,
   해당 Testcontainers 의존성, Examples workflow의 compile/test 경계,
   fail-closed 진단 수집기·회귀 테스트, 한·영 README와 승인된 설계·계획 문서
@@ -27,14 +27,14 @@ P1도 이 head에 반영했다. P2/P3는 현재 동작을 막지는 않지만 �
 | Developer API / failure contract | `review_api` (Ampere) | PASS WITH FOLLOW-UP | 첫 원인, cancellation sentinel, bounded flush/close, wrapper identity, malformed callback 계약을 보존한다. `Future.cancel(false)`가 이미 Kafka에 제출된 send 중단을 보장하지 않는 점은 P2다. |
 | Performance | `Nietzsche` | PASS WITH FOLLOW-UP | `maxInFlight` semaphore와 단일 IO worker, bounded drain/close로 범위를 제한한다. Kafka future 취소 후 최대 30초 flush 대기는 P2이며 benchmark 주장은 하지 않는다. |
 | Security / Supply chain | `Bernoulli` | PASS WITH FOLLOW-UP | URI·assignment·XML/exception 민감정보 redaction, bounded report walk/read, symlink·path traversal 차단, immutable action/image provenance를 확인했다. inspect 출력 상한은 P2다. |
-| Stability / Lifecycle | `Galileo` | PASS WITH FOLLOW-UP | late callback 무시, in-flight 취소, producer 단일 close, cancellation 중 close failure suppression, 실제 Kafka fixture 종료 경계를 검증했다. post-task Docker snapshot이 비어 있을 수 있는 lifecycle은 P2다. |
+| Stability / Lifecycle | `Galileo` | PASS WITH FOLLOW-UP | late callback 무시, in-flight 취소, producer 단일 close, cancellation 중 close failure suppression, 실제 Kafka fixture 종료 경계를 검증했다. post-task Docker 상태 자료가 비어 있을 수 있는 lifecycle은 P2다. |
 
 ### 후속 검토에서 반영한 P1 수정
 
 1. callback registration handoff 중 collector cancellation이 발생해도
    `SendState`가 `cancelState`를 통해 in-flight 집합과 semaphore에서 반드시
-   해제되도록 registration 전·후 terminal check와 결정적 회귀 테스트를
-   추가했다.
+   해제되도록 registration 전·후 terminal check와 스케줄링 경합에 강한
+   cleanup invariant 회귀 테스트를 추가했다.
 2. 같은 타입의 예외를 임의의 cause로 unwrap하지 않도록 coroutine boundary
    표식·동일 type/message 조건을 유지하고, 원본 wrapper와 cleanup cause의
    identity를 `shouldBeSameInstanceAs`로 검증했다.
@@ -62,13 +62,13 @@ P1도 이 head에 반영했다. P2/P3는 현재 동작을 막지는 않지만 �
 | Check | Evidence |
 |---|---|
 | TDD RED | 구현 전 targeted test가 `unresolved reference: producerResults`로 실패함을 확인했다. |
-| Targeted Kotlin | callback cancellation·wrapper identity·malformed callback을 포함한 영향 9 tests: `SUCCESS: Executed 9 tests in 1.9s`, `BUILD SUCCESSFUL`. 추가 upstream/close/wrapper 3 tests도 `SUCCESS: Executed 3 tests in 1.3s`. |
-| Module Kotlin | `:bluetape4k-examples-coroutines-demo:test --no-daemon --no-build-cache --no-configuration-cache --rerun-tasks --max-workers=1`: `SUCCESS: Executed 147 tests in 1m 9s (2 skipped)`, `BUILD SUCCESSFUL in 3m 10s`. Testcontainers는 Colima Docker socket으로 순차 실행했다. |
+| Targeted Kotlin | `CallbackFlowExamples`: `SUCCESS: Executed 21 tests in 1m 7s`, XML `21 tests / 0 skipped / 0 failures / 0 errors`, `BUILD SUCCESSFUL`. |
+| Module Kotlin | `:bluetape4k-examples-coroutines-demo:test --no-daemon --rerun-tasks --no-configuration-cache --max-workers=1`: XML 39 files, `148 total / 147 executed / 3 skipped / 0 failures / 0 errors`, `SUCCESS: Executed 147 tests (2 skipped)`, `BUILD SUCCESSFUL`. Testcontainers는 Colima Docker socket으로 순차 실행했다. |
 | Diagnostics Python | `py_compile` 및 `unittest discover`: 16 tests, `OK`. |
 | Static | `ruff check --ignore EXE001`, `actionlint .github/workflows/examples.yml`, workflow `shellcheck -s bash`, PyYAML parse 통과. raw Ruff의 EXE001은 100644 script mode 경고만 남아 의도적으로 mode를 바꾸지 않았다. |
 | Documentation | README 한·영 parity와 한국어 용어 검사 통과; `git diff --check` 통과. |
 | Provenance | local manifest의 action ref 4개가 모두 40자리 commit SHA이며 Kafka image digest가 고정됐다. |
-| Sanitized report | callback module 10 reports / 51,789 bytes, `report_truncated=false`, `secretKey`·`secret_key` 포함 민감정보 scan clean. |
+| Sanitized report | callback module 8 reports / 38,059 bytes, `report_truncated=false`, `secretKey`·`secret_key` 포함 민감정보 scan clean. |
 | Detekt | `:bluetape4k-examples-coroutines-demo:detekt` task가 없어 N/A; root detekt는 examples를 포함하지 않는다. |
 
 ## 잔여 P2/P3
@@ -79,7 +79,7 @@ P1도 이 head에 반영했다. P2/P3는 현재 동작을 막지는 않지만 �
   후속 hardening이 필요하다.
 - P2: compile parallel 대비 test serial의 개선폭을 정량 비교하는 baseline은
   아직 없다.
-- P2: `ShutdownQueue`가 Testcontainers 종료 뒤 snapshot에서 `containerId=null`
+- P2: `ShutdownQueue`가 Testcontainers 종료 뒤 상태 자료에서 `containerId=null`
   로 보이는 것은 정상 cleanup 결과지만, 운영 진단 문서에 lifecycle 의미를
   계속 명시해야 한다.
 - P3: 일부 테스트의 raw `require` 메시지는 Bluetape assertion helper로

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-epic-plan-7tier.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-epic-plan-7tier.md
@@ -1,0 +1,210 @@
+# Epic #1422 구현 계획 7-Tier 검토
+
+## 검토 상태
+
+- 작성일: 2026-08-26
+- 저장소: `bluetape4k/bluetape4k-projects`
+- 기준 branch: `feat/epic-1422-kafka-callback-flow`
+- 기준 base: `origin/develop` / `a907d144f39bfb94cba783cf65a5412e0714e9d5`
+- 최신 계획 commit: `eb00dd7316`
+- 승인된 설계 기준: `7d22431a975e12a237083c93d6e2e6749f966b9d`
+- 관련 Epic: [#1422](https://github.com/bluetape4k/bluetape4k-projects/issues/1422)
+- child 순서: [#1347](https://github.com/bluetape4k/bluetape4k-projects/issues/1347) → [#1353](https://github.com/bluetape4k/bluetape4k-projects/issues/1353)
+- 분류: Type A Full Feature, Step A-04
+- 검토 대상:
+  - `docs/superpowers/plans/2026-08-26-epic-1422-kafka-callback-flow-plan.md`
+  - `docs/superpowers/plans/2026-08-26-epic-1422-redisson-local-cache-plan.md`
+- 변경 경계: 구현 계획과 검토 문서만 검토했다. production API, module catalog,
+  dependency version, PR, merge, GitHub 상태는 변경하지 않았다.
+
+이 문서는 승인된 설계 명세를 실행 계획으로 분해한 뒤, 최신 계획 commit을
+여섯 개 독립 관점에서 다시 읽고 main-session 통합 검증을 수행한 결과다. 계획
+검토의 PASS/APPROVE는 실제 코드·Docker·hosted CI가 이미 통과했다는 뜻이
+아니며, 그 증거는 다음 구현 gate에서 별도로 수집한다.
+
+## 판정 규칙
+
+- P0 또는 P1은 구현 계획 gate를 막는다.
+- P2/P3는 계획 작업, 후속 이슈, 또는 명시적 검증 evidence에 소유자가 있어야
+  다음 gate로 넘긴다.
+- 최종 통합 조건은 모든 관점에서 P0=0/P1=0, P2/P3 처분 기록, 실행·검증
+  순서와 stop condition을 갖추는 것이다.
+
+## 독립 3-R 결과
+
+검토 lane은 native agent의 독립 관점으로 수행했다. lane identity와 기준 head를
+기록해 결과의 provenance를 보존한다.
+
+| Tier | 관점 | Lane | 기준 head | P0 | P1 | P2 | P3 | 판정 |
+|---|---|---|---|---:|---:|---:|---:|---|
+| 1 | Performance | `/root/spec_user` | `eb00dd7316` | 0 | 0 | 0 | 0 | PASS |
+| 2 | Stability | `/root/spec_stability` | `eb00dd7316` | 0 | 0 | 0 | 0 | PASS |
+| 3 | Security | `/root/spec_user` | `eb00dd7316` | 0 | 0 | 0 | 0 | PASS |
+| 4 | Operator/Ops | `/root/spec_user` | `eb00dd7316` | 0 | 0 | 0 | 0 | PASS |
+| 5 | Developer/API | `/root/spec_api` | `eb00dd7316` | 0 | 0 | 0 | 0 | APPROVE |
+| 6 | User/Caller | `/root/spec_user` | `eb00dd7316` | 0 | 0 | 0 | 0 | PASS |
+
+독립 관점 합계는 P0=0, P1=0, P2=0, P3=0이다. 모든 결과는 계획에 대한
+read-only 검토이며, 현재 worktree의 별도 미커밋 구현·diagnostics 변경은
+검토 lane에서 수정하지 않았다.
+
+### 핵심 evidence
+
+- **Performance:** Kafka의 `channelCapacity`/`maxInFlight` `1..16` 경계,
+  bounded drain/flush/close, Redisson `workers=4`·`rounds=256`·30초 실행,
+  5초 local reread와 45분 CI phase budget이 계획에 고정돼 있다.
+- **Stability:** callback·동기 send 예외·취소의 exactly-once state/permit
+  처리, late callback guard, first-cause, LAZY worker의 producer 소유와
+  bounded cleanup이 `try/finally`로 연결돼 있다. 모든 `AtomicInteger`
+  assertion은 `.get()`을 사용한다.
+- **Security:** Kafka/Redis image digest, GitHub Action commit SHA,
+  `persist-credentials: false`, 신규 container ID 범위, allowlist, redacted
+  diagnostics와 report file/byte cap이 고정돼 있다.
+- **Operator/Ops:** compile은 병렬로 유지하고 Testcontainers test는
+  `--max-workers=1`로 순차 실행한다. 실패 누적 후 후속 task와 `if: always()`
+  sanitized artifact를 실행하며, phase 시간·container provenance를 남긴다.
+- **Developer/API:** producer는 `CoroutineStart.LAZY` worker 내부에서 한 번
+  생성되고 그 worker의 `finally`가 close한다. `kotlinx.coroutines.sync.Semaphore`,
+  Future cancellation CAS, callbackFlow lifecycle, concrete
+  `CompositeCodec`, bounded `awaitRedis`가 구현 가능한 signature로 명시돼 있다.
+- **User/Caller:** partial result, backpressure, retry 없음, ordering 미보장,
+  cancellation, README locale parity, acceptance/issue/PR/DoD traceability가
+  실행 명령과 함께 추적된다.
+
+## 구현 범위와 소유권 검증
+
+### #1347 Kafka child
+
+- `examples/coroutines-demo/build.gradle.kts`: 기존
+  `:bluetape4k-kafka4`, `:bluetape4k-testcontainers`, `libs.testcontainers.kafka`
+  test dependency만 추가한다.
+- `CallbackFlowExamples.kt`: private `producerResults` adapter, deterministic
+  lifecycle fixture, digest-pinned Testcontainers broker, bounded consumer poll을
+  구현한다. production Kafka API는 건드리지 않는다.
+- `examples/coroutines-demo/README.md`와 `.ko.md`: 같은 task, Docker 조건,
+  dynamic topic, callback 결과·실패·취소 계약을 locale parity로 기록한다.
+- `.github/scripts/collect-testcontainers-diagnostics.py`와
+  `test_collect_testcontainers_diagnostics.py`: task별 신규 container,
+  allowlist/provenance, redaction, file/byte cap을 검증한다.
+- `.github/workflows/examples.yml`: compile 병렬 phase와 Testcontainers test
+  순차 phase를 분리하고 aggregate failure와 sanitized artifact를 수집한다.
+
+### #1353 Redisson child
+
+- `AbstractRedissonCoroutineTest.kt`: shared Redis/ShutdownQueue ownership은
+  보존하고 test-owned client만 `registerShutdown=false`로 분리한다. warm-up과
+  bounded shutdown을 유지한다.
+- `LocalCachedMapExamples.kt`와 `LocalCachedMapTest.kt`: Int/Double별 concrete
+  `CompositeCodec`, empty-key `addAndGetAsync`, 두 client invalidation,
+  `SuspendedJobTester`, negative `RedisException` contract를 구현한다.
+- 두 Redisson README는 동일한 명령·timeout·eventual consistency 설명을
+  유지한다. #1353은 #1347 parent head 위에 쌓으며 Kafka workflow 파일을
+  소유하지 않는다.
+
+## Acceptance와 계획 task 추적성
+
+| Acceptance | 계획 task | 실행 증거 |
+|---|---|---|
+| 실제 Kafka callback을 metadata `Flow`로 변환 | Kafka 1, 3, 4 | broker producer/consumer targeted test |
+| success/failure/cancellation/backpressure/shutdown | Kafka 2, 3, 4 | deterministic fixture, first-cause와 cleanup counter |
+| `bluetape4k-assertions` 사용 | Kafka 2, 4, 7; Redisson 2, 4 | `assertFailsWith`, `shouldBeEqualTo`, collection matchers |
+| Redis numeric atomic update | Redisson 1, 2, 3 | empty-key Int/Double round-trip와 remote read |
+| 두 client local invalidation | Redisson 4 | Awaitility 5초/100ms bounded reread |
+| README locale parity | Kafka 6; Redisson 5 | exact Gradle command와 parity script |
+| diagnostics/provenance | Kafka 5, 7 | Python fixture, sanitized report와 manifest |
+| stacked delivery/DoD | Kafka 7; Redisson 6 | child SHA, base/head, 6-R와 PR `## DoD Status` |
+
+## Lifecycle·동시성·보안 통합 점검
+
+- **Kafka producer ownership:** `producerFactory()`는 LAZY worker가 실제로
+  시작할 때 호출하고 nullable local ownership으로 `try/finally`에 들어간다.
+  생성 전 cancellation은 producer를 만들지 않으며, 생성 후에는 flush/close가
+  worker cleanup의 단일 경계다.
+- **Callback ordering:** callback은 state를 registry에 등록한 뒤 send되며,
+  동기·비동기·mixed callback 모두 completed CAS와 `finally`의 permit release를
+  공유한다. callback 결과의 ordering은 보장하지 않고 cardinality와 partial
+  result만 검증한다.
+- **Cancellation:** `awaitClose`는 sentinel을 먼저 세우고 in-flight Future를
+  `cancel(false)`한다. late callback은 terminal cause나 permit을 다시 만들지
+  않는다. cleanup cancellation은 삼키지 않고 close 시도 뒤 재전파한다.
+- **Redisson lifecycle:** shared client는 기존 `ShutdownQueue`가 소유하며,
+  invalidation test의 두 client는 `@AfterAll`에서 각각 bounded shutdown한다.
+  `awaitRedis`는 timeout/cancellation 때 underlying `RFuture`도 취소한다.
+- **Bounds:** callback channel/in-flight `1..16`, producer drain 30초,
+  producer/consumer close 5초, Redis future 5초, concurrent increment 30초,
+  invalidation reread 5초/100ms, diagnostics report 2,000,000 bytes를 사용한다.
+- **Security provenance:** Kafka digest
+  `sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130`와
+  Redis digest
+  `sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a`를
+  사용하고, workflow action은 immutable commit SHA로 고정한다. diagnostics는
+  URI userinfo/query, token, environment, payload, exception message를
+  sanitization한 결과만 artifact로 남긴다.
+
+## 이전 3-R 결함과 처분
+
+| 결함 | 보완 commit | 처분 |
+|---|---|---|
+| callback failure의 upstream 취소·단일 cleanup 경계 부족 | `6442daf69`, `ee9e524b4` | first-cause CAS, worker cleanup, producer close를 계획에 고정 |
+| 동기 callback과 반환 Future race | `f9e77ada7`, `25bcdf704` | per-send state, distinct Future, callback 처리 후 drain 확인 |
+| downstream cancellation과 late callback race | `752e474b9`, `f35448af9` | sentinel, immediate Future cancel, late callback 무시 |
+| diagnostics 무제한 수집·serial budget 불명확 | `93e05b334` | 신규 ID, 2MB cap, 45분 phase, `--max-workers=1` |
+| image/action/report provenance 부족 | `cc0167b90`, `ebd44a622`, `d7e9b752d` | digest allowlist, action SHA, redaction fixture, 원본 artifact 제외 |
+| warm-up client bounded shutdown 부족 | `dbcc0c5c9` | `shutdown(0, 5, TimeUnit.SECONDS)` 명시 |
+| producer 생성 시점이 worker ownership 밖에 있음 | `7d517ab8d`, `c2361dfa7` | LAZY worker `try/finally` 안에서 생성·close |
+| counter assertion이 AtomicInteger 객체를 직접 비교함 | `0fe4b7025`, `eb00dd7316` | 모든 counter assertion을 `.get()`으로 수정 |
+| Redisson local view가 update 이후 생성되거나 단일 reread임 | `c2361dfa7` | update 전에 두 view를 만들고 5초/100ms bounded reread |
+
+최신 계획의 P2/P3는 모두 처분됐고, 새로운 P0/P1은 없다. 명령·이미지·action
+문자열은 실행 시점에도 exact head에서 다시 확인한다.
+
+## CI·rollback·stacked delivery
+
+- compile task는 독립적으로 병렬 실행하되 Kafka/Redisson/Testcontainers test는
+  명시된 순서와 `--max-workers=1`로 순차 실행한다. 한 task가 실패해도 다음
+  task와 diagnostics를 실행하고 마지막에 aggregate status를 반환한다.
+- 각 task 전후 container ID 차집합만 수집하고, report는 지정된 경로·파일 수·총
+  바이트를 초과하지 않는다. artifact에는 sanitized report와 diagnostics만
+  넣으며, cap·allowlist·redaction 위반은 workflow failure다.
+- Kafka parent #1347을 먼저 구현·검증·PR로 고정하고, 그 exact head를 #1353
+  branch base로 사용한다. parent merge 전 temporary base/ref를 보존하고,
+  parent merge 후 child base를 `develop`으로 retarget해 fresh CI/review를
+  재실행한다. PR base에는 SHA를 사용하지 않는다.
+- rollback은 child commit 단위다. Kafka adapter/test 실패는 해당 example
+  commit만 되돌리고 기존 example을 보존한다. workflow/diagnostics 실패는
+  workflow commit만 되돌린다. producer/consumer cleanup timeout, unresolved
+  P1, exact-head CI failure가 있으면 merge-ready를 중단한다.
+- 정상적인 dynamic topic은 broker container 수명과 함께 폐기하므로 별도
+  삭제 명령을 추가하지 않는다. shared broker 잔여 topic 수집이 필요해지면
+  별도 운영 이슈로 분리한다.
+
+## 계획 검토 DoD
+
+- **SPW-01 PASS:** 독자, 목적, 범위, 기준 branch/base, Epic과 child 순서를
+  문서 첫 부분에 고정했다.
+- **SPW-02 PASS:** 여섯 lane의 최신 판정, acceptance/task 추적성, lifecycle,
+  bounds, security, rollback과 다음 gate를 포함했다.
+- **SPW-03 PASS:** 한국어 기술 문체를 사용하고 code token, command, URL,
+  version, SHA, status token을 원형으로 보존했다.
+- **SPW-04 PASS:** 설계 acceptance가 각 계획 task·실행 증거·child DoD에
+  연결되고, 계획 검토와 runtime/hosted 검증의 증거 경계를 분리했다.
+- **SPW-05 PASS:** 제목·표·목록·code span·링크·체크리스트를 read-back하고
+  `git diff --check`와 `audit-korean-terms.mjs`를 실행한다.
+
+## 통합 판정과 다음 gate
+
+**PASS — 구현 계획 gate 통과 (P0=0, P1=0, P2=0, P3=0).**
+
+승인된 설계와 최신 3-R 계획 검토가 수렴했으므로 다음 gate는 Step A-05
+`#1347` 구현/TDD다. 구현 시 기존 worktree의 별도 미커밋 변경을 먼저
+ownership 확인 후 계획에 맞춰 검토하고, build/test/6-R evidence를 채운다.
+실제 Docker/Testcontainers, detekt, actionlint, hosted exact-head CI, PR
+생성·merge는 이 문서의 완료 evidence가 아니며 각각 후속 gate에서 수행한다.
+
+## 검토 문서 DoD
+
+- [x] 두 구현 계획과 승인된 설계의 기준 commit/base가 일치한다.
+- [x] 여섯 3-R 결과가 최신 `eb00dd7316` 기준으로 기록됐다.
+- [x] P0/P1/P2/P3가 모두 0이고 처분·rollback·stop condition이 기록됐다.
+- [x] 한국어 용어·Markdown·diff 검증 명령과 증거 경계가 기록됐다.
+- [x] 구현·PR·merge mutation은 다음 gate로 남겼다.

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-epic-spec-7tier.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-epic-spec-7tier.md
@@ -1,0 +1,177 @@
+# Epic #1422 설계 명세 7-Tier 검토
+
+## 검토 상태
+
+- 작성일: 2026-08-26
+- 저장소: `bluetape4k/bluetape4k-projects`
+- 대상 명세: `docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md`
+- 기준 branch: `feat/epic-1422-kafka-callback-flow`
+- 기준 base: `origin/develop` / `a907d144f39bfb94cba783cf65a5412e0714e9d5`
+- 관련 Epic: [#1422](https://github.com/bluetape4k/bluetape4k-projects/issues/1422)
+- child 순서: [#1347](https://github.com/bluetape4k/bluetape4k-projects/issues/1347) → [#1353](https://github.com/bluetape4k/bluetape4k-projects/issues/1353)
+- 분류: Type A Full Feature, Step 2-R
+- 검토 방식: 여섯 개 독립 관점과 main-session 통합을 수행한 7-Tier 검토
+- 변경 경계: 명세·검토 문서만 대상이며 production code, workflow, GitHub 상태는 변경하지 않음
+
+이 문서는 승인된 설계 명세를 구현 전에 검증한 결과다. 각 lane은 최신 명세를
+독립적으로 다시 읽고 P0부터 P3까지 판정했으며, main-session은 중복·누락·상충
+사항과 다음 gate의 추적성을 통합했다.
+
+## 판정 규칙
+
+- P0 또는 P1은 구현·계획 gate를 막는다.
+- P2와 P3는 명세에서 수정하거나, 구현 계획·후속 이슈·검증 evidence로 소유자를
+  명확히 지정한 뒤 다음 단계로 넘긴다.
+- `APPROVE` 또는 `PASS`는 해당 관점의 P0/P1 blocker가 없다는 뜻이며, 실제 코드와
+  hosted CI가 완료되었다는 뜻이 아니다.
+- 최종 통합 조건은 P0=0, P1=0, 모든 P2/P3의 처분 기록, 다음 gate의 명시다.
+
+## 최종 독립 lane 결과
+
+| Tier | 관점 | P0 | P1 | P2 | P3 | 최종 판정 | 신뢰도 |
+|---|---|---:|---:|---:|---:|---|---|
+| 1 | Performance | 0 | 0 | 0 | 0 | APPROVE | 높음 |
+| 2 | Stability | 0 | 0 | 0 | 0 | PASS | 높음 |
+| 3 | Security | 0 | 0 | 1 | 0 | COMMENT | 높음 |
+| 4 | Operator/Ops | 0 | 0 | 2 | 0 | PASS WITH P2 FOLLOW-UP | 높음 |
+| 5 | Developer/API | 0 | 0 | 0 | 0 | APPROVE | 높음 |
+| 6 | User/Caller | 0 | 0 | 2 | 0 | PASS WITH P2 FOLLOW-UP | 높음 |
+| 7 | Main-session integration | 0 | 0 | 4 | 0 | PASS WITH FOLLOW-UP | 높음 |
+
+독립 lane 합계는 P0=0, P1=0, P2=5, P3=0이다. Main-session의 P2=4는
+서로 겹치는 항목을 하나의 구현 계획 작업으로 합친 통합 수치다.
+
+## 초기 검토의 blocker와 보완
+
+| 초기 관점 | 초기 문제 | 우선순위 | 명세 보완 및 처분 |
+|---|---|---:|---|
+| Stability | callback failure가 channel close에만 의존하고 worker/upstream 취소·단일 cleanup이 불명확함 | P1 | callback failure와 full buffer 모두 first-cause CAS, worker/upstream 취소, permit 회수, 단일 producer cleanup으로 고정했다. |
+| Stability | channel capacity와 Redisson numeric codec·빈 key 계약이 불명확함 | P1 | `channelCapacity`/`maxInFlight`를 `1..16`으로 제한하고, Int/Double별 concrete `CompositeCodec`와 빈 key `addAndGetAsync`를 명시했다. |
+| Ops | CI test loop, timeout, stacked child base가 추상적임 | P1 | test별 독립 Gradle invocation, `--max-workers=1`, 실패 누적, bounded diagnostics, parent merge 전 temporary base와 merge 후 `develop` retarget 절차를 고정했다. |
+| Developer/API | `awaitClose` cleanup 위치와 Kafka test dependency가 모호함 | P1 | signal-only `awaitClose`, `NonCancellable + Dispatchers.IO` worker cleanup, 기존 project/catalog의 `testImplementation`을 명시했다. |
+| User/Caller | 실행 명령·codec·Epic auto-close 경계가 불명확함 | P1 | 두 README의 정확한 targeted command, 동일 codec, 최종 child PR만 `Closes #1422`를 갖는 stacked 절차를 명시했다. |
+| Performance | in-flight·buffer·Redis workload·CI 실행 비용이 고정되지 않음 | P2 | `maxInFlight`, buffer policy, `workers=4`, `rounds=32*8`, timeout과 60분 budget 비교를 추가해 해소했다. |
+| Security | 입력 경계·로그 redaction·image/action provenance가 부족함 | P2/P3 | topic/key/header·payload 경계와 구조화 redaction을 추가했다. mutable image/action pinning은 이 Epic 범위 밖의 별도 보안 후속으로 남겼다. |
+
+## 현재 명세에서 확인한 핵심 계약
+
+### Kafka callbackFlow
+
+- private `producerResults` seam은 `Flow<ProducerRecord<String, String>>`를
+  `Flow<RecordMetadata>`로 바꾸고 실제 성공 경로는 `KafkaServer.Launcher`의
+  broker·producer·consumer로 검증한다.
+- `channelCapacity`와 `maxInFlight`는 각각 `1..16`이며, callback 결과는
+  `trySend`와 `BufferOverflow.SUSPEND`를 거친다. full은 drop하지 않고
+  `IllegalStateException("callback buffer is full")`을 첫 terminal cause로
+  기록한다.
+- callback 성공·실패·동기 `send` 예외의 permit/in-flight 추적은 공통 `finally`에서
+  정확히 한 번만 해제한다. first-cause는
+  `AtomicReference<Throwable?>.compareAndSet(null, cause)`로 고정하고 late
+  callback은 덮어쓰지 않는다.
+- `awaitClose`는 signal만 전달하며, worker의
+  `NonCancellable + Dispatchers.IO` finally가 callback drain·flush·bounded
+  producer close와 단일 cleanup을 소유한다. callback/flush는 30초, producer와
+  consumer close는 5초 bound를 사용한다.
+- 성공 cardinality와 실패·취소의 부분 결과/cleanup ordering을 분리하고,
+  diagnostic에는 module·topic·recordCount·failureKind·first cause type·cleanup
+  phase만 남긴다.
+
+### Redisson numeric/local cache
+
+- Int와 Double은 서로 다른 `RLocalCachedMap`과 map 이름을 사용한다.
+- 각 map의 front/back view에 동일한 concrete `CompositeCodec`를 전달하고,
+  빈 key에서 `addAndGetAsync`를 시작해 `HINCRBYFLOAT` 평문 숫자를 다시 읽는다.
+- 실제 future 대기는 `runSuspendIO`와 `withTimeout(5.seconds)`를 사용하며,
+  동시성은 `SuspendedJobTester(workers = 4, rounds = 32 * 8)`, invalidation은
+  Awaitility 5초/100ms로 검증한다.
+- shared server/client는 `ShutdownQueue`, numeric invalidation용 test-owned
+  client는 `newRedisson(registerShutdown = false)`와 `@AfterAll`이 소유한다.
+
+### CI·문서·stacked delivery
+
+- compile phase는 기존 병렬성을 유지하되 Kafka와 Redisson을 포함한 test phase는
+  명시된 순서의 별도 Gradle invocation으로 직렬 실행한다.
+- `set +e` loop가 후속 task를 계속 실행하고 마지막에 aggregate failure를
+  반환한다. `if: always()` artifact는 test report와 bounded sanitized
+  diagnostics를 함께 수집한다.
+- parent merge 전 child의 base/head SHA와
+  `train/epic-1422-parent-base`를 보존하고, parent merge 후 branch ref를
+  `develop`으로 retarget해 exact diff와 fresh CI/review를 다시 확인한다. SHA를
+  PR base로 사용하지 않는다.
+- 두 README는 같은 실행 명령과 Docker daemon, dynamic port, unique topic/map,
+  eventual invalidation, bounded timeout 설명을 유지한다.
+
+## P2/P3 처분과 구현 계획 추적
+
+다음 항목은 현재 Step 2-R을 막지 않지만 Step 3 계획에 반드시 작업·검증 항목으로
+들어가야 한다.
+
+1. **CI diagnostics/provenance manifest** — 각 test task가 bounded·sanitized
+   container log와 resolved image digest/action ref를
+   `examples/build/testcontainers-diagnostics/<task-name>/` 아래 manifest로
+   만든다. `if-no-files-found: ignore`에 의존하지 않고 manifest 존재를 검사하며,
+   누락은 `PENDING` 또는 workflow failure로 판정한다. 원문 exception, 환경 변수,
+   payload, credential-bearing URI는 저장하지 않는다. (Ops P2 2건의 통합 처분)
+2. **Security provenance follow-up** — 승인 registry의 immutable image digest와
+   workflow Action commit SHA pinning을 별도 보안 이슈로 분리한다. 이 Epic에서는
+   기존 `pull_request`와 `contents: read` 최소 권한, 실행 시 resolved ref 기록만
+   유지한다. (Security P2)
+3. **Redisson negative contract** — unsupported/mismatched numeric input에 대한
+   명시적 negative test와 기대 exception type을 #1353 구현 계획에 고정한다.
+   성공 경로에 잘못된 numeric class를 섞지 않는다. (User/Caller P2)
+4. **Conditional CI task catalog** — Ktor/Spring Boot 조건부 task의 현재 정확한
+   task명과 artifact 경로를 workflow 구현 전에 확인하고 actionlint/path filter와
+   함께 정적 검사한다. (User/Caller P2)
+
+이 처분은 새 production API나 dependency를 승인하는 것이 아니다. 각 항목은 기존
+helper·catalog·workflow 구조 안에서 구현하고, 결과를 child PR의 `## DoD Status`와
+7-Tier module review에 연결한다.
+
+## Main-session 통합 검증
+
+- **범위 추적성:** 명세의 #1347 Kafka slice, #1353 Redisson slice, README/CI,
+  stacked delivery 경계가 각각 acceptance criterion과 failure matrix에 연결된다.
+- **저장소 일관성:** 현재 `ProducerCoroutines.kt`, `KafkaServer.Launcher`,
+  `AbstractRedissonCoroutineTest`, `settings.gradle.kts`와 기존 assertions,
+  Testcontainers helper를 재사용하며 public production API·module registration은
+  바꾸지 않는다.
+- **lifecycle 상충 해소:** Kafka broker/server는 test base와 `ShutdownQueue`가
+  소유하고 Flow collection-scoped producer만 adapter가 닫는다. Redisson shared
+  client와 test-owned clients의 종료 주체도 분리됐다.
+- **실행 상충 해소:** compile 병렬화와 Testcontainers test 직렬화를 분리해 기존
+  속도와 container 경쟁 회피를 함께 보존한다.
+- **stack 상충 해소:** PR base는 branch ref만 사용하고 parent merge commit의
+  SHA는 evidence로만 기록한다. branch 자동 삭제를 매 단계 확인하고 필요하면
+  temporary ref를 먼저 보존한다.
+- **증거 경계:** 현재 결과는 명세 검토와 문서 검증이다. 실제 Kafka/Redis runtime,
+  workflow 실행, hosted CI, PR review, exact-head merge는 구현 이후 gate로 남는다.
+
+## 7-Tier 검토 DoD
+
+- **SPW-01 PASS:** 독자·목적·범위·기준 branch와 Epic/child 연결을 문서 첫 부분에
+  고정했다.
+- **SPW-02 PASS:** 초기 blocker, 최신 lane 판정, 핵심 계약, P2 처분, 통합 검증과
+  다음 gate를 포함했다.
+- **SPW-03 PASS:** 한국어 기술 문체를 사용하고 code token, command, URL, 숫자,
+  status token은 원형을 보존했다.
+- **SPW-04 PASS:** 명세와 각 독립 lane의 근거를 대조했으며 구현·CI 전 미확인
+  항목을 별도 증거 경계로 남겼다.
+- **SPW-05 PASS:** 제목·표·목록·code span·링크·checklist를 다시 읽고
+  `git diff --check`와 `audit-korean-terms.mjs`를 실행한다.
+- 모든 lane의 P0/P1 합계는 0이며, P2/P3는 위 처분 목록에 연결했다.
+
+## 다음 gate
+
+Step 2-R 통합 판정은 `PASS WITH FOLLOW-UP`이다. 설계 명세와 이 검토 문서를
+Lore commit으로 고정한 뒤, 사용자에게 작성된 명세를 검토·승인받는다. 승인 전에는
+`$writing-plans`와 구현을 시작하지 않는다. 승인 후 Step 3 구현 계획과 그 계획의
+7-Tier review를 수행하고, 먼저 #1347 child train을 구현한다.
+
+## 검토 문서 DoD
+
+- [x] 명세와 본 문서가 같은 기준 branch/base를 가리킨다.
+- [x] 여섯 독립 lane의 최신 결과와 main-session 통합 결과가 기록되었다.
+- [x] P0/P1이 0이고 모든 P2/P3의 소유 작업이 기록되었다.
+- [x] 문서 lint와 한국어 용어 audit를 통과했고 Lore commit read-back 절차를
+  고정했다.
+- [x] 본 문서 작성은 명세·검토 단계에 한정되며 code/PR/merge mutation은 없다.

--- a/docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md
+++ b/docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md
@@ -352,9 +352,10 @@ artifact upload는 `examples/**/build/test-results/**`,
 - Kafka/Redis image 또는 version을 변경하지 않는다. container startup 실패는
   코드 결함으로 분류하지 않고 raw Docker/CI evidence와 함께 별도 blocker로
   기록한다.
-- 기존 launcher의 mutable image tag와 workflow action reference를 이 Epic에서
-  pinning으로 바꾸지 않는다. 대신 실행마다 resolved image digest와 action
-  ref를 bounded evidence에 기록하고, immutable provenance 전환은 별도 보안
+- 기존 launcher의 mutable image tag는 변경하지 않되, 이 Epic이 수정하는
+  examples workflow의 action reference는 immutable commit SHA로 고정한다.
+  실행마다 resolved image digest와 action ref를 bounded evidence에 기록해
+  CI provenance를 fail-closed로 확인한다. 공용 image/tag 전환은 별도 보안
   후속 이슈로 분리한다.
 
 ## Acceptance criteria와 DoD

--- a/docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md
+++ b/docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md
@@ -1,0 +1,400 @@
+# Epic #1422 실행 가능한 통합 예제 계약 설계
+
+## 문서 상태
+
+- 작성일: 2026-08-26
+- 저장소: `bluetape4k/bluetape4k-projects`
+- 기준 branch: `feat/epic-1422-kafka-callback-flow`
+- 기준 base: `origin/develop` / `a907d144f39bfb94cba783cf65a5412e0714e9d5`
+- 관련 Epic: [#1422](https://github.com/bluetape4k/bluetape4k-projects/issues/1422)
+- child 순서: [#1347](https://github.com/bluetape4k/bluetape4k-projects/issues/1347) → [#1353](https://github.com/bluetape4k/bluetape4k-projects/issues/1353)
+- 분류: Type A — 여러 examples 모듈과 외부 broker/cache lifecycle을 함께 검증하는 Full Feature
+
+이 문서는 구현 전에 승인된 설계와 failure contract를 고정한다. public
+production API나 새 외부 의존성은 추가하지 않고, 기존 bluetape4k test
+infrastructure와 examples 모듈의 실행 가능한 회귀 검증을 확장한다.
+
+## 문제와 목표
+
+`examples/coroutines-demo`의 `CallbackFlowExamples`는 fake callback API만
+사용하고 있어 Kafka producer callback의 성공·실패·취소·종료 계약을
+보여 주지 못한다. `examples/redisson-demo`의 `LocalCachedMapExamples`는
+numeric `addAndGetAsync`가 FIXME로 남아 있어 `Int`/`Double` 변환과
+local/remote cache 일관성을 검증하지 못한다.
+
+Epic의 목표는 다음 두 예제를 실제 infrastructure 상호작용과 회귀 테스트로
+정렬하는 것이다.
+
+1. Kafka4 producer callback을 `Flow<RecordMetadata>`로 변환하고 callbackFlow
+   lifecycle을 검증한다.
+2. Redisson `RLocalCachedMap`의 numeric atomic update와 remote invalidation을
+   `Int`/`Double`별로 검증한다.
+3. 각 child를 독립 실행 가능한 stacked PR로 전달하고, 두 child가 모두
+   merge-ready가 된 뒤에만 merge한다.
+
+## 현재 근거와 재사용 결정
+
+### Local anchors
+
+| 영역 | 현재 근거 | 채택 결정 |
+|---|---|---|
+| Kafka producer | `infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt`의 `suspendSend`와 `sendAsFlow` | raw callback은 callbackFlow 계약을 보여 주는 범위에서만 사용하고, producer 생성·broker fixture는 기존 helper를 재사용한다. |
+| Kafka fixture | `testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/mq/KafkaServer.kt`의 `KafkaServer.Launcher` | `createStringProducer`, `createStringConsumer`, `bootstrapServers`를 사용한다. raw `GenericContainer`는 만들지 않는다. |
+| Coroutine assertions | `bluetape4k-assertions`와 `bluetape4k-junit5`가 examples dependency에 이미 존재 | `assertFailsWith`, `shouldBeEqualTo`, null/boolean/collection matcher를 사용한다. |
+| Redis fixture | `examples/redisson-demo/.../AbstractRedissonCoroutineTest.kt`의 `RedisServer.Launcher.redis`와 `newRedisson()` | client와 container lifecycle을 기존 base에 맡긴다. |
+| Local cache | `LocalCachedMapExamples.kt`, `LocalCachedMapTest.kt` | unique map name, 두 client, Awaitility invalidation 검증을 확장한다. |
+| Module registration | `settings.gradle.kts`의 `includeModules("examples", withProjectName = true, withBaseDir = true)` | module registration/catalog 변경은 없다. |
+
+### External contract anchors
+
+- Kotlin `callbackFlow` 문서는 builder가 즉시 반환되지 않도록
+  `awaitClose`를 사용하고, collector cancellation 때 callback resource를
+  해제해야 한다고 명시한다: [callbackFlow API](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/callback-flow.html), [awaitClose API](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/await-close.html).
+- 현재 로컬 Redisson 4.7.0 source의 `RMap.addAndGetAsync`는 전달한 `Number`
+  class를 `NumberConvertor`에 넘기고 Redis `HINCRBYFLOAT`를 호출한다.
+  따라서 map 하나에 `Int`와 `Double` 값을 섞지 않는다.
+- Redisson 공식 collection example도 `RLocalCachedMap`에서 numeric
+  `addAndGet`를 사용한다: [LocalCachedMapExamples.java](https://github.com/redisson/redisson-examples/blob/master/collections-examples/src/main/java/org/redisson/example/collections/LocalCachedMapExamples.java).
+
+## 범위와 책임 경계
+
+### 포함
+
+- `examples/coroutines-demo`의 Kafka callbackFlow example/test와 필요한
+  기존 project dependency 선언
+- `examples/redisson-demo`의 numeric LocalCachedMap example/test
+- 두 examples README의 실행 명령과 계약 설명
+- Testcontainers를 사용하는 examples CI test phase의 직렬 실행 보장
+- child별 7-Tier review evidence, Korean issue/PR DoD, exact-head CI evidence
+
+### 제외
+
+- Kafka public API, Redisson adapter, 또는 bluetape4k production API 변경
+- 새로운 외부 dependency, 새 Testcontainers launcher, 새 module 추가
+- Kafka consumer/producer 운영 설정의 일반화
+- benchmark 수치나 production throughput 주장
+- README diagram/이미지 변경
+
+### 소유권
+
+- Kafka producer는 한 Flow collection이 소유하고 terminal/cancellation 때
+  닫는다.
+- shared Redis/Redisson client와 Testcontainers server는 기존 test base와
+  `ShutdownQueue`가 소유한다. numeric invalidation에 추가로 만든 두 client는
+  test가 소유하고 `@AfterAll`에서 한 번만 닫으며, setup 실패에도 같은 cleanup
+  경계를 적용한다.
+- Kafka `KafkaServer.Launcher.kafka`와 shared Redis server는 기존 test base와
+  `ShutdownQueue`가 소유한다. Flow와 test는 broker/server 자체를 닫지 않고,
+  collection-scoped producer와 test-owned Redisson client만 닫는다.
+- 예제 테스트가 만든 map/topic 이름은 unique suffix를 사용하며 공유 상태를
+  재사용하지 않는다.
+
+## 선택한 설계
+
+### #1347 Kafka callbackFlow adapter
+
+private adapter는 다음 형태를 사용한다.
+
+```kotlin
+private fun producerResults(
+    records: Flow<ProducerRecord<String, String>>,
+    producerFactory: () -> Producer<String, String>,
+    channelCapacity: Int = 16,
+    maxInFlight: Int = 16,
+): Flow<RecordMetadata>
+```
+
+구현 계약은 다음과 같다.
+
+1. Flow를 collect할 때 producer를 만들고, worker coroutine을
+   `Dispatchers.IO`에서 시작한다.
+2. 각 record는 Kafka `Producer.send(record, callback)`으로 전송하며,
+   `maxInFlight`를 넘지 않도록 bounded semaphore를 사용한다. callback 성공·실패와
+   동기 `send` 예외의 모든 경로는 공통 `finally`에서 해당 permit과 in-flight
+   추적을 정확히 한 번만 해제한다.
+3. callback 성공은 `channel.trySend(metadata)`로 전달한다. 반환 Flow에는
+   `.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)`를
+   적용해 채널 용량과 overflow 정책을 고정하고, `trySend`가 full인지 이미
+   닫혔는지 구분한다.
+4. callback failure는 첫 원인을 보존해 worker와 upstream을 즉시 취소하고,
+   원래 throwable을 channel close cause로 전달한다. 첫 failure 이후 callback은
+   한 번만 diagnostic log를 남기고 결과를 버린다.
+5. `trySend`가 full이면 drop하지 않고 private
+   `IllegalStateException`(`callback buffer is full`)을 CAS로 첫 terminal
+   cause에 기록한 뒤 worker와 upstream을 취소하고 semaphore permit을 회수한다.
+   producer cleanup은 callback failure와 동일하게 한 번만 수행한다. `trySend`가
+   이미 닫힌 channel을 가리키면 downstream cancellation 여부를 확인하고,
+   이미 취소된 경우에는 새 오류로 덮어쓰지 않는다.
+6. upstream이 정상 종료되면 모든 in-flight callback이 drain된 뒤 worker가
+   `flush()`를 완료하고 channel을 닫는다.
+7. callback failure·upstream exception·collector cancellation의 우선순위는
+   첫 terminal cause로 고정한다. `flush`/`close` 예외는 첫 원인에 suppressed로
+   붙이고, 원인이 없을 때만 collector에 전달한다.
+   첫 원인은 `AtomicReference<Throwable?>.compareAndSet(null, cause)`로 한 번만
+   기록하며, late callback은 이 상태를 덮어쓰지 않는다.
+8. `channelCapacity`와 `maxInFlight`는 각각 `1..16` 범위만 허용한다. `Channel`
+   1-slot buffered semantics가 필요한 fixture는 `channelCapacity=1`과
+   `maxInFlight=2`로 collector를 잠가 두 번째 callback의 full을 재현한다. 진정한
+   rendezvous(`capacity=0`)는 이 private adapter 계약에서 사용하지 않는다.
+9. `awaitClose`는 cancellation signal만 보내고 blocking cleanup을 실행하지
+   않는다. worker의 `finally`가 `NonCancellable + Dispatchers.IO`에서
+   callback drain, bounded `close(Duration.ofSeconds(5))`와 단일 cleanup 완료를
+   소유한다. callbackFlow의 구조적 수명 종료가 worker 완료를 기다리며,
+   `runBlocking`으로 join을 우회하지 않는다.
+10. `CancellationException`은 broad catch에서 삼키지 않고 재전파한다.
+
+callback drain 또는 `flush()`가 30초 deadline을 넘기면
+`TimeoutCancellationException`을 첫 terminal cause로 보존하고 pending send를
+취소한 뒤 cleanup으로 진입한다. consumer도 `close(Duration.ofSeconds(5))`를
+사용하며, timeout은 실패 원인과 cleanup phase를 evidence에 남긴다.
+
+producer factory와 buffer 인자는 public API가 아니라 deterministic lifecycle
+테스트를 위한 private seam이다. 성공 경로는 반드시
+`KafkaServer.Launcher`의 실제 broker와 실제 `KafkaProducer`/`KafkaConsumer`로
+검증한다. 예제 fixture는 최대 128개 record와 record value 1KiB를 사용하고,
+topic은 128자, key는 128자, header 이름·값은 각각 256바이트 이하로 제한한다.
+각 callback drain/worker 작업은 30초 deadline, consumer poll은 10초,
+producer `close`는 5초 bound를 갖는다. topic·key·value·header에는 credential과
+원문 payload를 넣지 않는다. 최대 16개 callback이 동시에 진행되므로 metadata
+순서는 보장하지 않으며, 재시도는 이 예제 adapter가 수행하지 않는다. 입력
+record 수와 성공 callback metadata 수는 정상 성공 경로에서만 일치해야 한다.
+실패·취소 경로는 부분 결과, 최초 원인과 cleanup ordering을 검증한다.
+diagnostic log는 `module`, `topic`, `recordCount`, `failureKind`,
+`firstTerminalCauseType`, `cleanupPhase`만 구조화해 기록하고, cause message는
+저장하지 않는다.
+
+### #1353 Redisson numeric/local-remote adapter
+
+numeric 예제는 map 이름과 value type을 분리한다.
+
+- `RLocalCachedMap<String, Int>`: integer delta와 반환 `Int`를 검증한다.
+- `RLocalCachedMap<String, Double>`: fractional delta와 반환 `Double`를
+  검증한다.
+- `HINCRBYFLOAT`가 저장한 평문 숫자를 다시 읽을 수 있도록 map마다
+  `CompositeCodec(RedissonCodecs.String, RedissonCodecs.Int, RedissonCodecs.Int)`
+  또는 `CompositeCodec(RedissonCodecs.String, RedissonCodecs.Double,
+  RedissonCodecs.Double)`를 사용한다. front `RLocalCachedMap`과 remote
+  `RMap`은 같은 codec을 전달한다.
+- numeric key는 `fastPut`으로 직렬화한 값을 재사용하지 않고, 빈 key에서
+  `addAndGetAsync`로 초기화한다. 일반 직렬화 map과 atomic numeric map을
+  분리해 보여 준다.
+- 각 map의 remote view는 같은 codec을 전달한 `redisson.getMap`으로 읽고,
+  두 client의 local view는 `getAsync`/`containsKeyAsync`로 읽는다.
+- 실제 Redis 호출은 `runSuspendIO`와 Redisson future `await()`를 사용한다.
+  각 Future 대기는 `withTimeout(5.seconds)`로 감싸고, timeout/cancellation
+  시 해당 Future와 test-owned client를 즉시 정리한다.
+- concurrent increment는 `SuspendedJobTester(workers = 4, rounds = 32 * 8)`로
+  수행하고, 총 호출 수·remote 최종값·local reread를 모두 assertion한다.
+- remote `put`/`remove` 후 local cache가 `atMost(5.seconds)`, 100ms poll의
+  Awaitility 안에 반영되는 기존 테스트를 유지하고 numeric key에도 같은
+  계약을 추가한다. local cache는 eventual invalidation을 제공하므로 remote
+  변경 직후의 stale read를 허용하고, bounded await가 끝난 뒤 두 client를
+  다시 읽어 갱신값 또는 `null`을 확인한다.
+
+`HINCRBYFLOAT`는 숫자 hash field를 전제로 하므로 map value를 문자열이나
+서로 다른 numeric class로 혼합하지 않는다. `Double` 입력은 finite 값과
+고정된 작은 delta만 사용한다. unsupported/mismatched 입력은 예제의 성공
+경로로 포장하지 않고 명시적인 제약으로 문서화한다.
+
+## Failure matrix
+
+| 시나리오 | 기대 결과 | 검증 방법 |
+|---|---|---|
+| Kafka callback success | 입력 record마다 정확히 하나의 metadata가 Flow로 관찰되고 순서는 보장하지 않는다 | 실제 Kafka producer/consumer integration test |
+| Kafka callback failure | 원래 failure이 collector에 전달되고 producer가 닫힌다 | 닫힌 producer deterministic fixture + `assertFailsWith` |
+| collector cancellation | `CancellationException`이 보존되고 callback/producer 누수가 없다 | 실제 flow `take(1)`/job cancellation + close tracking fixture |
+| callback backpressure | `trySend` full이 drop되지 않고 `IllegalStateException`으로 종료된다 | `channelCapacity=1`, `maxInFlight=2`와 synchronous callback fixture |
+| normal terminal | send callback drain 후 flush와 channel close가 일어난다 | 실제 broker success test와 close tracking |
+| upstream exception | 최초 upstream exception이 collector에 전달되고 in-flight callback/producer가 한 번만 정리된다 | throwing upstream fixture + close tracking |
+| flush/close exception | 최초 terminal cause를 보존하고 cleanup exception은 suppressed로 남긴다 | failing producer fixture + `assertFailsWith` |
+| producer factory/send exception | factory 또는 동기 `send` 예외가 최초 원인으로 전달되고 producer/worker가 정리된다 | throwing factory/producer fixture + `assertFailsWith` |
+| Redis Int increment | 예상 `Int` 결과와 remote/local 값이 일치한다 | `addAndGetAsync` + bluetape assertions |
+| Redis Double increment | fractional `Double` 결과와 remote/local 값이 일치한다 | `addAndGetAsync` + type/value assertion |
+| concurrent increment | remote final value가 성공 호출 수와 일치한다 | `SuspendedJobTester`와 independent remote read |
+| remote invalidation | stale local read 뒤 다른 client의 local cache가 bounded time 안에 갱신/삭제된다 | Awaitility `until` + both clients + reread |
+| invalidation timeout | 무한 대기 없이 테스트가 실패한다 | explicit Awaitility timeout |
+
+## 테스트와 검증 전략
+
+### #1347
+
+- `CallbackFlowExamples`의 fake-only path를 실제 Kafka producer path로 교체한다.
+- success, producer failure, collector cancellation, backpressure, shutdown을
+  별도 descriptive test로 둔다.
+- producer factory 예외와 동기 `send` 예외를 callback failure와 분리해
+  검증하고, close 횟수·callback count·late callback·cleanup ordering을
+  deterministic fixture로 확인한다.
+- blocking Kafka API는 `Dispatchers.IO`에서만 실행한다.
+- consumer poll은 10초 bounded timeout을 사용하고 consumer를 명시적으로
+  닫는다. fixture는 topic, record count, callback failure kind만 구조화해
+  기록하며 payload·headers·credential-bearing URI와 원문 exception/env는
+  로그·artifact에 남기지 않는다.
+
+`examples/coroutines-demo`에는 `project(":bluetape4k-kafka4")`,
+`project(":bluetape4k-testcontainers")`, `libs.testcontainers.kafka`를
+`testImplementation`으로 명시한다. 모두 중앙 catalog/기존 project를
+재사용하며 새 버전 좌표는 추가하지 않는다.
+
+### #1353
+
+- `LocalCachedMapExamples`에 Int/Double numeric example과 제약 KDoc을 추가한다.
+- `LocalCachedMapTest`에 concurrent numeric update와 remote invalidation
+  regression을 추가한다.
+- real Redis test는 `runSuspendIO`로 실행하고 `SuspendedJobTester`를 우선
+  사용한다. ad hoc thread harness는 사용하지 않는다.
+- 각 numeric map에는
+  `CompositeCodec(RedissonCodecs.String, RedissonCodecs.Int, RedissonCodecs.Int)` 또는
+  `CompositeCodec(RedissonCodecs.String, RedissonCodecs.Double, RedissonCodecs.Double)`를
+  지정하고, front/back client가
+  같은 codec과 unique name을 공유한다. setup 실패 시에도 test-owned client는
+  `@AfterAll`에서 한 번만 닫고, shared `redissonClient`는
+  `ShutdownQueue`가 한 번만 소유하도록 경계를 분리한다. 이를 위해
+  `AbstractRedissonCoroutineTest.newRedisson(registerShutdown = false)` 경로로
+  test-owned client를 만들고, shared client만 기본 `registerShutdown = true`를
+  사용한다.
+
+### 모듈·CI 검증
+
+각 child마다 다음 순서로 실행한다.
+
+1. 변경된 단일 테스트 또는 compile task
+2. 해당 examples module 전체 test
+3. 필요한 detekt/static scan과 `git diff --check`
+4. 두 번째 module로 넘어가기 전 Testcontainers 종료·잔여 상태 확인
+
+`.github/workflows/examples.yml`은 Kafka와 Redisson container test가 동시에
+실행되지 않도록 compile과 test phase를 분리한다. compile task 목록은 기존처럼
+`--parallel`로 실행하고, 모든 `test` task 목록은 다음 순서의 shell loop에서
+각각 별도 `./gradlew <task>` invocation으로 실행한다.
+
+1. `:bluetape4k-examples-coroutines-demo:test` (Kafka)
+2. `:bluetape4k-examples-jpa-blazepersistence-demo:test`
+3. `:bluetape4k-examples-jpa-querydsl-demo:test`
+4. `:bluetape4k-examples-redisson-demo:test` (Redis)
+5. `:bluetape4k-examples-virtualthreads-demo:test`
+6. 조건부 Ktor/Spring Boot example test task
+
+각 invocation은 `--max-workers=1`과 기존 `GRADLE_OPTS`를 유지한다. shell은
+`set +e; status=0; for task in "${test_tasks[@]}"; do ./gradlew "$task"
+--max-workers=1 || status=1; done; set -e; exit "$status"` 형태로 실패를
+누적하고 가능한 후속 test를 계속 실행한 뒤 마지막에 aggregate failure를
+반환한다. `if: always()` artifact 단계는 모든 결과를 수집한다. test report와
+bounded container diagnostic log는
+`examples/build/testcontainers-diagnostics/<task-name>/` 경로에 저장하고,
+artifact upload는 `examples/**/build/test-results/**`,
+`examples/**/build/reports/tests/test/**`,
+`examples/build/testcontainers-diagnostics/**`를 포함한다. workflow를 변경하면
+`actionlint`, path filter, artifact upload 경로와 직렬 순서를 정적 검사한다.
+현재 60분 job timeout 안에 들어오는지 기존 병렬 실행의 wall-clock과 비교하고,
+초과하면 테스트 범위를 줄이지 말고 job budget 변경 근거를 기록한다.
+
+## 문서와 GitHub delivery
+
+- `README.md`와 `README.ko.md`는 같은 예제 목록, 실행 명령, failure/consistency
+  설명을 유지한다.
+- 정확한 targeted 명령은 다음과 같다. 두 명령 모두 worktree root에서
+  Docker/Testcontainers가 실행 가능한 상태로 수행한다.
+
+  ```bash
+  ./gradlew :bluetape4k-examples-coroutines-demo:test \
+    --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples'
+  ./gradlew :bluetape4k-examples-redisson-demo:test \
+    --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapExamples' \
+    --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest'
+  ```
+
+  전체 모듈 검증은 각각 `:bluetape4k-examples-coroutines-demo:test`와
+  `:bluetape4k-examples-redisson-demo:test`를 사용한다. 두 README에는 Docker
+  daemon, dynamic Testcontainers port, 테스트가 생성하는 unique topic/map,
+  eventual invalidation과 bounded timeout을 같은 문장으로 설명한다.
+- Epic #1422 본문의 stale `1.13.0` 표현은 live milestone `2.0.0`으로
+  갱신한다.
+- PR #1347은 `develop`을 base로 하고 `Closes #1347`을 포함한다.
+- PR #1353은 #1347 branch를 base로 하고 `Closes #1353`을 포함한다. 부모
+  merge 전 child PR의 base/head SHA를 기록하고, 임시 branch
+  `train/epic-1422-parent-base`를 parent head SHA에서 미리 만든 뒤 child base를
+  그 branch로 retarget한다. parent merge 직후 child base를 `develop` branch로
+  retarget하고, `develop` head가 parent merge SHA인지와 child exact diff를
+  확인한 뒤 child PR에만 `Closes #1422`를 추가한다. 그러면 Epic auto-close를
+  유발하는 최종 develop 대상 PR이 하나로 고정된다.
+- parent merge는 stack ancestry를 보존하는 merge commit 전략을 사용한다.
+  자동 branch 삭제 여부와 temporary branch 상태를 즉시 읽고, branch가
+  사라졌으면 parent merge SHA를 가리키는 새 temporary branch를 만든 뒤
+  `gh pr edit <child> --base develop`을 수행한다. SHA 자체를 PR base로
+  지정하지 않는다. child exact diff/CI/review를 fresh하게 재검증한 뒤에만
+  다음 merge approval을 받으며, temporary branch는 최종 cleanup에서 삭제한다.
+- merge 후 실제 auto-close 상태와 child/epic milestone을 GitHub에서 확인한다.
+- PR body 마지막에는 한국어 `## DoD Status`와 required check count,
+  exact head, 7-Tier artifact, known gaps를 기록한다.
+
+## 대안과 거부 이유
+
+| 대안 | 거부 이유 |
+|---|---|
+| 기존 `sendAsFlow`만 재사용 | callbackFlow registration, `trySend`, `awaitClose` 계약을 검증하지 못한다. |
+| public Kafka callback adapter 추가 | examples 범위를 넘어 public ABI/API와 release 문서 부담을 만든다. |
+| fake callback만으로 전체 테스트 | 실제 broker 상호작용과 producer shutdown 누수를 증명하지 못한다. |
+| Int/Double을 하나의 map에 혼합 | `HINCRBYFLOAT`의 runtime numeric conversion과 local cache 값을 모호하게 만든다. |
+| examples Testcontainers를 계속 `--parallel` 실행 | module 간 container lifecycle 경쟁을 허용하고 재현 가능한 CI 증거를 약화한다. |
+
+## 호환성·롤백
+
+- production artifact/API/ABI에는 변화가 없다.
+- examples test dependency는 기존 `:bluetape4k-kafka4`와
+  `:bluetape4k-testcontainers`를 재사용하며 catalog version을 수정하지 않는다.
+- 구현 실패 시 child branch에서 해당 example/test/docs 변경만 revert할 수
+  있다. workflow 직렬화 변경은 독립 commit으로 두어 필요하면 별도로 되돌린다.
+- rollback trigger는 exact-head test failure, unresolved P1, 또는 container
+  cleanup timeout이다. revert 뒤 affected module test·workflow static check를
+  다시 실행하고, PR `## DoD Status`와 child/Epic issue 상태에 rollback 및
+  재검증 결과를 기록한다. temporary branch/ref는 rollback 또는 merge 완료 후
+  목록을 재확인해 남은 참조가 없을 때만 삭제한다.
+- Kafka/Redis image 또는 version을 변경하지 않는다. container startup 실패는
+  코드 결함으로 분류하지 않고 raw Docker/CI evidence와 함께 별도 blocker로
+  기록한다.
+- 기존 launcher의 mutable image tag와 workflow action reference를 이 Epic에서
+  pinning으로 바꾸지 않는다. 대신 실행마다 resolved image digest와 action
+  ref를 bounded evidence에 기록하고, immutable provenance 전환은 별도 보안
+  후속 이슈로 분리한다.
+
+## Acceptance criteria와 DoD
+
+- [ ] #1347이 fake-only가 아닌 실제 Kafka broker callbackFlow를 제공한다.
+- [ ] #1347이 success/failure/cancellation/backpressure/shutdown을 검증한다.
+- [ ] #1353이 Int/Double `addAndGetAsync`와 `HINCRBYFLOAT` 제약을 검증한다.
+- [ ] #1353이 concurrent remote final value와 local reread 일치를 검증한다.
+- [ ] #1353이 remote change/remove invalidation을 두 client로 검증한다.
+- [ ] 모든 touched test assertion이 `bluetape4k-assertions`를 사용한다.
+- [ ] 두 README locale과 실행 명령이 source/test behavior와 일치한다.
+- [ ] examples Testcontainers test가 모듈 간 순차 실행된다.
+- [ ] child별 module test, static check, diff check가 fresh evidence로 기록된다.
+- [ ] child별 7-Tier review의 최신 통합 결과가 `P0=0`, `P1=0`이다.
+- [ ] 두 PR의 exact head, CI, review/thread, final `## DoD Status`가 확인된다.
+- [ ] fresh merge approval 전에는 merge하지 않는다.
+- [ ] merge 후 canonical `develop`, issue auto-close, worktree/branch cleanup을
+  live state로 검증한다.
+
+## 문서 작성 DoD
+
+- **SPW-01 PASS**: 독자는 bluetape4k contributor이며, Epic/child live metadata,
+  현재 Kafka·Redisson·Testcontainers source, workflow와 공식 API 문서를
+  근거로 삼았다. 구현 전 미확인 항목은 별도로 표시했다.
+- **SPW-02 PASS**: 문제·목표·범위·소유권·실패 모드·호환성·대안·테스트·CI
+  실행·acceptance·DoD를 포함했다.
+- **SPW-03 PASS**: 한국어 기술 문체와 일관된 용어를 적용하고 code token,
+  command, URL, 숫자와 status token을 보존했다. 한국어 자연스러움 checklist를
+  기준으로 문장과 표를 읽었다.
+- **SPW-04 PASS**: 설계 선택을 현재 worktree source, live issue metadata와
+  Kotlin/Redisson 공식 문서에 대조했다. 실제 broker/Redis runtime, CI와
+  exact-head는 구현 이후 검증해야 하는 미확인 항목으로 남겼다.
+- **SPW-05 PASS**: 최종 Markdown을 다시 읽고 제목·표·목록·code fence·link와
+  acceptance checklist를 확인했다. `git diff --check`와
+  `audit-korean-terms.mjs`가 통과했다.
+
+## 설계 gate
+
+- 설계 승인: 2026-08-26 사용자 승인 완료
+- Step 2-R: 이 문서와 현재 evidence를 대상으로 6개 perspective lane과
+  main-session integration을 수행한다.
+- 다음 gate: Step 2-R `P0=0`, `P1=0` 수렴 후 설계 문서 commit 및 사용자
+  문서 검토 승인

--- a/docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md
+++ b/docs/superpowers/specs/2026-08-26-epic-1422-executable-examples-design.md
@@ -5,7 +5,7 @@
 - 작성일: 2026-08-26
 - 저장소: `bluetape4k/bluetape4k-projects`
 - 기준 branch: `feat/epic-1422-kafka-callback-flow`
-- 기준 base: `origin/develop` / `a907d144f39bfb94cba783cf65a5412e0714e9d5`
+- 기준 base: `origin/develop` / `552d9921520492033ad650743e8696e6352402c2`
 - 관련 Epic: [#1422](https://github.com/bluetape4k/bluetape4k-projects/issues/1422)
 - child 순서: [#1347](https://github.com/bluetape4k/bluetape4k-projects/issues/1347) → [#1353](https://github.com/bluetape4k/bluetape4k-projects/issues/1353)
 - 분류: Type A — 여러 examples 모듈과 외부 broker/cache lifecycle을 함께 검증하는 Full Feature
@@ -278,12 +278,12 @@ numeric 예제는 map 이름과 value type을 분리한다.
 `set +e; status=0; for task in "${test_tasks[@]}"; do ./gradlew "$task"
 --max-workers=1 || status=1; done; set -e; exit "$status"` 형태로 실패를
 누적하고 가능한 후속 test를 계속 실행한 뒤 마지막에 aggregate failure를
-반환한다. `if: always()` artifact 단계는 모든 결과를 수집한다. test report와
-bounded container diagnostic log는
-`examples/build/testcontainers-diagnostics/<task-name>/` 경로에 저장하고,
-artifact upload는 `examples/**/build/test-results/**`,
-`examples/**/build/reports/tests/test/**`,
-`examples/build/testcontainers-diagnostics/**`를 포함한다. workflow를 변경하면
+반환한다. `if: always()` artifact 단계는 모든 결과를 수집한다. test report는
+민감 정보가 제거된 sanitized 사본만, bounded container diagnostic log는
+`examples/build/testcontainers-diagnostics/<task-name>/` 경로에 저장한다.
+artifact upload는 `examples/build/sanitized-test-reports/**`와
+`examples/build/testcontainers-diagnostics/**`만 포함하며 원본 report는
+업로드하지 않는다. workflow를 변경하면
 `actionlint`, path filter, artifact upload 경로와 직렬 순서를 정적 검사한다.
 현재 60분 job timeout 안에 들어오는지 기존 병렬 실행의 wall-clock과 비교하고,
 초과하면 테스트 범위를 줄이지 말고 job budget 변경 근거를 기록한다.

--- a/examples/coroutines-demo/README.ko.md
+++ b/examples/coroutines-demo/README.ko.md
@@ -108,8 +108,9 @@ Kotlin Coroutines의 다양한 기능과 사용 패턴을 학습하기 위한 �
 daemon이 필요하다. 각 테스트는 고유 topic을 사용하며 consumer poll과 producer
 close에는 제한 시간(timeout)이 있다. adapter는 send를 재시도하지 않고 metadata 순서를
 보장하지 않는다. collection이 실패하거나 취소되면 부분 결과가 관찰될 수 있고,
-첫 producer/callback 실패가 terminal cause로 유지되며 in-flight send future는 취소되고
-늦게 도착한 callback은 무시된 뒤 producer가 제한된 정리 과정에서 닫힌다.
+첫 producer/callback 실패가 terminal cause로 유지되며 in-flight send future는
+best-effort로 취소를 시도한다. 늦게 도착한 callback은 무시된 뒤 producer가 제한된
+정리 과정에서 닫힌다.
 
 ## 주요 학습 포인트
 

--- a/examples/coroutines-demo/README.ko.md
+++ b/examples/coroutines-demo/README.ko.md
@@ -87,11 +87,11 @@ Kotlin Coroutines의 다양한 기능과 사용 패턴을 학습하기 위한 �
 
 ```bash
 # 모든 예제 테스트 실행
-./gradlew :examples:coroutines:test
+./gradlew :bluetape4k-examples-coroutines-demo:test
 
 # 특정 예제만 실행
-./gradlew :examples:coroutines:test --tests "io.bluetape4k.examples.coroutines.guide.*"
-./gradlew :examples:coroutines:test --tests "io.bluetape4k.examples.coroutines.flow.*"
+./gradlew :bluetape4k-examples-coroutines-demo:test --tests "io.bluetape4k.examples.coroutines.guide.*"
+./gradlew :bluetape4k-examples-coroutines-demo:test --tests "io.bluetape4k.examples.coroutines.flow.*"
 ```
 
 ### Kafka callbackFlow 계약

--- a/examples/coroutines-demo/README.ko.md
+++ b/examples/coroutines-demo/README.ko.md
@@ -29,7 +29,7 @@ Kotlin Coroutines의 다양한 기능과 사용 패턴을 학습하기 위한 �
 | `SharedFlowExamples.kt`    | SharedFlow로 이벤트 버스 구현            |
 | `StateFlowExamples.kt`     | StateFlow로 상태 관리                 |
 | `ChannelFlowExamples.kt`   | channelFlow와 콜드/핫 플로우            |
-| `CallbackFlowExamples.kt`  | 콜백 기반 API를 Flow로 변환              |
+| `CallbackFlowExamples.kt`  | Kafka producer callback을 `Flow<RecordMetadata>`로 변환하고 backpressure·취소·정리를 제한 시간으로 검증 |
 
 ### Channel 예제 (channels/)
 
@@ -93,6 +93,23 @@ Kotlin Coroutines의 다양한 기능과 사용 패턴을 학습하기 위한 �
 ./gradlew :examples:coroutines:test --tests "io.bluetape4k.examples.coroutines.guide.*"
 ./gradlew :examples:coroutines:test --tests "io.bluetape4k.examples.coroutines.flow.*"
 ```
+
+### Kafka callbackFlow 계약
+
+실행 가능한 Kafka callback 예제는 다음 명령으로 실행한다.
+
+```bash
+./gradlew :bluetape4k-examples-coroutines-demo:test \
+  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples' \
+  --no-configuration-cache --max-workers=1
+```
+
+이 테스트는 Testcontainers가 동적 포트의 Kafka broker를 시작하므로 Docker
+daemon이 필요하다. 각 테스트는 고유 topic을 사용하며 broker poll과 producer
+close에는 제한 시간(timeout)이 있다. adapter는 send를 재시도하지 않고 metadata 순서를
+보장하지 않는다. collection이 실패하거나 취소되면 부분 결과가 관찰될 수 있고,
+첫 producer/callback 실패가 terminal cause로 유지되며 in-flight callback은 제한된
+정리 과정에서 취소된 뒤 producer가 닫힌다.
 
 ## 주요 학습 포인트
 

--- a/examples/coroutines-demo/README.ko.md
+++ b/examples/coroutines-demo/README.ko.md
@@ -105,11 +105,11 @@ Kotlin Coroutines의 다양한 기능과 사용 패턴을 학습하기 위한 �
 ```
 
 이 테스트는 Testcontainers가 동적 포트의 Kafka broker를 시작하므로 Docker
-daemon이 필요하다. 각 테스트는 고유 topic을 사용하며 broker poll과 producer
+daemon이 필요하다. 각 테스트는 고유 topic을 사용하며 consumer poll과 producer
 close에는 제한 시간(timeout)이 있다. adapter는 send를 재시도하지 않고 metadata 순서를
 보장하지 않는다. collection이 실패하거나 취소되면 부분 결과가 관찰될 수 있고,
-첫 producer/callback 실패가 terminal cause로 유지되며 in-flight callback은 제한된
-정리 과정에서 취소된 뒤 producer가 닫힌다.
+첫 producer/callback 실패가 terminal cause로 유지되며 in-flight send future는 취소되고
+늦게 도착한 callback은 무시된 뒤 producer가 제한된 정리 과정에서 닫힌다.
 
 ## 주요 학습 포인트
 

--- a/examples/coroutines-demo/README.md
+++ b/examples/coroutines-demo/README.md
@@ -109,8 +109,8 @@ on a dynamic port. Each test uses a unique topic, and consumer polling and
 producer closing have bounded timeouts. The adapter does not retry sends and
 does not guarantee metadata order. A failed or cancelled collection may expose
 partial results; the first producer/callback failure remains the terminal cause,
-and in-flight send futures are cancelled; late callbacks are ignored before
-bounded cleanup closes the producer.
+and cancellation of in-flight send futures is requested on a best-effort basis;
+late callbacks are ignored before bounded cleanup closes the producer.
 
 ## Key Learning Points
 

--- a/examples/coroutines-demo/README.md
+++ b/examples/coroutines-demo/README.md
@@ -105,11 +105,12 @@ Run the executable Kafka callback example with:
 ```
 
 This test requires a Docker daemon because Testcontainers starts a Kafka broker
-on a dynamic port. Each test uses a unique topic, and broker polling and
+on a dynamic port. Each test uses a unique topic, and consumer polling and
 producer closing have bounded timeouts. The adapter does not retry sends and
 does not guarantee metadata order. A failed or cancelled collection may expose
 partial results; the first producer/callback failure remains the terminal cause,
-and in-flight callbacks are cancelled before bounded cleanup closes the producer.
+and in-flight send futures are cancelled; late callbacks are ignored before
+bounded cleanup closes the producer.
 
 ## Key Learning Points
 

--- a/examples/coroutines-demo/README.md
+++ b/examples/coroutines-demo/README.md
@@ -87,11 +87,11 @@ A collection of examples for learning the features and usage patterns of Kotlin 
 
 ```bash
 # Run all example tests
-./gradlew :examples:coroutines:test
+./gradlew :bluetape4k-examples-coroutines-demo:test
 
 # Run specific examples
-./gradlew :examples:coroutines:test --tests "io.bluetape4k.examples.coroutines.guide.*"
-./gradlew :examples:coroutines:test --tests "io.bluetape4k.examples.coroutines.flow.*"
+./gradlew :bluetape4k-examples-coroutines-demo:test --tests "io.bluetape4k.examples.coroutines.guide.*"
+./gradlew :bluetape4k-examples-coroutines-demo:test --tests "io.bluetape4k.examples.coroutines.flow.*"
 ```
 
 ### Kafka callbackFlow contract

--- a/examples/coroutines-demo/README.md
+++ b/examples/coroutines-demo/README.md
@@ -29,7 +29,7 @@ A collection of examples for learning the features and usage patterns of Kotlin 
 | `SharedFlowExamples.kt`    | Implementing an event bus with SharedFlow      |
 | `StateFlowExamples.kt`     | State management with StateFlow                |
 | `ChannelFlowExamples.kt`   | channelFlow and cold/hot flows                 |
-| `CallbackFlowExamples.kt`  | Converting callback-based APIs to Flow         |
+| `CallbackFlowExamples.kt`  | Converting Kafka producer callbacks to `Flow<RecordMetadata>` with bounded backpressure, cancellation, and cleanup |
 
 ### Channel Examples (channels/)
 
@@ -93,6 +93,23 @@ A collection of examples for learning the features and usage patterns of Kotlin 
 ./gradlew :examples:coroutines:test --tests "io.bluetape4k.examples.coroutines.guide.*"
 ./gradlew :examples:coroutines:test --tests "io.bluetape4k.examples.coroutines.flow.*"
 ```
+
+### Kafka callbackFlow contract
+
+Run the executable Kafka callback example with:
+
+```bash
+./gradlew :bluetape4k-examples-coroutines-demo:test \
+  --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples' \
+  --no-configuration-cache --max-workers=1
+```
+
+This test requires a Docker daemon because Testcontainers starts a Kafka broker
+on a dynamic port. Each test uses a unique topic, and broker polling and
+producer closing have bounded timeouts. The adapter does not retry sends and
+does not guarantee metadata order. A failed or cancelled collection may expose
+partial results; the first producer/callback failure remains the terminal cause,
+and in-flight callbacks are cancelled before bounded cleanup closes the producer.
 
 ## Key Learning Points
 

--- a/examples/coroutines-demo/build.gradle.kts
+++ b/examples/coroutines-demo/build.gradle.kts
@@ -19,5 +19,8 @@ dependencies {
     testImplementation(project(":bluetape4k-idgenerators"))
     testImplementation(bt4k.java.uuid.generator)
 
+    testImplementation(project(":bluetape4k-kafka4"))
+    testImplementation(project(":bluetape4k-testcontainers"))
+    testImplementation(libs.testcontainers.kafka)
     testImplementation(project(":bluetape4k-junit5"))
 }

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -110,7 +110,23 @@ class CallbackFlowExamples {
                 .collect()
         }
 
-    private fun Throwable.recoveredOrSelf(): Throwable = this
+    /**
+     * kotlinx.coroutines는 suspend 경계에서 호출자 stack을 복원하려고 예외를 복사할 수 있다.
+     * 이 형태만 unwrap하고 임의의 same-type cause는 원래 identity와 진단 정보를 유지한다.
+     */
+    private fun Throwable.unwrapRecoveredCoroutineCause(): Throwable {
+        val nested = cause ?: return this
+        val recoveredAtCoroutineBoundary = stackTrace.any { it.className == "_COROUTINE._BOUNDARY._" }
+        if (!recoveredAtCoroutineBoundary || nested.javaClass != javaClass || nested.message != message) {
+            return this
+        }
+        suppressed.forEach { suppressedCause ->
+            if (suppressedCause !== nested && nested.suppressed.none { it === suppressedCause }) {
+                nested.addSuppressed(suppressedCause)
+            }
+        }
+        return nested
+    }
 
     private fun producerResults(
         records: Flow<ProducerRecord<String, String>>,
@@ -169,7 +185,7 @@ class CallbackFlowExamples {
                 if (!state.completed.compareAndSet(false, true)) return
                 try {
                     if (cause != null) {
-                        failOnce(cause.recoveredOrSelf())
+                        failOnce(cause.unwrapRecoveredCoroutineCause())
                     } else if (metadata != null) {
                         val result = trySend(metadata)
                         if (result.isFailure && !result.isClosed && !isDownstreamCancelled()) {
@@ -205,23 +221,23 @@ class CallbackFlowExamples {
                                 inFlight.remove(state)
                                 permits.release()
                             }
-                            if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
+                            if (!isDownstreamCancelled()) failOnce(cause.unwrapRecoveredCoroutineCause())
                             throw cause
                         } catch (cause: Throwable) {
                             if (state.completed.compareAndSet(false, true)) {
                                 inFlight.remove(state)
                                 permits.release()
                             }
-                            failOnce(cause.recoveredOrSelf())
+                            failOnce(cause.unwrapRecoveredCoroutineCause())
                             throw cause
                         }
                         ensureActive()
                     }
                 } catch (cause: CancellationException) {
-                    if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
+                    if (!isDownstreamCancelled()) failOnce(cause.unwrapRecoveredCoroutineCause())
                     throw cause
                 } catch (cause: Throwable) {
-                    failOnce(cause.recoveredOrSelf())
+                    failOnce(cause.unwrapRecoveredCoroutineCause())
                     throw cause
                 } finally {
                     producer?.let { activeProducer ->
@@ -234,18 +250,18 @@ class CallbackFlowExamples {
                                     runInterruptible { activeProducer.flush() }
                                 }
                             } catch (cause: TimeoutCancellationException) {
-                                cleanupFailure = cause.recoveredOrSelf()
+                                cleanupFailure = cause.unwrapRecoveredCoroutineCause()
                                 cancelInFlight()
-                                if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
+                                if (!isDownstreamCancelled()) failOnce(cause.unwrapRecoveredCoroutineCause())
                             } catch (cause: CancellationException) {
-                                cleanupFailure = cause.recoveredOrSelf()
-                                cleanupCancellation = cause.recoveredOrSelf() as? CancellationException
+                                cleanupFailure = cause.unwrapRecoveredCoroutineCause()
+                                cleanupCancellation = cause.unwrapRecoveredCoroutineCause() as? CancellationException
                                 cancelInFlight()
-                                if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
+                                if (!isDownstreamCancelled()) failOnce(cause.unwrapRecoveredCoroutineCause())
                             } catch (cause: Throwable) {
-                                cleanupFailure = cause.recoveredOrSelf()
+                                cleanupFailure = cause.unwrapRecoveredCoroutineCause()
                                 cancelInFlight()
-                                if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
+                                if (!isDownstreamCancelled()) failOnce(cause.unwrapRecoveredCoroutineCause())
                             }
 
                             var closeFailure: Throwable? = null
@@ -255,10 +271,10 @@ class CallbackFlowExamples {
                                     runInterruptible { activeProducer.close(Duration.ofSeconds(5)) }
                                 }
                             } catch (cause: CancellationException) {
-                                closeFailure = cause.recoveredOrSelf()
-                                closeCancellation = cause.recoveredOrSelf() as? CancellationException
+                                closeFailure = cause.unwrapRecoveredCoroutineCause()
+                                closeCancellation = cause.unwrapRecoveredCoroutineCause() as? CancellationException
                             } catch (cause: Throwable) {
-                                closeFailure = cause.recoveredOrSelf()
+                                closeFailure = cause.unwrapRecoveredCoroutineCause()
                             }
 
                             val first = terminalCause()
@@ -295,7 +311,7 @@ class CallbackFlowExamples {
             }
         }.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)
             .catch { cause ->
-                throw cause.recoveredOrSelf()
+                throw cause.unwrapRecoveredCoroutineCause()
             }
     }
 
@@ -308,7 +324,7 @@ class CallbackFlowExamples {
             producerResults(flowOf(record("failure")), { producer.producer }).toList()
         }
 
-        error shouldBeEqualTo failure
+        error.hasCause(failure).shouldBeTrue()
         producer.closeCount.get() shouldBeEqualTo 1
         producer.callbackCount.get() shouldBeEqualTo 1
     }
@@ -455,6 +471,10 @@ class CallbackFlowExamples {
 
         producer.closeCount.get() shouldBeEqualTo 1
         observed.message shouldBeEqualTo cancellation.message
+        val cancellationCleanup = sequenceOf(observed, observed.cause)
+            .filterNotNull()
+            .flatMap { it.suppressed.asSequence() }
+        cancellationCleanup.any { it.hasCause(closeFailure) }.shouldBeTrue()
     }
 
     @Test
@@ -484,14 +504,14 @@ class CallbackFlowExamples {
         val factoryError = assertFailsWith<IllegalArgumentException> {
             producerResults(flowOf(record("factory")), { throw factoryFailure }).toList()
         }
-        factoryError shouldBeEqualTo factoryFailure
+        factoryError.hasCause(factoryFailure).shouldBeTrue()
 
         val sendFailure = IllegalStateException("send failure")
         val sendProducer = TrackingProducer(sendError = sendFailure)
         val sendError = assertFailsWith<IllegalStateException> {
             producerResults(flowOf(record("send")), { sendProducer.producer }).toList()
         }
-        sendError shouldBeEqualTo sendFailure
+        sendError.hasCause(sendFailure).shouldBeTrue()
         sendProducer.closeCount.get() shouldBeEqualTo 1
     }
 
@@ -551,7 +571,7 @@ class CallbackFlowExamples {
             producerResults(flowOf(record("flush-failure")), { producer.producer }).toList()
         }
 
-        error shouldBeEqualTo flushFailure
+        error.hasCause(flushFailure).shouldBeTrue()
         producer.closeCount.get() shouldBeEqualTo 1
     }
 
@@ -571,8 +591,8 @@ class CallbackFlowExamples {
             ).toList()
         }
 
-        error shouldBeEqualTo upstreamFailure
-        error.suppressed.single() shouldBeEqualTo closeFailure
+        error.hasCause(upstreamFailure).shouldBeTrue()
+        upstreamFailure.suppressed.any { it.hasCause(closeFailure) }.shouldBeTrue()
         producer.closeCount.get() shouldBeEqualTo 1
     }
 
@@ -657,6 +677,15 @@ class CallbackFlowExamples {
         require(headerValue.toByteArray(Charsets.UTF_8).size <= 256)
         val headers = RecordHeaders().add(headerName, headerValue.toByteArray(Charsets.UTF_8))
         return ProducerRecord(topic, null, null, key, value, headers)
+    }
+
+    private fun Throwable.hasCause(expected: Throwable): Boolean {
+        var current: Throwable? = this
+        while (current != null) {
+            if (current === expected) return true
+            current = current.cause
+        }
+        return false
     }
 
     private class TrackingProducer(

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -84,7 +84,7 @@ class CallbackFlowExamples {
         override suspend fun produce(message: Message, callback: suspend (Result) -> Unit) {
             delay(100.microseconds)
             val result = Result(message.id)
-            log.debug { "Create result. message=$message, result=$result" }
+            log.debug { "Create result. module=callback-flow, recordCount=1, failureKind=none" }
             callback(result)
         }
     }

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -504,7 +504,8 @@ class CallbackFlowExamples {
         assertFailsWith<CancellationException> { task.await() }
         await.atMost(Duration.ofSeconds(5)) untilSuspending { producer.closeCount.get() > 0 }
         producer.closeCount.get() shouldBeEqualTo 1
-        producer.cancelledPendingSends() shouldBeEqualTo 1
+        producer.sendCount.get() shouldBeEqualTo producer.cancelledPendingSends()
+        producer.pendingSends.all { it.isCancelled }.shouldBeTrue()
     }
 
     @Test

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.examples.coroutines.flow
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.coroutines.assertResult
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
@@ -79,7 +80,6 @@ class CallbackFlowExamples {
     /**
      * Kafka Producer callback을 `callbackFlow`로 변환하고 backpressure·취소·정리 경계를 검증하는 예제다.
      */
-
     data class Message(val id: Long, val body: String)
     data class Result(val id: Long)
 
@@ -133,6 +133,7 @@ class CallbackFlowExamples {
         producerFactory: () -> Producer<String, String>,
         channelCapacity: Int = 16,
         maxInFlight: Int = 16,
+        beforeRegister: (() -> Unit)? = null,
     ): Flow<RecordMetadata> {
         require(channelCapacity in 1..16) { "channelCapacity must be between 1 and 16" }
         require(maxInFlight in 1..16) { "maxInFlight must be between 1 and 16" }
@@ -161,14 +162,16 @@ class CallbackFlowExamples {
             val inFlight = ConcurrentHashMap.newKeySet<SendState>()
             val upstreamJobRef = AtomicReference<Job?>()
 
-            fun cancelInFlight() {
-                inFlight.toList().forEach { state ->
-                    state.future.get()?.cancel(false)
-                    if (state.completed.compareAndSet(false, true)) {
-                        inFlight.remove(state)
-                        permits.release()
-                    }
+            fun cancelState(state: SendState) {
+                state.future.get()?.cancel(false)
+                if (state.completed.compareAndSet(false, true)) {
+                    inFlight.remove(state)
+                    permits.release()
                 }
+            }
+
+            fun cancelInFlight() {
+                inFlight.toList().forEach(::cancelState)
             }
 
             fun failOnce(cause: Throwable) {
@@ -191,6 +194,8 @@ class CallbackFlowExamples {
                         if (result.isFailure && !result.isClosed && !isDownstreamCancelled()) {
                             failOnce(IllegalStateException("callback buffer is full"))
                         }
+                    } else {
+                        failOnce(IllegalStateException("Kafka callback returned neither metadata nor failure"))
                     }
                 } finally {
                     inFlight.remove(state)
@@ -209,25 +214,30 @@ class CallbackFlowExamples {
                     records.collect { record ->
                         permits.acquire()
                         val state = SendState()
+                        beforeRegister?.invoke()
+                        if (terminalCause() != null || isDownstreamCancelled()) {
+                            cancelState(state)
+                            ensureActive()
+                            return@collect
+                        }
                         inFlight += state
+                        if (terminalCause() != null || isDownstreamCancelled()) {
+                            cancelState(state)
+                            ensureActive()
+                            return@collect
+                        }
                         try {
                             val future = activeProducer.send(record, callbackFor(state))
                             state.future.set(future)
                             if (terminalCause() != null || isDownstreamCancelled()) {
-                                future.cancel(false)
+                                cancelState(state)
                             }
                         } catch (cause: CancellationException) {
-                            if (state.completed.compareAndSet(false, true)) {
-                                inFlight.remove(state)
-                                permits.release()
-                            }
+                            cancelState(state)
                             if (!isDownstreamCancelled()) failOnce(cause.unwrapRecoveredCoroutineCause())
                             throw cause
                         } catch (cause: Throwable) {
-                            if (state.completed.compareAndSet(false, true)) {
-                                inFlight.remove(state)
-                                permits.release()
-                            }
+                            cancelState(state)
                             failOnce(cause.unwrapRecoveredCoroutineCause())
                             throw cause
                         }
@@ -324,9 +334,24 @@ class CallbackFlowExamples {
             producerResults(flowOf(record("failure")), { producer.producer }).toList()
         }
 
-        error.hasCause(failure).shouldBeTrue()
+        error.assertIdentityOrDirectCause(failure)
         producer.closeCount.get() shouldBeEqualTo 1
         producer.callbackCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `same type callback wrapper without coroutine boundary preserves wrapper identity`() = runSuspendIO {
+        val original = IllegalStateException("callback root")
+        val wrapper = IllegalStateException("callback wrapper", original)
+        val producer = TrackingProducer(callbackError = wrapper)
+
+        val error = assertFailsWith<IllegalStateException> {
+            producerResults(flowOf(record("wrapper")), { producer.producer }).toList()
+        }
+
+        error.assertIdentityOrDirectCause(wrapper)
+        error.cause?.let { it.cause ?: it } shouldBeSameInstanceAs original
+        producer.closeCount.get() shouldBeEqualTo 1
     }
 
     @Test
@@ -457,6 +482,32 @@ class CallbackFlowExamples {
     }
 
     @Test
+    fun `collector cancellation during registration handoff releases the send state`() = runSuspendIO {
+        val producer = TrackingProducer(holdCallbacks = true)
+        val registrationStarted = CountDownLatch(1)
+        val releaseRegistration = CountDownLatch(1)
+        val task = async {
+            producerResults(
+                records = flowOf(record("cancel-registration")),
+                producerFactory = { producer.producer },
+                beforeRegister = {
+                    registrationStarted.countDown()
+                    releaseRegistration.await(5, TimeUnit.SECONDS)
+                },
+            ).toList()
+        }
+
+        registrationStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        task.cancel()
+        releaseRegistration.countDown()
+
+        assertFailsWith<CancellationException> { task.await() }
+        await.atMost(Duration.ofSeconds(5)) untilSuspending { producer.closeCount.get() > 0 }
+        producer.closeCount.get() shouldBeEqualTo 1
+        producer.cancelledPendingSends() shouldBeEqualTo 1
+    }
+
+    @Test
     fun `collector cancellation keeps its outcome when close fails`() = runSuspendIO {
         val closeFailure = IllegalStateException("close after cancellation")
         val producer = TrackingProducer(holdCallbacks = true, closeError = closeFailure)
@@ -474,7 +525,7 @@ class CallbackFlowExamples {
         val cancellationCleanup = sequenceOf(observed, observed.cause)
             .filterNotNull()
             .flatMap { it.suppressed.asSequence() }
-        cancellationCleanup.any { it.hasCause(closeFailure) }.shouldBeTrue()
+        cancellationCleanup.single().cause shouldBeSameInstanceAs closeFailure
     }
 
     @Test
@@ -504,15 +555,27 @@ class CallbackFlowExamples {
         val factoryError = assertFailsWith<IllegalArgumentException> {
             producerResults(flowOf(record("factory")), { throw factoryFailure }).toList()
         }
-        factoryError.hasCause(factoryFailure).shouldBeTrue()
+        factoryError.assertIdentityOrDirectCause(factoryFailure)
 
         val sendFailure = IllegalStateException("send failure")
         val sendProducer = TrackingProducer(sendError = sendFailure)
         val sendError = assertFailsWith<IllegalStateException> {
             producerResults(flowOf(record("send")), { sendProducer.producer }).toList()
         }
-        sendError.hasCause(sendFailure).shouldBeTrue()
+        sendError.assertIdentityOrDirectCause(sendFailure)
         sendProducer.closeCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `malformed callback without metadata or failure is terminal`() = runSuspendIO {
+        val producer = TrackingProducer(callbackWithoutMetadata = true)
+
+        val error = assertFailsWith<IllegalStateException> {
+            producerResults(flowOf(record("malformed-callback")), { producer.producer }).toList()
+        }
+
+        error.message shouldBeEqualTo "Kafka callback returned neither metadata nor failure"
+        producer.closeCount.get() shouldBeEqualTo 1
     }
 
     @Test
@@ -571,7 +634,7 @@ class CallbackFlowExamples {
             producerResults(flowOf(record("flush-failure")), { producer.producer }).toList()
         }
 
-        error.hasCause(flushFailure).shouldBeTrue()
+        error.assertIdentityOrDirectCause(flushFailure)
         producer.closeCount.get() shouldBeEqualTo 1
     }
 
@@ -591,8 +654,8 @@ class CallbackFlowExamples {
             ).toList()
         }
 
-        error.hasCause(upstreamFailure).shouldBeTrue()
-        upstreamFailure.suppressed.any { it.hasCause(closeFailure) }.shouldBeTrue()
+        error.assertIdentityOrDirectCause(upstreamFailure)
+        upstreamFailure.suppressed.single().cause shouldBeSameInstanceAs closeFailure
         producer.closeCount.get() shouldBeEqualTo 1
     }
 
@@ -679,13 +742,10 @@ class CallbackFlowExamples {
         return ProducerRecord(topic, null, null, key, value, headers)
     }
 
-    private fun Throwable.hasCause(expected: Throwable): Boolean {
-        var current: Throwable? = this
-        while (current != null) {
-            if (current === expected) return true
-            current = current.cause
+    private fun Throwable.assertIdentityOrDirectCause(expected: Throwable) {
+        if (this !== expected) {
+            cause shouldBeSameInstanceAs expected
         }
-        return false
     }
 
     private class TrackingProducer(
@@ -693,6 +753,7 @@ class CallbackFlowExamples {
         private val sendError: Exception? = null,
         private val flushError: Exception? = null,
         val closeError: Exception? = null,
+        private val callbackWithoutMetadata: Boolean = false,
         private val holdCallbacks: Boolean = false,
         private val heldSendIndexes: Set<Int> = emptySet(),
         private val callbackStarted: CountDownLatch? = null,
@@ -729,7 +790,7 @@ class CallbackFlowExamples {
                     future
                 } else {
                     callbackCount.incrementAndGet()
-                    callback.onCompletion(metadata, callbackError)
+                    callback.onCompletion(if (callbackWithoutMetadata) null else metadata, callbackError)
                     sendStarted.complete(Unit)
                     CompletableFuture.completedFuture(metadata)
                 }

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -70,7 +70,7 @@ class CallbackFlowExamples {
     }
 
     /**
-     * TODO: Kafka Producer의 Callback 을 `callbackFlow` 를 이용하여 Flow 로 구현하는 예제를 만들자
+     * Kafka Producer callback을 `callbackFlow`로 변환하고 backpressure·취소·정리 경계를 검증하는 예제다.
      */
 
     data class Message(val id: Long, val body: String)
@@ -376,6 +376,27 @@ class CallbackFlowExamples {
     }
 
     @Test
+    fun `cancellation immediately after producer creation closes it once`() = runSuspendIO {
+        val producer = TrackingProducer(holdCallbacks = true)
+        val factoryStarted = CompletableDeferred<Unit>()
+        val task = async {
+            producerResults(
+                flowOf(record("immediate-cancel")),
+                {
+                    factoryStarted.complete(Unit)
+                    producer.producer
+                },
+            ).toList()
+        }
+
+        withTimeout(5.seconds) { factoryStarted.await() }
+        task.cancel()
+        assertFailsWith<CancellationException> { task.await() }
+
+        producer.closeCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
     fun `factory and synchronous send failures are terminal causes`() = runSuspendIO {
         val factoryFailure = IllegalArgumentException("factory failure")
         val factoryError = assertFailsWith<IllegalArgumentException> {
@@ -390,6 +411,23 @@ class CallbackFlowExamples {
         }
         sendError shouldBeEqualTo sendFailure
         sendProducer.closeCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `producer factory is invoked once for each collection`() = runSuspendIO {
+        val producer = TrackingProducer()
+        val factoryCalls = AtomicInteger()
+
+        producerResults(
+            records = flowOf(record("factory-once"), record("factory-twice")),
+            producerFactory = {
+                factoryCalls.incrementAndGet()
+                producer.producer
+            },
+        ).toList()
+
+        factoryCalls.get() shouldBeEqualTo 1
+        producer.closeCount.get() shouldBeEqualTo 1
     }
 
     @Test

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.coroutines.flow.extensions.log
+import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
@@ -22,6 +23,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
@@ -50,6 +52,8 @@ import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.header.internals.RecordHeaders
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
 import org.testcontainers.utility.DockerImageName
 import java.time.Duration
@@ -106,8 +110,7 @@ class CallbackFlowExamples {
                 .collect()
         }
 
-    private fun Throwable.recoveredOrSelf(): Throwable =
-        cause?.takeIf { it::class == this@recoveredOrSelf::class && it.message == message } ?: this
+    private fun Throwable.recoveredOrSelf(): Throwable = this
 
     private fun producerResults(
         records: Flow<ProducerRecord<String, String>>,
@@ -120,13 +123,19 @@ class CallbackFlowExamples {
 
         return callbackFlow {
             var producer: Producer<String, String>? = null
-            val downstreamCancellation = Any()
+            class DownstreamCancellation(val cause: CancellationException)
+
             val terminalState = AtomicReference<Any?>(null)
             val permits = Semaphore(maxInFlight)
+            val callbackFlowJob = currentCoroutineContext()[Job]
 
-            fun isDownstreamCancelled(): Boolean = terminalState.get() === downstreamCancellation
+            fun isDownstreamCancelled(): Boolean = terminalState.get() is DownstreamCancellation
 
-            fun terminalCause(): Throwable? = terminalState.get() as? Throwable
+            fun terminalCause(): Throwable? = when (val terminal = terminalState.get()) {
+                is DownstreamCancellation -> terminal.cause
+                is Throwable -> terminal
+                else -> null
+            }
 
             class SendState {
                 val future = AtomicReference<Future<RecordMetadata>?>(null)
@@ -147,7 +156,6 @@ class CallbackFlowExamples {
             }
 
             fun failOnce(cause: Throwable) {
-                if (isDownstreamCancelled()) return
                 if (terminalState.compareAndSet(null, cause)) {
                     cancelInFlight()
                     upstreamJobRef.get()?.cancel(CancellationException("producer terminal failure", cause))
@@ -277,9 +285,13 @@ class CallbackFlowExamples {
             upstreamJobRef.set(upstreamJob)
             upstreamJob.start()
             awaitClose {
-                terminalState.compareAndSet(null, downstreamCancellation)
+                val cancellation = callbackFlowJob
+                    ?.takeIf { it.isCancelled }
+                    ?.getCancellationException()
+                    ?: CancellationException("collector cancelled")
+                terminalState.compareAndSet(null, DownstreamCancellation(cancellation))
                 cancelInFlight()
-                upstreamJob.cancel(CancellationException("collector cancelled"))
+                upstreamJob.cancel(cancellation)
             }
         }.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)
             .catch { cause ->
@@ -366,9 +378,7 @@ class CallbackFlowExamples {
 
         withTimeout(5.seconds) { producer.sendStarted.await() }
         task.cancel()
-        withTimeout(5.seconds) {
-            while (producer.cancelledPendingSends() == 0) delay(10)
-        }
+        await.atMost(Duration.ofSeconds(5)) untilSuspending { producer.cancelledPendingSends() > 0 }
         val cancellation = assertFailsWith<CancellationException> { task.await() }
 
         producer.closeCount.get() shouldBeEqualTo 1
@@ -401,9 +411,7 @@ class CallbackFlowExamples {
         val callback = async(Dispatchers.IO) { producer.fireCallback() }
         callbackStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         task.cancel()
-        withTimeout(5.seconds) {
-            while (producer.closeCount.get() == 0) delay(10)
-        }
+        await.atMost(Duration.ofSeconds(5)) untilSuspending { producer.closeCount.get() > 0 }
         callbackGate.countDown()
         callback.await()
 
@@ -425,13 +433,28 @@ class CallbackFlowExamples {
 
         withTimeout(5.seconds) { producer.twoSendsStarted.await() }
         task.cancel()
-        withTimeout(5.seconds) {
-            while (producer.cancelledPendingSends() < 2) delay(10)
-        }
+        await.atMost(Duration.ofSeconds(5)) untilSuspending { producer.cancelledPendingSends() >= 2 }
         assertFailsWith<CancellationException> { task.await() }
 
         producer.closeCount.get() shouldBeEqualTo 1
         producer.cancelledPendingSends() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `collector cancellation keeps its outcome when close fails`() = runSuspendIO {
+        val closeFailure = IllegalStateException("close after cancellation")
+        val producer = TrackingProducer(holdCallbacks = true, closeError = closeFailure)
+        val cancellation = CancellationException("collector cancellation")
+        val task = async {
+            producerResults(flowOf(record("cancel-close-failure")), { producer.producer }).toList()
+        }
+
+        withTimeout(5.seconds) { producer.sendStarted.await() }
+        task.cancel(cancellation)
+        val observed = assertFailsWith<CancellationException> { task.await() }
+
+        producer.closeCount.get() shouldBeEqualTo 1
+        observed.message shouldBeEqualTo cancellation.message
     }
 
     @Test

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -1,8 +1,10 @@
 package io.bluetape4k.examples.coroutines.flow
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.coroutines.assertResult
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.coroutines.flow.extensions.log
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -54,11 +56,12 @@ import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.microseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -117,9 +120,13 @@ class CallbackFlowExamples {
 
         return callbackFlow {
             var producer: Producer<String, String>? = null
-            val terminalCause = AtomicReference<Throwable?>(null)
-            val downstreamCancelled = AtomicBoolean()
+            val downstreamCancellation = Any()
+            val terminalState = AtomicReference<Any?>(null)
             val permits = Semaphore(maxInFlight)
+
+            fun isDownstreamCancelled(): Boolean = terminalState.get() === downstreamCancellation
+
+            fun terminalCause(): Throwable? = terminalState.get() as? Throwable
 
             class SendState {
                 val future = AtomicReference<Future<RecordMetadata>?>(null)
@@ -140,8 +147,8 @@ class CallbackFlowExamples {
             }
 
             fun failOnce(cause: Throwable) {
-                if (downstreamCancelled.get()) return
-                if (terminalCause.compareAndSet(null, cause)) {
+                if (isDownstreamCancelled()) return
+                if (terminalState.compareAndSet(null, cause)) {
                     cancelInFlight()
                     upstreamJobRef.get()?.cancel(CancellationException("producer terminal failure", cause))
                     close(cause)
@@ -157,7 +164,7 @@ class CallbackFlowExamples {
                         failOnce(cause.recoveredOrSelf())
                     } else if (metadata != null) {
                         val result = trySend(metadata)
-                        if (result.isFailure && !result.isClosed && !downstreamCancelled.get()) {
+                        if (result.isFailure && !result.isClosed && !isDownstreamCancelled()) {
                             failOnce(IllegalStateException("callback buffer is full"))
                         }
                     }
@@ -182,7 +189,7 @@ class CallbackFlowExamples {
                         try {
                             val future = activeProducer.send(record, callbackFor(state))
                             state.future.set(future)
-                            if (terminalCause.get() != null || downstreamCancelled.get()) {
+                            if (terminalCause() != null || isDownstreamCancelled()) {
                                 future.cancel(false)
                             }
                         } catch (cause: CancellationException) {
@@ -190,7 +197,7 @@ class CallbackFlowExamples {
                                 inFlight.remove(state)
                                 permits.release()
                             }
-                            if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                            if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
                             throw cause
                         } catch (cause: Throwable) {
                             if (state.completed.compareAndSet(false, true)) {
@@ -203,7 +210,7 @@ class CallbackFlowExamples {
                         ensureActive()
                     }
                 } catch (cause: CancellationException) {
-                    if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                    if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
                     throw cause
                 } catch (cause: Throwable) {
                     failOnce(cause.recoveredOrSelf())
@@ -221,16 +228,16 @@ class CallbackFlowExamples {
                             } catch (cause: TimeoutCancellationException) {
                                 cleanupFailure = cause.recoveredOrSelf()
                                 cancelInFlight()
-                                if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                                if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
                             } catch (cause: CancellationException) {
                                 cleanupFailure = cause.recoveredOrSelf()
                                 cleanupCancellation = cause.recoveredOrSelf() as? CancellationException
                                 cancelInFlight()
-                                if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                                if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
                             } catch (cause: Throwable) {
                                 cleanupFailure = cause.recoveredOrSelf()
                                 cancelInFlight()
-                                if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                                if (!isDownstreamCancelled()) failOnce(cause.recoveredOrSelf())
                             }
 
                             var closeFailure: Throwable? = null
@@ -246,21 +253,21 @@ class CallbackFlowExamples {
                                 closeFailure = cause.recoveredOrSelf()
                             }
 
-                            val first = terminalCause.get()
+                            val first = terminalCause()
                             if (first != null && cleanupFailure != null && first !== cleanupFailure) {
                                 first.addSuppressed(cleanupFailure)
                             }
                             if (first != null && closeFailure != null && first !== closeFailure) {
                                 first.addSuppressed(closeFailure)
                             }
-                            if (first == null && closeFailure != null && !downstreamCancelled.get()) {
+                            if (first == null && closeFailure != null && !isDownstreamCancelled()) {
                                 failOnce(closeFailure)
                             }
-                            if (terminalCause.get() == null && !downstreamCancelled.get()) close()
-                            if (cleanupCancellation != null && terminalCause.get() == null) {
+                            if (terminalCause() == null && !isDownstreamCancelled()) close()
+                            if (cleanupCancellation != null && terminalCause() == null) {
                                 throw cleanupCancellation
                             }
-                            if (closeCancellation != null && terminalCause.get() == null) {
+                            if (closeCancellation != null && terminalCause() == null) {
                                 throw closeCancellation
                             }
                         }
@@ -270,7 +277,7 @@ class CallbackFlowExamples {
             upstreamJobRef.set(upstreamJob)
             upstreamJob.start()
             awaitClose {
-                downstreamCancelled.set(true)
+                terminalState.compareAndSet(null, downstreamCancellation)
                 cancelInFlight()
                 upstreamJob.cancel(CancellationException("collector cancelled"))
             }
@@ -373,6 +380,58 @@ class CallbackFlowExamples {
         val afterLate = assertFailsWith<CancellationException> { task.await() }
         afterLate::class shouldBeEqualTo cancellation::class
         afterLate.message shouldBeEqualTo cancellation.message
+    }
+
+    @Test
+    fun `collector cancellation wins over a concurrent callback failure`() = runSuspendIO {
+        val callbackFailure = IllegalStateException("late callback failure")
+        val callbackStarted = CountDownLatch(1)
+        val callbackGate = CountDownLatch(1)
+        val producer = TrackingProducer(
+            callbackError = callbackFailure,
+            holdCallbacks = true,
+            callbackStarted = callbackStarted,
+            callbackGate = callbackGate,
+        )
+        val task = async {
+            producerResults(flowOf(record("concurrent-cancel")), { producer.producer }).toList()
+        }
+
+        withTimeout(5.seconds) { producer.sendStarted.await() }
+        val callback = async(Dispatchers.IO) { producer.fireCallback() }
+        callbackStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        task.cancel()
+        withTimeout(5.seconds) {
+            while (producer.closeCount.get() == 0) delay(10)
+        }
+        callbackGate.countDown()
+        callback.await()
+
+        assertFailsWith<CancellationException> { task.await() }
+        producer.closeCount.get() shouldBeEqualTo 1
+        producer.callbackCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `collector cancellation cancels every in-flight send`() = runSuspendIO {
+        val producer = TrackingProducer(holdCallbacks = true)
+        val task = async {
+            producerResults(
+                records = flowOf(record("cancel-one"), record("cancel-two")),
+                producerFactory = { producer.producer },
+                maxInFlight = 2,
+            ).toList()
+        }
+
+        withTimeout(5.seconds) { producer.twoSendsStarted.await() }
+        task.cancel()
+        withTimeout(5.seconds) {
+            while (producer.cancelledPendingSends() < 2) delay(10)
+        }
+        assertFailsWith<CancellationException> { task.await() }
+
+        producer.closeCount.get() shouldBeEqualTo 1
+        producer.cancelledPendingSends() shouldBeEqualTo 2
     }
 
     @Test
@@ -557,7 +616,7 @@ class CallbackFlowExamples {
         } finally {
             withContext(NonCancellable + Dispatchers.IO) {
                 withTimeout(5.seconds) {
-                    consumer.close(Duration.ofSeconds(5))
+                    runInterruptible { consumer.close(Duration.ofSeconds(5)) }
                 }
             }
         }
@@ -584,6 +643,8 @@ class CallbackFlowExamples {
         val closeError: Exception? = null,
         private val holdCallbacks: Boolean = false,
         private val heldSendIndexes: Set<Int> = emptySet(),
+        private val callbackStarted: CountDownLatch? = null,
+        private val callbackGate: CountDownLatch? = null,
     ) {
         val producer: Producer<String, String> = mockk(relaxed = true)
         val callbackCount = AtomicInteger()
@@ -648,7 +709,9 @@ class CallbackFlowExamples {
         fun fireCallback() {
             pendingCallbacks.poll()?.let { pending ->
                 callbackCount.incrementAndGet()
-                pending.callback.onCompletion(metadata, null)
+                callbackStarted?.countDown()
+                callbackGate?.await(5, TimeUnit.SECONDS)
+                pending.callback.onCompletion(metadata, callbackError)
                 pending.future.complete(metadata)
             }
         }

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -1,24 +1,73 @@
 package io.bluetape4k.examples.coroutines.flow
 
-import io.bluetape4k.coroutines.flow.extensions.log
 import io.bluetape4k.assertions.coroutines.assertResult
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.coroutines.flow.extensions.log
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import io.bluetape4k.testcontainers.mq.KafkaServer
+import io.bluetape4k.utils.ShutdownQueue
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Semaphore
+import org.apache.kafka.clients.producer.Callback
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.header.internals.RecordHeaders
 import org.junit.jupiter.api.Test
+import org.testcontainers.utility.DockerImageName
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.microseconds
+import kotlin.time.Duration.Companion.seconds
 
 class CallbackFlowExamples {
 
-    companion object: KLoggingChannel()
+    companion object: KLoggingChannel() {
+        private const val KAFKA_IMAGE_REF =
+            "confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130"
+    }
 
     /**
      * TODO: Kafka Producer의 Callback 을 `callbackFlow` 를 이용하여 Flow 로 구현하는 예제를 만들자
@@ -53,6 +102,521 @@ class CallbackFlowExamples {
                 .onCompletion { channel.close() }
                 .collect()
         }
+
+    private fun Throwable.recoveredOrSelf(): Throwable =
+        cause?.takeIf { it::class == this@recoveredOrSelf::class && it.message == message } ?: this
+
+    private fun producerResults(
+        records: Flow<ProducerRecord<String, String>>,
+        producerFactory: () -> Producer<String, String>,
+        channelCapacity: Int = 16,
+        maxInFlight: Int = 16,
+    ): Flow<RecordMetadata> {
+        require(channelCapacity in 1..16) { "channelCapacity must be between 1 and 16" }
+        require(maxInFlight in 1..16) { "maxInFlight must be between 1 and 16" }
+
+        return callbackFlow {
+            var producer: Producer<String, String>? = null
+            val terminalCause = AtomicReference<Throwable?>(null)
+            val downstreamCancelled = AtomicBoolean()
+            val permits = Semaphore(maxInFlight)
+
+            class SendState {
+                val future = AtomicReference<Future<RecordMetadata>?>(null)
+                val completed = AtomicBoolean()
+            }
+
+            val inFlight = ConcurrentHashMap.newKeySet<SendState>()
+            val upstreamJobRef = AtomicReference<Job?>()
+
+            fun cancelInFlight() {
+                inFlight.toList().forEach { state ->
+                    state.future.get()?.cancel(false)
+                    if (state.completed.compareAndSet(false, true)) {
+                        inFlight.remove(state)
+                        permits.release()
+                    }
+                }
+            }
+
+            fun failOnce(cause: Throwable) {
+                if (downstreamCancelled.get()) return
+                if (terminalCause.compareAndSet(null, cause)) {
+                    cancelInFlight()
+                    upstreamJobRef.get()?.cancel(CancellationException("producer terminal failure", cause))
+                    close(cause)
+                } else {
+                    log.debug { "late Kafka callback ignored; failureKind=${cause::class.simpleName}" }
+                }
+            }
+
+            fun complete(state: SendState, metadata: RecordMetadata?, cause: Exception?) {
+                if (!state.completed.compareAndSet(false, true)) return
+                try {
+                    if (cause != null) {
+                        failOnce(cause.recoveredOrSelf())
+                    } else if (metadata != null) {
+                        val result = trySend(metadata)
+                        if (result.isFailure && !result.isClosed && !downstreamCancelled.get()) {
+                            failOnce(IllegalStateException("callback buffer is full"))
+                        }
+                    }
+                } finally {
+                    inFlight.remove(state)
+                    permits.release()
+                }
+            }
+
+            fun callbackFor(state: SendState): Callback = Callback { metadata, cause ->
+                complete(state, metadata, cause)
+            }
+
+            val upstreamJob = launch(context = Dispatchers.IO, start = CoroutineStart.LAZY) {
+                try {
+                    val activeProducer = producerFactory()
+                    producer = activeProducer
+                    records.collect { record ->
+                        permits.acquire()
+                        val state = SendState()
+                        inFlight += state
+                        try {
+                            val future = activeProducer.send(record, callbackFor(state))
+                            state.future.set(future)
+                            if (terminalCause.get() != null || downstreamCancelled.get()) {
+                                future.cancel(false)
+                            }
+                        } catch (cause: CancellationException) {
+                            if (state.completed.compareAndSet(false, true)) {
+                                inFlight.remove(state)
+                                permits.release()
+                            }
+                            if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                            throw cause
+                        } catch (cause: Throwable) {
+                            if (state.completed.compareAndSet(false, true)) {
+                                inFlight.remove(state)
+                                permits.release()
+                            }
+                            failOnce(cause.recoveredOrSelf())
+                            throw cause
+                        }
+                        ensureActive()
+                    }
+                } catch (cause: CancellationException) {
+                    if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                    throw cause
+                } catch (cause: Throwable) {
+                    failOnce(cause.recoveredOrSelf())
+                    throw cause
+                } finally {
+                    producer?.let { activeProducer ->
+                        withContext(NonCancellable + Dispatchers.IO) {
+                            var cleanupFailure: Throwable? = null
+                            var cleanupCancellation: CancellationException? = null
+                            try {
+                                withTimeout(30.seconds) {
+                                    while (inFlight.isNotEmpty()) delay(10)
+                                    runInterruptible { activeProducer.flush() }
+                                }
+                            } catch (cause: TimeoutCancellationException) {
+                                cleanupFailure = cause.recoveredOrSelf()
+                                cancelInFlight()
+                                if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                            } catch (cause: CancellationException) {
+                                cleanupFailure = cause.recoveredOrSelf()
+                                cleanupCancellation = cause.recoveredOrSelf() as? CancellationException
+                                cancelInFlight()
+                                if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                            } catch (cause: Throwable) {
+                                cleanupFailure = cause.recoveredOrSelf()
+                                cancelInFlight()
+                                if (!downstreamCancelled.get()) failOnce(cause.recoveredOrSelf())
+                            }
+
+                            var closeFailure: Throwable? = null
+                            var closeCancellation: CancellationException? = null
+                            try {
+                                withTimeout(5.seconds) {
+                                    runInterruptible { activeProducer.close(Duration.ofSeconds(5)) }
+                                }
+                            } catch (cause: CancellationException) {
+                                closeFailure = cause.recoveredOrSelf()
+                                closeCancellation = cause.recoveredOrSelf() as? CancellationException
+                            } catch (cause: Throwable) {
+                                closeFailure = cause.recoveredOrSelf()
+                            }
+
+                            val first = terminalCause.get()
+                            if (first != null && cleanupFailure != null && first !== cleanupFailure) {
+                                first.addSuppressed(cleanupFailure)
+                            }
+                            if (first != null && closeFailure != null && first !== closeFailure) {
+                                first.addSuppressed(closeFailure)
+                            }
+                            if (first == null && closeFailure != null && !downstreamCancelled.get()) {
+                                failOnce(closeFailure)
+                            }
+                            if (terminalCause.get() == null && !downstreamCancelled.get()) close()
+                            if (cleanupCancellation != null && terminalCause.get() == null) {
+                                throw cleanupCancellation
+                            }
+                            if (closeCancellation != null && terminalCause.get() == null) {
+                                throw closeCancellation
+                            }
+                        }
+                    }
+                }
+            }
+            upstreamJobRef.set(upstreamJob)
+            upstreamJob.start()
+            awaitClose {
+                downstreamCancelled.set(true)
+                cancelInFlight()
+                upstreamJob.cancel(CancellationException("collector cancelled"))
+            }
+        }.buffer(channelCapacity, onBufferOverflow = BufferOverflow.SUSPEND)
+            .catch { cause ->
+                throw cause.recoveredOrSelf()
+            }
+    }
+
+    @Test
+    fun `callback failure preserves first cause and closes producer once`() = runSuspendIO {
+        val failure = IllegalStateException("callback failure")
+        val producer = TrackingProducer(callbackError = failure)
+
+        val error = assertFailsWith<IllegalStateException> {
+            producerResults(flowOf(record("failure")), { producer.producer }).toList()
+        }
+
+        error shouldBeEqualTo failure
+        producer.closeCount.get() shouldBeEqualTo 1
+        producer.callbackCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `backpressure fails without dropping callback and closes producer once`() = runSuspendIO {
+        val producer = TrackingProducer(holdCallbacks = true)
+        val collectorGate = CompletableDeferred<Unit>()
+        val firstItemReceived = CompletableDeferred<Unit>()
+        supervisorScope {
+            val collection = async {
+                var received = 0
+                producerResults(
+                    records = flowOf(record("one"), record("two"), record("three")),
+                    producerFactory = { producer.producer },
+                    channelCapacity = 1,
+                    maxInFlight = 2,
+                ).collect {
+                    val index = received
+                    received += 1
+                    if (index == 0) {
+                        firstItemReceived.complete(Unit)
+                        collectorGate.await()
+                    }
+                }
+            }
+
+            withTimeout(5.seconds) { producer.twoSendsStarted.await() }
+            producer.pendingSends.distinct().size shouldBeEqualTo 2
+            producer.fireCallback()
+            withTimeout(5.seconds) { firstItemReceived.await() }
+            withTimeout(5.seconds) { producer.allSendsStarted.await() }
+            producer.pendingSends.distinct().size shouldBeEqualTo 3
+            producer.fireCallback()
+            producer.fireCallback()
+            collectorGate.complete(Unit)
+            val error = assertFailsWith<IllegalStateException> {
+                withTimeout(10.seconds) { collection.await() }
+            }
+
+            error.message shouldBeEqualTo "callback buffer is full"
+            producer.closeCount.get() shouldBeEqualTo 1
+            producer.callbackCount.get() shouldBeEqualTo 3
+        }
+    }
+
+    @Test
+    fun `in-flight permit is released after callback`() = runSuspendIO {
+        val producer = TrackingProducer()
+
+        producerResults(
+            records = flowOf(record("permit-one"), record("permit-two")),
+            producerFactory = { producer.producer },
+            channelCapacity = 2,
+            maxInFlight = 1,
+        ).toList()
+
+        producer.callbackCount.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `collector cancellation rethrows CancellationException and closes producer once`() = runSuspendIO {
+        val producer = TrackingProducer(holdCallbacks = true)
+        val task = async {
+            producerResults(flowOf(record("cancel")), { producer.producer }).toList()
+        }
+
+        withTimeout(5.seconds) { producer.sendStarted.await() }
+        task.cancel()
+        withTimeout(5.seconds) {
+            while (producer.cancelledPendingSends() == 0) delay(10)
+        }
+        val cancellation = assertFailsWith<CancellationException> { task.await() }
+
+        producer.closeCount.get() shouldBeEqualTo 1
+        producer.pendingSend.isCancelled shouldBeEqualTo true
+        producer.cancelledPendingSends() shouldBeEqualTo 1
+        producer.fireLateCallback()
+        producer.callbackCount.get() shouldBeEqualTo 0
+        producer.lateCallbackCount.get() shouldBeEqualTo 1
+        val afterLate = assertFailsWith<CancellationException> { task.await() }
+        afterLate::class shouldBeEqualTo cancellation::class
+        afterLate.message shouldBeEqualTo cancellation.message
+    }
+
+    @Test
+    fun `factory and synchronous send failures are terminal causes`() = runSuspendIO {
+        val factoryFailure = IllegalArgumentException("factory failure")
+        val factoryError = assertFailsWith<IllegalArgumentException> {
+            producerResults(flowOf(record("factory")), { throw factoryFailure }).toList()
+        }
+        factoryError shouldBeEqualTo factoryFailure
+
+        val sendFailure = IllegalStateException("send failure")
+        val sendProducer = TrackingProducer(sendError = sendFailure)
+        val sendError = assertFailsWith<IllegalStateException> {
+            producerResults(flowOf(record("send")), { sendProducer.producer }).toList()
+        }
+        sendError shouldBeEqualTo sendFailure
+        sendProducer.closeCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `normal completion drains callbacks flushes and closes once`() = runSuspendIO {
+        val producer = TrackingProducer()
+
+        producerResults(flowOf(record("normal")), { producer.producer }).toList()
+
+        producer.flushCount.get() shouldBeEqualTo 1
+        producer.closeCount.get() shouldBeEqualTo 1
+        producer.callbackCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `mixed synchronous and asynchronous callbacks drain before close`() = runSuspendIO {
+        val producer = TrackingProducer(heldSendIndexes = setOf(2))
+        val collection = async {
+            producerResults(
+                flowOf(record("sync"), record("async")),
+                { producer.producer },
+            ).toList()
+        }
+
+        withTimeout(5.seconds) { producer.twoSendsStarted.await() }
+        producer.fireCallback()
+        collection.await()
+
+        producer.callbackCount.get() shouldBeEqualTo 2
+        producer.flushCount.get() shouldBeEqualTo 1
+        producer.closeCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `flush failure becomes the terminal cause after callback drain`() = runSuspendIO {
+        val flushFailure = IllegalStateException("flush failure")
+        val producer = TrackingProducer(flushError = flushFailure)
+
+        val error = assertFailsWith<IllegalStateException> {
+            producerResults(flowOf(record("flush-failure")), { producer.producer }).toList()
+        }
+
+        error shouldBeEqualTo flushFailure
+        producer.closeCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `upstream exception remains primary and cleanup failure is suppressed`() = runSuspendIO {
+        val upstreamFailure = IllegalArgumentException("upstream failure")
+        val closeFailure = IllegalStateException("close failure")
+        val producer = TrackingProducer(closeError = closeFailure)
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            producerResults(
+                flow {
+                    emit(record("before-upstream-failure"))
+                    throw upstreamFailure
+                },
+                { producer.producer },
+            ).toList()
+        }
+
+        error shouldBeEqualTo upstreamFailure
+        error.suppressed.single() shouldBeEqualTo closeFailure
+        producer.closeCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `channel and in flight bounds reject invalid values`() = runSuspendIO {
+        assertFailsWith<IllegalArgumentException> {
+            producerResults(
+                flowOf(record("invalid-capacity")),
+                { TrackingProducer().producer },
+                channelCapacity = 0,
+            ).toList()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            producerResults(
+                flowOf(record("invalid-in-flight")),
+                { TrackingProducer().producer },
+                maxInFlight = 17,
+            ).toList()
+        }
+    }
+
+    @Test
+    fun `callback drain timeout cancels pending sends and preserves timeout cause`() = runSuspendIO(timeout = 40.seconds) {
+        val producer = TrackingProducer(holdCallbacks = true)
+
+        val error = assertFailsWith<TimeoutCancellationException> {
+            producerResults(flowOf(record("timeout")), { producer.producer }).toList()
+        }
+
+        error::class shouldBeEqualTo TimeoutCancellationException::class
+        producer.closeCount.get() shouldBeEqualTo 1
+        producer.pendingSend.isCancelled shouldBeEqualTo true
+        producer.cancelledPendingSends() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `real Kafka producer callbacks become metadata flow`() = runSuspendIO(timeout = 120.seconds) {
+        val topic = "epic-1422-callback-${Base58.randomString(8)}"
+        val records = (0 until 8).map { index ->
+            ProducerRecord(topic, "key-$index", "value-$index")
+        }
+
+        val broker = KafkaServer(DockerImageName.parse(KAFKA_IMAGE_REF)).apply {
+            start()
+            ShutdownQueue.register(this)
+        }
+        val consumer = KafkaServer.Launcher.createStringConsumer(broker)
+        try {
+            consumer.subscribe(listOf(topic))
+            val metadata = producerResults(
+                records = records.asFlow(),
+                producerFactory = { KafkaServer.Launcher.createStringProducer(broker) },
+            ).toList()
+
+            metadata shouldHaveSize records.size
+            val polled = withTimeout(10.seconds) {
+                buildList {
+                    while (size < records.size) {
+                        addAll(consumer.poll(Duration.ofMillis(250)).toList())
+                    }
+                }
+            }
+            polled shouldHaveSize records.size
+        } finally {
+            withContext(NonCancellable + Dispatchers.IO) {
+                withTimeout(5.seconds) {
+                    consumer.close(Duration.ofSeconds(5))
+                }
+            }
+        }
+    }
+
+    private fun record(value: String): ProducerRecord<String, String> {
+        val topic = "epic-1422-${Base58.randomString(8)}"
+        val key = "key"
+        val headerName = "x-epic-1422"
+        val headerValue = "example"
+        require(topic.length <= 128)
+        require(key.length <= 128)
+        require(value.toByteArray(Charsets.UTF_8).size <= 1024)
+        require(headerName.toByteArray(Charsets.UTF_8).size <= 256)
+        require(headerValue.toByteArray(Charsets.UTF_8).size <= 256)
+        val headers = RecordHeaders().add(headerName, headerValue.toByteArray(Charsets.UTF_8))
+        return ProducerRecord(topic, null, null, key, value, headers)
+    }
+
+    private class TrackingProducer(
+        private val callbackError: Exception? = null,
+        private val sendError: Exception? = null,
+        private val flushError: Exception? = null,
+        val closeError: Exception? = null,
+        private val holdCallbacks: Boolean = false,
+        private val heldSendIndexes: Set<Int> = emptySet(),
+    ) {
+        val producer: Producer<String, String> = mockk(relaxed = true)
+        val callbackCount = AtomicInteger()
+        val closeCount = AtomicInteger()
+        val flushCount = AtomicInteger()
+        val lateCallbackCount = AtomicInteger()
+        val sendStarted = CompletableDeferred<Unit>()
+        val twoSendsStarted = CompletableDeferred<Unit>()
+        val allSendsStarted = CompletableDeferred<Unit>()
+        val sendCount = AtomicInteger()
+        data class Pending(val callback: Callback, val future: CompletableFuture<RecordMetadata>)
+        val pendingCallbacks = ConcurrentLinkedQueue<Pending>()
+        val pendingSends = ConcurrentLinkedQueue<CompletableFuture<RecordMetadata>>()
+        val pendingSend: CompletableFuture<RecordMetadata>
+            get() = pendingSends.peek() ?: error("no pending Kafka send")
+        private val closed = AtomicBoolean()
+        private val metadata = mockk<RecordMetadata>(relaxed = true)
+
+        init {
+            every { producer.send(any<ProducerRecord<String, String>>(), any()) } answers {
+                if (sendError != null) throw sendError
+                val callback = secondArg<Callback>()
+                val index = sendCount.incrementAndGet()
+                val hold = holdCallbacks || index in heldSendIndexes
+                val resultFuture = if (hold) {
+                    val future = CompletableFuture<RecordMetadata>()
+                    pendingSends += future
+                    pendingCallbacks += Pending(callback, future)
+                    sendStarted.complete(Unit)
+                    future
+                } else {
+                    callbackCount.incrementAndGet()
+                    callback.onCompletion(metadata, callbackError)
+                    sendStarted.complete(Unit)
+                    CompletableFuture.completedFuture(metadata)
+                }
+                when (index) {
+                    2 -> twoSendsStarted.complete(Unit)
+                    3 -> allSendsStarted.complete(Unit)
+                }
+                resultFuture
+            }
+            every { producer.flush() } answers {
+                flushCount.incrementAndGet()
+                flushError?.let { throw it }
+            }
+            every { producer.close(any<Duration>()) } answers {
+                closeCount.incrementAndGet()
+                closed.set(true)
+                closeError?.let { throw it }
+            }
+        }
+
+        fun fireLateCallback() {
+            pendingCallbacks.poll()?.let { pending ->
+                if (closed.get()) lateCallbackCount.incrementAndGet()
+                pending.callback.onCompletion(metadata, null)
+                pending.future.complete(metadata)
+            }
+        }
+
+        fun fireCallback() {
+            pendingCallbacks.poll()?.let { pending ->
+                callbackCount.incrementAndGet()
+                pending.callback.onCompletion(metadata, null)
+                pending.future.complete(metadata)
+            }
+        }
+
+        fun cancelledPendingSends(): Int = pendingSends.count { it.isCancelled }
+    }
 
     @Test
     fun `get messages by callback flow`() = runTest {


### PR DESCRIPTION
## 요약

Kafka Producer callback을 `Flow<RecordMetadata>`로 연결하는 실행 가능한 #1347 예제를 추가한다. 실제 Kafka Testcontainers broker와 deterministic fake producer를 함께 사용해 성공·실패·취소·backpressure·flush/close 계약을 검증한다.

Closes #1347

## 변경 내용

- `CallbackFlowExamples`에 bounded `callbackFlow` producer bridge와 21개 회귀 테스트 추가
- collection-scoped producer 소유권, `awaitClose` 취소, in-flight 제한, late callback 무시, 첫 원인 및 cleanup suppression 고정
- callback registration handoff 취소 경합을 fail-closed로 정리하고 `shouldBeSameInstanceAs`로 예외 identity를 검증
- metadata와 failure가 모두 없는 malformed callback을 명시적 terminal failure로 처리
- pinned Kafka image digest, dynamic port, unique topic, bounded consumer/producer lifecycle 적용
- coroutines demo에 기존 Kafka4/Testcontainers 모듈 의존성만 추가
- Examples workflow를 compile parallel + test sequential로 정렬하고 action/image provenance와 sanitized diagnostics를 fail-closed로 수집
- `secretKey`/`secret_key` redaction과 oversized JUnit/HTML report compact 회귀 테스트 추가
- 한·영 README와 승인 설계/실행 계획 및 6-R review 증거 추가

## 검증

- Targeted: `CallbackFlowExamples` 21 tests — 0 skipped, 0 failures, 0 errors, XML 생성 및 `BUILD SUCCESSFUL`
- Module: `:bluetape4k-examples-coroutines-demo:test --no-daemon --rerun-tasks --no-configuration-cache --max-workers=1` — XML 148 total, 147 executed, 3 skipped, 0 failures, 0 errors, `BUILD SUCCESSFUL`
- Diagnostics: Python `py_compile` 및 `unittest discover` 20 tests `OK`; verbose JUnit/HTML compact·redaction·image-ID fail-closed 회귀 포함
- Workflow/static: `ruff check --ignore EXE001`, `actionlint`, `shellcheck -s bash`, PyYAML parse, `git diff --check` 통과
- Hosted exact-head `a6542e54f062ed0c880762f6da7886f585362b2e`: Examples run `32996076207` 성공(8분 24초). compile·9개 순차 test·diagnostics·artifact upload 모두 통과
- Hosted artifact: 10개 manifest 모두 `truncated=false`, `report_truncated=false`; report-scan 506 files / 398,889 bytes; serial test phase 339초
- Hosted exact-head CI run `32996076217` 성공(10분대); 전체 22개 status check와 aggregate coverage 통과
- Provenance: immutable action commit SHA 4개, Kafka image digest, sanitized callback report 8개 / 38,059 bytes 확인
- Detekt: 해당 module task 없음으로 N/A

## 6-R

[`2026-08-26-epic-1422-1347-module-6r.md`](https://github.com/bluetape4k/bluetape4k-projects/blob/a6542e54f062ed0c880762f6da7886f585362b2e/docs/superpowers/reviews/2026-08-26-epic-1422-1347-module-6r.md)에 요구사항·운영/CI·Developer API·성능·보안·안정성 독립 검토와 후속 보정을 기록했다. P0/P1은 0이다. 잔여 P2는 `Future.cancel(false)`의 underlying send 중단 한계, Docker inspect capture 상한, parallel baseline 부재, post-task lifecycle 상태 자료 의미, session label 없는 재사용 컨테이너 provenance이며, P3는 일부 raw `require` 스타일이다.

## DoD Status

- 상태: `PASS WITH FOLLOW-UP`; 구현·로컬 검증·hosted exact-head 검증 완료
- Required checks: 22/22; N/A: 1 (Detekt module task 없음); Blocked: 0
- base: `develop` / PR base commit `552d9921520492033ad650743e8696e6352402c2`; live `origin/develop`은 `939180e28e5b0ccddab137f8aa7df491ca890d78`로 이동해 merge gate에서 재확인 필요
- head: `feat/epic-1422-kafka-callback-flow` / `a6542e54f062ed0c880762f6da7886f585362b2e`
- mergeability: `MERGEABLE` / `CLEAN`; reviews 0, threads 0; linked issue #1347은 OPEN
- 다음 게이트: CG-16 fresh merge approval. 이 PR은 자동 병합하지 않으며 승인 전 merge하지 않는다. #1353은 #1347 merge 후에만 착수한다.
