### PR TITLE
[testcontainers][release] 의도적 skipped 테스트를 대표 실행 선택자에서 제외한다

### DIFF
--- a/docs/lessons/2026-08-27-testcontainers-release-junit-selector.md
+++ b/docs/lessons/2026-08-27-testcontainers-release-junit-selector.md
@@ -1,0 +1,40 @@
+# Testcontainers release gate의 대표 테스트 선택자 lesson
+
+## 맥락
+
+Full Nightly run `33049975063`가 exact head
+`45260871f58433a78f2d633c235010f661d22c6e`에서 LocalStack·RedisCluster
+family를 `blocked`로 집계했다. 두 Gradle 명령은 `BUILD SUCCESSFUL`로 끝났지만
+release-required JUnit 증적은 `tests=3, skipped=1`이었다.
+
+## 원인과 결정
+
+두 테스트 클래스에는 플랫폼 제약으로 의도적으로 비활성화한 메서드가 하나씩
+있다. 클래스 전체를 `--tests`로 선택하면 대표 테스트의 성공과 무관한 skipped
+메서드가 JUnit suite에 포함된다. release gate의 fail-closed `skipped=0` 계약은
+완화하지 않고, manifest에 `testSelector`를 명시해 대표 메서드만 실행한다.
+
+이 선택자는 `testPattern` 아래의 하나의 구체적인 `@Test` 메서드를 가리켜야
+하며 validator가 클래스 경계, 제어 문자, wildcard, 실제 Kotlin 테스트 선언을
+검사한다. 선택자가 없는 family는 기존 클래스 전체 선택 동작을 유지한다.
+
+## 결과
+
+LocalStack `run S3 Service`와 RedisCluster `create redis cluster server`를
+명시적으로 선택하면 두 family 모두 JUnit `tests=1, skipped=0`과
+`release_gate=true`를 생성한다. 모든 테스트를 실행하는 일반 모듈 경로의
+플랫폼별 비활성화 테스트 의미는 바뀌지 않는다.
+
+## 검증
+
+- Python 계약 테스트 78개 통과
+- `actionlint`, JVM release contract, `git diff --check`, manifest JSON 검증 통과
+- 격리 worktree의 LocalStack·RedisCluster end-to-end gate 각각 `1/1` 성공
+- Hosted PR CI 및 Full Nightly 재실행은 PR head에서 대기
+
+## 향후 지침
+
+release-required Testcontainers 클래스에 의도적인 `@Disabled` 메서드를 추가할
+때는 실행 가능한 대표 메서드를 `testSelector`로 함께 등록한다. all-disabled
+family를 release inventory에 남겨야 한다면 `releaseRequired=false` 지원 전용
+경계와 별도 증적을 사용하며, JUnit skipped 허용 범위를 전역으로 넓히지 않는다.

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -629,7 +629,7 @@ class GateRunner:
             task_index = next((index for index, part in enumerate(command) if part.startswith(":")), len(command) - 1)
             command.insert(task_index + 1, f"-Dtestcontainers.image-gate.evidence-dir={evidence_dir}")
         if "--tests" not in command:
-            selector = entry.get("testPattern")
+            selector = entry.get("testSelector", entry.get("testPattern"))
             command.extend(("--tests", str(selector)))
         if "--no-configuration-cache" not in command:
             command.append("--no-configuration-cache")

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -161,6 +161,21 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             self.assertIn("--tests", calls[0])
             self.assertTrue((Path(directory) / "summary.json").is_file())
 
+    def test_release_command_uses_explicit_test_selector(self) -> None:
+        selected = entry()
+        selected["testSelector"] = "example.FlociServerTest.representative_test"
+
+        with tempfile.TemporaryDirectory() as directory:
+            command = GateRunner([selected], Path(directory))._command(
+                selected,
+                Path(directory) / "evidence",
+            )
+
+        self.assertEqual(
+            "example.FlociServerTest.representative_test",
+            command[command.index("--tests") + 1],
+        )
+
     def test_release_required_generic_family_rejects_all_skipped_junit(self) -> None:
         def command_runner(command: list[str], timeout_seconds: int) -> SimpleNamespace:
             _write_generic_junit(command, tests=12, skipped=12)

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -85,9 +85,10 @@ def _write_generic_junit(
     skipped: int,
     failures: int = 0,
     errors: int = 0,
+    suite_name: str | None = None,
 ) -> None:
     evidence = _evidence_dir(command)
-    pattern = command[command.index("--tests") + 1]
+    pattern = suite_name or command[command.index("--tests") + 1]
     evidence.joinpath("TEST-generic.xml").write_text(
         f'<testsuite name="{pattern}" tests="{tests}" skipped="{skipped}" '
         f'failures="{failures}" errors="{errors}">'
@@ -174,6 +175,40 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
         self.assertEqual(
             "example.FlociServerTest.representative_test",
             command[command.index("--tests") + 1],
+        )
+
+    def test_explicit_selector_produces_successful_junit_release_evidence(self) -> None:
+        selected = entry()
+        selected["testSelector"] = "example.FlociServerTest.representative_test"
+        calls: list[list[str]] = []
+
+        def command_runner(command: list[str], timeout_seconds: int) -> SimpleNamespace:
+            calls.append(command)
+            _write_generic_junit(
+                command,
+                tests=1,
+                skipped=0,
+                suite_name=str(selected["testPattern"]),
+            )
+            return SimpleNamespace(returncode=0, stdout="BUILD SUCCESSFUL", stderr="")
+
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [selected],
+                Path(directory),
+                command_runner=command_runner,
+                max_attempts=1,
+            ).run()
+
+        result = summary["results"][0]
+        self.assertEqual("success", result["status"])
+        self.assertEqual("1/1", summary["coverage"])
+        self.assertTrue(summary["release_gate"])
+        self.assertEqual(1, result["junit"]["tests"])
+        self.assertEqual(0, result["junit"]["skipped"])
+        self.assertEqual(
+            selected["testSelector"],
+            calls[0][calls[0].index("--tests") + 1],
         )
 
     def test_release_required_generic_family_rejects_all_skipped_junit(self) -> None:

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -51,6 +51,15 @@ class TestTestcontainersImageGate(unittest.TestCase):
             selectors,
         )
 
+    def test_readmes_document_release_required_coverage(self) -> None:
+        coverage = f"{EXPECTED_RELEASE_FAMILY_COUNT}/{EXPECTED_RELEASE_FAMILY_COUNT}"
+        for readme_name in ("README.md", "README.ko.md"):
+            with self.subTest(readme=readme_name):
+                readme = (self.root / "testing/testcontainers" / readme_name).read_text(encoding="utf-8")
+                self.assertIn(coverage, readme)
+                self.assertNotIn("Stable publication requires `52/52`", readme)
+                self.assertNotIn("안정 버전 배포는 `52/52`", readme)
+
     def test_k3s_family_uses_the_existing_tagged_test_task(self) -> None:
         k3s = next(entry for entry in self.entries if entry["server"] == "K3sServer")
         self.assertEqual(":bluetape4k-testcontainers:k8sTest", k3s["testTask"])
@@ -135,6 +144,24 @@ class TestTestcontainersImageGate(unittest.TestCase):
             "testSelector must target a method under testPattern",
             " ".join(validate_manifest(invalid, self.root)),
         )
+
+    def test_manifest_rejects_non_concrete_or_unknown_test_selector(self) -> None:
+        pattern = self.entries[0]["testPattern"]
+        for selector in (
+            f"{pattern}.",
+            f"{pattern}.*",
+            f"{pattern}.missing.method",
+            f"{pattern}.missing\u2028method",
+        ):
+            with self.subTest(selector=selector):
+                errors = validate_manifest(
+                    [dict(self.entries[0], testSelector=selector)],
+                    self.root,
+                )
+                self.assertTrue(
+                    any("testSelector" in error for error in errors),
+                    errors,
+                )
 
     def test_manifest_rejects_unsafe_family_id(self) -> None:
         invalid = [dict(self.entries[0], id="../escape")]

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -37,6 +37,20 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertEqual(EXPECTED_RELEASE_FAMILY_COUNT, len(release_required))
         self.assertEqual(disabled, {entry["server"] for entry in self.entries if not entry["releaseRequired"]})
 
+    def test_method_selectors_exclude_intentionally_disabled_tests(self) -> None:
+        selectors = {
+            entry["server"]: entry["testSelector"]
+            for entry in self.entries
+            if "testSelector" in entry
+        }
+        self.assertEqual(
+            {
+                "LocalStackServer": "io.bluetape4k.testcontainers.aws.LocalStackServerTest.run S3 Service",
+                "RedisClusterServer": "io.bluetape4k.testcontainers.storage.RedisClusterServerTest.create redis cluster server",
+            },
+            selectors,
+        )
+
     def test_k3s_family_uses_the_existing_tagged_test_task(self) -> None:
         k3s = next(entry for entry in self.entries if entry["server"] == "K3sServer")
         self.assertEqual(":bluetape4k-testcontainers:k8sTest", k3s["testTask"])
@@ -109,6 +123,18 @@ class TestTestcontainersImageGate(unittest.TestCase):
     def test_invalid_manifest_reports_drift_without_running_docker(self) -> None:
         invalid = [dict(self.entries[0], image="wrong/image")]
         self.assertIn("image drift", " ".join(validate_manifest(invalid, self.root)))
+
+    def test_manifest_rejects_test_selector_outside_test_class(self) -> None:
+        invalid = [
+            dict(
+                self.entries[0],
+                testSelector="example.OtherServerTest.representative_test",
+            )
+        ]
+        self.assertIn(
+            "testSelector must target a method under testPattern",
+            " ".join(validate_manifest(invalid, self.root)),
+        )
 
     def test_manifest_rejects_unsafe_family_id(self) -> None:
         invalid = [dict(self.entries[0], id="../escape")]

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -40,6 +40,11 @@ IMAGE_PATTERN = re.compile(
 TAG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 WORKLOAD_PATTERN = re.compile(r"^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+\.[A-Za-z_$][\w$]*(?:\(\))?$")
+TEST_METHOD_DECLARATION_PATTERN = re.compile(
+    r"(?ms)^\s*@Test(?:\s*\([^)]*\))?\s*(?:\r?\n\s*)+"
+    r"fun\s+(`(?P<quoted>[^`]+)`|(?P<identifier>[A-Za-z_][A-Za-z0-9_]*))\s*\("
+)
+TEST_SELECTOR_WILDCARDS = frozenset("*?[]{}")
 
 
 class SelectionError(ValueError):
@@ -83,7 +88,25 @@ def _safe_string(value: object, pattern: re.Pattern[str]) -> bool:
     return isinstance(value, str) and bool(pattern.fullmatch(value)) and "\x00" not in value
 
 
-def _validate_test_selector(entry: dict[str, Any], prefix: str, errors: list[str]) -> None:
+def _test_method_names(test_source: Path) -> set[str]:
+    """Return concrete JUnit @Test method names declared in a Kotlin source file."""
+
+    try:
+        text = test_source.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    return {
+        match.group("quoted") or match.group("identifier")
+        for match in TEST_METHOD_DECLARATION_PATTERN.finditer(text)
+    }
+
+
+def _validate_test_selector(
+    entry: dict[str, Any],
+    prefix: str,
+    test_source: Path,
+    errors: list[str],
+) -> None:
     selector = entry.get("testSelector")
     if selector is None:
         return
@@ -91,12 +114,21 @@ def _validate_test_selector(entry: dict[str, Any], prefix: str, errors: list[str
     if (
         not isinstance(selector, str)
         or not selector.strip()
+        or selector != selector.strip()
+        or not selector.isprintable()
         or "\x00" in selector
-        or any(character in selector for character in "\r\n\t")
         or not isinstance(pattern, str)
         or not selector.startswith(f"{pattern}.")
     ):
         errors.append(f"{prefix}.testSelector must target a method under testPattern")
+        return
+
+    method_name = selector[len(pattern) + 1 :]
+    if not method_name or any(character in method_name for character in TEST_SELECTOR_WILDCARDS):
+        errors.append(f"{prefix}.testSelector must name one concrete @Test method")
+        return
+    if test_source.is_file() and method_name not in _test_method_names(test_source):
+        errors.append(f"{prefix}.testSelector must match an @Test method in {entry['testSource']}")
 
 
 def canonical_architecture(value: object) -> str | None:
@@ -282,7 +314,7 @@ def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[
             errors.append(f"diagnostics is empty for {server}")
         if not isinstance(entry["releaseRequired"], bool):
             errors.append(f"releaseRequired must be boolean for {server}")
-        _validate_test_selector(entry, prefix, errors)
+        _validate_test_selector(entry, prefix, test_source, errors)
         _validate_platforms(entry, prefix, errors)
         test_task = entry.get("testTask")
         if test_task is not None and (

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -83,6 +83,22 @@ def _safe_string(value: object, pattern: re.Pattern[str]) -> bool:
     return isinstance(value, str) and bool(pattern.fullmatch(value)) and "\x00" not in value
 
 
+def _validate_test_selector(entry: dict[str, Any], prefix: str, errors: list[str]) -> None:
+    selector = entry.get("testSelector")
+    if selector is None:
+        return
+    pattern = entry.get("testPattern")
+    if (
+        not isinstance(selector, str)
+        or not selector.strip()
+        or "\x00" in selector
+        or any(character in selector for character in "\r\n\t")
+        or not isinstance(pattern, str)
+        or not selector.startswith(f"{pattern}.")
+    ):
+        errors.append(f"{prefix}.testSelector must target a method under testPattern")
+
+
 def canonical_architecture(value: object) -> str | None:
     """Normalize Docker/runner architecture aliases to the gate vocabulary."""
 
@@ -266,6 +282,7 @@ def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[
             errors.append(f"diagnostics is empty for {server}")
         if not isinstance(entry["releaseRequired"], bool):
             errors.append(f"releaseRequired must be boolean for {server}")
+        _validate_test_selector(entry, prefix, errors)
         _validate_platforms(entry, prefix, errors)
         test_task = entry.get("testTask")
         if test_task is not None and (

--- a/scripts/testcontainers_image_gate_manifest.json
+++ b/scripts/testcontainers_image_gate_manifest.json
@@ -43,6 +43,7 @@
       "image": "localstack/localstack",
       "tag": "4",
       "testPattern": "io.bluetape4k.testcontainers.aws.LocalStackServerTest",
+      "testSelector": "io.bluetape4k.testcontainers.aws.LocalStackServerTest.run S3 Service",
       "readiness": "testcontainers_wait_strategy_and_workload_readiness",
       "workload": "io.bluetape4k.testcontainers.aws.LocalStackServerTest:representative_test",
       "diagnostics": [
@@ -895,6 +896,7 @@
       "image": "tommy351/redis-cluster",
       "tag": "6.2",
       "testPattern": "io.bluetape4k.testcontainers.storage.RedisClusterServerTest",
+      "testSelector": "io.bluetape4k.testcontainers.storage.RedisClusterServerTest.create redis cluster server",
       "readiness": "testcontainers_wait_strategy_and_workload_readiness",
       "workload": "io.bluetape4k.testcontainers.storage.RedisClusterServerTest:representative_test",
       "diagnostics": [

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -191,8 +191,10 @@ skipped 테스트가 유효한 실행을 가리지 않도록 해당 메서드만
 경로로 한정합니다. 선택된 family는 `max-parallel: 1`로 순차 실행하고
 `success`, `product_failure`,
 `infrastructure_failure`, `blocked`로 분류하며 `summary.json`, `summary.md`,
-family별 JSON을 남깁니다. 안정 버전 배포는 `52/52`, `release_gate=true`,
-모든 실패 분류 0을 요구합니다. Docker Hub 인증과 mirror 설정은 환경변수 또는
+family별 JSON을 남깁니다. 안정 버전 배포는 release-required family 48개
+전체(`48/48`), `release_gate=true`, 모든 실패 분류 0을 요구합니다. 나머지
+4개 family는 support inventory로 별도 보고합니다. Docker Hub 인증과 mirror
+설정은 환경변수 또는
 CI secret으로만 전달하며, 증거에는 credential을 기록하지 않습니다.
 
 <!-- TESTCONTAINERS_IMAGE_GATE_COMMAND_START -->

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -182,7 +182,9 @@ Java 25+에서 Ignite 2 thin-client 테스트에 필요한 JVM 옵션은
 52개 Docker 기반 서버 family는
 [`scripts/testcontainers_image_gate_manifest.json`](../../scripts/testcontainers_image_gate_manifest.json)에 선언합니다.
 manifest는 고정 image/tag와 Kotlin wrapper, 대표 테스트 클래스, readiness 계약,
-workload 증거, 진단 명령을 연결합니다.
+workload 증거, 진단 명령을 연결합니다. 클래스에 의도적으로 비활성화한 메서드가
+있으면 `testSelector`로 실행할 대표 메서드를 명시할 수 있으며, gate는 무관한
+skipped 테스트가 유효한 실행을 가리지 않도록 해당 메서드만 실행합니다.
 
 동일한 실행기를 전체 Nightly와 안정 버전 배포 workflow에서 사용합니다. PR은
 저비용 JVM·모듈 검증을 유지하고 Docker 기반 family gate는 전체 Nightly/배포

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -189,8 +189,10 @@ gate is intentionally reserved for the full Nightly/release path. The runner
 executes the selected families sequentially (`max-parallel: 1`),
 records `success`, `product_failure`, `infrastructure_failure`, or `blocked`,
 and writes `summary.json`, `summary.md`, and one JSON file per family. Stable
-publication requires `52/52`, `release_gate=true`, and zero failure-classification
-counts. Docker Hub authentication and mirror settings are supplied through
+publication requires all 48 release-required families (`48/48`),
+`release_gate=true`, and zero failure-classification counts; the remaining four
+families are support inventory and are reported separately. Docker Hub
+authentication and mirror settings are supplied through
 environment variables or CI secrets; credentials are redacted from evidence.
 
 <!-- TESTCONTAINERS_IMAGE_GATE_COMMAND_START -->

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -178,7 +178,10 @@ should use `FlociServer` or `MiniStackServer`.
 The 52 Docker-backed server families are declared in
 [`scripts/testcontainers_image_gate_manifest.json`](../../scripts/testcontainers_image_gate_manifest.json).
 The manifest links each pinned image/tag to its Kotlin wrapper, representative
-test class, readiness contract, workload evidence, and diagnostic commands.
+test class, readiness contract, workload evidence, and diagnostic commands. A
+family may provide `testSelector` when the class contains an intentionally
+disabled method; the gate then runs the explicit representative method so a
+valid execution is not reported with an unrelated skipped test.
 
 The same runner is used by the full Nightly and stable release workflows. Pull
 requests keep their low-cost JVM and module checks; the Docker-backed family


### PR DESCRIPTION
## 요약

Full Nightly image gate가 실제 대표 테스트는 성공했지만 클래스 안의 의도적인 `@Disabled` 메서드를 `skipped=1`로 집계해 LocalStack·RedisCluster release family를 차단한 문제를 수정합니다.

Refs #1518

## 원인

`run_testcontainers_image_gate.py`의 generic release 명령은 테스트 클래스 전체를 `--tests`로 선택했습니다. 두 클래스 모두 플랫폼 제약으로 비활성화된 메서드가 하나씩 있어 Gradle은 `BUILD SUCCESSFUL`과 함께 JUnit `tests=3, skipped=1`을 생성했고, fail-closed parser가 올바르게 증적을 거부했습니다.

## 변경

- manifest에 LocalStack S3 및 RedisCluster 생성 대표 메서드의 `testSelector`를 명시합니다.
- generic runner가 선택자가 있으면 클래스 대신 해당 Gradle 테스트 선택자를 실행합니다.
- selector가 `testPattern` 아래의 하나의 구체적인 `@Test` 메서드를 가리키는지 검증하고 wildcard·제어문자·존재하지 않는 메서드를 거부합니다.
- selector → JUnit 증적 → release summary 경로의 회귀 테스트를 추가합니다.
- Testcontainers 한·영 README의 안정 배포 계약을 실제 release-required family `48/48`로 정렬합니다.
- 원인과 운영 지침을 `docs/lessons/2026-08-27-testcontainers-release-junit-selector.md`에 기록합니다.

## 검증

- Python 계약·runner 테스트 78개 통과
- `actionlint` 통과
- `./scripts/check-jvm-release-contract.sh` 통과
- `git diff --check`, Python compile, manifest JSON 검증 통과
- LocalStack family gate: `1/1`, JUnit `tests=1, skipped=0`, `release_gate=true`
- RedisCluster family gate: `1/1`, JUnit `tests=1, skipped=0`, `release_gate=true`
- Colima/Docker local runtime: running, Docker `29.2.1`, aarch64
- Hosted PR CI run `33061717140`: 24/24 success at exact PR head
- PR `#1545`는 `5d0c22dab9169821fdaa75c321c2b1d627b2eb41`로 `rebase` merge 완료
- canonical `develop`은 최신 `5229b386df7e7a62f5e9816a259f0d4241718425`에 동기화되었고 merge commit을 포함합니다.
- Full Nightly run `33062911098`은 merge commit exact head에서 43/43 success입니다.
- x64 image gate: release `48/48`, selected `52/52`, product/infrastructure failure `0`, blocked `0`, `release_gate=true`
- arm64 Ignite2 gate: release `1/1`, product/infrastructure failure `0`, blocked `0`, `release_gate=true`
- LocalStack 및 RedisCluster hosted JUnit 증적: 각각 `tests=1, skipped=0`
- Nightly Status 및 Coverage Report 통과; Coveralls: https://coveralls.io/jobs/186905362

## 위험과 범위

`releaseRequired`와 fail-closed `skipped=0` 계약은 완화하지 않습니다. 명시적 selector가 없는 family의 기존 클래스 선택 동작은 그대로 유지합니다. Snapshot 게시나 release publication은 이 PR의 승인을 넘어 별도 게이트이며 dispatch하지 않았습니다.

## DoD Status

Required checks: 24/24; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-10 | 범위·원인·구현·로컬 검증·커밋 | PASS | `8e75042bf0c2cafc590cbc66b7af7e3e4f3c5402`, Python 78개, actionlint, JVM contract, 두 family gate | none |
| CG-11 | PR 생성 권한·`develop <- fix/1518-junit-selector` | PASS | PR live metadata | none |
| CG-12 | exact head 원격 게시 | PASS | PR head에서 hosted CI 24/24 success | none |
| CG-13 | PR metadata/body live read-back | PASS | state MERGED, milestone `2.0.0`, assignee `debop`, labels `test`/`ci`/`tech-debt` | none |
| CG-14 | exact-head CI·독립 리뷰·thread | PASS | run `33061717140` 24/24 success, P0/P1 없음, reviews/comments/threads 0 | none |
| CG-15 | merge-ready 보고 | PASS | merge 전 base `develop`, `MERGEABLE`/`CLEAN`, fresh approval 확보 | none |
| CG-16 | fresh approval 및 rebase merge | PASS | PR `#1545`, mergedAt `2026-08-27T10:23:14Z`, merge commit `5d0c22d…` | none |
| CG-17 | canonical sync | PASS | `HEAD=origin/develop=5229b386…`, tracked tree clean, `5d0c22d…` ancestor | none |
| CG-18 | post-merge Full Nightly exact-head 검증 | PASS | run `33062911098`, 43/43 success, x64 `48/48` + selected `52/52`, arm64 `1/1`, Nightly Status pass | none |

Final status: DONE (승인 범위)

Unchecked required items: 없음. Snapshot dispatch/publication은 별도 승인 게이트로 보류합니다.
