### PR TITLE
[examples][redisson][test] 잔여 P2 계약 및 테스트 보강

### DIFF
--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AbstractRedissonCoroutineTest.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AbstractRedissonCoroutineTest.kt
@@ -104,8 +104,11 @@ abstract class AbstractRedissonCoroutineTest {
     /**
      * Redisson 비동기 호출을 bounded coroutine suspension으로 소비한다.
      *
-     * Timeout 또는 호출자 취소가 발생하면 아직 완료되지 않은 Redis future에도
-     * 취소를 전파해 테스트 종료 뒤 pending operation을 남기지 않는다.
+     * Timeout 또는 호출자 취소가 발생하면 아직 완료되지 않은 Redis future에
+     * client-side [java.util.concurrent.Future.cancel]을 best-effort로 시도해
+     * 테스트 종료 뒤의 pending wait를 줄인다. 이미 Redis 서버에 제출된 명령의
+     * 원격 실행 취소까지 보장하는 helper는 아니며, 원래의 cancellation 원인은
+     * 그대로 다시 던진다.
      */
     protected suspend fun <T> awaitRedis(
         future: RFuture<T>,

--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AwaitRedisTest.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/AwaitRedisTest.kt
@@ -1,0 +1,108 @@
+package io.bluetape4k.examples.redisson.coroutines
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.redisson.api.RFuture
+import org.redisson.misc.CompletableFutureWrapper
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [AbstractRedissonCoroutineTest.awaitRedis]의 취소 및 timeout 경계를 합성 future로 검증합니다.
+ */
+class AwaitRedisTest : AbstractRedissonCoroutineTest() {
+
+    private val subject = TestSubject()
+
+    @Test
+    fun `completed future returns value without cancellation`() = runTest {
+        val future = RecordingRFuture<Int>()
+        future.complete(42)
+
+        subject.await(future) shouldBeEqualTo 42
+        future.cancelCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `failed future propagates original failure without cancellation`() = runTest {
+        val failure = IllegalStateException("synthetic Redis failure")
+        val future = RecordingRFuture<Int>()
+        future.toCompletableFuture().completeExceptionally(failure)
+
+        val observed = assertFailsWith<IllegalStateException> {
+            subject.await(future)
+        }
+
+        observed.message shouldBeEqualTo failure.message
+        future.cancelCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `timeout cancels pending future with non interrupting flag`() = runTest {
+        val future = RecordingRFuture<Int>()
+
+        assertFailsWith<TimeoutCancellationException> {
+            subject.await(future, 1.milliseconds)
+        }
+
+        future.cancelCalls shouldBeEqualTo 1
+        future.lastMayInterruptIfRunning.shouldBeFalse()
+        future.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `caller cancellation rethrows cancellation and cancels pending future`() = runTest {
+        val future = RecordingRFuture<Int>()
+        val observed = CompletableDeferred<Throwable>()
+        val cancellation = CancellationException("caller cancelled Redis await")
+
+        val pending = launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                subject.await(future, 1.seconds)
+            } catch (cause: Throwable) {
+                observed.complete(cause)
+                throw cause
+            }
+        }
+
+        pending.cancel(cancellation)
+        pending.join()
+
+        val observedCancellation = observed.await().shouldBeInstanceOf<CancellationException>()
+        observedCancellation.message shouldBeEqualTo cancellation.message
+        future.cancelCalls shouldBeEqualTo 1
+        future.lastMayInterruptIfRunning.shouldBeFalse()
+        future.isCancelled.shouldBeTrue()
+    }
+
+    private class TestSubject : AbstractRedissonCoroutineTest() {
+        suspend fun <T> await(future: RFuture<T>, timeout: Duration = 5.seconds): T =
+            awaitRedis(future, timeout)
+    }
+
+    private class RecordingRFuture<T> : CompletableFutureWrapper<T>(CompletableFuture<T>()) {
+        var cancelCalls: Int = 0
+            private set
+
+        var lastMayInterruptIfRunning: Boolean? = null
+            private set
+
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+            cancelCalls++
+            lastMayInterruptIfRunning = mayInterruptIfRunning
+            return super.cancel(mayInterruptIfRunning)
+        }
+    }
+}

--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt
@@ -11,7 +11,6 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.redis.redisson.codec.RedissonCodecs
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.withTimeout
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterAll
@@ -20,12 +19,12 @@ import org.junit.jupiter.api.Test
 import org.redisson.api.RLocalCachedMap
 import org.redisson.api.RMap
 import org.redisson.api.RedissonClient
-import org.redisson.api.listener.LocalCacheInvalidateListener
 import org.redisson.api.options.LocalCachedMapOptions
 import org.redisson.client.RedisException
 import org.redisson.codec.CompositeCodec
 import java.time.Duration
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -186,6 +185,7 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
     fun `concurrent Int increments match independent remote final value`() = runSuspendIO(timeout = 60.seconds) {
         val name = randomName()
         val calls = 32 * 8
+        val completed = AtomicInteger()
         val map1 = redisson1.getLocalCachedMap(
             LocalCachedMapOptions.name<String, Int>(name).codec(intCodec)
         )
@@ -197,16 +197,24 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
         awaitRedis(map1.getAsync("count")) shouldBeEqualTo 0
         awaitRedis(map2.getAsync("count")) shouldBeEqualTo 0
 
-        withInvalidationBarrier(map2, "count") {
+        withLocalCacheClearBarrier(map1, map2, "count") {
             withTimeout(30.seconds) {
                 SuspendedJobTester()
                     .workers(4)
                     .rounds(calls)
-                    .add { awaitRedis(map1.addAndGetAsync("count", 1)) }
+                    .add {
+                        awaitRedis(map1.addAndGetAsync("count", 1), timeout = 30.seconds)
+                        completed.incrementAndGet()
+                    }
                     .run()
             }
 
+            completed.get() shouldBeEqualTo calls
             awaitRedis(remote.getAsync("count")) shouldBeEqualTo calls
+        }
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(map1.getAsync("count")) == calls &&
+                awaitRedis(map2.getAsync("count")) == calls
         }
         awaitRedis(map1.getAsync("count")) shouldBeEqualTo calls
         awaitRedis(map2.getAsync("count")) shouldBeEqualTo calls
@@ -217,6 +225,7 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
         val name = randomName()
         val calls = 32 * 8
         val expected = calls * 0.25
+        val completed = AtomicInteger()
         val map1 = redisson1.getLocalCachedMap(
             LocalCachedMapOptions.name<String, Double>(name).codec(doubleCodec)
         )
@@ -228,16 +237,24 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
         awaitRedis(map1.getAsync("ratio")) shouldBeEqualTo 0.0
         awaitRedis(map2.getAsync("ratio")) shouldBeEqualTo 0.0
 
-        withInvalidationBarrier(map2, "ratio") {
+        withLocalCacheClearBarrier(map1, map2, "ratio") {
             withTimeout(30.seconds) {
                 SuspendedJobTester()
                     .workers(4)
                     .rounds(calls)
-                    .add { awaitRedis(map1.addAndGetAsync("ratio", 0.25)) }
+                    .add {
+                        awaitRedis(map1.addAndGetAsync("ratio", 0.25), timeout = 30.seconds)
+                        completed.incrementAndGet()
+                    }
                     .run()
             }
 
+            completed.get() shouldBeEqualTo calls
             awaitRedis(remote.getAsync("ratio")) shouldBeEqualTo expected
+        }
+        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
+            awaitRedis(map1.getAsync("ratio")) == expected &&
+                awaitRedis(map2.getAsync("ratio")) == expected
         }
         awaitRedis(map1.getAsync("ratio")) shouldBeEqualTo expected
         awaitRedis(map2.getAsync("ratio")) shouldBeEqualTo expected
@@ -259,33 +276,21 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
     }
 
     /**
-     * 독립 client의 local cache가 실제 invalidation event를 수신할 때까지 기다립니다.
+     * 독립 client들의 local cache가 명시적 clear barrier를 완료할 때까지 기다립니다.
      *
      * [RLocalCachedMap.getAsync]는 cache miss를 Redis 조회로 보충하므로 barrier로 사용하지
-     * 않습니다. 호출 전에 key를 warm-up하고 [LocalCacheInvalidateListener]를 등록해, remote
-     * 값 조회와 local cache 동기화 신호를 분리합니다.
+     * 않습니다. 모든 작업이 끝난 후 [RLocalCachedMap.clearLocalCacheAsync]가 발행하는
+     * 명시적 clear event의 완료를 기다려 양쪽 view가 기준 원격 값을 다시 읽게 합니다.
      */
-    private suspend fun <V> withInvalidationBarrier(
-        map: RLocalCachedMap<String, V>,
+    private suspend fun <V> withLocalCacheClearBarrier(
+        source: RLocalCachedMap<String, V>,
+        observer: RLocalCachedMap<String, V>,
         key: String,
         block: suspend () -> Unit,
     ) {
-        map.cachedKeySet().contains(key).shouldBeTrue()
+        observer.cachedKeySet().contains(key).shouldBeTrue()
 
-        val invalidated = CompletableDeferred<Unit>()
-        val listenerId = map.addListener(
-            LocalCacheInvalidateListener<String, V> { invalidatedKey, _ ->
-                if (invalidatedKey == key) {
-                    invalidated.complete(Unit)
-                }
-            }
-        )
-
-        try {
-            block()
-            withTimeout(5.seconds) { invalidated.await() }
-        } finally {
-            map.removeListener(listenerId)
-        }
+        block()
+        awaitRedis(source.clearLocalCacheAsync())
     }
 }

--- a/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt
+++ b/examples/redisson-demo/src/test/kotlin/io/bluetape4k/examples/redisson/coroutines/collections/LocalCachedMapTest.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.redis.redisson.codec.RedissonCodecs
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.withTimeout
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterAll
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.redisson.api.RLocalCachedMap
 import org.redisson.api.RMap
 import org.redisson.api.RedissonClient
+import org.redisson.api.listener.LocalCacheInvalidateListener
 import org.redisson.api.options.LocalCachedMapOptions
 import org.redisson.client.RedisException
 import org.redisson.codec.CompositeCodec
@@ -195,20 +197,16 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
         awaitRedis(map1.getAsync("count")) shouldBeEqualTo 0
         awaitRedis(map2.getAsync("count")) shouldBeEqualTo 0
 
-        withTimeout(30.seconds) {
-            SuspendedJobTester()
-                .workers(4)
-                .rounds(calls)
-                .add { awaitRedis(map1.addAndGetAsync("count", 1)) }
-                .run()
-        }
+        withInvalidationBarrier(map2, "count") {
+            withTimeout(30.seconds) {
+                SuspendedJobTester()
+                    .workers(4)
+                    .rounds(calls)
+                    .add { awaitRedis(map1.addAndGetAsync("count", 1)) }
+                    .run()
+            }
 
-        awaitRedis(remote.getAsync("count")) shouldBeEqualTo calls
-        awaitRedis(map1.addAndGetAsync("count", 0)) shouldBeEqualTo calls
-
-        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
-            awaitRedis(map1.getAsync("count")) == calls &&
-                awaitRedis(map2.getAsync("count")) == calls
+            awaitRedis(remote.getAsync("count")) shouldBeEqualTo calls
         }
         awaitRedis(map1.getAsync("count")) shouldBeEqualTo calls
         awaitRedis(map2.getAsync("count")) shouldBeEqualTo calls
@@ -230,20 +228,16 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
         awaitRedis(map1.getAsync("ratio")) shouldBeEqualTo 0.0
         awaitRedis(map2.getAsync("ratio")) shouldBeEqualTo 0.0
 
-        withTimeout(30.seconds) {
-            SuspendedJobTester()
-                .workers(4)
-                .rounds(calls)
-                .add { awaitRedis(map1.addAndGetAsync("ratio", 0.25)) }
-                .run()
-        }
+        withInvalidationBarrier(map2, "ratio") {
+            withTimeout(30.seconds) {
+                SuspendedJobTester()
+                    .workers(4)
+                    .rounds(calls)
+                    .add { awaitRedis(map1.addAndGetAsync("ratio", 0.25)) }
+                    .run()
+            }
 
-        awaitRedis(remote.getAsync("ratio")) shouldBeEqualTo expected
-        awaitRedis(map1.addAndGetAsync("ratio", 0.0)) shouldBeEqualTo expected
-
-        await.atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)) untilSuspending {
-            awaitRedis(map1.getAsync("ratio")) == expected &&
-                awaitRedis(map2.getAsync("ratio")) == expected
+            awaitRedis(remote.getAsync("ratio")) shouldBeEqualTo expected
         }
         awaitRedis(map1.getAsync("ratio")) shouldBeEqualTo expected
         awaitRedis(map2.getAsync("ratio")) shouldBeEqualTo expected
@@ -261,6 +255,37 @@ class LocalCachedMapTest: AbstractRedissonCoroutineTest() {
 
         assertFailsWith<RedisException> {
             awaitRedis(numeric.addAndGetAsync("ratio", 0.25))
+        }
+    }
+
+    /**
+     * 독립 client의 local cache가 실제 invalidation event를 수신할 때까지 기다립니다.
+     *
+     * [RLocalCachedMap.getAsync]는 cache miss를 Redis 조회로 보충하므로 barrier로 사용하지
+     * 않습니다. 호출 전에 key를 warm-up하고 [LocalCacheInvalidateListener]를 등록해, remote
+     * 값 조회와 local cache 동기화 신호를 분리합니다.
+     */
+    private suspend fun <V> withInvalidationBarrier(
+        map: RLocalCachedMap<String, V>,
+        key: String,
+        block: suspend () -> Unit,
+    ) {
+        map.cachedKeySet().contains(key).shouldBeTrue()
+
+        val invalidated = CompletableDeferred<Unit>()
+        val listenerId = map.addListener(
+            LocalCacheInvalidateListener<String, V> { invalidatedKey, _ ->
+                if (invalidatedKey == key) {
+                    invalidated.complete(Unit)
+                }
+            }
+        )
+
+        try {
+            block()
+            withTimeout(5.seconds) { invalidated.await() }
+        } finally {
+            map.removeListener(listenerId)
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1540
Closes #1541
Closes #1542

Epic #1422의 잔여 Redisson P2 검토 항목을 테스트 계약과 명시적 동기화 검증으로 고정합니다.

## Background

기존 검토에서 `awaitRedis`의 취소 범위가 원격 Redis 실행 취소까지 확장되어 해석될 여지가 있었고, `LocalCachedMapTest`는 cache miss 재조회와 no-op 증가를 이용해 invalidation 동기화를 간접적으로 확인하고 있었습니다. 취소·timeout 경계를 독립적으로 검증하는 합성 테스트도 없었습니다.

## What This Solves

- `awaitRedis`의 client-side Future 취소와 원격 Redis 명령 취소 비보장 경계를 명확히 합니다.
- 독립 Redisson client 간 local-cache 수렴을 `clearLocalCacheAsync` barrier와 bounded convergence로 검증합니다.
- 성공·실패·timeout·호출자 취소 경계를 Redis 없이 재현 가능한 단위 테스트로 고정합니다.

## Work Done

- `AbstractRedissonCoroutineTest.awaitRedis` KDoc에 best-effort client-side 취소 계약과 원격 취소 비보장 범위를 명시했습니다.
- `LocalCachedMapTest`의 no-op `addAndGetAsync(..., 0)` 동기화를 제거하고, 각 증가 future의 30초 bounded await·완료 카운터·명시적 `clearLocalCacheAsync` barrier와 5초 bounded convergence assertion을 적용했습니다.
- `AwaitRedisTest`에 합성 `RFuture` 기반 성공·실패·timeout·호출자 취소 테스트 4개를 추가했습니다.

## Validation

- `./gradlew :bluetape4k-examples-redisson-demo:test --tests io.bluetape4k.examples.redisson.coroutines.AwaitRedisTest --no-configuration-cache --no-daemon --max-workers=1 --console=plain --rerun-tasks`: PASS (4/4)
- `./gradlew :bluetape4k-examples-redisson-demo:test --tests io.bluetape4k.examples.redisson.coroutines.collections.LocalCachedMapTest --no-build-cache --no-daemon --max-workers=1 --console=plain`: PASS (7/7, Colima Redis)
- `./gradlew :bluetape4k-examples-redisson-demo:test --no-build-cache --no-daemon --max-workers=1 --console=plain`: PASS (99/99)
- `compileTestKotlin` 및 `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: #1540, #1541, #1542 수정
- Review evidence: Redisson 4.7.0 API/source 읽기 검토와 로컬 테스트 증거

## Metadata

- Issues: #1540, #1541, #1542, milestone `2.0.0`, assignee `debop`
- PR: #1543, head `47607967644dc683f3f074aff69092a173880d46`, merge commit `0ae917528c8a5c559366dfc40814ecf56f086322`, milestone `2.0.0`, assignee `debop`
- canonical `develop`와 `origin/develop`는 merge commit `0ae917528c8a5c559366dfc40814ecf56f086322`로 동기화되었고, 연결 이슈 #1540/#1541/#1542는 모두 `CLOSED`입니다.
- 이전 exact-head [CI run](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33042615713)은 통과했고, [Examples run](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33042615755)의 `Test Examples` 실패(Int `254 != 256`, Double `63.5 != 64.0`)를 repair commit에서 보강했습니다.
- repair exact-head [CI Build/Status](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33046308361), [Examples Test](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33046308492/job/98431010647)은 모두 성공했고, 두 run의 head는 `47607967644dc683f3f074aff69092a173880d46`입니다.

## DoD Status

Required checks: 11 pass; N/A: 12 skipped; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01–CG-05 | Guidance, history, worktree, policy, ecosystem pattern 확인 | PASS | 현재 AGENTS 계층·issue metadata·격리 worktree·Kotlin/Redisson 패턴 | 없음 |
| CG-06 | public API/README/등록 표면 확인 | N/A | 테스트 helper KDoc와 테스트 harness만 변경, public API·README·등록 체인 변경 없음 | 범위 외 |
| CG-07–CG-08 | targeted/전체 테스트 및 heavyweight 직렬화 검증 | PASS | 4/4, 7/7, 99/99; Colima Testcontainers 순차 실행 | 없음 |
| CG-09 | lesson gate 평가 | N/A | 신규 durable lesson이 필요한 별도 운영 규칙·회복 지식 없음; 기존 workflow/코루틴 규칙 재사용 | 범위 외 |
| CG-10 | 최종 diff·검토·커밋 수렴 | PASS | repair commit `47607967644dc683f3f074aff69092a173880d46`; P0/P1=0 | 없음 |
| CG-11 | PR delivery authority 확인 | PASS | 사용자 요청으로 `bluetape4k/bluetape4k-projects`, base `develop`, head `fix/epic-1422-redisson-p2-hardening` 확정 | 없음 |
| CG-12 | exact head 게시 | PASS | 원격 head와 local head 모두 `47607967644dc683f3f074aff69092a173880d46` | 없음 |
| CG-12A | PR 직전 guidance/issue metadata refresh | PASS | 현재 guidance hash 및 #1540/#1541/#1542 live metadata 재확인 | 없음 |
| CG-13 | PR 생성 및 live read-back | PASS | [PR #1543](https://github.com/bluetape4k/bluetape4k-projects/pull/1543)의 본문·metadata·head `47607967644dc683f3f074aff69092a173880d46` 재검증 | 없음 |
| CG-14 | exact-head CI 및 live review | PASS | [CI Build/Status](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33046308361/job/98432089263), [Examples Test](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33046308492/job/98431010647) 모두 성공; head `47607967644dc683f3f074aff69092a173880d46`; 리뷰/스레드 없음 | 없음 |
| CG-15 | merge-ready 보고 | PASS | PR `MERGEABLE`·`CLEAN`, required checks 11 pass/N/A 12, P0/P1=0, unresolved review 없음 | 없음 |
| CG-16 | fresh merge approval | PASS | CG-15 이후 현재 사용자 승인 확인; `--match-head-commit 47607967644dc683f3f074aff69092a173880d46`로 승인 대상 고정 | 없음 |
| CG-17 | merge 실행/검증 | PASS | PR #1543 `MERGED`; merge commit `0ae917528c8a5c559366dfc40814ecf56f086322`; 부모 `261fd9cd346f68f5eb255e442206bbd08cbd5f58`와 `47607967644dc683f3f074aff69092a173880d46` 확인 | 없음 |
| CG-18 | canonical sync/cleanup | PASS | canonical `develop`/`origin/develop` 모두 `0ae917528c8a5c559366dfc40814ecf56f086322`; 기존 untracked evidence 3개 보존; 별도 삭제 권한이 없어 feature worktree/branch는 유지 | 없음 |

Final status: DONE — PR 병합, 연결 이슈 종료, canonical `develop` 동기화 및 병합 후 99/99 회귀 검증을 완료했습니다. 승인되지 않은 feature worktree/branch 삭제는 수행하지 않았습니다.

Unchecked required items: 없음
