### PR TITLE
[ci][spring-boot] PR 변경의 Spring Boot 도메인 테스트 경로를 닫는다

### DIFF
--- a/.github/scripts/test-aggregate-kover-coverage.py
+++ b/.github/scripts/test-aggregate-kover-coverage.py
@@ -181,6 +181,29 @@ class AggregateKoverCoverageTest(unittest.TestCase):
         self.assertIn("'infra/nats'", workflow)
         self.assertIn("test-search-messaging, test-kafka-infra", workflow)
 
+    def test_ci_routes_spring_boot_changes_to_test_and_coverage_manifest(self):
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("spring-boot: ${{ steps.filter.outputs.spring-boot }}", workflow)
+        self.assertIn("'spring-boot/**'", workflow)
+        self.assertIn("test-spring-boot:", workflow)
+        self.assertIn(
+            "test-spring-boot=${{ needs.test-spring-boot.result }}",
+            workflow,
+        )
+        self.assertIn(
+            "if grep -q '^test-spring-boot=success$' coverage-artifacts/expected-jobs.manifest",
+            workflow,
+        )
+        for module in (
+            "spring-boot/core",
+            "spring-boot/redis",
+            "spring-boot/r2dbc",
+            "spring-boot/mongodb",
+            "spring-boot/cassandra",
+            "spring-boot/hibernate-lettuce",
+        ):
+            self.assertIn(f"'{module}'", workflow)
+
     def test_ci_keeps_coveralls_out_of_path_filtered_coverage(self):
         workflow = CI_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("id: aggregate-coverage", workflow)

--- a/.github/scripts/test-ci-domain-parallelization.py
+++ b/.github/scripts/test-ci-domain-parallelization.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import re
 import unittest
 from pathlib import Path
@@ -50,6 +51,7 @@ DOMAIN_JOBS = (
     "test-kafka-infra",
     "test-telemetry-infra",
     "test-data",
+    "test-spring-boot",
 )
 
 
@@ -103,6 +105,7 @@ class CiDomainParallelizationTest(unittest.TestCase):
         status_needs = inline_needs(job_block(self.workflow, "ci-status"))
         self.assertIn("build", status_needs)
         self.assertIn("coverage-report", status_needs)
+        self.assertIn("test-spring-boot", status_needs)
         self.assertNotIn("testcontainers-image-gate", status_needs)
 
     def test_coverage_report_still_waits_for_every_coverage_job(self):
@@ -121,6 +124,50 @@ class CiDomainParallelizationTest(unittest.TestCase):
         for path_pattern in SHARED_FILTER_PATHS:
             with self.subTest(path_pattern=path_pattern):
                 self.assertIn(path_pattern, shared_filter)
+
+    def test_spring_boot_fixture_routes_to_the_spring_boot_test_job(self):
+        changes = job_block(self.workflow, "changes")
+        self.assertIn(
+            "spring-boot: ${{ steps.filter.outputs.spring-boot }}",
+            changes,
+        )
+        spring_filter = path_filter_block(self.workflow, "spring-boot")
+        self.assertIn("'spring-boot/**'", spring_filter)
+        fixture = (
+            "spring-boot/cassandra/src/test/kotlin/"
+            "io/bluetape4k/spring/cassandra/convert/CassandraTypeMappingTest.kt"
+        )
+        filter_patterns = re.findall(r"^              - '([^']+)'$", spring_filter, re.MULTILINE)
+        self.assertTrue(any(fnmatch.fnmatchcase(fixture, pattern) for pattern in filter_patterns))
+
+        spring_job = job_block(self.workflow, "test-spring-boot")
+        self.assertIn(
+            "needs.changes.outputs['spring-boot'] == 'true'",
+            spring_job,
+        )
+        self.assertIn(
+            ":bluetape4k-spring-boot-cassandra:test",
+            spring_job,
+        )
+        self.assertIn(
+            ":bluetape4k-spring-boot-cassandra:koverXmlReport",
+            spring_job,
+        )
+
+    def test_spring_boot_skip_is_not_accepted_when_changes_are_detected(self):
+        status = job_block(self.workflow, "ci-status")
+        self.assertIn(
+            "SPRING_BOOT_CHANGED: ${{ needs.changes.outputs['spring-boot'] }}",
+            status,
+        )
+        self.assertIn(
+            "SPRING_BOOT_RESULT: ${{ needs.test-spring-boot.result }}",
+            status,
+        )
+        self.assertIn(
+            '[[ "$SPRING_BOOT_CHANGED" == "true" && "$SPRING_BOOT_RESULT" == "skipped" ]]',
+            status,
+        )
 
     def test_ci_and_nightly_exclude_benchmark_tag(self):
         for workflow_path in (CI_WORKFLOW, NIGHTLY_WORKFLOW):
@@ -166,6 +213,14 @@ class CiDomainParallelizationTest(unittest.TestCase):
         self.assertIn("--scope full", image_gate)
         self.assertIn("test-testcontainers:", nightly)
         self.assertIn("test-testcontainers-spring:", nightly)
+
+    def test_nightly_spring_boot_matrix_is_full_scope_only(self):
+        nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+        spring_job = job_block(nightly, "test-spring-docker")
+        self.assertIn(
+            "if: ${{ needs.plan.outputs.run_standard == 'true' }}",
+            spring_job,
+        )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
       kafka-infra: ${{ steps.filter.outputs.kafka-infra }}
       telemetry-infra: ${{ steps.filter.outputs.telemetry-infra }}
       data: ${{ steps.filter.outputs.data }}
+      spring-boot: ${{ steps.filter.outputs.spring-boot }}
     steps:
       - uses: actions/checkout@v7
       - name: Validate CSV CI coverage
@@ -215,6 +216,8 @@ jobs:
             data:
               - 'data/**'
               - 'cache/hibernate-cache-lettuce/**'
+            spring-boot:
+              - 'spring-boot/**'
 
   # ── 2. 전체 빌드 (테스트 제외) ──────────────────────────────────────────
   catalog-governance:
@@ -1048,9 +1051,112 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  # ── 7-d. Spring Boot 모듈 테스트 — PR 변경 시 실행, Nightly full에서도 실행 ──
+  # 검증된 Nightly matrix와 production 모듈·demo 목록을 공유해
+  # spring-boot/** 변경이 PR CI에서 테스트 없이 통과하지 않도록 한다.
+  test-spring-boot:
+    name: Test / Spring Boot (${{ matrix.group }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    needs: [changes, catalog-governance]
+    if: ${{ needs.changes.outputs['spring-boot'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: core-redis-r2dbc
+            test_tasks: >-
+              :bluetape4k-spring-boot-core:test
+              :bluetape4k-spring-boot-redis:test
+              :bluetape4k-spring-boot-r2dbc:test
+            kover_tasks: >-
+              :bluetape4k-spring-boot-core:koverXmlReport
+              :bluetape4k-spring-boot-redis:koverXmlReport
+              :bluetape4k-spring-boot-r2dbc:koverXmlReport
+          - group: batch-nosql
+            test_tasks: >-
+              :bluetape4k-spring-boot-mongodb:test
+              :bluetape4k-spring-boot-cassandra:test
+              :bluetape4k-spring-boot-hibernate-lettuce:test
+            kover_tasks: >-
+              :bluetape4k-spring-boot-mongodb:koverXmlReport
+              :bluetape4k-spring-boot-cassandra:koverXmlReport
+              :bluetape4k-spring-boot-hibernate-lettuce:koverXmlReport
+          - group: demos
+            test_tasks: >-
+              :bluetape4k-spring-boot-cassandra-demo:test
+              :bluetape4k-spring-boot-hibernate-lettuce-demo:test
+            kover_tasks: ""
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Build mock-web-server Docker image
+        run: ./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Build mock-webflux-server Docker image
+        run: ./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Verify default mock-server image tags
+        run: |
+          docker image inspect bluetape4k/mock-web-server:2.0.0
+          docker image inspect bluetape4k/mock-webflux-server:2.0.0
+
+      - name: Test Spring Boot modules (${{ matrix.group }})
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          shell: bash
+          command: |
+            read -ra tasks <<< "$TEST_TASKS"
+            ./gradlew "${tasks[@]}" --max-workers=2 --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          TEST_TASKS: ${{ matrix.test_tasks }}
+
+      - name: Generate Kover XML report
+        if: ${{ always() && matrix.kover_tasks != '' }}
+        env:
+          KOVER_TASKS: ${{ matrix.kover_tasks }}
+        run: |
+          read -ra tasks <<< "$KOVER_TASKS"
+          ./gradlew "${tasks[@]}" --parallel --no-configuration-cache
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-spring-boot-${{ matrix.group }}
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 30
+
+      - name: Upload coverage report
+        if: ${{ always() && matrix.kover_tasks != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-spring-boot-${{ matrix.group }}
+          path: '**/build/reports/kover/'
+          if-no-files-found: error
+          retention-days: 30
+
   # ── 나머지 모듈 → Nightly에서 실행 ─────────────────────────────────
-  # utils 전체, misc, spring3-docker, spring4-docker,
-  # testcontainers 는 nightly-tests.yml (매일 03:00 KST) 에서 실행
+  # utils 전체, misc, testcontainers는 nightly-tests.yml (매일 03:00 KST)에서
+  # 실행하며, Spring Boot는 위 PR matrix와 nightly-tests.yml full scope에서
+  # 실행한다.
   # exposed 모듈은 bluetape4k-exposed 독립 레포로 분리됨 (#334)
 
   # ── 8. 커버리지 집계 ──────────────────────────────────────────────────────
@@ -1058,7 +1164,7 @@ jobs:
     name: Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test-core, test-io, test-io-http, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data]
+    needs: [test-core, test-io, test-io-http, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, test-spring-boot]
     if: always()
     steps:
       - uses: actions/checkout@v7
@@ -1078,6 +1184,7 @@ jobs:
             test-kafka-infra=${{ needs.test-kafka-infra.result }}
             test-telemetry-infra=${{ needs.test-telemetry-infra.result }}
             test-data=${{ needs.test-data.result }}
+            test-spring-boot=${{ needs.test-spring-boot.result }}
         run: |
           mkdir -p coverage-artifacts
           printf '%s\n' "$EXPECTED_COVERAGE_JOBS" > coverage-artifacts/expected-jobs.manifest
@@ -1094,6 +1201,16 @@ jobs:
             printf '%s\n' \
               'infra/elasticsearch' \
               'infra/nats' \
+              >> coverage-artifacts/expected-modules.manifest
+          fi
+          if grep -q '^test-spring-boot=success$' coverage-artifacts/expected-jobs.manifest; then
+            printf '%s\n' \
+              'spring-boot/core' \
+              'spring-boot/redis' \
+              'spring-boot/r2dbc' \
+              'spring-boot/mongodb' \
+              'spring-boot/cassandra' \
+              'spring-boot/hibernate-lettuce' \
               >> coverage-artifacts/expected-modules.manifest
           fi
           if grep -q '=success$' coverage-artifacts/expected-jobs.manifest; then
@@ -1143,16 +1260,22 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, coverage-report]
+    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, test-ktor, test-key-utils, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, test-spring-boot, coverage-report]
     if: always()
     steps:
       - name: Check all jobs
         env:
           RESULTS: ${{ join(needs.*.result, ',') }}
+          SPRING_BOOT_CHANGED: ${{ needs.changes.outputs['spring-boot'] }}
+          SPRING_BOOT_RESULT: ${{ needs.test-spring-boot.result }}
         run: |
           echo "Job results: $RESULTS"
           if echo "$RESULTS" | grep -qE "failure|cancelled"; then
             echo "CI failed"
+            exit 1
+          fi
+          if [[ "$SPRING_BOOT_CHANGED" == "true" && "$SPRING_BOOT_RESULT" == "skipped" ]]; then
+            echo "Spring Boot changes were detected but the Spring Boot test job was skipped"
             exit 1
           fi
           echo "CI passed (skipped jobs treated as success)"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1018,7 +1018,8 @@ jobs:
           retention-days: 14
 
   # ── Spring Boot Docker 테스트 — Matrix 병렬 ───────────────────────────
-  # 3 groups run in parallel on separate runners
+  # Daily smoke(run_standard=false)에서는 생략하고 weekly/manual full에서 실행한다.
+  # PR CI의 spring-boot/** 변경도 같은 세 group을 별도 test-spring-boot job으로 실행한다.
   test-spring-docker:
     name: Test / Spring Boot (${{ matrix.group }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes #1517

`spring-boot/**` 변경이 PR에서 실제 Spring Boot 도메인 테스트를 실행하도록 CI 경로를 연결하고, 변경 감지 후 테스트 job이 건너뛰어지는 경우를 실패로 처리합니다.

## Background

Issue #1517은 Spring Boot 모듈 변경이 공통 경로의 빌드만 통과하고 도메인 테스트는 Nightly full에 남아 있던 검증 공백을 다룹니다. PR에서는 변경 도메인의 테스트와 Kover 결과를 실행하고, Nightly는 기존 smoke/full 경계를 유지합니다.

## What This Solves

- `spring-boot/**` 변경을 PR용 Spring Boot 테스트 matrix로 라우팅합니다.
- core/redis/r2dbc, batch/nosql, demo 그룹의 실제 Gradle 테스트를 실행합니다.
- Spring Boot 변경 감지 후 `test-spring-boot`가 skipped이면 CI Status가 fail-closed 하도록 보장합니다.
- Kover coverage manifest와 CI contract test에 Spring Boot 경로를 반영합니다.

## Work Done

- `.github/workflows/ci.yml`에 `spring-boot` path filter/output, `test-spring-boot` matrix, 테스트·Kover artifact, coverage manifest, CI Status guard를 추가했습니다.
- `.github/workflows/nightly-tests.yml` 주석을 PR matrix와 Nightly smoke/full 책임에 맞게 정리했습니다.
- `.github/scripts/test-ci-domain-parallelization.py`와 `.github/scripts/test-aggregate-kover-coverage.py`에 routing/skip/coverage 회귀 검증을 추가했습니다.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml` ✅
- `python3 .github/scripts/test-ci-domain-parallelization.py -v` — 15 tests passed ✅
- `python3 .github/scripts/test-aggregate-kover-coverage.py -v` — 27 tests passed ✅
- `ruby scripts/validate-ci-csv-coverage.rb` ✅
- `ruby scripts/validate-ci-kafka4-coverage.rb` ✅
- `ruby scripts/validate-ci-kafka4-coverage_test.rb` ✅
- Spring Boot core/batch/demo Gradle test matrices — `BUILD SUCCESSFUL` ✅
- Spring Boot core/batch Kover XML reports — `BUILD SUCCESSFUL`, 6 reports ✅
- Kover aggregate simulation — 10,362 covered / 1,558 missed (86.93%) ✅
- `git diff --check` ✅
- CI skip guard simulation — changed+skipped exits 1; unchanged+skipped exits 0 ✅

## Review Notes

- 독립 최종 리뷰: P0/P1/P3 `0`; P2 `1`(hosted check 수치 25/25 표기)을 `24/24`로 정정했습니다.
- GitHub formal review `0`, issue comment `0`, 미해결 GraphQL review thread `0`.
- 단일 개발자 저장소 증거: collaborators=`debop` only, `.github/CODEOWNERS` 없음, `develop` required approving review count=`0`, code-owner review=`false`; 따라서 CG-14 human-review subgate는 `N/A (single-developer lane)`로 기록합니다.
- 로컬 contract/actionlint/Gradle/Kover 검증과 GitHub-hosted exact-head CI 확인을 완료했습니다.

## Metadata

- Issue: #1517
- Milestone: `2.0.0`
- Assignee: `debop`
- Labels: `test`, `ci`, `tech-debt`
- Base: `develop`
- Head: `chore/1517-spring-boot-ci-routing`
- Commit: `0170ac7fc1771a892409b2406836cef8f2460cbe`
- PR: #1533 — https://github.com/bluetape4k/bluetape4k-projects/pull/1533
- CI: success — https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32998450372 (exact head `0170ac7fc1771a892409b2406836cef8f2460cbe`)
- Merge: squash — `ffaeff151368e16477570207dd498f1fbb068967` (2026-08-27T03:06:44Z)
- Canonical `develop`: `f965b87aa8d456ce5f8961f48c592a3fc57397e1` = `origin/develop`

## DoD Status

- **Status:** `DONE` — exact-head hosted CI, review, fresh approval, squash merge, canonical sync, cleanup 및 completion receipt 완료
- Required checks: `24/24` hosted checks passed; local validation suites: all PASS
- N/A: `3` (E-01 language/support; E-04 managed-source sync; CG-14 human-review subgate: single-developer lane)
- Blocked: `0`
- [x] 승인된 #1517 범위와 Issue acceptance criteria에 맞는 CI routing 구현
- [x] Spring Boot matrix, Kover manifest, fail-closed skip guard 추가
- [x] actionlint, contract tests, Gradle matrix, Kover, validators, diff check 통과
- [x] Lore commit 및 semantic branch 원격 exact-head publication
- [x] CG-14 exact-head hosted CI, reviews, threads, mergeability, independent final review 완료; human-review subgate `N/A (single-developer lane)`
- [x] CG-15 merge-ready report
- [x] CG-16 fresh merge approval
- [x] CG-17 execute/verify merge — squash commit `ffaeff151368e16477570207dd498f1fbb068967`
- [x] CG-18 canonical sync, integrated worktree/branch cleanup, final completion receipt 및 DoD closeout
