### PR TITLE
[examples] RLocalCachedMap 숫자 원자적 갱신과 로컬 무효화 예제 완성

### DIFF
--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1353-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1353-module-6r.md
@@ -71,20 +71,22 @@
 | Static topology | `:bluetape4k-examples-redisson-demo:detekt`는 examples/demo가 root detekt 분석에서 명시적으로 제외되어 task N/A; `detektSourceCoverage`는 `76 modules / 4165 Kotlin files`로 `BUILD SUCCESSFUL`. |
 | Documentation | 한·영 README의 Gradle task, 두 test class, `CompositeCodec`, `HINCRBYFLOAT`, Docker dynamic-port 설명 parity와 `git diff --check` 통과. |
 | Scope | `git diff develop...HEAD`에 5개 계획 파일만 있고 `build.gradle.kts`·workflow·version catalog 변경 및 새 dependency가 없다. |
+| Hosted exact-head | PR #1538 head `e63615e21455ec0717ea9d374102a170d310a0d6`; Examples run `33037657067`와 CI run `33037657072` 성공. Required checks `11/11`, N/A `12`, Blocked `0`; Examples diagnostics artifact `507 files / 400,396 bytes`, `truncated=false`, `report_truncated=false`. |
 
 ## Merge gate
 
-로컬 6-R 검토와 module verification은 완료했다. 아직 child branch를 원격에
-publish하지 않았으므로 PR hosted exact-head checks, review threads, linked issue,
-assignee/labels/milestone, mergeability는 fresh reread가 필요하다. #1353 병합은
-부모 #1531 병합 승인과 별개의 게이트이며, hosted evidence가 green이어도 새
-명시적 병합 승인을 받기 전에는 merge·auto-merge를 수행하지 않는다.
+로컬 6-R 검토, module verification, PR hosted exact-head checks는 완료했다.
+PR #1538은 `MERGEABLE`/`CLEAN`이고 `debop`, `2.0.0`, `enhancement/test/examples`
+metadata, linked issues #1353/#1422를 확인했다. GitHub review는 아직 없으며,
+#1353 병합은 부모 #1531 병합 승인과 별개의 게이트다. hosted evidence가 green이어도
+새 명시적 병합 승인을 받기 전에는 merge·auto-merge를 수행하지 않는다.
 
 ## DoD Status
 
-- 상태: `PASS WITH FOLLOW-UP`
+- 상태: `PASS WITH FOLLOW-UP — merge approval pending`
 - P0: `0`, P1: `0`, P2: `3`, P3: `1`
 - #1353 수용 기준은 로컬 실행 가능한 예제·회귀 테스트·한/영 문서로 충족했고,
-  bounded Redis lifecycle과 negative contract도 fresh test evidence로 확인했다.
-- 다음 게이트: 이 review artifact를 commit한 뒤 branch push, PR 생성, hosted
-  exact-head checks/reviews/threads/linked issue/mergeability를 확인한다.
+  bounded Redis lifecycle과 negative contract는 local/hosted test evidence로
+  확인했다.
+- 다음 게이트: 사용자의 새 #1353 merge approval 후 exact head와 base를 다시 읽고
+  병합한다. 현재는 merge하지 않는다.

--- a/docs/superpowers/reviews/2026-08-26-epic-1422-1353-module-6r.md
+++ b/docs/superpowers/reviews/2026-08-26-epic-1422-1353-module-6r.md
@@ -1,0 +1,90 @@
+# Epic #1422 / #1353 Redisson LocalCachedMap 6-R 검토
+
+## 검토 범위
+
+- 대상: Epic #1422의 두 번째 child #1353 Redisson `RLocalCachedMap` 숫자
+  `addAndGetAsync`·두 client cache 동기화 예제
+- 브랜치: `feat/epic-1422-redisson-local-cache`
+- 기준 base: `develop` / `f965b87aa8d456ce5f8961f48c592a3fc57397e1`
+- 검토 head: `a3a914ed4f`
+- 변경 범위: Redisson coroutine test lifecycle helper, Int/Double
+  `CompositeCodec` 예제·회귀 테스트, 한·영 README
+- 비범위: production Redisson API, dependency/version catalog, workflow,
+  `examples/redisson-demo/build.gradle.kts`
+
+## 6-R 검토 결과
+
+구현 head를 요구사항, 운영 lifecycle, 개발자 계약, 성능, 보안·공급망,
+안정성 관점에서 source-read-only로 재검토했다. 모든 관점에서 P0/P1 blocker는
+발견되지 않았으며, 아래 P2/P3는 현재 동작을 막지 않는 후속 hardening 항목이다.
+
+| Lens | 결과 | 핵심 근거 |
+|---|---|---|
+| Requirements / User-Caller | PASS WITH FOLLOW-UP | Int/Double 예제, 동일 front/back codec, 동시 최종값, 두 local cached map 간 비동기 무효화, 음수 `RedisException` 계약과 README가 일치한다. |
+| Ops / Lifecycle | PASS WITH FOLLOW-UP | shared client는 기존 `ShutdownQueue` 소유권을 유지하고 test-owned 두 client는 `registerShutdown=false`와 `@AfterAll` bounded shutdown으로 한 번만 닫는다. Redis warm-up client도 5초 상한으로 닫는다. |
+| Developer API / Failure Contract | PASS WITH FOLLOW-UP | `awaitRedis`가 5초 기본 deadline과 timeout/cancellation 시 `future.cancel(false)`를 제공하고, `CompositeCodec(String, numeric, numeric)`을 front/back에 동일하게 전달한다. |
+| Performance | PASS WITH FOLLOW-UP | `SuspendedJobTester(workers=4, rounds=32*8)`로 ad hoc thread 없이 원자 증가를 검증하고, Awaitility는 100 ms polling·5초 상한으로 제한한다. |
+| Security / Supply Chain | PASS WITH FOLLOW-UP | 새 dependency·workflow 변경이 없고 Redis image는 immutable digest로 고정된다. 음수 테스트는 Redis endpoint를 노출하지 않고 예외 타입만 검증한다. |
+| Stability / Lifecycle | PASS WITH FOLLOW-UP | Int/Double map 이름을 분리해 codec 교차 오염을 막고, 두 local view를 먼저 warm한 뒤 원격 최종값과 bounded reread를 비교한다. cleanup 실패는 두 client를 모두 시도하고 suppressed cause를 보존한다. |
+
+## 요구사항 대조
+
+1. `LocalCachedMapExamples`에서 빈 Int key에 `32 + 10 = 42`, 빈 Double key에
+   `0.25`를 `addAndGetAsync`로 기록하고 backend view로 재조회한다.
+2. Int/Double 동시 증가 각각 256회(`4 workers × 256 rounds`) 후 독립
+   `RMap`의 원격 최종값과 두 local view를 비교한다.
+3. `frontCache1`의 put/update/remove가 `frontCache2`의 캐시를 비동기적으로
+   무효화하는 계약을 5초/100 ms bounded Awaitility로 고정한다.
+4. String으로 저장한 비수치 값을 Double numeric view에서 증가할 때
+   `RedisException`이 발생함을 확인하고, README에 `HINCRBYFLOAT`와 numeric
+   codec 제약을 설명한다.
+
+직접적인 raw `RMap` update는 이미 채워진 LocalCachedMap cache에 invalidation
+이벤트를 발행하지 않으므로, 테스트는 실제로 invalidation 채널을 사용하는
+`frontCache1` 쓰기를 “remote client 변경” 계약으로 명시한다. README도 이 범위를
+“one local cached map을 통한 쓰기”로 제한해 외부 raw map mutation을 과장하지
+않는다.
+
+## 후속 P2/P3
+
+- P2: `future.cancel(false)`는 Redis command가 이미 서버에 제출된 뒤의
+  원격 실행 취소를 보장하지 않는다. 현재 helper의 목적은 coroutine timeout 뒤
+  pending future를 남기지 않는 best-effort 경계이며, production cancellation
+  보장으로 확장하지 않아야 한다.
+- P2: 동시 증가 테스트의 `addAndGetAsync(..., 0)` 호출은 두 번째 local view에
+  마지막 invalidation 관찰 기회를 주는 test synchronization nudge다. Redisson
+  pub/sub ordering을 독립 계약으로 승격할 때는 명시적 barrier 또는 별도
+  invalidation event assertion을 검토한다.
+- P2: `awaitRedis`의 cancellation branch는 integration timeout으로 간접 검증되고
+  helper 자체의 synthetic cancelled/timeout future 단위 테스트는 없다.
+- P3: `LocalCachedMapExamples.kt`의 import 순서는 기존 예제 스타일과 달리
+  정렬되지 않았지만 compile/test 동작에는 영향이 없다.
+
+## 검증 증거
+
+| Check | Evidence |
+|---|---|
+| TDD RED | helper 구현 전 targeted test가 `awaitRedis` unresolved reference 4건으로 실패했다. |
+| Compile gate | `./gradlew :bluetape4k-examples-redisson-demo:testClasses --no-configuration-cache --max-workers=1`: `BUILD SUCCESSFUL`. |
+| Targeted Kotlin | `LocalCachedMapExamples` + `LocalCachedMapTest`를 `--rerun-tasks`로 순차 실행: `10 passing`, `BUILD SUCCESSFUL` (40초). |
+| Module Kotlin | `./gradlew :bluetape4k-examples-redisson-demo:test --no-configuration-cache --max-workers=1 --rerun-tasks`: `95 passing`, `BUILD SUCCESSFUL` (1분 57초). |
+| Static topology | `:bluetape4k-examples-redisson-demo:detekt`는 examples/demo가 root detekt 분석에서 명시적으로 제외되어 task N/A; `detektSourceCoverage`는 `76 modules / 4165 Kotlin files`로 `BUILD SUCCESSFUL`. |
+| Documentation | 한·영 README의 Gradle task, 두 test class, `CompositeCodec`, `HINCRBYFLOAT`, Docker dynamic-port 설명 parity와 `git diff --check` 통과. |
+| Scope | `git diff develop...HEAD`에 5개 계획 파일만 있고 `build.gradle.kts`·workflow·version catalog 변경 및 새 dependency가 없다. |
+
+## Merge gate
+
+로컬 6-R 검토와 module verification은 완료했다. 아직 child branch를 원격에
+publish하지 않았으므로 PR hosted exact-head checks, review threads, linked issue,
+assignee/labels/milestone, mergeability는 fresh reread가 필요하다. #1353 병합은
+부모 #1531 병합 승인과 별개의 게이트이며, hosted evidence가 green이어도 새
+명시적 병합 승인을 받기 전에는 merge·auto-merge를 수행하지 않는다.
+
+## DoD Status
+
+- 상태: `PASS WITH FOLLOW-UP`
+- P0: `0`, P1: `0`, P2: `3`, P3: `1`
+- #1353 수용 기준은 로컬 실행 가능한 예제·회귀 테스트·한/영 문서로 충족했고,
+  bounded Redis lifecycle과 negative contract도 fresh test evidence로 확인했다.
+- 다음 게이트: 이 review artifact를 commit한 뒤 branch push, PR 생성, hosted
+  exact-head checks/reviews/threads/linked issue/mergeability를 확인한다.

--- a/examples/redisson-demo/README.ko.md
+++ b/examples/redisson-demo/README.ko.md
@@ -45,7 +45,7 @@
 | `SortedSetExamples.kt`         | RSortedSet - 정렬 집합              |
 | `RingBufferExamples.kt`        | RRingBuffer - 링 버퍼              |
 | `StreamExamples.kt`            | RStream - Redis Streams         |
-| `LocalCachedMapExamples.kt`    | RLocalCachedMap - 로컬 캐시 맵       |
+| `LocalCachedMapExamples.kt`    | RLocalCachedMap - 숫자 원자적 갱신과 로컬 무효화 |
 | `SetMultimapCacheExamples.kt`  | RSetMultimapCache - 멀티맵 캐시      |
 | `ListMultimapCacheExamples.kt` | RListMultimapCache - 리스트 멀티맵 캐시 |
 
@@ -110,18 +110,37 @@ bloomFilter.add("user@example.com")
 val exists = bloomFilter.contains("user@example.com")  // true
 ```
 
+### LocalCachedMap 숫자 갱신과 무효화
+
+`LocalCachedMapExamples.kt`는 Int와 Double 값을 서로 다른 맵에 저장하고,
+로컬 view와 backend view에 동일한 `CompositeCodec`(String key와 해당 숫자
+value codec)를 전달합니다. `addAndGetAsync`는 Redis의 `HINCRBYFLOAT`를
+사용하므로 hash field에 저장된 값도 숫자로 해석될 수 있어야 합니다. 타입이
+맞지 않는 값을 저장한 경우에는 Redisson `RedisException`이 발생하는 음수
+계약을 테스트합니다.
+
+`LocalCachedMapTest.kt`는 두 Redisson client를 사용합니다. 한 local cached
+map을 통한 쓰기는 다른 client의 캐시 값을 비동기적으로 무효화합니다. 쓰기
+직후의 읽기에서는 이전 값이 잠시 보일 수 있으므로, 100 ms 간격으로 최대
+5초까지 대기한 뒤 갱신된 값 또는 삭제 결과를 확인합니다. 테스트는
+Testcontainers로 Redis를 시작하고 동적 포트를 사용하므로 Docker daemon이
+실행 중이어야 합니다.
+
 ## 실행 방법
 
 ```bash
 # Redis 실행 (Docker)
 docker run -d --name redis -p 6379:6379 redis:7
 
-# 모든 예제 실행
-./gradlew :examples:redisson:test
+# 이 모듈의 모든 예제 실행
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --no-configuration-cache --max-workers=1
 
-# 특정 카테고리만 실행
-./gradlew :examples:redisson:test --tests "*locks*"
-./gradlew :examples:redisson:test --tests "*collections*"
+# LocalCachedMap 계약 테스트 실행
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapExamples' \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest' \
+  --no-configuration-cache --max-workers=1
 ```
 
 ## 요구사항

--- a/examples/redisson-demo/README.md
+++ b/examples/redisson-demo/README.md
@@ -45,7 +45,7 @@ A collection of examples demonstrating distributed Redis patterns using [Redisso
 | `SortedSetExamples.kt`         | RSortedSet - sorted set                  |
 | `RingBufferExamples.kt`        | RRingBuffer - ring buffer                |
 | `StreamExamples.kt`            | RStream - Redis Streams                  |
-| `LocalCachedMapExamples.kt`    | RLocalCachedMap - locally cached map     |
+| `LocalCachedMapExamples.kt`    | RLocalCachedMap - numeric atomic updates and local invalidation |
 | `SetMultimapCacheExamples.kt`  | RSetMultimapCache - set multimap cache   |
 | `ListMultimapCacheExamples.kt` | RListMultimapCache - list multimap cache |
 
@@ -110,18 +110,36 @@ bloomFilter.add("user@example.com")
 val exists = bloomFilter.contains("user@example.com")  // true
 ```
 
+### LocalCachedMap numeric updates and invalidation
+
+`LocalCachedMapExamples.kt` keeps Int and Double values in separate maps and
+passes the same `CompositeCodec` (String keys plus the matching numeric value
+codec) to both the local and backend views. `addAndGetAsync` uses Redis
+`HINCRBYFLOAT`, so the stored hash field must already be numeric-compatible;
+the negative test records Redisson's `RedisException` for a mismatched value.
+
+`LocalCachedMapTest.kt` uses two Redisson clients. A write through one local
+cached map invalidates the other client's cached value asynchronously. A read
+immediately after the write may still observe the old value; the example waits
+up to five seconds with a 100 ms poll interval before asserting the refreshed
+value or deletion. The tests start Redis through Testcontainers, use its dynamic
+port, and therefore require a running Docker daemon.
+
 ## How to Run
 
 ```bash
 # Start Redis (Docker)
 docker run -d --name redis -p 6379:6379 redis:7
 
-# Run all examples
-./gradlew :examples:redisson:test
+# Run all examples in this module
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --no-configuration-cache --max-workers=1
 
-# Run a specific category
-./gradlew :examples:redisson:test --tests "*locks*"
-./gradlew :examples:redisson:test --tests "*collections*"
+# Run the LocalCachedMap contract tests
+./gradlew :bluetape4k-examples-redisson-demo:test \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapExamples' \
+  --tests 'io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest' \
+  --no-configuration-cache --max-workers=1
 ```
 
 ## Requirements

--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AbstractRedissonCoroutineTest.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AbstractRedissonCoroutineTest.kt
@@ -7,23 +7,52 @@ import io.bluetape4k.junit5.faker.Fakers
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.error
 import io.bluetape4k.redis.redisson.codec.RedissonCodecs
+import io.bluetape4k.support.classIsPresent
 import io.bluetape4k.testcontainers.storage.RedisServer
 import io.bluetape4k.utils.ShutdownQueue
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withTimeout
 import org.redisson.Redisson
+import org.redisson.api.RFuture
 import org.redisson.api.RedissonClient
 import org.redisson.config.Config
+import org.testcontainers.utility.DockerImageName
 import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 abstract class AbstractRedissonCoroutineTest {
 
     companion object: KLoggingChannel() {
 
         @JvmStatic
-        val redis: RedisServer by lazy { RedisServer.Launcher.redis }
+        val redis: RedisServer by lazy {
+            RedisServer(
+                DockerImageName.parse(
+                    "redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a"
+                )
+            ).apply {
+                start()
+                ShutdownQueue.register(this)
+
+                if (classIsPresent("org.redisson.Redisson")) {
+                    val warmupClient = Redisson.create(
+                        RedisServer.Launcher.RedissonLib.getRedissonConfig(url)
+                    )
+                    try {
+                        RedisServer.Launcher.RedissonLib.warmupPubSubChannel(warmupClient)
+                    } finally {
+                        warmupClient.shutdown(0, 5, TimeUnit.SECONDS)
+                    }
+                }
+            }
+        }
 
         @JvmStatic
         val redissonClient by lazy { newRedisson() }
@@ -43,7 +72,7 @@ abstract class AbstractRedissonCoroutineTest {
 
 
         @JvmStatic
-        protected fun newRedisson(): RedissonClient {
+        protected fun newRedisson(registerShutdown: Boolean = true): RedissonClient {
             val config = Config().apply {
                 useSingleServer()
                     .setAddress(redis.url)
@@ -64,10 +93,31 @@ abstract class AbstractRedissonCoroutineTest {
                 setTcpUserTimeout(5000)
             }
 
-            return Redisson.create(config).apply {
-                ShutdownQueue.register { shutdown() }
-            } as Redisson
+            return Redisson.create(config).also { client ->
+                if (registerShutdown) {
+                    ShutdownQueue.register { client.shutdown() }
+                }
+            }
         }
+    }
+
+    /**
+     * Redisson 비동기 호출을 bounded coroutine suspension으로 소비한다.
+     *
+     * Timeout 또는 호출자 취소가 발생하면 아직 완료되지 않은 Redis future에도
+     * 취소를 전파해 테스트 종료 뒤 pending operation을 남기지 않는다.
+     */
+    protected suspend fun <T> awaitRedis(
+        future: RFuture<T>,
+        timeout: kotlin.time.Duration = 5.seconds,
+    ): T = try {
+        withTimeout(timeout) { future.await() }
+    } catch (cause: TimeoutCancellationException) {
+        future.cancel(false)
+        throw cause
+    } catch (cause: CancellationException) {
+        future.cancel(false)
+        throw cause
     }
 
     protected val redisson: RedissonClient get() = redissonClient

--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapExamples.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapExamples.kt
@@ -2,32 +2,50 @@ package io.bluetape4k.examples.redisson.coroutines.collections
 
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.examples.redisson.coroutines.AbstractRedissonCoroutineTest
+import io.bluetape4k.redis.redisson.codec.RedissonCodecs
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContainSame
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
 import org.redisson.api.RLocalCachedMap
+import org.redisson.api.RMap
 import org.redisson.api.options.LocalCachedMapOptions
+import org.redisson.codec.CompositeCodec
 import java.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+
+private val intCodec = CompositeCodec(
+    RedissonCodecs.String,
+    RedissonCodecs.Int,
+    RedissonCodecs.Int,
+)
+
+private val doubleCodec = CompositeCodec(
+    RedissonCodecs.String,
+    RedissonCodecs.Double,
+    RedissonCodecs.Double,
+)
 
 /**
  * Redisson [RLocalCachedMap] 은 NearCache 와 같은 역할을 수행한다.
  *
  * 참고: [Redisson 7.-Distributed-collections](https://github.com/redisson/redisson/wiki/7.-Distributed-collections)
+ *
+ * 숫자 증분 예제는 String key와 숫자 value를 같은 [CompositeCodec]으로 구성한다.
+ * Redisson의 `addAndGetAsync`는 Redis hash field에 `HINCRBYFLOAT`를 실행하므로,
+ * Int와 Double map을 섞지 않고 각 타입에 맞는 value codec을 사용해야 한다.
  */
 class LocalCachedMapExamples: AbstractRedissonCoroutineTest() {
 
     companion object: KLoggingChannel()
 
     @Test
-    fun `simple local cached map`() = runTest {
+    fun `simple local cached map`() = runSuspendIO(timeout = 60.seconds) {
         val cachedMapName = "local:" + Base58.randomString(8)
 
         val options = LocalCachedMapOptions.name<String, Int>(cachedMapName)
@@ -41,43 +59,70 @@ class LocalCachedMapExamples: AbstractRedissonCoroutineTest() {
                 Duration.ofMillis(attempt * 10L + 10)
             }  // 재시도 간격
             .timeout(Duration.ofSeconds(10))
+            .codec(intCodec)
 
 
         val cachedMap: RLocalCachedMap<String, Int> = redisson.getLocalCachedMap(options)
 
         // NOTE: fastPutAsync 의 결과는 new insert 인 경우는 true, update 는 false 를 반환한다.
-        cachedMap.fastPutAsync("a", 1).await().shouldBeTrue()
-        cachedMap.fastPutAsync("b", 2).await().shouldBeTrue()
-        cachedMap.fastPutAsync("c", 3).await().shouldBeTrue()
+        awaitRedis(cachedMap.fastPutAsync("a", 1)).shouldBeTrue()
+        awaitRedis(cachedMap.fastPutAsync("b", 2)).shouldBeTrue()
+        awaitRedis(cachedMap.fastPutAsync("c", 3)).shouldBeTrue()
 
-        cachedMap.containsKeyAsync("a").await().shouldBeTrue()
+        awaitRedis(cachedMap.containsKeyAsync("a")).shouldBeTrue()
 
-        cachedMap.getAsync("c").await() shouldBeEqualTo 3
-        // FIXME: HINCRBYFLOAT 를 호출한다
-        // cachedMap.addAndGetAsync("a", 32).await() shouldBeEqualTo 33
+        awaitRedis(cachedMap.getAsync("c")) shouldBeEqualTo 3
 
         // 저장된 Int 형태의 저장 크기
-        // cachedMap.valueSizeAsync("c").await() shouldBeEqualTo 2
+        // valueSizeAsync 결과는 codec에 따라 저장된 Int 바이트 크기를 반환한다.
 
         val keys = setOf("a", "b", "c")
 
-        val mapSlice = cachedMap.getAllAsync(keys).await()
+        val mapSlice = awaitRedis(cachedMap.getAllAsync(keys))
         mapSlice shouldBeEqualTo mapOf("a" to 1, "b" to 2, "c" to 3)
 
-        cachedMap.readAllKeySetAsync().await() shouldContainSame setOf("a", "b", "c")
-        cachedMap.readAllValuesAsync().await() shouldContainSame listOf(1, 2, 3)
-        cachedMap.readAllEntrySetAsync().await()
+        awaitRedis(cachedMap.readAllKeySetAsync()) shouldContainSame setOf("a", "b", "c")
+        awaitRedis(cachedMap.readAllValuesAsync()) shouldContainSame listOf(1, 2, 3)
+        awaitRedis(cachedMap.readAllEntrySetAsync())
             .associate { it.key to it.value } shouldContainSame mapOf("a" to 1, "b" to 2, "c" to 3)
 
         // 신규 Item일 경우 true, Update 시에는 false 를 반환한다
-        cachedMap.fastPutAsync("a", 100).await().shouldBeFalse()
-        cachedMap.fastPutAsync("d", 33).await().shouldBeTrue()
+        awaitRedis(cachedMap.fastPutAsync("a", 100)).shouldBeFalse()
+        awaitRedis(cachedMap.fastPutAsync("d", 33)).shouldBeTrue()
 
         // 삭제 시에는 삭제된 갯수를 반환
-        cachedMap.fastRemoveAsync("b").await() shouldBeEqualTo 1L
+        awaitRedis(cachedMap.fastRemoveAsync("b")) shouldBeEqualTo 1L
 
         // Remote 에 저장되었나 본다
-        val backendMap = redisson.getMap<String, Int>(cachedMapName)
-        backendMap.containsKey("a").shouldBeTrue()
+        val backendMap = redisson.getMap<String, Int>(cachedMapName, intCodec)
+        awaitRedis(backendMap.containsKeyAsync("a")).shouldBeTrue()
+    }
+
+    @Test
+    fun `empty Int key is initialized by addAndGetAsync`() = runSuspendIO(timeout = 60.seconds) {
+        val name = randomName()
+        val cachedMap: RLocalCachedMap<String, Int> = redisson.getLocalCachedMap(
+            LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
+        )
+
+        val first = awaitRedis(cachedMap.addAndGetAsync("count", 32))
+        val second = awaitRedis(cachedMap.addAndGetAsync("count", 10))
+        val backendMap: RMap<String, Int> = redisson.getMap(name, intCodec)
+
+        first shouldBeEqualTo 32
+        second shouldBeEqualTo 42
+        awaitRedis(backendMap.getAsync("count")) shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `empty Double key is initialized by HINCRBYFLOAT`() = runSuspendIO(timeout = 60.seconds) {
+        val name = randomName()
+        val cachedMap: RLocalCachedMap<String, Double> = redisson.getLocalCachedMap(
+            LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
+        )
+        val backendMap: RMap<String, Double> = redisson.getMap(name, doubleCodec)
+
+        awaitRedis(cachedMap.addAndGetAsync("ratio", 0.25)) shouldBeEqualTo 0.25
+        awaitRedis(backendMap.getAsync("ratio")) shouldBeEqualTo 0.25
     }
 }

--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt
@@ -1,14 +1,17 @@
 package io.bluetape4k.examples.redisson.coroutines.collections
 
-import io.bluetape4k.examples.redisson.coroutines.AbstractRedissonCoroutineTest
-import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.logging.debug
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.examples.redisson.coroutines.AbstractRedissonCoroutineTest
+import io.bluetape4k.junit5.awaitility.untilSuspending
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.redis.redisson.codec.RedissonCodecs
+import kotlinx.coroutines.withTimeout
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -17,9 +20,25 @@ import org.redisson.api.RLocalCachedMap
 import org.redisson.api.RMap
 import org.redisson.api.RedissonClient
 import org.redisson.api.options.LocalCachedMapOptions
+import org.redisson.client.RedisException
+import org.redisson.codec.CompositeCodec
 import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+
+private val intCodec = CompositeCodec(
+    RedissonCodecs.String,
+    RedissonCodecs.Int,
+    RedissonCodecs.Int,
+)
+
+private val doubleCodec = CompositeCodec(
+    RedissonCodecs.String,
+    RedissonCodecs.Double,
+    RedissonCodecs.Double,
+)
 
 /**
  * [RLocalCachedMap] 예제
@@ -40,85 +59,208 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
         .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.LFU)
         .maxIdle(10.seconds.toJavaDuration())
         .timeToLive(5.seconds.toJavaDuration())
-
+        .codec(intCodec)
 
     private val options2 = LocalCachedMapOptions.name<String, Int>(cacheName)
         .cacheSize(100)
         .evictionPolicy(LocalCachedMapOptions.EvictionPolicy.LFU)
         .maxIdle(10.seconds.toJavaDuration())
         .timeToLive(5.seconds.toJavaDuration())
+        .codec(intCodec)
 
     private val frontCache1: RLocalCachedMap<String, Int> by lazy { redisson1.getLocalCachedMap(options1) }
     private val frontCache2: RLocalCachedMap<String, Int> by lazy { redisson2.getLocalCachedMap(options2) }
-    private val backCache: RMap<String, Int> by lazy { redisson.getMap(cacheName) }
+    private val backCache: RMap<String, Int> by lazy { redisson.getMap(cacheName, intCodec) }
 
     @BeforeAll
     fun setup() {
-        redisson1 = newRedisson()
-        redisson2 = newRedisson()
+        redisson1 = newRedisson(registerShutdown = false)
+        redisson2 = newRedisson(registerShutdown = false)
     }
 
     @AfterAll
     fun cleanup() {
+        var firstFailure: Throwable? = null
+
         if (this::redisson1.isInitialized) {
-            redisson1.shutdown()
+            runCatching { redisson1.shutdown(0, 5, TimeUnit.SECONDS) }
+                .onFailure { firstFailure = it }
         }
         if (this::redisson2.isInitialized) {
-            redisson2.shutdown()
+            runCatching { redisson2.shutdown(0, 5, TimeUnit.SECONDS) }
+                .onFailure { failure ->
+                    if (firstFailure == null) {
+                        firstFailure = failure
+                    } else {
+                        checkNotNull(firstFailure).addSuppressed(failure)
+                    }
+                }
         }
+
+        firstFailure?.let { throw it }
     }
 
     @Test
-    fun `frontCache1 에 cache item을 추가하면 frontCache2에 추가됩니다`() = runTest {
+    fun `frontCache1 에 cache item을 추가하면 frontCache2에 추가됩니다`() = runSuspendIO(timeout = 60.seconds) {
         val keyToAdd = randomName()
 
         log.debug { "front cache1: put key=$keyToAdd" }
-        frontCache1.fastPutAsync(keyToAdd, 42).await()
-        await.until { backCache.containsKey(keyToAdd) }
+        awaitRedis(frontCache1.fastPutAsync(keyToAdd, 42)).shouldBeTrue()
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(backCache.containsKeyAsync(keyToAdd))
+        }
 
         log.debug { "front cache2: get key=$keyToAdd" }
-        frontCache2.getAsync(keyToAdd).await() shouldBeEqualTo 42
+        awaitRedis(frontCache2.getAsync(keyToAdd)) shouldBeEqualTo 42
     }
 
     @Test
-    fun `frontCache1의 cache item을 삭제하면 frontCache2에서도 삭제됩니다`() = runTest {
+    fun `frontCache1의 cache item을 삭제하면 frontCache2에서도 삭제됩니다`() = runSuspendIO(timeout = 60.seconds) {
         val keyToRemove = randomName()
 
         log.debug { "front cache1: put $keyToRemove" }
-        frontCache1.fastPutAsync(keyToRemove, 42).await()
-        await.until { backCache.containsKey(keyToRemove) }
-        frontCache2.getAsync(keyToRemove).await() shouldBeEqualTo 42
+        awaitRedis(frontCache1.fastPutAsync(keyToRemove, 42)).shouldBeTrue()
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(backCache.containsKeyAsync(keyToRemove))
+        }
+        awaitRedis(frontCache2.getAsync(keyToRemove)) shouldBeEqualTo 42
 
         log.debug { "front cache1: remove $keyToRemove" }
-        frontCache1.fastRemoveAsync(keyToRemove).await()
-        await.until { !backCache.containsKey(keyToRemove) }
-        frontCache2.getAsync(keyToRemove).await().shouldBeNull()
+        awaitRedis(frontCache1.fastRemoveAsync(keyToRemove)) shouldBeEqualTo 1L
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            !awaitRedis(backCache.containsKeyAsync(keyToRemove))
+        }
+        awaitRedis(frontCache2.getAsync(keyToRemove)).shouldBeNull()
     }
 
     @Test
-    fun `backCache에 cache item을 추가하면 frontCache 에 반영된다`() = runTest {
+    fun `backCache에 cache item을 추가하면 frontCache 에 반영된다`() = runSuspendIO(timeout = 60.seconds) {
         val key = randomName()
 
-        // 초기에 frontCache에 존재하지 않는다.
-        frontCache1.containsKeyAsync(key).await().shouldBeFalse()
-        frontCache2.containsKeyAsync(key).await().shouldBeFalse()
+        awaitRedis(frontCache1.containsKeyAsync(key)).shouldBeFalse()
+        awaitRedis(frontCache2.containsKeyAsync(key)).shouldBeFalse()
 
-        // bachCache에 cache 등록
-        backCache.fastPutAsync(key, 42).await()
+        awaitRedis(backCache.fastPutAsync(key, 42)).shouldBeTrue()
 
-        await.atMost(Duration.ofSeconds(1)).until { frontCache1.containsKey(key) }
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(frontCache1.containsKeyAsync(key)) &&
+                awaitRedis(frontCache2.containsKeyAsync(key))
+        }
 
-        // frontCache에 등록 반영
-        frontCache1.containsKeyAsync(key).await().shouldBeTrue()
-        frontCache2.containsKeyAsync(key).await().shouldBeTrue()
+        awaitRedis(frontCache1.containsKeyAsync(key)).shouldBeTrue()
+        awaitRedis(frontCache2.containsKeyAsync(key)).shouldBeTrue()
 
-        // backCache에서 cache 삭제
-        backCache.fastRemoveAsync(key).await() shouldBeEqualTo 1L
+        awaitRedis(backCache.fastRemoveAsync(key)) shouldBeEqualTo 1L
 
-        await.atMost(Duration.ofSeconds(1)).until { !frontCache1.containsKey(key) }
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            !awaitRedis(frontCache1.containsKeyAsync(key)) &&
+                !awaitRedis(frontCache2.containsKeyAsync(key))
+        }
 
-        // frontCache에 삭제 반영
-        frontCache1.containsKeyAsync(key).await().shouldBeFalse()
-        frontCache2.containsKeyAsync(key).await().shouldBeFalse()
+        awaitRedis(frontCache1.containsKeyAsync(key)).shouldBeFalse()
+        awaitRedis(frontCache2.containsKeyAsync(key)).shouldBeFalse()
+    }
+
+    @Test
+    fun `frontCache1 remote update invalidates both cached values`() = runSuspendIO(timeout = 60.seconds) {
+        val key = randomName()
+
+        awaitRedis(frontCache1.fastPutAsync(key, 7)).shouldBeTrue()
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(frontCache1.getAsync(key)) == 7 &&
+                awaitRedis(frontCache2.getAsync(key)) == 7
+        }
+
+        awaitRedis(frontCache1.fastPutAsync(key, 42)).shouldBeFalse()
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(frontCache1.getAsync(key)) == 42 &&
+                awaitRedis(frontCache2.getAsync(key)) == 42
+        }
+
+        awaitRedis(frontCache1.fastRemoveAsync(key)) shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `concurrent Int increments match independent remote final value`() = runSuspendIO(timeout = 60.seconds) {
+        val name = randomName()
+        val calls = 32 * 8
+        val map1 = redisson1.getLocalCachedMap(
+            LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
+        )
+        val map2 = redisson2.getLocalCachedMap(
+            LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
+        )
+        val remote = redisson.getMap<String, Int>(name, intCodec)
+        awaitRedis(remote.fastPutAsync("count", 0)).shouldBeTrue()
+        awaitRedis(map1.getAsync("count")) shouldBeEqualTo 0
+        awaitRedis(map2.getAsync("count")) shouldBeEqualTo 0
+
+        withTimeout(30.seconds) {
+            SuspendedJobTester()
+                .workers(4)
+                .rounds(calls)
+                .add { awaitRedis(map1.addAndGetAsync("count", 1)) }
+                .run()
+        }
+
+        awaitRedis(remote.getAsync("count")) shouldBeEqualTo calls
+        awaitRedis(map1.addAndGetAsync("count", 0)) shouldBeEqualTo calls
+
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(map1.getAsync("count")) == calls &&
+                awaitRedis(map2.getAsync("count")) == calls
+        }
+        awaitRedis(map1.getAsync("count")) shouldBeEqualTo calls
+        awaitRedis(map2.getAsync("count")) shouldBeEqualTo calls
+    }
+
+    @Test
+    fun `concurrent Double increments match independent remote final value`() = runSuspendIO(timeout = 60.seconds) {
+        val name = randomName()
+        val calls = 32 * 8
+        val expected = calls * 0.25
+        val map1 = redisson1.getLocalCachedMap(
+            LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
+        )
+        val map2 = redisson2.getLocalCachedMap(
+            LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
+        )
+        val remote = redisson.getMap<String, Double>(name, doubleCodec)
+        awaitRedis(remote.fastPutAsync("ratio", 0.0)).shouldBeTrue()
+        awaitRedis(map1.getAsync("ratio")) shouldBeEqualTo 0.0
+        awaitRedis(map2.getAsync("ratio")) shouldBeEqualTo 0.0
+
+        withTimeout(30.seconds) {
+            SuspendedJobTester()
+                .workers(4)
+                .rounds(calls)
+                .add { awaitRedis(map1.addAndGetAsync("ratio", 0.25)) }
+                .run()
+        }
+
+        awaitRedis(remote.getAsync("ratio")) shouldBeEqualTo expected
+        awaitRedis(map1.addAndGetAsync("ratio", 0.0)) shouldBeEqualTo expected
+
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(map1.getAsync("ratio")) == expected &&
+                awaitRedis(map2.getAsync("ratio")) == expected
+        }
+        awaitRedis(map1.getAsync("ratio")) shouldBeEqualTo expected
+        awaitRedis(map2.getAsync("ratio")) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `non numeric stored value is rejected by numeric increment`() = runSuspendIO(timeout = 60.seconds) {
+        val name = randomName()
+        val raw = redisson.getMap<String, String>(name, RedissonCodecs.String)
+        awaitRedis(raw.fastPutAsync("ratio", "not-a-number")).shouldBeTrue()
+
+        val numeric = redisson1.getLocalCachedMap(
+            LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
+        )
+
+        assertFailsWith<RedisException> {
+            awaitRedis(numeric.addAndGetAsync("ratio", 0.25))
+        }
     }
 }


### PR DESCRIPTION
## 요약

Epic #1422의 child #1353을 독립 PR로 구현했다. `RLocalCachedMap`의 Int/Double
`addAndGetAsync`를 실제 Redis `HINCRBYFLOAT` 경로로 실행하고, 두 Redisson
client의 로컬 캐시 무효화·동시 증가·숫자 codec 오류 계약을 회귀 테스트로 고정한다.

Closes #1353
Closes #1422

## 변경 사항

- `CompositeCodec(String, Int, Int)`와 `CompositeCodec(String, Double, Double)`을
  local/backend view에 동일하게 전달했다.
- 빈 Int/Double key의 atomic increment와 backend 재조회를 예제로 추가했다.
- `SuspendedJobTester(workers=4, rounds=32*8)`로 동시 최종값을 검증하고,
  두 local view가 bounded reread 뒤 독립 remote final value와 일치하는지 확인한다.
- 두 client 간 put/update/remove invalidation을 Awaitility 5초/100 ms 계약으로
  고정하고, 비수치 저장값은 `RedisException`으로 거부한다.
- shared Redisson client와 test-owned client의 종료 경계를 분리하고,
  `awaitRedis`에 bounded timeout/cancellation 전파를 추가했다.
- 한·영 README에 `HINCRBYFLOAT`, numeric codec 제약, eventual consistency,
  Docker/Testcontainers dynamic port와 실제 Gradle task를 문서화했다.

## 검증

- TDD RED: helper 구현 전 targeted test가 `awaitRedis` unresolved reference 4건으로 실패.
- `./gradlew :bluetape4k-examples-redisson-demo:testClasses --no-configuration-cache --max-workers=1` — `BUILD SUCCESSFUL`.
- targeted `LocalCachedMapExamples` + `LocalCachedMapTest` (`--rerun-tasks`) — `10 passing`, `BUILD SUCCESSFUL`.
- `./gradlew :bluetape4k-examples-redisson-demo:test --no-configuration-cache --max-workers=1 --rerun-tasks` — `95 passing`, `BUILD SUCCESSFUL`.
- `detektSourceCoverage` — `76 modules / 4165 Kotlin files`, `BUILD SUCCESSFUL`; examples/demo detekt task는 root 분석 제외로 N/A.
- `git diff --check` 및 README 한·영 command/term parity 통과.
- 6-R review: [`2026-08-26-epic-1422-1353-module-6r.md`](../blob/feat/epic-1422-redisson-local-cache/docs/superpowers/reviews/2026-08-26-epic-1422-1353-module-6r.md), P0=0/P1=0.
- hosted exact-head head `50778c0477ad88c9a635b139732f227344b59c1e`: Examples run `33038118498` 성공, CI run `33038118497` 성공.
- Required checks: `11/11`; N/A: `12`; Blocked: `0`. Examples artifact `507 files / 400,404 bytes`, `truncated=false`, `report_truncated=false`.

## 범위 및 후속

- `build.gradle.kts`, version catalog, workflow, production API, 새 dependency는
  변경하지 않았다.
- raw `RMap` 직접 update는 이미 채워진 local cache에 invalidation 이벤트를
  발행하지 않으므로, 문서와 테스트는 실제 invalidation 채널을 사용하는 local
  cached map write 범위로 명시한다.
- `Future.cancel(false)`는 best-effort pending future 정리이며 원격 Redis 명령
  취소 보장을 의미하지 않는다(P2 follow-up).
- PR metadata는 assignee `debop`, milestone `2.0.0`, labels
  `enhancement/test/examples`로 설정했다.

## DoD Status

- 상태: `DONE — merged`
- PR #1538은 exact-head `50778c0477…` 검증과 명시적 승인 후 merge commit
  `c921c30454961688b630f587d6c6d0b16e334f39`로 `develop`에 병합되었다.
- 이슈 #1353과 Epic #1422는 완료 처리되었고, canonical `develop`은
  `origin/develop`과 동일하다.
