### PR TITLE
[feat(science)] CoordinateAxis2D·CF auxiliary 격자 임포트 지원

### DIFF
--- a/docs/benchmarks/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary.md
+++ b/docs/benchmarks/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary.md
@@ -1,0 +1,125 @@
+# NetCDF `CoordinateAxis2D`·CF auxiliary bounded 임포트 벤치마크
+
+## 목적과 범위
+
+이 기록은 Epic #1421의 child #1352에서 `CoordinateAxis2D`와 numeric CF
+auxiliary coordinate를 기존 `NetCdfGridValueTable`에 bounded 하게 임포트하는
+경로의 성능·메모리 계약을 검증한다. schema migration, 새 dependency,
+workflow 변경은 포함하지 않는다.
+
+비교 기준은 `origin/develop`의 기준 SHA이고, feature 측정은 동일한 fixture와
+동일한 Testcontainers 경로를 사용한 구현 branch 실행 기준 데이터다. 1D 경로는
+기준 대비 throughput reference gate를 적용하고, 2D+auxiliary 경로는 회귀 기준선이
+없는 보고용 결과로 보존한다.
+
+## 고정 workload
+
+- 생성기: `NetCdfSampleWriter.writeLargeContractSample(path, 1024, 1024)`와
+  동일한 deterministic generator.
+- 셀 수: `1,048,576` (`1024 × 1024`).
+- 값/좌표: row-major 순서의 고유한 `(longitude, latitude, value)` 조합과
+  하나의 numeric auxiliary coordinate를 사용한다. 1D 비교는 같은 cell-value
+  workload를 `temperature_1d`로 읽고, 2D 보고값은 `temperature_2d`와 auxiliary를
+  함께 읽는다.
+- fixture SHA-256:
+  `2de7ae11c2279bf2f0b30148f485c7932572cad45ed91274906ca22ba631e6a5`
+- 타일/배치 계약: tile read 최대 `65,536` cells, JDBC pending rows 최대 `1,000`.
+  아래 feature 1D reference run은 당시 `65,536` values read와 `1,000` rows
+  flush를 사용했다. 이후 최종 hardening에서 rank 1 read도 `1,000` values로
+  낮췄으므로, 아래 수치는 final exact benchmark가 아니다. spatial 경로는 tile
+  read와 JDBC flush 상한을 각각 적용한다.
+
+## 재현 명령
+
+기준과 feature 모두 다음 selector를 사용했다.
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.benchmark - large1d*' \
+  -PincludeTags=slow-netcdf --no-configuration-cache --console=plain
+```
+
+2D+auxiliary 보고값은 다음 selector로 실행했다.
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.benchmark - large2d*' \
+  -PincludeTags=slow-netcdf --no-configuration-cache --console=plain
+```
+
+각 실행은 Testcontainers를 포함하므로 동시에 실행하지 않았다. 테스트 결과와
+Gradle 출력은 모두 `BUILD SUCCESSFUL`이었다.
+
+## 실행 환경과 기준 데이터
+
+- 기준 branch/SHA: detached baseline worktree,
+  `origin/develop@45260871f58433a78f2d633c235010f661d22c6e`.
+- feature 실행 기준 데이터: `feat/1352-coordinate-axis2d-cf-grid`의 구현 diff가 있는
+  상태에서 측정했다. 이후 duplicate backing-accounting, strict CRS/axis 검증,
+  경계 예외 처리를 보완했으므로 아래 수치는 최종 코드의 exact benchmark가
+  아니라 pre-final reference로 보존한다. 최종 코드의 correctness와 cap은
+  fresh test evidence로 다시 검증했다.
+- OS/runtime: macOS, Colima Virtualization Framework, Docker context `default`.
+- Docker: `29.2.1` (`aarch64`), `postgis/postgis:16-3.5` (`amd64` image를 arm64
+  환경에서 emulation).
+- JVM: GraalVM JDK 25 (`/Library/Java/JavaVirtualMachines/graalvm-jdk-25`).
+- Gradle: `9.7.0` wrapper.
+
+## 결과
+
+| 경로 | cells | elapsed | cells/sec | peak heap | 판정 |
+|---|---:|---:|---:|---:|---|
+| baseline 1D | 1,048,576 | 159,123 ms | 6,589.72 | 504,616,768 B (약 481.1 MiB) | 비교 기준 |
+| feature 1D (pre-final reference) | 1,048,576 | 160,075 ms | 6,550.53 | 182,604,160 B (약 174.1 MiB) | baseline 대비 +0.598%, reference gate 통과 |
+| feature 2D + CF auxiliary (pre-final reference) | 1,048,576 | 260,697 ms | 4,022.20 | 308,149,776 B (약 293.9 MiB) | 기준선이 없는 보고용 |
+
+1D feature reference elapsed는 `160,075 ms`, baseline은 `159,123 ms`로 측정되어
+`(160075 / 159123 - 1) × 100 = +0.598%`이다. 이는 최종 rank 1 read cap
+hardening 전 측정값이다. JVM peak heap은 NetCDF,
+PostgreSQL/Testcontainers, Gradle와 공유되므로 bounded 계약의 판정값으로
+사용하지 않고 참고값으로만 기록한다.
+
+## 구현 내부 working-set 회계
+
+고정 상수로 계산한 import-owned working set은 JVM peak와 분리해 검증했다.
+
+| 항목 | 1D | 2D + auxiliary |
+|---|---:|---:|
+| tile buffer (`65,536 × 8`) | 524,288 B | 524,288 B |
+| coordinate window (`65,536 × (2 + 1) × 8`) | 0 B | 1,572,864 B |
+| serializer/batch scratch (`1,000 × (256 + 8,192)`) | 8,448,000 B | 8,448,000 B |
+| duplicate key set (보수치 `cells × 32`) | 0 B | 33,554,432 B (약 32.00 MiB) |
+| 총 owned working set | 8,972,288 B (약 8.56 MiB) | 44,099,584 B (약 42.06 MiB) |
+
+2D의 `coordinateBytes + duplicateSetBytes`는 약 33.5 MiB로 `64 MiB`
+working-set cap 이하이고, 총 owned working set은 약 42.1 MiB로 `128 MiB`
+cap 이하이다. duplicate key set은 승인된 `cells × 32` 보수 회계를
+`MemoryBudget`에 사용하며, 실제 backing table의 capacity·slot 회계는
+별도 구현 counter(`capacity × 25 B`)로 관찰한다.
+coordinate cache는 `64 MiB`, JSONB auxiliary는 `8,192` UTF-8 bytes,
+tile은 `65,536` cells, JDBC batch는 `1,000` rows cap을 사용한다.
+
+## 해석과 제한
+
+- 1D reference throughput gate는 통과했다. 당시 65,536-value read와
+  1,000-row flush를 사용해 bounded read와 batch 계약을 동시에 유지했으며,
+  최종 코드는 rank 1 read를 1,000 values로 더 보수적으로 제한한다. 최종
+  hardening 이후 동일 조건의 재측정은 후속 작업이다.
+- 2D+auxiliary 결과는 tile-local coordinate window가 per-cell coordinate
+  read보다 안정적이라는 구현 경향을 확인하는 pre-final reference이며,
+  기존 baseline이 없으므로 회귀 pass/fail 기준으로 해석하지 않는다.
+- 계획된 `1회 warm-up + 3회 측정 median`은 실행하지 않았다. arm64에서
+  `amd64` PostGIS image를 emulation하고 각 Testcontainers 실행이 약
+  2.5–4.5분 걸려 단일 성공 실행 결과만 남겼다. 따라서 median,
+  표준편차, 통계적 유의성은 주장하지 않는다.
+- feature 1D 첫 시도에서 PostgreSQL EOF가 발생했으나 Colima/docker 상태를
+  확인한 뒤 동일 selector를 재실행해 성공했다. 실패 실행은 환경 hiccup으로
+  분리했고 성공 실행만 수치에 사용했다.
+
+## DoD Status
+
+- 상태: bounded import 및 1D throughput reference **PASS**.
+- 메모리/타일/배치 cap: **PASS** (고정 counter 회계).
+- 2D+CF auxiliary: **PASS (pre-final reference, 보고용)**.
+- warm-up + 3회 median: **PENDING** — emulation 환경에서 단일 실행 결과만 확보.
+- schema/dependency/workflow 변경: **없음**.

--- a/docs/followup-issues/utils-science-readme-rewrite.md
+++ b/docs/followup-issues/utils-science-readme-rewrite.md
@@ -20,7 +20,7 @@ README는 다음 기준 정보를 한·영 동일하게 설명합니다.
 | 영역 | 현재 계약 | 근거 |
 |------|-----------|------|
 | 서비스 API | 동기(blocking) `registerFile()`과 `importGridValues()` | [`NetCdfCatalogService.kt`](../../utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt) |
-| 변수 범위 | rank 1~4, 1차원 좌표축 | 서비스 KDoc 및 `VariableAxisMap` |
+| 변수 범위 | rank 1~4, 1·2차원 좌표축, numeric CF auxiliary | 서비스 KDoc 및 `VariableAxisMap` |
 | 저장 의미 | rank별 `timeIdx`·`levelIdx`·`location` 매핑 | 서비스 KDoc, `NetCdfGridValueTable` |
 | 재개·동시성 | `(fileId, variableName)`별 5분 heartbeat lease와 `lastSliceIdx` cursor | `NetCdfImportProgressRepository`, 서비스 테스트 |
 | CRS | EPSG:4326/4269/3857/3031/3413 및 UTM 32601~32660·32701~32760 화이트리스트 | `CoordinateReprojector` 및 서비스 테스트 |
@@ -62,13 +62,25 @@ implementation("edu.ucar:netcdf4:5.9.1")
 ## 후속 연결
 
 문서 계약이 확정되었으므로 Epic [#1421](https://github.com/bluetape4k/bluetape4k-projects/issues/1421)의
-다음 단계는 #1352입니다. #1352에서는 2D 좌표축·CF auxiliary coordinate fixture,
-셀 좌표 보존, 지원·비지원 CRS, 기존 rank 1~4 및 lease/resume 회귀를 코드와 테스트로
-고정해야 합니다.
+다음 단계로 #1352 구현 child가 이어졌습니다.
+
+## #1352 구현 결과
+
+현재 child는 다음 계약을 구현하고 테스트로 고정합니다.
+
+- `CoordinateAxis1D`와 `CoordinateAxis2D`, CF numeric auxiliary coordinate를 bounded tile로 읽습니다.
+- `[time, x, y]` 같은 비표준 dimension 순서도 full-rank index로 보존하고,
+  canonical `(lon, lat)`은 `location`, auxiliary는 `attrs` JSONB에 저장합니다.
+- slice 전체 duplicate preflight, strict CRS whitelist/EPSG parser, 파일 fingerprint,
+  progress quarantine, lease fence, typed exception과 resource budget을 적용합니다.
+- 기존 rank 1~4, NaN/`_FillValue`, resume/lease 및 PostGIS read-back 회귀를 유지합니다.
+
+구현 child의 PR 생성·exact-head CI·rebase merge는 별도 게이트이며, 이 문서는 해당
+게이트가 닫히기 전의 후속 상태 기록입니다.
 
 ## DoD Status
 
 - 상태: 문서 정합화 완료
 - 코드 동작 변경: 없음
 - EN/KO README 범위·의존성·quick start·테스트 프로필: 반영
-- 후속 기능 #1352: 별도 대기
+- #1352 좌표축/auxiliary 구현: branch 검증 완료, PR·merge 게이트 대기

--- a/docs/lessons/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary.md
+++ b/docs/lessons/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary.md
@@ -1,0 +1,69 @@
+# NetCDF `CoordinateAxis2D`·CF auxiliary 구현 교훈
+
+## 관찰된 핵심 교훈
+
+### tile-local coordinate window가 필요하다
+
+2D 축을 셀마다 `read1D`/`read2D`로 다시 읽으면 NetCDF 접근 호출 수가 셀 수에
+비례해 증가한다. `CoordinateAxis2D`와 CF auxiliary 값은 현재 tile의 row/column
+window를 한 번만 읽고, tile-local index로 재사용해야 bounded 메모리와 실제
+throughput을 함께 유지할 수 있다. projected CRS에서도 coordinate source와
+reprojection point provider를 tile 경계 안에 두어야 한다.
+
+### 1D에서는 read window와 JDBC batch를 분리한다
+
+1D reference run에서는 최대 `65,536`개를 한 번에 읽되, JDBC pending rows는
+`1,000`개에서 flush하는 방식이 효과적이었다. 이 경계를 적용한 pre-final
+feature 측정은 baseline 대비 `+0.598%`(`160,075 ms` 대 `159,123 ms`)로
+`20%` reference gate를 통과했다. 최종 hardening에서는 rank 1 read도
+`1,000` values로 낮췄으므로 위 수치는 final exact benchmark가 아니다. 큰
+NetCDF read window와 작은 DB batch를 같은 수치로 묶으면 importer가 불필요하게
+느려지므로 두 cap을 독립적으로 유지한다.
+
+### 마지막 checkpoint는 renew 후 complete해야 한다
+
+마지막 row write와 lease fence 뒤에 같은 transaction에서 `renewLease`로
+`lastSliceIdx`를 먼저 기록하고 `markCompleted`를 호출해야 한다. 이 순서를
+지키면 `COMPLETED` 상태의 terminal checkpoint, `completedAt`, null lease가
+동시에 보장되고, 재시작 직전의 유효한 lease도 만료되지 않는다.
+
+### malformed progress는 덮어쓰지 말고 격리한다
+
+`IN_PROGRESS`인데 `lease_expires_at`이 null인 progress row는 정상 owner로
+취급해 덮어쓰면 안 된다. acquire 조건에서 제외하고 row lock 아래
+`CORRUPT_PROGRESS:<progressId>`로 격리한 뒤 재시도해야 한다. 반대로
+`COMPLETED`의 invariant 오류는 terminal 결과를 바꾸지 않고 typed
+`CorruptProgress`로 중단한다.
+
+### duplicate와 schema 경계는 기존 구조를 재사용한다
+
+중복 canonical coordinate는 두 번째 pass에서 insert하기 전에 slice 전체를
+검사해야 부분 row가 남지 않는다. 기존 `location`은 `(longitude, latitude)`
+PostGIS point로, 기존 `attrs` JSONB는 numeric CF auxiliary로 재사용하면 새
+table/column이나 migration 없이 기존 consumer와 호환된다.
+
+### 벤치마크 환경과 통계 한계를 분리해 기록한다
+
+이번 실행은 macOS Colima arm64에서 `postgis/postgis:16-3.5` amd64 image를
+emulation했다. 1D와 2D 실행은 Testcontainers를 순차 실행하고 성공 출력만
+기록했지만, 각 실행 시간이 길어 계획한 `1 warm-up + 3 measured median`은
+완료하지 못했다. 그러므로 수치는 단일 성공 실행 결과이며, median·분산·통계적
+유의성을 주장하지 않는다. 후속 성능 비교에서는 같은 fixture SHA와 같은
+container/runtime 조건을 먼저 고정한다.
+
+## 재사용할 검증 순서
+
+1. fixture generator와 SHA-256을 baseline/feature 양쪽에서 확인한다.
+2. tile read, coordinate window, pending JDBC rows, serializer/duplicate
+   working-set counter를 cap과 대조한다.
+3. rank 1 throughput reference와 rank 2+ 보고용 결과를 별도 판정한다.
+4. Testcontainers hiccup는 runtime 상태를 확인하고 동일 selector를 재실행한
+   뒤, 실패와 성공을 문서에서 분리한다.
+
+## DoD Status
+
+- tile-local coordinate window·1D read/batch 분리·checkpoint 순서·progress 격리:
+  **구현 및 회귀 테스트 PASS**.
+- 기존 schema 재사용과 duplicate preflight: **구현 및 계약 테스트 PASS**.
+- benchmark 환경/단일 실행 제한 기록: **완료**.
+- 반복 median benchmark: **PENDING** — 별도 후속 실행이 필요하다.

--- a/docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design-review.md
+++ b/docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design-review.md
@@ -1,0 +1,134 @@
+# #1352 NetCDF CoordinateAxis2D·CF auxiliary 설계 통합 검토
+
+## 검토 범위와 기준
+
+- **검토 일자**: 2026-08-27
+- **이슈/에픽**: [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352) /
+  [#1421](https://github.com/bluetape4k/bluetape4k-projects/issues/1421)
+- **검토 대상**: `docs/superpowers/specs/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design.md`
+- **기준 branch/SHA**: `feat/1352-coordinate-axis2d-cf-grid` /
+  `origin/develop@45260871f58433a78f2d633c235010f661d22c6e`
+- **선행 train**: PR #1512가 #1343 문서 계약을 `develop`에 rebase merge한 상태
+- **검토 방식**: main-session 설계 통합과 Performance, Stability/Ops, Security,
+  Developer/API, User/caller 여섯 독립 관점의 최신 명세 재검토
+- **변경 경계**: 이 문서는 읽기 전용 관점 검토 기록이며 코드·스키마·workflow·PR·merge를
+  변경하지 않는다.
+
+## 통합 판정
+
+| 우선순위 | 관점 | 최신 근거 | 판정/조치 | 재검토 |
+|---|---|---|---|---|
+| P0 | 전체 | 승인된 목표, 저장 경계, lease fence, 중복 정책과 실패 중지가 명세에 연결됨 | 0건 | 불필요 |
+| P1 | 전체 | 여섯 관점 최신 재검토가 모두 P1=0 | 0건 | 불필요 |
+| P2 | 전체 | 각 관점에서 발견된 미완 계약을 명세에 반영함; Ops의 metric label allowlist·lease TTL/runbook·artifact retention은 후속 운영 문서 보강으로 기록 | 0건 | 불필요 |
+| P3 | 전체 | 최신 재검토에서 별도 잔여 사항 없음 | 0건 | 불필요 |
+
+**최종 verdict: PASS (P0=0, P1=0, P2=0, P3=0).** 후속 계획 검토에서 확인된 API·호출자
+보완까지 명세에 반영했으며, 구현 착수 전 2026-08-27 사용자 승인을 수신했다.
+
+## 여섯 관점별 확인
+
+### Performance
+
+- bounded tile read(`<=65,536` cells), JDBC batch(`<=1,000` rows), coordinate/cache
+  64 MiB, owned working-set 128 MiB와 checked `Long` 산식을 고정했다.
+- spatial slice를 preflight와 write의 두 pass로 분리해 tile 경계 duplicate를 놓치지 않고,
+  preflight 이전 DB insert를 금지한다.
+- `CoordinateReader.read1D/read2D`가 모든 축/auxiliary 접근을 bounded window로 통일하고,
+  `read2D`의 row-major flat layout과 `index = localRow * columnCount + localColumn`을
+  명시했다. full-grid materialization과 직접 `getCoordValue` 우회는 금지된다.
+- 1D 동일 cell-count baseline과 2D+auxiliary report-only benchmark, clean DB·동일 JVM/
+  PostGIS·warm-up/median 절차가 있어 성능 주장을 과장하지 않는다.
+
+### Stability/Ops
+
+- `lease_expires_at`을 acquire마다 새로 발급하는 opaque token으로 사용하고, tile 시작·commit·
+  `markFailed` 모두 status/token/`> CURRENT_TIMESTAMP` CAS와 affected-row=1을 요구한다.
+- progress row lock을 tile commit까지 유지하며, 중간 tile은 checkpoint를 전진시키지 않고
+  마지막 tile만 `renewLease(lastSliceIdx=...)`를 같은 transaction에 포함한다.
+- `PENDING/FAILED`, `IN_PROGRESS`, `COMPLETED` invariant, null lease repair, checkpoint 범위,
+  fingerprint와 `CorruptProgress`를 명시했다. cancellation/interrupt는 `FAILED`로 바꾸지 않고
+  원래 예외와 interrupt 상태를 보존한다.
+- DB UTC를 단일 시계로 사용하고, metric label allowlist·lease TTL/runbook·artifact retention은
+  구현 후 운영 문서 보강 항목으로 남긴다. 현재 P0/P1 차단 사유는 아니다.
+
+### Security
+
+- trusted-admin 경계, regular-file·NUL/control·URI·symlink 거부, 구성요소별 `NOFOLLOW_LINKS`,
+  open 전후 identity 재검증으로 path/TOCTOU 경계를 고정했다.
+- file size, metadata·dimension·variable·cell·slice·cache·working-set hard limit과 caller
+  deadline을 명시해 입력 metadata가 자원을 무한히 소비하지 않도록 했다.
+- EPSG ASCII/integral grammar, 충돌 attribute 거부, whitelist와 final lon/lat bounds를
+  명시하고 WGS84 묵시 fallback을 금지했다.
+- JSONB는 NFC strict UTF-8 key, control/surrogate/예약 접두사 거부, 8,192-byte cap과 typed
+  placeholder를 사용한다. batch의 설명되지 않은 결과는 bounded 검증 후 rollback한다.
+
+### Developer/API
+
+- 공개 blocking `registerFile`/`importGridValues` 시그니처와 기존 `location`/`attrs` schema를
+  유지한다. 새 다섯 subtype(`UnsupportedCoordinateAxis`, `DuplicateCoordinate`,
+  `ResourceLimitExceeded`, `FileChanged`, `CorruptProgress`)는 2.0.0 major 경계의 sealed
+  subtype임을 명시하고, base catch/`else` migration과 compile fixture를 계획했다.
+  nullable `timeDim`/`levelDim`은 조건부 full-rank assignment로 처리하고, rank 1
+  `TileRow`의 nullable location·typed SQL NULL invariant와 기존 custom `leaseTtl`을 보존한다.
+- `VariableReader`는 data variable, `CoordinateReader`는 모든 axis/auxiliary, `CoordinateSampler`
+  는 caller-owned mutable target, `TileBatchWriter`는 active Exposed transaction의 동일
+  `java.sql.Connection`만 받는 것으로 역할을 분리했다.
+- writer는 새 DataSource/transaction/connection close를 하지 않으며, `PreparedStatement`만
+  닫는다. identity·rollback 원자성·batch status를 recording seam으로 검증한다.
+- auxiliary map lifetime은 동기 직렬화 및 다음 셀 전 clear로 고정하고, row-major `read2D` layout과
+  reversed-axis fixture를 수용 기준에 연결했다.
+
+### User/caller
+
+- trusted-admin 환경의 blocking Kotlin 호출을 virtual-thread `Future`에서 실행하고,
+  caller-owned deadline/interrupt, cooperative cancel, bounded `shutdownNow()`/
+  `awaitTermination`, timeout 후 progress·lease·partial-row side-effect 재확인,
+  `location`/`attrs` read-back 예시를 명세와 README/KDoc 갱신 항목에 포함했다.
+- 다섯 sealed subtype 모두의 migration branch/기본 `else`를 기록하고,
+  `UnsupportedCoordinateAxis`/`UnsupportedProjection`/`ResourceLimitExceeded`,
+  `FileOpen`/`FileChanged`/`MissingCoordinate`/`VariableNotFound`/`UnsupportedVariable`,
+  `DuplicateCoordinate`는 수정 후 항상 새 등록·새 `fileId`를 사용한다. `CorruptProgress`는
+  `SELECT ... FOR UPDATE` 기준 상태 기록과 audit/quarantine, 기존 column 기반 `FAILED` 격리
+  또는 `COMPLETED` 차단, partial-row 보존·삭제 후 새 import 절차를 구체화했다.
+  `ImportAlreadyRunning`/`ImportLeaseLost`는 3회·1/2/4초 backoff로 제한하고 무한 재시도는
+  허용하지 않는다.
+- 기존 `location` 기반 소비자는 auxiliary key를 해석하지 않아도 동작하며, schema migration·
+  release note·workflow 변경은 이번 child 범위 밖으로 고정했다.
+
+## 핵심 보완 이력
+
+초기 설계 승인 후 Step 2-R에서 확인된 P1/P2를 다음처럼 보완했다.
+
+1. 대용량 전체 배열 read, 배치·cache·working-set 상한, duplicate preflight와 고정 benchmark를
+   추가했다.
+2. lease token CAS, row lock, checkpoint 순서, DB UTC clock, malformed progress와 fingerprint를
+   명시했다.
+3. schema migration 없이 duplicate coordinate 유실을 막도록 slice-wide exact key 검사를 추가했다.
+4. strict CRS grammar/bounds, trusted path·TOCTOU, JSONB key/payload와 resource limits를
+   고정했다.
+5. sealed exception의 다섯 subtype 2.0.0 migration, `CoordinateReader` bounded seam,
+   nullable rank index와 동일 Exposed connection/TTL compatibility, rollback 원자성,
+   auxiliary lifetime, caller 복구 예시를 추가했다.
+
+## 수용 기준·writer gate
+
+| 항목 | 판정 | 근거 |
+|---|---|---|
+| #1352 수용 기준이 fixture/read-back/CRS/regression/performance로 매핑됨 | PASS | 설계 §9 표와 §6 테스트 목록 |
+| Type A 여섯 관점 최신 재검토 | PASS | 각 관점 P0/P1/P2/P3=0 |
+| 공개 API·schema·migration 경계 | PASS | 설계 §2.2, §4.4, §5, §7 |
+| rollback·lease·cancellation·resource 중지 조건 | PASS | 설계 §2.3, §4.3, §5, §8 |
+| SPW-01 audience/purpose/evidence | PASS | 이슈·선행 PR·기준 SHA·저장소 근거를 명시 |
+| SPW-02 artifact contract | PASS | 문제·대안·내부 계약·오류·테스트·DoD 포함 |
+| SPW-03 Korean technical register | PASS | 사용자/검토자용 한국어, 코드/API/명령 토큰 보존 |
+| SPW-04 technical traceability | PASS | source anchor·schema·lease·수용 기준 연결 |
+| SPW-05 read-back | PASS | heading/table/code fence·결정·범위·잔여 P2를 재독 |
+
+## 결론과 다음 게이트
+
+설계는 구현에 전달할 수 있는 상태이며 최신 독립 검토의 P0/P1 차단 결함이 없다. 다만 Step
+2-R에서 공개 API 호환성·트랜잭션 경계·호출자 복구 절차가 보완되었으므로, 이전 설계 승인이
+이 보완까지 자동으로 승인한 것으로 간주하지 않는다. 사용자의 **명세 재승인**을 2026-08-27에
+수신했으며, 다음 게이트는 `writing-plans`와 Step 3-R 계획 검토이고 코드는 그 이후에만 수정한다. PR 생성·rebase
+merge·release/dispatch는 이 문서 범위가 아니며 exact-head와 fresh approval을 별도로 요구한다.

--- a/docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan-review.md
+++ b/docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan-review.md
@@ -1,0 +1,160 @@
+# #1352 NetCDF CoordinateAxis2D·CF auxiliary 구현 계획 통합 검토
+
+## 검토 범위와 기준
+
+- **검토 일자**: 2026-08-27
+- **이슈/에픽**: [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352) /
+  [#1421](https://github.com/bluetape4k/bluetape4k-projects/issues/1421)
+- **검토 대상**: 승인 명세 `docs/superpowers/specs/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design.md`,
+  구현 계획 `docs/superpowers/plans/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan.md`
+- **기준 branch/SHA**: `feat/1352-coordinate-axis2d-cf-grid` /
+  `origin/develop@45260871f58433a78f2d633c235010f661d22c6e`
+- **선행 train**: PR #1512가 Issue #1343 문서 계약을 `develop`에 rebase merge
+- **검토 방식**: main-session architecture 통합과 Performance, Security,
+  Stability/Ops, Developer/API, User/caller 독립 관점의 최신 계획 재검토
+- **변경 경계**: Step 3-R 산출물 검토 기록이다. 구현 코드·스키마·workflow·PR·merge는
+  이 단계에서 변경하지 않는다.
+
+## 통합 판정
+
+| 우선순위 | 관점 | 최신 판정 | 근거/처분 |
+|---|---|---|---|
+| P0 | 전체 | 0건 | 명세 요구가 파일·task·테스트·중지 조건과 연결되고, schema/dependency/workflow 경계가 고정됨 |
+| P1 | 전체 | 0건 | API의 nullable dimension/null location·custom TTL·exact tuple과 호출자의 executor/migration/CorruptProgress recovery 보완 후 독립 재검토 PASS |
+| P2 | 전체 | 0건 | 동일 보완 사항의 retry/backoff·timeout side-effect recheck·compatibility fixture 보완 후 독립 재검토 PASS |
+| P3 | 전체 | 0건 | 별도 잔여 경미 사항 없음 |
+
+**최종 verdict: PASS (P0=0, P1=0, P2=0, P3=0).** API, Stability/Ops, User/caller 독립
+재검토와 보완 후 계획·명세 정합성 확인을 통과했다. Step 3-R/3-P를 통과했으며 다음
+게이트는 승인 산출물 commit 후 TDD 구현이다. hosted CI·실행 테스트·benchmark는 구현
+이후 증거로 남긴다.
+
+## 관점별 확인
+
+### Architecture / main session
+
+- 공개 blocking `registerFile`/`importGridValues`, 기존 `location`/`attrs`, 기존 table/index와
+  Exposed 연결 경계를 유지한다. 새 table/column/schema migration, dependency, settings/BOM,
+  module registration, workflow 변경은 N/A 이유와 함께 범위 밖으로 고정했다.
+- Epic #1421 train은 선행 PR #1512(T0, #1343 문서)를 `develop`에 반영한 뒤 현재 #1352
+  child(T1)를 `develop` base로 올리는 순서로 고정하고, T1은 exact-head fresh approval 후
+  rebase merge한다. Epic close는 두 child의 live DoD를 재확인한 뒤로 유보한다.
+- `VariableAxisMap` → bounded reader/sampler → deterministic tile planner → serializer/writer →
+  service/progress repository 순서가 파일 소유권과 task 순서로 분리되어 역순 의존이 없다.
+- 선행 PR #1512의 문서 계약과 기준 SHA를 plan/benchmark/rollback에 고정하고, child #1352만
+  구현 train으로 유지한다.
+
+### Performance
+
+- `CoordinateReader.read1D/read2D`, rank-1 window와 rank 2–4 tile read가 full-array를 만들지
+  않으며 tile cell은 65,536 이하, JDBC batch/pending rows는 1,000 이하이다.
+- `MAX_FIXED_ROW_BYTES=256L`, checked `batchPayloadBytes`,
+  `serializerScratchBytes=max(rawScratchBytes,batchPayloadBytes)`, coordinate/duplicate 64 MiB,
+  owned working-set 128 MiB를 첫 tile 전에 계산한다.
+- 두 pass duplicate preflight, row-major `read2D`, same generator 1D baseline/2D report-only
+  benchmark, exact baseline SHA와 `MemoryMXBean`/counter 기록으로 성능 주장을 제한한다.
+
+### Security
+
+- trusted-admin regular-file·NUL/control·URI·symlink·size guard와 open 전후 identity 검증을
+  명시하고, 불일치 시 dataset close·DB progress 불변·`FileChanged`를 보장한다.
+- verified dataset 뒤 bounded non-recursive stack/queue metadata scan을 수행하고
+  `MAX_GROUP_COUNT=256`, `MAX_GROUP_DEPTH=32`, 1 MiB metadata cap에서 map materialization 전
+  조기 중지한다.
+- strict EPSG grammar/whitelist, source/final coordinate bounds, JSONB NFC/UTF-8/control/
+  reserved-prefix/8,192-byte cap, typed placeholder와 bounded batch result 처리를 고정했다.
+
+### Stability/Ops
+
+- 최초 missing-row upsert, unique `(file_id, variable_name)` race, malformed
+  `IN_PROGRESS`+null lease repair, 미래 expiry `ImportAlreadyRunning`, stale fence
+  `ImportLeaseLost`를 구분한다. 비교 시계는 DB UTC `CURRENT_TIMESTAMP`다.
+- 각 tile transaction은 시작·read/write·commit fence를 검사하고 현재 tile만 rollback한다.
+  이전에 commit된 tile/slice는 보존하며, duplicate는 두 번째 pass 전에 slice 전체가 0 rows다.
+- 마지막 row write/fence 뒤 DB commit 전에 같은 transaction에서 `markCompleted`를 호출해
+  terminal status/completedAt/lease clear/checkpoint invariant를 원자적으로 보장한다.
+- cancellation/interrupt는 `FAILED` 전환 없이 원래 예외와 interrupt를 보존하고,
+  `Future.cancel(true)`·`shutdownNow()`·bounded `awaitTermination` 뒤 connection=0/추가 renew
+  없음과 현재 tile rollback을 확인한다. 운영 runbook은 5분 TTL·stale progress·rollback·
+  allowlisted rejection metric과 alert를 포함한다.
+
+### Developer/API
+
+- sealed `NetCdfException` 다섯 새 subtype과 2.0.0 migration/`else` catch fixture,
+  구조화된 오류 필드를 계획했다. nullable `timeDim`/`levelDim`은 조건부 full-rank
+  assignment로 처리하고, rank 1 `TileRow`의 nullable location과 typed SQL NULL
+  binding invariant를 고정한다. 기존 custom `leaseTtl`은 DB interval parameter로
+  보존하며, 30a/32는 raw `ST_X/ST_Y/value` exact tuple을 검증한다. `CoordinateSampler`는
+  caller-owned `MutableCoordinateSample`와 즉시 `readOnlyCopy()` lifetime을 사용하고
+  target/map을 보유하지 않는다.
+- `TileBatchWriter.write(connection, rows)`는 active Exposed transaction의 동일 JDBC
+  connection만 받아 새 transaction/DataSource/close를 금지하고, prepared statement만 닫는다.
+- full-rank `Index.set`, dimension-order fixture, CRS/auxiliary/duplicate/error tests와
+  기존 rank 1–4 회귀를 Task 1–7에 매핑했다.
+
+### User/caller
+
+- blocking API를 virtual-thread executor에서 실행하고, timeout/interrupt/cancellation/
+  execution failure을 처리한 뒤 `Future.cancel(true)`, `shutdownNow()`/30초
+  `awaitTermination`을 수행하는 EN·KO 예시를 계획했다. cooperative cancel 경고와
+  timeout 후 progress/lease/partial-row side-effect 재확인도 포함했다.
+- `location`은 `(lon,lat)`이고 numeric CF auxiliary는 `attrs`로 간다는 read-back, supported
+  CRS/hard limits, trusted-admin/authN/authZ/tenant/root 책임을 문서화한다.
+- 다섯 새 sealed subtype 모두의 exhaustive `when` 대응과, 입력·metadata·경로·축·변수
+  변경 시 항상 새 등록·새 `fileId`를 사용하는 규칙을 문서화한다. `CorruptProgress`는
+  `SELECT ... FOR UPDATE` 기준 상태 기록/audit/quarantine, 기존 column 기반 `FAILED` 격리 또는
+  `COMPLETED` 차단, partial-row retention/delete 후 새 import의 concrete 절차를 갖는다.
+  `ImportAlreadyRunning`/`ImportLeaseLost`는 3회·1/2/4초 backoff로 제한하고 소진 시
+  typed error/alert를 표면화하며, 무한 retry·health endpoint 책임 전가·schema migration을
+  허용하지 않는다.
+
+## 초기 발견과 반영 이력
+
+1. Performance: rank-1/full-array·batch payload 산식 모호성을 window, `MAX_FIXED_ROW_BYTES`,
+   checked budget, fixed benchmark로 보완했다.
+2. Security: metadata map materialization 순서와 group depth/count, open TOCTOU를 verified
+   open → bounded stack/queue scan → materialization 순서로 보완했다.
+3. Stability/Ops: terminal `markCompleted`, cancellation lifecycle, null lease/initial upsert,
+   active lease 분기, tile별 rollback 의미를 명시했다.
+4. Developer/API: mutable sample·same connection·full-rank index·strict EPSG·cross-tile exact
+   tuple과 compile fixture를 구체화했다.
+5. User/caller: register/import 모두 blocking이라는 점, bounded executor 종료, 예외 recovery와
+   2.0.0 migration 책임을 EN·KO 문서 task에 연결했다.
+6. 최신 독립 재검토의 API P1/P2는 nullable dimension assignment, rank-1 null location,
+   custom lease TTL, exact tuple read-back을 보완하는 patch로 반영했다. User/caller P1/P2는
+   명세·계획 예시 parity, 다섯 subtype migration, concrete `CorruptProgress` 격리,
+   changed-file 새 `fileId`, 유한 retry/backoff, cooperative cancellation과 side-effect
+   재확인을 보완하는 patch로 반영했고, API·Stability/Ops·User/caller 최종 재검토가
+   모두 P0/P1/P2/P3=0임을 확인했다.
+
+## Step 3-P 위험 예측과 rollback
+
+| 위험 신호 | 완화/검증 | rollback |
+|---|---|---|
+| dimension order 전치 | `[time,y,x]`, `[time,x,y]`, `[y,x,time]` exact `ST_X/ST_Y/value` read-back | Task 5부터 수정·재실행 |
+| stale owner 혼합 | token/status/DB-UTC fence와 stale renew/complete/fail tests | 현재 기능 commit revert, progress row 격리 |
+| duplicate 유실 | slice-wide first pass exact key set, cross-tile rows=0 | tile engine 수정 후 service suite 재실행 |
+| heap/batch 초과 | tile/batch/JSONB/working-set counters와 fixed benchmark | limits/planner/writer commit revert |
+| 취소 partial write | first-write/flush cancel, current tile rollback, prior tile 보존, await termination | cancellation seam 수정·재실행 |
+| corrupt COMPLETED no-op | verified dataset totalSlices/checkpoint invariant | progress 검증 수정 후 재실행 |
+| path/metadata TOCTOU | open 전후 identity와 map 전 bounded scan | guard commit revert, 새 fileId 등록 |
+| observability 오염 | stable reason·control sanitation·allowlist labels/rejection metric | metric 변경 revert |
+| NetCDF/Testcontainers 오탐 | heavy invocation 순차, Colima/context/info 진단 | 환경 수정 후 동일 selector 재실행 |
+
+schema migration이 없으므로 DB rollback은 각 transaction rollback과 fixture cleanup으로 한정하고,
+구현 실패 시 branch-local commit만 `git revert`한다. canonical `develop`과 다른 worktree는
+건드리지 않는다.
+
+## Writer gate와 Step 3-R 종료
+
+| 항목 | 판정 | 근거 |
+|---|---|---|
+| SPW-01 audience/purpose/evidence | PASS | #1352/#1421, 선행 #1512, 기준 SHA, source anchor, stop condition |
+| SPW-02 artifact contract | PASS | goal/architecture/file ownership/task/test/docs/rollback |
+| SPW-03 Korean technical register | PASS | 설명·결정은 한국어, code/API/command/path token 보존 |
+| SPW-04 technical traceability | PASS | 명세 §1–§10 요구를 Task 1–9와 gate/rollback에 연결 |
+| SPW-05 read-back | PASS | plan/spec heading·checkbox·code fence·selector·expected result 재독 및 placeholder/terminology/diff check |
+
+Step 3-R 종료 조건을 모두 충족했다. 승인 산출물(spec·design review·plan·본 plan review)을
+먼저 Lore commit한 뒤, `$test-driven-development`와 `$bluetape-kotlin-patterns`를 다시 읽고
+코드 RED/GREEN 구현을 시작한다. 구현 전까지 코드·schema·workflow·PR·merge는 변경하지 않는다.

--- a/docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan-review.md
+++ b/docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan-review.md
@@ -68,7 +68,9 @@
 
 - 최초 missing-row upsert, unique `(file_id, variable_name)` race, malformed
   `IN_PROGRESS`+null lease repair, 미래 expiry `ImportAlreadyRunning`, stale fence
-  `ImportLeaseLost`를 구분한다. 비교 시계는 DB UTC `CURRENT_TIMESTAMP`다.
+  `ImportLeaseLost`를 구분한다. 비교 시계는 DB UTC wall clock이며 lease
+  fence에는 `clock_timestamp()`를 사용하고, audit timestamp에는
+  `CURRENT_TIMESTAMP`를 유지한다.
 - 각 tile transaction은 시작·read/write·commit fence를 검사하고 현재 tile만 rollback한다.
   이전에 commit된 tile/slice는 보존하며, duplicate는 두 번째 pass 전에 slice 전체가 0 rows다.
 - 마지막 row write/fence 뒤 DB commit 전에 같은 transaction에서 `markCompleted`를 호출해
@@ -145,6 +147,38 @@ schema migration이 없으므로 DB rollback은 각 transaction rollback과 fixt
 구현 실패 시 branch-local commit만 `git revert`한다. canonical `develop`과 다른 worktree는
 건드리지 않는다.
 
+## Step 3-R 구현 증거 (2026-08-27)
+
+승인된 계획의 구현 경계를 실제 source·fixture·테스트·benchmark 결과로 재확인했다.
+
+| 증거 | 결과 | 비고 |
+|---|---|---|
+| typed exception·checked limits·path fingerprint | **PASS** | `NetCdfException`, `NetCdfImportLimits`, `NetCdfFileGuard`와 pure contract test가 구조화된 오류·overflow·file identity를 검증 |
+| 1D/2D axis·CF auxiliary·dimension order | **PASS** | `VariableAxisMap`, tile-local sampler, curvilinear/CF/order fixture와 PostGIS exact tuple/attrs read-back |
+| CRS·duplicate·JSONB·same-connection writer | **PASS** | strict EPSG whitelist, slice-wide duplicate preflight, NFC/UTF-8 cap, bounded JDBC batch 계약 |
+| lease/progress/cancellation/resource budget | **PASS** | DB UTC CAS, malformed progress quarantine, fence-before-read/write, terminal renew→complete, fixed working-set accounting |
+| regression suite | **PASS** | `:bluetape4k-science:test`: `SUCCESS: Executed 233 tests` |
+| 1D throughput reference gate | **PASS (pre-final reference)** | baseline 159,123 ms, feature 160,075 ms, `+0.598% < 20%` |
+| 2D + auxiliary bounded report | **PASS (pre-final reference, 보고용)** | 1,048,576 cells, 260,697 ms, fixed tile/batch/working-set caps |
+
+소스·문서 범위에는 schema/table/column migration, dependency, module catalog,
+workflow 변경이 없다. 기존 rank 1–4 회귀와 새 pure/service 계약을 함께 실행했고,
+feature의 임시 benchmark harness는 결과를 기록한 뒤 제거했다.
+
+### 구현 단계의 보류 증거
+
+계획에 있던 `1회 warm-up + 3회 측정 median`은 macOS arm64에서 amd64 PostGIS
+image를 emulation하는 환경과 2.5–4.5분의 Testcontainers 실행 시간 때문에 단일
+성공한 단일 실행 결과로 제한했다. 따라서 benchmark 문서는 median·표준편차를 주장하지
+않으며, 반복 측정과 최종 rank 1 read cap 기준 재측정은 후속 성능 작업으로
+남긴다. 이 제한은 구현 correctness와 bounded memory 판정과 분리하며, 1D
+`<20%` 수치는 pre-final reference gate로만 기록한다.
+
+**Step 3-R 구현 verdict: PASS with benchmark WATCH.** 계획의 기능·안전·운영
+계약은 구현과 fresh local evidence로 통과했으며, 반복 median만 미실행이다. 다음
+게이트는 변경 범위 audit, Lore implementation commit, PR exact-head CI/review,
+fresh merge approval이다.
+
 ## Writer gate와 Step 3-R 종료
 
 | 항목 | 판정 | 근거 |
@@ -155,6 +189,8 @@ schema migration이 없으므로 DB rollback은 각 transaction rollback과 fixt
 | SPW-04 technical traceability | PASS | 명세 §1–§10 요구를 Task 1–9와 gate/rollback에 연결 |
 | SPW-05 read-back | PASS | plan/spec heading·checkbox·code fence·selector·expected result 재독 및 placeholder/terminology/diff check |
 
-Step 3-R 종료 조건을 모두 충족했다. 승인 산출물(spec·design review·plan·본 plan review)을
+Step 3-R 구현 종료 조건을 모두 충족했다. 승인 산출물(spec·design review·plan·본 plan review)을
 먼저 Lore commit한 뒤, `$test-driven-development`와 `$bluetape-kotlin-patterns`를 다시 읽고
-코드 RED/GREEN 구현을 시작한다. 구현 전까지 코드·schema·workflow·PR·merge는 변경하지 않는다.
+RED/GREEN 구현과 local verification을 완료했다. 다음 변경은 implementation Lore commit,
+PR exact-head CI/review, fresh merge approval, rebase merge 순서로 진행하며 schema·workflow와
+canonical `develop`은 merge gate 전까지 변경하지 않는다.

--- a/docs/superpowers/plans/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan.md
+++ b/docs/superpowers/plans/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan.md
@@ -1,0 +1,901 @@
+# NetCDF `CoordinateAxis2D`·CF auxiliary coordinate 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `bluetape4k-science`의 blocking NetCDF importer가 `CoordinateAxis1D`와 `CoordinateAxis2D`, CF auxiliary numeric coordinate, 비표준 dimension 순서와 지원 CRS를 bounded 메모리·원자적 lease·기존 schema 안에서 정확히 저장하도록 확장한다.
+
+**Architecture:** 공개 `NetCdfCatalogService.registerFile`/`importGridValues` API와 기존 `NetCdfGridValueTable`을 유지한다. 내부 `VariableAxisMap`과 bounded `CoordinateReader`/`CoordinateSampler`가 축과 CF `coordinates`를 해석하고, slice-wide duplicate preflight 후 deterministic tile planner가 data/coordinate를 읽어 동일 Exposed transaction의 JDBC writer로 저장한다. 파일 fingerprint, typed exception, resource budget, progress CAS fence는 각각 작은 internal component로 분리한다.
+
+**Tech Stack:** Kotlin 2.4, JVM 25, Gradle 9.7.0, NetCDF-Java 5.9.1, JetBrains Exposed v1 JDBC, PostgreSQL/PostGIS, Jackson JSONB, Proj4J, Micrometer, JUnit 5, MockK/Kluent-style bluetape4k assertions, Testcontainers.
+
+---
+
+## 0. 실행 전 고정 조건
+
+- 기준: `origin/develop@45260871f58433a78f2d633c235010f661d22c6e`
+- worktree: `.worktrees/feat/1352-coordinate-axis2d-cf-grid`
+- branch: `feat/1352-coordinate-axis2d-cf-grid`
+- 선행 train: merged PR #1512 → Issue #1343 문서 계약
+- 승인 설계: `docs/superpowers/specs/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design.md`
+- 변경하지 않을 것: 새 dependency, 새 table/column, schema migration, settings/BOM/catalog 등록, workflow, `CHANGELOG.md`, release note
+- heavy Testcontainers 검증은 한 번에 하나의 Gradle invocation으로 순차 실행한다.
+- 모든 commit은 Lore intent/trailer 형식을 사용하고, PR/문서/KDoc/commit 메시지는 한국어로 작성한다.
+
+### 0.1 Stacked PR train 순서
+
+Epic #1421의 child train은 다음 순서로 고정한다.
+
+1. **T0 문서 계약** — #1343의 문서 PR #1512가 `develop`에 rebase merge되어
+   기준 SHA에 이미 반영되었다.
+2. **T1 구현 child** — 현재 branch/worktree의 #1352 구현만 `develop`을 base로 올리고,
+   PR body에서 `#1352`와 `#1421`, 선행 PR #1512를 연결한다. 코드·fixture·문서·benchmark는
+   이 child의 범위로 제한한다.
+
+T1의 exact head CI·review·metadata를 새로 확인한 뒤 fresh merge approval을 받아야
+`gh pr merge --rebase --delete-branch`를 실행한다. merge 후 canonical `develop`은
+fast-forward 동기화하고, Epic #1421은 #1343/#1352의 live 상태와 DoD를 다시 읽은 뒤에만
+닫는다. auto-merge, squash/merge commit, branch 삭제의 독자적 선택은 사용하지 않는다.
+
+## 1. 파일·소유권 지도
+
+| 책임 | 파일 | 변경 유형 |
+|---|---|---|
+| 공개 오류와 major migration | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/NetCdfException.kt` | 수정 |
+| import hard limit·checked arithmetic·duplicate key | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimits.kt` | 생성 |
+| trusted path·TOCTOU·fingerprint | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuard.kt` | 생성 |
+| 축 binding·CF coordinate 탐지 | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/VariableAxisMap.kt` | 수정 |
+| bounded variable/coordinate window와 sampler | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSampler.kt` | 생성 |
+| whitelist CRS와 tile-local reprojection | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/CoordinateReprojector.kt` | 수정 |
+| row/column tile shape와 full-rank index | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlanner.kt` | 생성 |
+| numeric auxiliary JSONB·NFC/UTF-8 cap | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializer.kt` | 생성 |
+| same-connection JDBC batch writer | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTileBatchWriter.kt` | 생성 |
+| rank 1–4 orchestration·metrics·KDoc | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt` | 수정 |
+| acquire/renew/assert/fail CAS와 UTC clock | `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/repository/NetCdfImportProgressRepository.kt` | 수정 |
+| fixture 생성 | `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/support/NetCdfSampleWriter.kt` | 수정 |
+| service/PostGIS/Testcontainers contract | `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt` | 수정 |
+| internal pure contract tests | `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSamplerTest.kt`, `NetCdfImportLimitsTest.kt`, `NetCdfAuxiliarySerializerTest.kt`, `NetCdfTilePlannerTest.kt` | 생성 |
+| API compile/error tests | `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/NetCdfExceptionApiCompatibilityTest.kt` | 생성 |
+| public docs | `utils/science/README.md`, `utils/science/README.ko.md` | 수정 |
+| follow-up status | `docs/followup-issues/utils-science-readme-rewrite.md` | 수정 |
+| fixed benchmark result | `docs/benchmarks/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary.md` | 실행 후 생성 |
+| implementation lesson | `docs/lessons/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary.md` | PR 전 생성 |
+| 통합 계획 검토 | `docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan-review.md` | Step 3-R/3-P gate 기록 |
+
+테이블 정의인 `NetCdfTables.kt`, `NetCdfModels.kt`, 모듈 등록·BOM·CI workflow는 schema/API 데이터 모델을 그대로 유지하므로 변경하지 않는다. `attrs`와 `NetCdfFileTable.globalAttrs`의 기존 JSONB를 재사용한다.
+
+## 2. Task 1 — RED fixture와 pure contract 테스트 고정
+
+**Files:**
+
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/support/NetCdfSampleWriter.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+- Create: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimitsTest.kt`
+- Create: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlannerTest.kt`
+- Create: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSamplerTest.kt`
+- Create: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializerTest.kt`
+- Create: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/NetCdfExceptionApiCompatibilityTest.kt`
+
+- [ ] **Step 1.1: fixture API와 실패 테스트를 먼저 작성한다.**
+
+`NetCdfSampleWriter`에 다음 호출 표면과 deterministic expected-value 상수를
+먼저 선언한다. 함수 본문은 기존 `writeSample`과 같은 NetCDF-3 builder를 사용해
+완성할 때까지 컴파일 RED가 유지되며, 구현 단계에서 각 fixture의 차원·속성·값을
+명시적으로 채운다. `writeLargeContractSample`은 동일한 deterministic generator로
+`temperature_1d`(1D)와 `temperature_2d`(2D+one auxiliary)를 함께 만들 수 있어
+baseline과 feature가 같은 cell-value workload를 사용한다.
+
+```kotlin
+fun writeCurvilinearSample(path: Path, dataOrder: List<String> = listOf("time", "y", "x")): Path
+fun writeCfAuxiliarySample(path: Path): Path
+fun writeProjected2DSample(path: Path, sourceCrs: String): Path
+fun writeDuplicateCoordinateSample(path: Path, duplicateAcrossTiles: Boolean): Path
+fun writeLargeContractSample(path: Path, rows: Int = 1_024, columns: Int = 1_024): Path
+
+const val CURVILINEAR_ROWS: Int = 3
+const val CURVILINEAR_COLUMNS: Int = 4
+val CURVILINEAR_VALUES: DoubleArray = doubleArrayOf(
+    0.0, 1.0, 2.0, 3.0,
+    4.0, 5.0, 6.0, 7.0,
+    8.0, 9.0, 10.0, 11.0,
+)
+```
+
+`writeProjected2DSample`은 `sourceCrs`를 `.toInt()`로 변환하지 않고 `EPSG:` 접두사
+뒤 원문을 NetCDF `epsg_code` string attribute로 기록한다. 따라서 `EPSG:+4326`,
+`EPSG:4326.0`, overflow와 충돌 값을 파일 생성 단계에서 삼키지 않고 service의 strict
+parser가 `UnsupportedProjection`으로 판정할 수 있다.
+
+`writeDuplicateCoordinateSample(..., duplicateAcrossTiles = true)`는 최소
+`257×257` spatial grid를 만들고 planner가 분리하는 row tile의 경계 양쪽(예: row 0과
+row 255, 같은 column)에 동일 canonical point를 배치한다. `false`는 작은 단일-tile
+fixture로 유지해 duplicate key set의 정상 경로도 검증한다.
+
+`NetCdfCatalogServiceTest`에는 다음 이름의 테스트를 먼저 추가한다. 기존 rank 1–4 테스트는 유지한다.
+
+```kotlin
+@Test
+fun `30a - curvilinear 2D axes preserve every cell coordinate and value`(@TempDir dir: Path) {
+    val path = NetCdfSampleWriter.writeCurvilinearSample(dir.resolve("curvilinear.nc"))
+    val fileId = service.registerFile(path.absolutePathString())
+    service.importGridValues(fileId, "temperature")
+    val readBack = readSpatialTuples(fileId)
+    readBack shouldBe NetCdfSampleWriter.CURVILINEAR_TUPLES
+}
+
+@Test
+fun `31 - CF coordinates stores altitude in attrs and excludes time axis`(@TempDir dir: Path) {
+    val path = NetCdfSampleWriter.writeCfAuxiliarySample(dir.resolve("cf-aux.nc"))
+    val fileId = service.registerFile(path.absolutePathString())
+    service.importGridValues(fileId, "temperature")
+    val attrs = transaction(db) {
+        NetCdfGridValueTable.selectAll()
+            .where { NetCdfGridValueTable.fileId eq fileId }
+            .mapNotNull { it[NetCdfGridValueTable.attrs] }
+    }
+    attrs.all { "altitude" in it && "time" !in it } shouldBeEqualTo true
+}
+
+@Test
+fun `32 - non standard data dimension order uses full rank index`(@TempDir dir: Path) {
+    val path = NetCdfSampleWriter.writeCurvilinearSample(
+        dir.resolve("order.nc"), dataOrder = listOf("time", "x", "y"),
+    )
+    val fileId = service.registerFile(path.absolutePathString())
+    service.importGridValues(fileId, "temperature")
+    val readBack = readSpatialTuples(fileId)
+    readBack shouldBe NetCdfSampleWriter.CURVILINEAR_TUPLES
+}
+
+@Test
+fun `33 - duplicate canonical coordinate is rejected before any insert`(@TempDir dir: Path) {
+    val path = NetCdfSampleWriter.writeDuplicateCoordinateSample(
+        dir.resolve("duplicate.nc"), duplicateAcrossTiles = true,
+    )
+    val fileId = service.registerFile(path.absolutePathString())
+    assertFailsWith<NetCdfException.DuplicateCoordinate> {
+        service.importGridValues(fileId, "temperature")
+    }
+    transaction(db) {
+        NetCdfGridValueTable.selectAll().where { NetCdfGridValueTable.fileId eq fileId }.count()
+    } shouldBeEqualTo 0L
+}
+
+@Test
+fun `34 - unsupported grid mapping and malformed EPSG are typed failures`(@TempDir dir: Path) {
+    val projected = NetCdfSampleWriter.writeProjected2DSample(dir.resolve("bad-crs.nc"), "EPSG:9999999")
+    val projectedId = service.registerFile(projected.absolutePathString())
+    assertFailsWith<NetCdfException.UnsupportedProjection> {
+        service.importGridValues(projectedId, "temperature")
+    }
+    val malformed = NetCdfSampleWriter.writeProjected2DSample(dir.resolve("malformed-crs.nc"), "EPSG:+4326")
+    val malformedId = service.registerFile(malformed.absolutePathString())
+    assertFailsWith<NetCdfException.UnsupportedProjection> {
+        service.importGridValues(malformedId, "temperature")
+    }
+}
+```
+
+테스트 본문은 `service.registerFile(path.absolutePathString())`, `service.importGridValues(fileId, "temperature")`, PostGIS `ST_X/ST_Y`, JSONB `attrs`, `assertFailsWith<NetCdfException.*>`를 사용한다.
+
+`readSpatialTuples(fileId)`는 raw SQL로 `time_idx`, `level_idx`, `ST_X(location)`,
+`ST_Y(location)`, `value`를 조회하고 fixture가 정의한 `(timeIdx, levelIdx, row,
+column)` 순서로 정렬한 tuple을 반환한다. 30a와 32는 이 tuple 전체를
+`CURVILINEAR_TUPLES`와 exact 비교한다. 값 집합 크기만 비교하거나 `timeIdx/value`만
+비교하지 않으며, 전치·행/열 반전이 set 비교를 우회하지 못하도록 모든 좌표와 값이
+고유한 fixture를 사용한다.
+
+- [ ] **Step 1.2: pure contract의 최소 RED를 실행한다.**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.internal.*' \
+  --tests 'io.bluetape4k.science.exposed.NetCdfExceptionApiCompatibilityTest' \
+  --no-configuration-cache --console=plain
+```
+
+Expected: `FAILED` because the new fixture/internal types and behavior are not yet
+implemented. 이 실패는 구현 전 RED 증거이며, Testcontainers suite를 이 단계에서
+병렬 실행하지 않는다.
+
+## 3. Task 2 — typed exception, resource limit, path/fingerprint 경계
+
+**Files:**
+
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/NetCdfException.kt`
+- Create: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimits.kt`
+- Create: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuard.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimitsTest.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/NetCdfExceptionApiCompatibilityTest.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+
+- [ ] **Step 2.1: exception hierarchy와 API migration을 구현한다.**
+
+`NetCdfException`의 sealed base에 다음 public subtype과 구조화된 필드를 추가한다. 메시지는 변수·축·원인을 포함하고, 다섯 subtype 모두를 `2.0.0` major migration으로 문서화한다. 기존 소비자가 구체 subtype exhaustive `when`을 사용하면 다섯 branch를 추가해야 하며, base-type catch에는 `else`/기본 오류 경로를 둔다.
+
+```kotlin
+class UnsupportedCoordinateAxis(
+    val variableName: String,
+    val coordinateName: String?,
+    val reason: String,
+) : NetCdfException("Unsupported coordinate axis: variable=$variableName coordinate=$coordinateName reason=$reason")
+
+class DuplicateCoordinate(
+    val fileId: Long,
+    val variableName: String,
+    val timeIdx: Int,
+    val levelIdx: Int,
+    val longitude: Double,
+    val latitude: Double,
+) : NetCdfException("Duplicate coordinate: fileId=$fileId variable=$variableName time=$timeIdx level=$levelIdx lon=$longitude lat=$latitude")
+
+class ResourceLimitExceeded(val resource: String, val limit: Long, val actual: Long) :
+    NetCdfException("Resource limit exceeded: $resource limit=$limit actual=$actual")
+
+class FileChanged(val fileId: Long, val expectedFingerprint: String, val actualFingerprint: String) :
+    NetCdfException("NetCDF file changed while import was resumable: fileId=$fileId")
+
+class CorruptProgress(val progressId: Long, val detail: String) :
+    NetCdfException("Corrupt NetCDF import progress: progressId=$progressId detail=$detail")
+```
+
+`NetCdfExceptionApiCompatibilityTest`는 다섯 새 subtype(`UnsupportedCoordinateAxis`,
+`DuplicateCoordinate`, `ResourceLimitExceeded`, `FileChanged`, `CorruptProgress`)의
+known branch와 `else`를 가진 base-type `when` fixture를 컴파일하고, 각 구조화 필드·stable
+reason 보존을 검증한다.
+
+- [ ] **Step 2.2: checked limits와 duplicate key set을 구현한다.**
+
+`NetCdfImportLimits.kt`에 설계의 token 32, auxiliary 16, 이름 128 bytes, variables 1,024, group dimensions 256, metadata 1 MiB, cells 100,000,000, slices 1,000,000, tile 65,536, batch 1,000, JSONB 8,192, coordinate cache 64 MiB, duplicate set 32 MiB, owned working-set 128 MiB 상수를 둔다. `Math.multiplyExact`/`addExact` 기반 `Long` 산식으로 overflow를 `ResourceLimitExceeded`로 바꾸고 `Int` API 호출 전에 검사한다.
+
+```kotlin
+internal fun checkedProduct(vararg factors: Long): Long =
+    factors.fold(1L) { acc, factor -> Math.multiplyExact(acc, factor) }
+
+internal data class MemoryBudget(
+    val tileBufferBytes: Long,
+    val coordinateBytes: Long,
+    val serializerScratchBytes: Long,
+    val duplicateSetBytes: Long,
+) {
+    val ownedWorkingSetBytes: Long
+        get() = Math.addExact(
+            Math.addExact(tileBufferBytes, coordinateBytes),
+            Math.addExact(serializerScratchBytes, duplicateSetBytes),
+        )
+}
+```
+
+`MAX_GROUP_COUNT = 256L`, `MAX_GROUP_DEPTH = 32L`도 metadata preflight hard limit으로
+고정한다. root/group 순회는 재귀 호출 대신 명시적 stack/queue를 사용하고, group을
+방문할 때마다 count/depth를 checked 검증한다. 깊은 빈 nested group과 count 초과
+fixture는 variable/attribute map을 materialize하기 전에 `ResourceLimitExceeded`로
+조기 중지되는지 확인한다. `MAX_FIXED_ROW_BYTES = 256L`을 고정된 보수 상수로 두고, writer가 소유하는
+`batchPayloadBytes`를 `checkedProduct(MAX_BATCH_ROWS, MAX_FIXED_ROW_BYTES + MAX_AUXILIARY_JSONB_BYTES)`로
+계산한다. `serializerScratchBytes`는 raw serializer scratch와 이 batch payload 중 큰
+값으로 설정한다(`max(MAX_AUXILIARY_JSONB_BYTES, batchPayloadBytes)`). 따라서 JSON
+문자열·고정 column payload·pending row list를 같은 checked 상한으로 계측하고,
+overflow나 `ownedWorkingSetBytes > MAX_OWNED_WORKING_SET_BYTES`는 첫 tile 전에
+`ResourceLimitExceeded`로 중지한다. benchmark counter에도 `batchPayloadBytes`와
+실제 `pendingRows`를 함께 기록해 이 보수 상한이 실행 중에도 유지되는지 확인한다.
+
+open-addressed `LongArray` pair key set은 `-0.0/+0.0`을 `+0.0`으로 정규화하고, 32 MiB budget을 넘으면 insert 없이 실패시킨다. 등록 전에는
+NetCDF root/group를 bounded recursive scan하여 variable·dimension 수, 이름의 UTF-8
+합계, attribute/global metadata의 UTF-8 합계를 먼저 계산한다. 이 preflight는
+`variables`/`attributes`/`globalAttrs` map을 materialize하거나 DB에 저장하기 전에
+실행하고, 초과 시 `ResourceLimitExceeded`를 반환한다. nested-group·deep/empty-group
+및 1 MiB 경계 fixture로 명시적 stack 순서와 조기 중지를 검증한다. writer의
+`batchPayloadBytes`는
+`MAX_BATCH_ROWS * (MAX_FIXED_ROW_BYTES + MAX_AUXILIARY_JSONB_BYTES)`의 checked 상한으로
+계산해 `serializerScratchBytes = max(rawScratchBytes, batchPayloadBytes)`에 포함하고,
+`coordinateBytes + duplicateSetBytes`
+64 MiB 및 전체 `ownedWorkingSetBytes` 128 MiB를 넘으면 tile을 시작하지 않는다.
+
+- [ ] **Step 2.3: trusted file guard를 구현한다.**
+
+`NetCdfFileGuard.validateForRegister`와 `verifyForResume`는 NUL/control/URI scheme/원격 URL/non-regular path/component symlink를 거부하고, canonical component를 `NOFOLLOW_LINKS`로 확인한다. `fileKey|size|lastModifiedTime.epochNanos`를 ASCII fingerprint로 생성하며 open 전·후 stat을 비교한다. fingerprint가 누락되거나 불일치하면 `FileChanged`로 중단하고 항상 새 등록·새 `fileId`를 사용한다. old `fileId`의 progress/partial rows를 resume에 재사용하지 않는다. `MAX_FILE_BYTES=64L * 1024 * 1024 * 1024`를 초과하면 `ResourceLimitExceeded`, 불일치는 `FileChanged`다. `openVerifiedDataset`는
+resume fingerprint 검증 직후 identity를 캡처하고 dataset을 연 다음 즉시 다시
+stat한다. 두 identity가 다르면 dataset을 닫고 DB progress 변경 없이
+`FileChanged`를 발생시킨다. validation/open 사이 rename·symlink 교체와 대형
+metadata fixture는 등록·resume 조기 거부를 검증한다.
+
+Run after implementation:
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.*path*' \
+  --tests 'io.bluetape4k.science.exposed.service.internal.NetCdfImportLimitsTest' \
+  --no-configuration-cache --console=plain
+```
+
+Expected: path/resource/exception tests PASS; any remaining axis/tile tests stay RED.
+
+## 4. Task 3 — progress lease fence와 상태 복구
+
+**Files:**
+
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/repository/NetCdfImportProgressRepository.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+
+- [ ] **Step 3.1: repository에 DB UTC와 opaque lease token을 고정한다.**
+
+기존 public `acquireLease(fileId, variableName, leaseTtl: Duration)` 시그니처와 custom TTL을
+보존한다. `leaseTtl`은 양의 whole-second로 검증하고 기본값만 5분으로 둔다. SQL에는
+`leaseTtl.toSeconds()`를 parameter로 바인딩하며 DB UTC 기준의
+`CURRENT_TIMESTAMP + (? * INTERVAL '1 second')`만 사용한다. `acquireLease`는 매번 DB 기준
+expiry를 새로 발급하고 기존 token을 재사용하지 않는다.
+단일 row CAS는 최초 row가 없으면 `IN_PROGRESS` row를 생성하는 upsert로 처리하고,
+기존 `PENDING/FAILED` 또는 만료된 `IN_PROGRESS`만 takeover하며, 새 expiry 값을 DB에서
+반환해 opaque token으로 사용한다. acquire 직전 같은 transaction에서
+`SELECT ... FOR UPDATE`로 기존 row를 잠그고, `status=IN_PROGRESS`인데
+`lease_expires_at IS NULL`인 malformed row는 `FAILED`로 repair한 뒤 새 lease를
+획득한다. `status=IN_PROGRESS`이고 expiry가 미래인 row는 `ImportAlreadyRunning`으로
+분리한다. 따라서 최초 동시 acquire는 unique key 아래 정확히 한 owner만 만들고,
+acquire의 affected-row=0은 active lease 경쟁일 때만 `ImportAlreadyRunning`이다.
+`COMPLETED` race는 row를 다시 읽어 검증된 no-op으로 분기하고, 이미 획득한
+owner의 후속 fence 실패만 `ImportLeaseLost`다.
+
+```sql
+INSERT INTO netcdf_import_progress
+    (file_id, variable_name, status, last_slice_idx, lease_expires_at, started_at, updated_at)
+VALUES (?, ?, 'IN_PROGRESS', NULL, CURRENT_TIMESTAMP + (? * INTERVAL '1 second'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT (file_id, variable_name) DO UPDATE
+SET status = 'IN_PROGRESS', lease_expires_at = CURRENT_TIMESTAMP + (? * INTERVAL '1 second'),
+    error_message = NULL, updated_at = CURRENT_TIMESTAMP
+WHERE netcdf_import_progress.status IN ('PENDING', 'FAILED')
+   OR (netcdf_import_progress.status = 'IN_PROGRESS'
+       AND netcdf_import_progress.lease_expires_at <= CURRENT_TIMESTAMP)
+RETURNING id, lease_expires_at
+```
+
+insert/update의 두 TTL parameter는 같은 검증된 `leaseTtl.toSeconds()` 값으로
+바인딩한다. custom TTL(예: 30초/10분)과 기본 5분을 각각 호출하는 compatibility
+test에서 expiry가 DB `CURRENT_TIMESTAMP` 기준으로 계산되고, 기존 public repository
+호출자가 시그니처 변경 없이 동작하는지 확인한다.
+
+`assertLeaseOwner`/`touchLease`/`renewLease`/`markCompleted`/`markFailed`는 모두 다음 predicate를 사용한다.
+
+```sql
+WHERE id = ?
+  AND status = 'IN_PROGRESS'
+  AND lease_expires_at = ?
+  AND lease_expires_at > CURRENT_TIMESTAMP
+```
+
+acquire와 위 fence의 affected row가 1이 아니면 즉시 해당 경로의 typed exception을
+던지고, progress row lock은 같은 transaction commit까지 유지한다. SQL 비교에
+`Instant.now()`를 쓰지 않으며, 테스트에는 deterministic DB-clock seam을 주입한다. 두 importer가 만료
+경계에서 동시에 takeover를 시도하는 concurrency fixture는 정확히 한 쪽만 새 token과
+affected row=1을 얻는지 검증한다.
+
+- [ ] **Step 3.2: invariant repair와 cancellation/failure 경로를 테스트 우선으로 완성한다.**
+
+`PENDING/FAILED`, `IN_PROGRESS`, `COMPLETED` invariant, null lease repair, `-1..totalSlices-1` checkpoint, COMPLETED 마지막 slice 불일치 `CorruptProgress`, stale importer rollback, cancellation/interrupt의 lease expiry 위임을 테스트한다. `COMPLETED` no-op은 dataset을 verified-open하여 실제 `totalSlices`와 checkpoint를 먼저 검증한 뒤에만 허용하고, 불일치면 `CorruptProgress`로 종료한다. 마지막 `totalSlices - 1` slice의 row write/lease fence 뒤 DB commit 전에 같은 transaction에서 `markCompleted`를 호출하고, fence 또는 `markCompleted` 실패 시 전체 현재 transaction을 rollback한다. `status=COMPLETED`, `completedAt != null`, `lease_expires_at = null`, 마지막 checkpoint 불변식을 검증한다. `markFailed` 실패는 원래 exception에 suppressed로 추가하고, cancellation은 `FAILED`로 전환하지 않는다.
+
+`CorruptProgress`는 library 내부에서 자동 reset하거나 재시도하지 않는다. application-owned
+admin recovery는 먼저 `SELECT ... FOR UPDATE`로 progress row를 잠그고 status, checkpoint,
+lease, error의 immutable 기준 상태 기록과 `progressId`를 audit/quarantine에 기록한다. 기존
+column만 사용할 때 `PENDING/IN_PROGRESS/FAILED` row는 기준 상태 기록 후 stable
+`CORRUPT_PROGRESS:<progressId>`를 `error_message`에 기록하고 `FAILED`, `lease=null`로
+격리하며, `COMPLETED` row는 변경하지 않고 old `fileId`를 차단한다. partial rows는 old
+`fileId`에 묶어 retention 정책에 따라 보존하거나 삭제하고, 수정·검증한 파일은 반드시
+새 등록·새 `fileId`로 import한다. in-place reset API가 없다는 것을 runbook과 테스트에
+명시하고, 격리 전후에 old progress가 재사용되지 않는지 검증한다.
+
+`IN_PROGRESS` + `lease_expires_at IS NULL` repair, 미래 expiry의
+`ImportAlreadyRunning`(rejection metric 비증가), 만료 경계의 단일 takeover,
+후속 owner fence 실패의 `ImportLeaseLost`를 각각 독립 테스트로 고정한다.
+
+`ImportAlreadyRunning`과 `ImportLeaseLost`의 caller retry policy는
+`MAX_LEASE_RETRIES = 3`, backoff `1초 → 2초 → 4초`로 고정한다. 각 시도 전 DB에서
+현재 lease/status를 다시 읽고, 세 번 소진하면 원래 typed exception을 표면화하고
+alert를 발생시킨다. `FileChanged`, `DuplicateCoordinate`, `CorruptProgress`에는 이
+retry policy를 적용하지 않으며, 무한 loop를 만들지 않는다.
+
+```kotlin
+assertFailsWith<NetCdfException.ImportLeaseLost> {
+    transaction(db) {
+        progressRepo.renewLease(stale.id, stale.leaseExpiresAt!!, lastSliceIdx = 99L)
+    }
+}
+```
+
+- [ ] **Step 3.3: progress 테스트를 순차 실행한다.**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.23*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.*progress*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.*cancellation*' \
+  --no-configuration-cache --console=plain
+```
+
+Expected: initial upsert/unique-key race, stale lease/takeover/null repair/checkpoint/terminal-transition tests PASS. Testcontainers는 이 invocation만 실행한다.
+
+## 5. Task 4 — axis map, bounded readers, sampler, CRS
+
+**Files:**
+
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/VariableAxisMap.kt`
+- Create: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSampler.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/CoordinateReprojector.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSamplerTest.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+
+- [ ] **Step 4.1: `VariableAxisMap`에 CF 역할·dimension binding을 구현한다.**
+
+dimension axis → CF `coordinates` token → `AxisType`/`standard_name`/units/name fallback 순서로 후보를 수집한다. full/short name ambiguity, time/level 재분류, rank/shape/dimension mismatch, 빈 spatial dimension을 typed exception으로 거부한다. `latBinding`/`lonBinding`은 1D 또는 2D axis와 axis dimension 순서를 보존하고, auxiliary는 numeric rank 1/2이며 grid dimension 부분집합이어야 한다.
+
+- [ ] **Step 4.2: `CoordinateReader`와 sampler를 bounded window로 구현한다.**
+
+```kotlin
+internal interface VariableReader {
+    fun read(origin: IntArray, shape: IntArray): UcarArray
+}
+
+internal interface CoordinateReader {
+    fun read1D(axisName: String, origin: Int, length: Int): DoubleArray
+    fun read2D(
+        axisName: String,
+        rowOrigin: Int,
+        columnOrigin: Int,
+        rowCount: Int,
+        columnCount: Int,
+    ): DoubleArray
+}
+
+internal interface CoordinateSampler {
+    fun sample(globalRow: Int, globalColumn: Int, target: MutableCoordinateSample)
+}
+
+internal class MutableCoordinateSample {
+    var longitude: Double = 0.0
+    var latitude: Double = 0.0
+    val auxiliary: MutableMap<String, Double> = LinkedHashMap()
+
+    fun clear() {
+        longitude = 0.0
+        latitude = 0.0
+        auxiliary.clear()
+    }
+
+    fun readOnlyCopy(): CoordinateSample = CoordinateSample(longitude, latitude, auxiliary.toMap())
+}
+
+internal data class CoordinateSample(
+    val longitude: Double,
+    val latitude: Double,
+    val auxiliary: Map<String, Double>,
+)
+```
+
+`read2D`는 row-major flat 배열(`localRow * columnCount + localColumn`)을 반환한다. `CoordinateSampler.sample`은 호출자가 소유한 `MutableCoordinateSample`을 매 셀 clear한 뒤 채우고, sampler는 target·`CoordinateSample`·auxiliary map을 보유하지 않는다. service는 같은 셀에서 즉시 `readOnlyCopy()`를 만들고 JSONB를 직렬화한 뒤 다음 셀을 요청한다. `CoordinateSample` 복사본과 그 map은 tile 밖으로 전달하지 않는다. direct `getCoordValue` 우회는 금지한다. spatial non-finite와 최종 lon/lat 범위를 검증하고 non-spatial non-finite auxiliary는 생략한다. 이 읽기 전용 복사본 경로의 transient allocation과 GC/peak-heap은 Task 8.2 benchmark에서 관찰하고 owned working-set에는 bounded payload 상한을 포함한다.
+
+- [ ] **Step 4.3: CRS whitelist와 reprojection을 연결한다.**
+
+EPSG 4326/4269/3857/32601–32660/32701–32760/3413/3031 및 `latitude_longitude`만 허용한다. `grid_mapping`이 있으면 mapping variable을 반드시 해석하고, ASCII digits/integral numeric exact parse·충돌·overflow·공백·부호·소수형을 거부한다. source/final finite와 bounds를 모두 검사한다.
+
+- [ ] **Step 4.4: axis reader/sampler pure 테스트를 GREEN으로 만든다.**
+
+2D row/column orientation, reversed axis, 1D fallback, CF `coordinates="time lat lon altitude"`, ambiguous/missing/unsupported rank/shape, non-finite, projected CRS/unsupported mapping을 `assertFailsWith`와 exact sample 비교로 검증한다. `MutableCoordinateSample`이 매 셀 clear되고 `readOnlyCopy()`가 다음 셀 변이에 영향을 받지 않는지, sampler가 target/map을 보유하지 않는지 recording seam으로 검증한다.
+
+Run:
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.internal.NetCdfCoordinateSamplerTest' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.30a*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.31*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.34*' \
+  --no-configuration-cache --console=plain
+```
+
+Expected: axis/CRS tests PASS; tile writer integration remains RED until Task 5–6.
+
+## 6. Task 5 — deterministic tile planner와 rank 1–4 data mapping
+
+**Files:**
+
+- Create: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlanner.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlannerTest.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+
+- [ ] **Step 5.1: tile planner와 full-rank index를 구현한다.**
+
+`tileCols=min(lonN,65_536)`, `tileRows=min(latN,max(1,65_536/tileCols))`에서 시작하고 checked product가 65,536 이하가 되도록 축소한다. rank 2–4 `variable.read(tileOrigin,tileShape)`는 time/level=1, row/column=tile shape, 나머지=1이다. `Index`와 `IntArray`는 tile 안에서 재사용한다. rank 1 time-only도 `origin=[offset]`, `shape=[min(remaining,1_000)]` window로 읽고 매 window마다 최대 1,000행을 flush한다. rank 1 window 경계에서도 checked cell limit, heartbeat, cancellation/deadline을 검사하고 `RecordingVariableReader`로 1,001개 이상 fixture의 full-array read와 batch 초과를 금지한다.
+
+각 tile loop는 `val sampleTarget = MutableCoordinateSample()` 하나만 생성하고, 모든
+셀에서 `CoordinateSampler.sample(..., sampleTarget)` → `readOnlyCopy()` → serializer
+순서로 사용한다.
+
+```kotlin
+timeDim?.let { indices[it] = 0 }
+levelDim?.let { indices[it] = 0 }
+indices[gridRowDim] = localRow
+indices[gridColumnDim] = localColumn
+val raw = tileData.getDouble(tileIndex.set(indices))
+sampler.sample(tileRowOrigin + localRow, tileColumnOrigin + localColumn, sampleTarget)
+val sample = sampleTarget.readOnlyCopy()
+```
+
+`timeDim`/`levelDim`은 rank에 따라 `Int?`이며, 없는 축에는 assignment를 수행하지
+않는다. local time/level은 존재할 때만 항상 0이고 global 값은 `tileOrigin`에만 둔다.
+`sampleTarget`은
+tile loop가 소유하고 매 셀 clear하며, `sample`은 같은 셀에서 serializer로 즉시
+소비한 뒤 버린다. tile data/axis window/serializer scratch는 transaction `finally`에서
+폐기한다. rank 1 time-only 경로도 동일한 cancel/deadline·heartbeat와 batch cap을 유지한다.
+
+- [ ] **Step 5.2: slice-wide two-pass와 duplicate 정책을 구현한다.**
+
+첫 pass는 tile read/coordinate validation/key set만 수행하고 매 tile 경계와 tile read 직후에 heartbeat fence·cancellation/deadline을 확인한다. 첫 pass 성공 전에는 DB insert가 없어야 한다. 두 번째 pass는 tile별 transaction으로 실행하며 tile 경계·write 직전·commit 직전에 같은 control seam을 검사한다. `CancellationException`/interrupt는 원래 예외와 interrupt 상태를 보존하며 `FAILED` 전환 없이 현재 tile transaction만 rollback한다. 이미 commit된 이전 tile과 slice는 보존할 수 있고, 취소된 현재 tile의 rows만 tile 시작 시점으로 복귀해야 한다. timeout caller는 `Future.cancel(true)`를 사용할 수 있다. duplicate면 첫 pass에서 `DuplicateCoordinate`로 slice 전체를 거부하므로 두 번째 pass의 어떤 tile도 insert되지 않아 해당 slice rows-written=0이어야 한다. 첫 write 직전과 flush 중 취소를 각각 주입하고, `*cancellation*` selector로 두 경로를 순차 검증한다.
+
+- [ ] **Step 5.3: data-order/large shape 테스트를 GREEN으로 만든다.**
+
+`[time,y,x]`, `[time,x,y]`, `[y,x,time]`, rank 2–4, tile 경계 offset, empty/overflow dimensions, `1024×1024` tile read cell cap을 검증한다. `RecordingVariableReader`에서 full-array read가 없고 각 read shape product가 65,536 이하임을 확인한다.
+
+Run:
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.internal.NetCdfTilePlannerTest' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.6*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.7*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.8*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.32*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.33*' \
+  --no-configuration-cache --console=plain
+```
+
+## 7. Task 6 — auxiliary JSONB serializer와 same-connection JDBC writer
+
+**Files:**
+
+- Create: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializer.kt`
+- Create: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTileBatchWriter.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializerTest.kt`
+- Test: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+
+- [ ] **Step 6.1: serializer와 row payload를 구현한다.**
+
+NFC strict UTF-8 key, invalid surrogate/control/length/canonical collision/`__bluetape4k_` 거부, numeric-only map, escaped UTF-8 8,192-byte cap, empty map `NULL`을 구현한다. JSONB는 Jackson serializer를 재사용하고 `PGobject` 또는 typed `jsonb` placeholder로만 bind한다.
+
+```kotlin
+internal data class TileRow(
+    val fileId: Long,
+    val variableName: String,
+    val longitude: Double?,
+    val latitude: Double?,
+    val timeIdx: Int,
+    val levelIdx: Int,
+    val value: Double,
+    val attrsJson: String?,
+)
+
+internal data class BatchWriteResult(val inserted: Int, val conflicts: Int)
+```
+
+serializer는 `MutableCoordinateSample.readOnlyCopy()`가 만든 현재 셀의
+`CoordinateSample`을 `TileRow`로 변환하고, `TileBatchWriter`가 행을 보유하지 않는
+동기 lifetime 계약을 지키며 다음 sample 전에 즉시 직렬화한다. service는 tile 전체 행을
+materialize하지 않고 `pendingRows.size <= 1_000`인 bounded chunk만 유지한다.
+encoded attrs와 고정 row payload byte는 `MemoryBudget`의 checked batch payload
+상한에 포함하고, 다음 chunk를 만들기 전에 이전 list·문자열 참조를 폐기한다.
+rank 1 time-only row는 `longitude == null && latitude == null`, rank 2–4 spatial row는
+두 값 모두 non-null이어야 하며, mixed-null row는 writer에 전달하기 전에 내부 invariant
+위반으로 거부한다. writer는 두 값이 모두 null이면 기존 `location` column에 typed SQL
+`NULL`을 바인딩하고, 둘 다 값이 있으면 `(longitude, latitude)` 순서로 PostGIS point를
+바인딩한다. rank별 null-binding과 connection recording을 함께 검증한다.
+
+- [ ] **Step 6.2: writer의 transaction/connection 경계를 구현한다.**
+
+```kotlin
+internal interface TileBatchWriter {
+    fun write(connection: java.sql.Connection, rows: List<TileRow>): BatchWriteResult
+}
+```
+
+writer는 `TransactionManager.current().connection.connection`과 동일한 connection만 받고, `DataSource.getConnection`, 새 Exposed/JDBC transaction, connection close를 하지 않는다. 호출 입력 `rows.size`가 1,000을 초과하면 즉시 `ResourceLimitExceeded`로 거부해 tile-wide list를 차단한다. `PreparedStatement`만 닫고, batch 행 수를 1,000 이하로 flush한다. 각 flush 뒤 payload 참조를 해제하고 control seam을 검사한다. `1`/`0`만 정상이며 `SUCCESS_NO_INFO`/기타 값은 bounded canonical-key 조회 후 설명되지 않으면 rollback한다.
+
+- [ ] **Step 6.3: DB writer와 JSONB 테스트를 GREEN으로 만든다.**
+
+recording writer에서 connection identity, `rows.size <= 1_000`, pending rows/encoded
+payload 상한, flush/commit 순서, 두 번째 pass 첫 write 직전·flush 중 취소 후 현재
+tile rollback을 검증한다. 이전에 commit된 tile/slice rows는 보존되는지 함께 확인한다.
+active connection=0 및 추가 lease renew 없음은 bounded
+`awaitTermination` 뒤 recording seam으로 확인한다. adjacent cell auxiliary 값 오염, quote/injection-like key,
+UTF-8 8,192/8,193 boundary, empty attrs와 idempotent conflict를 검증한다.
+
+Run:
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.internal.NetCdfAuxiliarySerializerTest' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.31*' \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.33*' \
+  --no-configuration-cache --console=plain
+```
+
+## 8. Task 7 — service 통합, metrics, 기존 회귀
+
+**Files:**
+
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/support/NetCdfSampleWriter.kt`
+
+- [ ] **Step 7.1: register/import 진입점에 guard와 fingerprint를 연결한다.**
+
+`registerFile`은 path guard/pre-stat → NetCDF open 전후 identity 확인 → verified
+dataset의 bounded metadata preflight(명시적 stack/queue) → map materialization →
+reserved fingerprint collision 확인 → DB 저장 순서를 지킨다. `importGridValues`는
+다음 순서를 고정한다.
+
+```text
+record 조회(없으면 lease/metric 없이 FileRecordNotFound)
+→ guard와 persisted fingerprint 확인
+→ openVerifiedDataset(open 전후 identity 재검증)
+→ variable/axis/CRS/limits와 실제 totalSlices 검증
+→ progress 조회 및 invariant/checkpoint 검증
+→ COMPLETED이면 검증된 checkpoint가 마지막 slice일 때만 no-op 반환
+→ 그 밖에는 lease acquire(CAS) 후 동일 dataset identity를 재확인하고 import
+```
+
+검증 단계에서는 progress checkpoint와 metric을 변경하지 않으며, 검증을 통과한 뒤
+별도 phase에서만 lease 필드 acquire를 수행한다. lease acquire가 경쟁으로
+`COMPLETED`를 반환하면 같은 invariant를 다시 검증한다. TOCTOU는 dataset을 닫고
+`FileChanged`로 종료한다. 실제 slice import 이후에만 checkpoint/metric을 전진시키고,
+마지막 slice의 row write와 lease fence를 수행한 뒤 DB commit 전에 같은 transaction에서
+`markCompleted`를 호출한다. 이 호출은
+`status=COMPLETED`, `completedAt != null`, `lease_expires_at = null`,
+`lastSliceIdx = totalSlices - 1`을 한 transaction에서 보장한다. 불일치는
+`CorruptProgress`로 종료한다.
+
+- [ ] **Step 7.2: rank 1–4를 공통 tile engine으로 전환한다.**
+
+rank 1은 location/attrs null과 time index를 유지한다. rank 2–4는 `VariableAxisMap`/sampler/tile planner/writer를 사용하고, 마지막 tile만 checkpoint를 전진시킨다. 마지막 `totalSlices - 1` tile의 row write/lease fence를 수행한 뒤 DB commit 전에 `markCompleted`를 호출해 terminal status/lease clear/completedAt/checkpoint invariant를 같은 transaction에서 검증한다. fence 또는 `markCompleted` 실패 시 현재 transaction 전체를 rollback한다. success/failure/nan/records/slice timer metric 이름과 low-cardinality label을 기존 계약에 맞춰 유지한다. pre-lease 입력 거부는 `netcdf.import.rejected`의 고정 allowlist(`reason=resource|axis|crs|duplicate|path|progress`)만 증가시키고, `FileRecordNotFound`/`ImportAlreadyRunning`은 기존 비증가 계약을 유지한다. 예외·로그 detail은 stable reason code와 CR/LF/control 제거·길이 제한을 적용하고, raw variable/coordinate/path 이름은 metric label로 사용하지 않는 allowlist를 고정한다. reason sanitation·rejection counter 증가/비증가와 label cardinality 회귀를 검증한다.
+
+- [ ] **Step 7.3: 기존 service suite를 순차 실행한다.**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest' \
+  --no-configuration-cache --console=plain
+```
+
+Expected: 기존 rank 1–4, NaN/FillValue, CRS, resume/no-op, lease takeover, metrics tests와 새 30a–34 tests가 모두 PASS. 실패하면 raw Testcontainers 로그를 읽고 원인 수정 후 이 단계부터 재실행한다.
+
+## 9. Task 8 — fixture benchmark와 문서 계약
+
+**Files:**
+
+- Modify: `utils/science/README.md`
+- Modify: `utils/science/README.ko.md`
+- Modify: `docs/followup-issues/utils-science-readme-rewrite.md`
+- Create: `docs/benchmarks/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary.md`
+- Temporary (discard before commit): `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt` benchmark-only harness
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt` KDoc
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/VariableAxisMap.kt` KDoc
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/CoordinateReprojector.kt` KDoc
+
+- [ ] **Step 8.1: public KDoc/README EN·KO를 실제 계약으로 갱신한다.**
+
+blocking `registerFile`/`importGridValues` 호출을 모두 worker/virtual-thread executor에서 실행하는 예시, `location` lon-first와 `attrs["altitude"]`, 2D/CF coordinate, supported CRS, hard limits, `FileOpen`/`FileChanged`/`CorruptProgress`/`DuplicateCoordinate` 복구를 양 locale에 같은 구조로 기록한다. `registerFile`도 blocking이며 open 단계가 caller deadline을 선점할 수 있으므로 bounded executor와 명시적 shutdown을 사용한다. timeout 뒤 작업이 계속 lease/connection을 점유하지 않도록 등록된 `fileId`를 관찰할 수 있는 `Future`를 보존하고 `TimeoutException`에서 `cancel(true)`를 호출하며, 구현은 open 직후·tile 경계·write/commit 직전 취소를 관찰하고 `CancellationException`/interrupt 상태를 보존한다. `cancel(true)`는 협력적 취소일 뿐 완료나 side effect 부재를 보장하지 않는다. 호출자는 `cancel(true)` 뒤 `shutdownNow()`와 함께 최대 30초의 bounded `awaitTermination`으로 worker 종료를 기다리고, `awaitTermination` 자체가 interrupt되면 interrupt 상태를 복원한 뒤 실패를 표면화한다. worker가 30초 안에 종료되지 않으면 재시도하지 않고 운영자에게 escalation한다. timeout/interrupt 뒤 재시도하기 전에는 관찰된 `fileId`의 DB progress·lease·partial rows를 재조회해 active connection=0, 추가 renew 없음, 현재 tile rollback을 확인한다. 이 side-effect 재확인을 통과하지 못하면 재시도하지 않는다. recording connection/lease seam에서 이 조건을 검증한다. 첫 write 직전과 flush 중 취소 테스트는 이전에 commit된 tile/slice의 rows는 보존하고 현재 tile rows만 시작 시점으로 복귀하는지 검증한다. duplicate preflight 실패는 두 번째 pass 전에 slice rows-written=0으로 유지되는지 별도로 확인한다. trusted-admin 전용 경계와 caller가 authN/authZ·tenant ownership·허용 root allowlist를 보장해야 한다는 책임, identity-only fingerprint의 same inode/size/mtime 한계와 immutable 저장소 전제도 명시한다. README의 기존 “CoordinateAxis2D 비지원” 문구를 제거하고 migration/dependency 책임은 보존한다. 2.0.0 sealed-exception migration subsection에는 다섯 새 subtype(`UnsupportedCoordinateAxis`, `DuplicateCoordinate`, `ResourceLimitExceeded`, `FileChanged`, `CorruptProgress`) 각각의 exhaustive `when` branch와 base catch의 `else` 호환 패턴을 함께 기록한다. 입력·metadata·경로·축·변수 오류는 수정 후 항상 새 등록·새 `fileId`를 사용하고, fingerprint가 변경된 old progress/partial rows를 resume하지 않는다. `CorruptProgress`는 자동 retry하지 않고 progress row를 `SELECT ... FOR UPDATE`로 잠가 기준 상태 기록/audit/quarantine한 뒤 기존 column의 `FAILED`+`CORRUPT_PROGRESS:<progressId>` 또는 `COMPLETED` 차단으로 격리하고 partial rows를 retention 정책에 따라 보존·삭제한 다음 새 `fileId`로 import한다. `ImportAlreadyRunning`/`ImportLeaseLost`는 최대 3회(1초·2초·4초 backoff)만 시도하고 소진 시 원래 typed exception과 alert를 표면화한다. `FileRecordNotFound`/`VariableNotFound`/`UnsupportedVariable`는 record/variable을 보정한 뒤 기존 progress를 임의로 재사용하지 않고 새 호출·새 `fileId`로 처리한다. `NetCdfExceptionApiCompatibilityTest` compile fixture와 양 locale read-back을 연결한다. health/readiness endpoint는 이 library 범위가 아니므로 N/A로 기록하고, application operator가 DB 연결·PostGIS/NetCDF runtime·DB/host UTC 동기화를 사전 점검한다. README/follow-up runbook에는 기본 5분 lease TTL과 custom TTL compatibility, stale progress 소유권·격리·rollback 절차, `netcdf.import.rejected` allowlist와 기본 alert(자원 거부 1건 또는 5분 내 `ImportLeaseLost` 2건)를 명시하며, threshold 조정 권한은 배포 애플리케이션에 둔다.
+
+```kotlin
+val executor = Executors.newVirtualThreadPerTaskExecutor()
+val registeredFileId = AtomicLong(-1L)
+val task: Future<Long> = executor.submit {
+    val fileId = catalog.registerFile("/data/grid.nc") // blocking; trusted-admin path
+    registeredFileId.set(fileId)
+    catalog.importGridValues(fileId, "temperature") // blocking; tile-boundary cancel
+    fileId
+}
+try {
+    val fileId = task.get(30, TimeUnit.MINUTES)
+    println("imported fileId=$fileId")
+} catch (timeout: TimeoutException) {
+    task.cancel(true) // caller owns cancellation and interrupt propagation
+    throw timeout
+} catch (interrupted: InterruptedException) {
+    task.cancel(true)
+    Thread.currentThread().interrupt()
+    throw interrupted
+} catch (cancelled: CancellationException) {
+    throw cancelled
+} catch (failure: ExecutionException) {
+    throw (failure.cause ?: failure)
+} finally {
+    executor.shutdownNow()
+    try {
+        check(executor.awaitTermination(30, TimeUnit.SECONDS)) { "import worker did not terminate" }
+    } catch (interrupted: InterruptedException) {
+        Thread.currentThread().interrupt()
+        throw interrupted
+    }
+}
+// timeout/interrupt 후에는 registeredFileId의 progress·lease·partial rows를 재조회하고
+// side effect가 종료된 경우에만 caller retry policy(MAX_LEASE_RETRIES=3)를 적용한다.
+```
+
+- [ ] **Step 8.2: fixed benchmark를 실행하고 결과를 저장한다.**
+
+`writeLargeContractSample(rows=1_024, columns=1_024)`가 같은 deterministic value generator로
+`temperature_1d`와 `temperature_2d`+one auxiliary를 만든다. feature worktree에서 fixture를
+한 번 생성해 SHA-256과 경로를 고정하고, baseline worktree에는 그 파일을 복사한다. baseline과
+feature 각각에 동일한 임시 benchmark-only JUnit harness를 적용해(커밋하지 않음) 정확히 다음
+순서로 `temperature_1d`를 측정한다: 새 baseline worktree를
+`45260871f58433a78f2d633c235010f661d22c6e`로
+만들고, clean DB/Testcontainers에서 1 warm-up 후 3회 순차 실행; feature에서도 새
+fileId/clean DB로 같은 1+3회 실행. 각 실행은 fixture read 시작부터 마지막 commit까지
+측정하고 생성·register 시간은 제외한다. harness 적용·제거 명령과 두 worktree의 commit SHA,
+fixture SHA-256, 정확한 Gradle `--tests` selector를 artifact에 기록한다. 동일 JVM/Gradle/
+PostGIS image, JVM `-Xmx`, Docker image, run durations/median, observed peak heap, owned
+counters를 함께 남긴다. 1D throughput은 baseline median 대비 20% 이상 하락하지 않아야
+하며 2D+auxiliary cells/sec는 report-only다. 두 경로 모두 `pendingRows<=1_000`, tile read
+`<=65,536`, owned working-set `<=128 MiB`를 counter/assertion으로 증명한다.
+
+임시 harness의 테스트 이름은 `large1d throughput uses fixed generator`와
+`large2d auxiliary stays within bounded contract`로 고정하고, baseline/feature 모두 다음
+selector를 사용한다.
+
+```bash
+git worktree add --detach .worktrees/chore/1352-coordinate-axis2d-cf-grid-baseline \
+  45260871f58433a78f2d633c235010f661d22c6e
+(cd .worktrees/chore/1352-coordinate-axis2d-cf-grid-baseline && \
+  test "$(git rev-parse HEAD)" = "45260871f58433a78f2d633c235010f661d22c6e" && \
+  ./gradlew :bluetape4k-science:test \
+    --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.large1d*' \
+    -PincludeTags=slow-netcdf --no-configuration-cache --console=plain)
+(cd .worktrees/feat/1352-coordinate-axis2d-cf-grid && \
+  ./gradlew :bluetape4k-science:test \
+    --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.large1d*' \
+    -PincludeTags=slow-netcdf --no-configuration-cache --console=plain)
+```
+
+2D+auxiliary는 workload가 달라 feature worktree에서만 report-only로 다음 selector를
+별도 실행하고, baseline gate에는 포함하지 않는다.
+
+```bash
+(cd .worktrees/feat/1352-coordinate-axis2d-cf-grid && \
+  ./gradlew :bluetape4k-science:test \
+    --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest.large2d*' \
+    -PincludeTags=slow-netcdf --no-configuration-cache --console=plain)
+```
+
+임시 harness는 `ManagementFactory.getMemoryMXBean().heapMemoryUsage.used`를 fixture read
+직전·각 tile/flush 경계·마지막 commit 직후에 기록하고, 최대 관측값을 peak heap으로
+보고한다. `MemoryBudget` counters(`tileCells`, `pendingRows`, `batchPayloadBytes`,
+`coordinateBytes`, `duplicateSetBytes`, `ownedWorkingSetBytes`)는 같은 시점에 JSON/CSV로
+남기며, JFR은 선택적 진단 자료로만 첨부한다.
+
+각 worktree에서 harness 적용 전후 `git status --short`가 원상 복귀하고, benchmark worktree는
+결과 artifact를 고정한 뒤에만 제거한다.
+
+Run the baseline `large1d*` commands and the feature `large2d*` report-only command
+sequentially; never run the two Testcontainers invocations concurrently.
+
+- [ ] **Step 8.3: 문서 audit를 실행한다.**
+
+```bash
+node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  utils/science/README.ko.md \
+  docs/followup-issues/utils-science-readme-rewrite.md
+git diff --check
+```
+
+Expected: terminology audit passed, whitespace check has no output, EN/KO section and code example read-back matches source.
+
+## 10. Task 9 — 표준 검증·위험 예측·rollback
+
+**Files:**
+
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/NetCdfException.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimits.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuard.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/VariableAxisMap.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSampler.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/CoordinateReprojector.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlanner.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializer.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTileBatchWriter.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/repository/NetCdfImportProgressRepository.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/support/NetCdfSampleWriter.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+- Create: `docs/lessons/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary.md`
+
+- [ ] **Step 9.1: triggered risk register를 실행 증거와 연결한다.**
+
+| 위험 | 조기 신호 | 완화·재실행 |
+|---|---|---|
+| dimension order 전치 | `[time,x,y]` read-back 불일치 | Task 5 full-rank index 수정 후 Task 5.3/7.3 재실행 |
+| stale owner가 새 owner를 덮음 | `ImportLeaseLost` 뒤 row 혼합 | Task 3 CAS/row-lock test와 Task 7.3 재실행 |
+| duplicate가 unique index에서 유실 | cross-tile row count 감소 | Task 5 two-pass preflight 수정 후 Task 7.3 재실행 |
+| tile/JSONB heap 증가 | owned counter 또는 batch cap 초과 | Task 2 budget/Task 5 planner/Task 6 serializer 수정 후 benchmark 재실행 |
+| second pass 중 취소가 partial write를 남김 | `Future.cancel(true)` 뒤 rows-written 증가 또는 FAILED 전환 | Task 5.2/6.2 control seam·rollback 수정 후 cancellation suite 재실행 |
+| 손상된 COMPLETED progress가 no-op으로 통과 | totalSlices/checkpoint 불일치가 감지되지 않음 | Task 3.2/7.1 verified-open invariant 수정 후 progress suite 재실행 |
+| path TOCTOU/fingerprint 혼합 | same-size mutation resume 성공 | Task 2 guard 수정 후 path/fingerprint tests 재실행 |
+| 등록 metadata가 map materialize 전에 heap을 소진 | nested/1 MiB fixture에서 늦은 실패 | Task 2.2 preflight scan 수정 후 metadata suite 재실행 |
+| 입력 이름이 log/metric cardinality를 오염 | CR/LF/control 또는 raw variable label 관찰 | Task 7.2 sanitation/label allowlist 수정 후 observability suite 재실행 |
+| NetCDF/Testcontainers 환경 오탐 | Connection refused 또는 mount error | `colima status`, `docker context show`, `docker info` 확인 후 재시도; healthy Colima 재시작 금지 |
+| public sealed API source break | consumer exhaustive when compile error | 2.0.0 migration fixture/KDoc 수정 후 API test 재실행 |
+
+- [ ] **Step 9.2: proportional module verification을 실행한다.**
+
+```bash
+./gradlew :bluetape4k-science:compileKotlin \
+  --no-configuration-cache --console=plain
+./gradlew :bluetape4k-science:test \
+  --no-configuration-cache --console=plain
+./gradlew :bluetape4k-science:test \
+  -PincludeTags=slow-netcdf --no-configuration-cache --console=plain
+./gradlew :bluetape4k-science:detekt \
+  --no-configuration-cache --console=plain
+git diff --check
+```
+
+Expected: compile/test/slow-netcdf/detekt PASS, `git diff --check` no output. 실패 시 실패 task의 raw output을 진단하고 해당 Task부터 RED/GREEN을 반복한다.
+
+- [ ] **Step 9.3: spec-to-plan read-back과 rollback을 확인한다.**
+
+`rg -n`으로 spec의 `CoordinateAxis2D`, CF auxiliary, tile/cache/batch/working-set, CRS, duplicate, lease/fingerprint, API migration, README/benchmark 각 요구가 이 plan의 Task 2–9에 매핑됐는지 확인한다. 구현 실패 시 branch-local commit을 `git revert <commit>`으로 되돌리고 canonical `develop`이나 다른 worktree는 건드리지 않는다. schema migration이 없으므로 DB rollback은 transaction rollback과 테스트 fixture cleanup으로 한정한다.
+
+## Writer gate
+
+| 항목 | 판정 | 근거 |
+|---|---|---|
+| SPW-01 audience/purpose/evidence | PASS | #1352/#1421, 선행 PR #1512, 기준 SHA, 현재 source anchor와 구현 stop condition을 명시했다. |
+| SPW-02 artifact contract | PASS | goal·architecture·파일 소유권·ordered task·테스트·문서·rollback을 포함한다. |
+| SPW-03 Korean technical register | PASS | 계획 설명은 한국어로 작성하고 코드·API·명령·경로·식별자 토큰은 보존했다. terminology audit가 통과했다. |
+| SPW-04 technical traceability | PASS | 승인 명세 §1–§10 요구를 Task 1–9 및 Step 3-R/3-P/commit/rollback 증거에 연결했다. |
+| SPW-05 read-back | PASS | heading·파일 경로·checkbox·code fence·기대 결과를 재독했고 placeholder scan과 `git diff --no-index --check`가 통과했다. |
+
+계획 자체의 writer gate는 통합 Step 3-R review에서 다시 판정하며, P0/P1 발견 시 해당 항목을
+수정하고 영향을 받은 렌즈를 재실행한다.
+
+## 11. Commit 순서와 Lore 형식
+
+- [ ] **Step 11.1: 승인 산출물을 먼저 commit한다.**
+
+```bash
+git add docs/superpowers/specs/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design.md \
+  docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design-review.md \
+  docs/superpowers/plans/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan.md \
+  docs/review/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-plan-review.md
+git commit -m "좌표축 임포트 구현 범위를 실행 가능한 계약으로 고정"
+```
+
+Commit body는 다음 trailer를 포함한다.
+
+```text
+Constraint: 기존 NetCDF schema/API와 protected develop을 유지
+Rejected: 좌표 전용 테이블과 schema migration | child 범위를 불필요하게 확장
+Confidence: high
+Scope-risk: broad
+Directive: CoordinateReader와 동일 Exposed Connection 경계를 우회하지 말 것
+Tested: specification/review/plan terminology audit와 diff check
+Not-tested: implementation code and hosted CI
+```
+
+- [ ] **Step 11.2: implementation을 기능 경계별로 commit한다.**
+
+권장 순서는 `예외·guard·limits` → `progress fence` → `axis/reader/CRS` → `tile engine` → `serializer/writer` → `service integration` → `fixtures/tests` → `docs/benchmark/lesson`이다. 각 commit마다 `git diff --check`와 해당 Task의 targeted Gradle test를 실행하고 Lore trailers를 포함한다.
+
+## 12. Step 3-R 종료 조건
+
+- 모든 설계 §1–§10 요구가 Task 1–11의 concrete file/task/command에 매핑된다.
+- 선행 산출물(spec → plan → tests → implementation → docs)이 역순 의존 없이 실행된다.
+- success/failure/edge/concurrency/cancellation/backend/Testcontainers/benchmark 경로가 명시된다.
+- schema/settings/BOM/workflow/Kover/Nightly 변경은 N/A 이유가 기록된다. 기존 `slow-netcdf` nightly 실행은 Task 8–9에서 검증한다.
+- Exposed deprecated import/receiver shadowing, Kotlin cancellation, resource close, same-connection JDBC 경계는 구현 후 source scan과 테스트로 확인한다.
+- plan과 통합 review가 writer SPW-01..05 PASS, 최신 P0=0/P1=0일 때만 Step 3-R PASS로 닫는다.
+- Step 3-R PASS와 plan commit 전에는 implementation code를 수정하지 않는다.

--- a/docs/superpowers/specs/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design.md
+++ b/docs/superpowers/specs/2026-08-27-netcdf-coordinate-axis2d-cf-auxiliary-design.md
@@ -1,0 +1,405 @@
+# NetCDF `CoordinateAxis2D`·CF auxiliary coordinate 설계
+
+- **일자**: 2026-08-27
+- **이슈**: [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352)
+- **Epic**: [#1421](https://github.com/bluetape4k/bluetape4k-projects/issues/1421)
+- **선행 train 단계**: [PR #1512](https://github.com/bluetape4k/bluetape4k-projects/pull/1512) — #1343 문서 계약, `develop` 반영 완료
+- **구현 branch/worktree**: `feat/1352-coordinate-axis2d-cf-grid` / `.worktrees/feat/1352-coordinate-axis2d-cf-grid`
+- **기준**: `origin/develop@45260871f58433a78f2d633c235010f661d22c6e`
+- **대상 모듈**: `bluetape4k-science` (`utils/science`)
+- **상태**: Step 2-R 통합 PASS (2026-08-27 사용자 명세 재승인 완료; Step 3-R 계획 검토 진행)
+
+## 1. 문제와 목표
+
+현재 `NetCdfCatalogService`는 데이터 변수의 dimension 이름으로 `CoordinateAxis1D`만 찾습니다. 따라서 curvilinear grid의 `CoordinateAxis2D` lat/lon과 데이터 변수의 CF `coordinates` 속성에 열거된 auxiliary coordinate를 `MissingCoordinate`로 거부합니다. 데이터 값과 셀 좌표를 함께 보존해야 하는 #1352의 수용 기준을 만족하려면 축 탐지, 셀 인덱싱, CRS 변환, 저장 경로를 하나의 내부 계약으로 확장해야 합니다.
+
+이번 변경의 목표는 다음과 같습니다.
+
+1. `CoordinateAxis1D`와 `CoordinateAxis2D`를 같은 내부 좌표 sampler 계약으로 읽는다.
+2. CF `coordinates` 속성으로 선언된 lat/lon 및 추가 numeric auxiliary coordinate를 해석한다.
+3. 변수 dimension 순서와 좌표 dimension 순서를 별도로 보존해 `[time, x, y]` 같은 데이터도 정확히 매핑한다.
+4. canonical `(lon, lat)`은 기존 PostGIS `location`에 저장하고, lat/lon 이외의 auxiliary 값은 기존 JSONB `attrs`에 저장한다.
+5. 기존 rank 1–4, 1D 축, CRS whitelist, NaN/`_FillValue`, resume/lease, metrics 계약을 회귀 없이 유지한다.
+
+## 2. 현재 근거와 제약
+
+### 2.1 저장소 근거
+
+- `NetCdfCatalogService.kt`의 `importSlice2D`는 `UcarArray.indexIterator`와 `(i, j)`를 직접 결합한다. 데이터 dimension 순서가 바뀌면 좌표와 값의 대응을 보장할 수 없다.
+- `VariableAxisMap.kt`는 `dataset.findCoordinateAxis(dimensionName)` 결과가 `CoordinateAxis1D`가 아니면 `MissingCoordinate`를 발생시킨다.
+- `CoordinateReprojector.kt`는 현재 `CoordinateAxis1D`만 캐시하고, EPSG:4326/4269/3857/32601–32660/32701–32760/3413/3031을 지원한다.
+- `NetCdfGridValueTable.location`은 nullable PostGIS POINT(EPSG:4326)이고 `attrs`는 nullable JSONB `Map<String, Any?>`다. 기존 partial unique index는 `location`과 `(fileId, variableName, timeIdx, levelIdx)`에만 의존하므로 auxiliary 값을 `attrs`에 넣어도 중복 계약은 변하지 않는다.
+- `NetcdfDatasets.openDataset(String)`은 NetCDF-Java 5.9.1의 default enhance mode로 dataset을 열며, CF convention이 `coordinates`에 열거된 변수를 coordinate axis로 만든다. `CoordinateAxis2D.getCoordValue(int, int)`로 2D 값을 셀 단위로 읽을 수 있다.
+- `utils/science` compile baseline은 `./gradlew :bluetape4k-science:compileKotlin --no-configuration-cache --console=plain`으로 성공했다.
+
+### 2.2 범위 제약
+
+- 공개 서비스 메서드 시그니처와 blocking 호출 모델은 유지한다.
+- 새 dependency, 새 테이블, schema migration, workflow 변경은 포함하지 않는다.
+- `rotated_latitude_longitude`·tripolar처럼 EPSG whitelist로 해석할 수 없는 grid mapping은 이번 변경에서도 지원하지 않고 typed exception으로 거부한다.
+- 이 서비스의 파일 open/import API는 신뢰된 운영 경계에서만 호출하는 trusted-admin API다. HTTP 요청 등 외부 입력을 그대로 `filePath`로 전달하지 않으며, 구현은 NUL/control 문자·URI scheme·regular file이 아닌 경로·경로 구성요소의 심볼릭 링크를 `FileOpen`으로 거부한다. 원격 URL은 지원하지 않는다. canonical path를 구성요소별 `NOFOLLOW_LINKS`로 확인하고, open 직전·직후 `fileKey/size/lastModifiedTime` identity를 재검증해 TOCTOU를 차단한다.
+- 파일 크기는 open 전과 resume 시 `MAX_FILE_BYTES = 64 GiB` 이하인지 확인한다. NetCDF-Java의 blocking open 자체에는 이 모듈이 별도 timeout을 강제하지 않으므로 외부 호출자는 전체 deadline을 소유한다.
+- 대용량 파일의 전체 데이터 배열을 한 번에 읽지 않는다. 기존 논리적 slice와 lease 갱신 경계를 유지하되, 각 slice는 bounded tile read로 나눈다.
+- 한 import는 하나의 blocking caller/DB connection만 사용하고 tile을 병렬화하지 않는다. 내부 무한 재시도·자동 backoff는 없으며, caller의 deadline/interrupt가 다음 tile 경계에서 관찰된다. 전체 실행 시간·connection 점유 상한은 호출자가 제공하는 deadline으로 제한한다.
+
+### 2.3 자원 예산과 중복 좌표 정책
+
+악의적이거나 손상된 metadata가 CPU·heap·DB 연결을 고갈시키지 않도록 다음 hard limit을 import 전에 검사한다. 모든 dimension product와 byte 계산은 `Long` checked arithmetic로 수행한 뒤 `Int` API에 내린다.
+
+| 예산 | 기본 상한 | 초과 시 동작 |
+|---|---:|---|
+| `coordinates` attribute token 수 | 32 | `ResourceLimitExceeded` + `netcdf.import.rejected{reason=resource}` |
+| auxiliary coordinate 변수 수 | 16 | 동일 |
+| coordinate variable 이름 UTF-8 길이 | 128 bytes | 동일 |
+| NetCDF variable 수 | 1,024 | 동일 |
+| dataset 전체 group dimension 수 | 256 | 동일 |
+| 등록 metadata UTF-8 payload | 1 MiB | 동일 |
+| 한 import logical cell 수 | 100,000,000 | 동일 |
+| 한 import logical slice 수 | 1,000,000 | 동일 |
+| 한 spatial tile read 셀 수 | 65,536 | tile shape을 더 작게 분할 |
+| 한 JDBC `executeBatch` 행 수 | 1,000 | 같은 tile 안에서 추가 flush |
+| 한 셀 auxiliary JSONB payload | 8,192 bytes | `ResourceLimitExceeded` |
+| import 중 coordinate cache | 64 MiB | 전체-grid cache를 만들지 않고 tile/lazy 경로로 전환; 그래도 초과하면 실패 |
+| duplicate 검사용 primitive key set | 32 MiB (64 MiB 총 예산에 포함) | uniqueness를 증명할 수 없으므로 `ResourceLimitExceeded` |
+| 한 import의 owned working-set (tile/data/serializer/cache/set) | 128 MiB | tile을 줄여도 초과하면 실패 |
+
+2D coordinate는 import 수명 동안 전체 grid를 캐시하지 않는다. geographic 2D와 auxiliary 값은 현재 tile에서만 읽고 폐기하며, projected 변환 pair cache도 위 64 MiB 예산 안에서만 유지한다. cache와 duplicate 검사용 primitive key set의 크기는 실제 셀 수가 아닌 `Long` 바이트 산식으로 계측한다. tile data buffer·serializer scratch·cache·duplicate set을 합친 모듈 소유 working-set은 128 MiB를 넘지 않는다. JVM/NetCDF-Java 내부 peak heap은 이 예산과 분리한 관찰값으로 보고한다. 빈 auxiliary map은 JSONB를 생성하지 않고 `attrs=null`로 저장한다.
+
+내부 `MemoryBudget`는 다음 checked `Long` 산식으로 tile 전에 상한을 판정한다: `tileBufferBytes = tileCells × 8`, `coordinateBytes = tileCells × (spatialAxisCount + auxiliaryCount) × 8`, `serializerScratchBytes = MAX_AUXILIARY_JSONB_BYTES`, `duplicateSetBytes = sliceCells × 32` (open-addressed primitive pair key의 보수적 entry 비용), `ownedWorkingSet = 합계`. `coordinateBytes + duplicateSetBytes`는 64 MiB, 전체 `ownedWorkingSet`은 128 MiB를 넘을 수 없다. 이 계산은 JVM peak heap 추정치가 아니라 서비스가 소유한 배열·key·serializer buffer에만 적용한다.
+
+현재 schema의 `(file_id, variable_name, time_idx, level_idx, location-hash)` unique index는 같은 canonical 위치를 가진 서로 다른 셀을 식별하지 못한다. 이번 child에서 schema migration을 추가하지 않으므로, 각 `(timeIdx, levelIdx)` spatial slice는 DB insert 전에 canonical `(lon,lat)`의 exact bit-pair 중복을 bounded primitive set으로 검사한다. key 생성 시 `-0.0`과 `+0.0`은 PostGIS의 동일 좌표 의미에 맞춰 `+0.0`으로 canonicalize하고, NaN/무한대는 앞선 spatial validation에서 거부한다. 중복이 발견되면 `DuplicateCoordinate`로 해당 slice 전체를 rollback하며, 조용한 `ON CONFLICT DO NOTHING` 유실은 허용하지 않는다. duplicate 검사 예산을 초과해 uniqueness를 증명할 수 없는 slice도 `ResourceLimitExceeded`로 거부한다. 기존 재시도는 이미 성공한 slice의 동일 row를 `ON CONFLICT DO NOTHING`으로 멱등 처리한다.
+
+## 3. 설계 대안과 결정
+
+### 대안 A — 내부 sampler와 기존 `location`/`attrs` 재사용 (채택)
+
+축의 차원 수와 방향을 숨기는 내부 `CoordinateSampler`를 추가하고, 서비스는 sampler에서 셀 좌표와 auxiliary 값을 받는다. 저장 schema는 바꾸지 않고 `location`에 canonical 공간 좌표를, `attrs`에 추가 auxiliary 값을 저장한다.
+
+- 장점: 기존 API·DDL·partial unique index·조회 모델을 유지한다. 1D와 2D를 같은 import loop에서 검증할 수 있다.
+- 비용: JSONB를 셀마다 직렬화하며 auxiliary 값의 ad-hoc 조회는 전용 테이블보다 불편하다. 따라서 지원 auxiliary는 numeric rank 1/2와 grid dimension에 정렬되는 값으로 제한하고, 셀 payload와 allocation 예산을 문서화한다.
+
+### 대안 B — 셀 좌표 전용 테이블 추가
+
+`netcdf_grid_value_coordinates`를 추가해 coordinate variable 이름, 값, dimension 위치를 정규화한다.
+
+- 장점: 개별 auxiliary 값의 검색과 인덱싱이 명확하다.
+- 거부 이유: migration·foreign key·upsert·cleanup·repository API가 함께 바뀌고, 이번 child가 요구하는 기존 import 계약보다 범위가 커진다.
+
+### 대안 C — 2D 축을 1D로 평탄화
+
+행/열별 대표 좌표로 축을 줄여 기존 `CoordinateAxis1D` 경로를 재사용한다.
+
+- 거부 이유: curvilinear grid의 셀별 좌표를 잃어 수용 기준을 위반한다.
+
+## 4. 내부 계약
+
+### 4.1 `VariableAxisMap`
+
+기존 `latDim`/`lonDim`만으로는 auxiliary 2D 축의 dimension 순서를 표현할 수 없으므로 내부 map을 다음 정보로 확장한다.
+
+- `timeDim`, `levelDim`: 데이터 변수 rank에서의 시간·레벨 위치. 해당 축이
+  없는 rank에서는 `null`이며, full-rank index에 조건부로만 반영한다.
+- `gridRowDim`, `gridColumnDim`: 공간 격자의 행·열 dimension 위치
+- `latBinding`, `lonBinding`: coordinate variable 이름, `CoordinateAxis1D` 또는 `CoordinateAxis2D`, 축 dimension 위치와 shape
+- `auxiliaryBindings`: lat/lon이 아닌 CF coordinate variable의 이름, numeric rank, dimension 매핑
+
+축 후보는 다음 순서로 수집한다.
+
+1. 데이터 변수 dimension에 대응하는 `dataset.findCoordinateAxis(dimensionName)` 결과
+2. 데이터 변수의 `coordinates` attribute에 나열된 이름
+3. `AxisType`, `standard_name`, 단위, 기존 이름 fallback(`lat`, `latitude`, `y`, `lon`, `longitude`, `x` 등)
+
+후보 이름은 full name과 short name을 모두 비교하되, 같은 역할에 둘 이상의 서로 다른 축이 남으면 추측하지 않고 `UnsupportedCoordinateAxis`를 발생시킨다. 2D lat/lon binding은 두 축이 공유하는 두 grid dimension을 기록하며, 축 내부의 행/열 순서는 coordinate axis의 dimension 순서를 따른다.
+
+지원하는 auxiliary coordinate는 다음과 같다.
+
+- numeric rank 1: 하나의 grid dimension에 정렬된 값
+- numeric rank 2: 두 grid dimension에 정렬된 값
+- grid dimension의 부분집합이 아닌 rank 또는 문자열/object 값: `UnsupportedCoordinateAxis`
+
+### 4.2 `CoordinateSampler`와 `CoordinateReprojector`
+
+내부 sampler의 논리적 결과는 다음과 같다.
+
+```text
+CoordinateSample(
+    longitude: Double,
+    latitude: Double,
+    auxiliary: Map<String, Double>
+)
+```
+
+`CoordinateSample`의 `auxiliary`는 타일의 다음 셀을 샘플링하기 전까지 유효한
+읽기 전용 복사본이다. sampler는 다음 호출에서 내부 map을 재사용할 수 있고,
+`TileBatchWriter`는 행을 보유하거나 비동기로 전달하지 않고 같은 호출 안에서
+JSONB를 즉시 직렬화한 뒤에만 다음 셀을 요청한다. 연속 셀의 값이 섞이지 않는
+fixture를 고정해 이 lifetime 계약을 검증한다.
+
+- 1D axis는 `CoordinateReader.read1D(axisName, origin, length)`가 반환한
+  bounded window에서 row/column 값을 조회한다.
+- 2D axis는 `CoordinateReader.read2D(axisName, rowOrigin, columnOrigin,
+  rowCount, columnCount)`가 반환한 bounded window에서 binding이 기록한 axis
+  dimension 순서로 local 값을 조회한다. sampler가 `getCoordValue`를 직접
+  호출하거나 reader seam을 우회하는 경로는 허용하지 않는다.
+- auxiliary 값은 같은 row/column 인덱스로 샘플링하고 lat/lon 이름은 중복 저장하지 않는다.
+- CF `coordinates` 목록의 `AxisType.Time` 및 level/vertical 축은 기존 `timeDim`/`levelDim` binding으로 소비하며 `auxiliaryBindings`에 다시 넣지 않는다. 같은 token이 spatial 역할과 time/level 역할에 동시에 매핑되거나 역할이 충돌하면 `UnsupportedCoordinateAxis`다.
+- spatial 좌표는 유한한 값이어야 한다. lat/lon이 NaN 또는 무한대이면 잘못된 POINT를 쓰지 않고 `UnsupportedCoordinateAxis`로 import을 실패시킨다. 비공간 auxiliary의 비유한 값은 해당 key를 생략한다.
+
+CRS 정책은 기존 whitelist를 유지한다.
+
+- EPSG:4326/4269: 1D 또는 2D geographic 좌표를 그대로 `(lon, lat)`으로 사용
+- EPSG:3857, UTM 32601–32660/32701–32760, EPSG:3413/3031: source x/y를 셀 좌표로 읽어 EPSG:4326으로 변환
+- `grid_mapping_name=latitude_longitude`는 EPSG:4326으로 해석
+- 그 외 mapping name, EPSG, proj4j 변환 실패는 `UnsupportedProjection`
+
+Projected 좌표는 tile 범위에서만 source pair를 읽고 필요할 때 bounded pair cache에 넣는다. 2D source axis와 auxiliary coordinate는 axis dimension binding으로 `(row, column)`을 계산한다. 전체 grid를 `grid cell 수 × 2 doubles`로 복제하지 않으며, pair/auxiliary cache·duplicate key set이 64 MiB 예산을 넘으면 즉시 실패한다. 반복되는 time/level slice는 tile을 다시 읽되 coordinate 전체를 장기간 보유하지 않는다. 1D `coordValues`도 전체 축 배열을 materialize하지 않고 필요한 tile 구간만 bounded read/cache한다.
+
+source 좌표와 재투영 후 좌표 모두 유한해야 한다. 최종 longitude는 `[-180, 180]`, latitude는 `[-90, 90]` 범위여야 하며 범위를 벗어나면 `UnsupportedProjection`으로 거부한다. `grid_mapping` attribute가 존재하면 mapping variable을 반드시 해석한다. `latitude_longitude` 또는 ASCII 정규식 `[0-9]+`에 맞는 exact integer EPSG 문자열만 허용하고, 공백·부호·소수형(`4326.0`)·중복/충돌 attribute·malformed/missing/overflow 값은 WGS84로 fallback하지 않고 `UnsupportedProjection`으로 거부한다.
+
+EPSG attribute는 `String`의 ASCII digits 또는 NetCDF integral numeric type만 허용하며, integral numeric은 소수부가 0인지와 `Int` 범위 내인지 먼저 확인한 뒤 문자열로 변환한다. `epsg_code`, `spatial_ref`, `grid_mapping_name`이 함께 있으면 동일한 CRS를 가리킬 때만 허용하고, 하나라도 충돌하거나 `latitude_longitude`와 다른 EPSG가 공존하면 거부한다.
+
+### 4.3 dimension 순서를 보존하는 데이터 read
+
+각 rank별 논리적 slice는 기존 origin/shape와 lease 경계를 유지하되, 셀 값을 `indexIterator` 순서에 의존하지 않는다. spatial dimension이 0이거나 dimension product가 음수/overflow이면 빈 import으로 진행하지 않고 `UnsupportedCoordinateAxis`로 거부한다. spatial dimension은 결정적인 row-major tile planner로 나눈다. `tileCols = min(lonN, 65,536)`, `tileRows = min(latN, max(1, 65,536 / tileCols))`로 시작하고, `tileRows * tileCols`를 checked `Long`으로 계산해 65,536을 넘으면 더 작은 shape으로 내린다. rank 2–4의 `variable.read(origin, shape)`에는 time/level dimension을 1로, tile row/column dimension을 planner shape으로 넣으며, 그 외 dimension은 1로 둔다. tile마다 read된 `UcarArray`와 coordinate/serializer scratch는 transaction 종료 후 즉시 참조를 버린다.
+
+```text
+timeDim?.let { indices[it] = 0 }    // currentTime은 tileOrigin[it]에 있음
+levelDim?.let { indices[it] = 0 }   // currentLevel은 tileOrigin[it]에 있음
+indices[gridRowDim] = row - tileRowOrigin
+indices[gridColumnDim] = column - tileColumnOrigin
+raw = tileData.getDouble(tileIndex.set(indices))
+sample = sampler.sample(tileRowOrigin + localRow, tileColumnOrigin + localColumn)
+```
+
+따라서 `[time, y, x]`, `[time, x, y]`, `[y, x, time]` 모두 같은 셀 좌표와 값으로 저장된다. `timeIdx`와 `levelIdx`는 map의 위치를 사용하고, `lastSliceIdx` 선형화와 heartbeat lease는 변경하지 않는다.
+
+`tileIndex`와 `indices`는 `tileShape` rank로 한 번 생성해 tile 안에서 재사용한다. `variable.read(tileOrigin, tileShape)` 결과의 local time/level은 항상 0이고 global currentTime/currentLevel은 `tileOrigin`에만 둔다. `timeDim`/`levelDim`이 `null`이면 해당 assignment를 생략하고, 존재할 때만 local index 0을 쓴다. local row/column offset만 `tileIndex`에 넣고, 2D axis는 `tileRowOrigin + localRow`/`tileColumnOrigin + localColumn`, 1D axis는 해당 global offset으로 읽는다. tile의 `UcarArray`, axis window, auxiliary window, serializer scratch는 `finally`에서 참조를 해제하며 다음 tile과 공유하지 않는다.
+
+`Index`와 `IntArray`는 tile 안에서 재사용하고, 가능한 경우 precomputed stride를 사용한다. 별도 column을 추가하지 않고 `lease_expires_at`의 DB timestamp를 opaque lease token으로 사용한다. 기존 public `acquireLease(fileId, variableName, leaseTtl: Duration)` 시그니처와 custom TTL을 유지하며, 기본 TTL만 5분이다. `leaseTtl`은 양의 whole-second로 검증하고 SQL에는 초 단위 parameter를 `CURRENT_TIMESTAMP + (? * INTERVAL '1 second')`로 바인딩해 애플리케이션 clock을 사용하지 않는다. acquire마다 DB UTC 기준의 새 expiry를 발급하며 token 재사용을 허용하지 않는다. 각 tile transaction은 progress row lock이 tile commit까지 유지되는 다음 순서를 지킨다.
+
+1. `assertLeaseOwner`/`touchLease`가 `WHERE id=? AND status='IN_PROGRESS' AND lease_expires_at=? AND lease_expires_at > CURRENT_TIMESTAMP` 조건으로 현재 expected lease token을 원자적으로 검증·연장한다. affected row가 1이 아니면 즉시 `ImportLeaseLost`를 발생시킨다. 이 UPDATE/`SELECT ... FOR UPDATE`가 보유한 progress row lock은 transaction commit까지 유지되어 takeover가 대기하도록 한다.
+2. tile을 최대 1,000행씩 JDBC batch flush한다.
+3. commit 직전에 같은 token/status/`lease_expires_at > CURRENT_TIMESTAMP` 조건으로 `assertLeaseOwner`를 다시 수행한다. 마지막 tile에서만 `renewLease(lastSliceIdx=sliceIdx)`를 같은 transaction에 포함하고, 중간 tile은 checkpoint를 전진시키지 않고 `touchLease`만 수행한다. 이 fence가 통과하지 않으면 insert·checkpoint·lease 변경 모두 rollback한다.
+
+각 spatial slice는 **두 pass**로 처리한다. 첫 pass는 tile read만 수행해 slice 전체 canonical `(lon,lat)` exact key를 duplicate set에 넣고 uniqueness를 증명한다. preflight tile을 읽은 뒤 매 경계에서 checkpoint를 전진시키지 않는 `touchLease`/expiry fence와 cancellation/deadline 검사를 수행한다. 이 pass가 성공하기 전에는 어떤 DB insert도 시작하지 않는다. 두 번째 pass에서만 tile transaction을 실행한다. 따라서 tile 경계의 duplicate도 놓치지 않으며, preflight 실패는 이전 tile commit이 없는 상태에서 slice 전체를 거부한다.
+
+tile 중간 장애는 논리적 slice를 미완료로 남기고, 재시도 시 `ON CONFLICT DO NOTHING`으로 이미 기록된 동일 row를 건너뛴다. lease token 검증이 시작·commit 직전 어느 쪽에서든 실패하면 insert와 progress 변경이 같은 transaction에서 rollback되어 stale importer가 새 owner의 progress를 덮어쓸 수 없다. `markFailed`도 동일한 token/status/`lease_expires_at > CURRENT_TIMESTAMP` 조건과 affected-row 검사를 사용하며, 실패 시 원래 예외를 가리지 않고 suppressed로 보존한다.
+
+내부 seam의 소유권과 트랜잭션 경계는 다음 signature 수준으로 고정한다.
+
+- `VariableReader.read(origin: IntArray, shape: IntArray): UcarArray`는 data
+  variable만 감싸며, 구현은 각 호출의 rank·origin·shape·cell count를 기록할 수
+  있어야 한다. production은 full-array read를 만들지 않고 tile만 반환하며,
+  반환 배열의 소유자는 호출자이고 tile `finally`에서 참조를 폐기한다.
+- `CoordinateReader.read1D(axisName: String, origin: Int, length: Int): DoubleArray`와
+  `read2D(axisName: String, rowOrigin: Int, columnOrigin: Int, rowCount: Int,
+  columnCount: Int): DoubleArray`는 모든 `CoordinateAxis1D`/`CoordinateAxis2D`와
+  auxiliary 접근을 감싼다. 내부에서 NetCDF `getCoordValue`를 사용하더라도
+  bounded window 안에서만 호출하며, recording seam은 두 API의 origin/shape와
+  cell count를 기록한다. `read2D` 결과는 row-major flat 배열이며
+  `index = localRow * columnCount + localColumn`으로 해석한다. 반환 배열은 tile
+  `finally`에서 폐기하고 full-grid materialization은 금지한다.
+- `CoordinateSampler.sample(globalRow: Int, globalColumn: Int,
+  target: MutableCoordinateSample): Unit`은 `VariableReader`/`CoordinateReader`가
+  제공한 읽기 window와 axis dimension 순서를 사용한다. `target`은 호출자가
+  소유하고 다음 셀 전에 clear하며, sampler는 `CoordinateSample` 또는 auxiliary
+  map을 보유하지 않는다.
+- `TileBatchWriter.write(connection: java.sql.Connection,
+  rows: List<TileRow>): BatchWriteResult`는 **현재 Exposed transaction이 보유한
+  동일 `Connection`만** 받는다. production writer는 `DataSource.getConnection`,
+  새 JDBC/Exposed transaction, connection close를 수행하지 않으며
+  `PreparedStatement`만 닫는다. 따라서 lease fence, insert, checkpoint, commit과
+  rollback이 하나의 DB transaction/row lock 안에 있다. 테스트 seam은
+  `connection === TransactionManager.current().connection.connection`,
+  executeBatch 행 수, commit 순서와 강제 rollback 뒤의 rows-written를 기록해
+  이 원자성을 검증한다.
+
+운영 JDBC writer는 위 `TileBatchWriter` seam을 통해
+`PreparedStatement.addBatch/executeBatch`를 호출한다. 테스트 구현은 각
+`executeBatch` 호출의 pending 행 수 목록(모든 원소가 `<=1,000`인지 assertion),
+flush 횟수·commit 순서·rows-written를 기록한다. `VariableReader` recording seam은
+모든 data `read(origin, shape)`와 `CoordinateReader`의 1D/2D window 및 cell
+count를 기록해 non-contiguous dimension, coordinate window 상한, full-array read를
+검증한다.
+PostgreSQL batch 결과는 `1`(insert) 또는 `0`(멱등 conflict)만 정상으로 취급하며,
+`SUCCESS_NO_INFO`/기타 반환값은 동일 canonical key의 별도 bounded 조회로
+검증한 뒤 설명되지 않으면 transaction을 rollback한다. 0행 conflict도 preflight와
+기존 checkpoint가 가리키는 동일 row인지 확인하지 못하면 rollback한다.
+
+### 4.4 저장 계약
+
+`NetCdfGridValueTable`의 기존 컬럼을 그대로 사용한다.
+
+| 값 | 저장 위치 | 계약 |
+|---|---|---|
+| spatial longitude/latitude | `location` | `ST_SetSRID(ST_MakePoint(lon, lat), 4326)`; longitude first |
+| 추가 CF auxiliary 값 | `attrs` | `{ "coordinateVariableName": numericValue }`; lat/lon key는 제외 |
+| rank 1 time-only 값 | `location=null`, `attrs=null` | 기존 계약 유지 |
+
+`attrs`는 셀별 map을 재사용하는 serializer로 numeric 값만 직렬화하고, 빈 map은 `NULL`로 둔다. 결과 문자열은 escaped UTF-8 byte length를 계산한 뒤 8,192 bytes 이하일 때만 `PreparedStatement`의 typed `jsonb`/`PGobject` placeholder로 바인딩하며 SQL interpolation은 하지 않는다. key는 원래 full coordinate variable name을 Unicode NFC로 정규화한 strict UTF-8 형태로 사용하고, invalid surrogate·control 문자·길이 초과·canonicalization 후 충돌을 거부한다. 예약된 `__bluetape4k_` 접두사는 coordinate variable name으로 사용할 수 없다. JSONB 직렬화 또는 batch binding 실패는 해당 tile transaction을 실패시키고 원래 예외를 보존한 채 best-effort `FAILED` 기록을 남긴다. 기존 partial unique index와 `ON CONFLICT DO NOTHING`은 재시도 멱등성을 위해 유지한다.
+
+내부 `TileRow`의 `longitude`/`latitude`는 `Double?`이다. rank 1 time-only 행은 두 값이
+모두 `null`이어야 하며, rank 2–4 spatial 행은 둘 다 non-null이어야 한다. 한 쪽만
+`null`인 mixed 상태는 SQL에 바인딩하기 전에 내부 invariant 위반으로 거부한다. writer는
+두 값이 모두 `null`이면 기존 `location` column에 typed SQL `NULL`을 바인딩하고, 두 값이
+모두 non-null이면 `(lon, lat)` 순서로 PostGIS point를 만든다. 이 invariant를 rank별
+테스트와 recording writer에서 고정해 nullable API와 저장 계약이 어긋나지 않게 한다.
+
+## 5. 오류와 상태 전이
+
+- 필수 spatial coordinate가 없으면 `MissingCoordinate`.
+- coordinate axis가 ambiguous하거나 rank/shape/dimension이 지원 계약과 맞지 않으면 새 `NetCdfException.UnsupportedCoordinateAxis`.
+- 같은 spatial slice에서 canonical 위치가 중복되면 `NetCdfException.DuplicateCoordinate`.
+- dimension product, token/count, cache, batch, JSONB 또는 파일 크기 예산을 넘으면 `NetCdfException.ResourceLimitExceeded`.
+- whitelist 밖 CRS 또는 proj4j 변환 실패, malformed/missing `grid_mapping`(projected axis), 정확히 해석할 수 없는 EPSG 값은 `UnsupportedProjection`이다. `grid_mapping`이 존재할 때 WGS84로 묵시적 fallback하지 않는다. EPSG는 정수 문자열을 exact parse하며 numeric narrowing/overflow를 허용하지 않는다.
+- NUL/control 문자, URI scheme, 원격 URL, 심볼릭 링크 경로, regular file이 아닌
+  경로 또는 실제 open 실패는 `NetCdfException.FileOpen`으로 감싼다. 호출자는
+  허용된 regular file 경로로 수정한 뒤 `registerFile`을 새로 호출하고 새
+  `fileId`로 import해야 하며, 잘못된 경로의 progress를 resume하지 않는다.
+- 데이터 값 NaN/`_FillValue`는 기존처럼 행을 skip하고 `netcdf.import.nan.skipped`를 증가시킨다.
+- import 시작 시 persisted file identity `(fileKey, size, lastModifiedTime)`와 현재 regular-file identity를 비교한다. 이 identity는 기존 file record의 JSONB metadata에 예약된 `__bluetape4k_source_fingerprint`로 보존하며, fingerprint는 `fileKey|size|lastModifiedTime.epochNanos`의 strict ASCII 표현으로 기록한다. `fileKey`가 없는 파일과 예약 key를 이미 가진 input metadata는 등록을 거부한다. 누락되거나 불일치하는 fingerprint는 항상 `FileChanged`로 중단하고, 수정된 파일은 반드시 새 등록·새 `fileId`를 만든다. 기존 `fileId`의 progress 또는 partial rows를 조용히 재사용하지 않는다. 누락된 구형 record도 새 import만 허용하고 resume은 `FileChanged`로 중단한다. 파일 내용은 progress가 존재하는 동안 immutable하다는 운영 전제를 함께 문서화하고, validation 직후 다시 stat하여 TOCTOU 교체도 감지한다.
+- progress invariant는 `PENDING/FAILED => lease=null, completedAt=null`, `IN_PROGRESS => lease!=null, completedAt=null`, `COMPLETED => lease=null, completedAt!=null`이며, checkpoint는 dataset의 실제 `totalSlices`에 대해 `-1..totalSlices-1` 범위여야 한다. `IN_PROGRESS`인데 `lease_expires_at IS NULL`인 malformed progress는 acquire 단계에서 row lock 아래 원자적으로 `FAILED` repair 후 새 lease를 부여한다. 상태/owner/token invariant가 서로 어긋나거나 `COMPLETED` checkpoint가 마지막 slice와 다르면 `CorruptProgress`로 중단한다. 이때 `COMPLETED`로 추측 전환하지 않는다.
+- 모든 tile transaction은 lease fence를 수행한다. `CancellationException`/`InterruptedException`은 원래 예외와 interrupt 상태를 보존하고 `FAILED`로 바꾸지 않으며 lease expiry에 맡긴다. 그 밖의 실패는 best-effort `markFailed`를 시도하되 mark 자체의 오류를 원래 예외에 suppressed로 추가한다. slice timer는 성공·실패 모두 `finally`에서 종료한다.
+- 기존 `ImportAlreadyRunning`, `ImportLeaseLost`, `FAILED`/`COMPLETED` 및 재호출 no-op 계약은 변경하지 않는다.
+
+lease 만료 비교·연장은 DB의 UTC `CURRENT_TIMESTAMP`를 단일 기준으로 사용하고, 애플리케이션 clock을 SQL 비교값으로 사용하지 않는다. 테스트에서는 repository에 주입한 deterministic clock 또는 DB clock fixture로 만료 직전/동시 takeover 경계를 고정한다. 운영 문서에는 DB와 importer 호스트의 UTC 동기화 요구를 남긴다.
+
+`UnsupportedCoordinateAxis`, `DuplicateCoordinate`, `ResourceLimitExceeded`,
+`FileChanged`, `CorruptProgress`는 `2.0.0` major release에서 sealed base에 추가하는
+다섯 public subtype이다. 따라서 `1.x` 소비자가 구체 subtype을 exhaustive `when`으로
+분기했다면 재컴파일 때 다섯 branch를 추가해야 하며, 새 API를 받는 코드는 구체 subtype
+대신 `NetCdfException`을 catch하고 `when`에 `else`/기본 오류 경로를 둔다. 공개 API
+호환성 테스트는 다섯 subtype branch와 base-type `else` fixture를 모두 컴파일하고,
+각 구조화 필드와 stable reason이 보존되는지 검증한다. 오류 메시지에는 변수·축·원인,
+fileId/progressId 또는 resource limit 등 subtype별 진단 필드를 포함한다.
+
+## 6. 테스트 설계
+
+`NetCdfSampleWriter`에 다음 fixture를 추가한다.
+
+1. 2D geographic `lat(y,x)`, `lon(y,x)`, `temperature(time,y,x)` fixture
+2. CF `coordinates="lat lon altitude"`와 `altitude(y,x)` auxiliary fixture
+3. 데이터 dimension 순서를 `[time,x,y]`로 바꾼 fixture
+4. 지원 projected CRS fixture와 unsupported `grid_mapping_name` fixture
+5. duplicate canonical point, malformed/overflow EPSG, invalid range, remote/symlink/NUL path fixture
+6. `coordinates="time lat lon altitude"` fixture에서 time/level rank-1 축을 auxiliary로 오인하지 않는 경로
+
+`NetCdfCatalogServiceTest` 및 필요한 internal unit test에서 다음을 고정한다.
+
+- 각 셀의 `(lon, lat, value)` read-back과 JSONB auxiliary 값
+- 2D 축의 행/열 orientation과 비표준 변수 dimension 순서
+- `CoordinateReader.read2D` row-major index 공식과 row/column이 뒤집힌 축 fixture
+- 지원 CRS reprojection 결과와 `UnsupportedProjection`
+- 누락·ambiguous·shape 불일치 축의 `UnsupportedCoordinateAxis`
+- 기존 1D 및 rank 1–4, NaN/`_FillValue`, upsert 회귀
+- 2D fixture의 resume, stale lease, 동시 호출, progress 상태, Micrometer counter/timer
+- 강제 lease takeover 중 stale importer rollback, null lease repair, out-of-range checkpoint, same-size 파일 교체와 validation/open 사이 TOCTOU 후 resume 거부
+- 서로 다른 두 tile 경계(row/column offset이 다른 위치)에 동일 canonical point를 배치한 fixture에서 두 번째 pass 시작 전 `rows-written=0`과 `DuplicateCoordinate`를 확인한다.
+- progress 상태 invariant, owner/token 불일치, `COMPLETED` checkpoint 불일치, DB UTC clock 만료 경계와 injected clock 테스트
+- `NetCdfException`을 base 타입으로 catch하고 `else` 경로를 둔 대표 `2.0.0` 소비자
+  compile fixture, 새 `UnsupportedCoordinateAxis`의 변수·축·원인 필드 보존
+- 대용량 contract fixture는 고정 `1024×1024` spatial cells, deterministic values, one auxiliary, `slow-netcdf` tag로 생성한다. 1D regression baseline은 동일한 cell 수·값 생성기를 사용하는 기존 1D path로 별도 고정하고, 2D+auxiliary `cells/sec`는 workload가 다르므로 절대 측정값으로만 보고한다. 각 baseline/feature run은 새 unique fileId와 clean DB(테이블 truncate 또는 새 Testcontainers instance)로 시작해 `ON CONFLICT`/기존 progress가 측정치를 왜곡하지 않게 한다. baseline과 feature 모두 동일 JVM/Gradle/PostGIS image, 1 warm-up + 3 sequential measured runs, median을 사용한다. `cells/sec` 범위는 fixture read 시작부터 마지막 tile commit까지(생성·register 제외)다. 결과 artifact에 JVM `-Xmx`, Docker image, Gradle command, run durations/median, peak heap(관찰값), owned working-set counters를 남긴다. tile read 셀 수 `<=65,536`, JDBC batch 행 수 `<=1,000`, owned working-set `<=128 MiB`, 1D path 처리량은 origin baseline median 대비 20% 이상 하락하지 않아야 한다.
+- JSONB key control/quote/injection-like name, invalid surrogate, empty attrs, escaped UTF-8 payload의 8,192/8,193-byte 경계, typed placeholder binding을 검증한다.
+
+실제 PostGIS/Testcontainers 검증은 모듈 간 동시 실행을 피하고 한 Gradle invocation에서 순차적으로 수행한다.
+
+## 7. 문서와 호환성
+
+- `NetCdfCatalogService`와 internal class KDoc에서 `CoordinateAxis2D`가 지원 범위임을 설명하고, unsupported axis/CRS 예외를 갱신한다.
+- `utils/science/README.md`와 `README.ko.md`의 기능표·예제·제약을 동일하게 갱신한다.
+- `docs/followup-issues/utils-science-readme-rewrite.md`의 #1352 후속 상태를 구현 결과와 일치시킨다.
+  - public schema migration은 없다. 기존 `attrs`를 읽는 소비자는 영향이 없고, 새 auxiliary key를 해석하지 않아도 `location` 기반 기존 조회는 계속 동작한다.
+- README와 KDoc에는 다음 blocking 호출·복구 예시를 포함한다.
+
+  ```kotlin
+  val executor = Executors.newVirtualThreadPerTaskExecutor()
+  val task: Future<Long> = executor.submit {
+      val fileId = service.registerFile("/srv/netcdf/grid.nc") // trusted-admin 경계
+      service.importGridValues(fileId, "temperature")
+      fileId
+  }
+  try {
+      val fileId = task.get(30, TimeUnit.MINUTES)
+      // DB read-back: location=(lon, lat), attrs["altitude"]=numeric value
+      fileId
+  } catch (timeout: TimeoutException) {
+      task.cancel(true) // cooperative interrupt; completion is not implied
+      throw timeout
+  } finally {
+      executor.shutdownNow()
+      check(executor.awaitTermination(30, TimeUnit.SECONDS)) {
+          "import worker did not terminate"
+      }
+  }
+  ```
+
+  `cancel(true)`는 협력적 취소일 뿐 worker 종료나 side effect 부재를 보장하지 않는다.
+  timeout/interrupt 뒤에는 bounded `awaitTermination`을 기다리고, 등록된 `fileId`가
+  있으면 DB에서 progress·lease·partial rows를 재조회해 active connection=0, 추가
+  renew 없음, 현재 tile rollback을 확인한 뒤에만 재시도한다. worker가 30초 안에 종료되지
+  않거나 상태를 증명할 수 없으면 재시도하지 않고 운영자에게 escalation한다.
+
+  `UnsupportedCoordinateAxis`/`UnsupportedProjection`/`ResourceLimitExceeded`는
+  입력·metadata를 고친 뒤 항상 새 등록·새 `fileId`로 호출한다. `FileOpen`/`FileChanged`/
+  `MissingCoordinate`/`VariableNotFound`/`UnsupportedVariable`/`DuplicateCoordinate`도
+  경로·파일·축·변수를 수정한 뒤 새 `fileId`를 만들며, 변경된 fingerprint의 기존
+  progress/partial rows를 재사용하지 않는다. `CorruptProgress`는 자동 재시도를 중지하고,
+  application-owned admin 절차에서 progress row를 `SELECT ... FOR UPDATE`로 잠근 뒤
+  상태·checkpoint·lease의 기준 상태 기록과 `progressId`를 audit/quarantine에 기록한다.
+  기존 column만 사용하는 경우 기준 상태 기록 후 `PENDING/IN_PROGRESS/FAILED` row는
+  stable `CORRUPT_PROGRESS:<progressId>` 오류와 함께 `FAILED`, `lease=null`로 격리하고,
+  `COMPLETED` row는 변경하지 않은 채 old `fileId`를 차단한다. partial rows는 old
+  `fileId`에 묶어 보존하거나 tenant retention 정책에 따라 삭제한 뒤, 수정·검증한 파일을
+  반드시 새 등록·새 `fileId`로 import한다. library 내부에는 progress in-place reset API가
+  없으며, 명시적 admin repair 없이 reset하지 않는다.
+
+  `ImportAlreadyRunning`/`ImportLeaseLost`는 각각 최대 3회만 재시도하고 backoff는
+  1초·2초·4초로 제한한다. 세 번 소진하면 원래 typed exception을 표면화하고 alert를
+  발생시키며 무한 loop를 만들지 않는다. `CancellationException`/interrupt는 원래
+  예외와 interrupt 상태를 보존한 채 호출자가 취소 결과를 처리한다.
+- `CHANGELOG.md`와 release note는 이번 요청에 포함하지 않으며, release workflow에서 별도 작성한다.
+
+## 8. 실패 모드와 완화
+
+| 실패 모드 | 조기 신호 | 완화 |
+|---|---|---|
+| 2D axis 행/열 방향을 잘못 해석 | fixture의 한 셀 위치가 기대값과 불일치 | axis dimension 순서와 데이터 dimension 위치를 별도 binding하고 read-back 테스트 고정 |
+| auxiliary 값과 데이터 셀 shape 불일치 | map 생성 시 rank/shape mismatch | import 전에 shape 검증 후 `UnsupportedCoordinateAxis`로 조기 거부 |
+| dimension 순서가 바뀐 변수의 값/좌표 엇갈림 | `[time,x,y]` fixture에서 값이 전치됨 | `Index.set(IntArray)` 기반 full-rank lookup 사용, iterator 사용 금지 |
+| JSONB 직렬화 또는 batch binding 실패 | tile transaction 예외, progress `FAILED` | numeric map·payload cap·typed placeholder만 허용하고 원래 예외를 보존한 best-effort failure 기록 |
+| projected 2D cache의 메모리 증가 | 대용량 fixture heap pressure | bounded tile/lazy cache, 64 MiB budget, checked `Long` 산식, peak heap/cells-sec gate |
+| unsupported grid mapping을 WGS84로 오인 | rotated/tripolar fixture가 성공함 | EPSG/grid_mapping whitelist를 먼저 검사하고 typed exception 테스트 고정 |
+| lease 만료 중 stale tile이 새 owner를 덮어씀 | takeover race에서 progress/row 혼합 | 모든 tile transaction에 lease fence, 중간 tile checkpoint 금지, 실패 시 전체 transaction rollback |
+| 동일 위치의 서로 다른 셀이 unique index에서 사라짐 | duplicate point fixture의 row 수 부족 | schema migration 없이 duplicate preflight 후 `DuplicateCoordinate` rollback; 조용한 conflict 유실 금지 |
+| malformed progress가 영구 잠금 또는 조기 완료를 만듦 | null lease/범위 밖 checkpoint | acquire repair와 범위 검증, `CorruptProgress`/metric, COMPLETED 추측 금지 |
+| 파일 교체 후 resume으로 데이터 혼합 | size mismatch 또는 fixture fingerprint 차이 | trusted immutable-file 전제와 size check; 불일치 시 `FileChanged`로 재등록 요구 |
+| lease token/상태 invariant가 깨진 progress | null owner, stale token, 조기 COMPLETED | row lock 아래 원자 repair/검증, DB UTC clock과 affected-row fence, `CorruptProgress`로 중단 |
+| metadata 총량 또는 압축 고팽창으로 자원 고갈 | variable/dimension/metadata/cell/slice 예산 초과 | 등록·import 전 hard limit, checked `Long`, rejection metric, caller deadline |
+
+## 9. 수용 기준과 DoD
+
+| #1352 기준 | 검증 방법 | 완료 조건 |
+|---|---|---|
+| 2D lat/lon 및 CF auxiliary fixture import | `NetCdfCatalogServiceTest` | fixture 생성·import·row read-back PASS |
+| 셀 좌표와 값 매핑 보존 | 2D/비표준 dimension order 테스트 | 모든 셀의 좌표·값이 기대 인덱스와 일치 |
+| 지원 CRS reprojection 및 unsupported CRS error | EPSG fixture와 `assertFailsWith` | 변환 결과 PASS, `UnsupportedProjection` PASS |
+| 기존 1D/rank 1–4 및 resume/lease 회귀 | 기존 전체 service test + 2D resume/concurrency | 회귀 0건, progress 상태와 lease 경계 PASS |
+| 대용량 memory/performance 및 schema 영향 문서화 | KDoc/README/spec, 고정 bounded fixture fresh run | 전체 배열 read 없음, tile/batch/cache/owned working-set/throughput 예산 PASS, JVM peak은 별도 관찰값, migration 없음과 duplicate 거부 정책 명시 |
+
+최종 구현 DoD는 다음 상태에서만 `PASS`다.
+
+- 승인된 명세·계획과 branch diff가 일치한다.
+- targeted Testcontainers 테스트, compile, detekt/static check, `git diff --check`가 fresh run에서 성공한다.
+- Type A 독립 review 6개 관점과 통합 review에 P0/P1이 없다.
+- PR body가 한국어이고 마지막 섹션이 정확히 `## DoD Status`다.
+- exact-head CI/review와 merge-ready report를 확인한 뒤, 사용자의 fresh approval 후에만 rebase merge한다.
+
+## 10. Writer gate
+
+| 항목 | 결과 | 근거 |
+|---|---|---|
+| SPW-01 audience/purpose/evidence | PASS | #1352/#1421, current source anchors, NetCDF-Java 5.9.1 API, baseline compile을 명시했다. |
+| SPW-02 artifact contract | PASS | 문제, 제약, 대안, 내부 계약, 자원·보안 경계, 오류, 테스트, 호환성, 실패 모드, 수용 기준을 포함했다. |
+| SPW-03 Korean technical register | PASS | 한국어 기술 문체를 사용하고 API·명령·식별자·URL·숫자는 보존했다. |
+| SPW-04 technical traceability | PASS | 기존 `VariableAxisMap`, `CoordinateReprojector`, service read path, schema unique index/lease, issue acceptance를 각 결정에 연결했다. |
+| SPW-05 read-back | PASS | Markdown heading/table/code fence와 결정·제약·unchecked 범위를 재독했다. |

--- a/utils/science/README.ko.md
+++ b/utils/science/README.ko.md
@@ -21,10 +21,11 @@ GIS 좌표 변환, Shapefile 처리, JTS 도형 연산, PostGIS 데이터베이�
 > 서비스는 UCAR netCDF-Java 5.9.1 기반의 동기(blocking) API이며 UCAR 아티팩트는
 > `compileOnly`로 선언되어 있으므로 서비스를 호출하는 애플리케이션이 런타임에 제공해야 합니다.
 >
-> 현재 임포터는 rank 1~4 변수와 1차원 좌표축을 지원합니다. 5분 heartbeat lease 기반
-> 슬라이스 재개, EPSG:4326 재투영을 위한 CRS 화이트리스트, NaN/`_FillValue` 자동 skip도
-> 제공합니다. `CoordinateAxis2D`와 CF auxiliary-coordinate 격자는 현재 범위 밖이며
-> 후속 이슈 [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352)에서 다룹니다.
+> 현재 임포터는 rank 1~4 변수와 1·2차원 좌표축, numeric CF auxiliary coordinate를
+> 지원합니다. bounded tile read, slice 전체 중복 사전 검증, 5분 heartbeat lease 기반
+> 재개, EPSG:4326 재투영을 위한 CRS 화이트리스트, NaN/`_FillValue` 자동 skip도
+> 제공합니다. 보조 좌표 값은 기존 `attrs` JSONB에 저장하고 canonical
+> `(longitude, latitude)`는 기존 PostGIS `location`에 저장합니다.
 
 ---
 
@@ -116,7 +117,7 @@ io.bluetape4k.science/
 | | NetCDF 격자 값 저장 스키마 | `NetCdfGridValueTable` ✅ |
 | | `.nc` 파일 등록 | `NetCdfCatalogService.registerFile()` ✅ |
 | | rank 1~4 격자 임포트 | `NetCdfCatalogService.importGridValues()` ✅ |
-| | CoordinateAxis2D / auxiliary 좌표 | 후속 [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352) |
+| | CoordinateAxis2D / CF auxiliary 좌표 | `NetCdfCatalogService.importGridValues()` ✅ |
 
 ---
 
@@ -298,14 +299,47 @@ val fileId = catalog.registerFile("/data/era5/ERA5_2024_01.nc")
 catalog.importGridValues(fileId, variableName = "temperature")
 ```
 
+두 호출은 blocking이므로 호출자가 virtual-thread의 deadline과 취소 수명주기를
+소유해야 합니다. timeout은 cooperative cancel일 뿐 import 완료를 의미하지 않으므로,
+재시도하기 전에 progress row를 조회하세요.
+
+```kotlin
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+val executor = Executors.newVirtualThreadPerTaskExecutor()
+val task = executor.submit {
+    val fileId = catalog.registerFile("/srv/netcdf/grid.nc") // trusted-admin 경로
+    catalog.importGridValues(fileId, "temperature")
+    fileId
+}
+try {
+    task.get(30, TimeUnit.MINUTES)
+} catch (timeout: TimeoutException) {
+    task.cancel(true)
+    throw timeout
+} finally {
+    executor.shutdownNow()
+    check(executor.awaitTermination(30, TimeUnit.SECONDS)) { "import worker did not stop" }
+}
+```
+
 지원 rank의 저장 좌표는 다음과 같습니다.
 
 | 변수 rank | 저장 좌표 |
 |-----------|----------|
 | 1D (`time`) | `timeIdx=t`, `levelIdx=0`, `location=null` |
-| 2D (`lat`, `lon`) | `timeIdx=0`, `levelIdx=0`, 셀마다 PostGIS `POINT` |
+| 2D (`lat`, `lon`), `CoordinateAxis2D` 포함 | `timeIdx=0`, `levelIdx=0`, 셀마다 PostGIS `POINT` |
 | 3D (`time`, `lat`, `lon`) | `timeIdx=t`, `levelIdx=0`, 셀마다 `POINT` |
 | 4D (`time`, `level`, `lat`, `lon`) | `timeIdx=t`, `levelIdx=k`, 셀마다 `POINT` |
+
+CF `coordinates` 토큰 중 time·level·latitude·longitude가 아닌 numeric 좌표는
+auxiliary coordinate로 취급해 `attrs`에 직렬화합니다(예: `{"altitude": 125.0}`).
+`[time, x, y]` 같은 비표준 데이터 dimension 순서도 보존하며, tile은 65,536셀,
+JDBC batch는 1,000행으로 제한합니다. slice를 쓰기 전에 canonical 좌표 중복을 검증하고,
+지원하지 않는 축·잘못된 CRS metadata·변경된 파일·손상된 progress·자원 한도 초과는
+typed `NetCdfException` 하위 타입으로 보고합니다.
 
 각 `(fileId, variableName)` 임포트는 5분 heartbeat lease와 슬라이스 cursor를
 사용합니다. `COMPLETED` 상태는 no-op이며, 실패했거나 만료된 임포트는
@@ -376,13 +410,14 @@ catalog.importGridValues(fileId, variableName = "temperature")
 | `NetCdfFileRepository` | ✅ | 파일 메타데이터 CRUD (`save`, `findById`, `findAll`, `deleteById`) |
 | `NetCdfFileTable` | ✅ | JSONB 컬럼 + PostGIS bbox + 시간 범위 |
 | `NetCdfGridValueTable` | ✅ | 격자 값 테이블 (location: PostGIS POINT, value, timeIdx, levelIdx) |
-| `NetCdfCatalogService` | ✅ | 동기 `registerFile()`·`importGridValues()`; rank 1~4, lease/resume, CRS 화이트리스트, NaN/`_FillValue` 처리 |
+| `NetCdfCatalogService` | ✅ | 동기 `registerFile()`·`importGridValues()`; rank 1~4, 1D/2D 축, CF numeric auxiliary, bounded tile, lease/resume, CRS 화이트리스트, NaN/`_FillValue` 처리 |
 
 `NetCdfCatalogService`는 안정적인 sealed 예외 계약을 제공합니다. 빈 경로와
 변수명은 `IllegalArgumentException`을 발생시키며, 파일·변수·좌표 누락,
-지원하지 않는 rank/CRS, 활성 lease, lease 손실은 각각의 `NetCdfException`
-하위 타입으로 보고합니다. `CoordinateAxis2D`는 현재 `MissingCoordinate`로
-거부되며 [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352)에서 별도로 추적합니다.
+지원하지 않는 rank/축/CRS, 활성 lease, lease 손실, 파일 변경, 손상된 progress,
+좌표 중복, 자원 한도 초과는 각각의 `NetCdfException` 하위 타입으로 보고합니다.
+기존 schema를 재사용해 `location`에는 canonical `(lon, lat)`, `attrs`에는
+bounded numeric auxiliary JSONB를 저장합니다.
 
 ---
 

--- a/utils/science/README.md
+++ b/utils/science/README.md
@@ -22,10 +22,12 @@ Shapefile I/O, JTS geometry operations, PostGIS database pipelines, and NetCDF m
 > The service is a blocking API backed by UCAR netCDF-Java 5.9.1, and the UCAR artifacts remain
 > `compileOnly`: applications that call the service must provide them at runtime.
 >
-> The current importer supports rank 1–4 variables and one-dimensional coordinate axes. It also
-> provides resumable slice imports with a five-minute heartbeat lease, a CRS whitelist with
-> reprojection to EPSG:4326, and automatic NaN/`_FillValue` skipping. `CoordinateAxis2D` and CF
-> auxiliary-coordinate grids are outside the current scope; see follow-up issue [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352).
+> The current importer supports rank 1–4 variables, one- and two-dimensional coordinate axes,
+> and numeric CF auxiliary coordinates. It provides bounded tile reads, slice-wide duplicate
+> preflight, resumable imports with a five-minute heartbeat lease, a CRS whitelist with
+> reprojection to EPSG:4326, and automatic NaN/`_FillValue` skipping. Auxiliary values are
+> stored in the existing `attrs` JSONB column; canonical `(longitude, latitude)` values remain
+> in the existing PostGIS `location` column.
 
 ---
 
@@ -115,7 +117,7 @@ io.bluetape4k.science/
 | | NetCDF grid value storage schema | `NetCdfGridValueTable` ✅ |
 | | `.nc` file registration | `NetCdfCatalogService.registerFile()` ✅ |
 | | Rank 1–4 grid import | `NetCdfCatalogService.importGridValues()` ✅ |
-| | CoordinateAxis2D / auxiliary coordinates | Follow-up [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352) |
+| | CoordinateAxis2D / CF auxiliary coordinates | `NetCdfCatalogService.importGridValues()` ✅ |
 
 ---
 
@@ -297,14 +299,48 @@ val fileId = catalog.registerFile("/data/era5/ERA5_2024_01.nc")
 catalog.importGridValues(fileId, variableName = "temperature")
 ```
 
+Because both calls are blocking, a virtual-thread caller should own its deadline
+and cancellation lifecycle. A timeout cancels cooperatively; it does not imply
+that an import completed, so callers should read the progress row before retrying.
+
+```kotlin
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+val executor = Executors.newVirtualThreadPerTaskExecutor()
+val task = executor.submit {
+    val fileId = catalog.registerFile("/srv/netcdf/grid.nc") // trusted-admin path
+    catalog.importGridValues(fileId, "temperature")
+    fileId
+}
+try {
+    task.get(30, TimeUnit.MINUTES)
+} catch (timeout: TimeoutException) {
+    task.cancel(true)
+    throw timeout
+} finally {
+    executor.shutdownNow()
+    check(executor.awaitTermination(30, TimeUnit.SECONDS)) { "import worker did not stop" }
+}
+```
+
 The importer maps the supported ranks as follows:
 
 | Variable rank | Stored coordinates |
 |---------------|--------------------|
 | 1D (`time`) | `timeIdx=t`, `levelIdx=0`, `location=null` |
-| 2D (`lat`, `lon`) | `timeIdx=0`, `levelIdx=0`, one PostGIS `POINT` per cell |
+| 2D (`lat`, `lon`), including `CoordinateAxis2D` | `timeIdx=0`, `levelIdx=0`, one PostGIS `POINT` per cell |
 | 3D (`time`, `lat`, `lon`) | `timeIdx=t`, `levelIdx=0`, one `POINT` per cell |
 | 4D (`time`, `level`, `lat`, `lon`) | `timeIdx=t`, `levelIdx=k`, one `POINT` per cell |
+
+CF `coordinates` tokens that are not time, level, latitude, or longitude are treated as
+numeric auxiliary coordinates and serialized into `attrs` (for example,
+`{"altitude": 125.0}`). The importer preserves non-standard data dimension order such as
+`[time, x, y]`, bounds each tile to 65,536 cells and each JDBC batch to 1,000 rows, and
+rejects duplicate canonical coordinates before writing a slice. Unsupported axes, malformed
+CRS metadata, changed files, corrupt progress, and resource-limit violations are reported as
+typed `NetCdfException` subtypes.
 
 Each `(fileId, variableName)` import has a five-minute heartbeat lease and a
 slice cursor. `COMPLETED` imports are no-ops; a failed or expired import resumes
@@ -375,13 +411,14 @@ and counted by `netcdf.import.nan.skipped`.
 | `NetCdfFileRepository` | ✅ | File metadata CRUD (`save`, `findById`, `findAll`, `deleteById`) |
 | `NetCdfFileTable` | ✅ | Exposed table — JSONB columns + PostGIS bbox + time range |
 | `NetCdfGridValueTable` | ✅ | Grid value table (location: PostGIS POINT, value, timeIdx, levelIdx) |
-| `NetCdfCatalogService` | ✅ | Blocking `registerFile()` and `importGridValues()`; rank 1–4, lease/resume, CRS whitelist, NaN/`_FillValue` handling |
+| `NetCdfCatalogService` | ✅ | Blocking `registerFile()` and `importGridValues()`; rank 1–4, 1D/2D axes, CF numeric auxiliary coordinates, bounded tiles, lease/resume, CRS whitelist, NaN/`_FillValue` handling |
 
 `NetCdfCatalogService` exposes a stable sealed-exception contract. Blank paths or
 variable names raise `IllegalArgumentException`; missing files, variables,
-coordinates, unsupported ranks/CRS, active leases, and lost leases are reported
-as the corresponding `NetCdfException` subtype. `CoordinateAxis2D` is currently
-rejected as `MissingCoordinate` and is tracked separately in [#1352](https://github.com/bluetape4k/bluetape4k-projects/issues/1352).
+coordinates, unsupported ranks/axes/CRS, active leases, lost leases, changed
+files, corrupt progress, duplicates, and resource-limit violations are reported
+as the corresponding `NetCdfException` subtype. Existing schema columns are reused:
+`location` stores canonical `(lon, lat)` and `attrs` stores bounded numeric auxiliary JSONB.
 
 ---
 

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/NetCdfException.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/NetCdfException.kt
@@ -10,8 +10,13 @@ package io.bluetape4k.science.exposed
  * - [FileRecordNotFound] : DB 에 등록된 파일 레코드가 없을 때
  * - [VariableNotFound] : 지정된 변수가 파일에 없을 때
  * - [UnsupportedVariable] : 변수 rank 가 지원 범위(1~4) 외일 때
- * - [MissingCoordinate] : lat/lon/level 좌표축이 누락되었거나 [ucar.nc2.dataset.CoordinateAxis1D] 가 아닐 때
- * - [UnsupportedProjection] : 좌표 참조계가 화이트리스트(EPSG:4326/3857/3031/3413/UTM 32601~32660·32701~32760) 외이거나 proj4j 변환 실패 시
+ * - [MissingCoordinate] : lat/lon/level 좌표축이 누락되었을 때
+ * - [UnsupportedCoordinateAxis] : 축이 CF 역할·차원·자료형 계약을 만족하지 않을 때
+ * - [UnsupportedProjection] : 좌표 참조계가 화이트리스트(EPSG:4326/4269/3857/3031/3413/UTM 32601~32660·32701~32760) 외이거나 proj4j 변환 실패 시
+ * - [DuplicateCoordinate] : 한 slice 안에서 정규화된 좌표 키가 중복될 때
+ * - [ResourceLimitExceeded] : bounded import resource budget 을 초과할 때
+ * - [FileChanged] : 등록·재개 중 파일 identity fingerprint 가 바뀔 때
+ * - [CorruptProgress] : progress checkpoint/status invariant 가 손상되었을 때
  * - [ImportAlreadyRunning] : 동일 (fileId, variableName) import 가 이미 lease 를 소유 중일 때
  * - [ImportLeaseLost] : lease 만료 후 다른 importer 가 같은 progress row 를 재획득했을 때
  *
@@ -35,13 +40,23 @@ sealed class NetCdfException(message: String, cause: Throwable? = null): Runtime
     class UnsupportedVariable(variableName: String, rank: Int):
         NetCdfException("Variable '$variableName' has unsupported rank=$rank (must be 1, 2, 3, or 4)")
 
-    /**
-     * lat/lon/level 좌표축이 누락되었거나 [ucar.nc2.dataset.CoordinateAxis1D] 가 아닐 때 발생합니다.
-     *
-     * `CoordinateAxis2D` (curvilinear / rotated pole / tripolar grid) 는 본 구현 스코프 외입니다.
-     */
+    /** 필수 좌표축이 누락되었을 때 발생합니다. */
     class MissingCoordinate(axisName: String):
-        NetCdfException("Required coordinate axis '$axisName' is missing or not a 1D numeric axis")
+        NetCdfException("Required coordinate axis '$axisName' is missing")
+
+    /**
+     * 좌표축이 CF 역할·차원·자료형 계약을 만족하지 않을 때 발생합니다.
+     *
+     * 이 subtype 추가는 2.0.0 major API migration 대상입니다. 기존 sealed
+     * `when` 소비자는 명시적인 branch 또는 `else`를 추가해야 합니다.
+     */
+    class UnsupportedCoordinateAxis(
+        val variableName: String,
+        val coordinateName: String?,
+        val reason: String,
+    ): NetCdfException(
+        "Unsupported coordinate axis: variable=$variableName coordinate=$coordinateName reason=$reason",
+    )
 
     /**
      * proj4j 로 EPSG:4326 으로 재투영할 수 없는 CRS 일 때 발생합니다.
@@ -50,6 +65,39 @@ sealed class NetCdfException(message: String, cause: Throwable? = null): Runtime
      */
     class UnsupportedProjection(srcCrs: String, cause: Throwable? = null):
         NetCdfException("Unsupported projection: '$srcCrs' (cannot reproject to EPSG:4326)", cause)
+
+    /** 동일 slice 안에서 canonical 좌표 키가 중복될 때 발생합니다. */
+    class DuplicateCoordinate(
+        val fileId: Long,
+        val variableName: String,
+        val timeIdx: Int,
+        val levelIdx: Int,
+        val longitude: Double,
+        val latitude: Double,
+    ): NetCdfException(
+        "Duplicate coordinate: fileId=$fileId variable=$variableName time=$timeIdx level=$levelIdx " +
+            "lon=$longitude lat=$latitude",
+    )
+
+    /** import 가 bounded resource budget 을 초과할 때 발생합니다. */
+    class ResourceLimitExceeded(
+        val resource: String,
+        val limit: Long,
+        val actual: Long,
+    ): NetCdfException("Resource limit exceeded: $resource limit=$limit actual=$actual")
+
+    /** 파일 fingerprint 가 등록 시점 또는 resume 시점과 달라졌을 때 발생합니다. */
+    class FileChanged(
+        val fileId: Long,
+        val expectedFingerprint: String,
+        val actualFingerprint: String,
+    ): NetCdfException("NetCDF file changed while import was resumable: fileId=$fileId")
+
+    /** progress checkpoint/status invariant 가 손상되었을 때 발생합니다. */
+    class CorruptProgress(
+        val progressId: Long,
+        val detail: String,
+    ): NetCdfException("Corrupt NetCDF import progress: progressId=$progressId detail=$detail")
 
     /**
      * 동일 (fileId, variableName) import 가 활성 lease 를 보유 중일 때 발생합니다.

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/repository/NetCdfImportProgressRepository.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/repository/NetCdfImportProgressRepository.kt
@@ -96,57 +96,61 @@ class NetCdfImportProgressRepository {
         variableName: String,
         leaseTtl: Duration = DEFAULT_LEASE_TTL,
     ): NetCdfImportProgress {
-        // Step 1: 기존 row 조회 (COMPLETED 분기)
-        val existing = findByFileAndVariable(fileId, variableName)
-        if (existing != null && existing.status == NetCdfImportStatus.COMPLETED) {
-            log.info { "lease skipped — already completed: fileId=$fileId var=$variableName" }
-            return existing
+        require(leaseTtl.seconds > 0L && leaseTtl.nano == 0) {
+            "leaseTtl must be a positive whole-second duration: $leaseTtl"
         }
-
-        // Step 2: 조건부 UPSERT (PENDING / FAILED / 만료 IN_PROGRESS 만 허용)
-        val now = Instant.now()
-        val leaseExp = now.plus(leaseTtl)
-        // started_at 은 최초 시작 시각을 보존 — 재개(FAILED→IN_PROGRESS) 시 COALESCE 로 기존 값 유지 (M3).
-        // 컬럼은 NOT NULL 이라 EXCLUDED.started_at 분기는 dead — 의도된 방어적 안전망.
+        val leaseSeconds = leaseTtl.seconds
         val sql = """
             INSERT INTO netcdf_import_progress
                 (file_id, variable_name, status, last_slice_idx, lease_expires_at, error_message,
                  started_at, completed_at, updated_at)
-            VALUES (?, ?, ?, NULL, ?, NULL, ?, NULL, ?)
+            VALUES (?, ?, 'IN_PROGRESS', NULL,
+                    clock_timestamp() + (? * INTERVAL '1 second'), NULL,
+                    CURRENT_TIMESTAMP, NULL, CURRENT_TIMESTAMP)
             ON CONFLICT (file_id, variable_name)
             DO UPDATE SET
-                status = EXCLUDED.status,
-                lease_expires_at = EXCLUDED.lease_expires_at,
-                started_at = COALESCE(netcdf_import_progress.started_at, EXCLUDED.started_at),
+                status = 'IN_PROGRESS',
+                lease_expires_at = clock_timestamp() + (? * INTERVAL '1 second'),
                 error_message = NULL,
-                updated_at = EXCLUDED.updated_at
+                completed_at = NULL,
+                updated_at = CURRENT_TIMESTAMP
             WHERE
                 netcdf_import_progress.status IN ('PENDING', 'FAILED')
                 OR (netcdf_import_progress.status = 'IN_PROGRESS'
-                    AND netcdf_import_progress.lease_expires_at < ?)
-            RETURNING id, status, last_slice_idx, lease_expires_at, started_at, updated_at
+                    AND netcdf_import_progress.lease_expires_at <= clock_timestamp())
+            RETURNING id, file_id, variable_name, status, last_slice_idx, lease_expires_at,
+                      error_message, started_at, completed_at, updated_at
         """.trimIndent()
 
         val conn = TransactionManager.current().connection.connection as java.sql.Connection
         return conn.prepareStatement(sql).use { stmt ->
             stmt.setLong(1, fileId)
             stmt.setString(2, variableName)
-            stmt.setString(3, NetCdfImportStatus.IN_PROGRESS.name)
-            stmt.setTimestamp(4, Timestamp.from(leaseExp))
-            stmt.setTimestamp(5, Timestamp.from(now))
-            stmt.setTimestamp(6, Timestamp.from(now))
-            stmt.setTimestamp(7, Timestamp.from(now))
+            stmt.setLong(3, leaseSeconds)
+            stmt.setLong(4, leaseSeconds)
 
             stmt.executeQuery().use { rs ->
                 if (!rs.next()) {
-                    // 0 row 갱신 — 활성 lease 보유 중인 다른 프로세스 존재 또는 동시 호출 race
+                    val current = findByFileAndVariable(fileId, variableName)
+                    if (current?.status == NetCdfImportStatus.COMPLETED) {
+                        log.info { "lease skipped — already completed: fileId=$fileId var=$variableName" }
+                        return@use current
+                    }
+                    if (current?.status == NetCdfImportStatus.IN_PROGRESS && current.leaseExpiresAt == null) {
+                        repairMalformedLease(current.id)
+                        return@use acquireLease(fileId, variableName, leaseTtl)
+                    }
                     throw NetCdfException.ImportAlreadyRunning(fileId, variableName)
                 }
                 val newId = rs.getLong("id")
+                val newFileId = rs.getLong("file_id")
+                val newVariableName = rs.getString("variable_name")
                 val newStatus = NetCdfImportStatus.valueOf(rs.getString("status"))
                 val newLastSliceIdx = rs.getLong("last_slice_idx").takeUnless { rs.wasNull() }
                 val newLeaseExp = rs.getTimestamp("lease_expires_at")?.toInstant()
+                val newError = rs.getString("error_message")
                 val newStartedAt = rs.getTimestamp("started_at").toInstant()
+                val newCompletedAt = rs.getTimestamp("completed_at")?.toInstant()
                 val newUpdatedAt = rs.getTimestamp("updated_at").toInstant()
 
                 log.debug {
@@ -156,14 +160,14 @@ class NetCdfImportProgressRepository {
 
                 NetCdfImportProgress(
                     id = newId,
-                    fileId = fileId,
-                    variableName = variableName,
+                    fileId = newFileId,
+                    variableName = newVariableName,
                     status = newStatus,
                     lastSliceIdx = newLastSliceIdx,
                     leaseExpiresAt = newLeaseExp,
-                    errorMessage = null,
+                    errorMessage = newError,
                     startedAt = newStartedAt,
-                    completedAt = null,
+                    completedAt = newCompletedAt,
                     updatedAt = newUpdatedAt,
                 )
             }
@@ -184,25 +188,57 @@ class NetCdfImportProgressRepository {
         lastSliceIdx: Long,
         leaseTtl: Duration = DEFAULT_LEASE_TTL,
     ): Instant {
-        val now = Instant.now()
-        val newExpires = now.plus(leaseTtl)
+        require(leaseTtl.seconds > 0L && leaseTtl.nano == 0) {
+            "leaseTtl must be a positive whole-second duration: $leaseTtl"
+        }
         val sql = """
             UPDATE netcdf_import_progress
-            SET last_slice_idx = ?, lease_expires_at = ?, updated_at = ?
+            SET last_slice_idx = ?,
+                lease_expires_at = clock_timestamp() + (? * INTERVAL '1 second'),
+                updated_at = CURRENT_TIMESTAMP
             WHERE id = ? AND status = 'IN_PROGRESS' AND lease_expires_at = ?
+              AND lease_expires_at > clock_timestamp()
             RETURNING lease_expires_at
         """.trimIndent()
         val conn = TransactionManager.current().connection.connection as java.sql.Connection
         conn.prepareStatement(sql).use { stmt ->
             stmt.setLong(1, lastSliceIdx)
-            stmt.setTimestamp(2, Timestamp.from(newExpires))
-            stmt.setTimestamp(3, Timestamp.from(now))
-            stmt.setLong(4, progressId)
-            stmt.setTimestamp(5, Timestamp.from(expectedLeaseExpiresAt))
+            stmt.setLong(2, leaseTtl.seconds)
+            stmt.setLong(3, progressId)
+            stmt.setTimestamp(4, Timestamp.from(expectedLeaseExpiresAt))
             stmt.executeQuery().use { rs ->
                 if (!rs.next()) {
                     throw NetCdfException.ImportLeaseLost(progressId)
                 }
+                return rs.getTimestamp("lease_expires_at").toInstant()
+            }
+        }
+    }
+
+    /** checkpoint를 전진시키지 않고 현재 owner lease만 연장합니다. */
+    fun touchLease(
+        progressId: Long,
+        expectedLeaseExpiresAt: Instant,
+        leaseTtl: Duration = DEFAULT_LEASE_TTL,
+    ): Instant {
+        require(leaseTtl.seconds > 0L && leaseTtl.nano == 0) {
+            "leaseTtl must be a positive whole-second duration: $leaseTtl"
+        }
+        val sql = """
+            UPDATE netcdf_import_progress
+            SET lease_expires_at = clock_timestamp() + (? * INTERVAL '1 second'),
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ? AND status = 'IN_PROGRESS' AND lease_expires_at = ?
+              AND lease_expires_at > clock_timestamp()
+            RETURNING lease_expires_at
+        """.trimIndent()
+        val conn = TransactionManager.current().connection.connection as java.sql.Connection
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setLong(1, leaseTtl.seconds)
+            stmt.setLong(2, progressId)
+            stmt.setTimestamp(3, Timestamp.from(expectedLeaseExpiresAt))
+            stmt.executeQuery().use { rs ->
+                if (!rs.next()) throw NetCdfException.ImportLeaseLost(progressId)
                 return rs.getTimestamp("lease_expires_at").toInstant()
             }
         }
@@ -214,19 +250,17 @@ class NetCdfImportProgressRepository {
      * @throws NetCdfException.ImportLeaseLost 같은 progress row 를 다른 importer 가 재획득했을 때
      */
     fun markCompleted(progressId: Long, expectedLeaseExpiresAt: Instant) {
-        val now = Instant.now()
         val sql = """
             UPDATE netcdf_import_progress
-            SET status = 'COMPLETED', completed_at = ?, lease_expires_at = NULL,
-                error_message = NULL, updated_at = ?
+            SET status = 'COMPLETED', completed_at = CURRENT_TIMESTAMP, lease_expires_at = NULL,
+                error_message = NULL, updated_at = CURRENT_TIMESTAMP
             WHERE id = ? AND status = 'IN_PROGRESS' AND lease_expires_at = ?
+              AND lease_expires_at > clock_timestamp()
         """.trimIndent()
         val conn = TransactionManager.current().connection.connection as java.sql.Connection
         conn.prepareStatement(sql).use { stmt ->
-            stmt.setTimestamp(1, Timestamp.from(now))
-            stmt.setTimestamp(2, Timestamp.from(now))
-            stmt.setLong(3, progressId)
-            stmt.setTimestamp(4, Timestamp.from(expectedLeaseExpiresAt))
+            stmt.setLong(1, progressId)
+            stmt.setTimestamp(2, Timestamp.from(expectedLeaseExpiresAt))
             if (stmt.executeUpdate() != 1) {
                 throw NetCdfException.ImportLeaseLost(progressId)
             }
@@ -242,23 +276,67 @@ class NetCdfImportProgressRepository {
      * @throws NetCdfException.ImportLeaseLost 같은 progress row 를 다른 importer 가 재획득했을 때
      */
     fun markFailed(progressId: Long, expectedLeaseExpiresAt: Instant, errorMessage: String) {
-        val now = Instant.now()
         val sql = """
             UPDATE netcdf_import_progress
-            SET status = 'FAILED', error_message = ?, lease_expires_at = NULL, updated_at = ?
+            SET status = 'FAILED', error_message = ?, lease_expires_at = NULL, updated_at = CURRENT_TIMESTAMP
             WHERE id = ? AND status = 'IN_PROGRESS' AND lease_expires_at = ?
+              AND lease_expires_at > clock_timestamp()
         """.trimIndent()
         val conn = TransactionManager.current().connection.connection as java.sql.Connection
         conn.prepareStatement(sql).use { stmt ->
             stmt.setString(1, errorMessage.take(MAX_ERROR_MESSAGE_LENGTH))
-            stmt.setTimestamp(2, Timestamp.from(now))
-            stmt.setLong(3, progressId)
-            stmt.setTimestamp(4, Timestamp.from(expectedLeaseExpiresAt))
+            stmt.setLong(2, progressId)
+            stmt.setTimestamp(3, Timestamp.from(expectedLeaseExpiresAt))
             if (stmt.executeUpdate() != 1) {
                 throw NetCdfException.ImportLeaseLost(progressId)
             }
         }
         log.warn { "import marked FAILED — progressId=$progressId msg=${errorMessage.take(200)}" }
+    }
+
+    /**
+     * 관리자 확인이 필요한 손상 checkpoint를 stable marker로 격리합니다.
+     *
+     * COMPLETED 행은 이미 외부에 관측된 성공 결과이므로 절대로 변경하지 않습니다.
+     * 호출자는 이 메서드가 반환된 뒤 [NetCdfException.CorruptProgress]를 던져야 합니다.
+     */
+    fun quarantineCorruptProgress(progressId: Long, detail: String) {
+        val conn = TransactionManager.current().connection.connection as java.sql.Connection
+        conn.prepareStatement(
+            "SELECT status FROM netcdf_import_progress WHERE id = ? FOR UPDATE",
+        ).use { select ->
+            select.setLong(1, progressId)
+            select.executeQuery().use { rs ->
+                if (!rs.next() || rs.getString(1) == NetCdfImportStatus.COMPLETED.name) return
+            }
+        }
+        conn.prepareStatement(
+            """
+            UPDATE netcdf_import_progress
+            SET status = 'FAILED', error_message = ?, lease_expires_at = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ? AND status <> 'COMPLETED'
+            """.trimIndent(),
+        ).use { update ->
+            update.setString(1, "CORRUPT_PROGRESS:$progressId:${detail.take(512)}")
+            update.setLong(2, progressId)
+            update.executeUpdate()
+        }
+    }
+
+    private fun repairMalformedLease(progressId: Long) {
+        val sql = """
+            UPDATE netcdf_import_progress
+            SET status = 'FAILED', error_message = ?, lease_expires_at = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ? AND status = 'IN_PROGRESS' AND lease_expires_at IS NULL
+        """.trimIndent()
+        val conn = TransactionManager.current().connection.connection as java.sql.Connection
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, "CORRUPT_PROGRESS:$progressId")
+            stmt.setLong(2, progressId)
+            stmt.executeUpdate()
+        }
     }
 }
 

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt
@@ -1,55 +1,65 @@
 package io.bluetape4k.science.exposed.service
 
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.science.exposed.NetCdfException
 import io.bluetape4k.science.exposed.model.NetCdfFileRecord
+import io.bluetape4k.science.exposed.model.NetCdfImportProgress
 import io.bluetape4k.science.exposed.model.NetCdfImportStatus
 import io.bluetape4k.science.exposed.model.NetCdfVariableInfo
 import io.bluetape4k.science.exposed.repository.NetCdfFileRepository
 import io.bluetape4k.science.exposed.repository.NetCdfImportProgressRepository
+import io.bluetape4k.science.exposed.service.internal.CoordinateKeySet
 import io.bluetape4k.science.exposed.service.internal.CoordinateReprojector
+import io.bluetape4k.science.exposed.service.internal.JdbcTileBatchWriter
+import io.bluetape4k.science.exposed.service.internal.MAX_AUXILIARY_JSONB_BYTES
+import io.bluetape4k.science.exposed.service.internal.MAX_BATCH_ROWS
+import io.bluetape4k.science.exposed.service.internal.MAX_CELLS
+import io.bluetape4k.science.exposed.service.internal.MAX_DUPLICATE_ENTRY_BYTES
+import io.bluetape4k.science.exposed.service.internal.MAX_GROUP_COUNT
+import io.bluetape4k.science.exposed.service.internal.MAX_GROUP_DEPTH
+import io.bluetape4k.science.exposed.service.internal.MAX_GROUP_DIMENSIONS
+import io.bluetape4k.science.exposed.service.internal.MAX_METADATA_BYTES
+import io.bluetape4k.science.exposed.service.internal.MAX_SLICES
+import io.bluetape4k.science.exposed.service.internal.MAX_TILE_CELLS
+import io.bluetape4k.science.exposed.service.internal.MAX_VARIABLES
+import io.bluetape4k.science.exposed.service.internal.MAX_VARIABLE_NAME_BYTES
+import io.bluetape4k.science.exposed.service.internal.MemoryBudget
+import io.bluetape4k.science.exposed.service.internal.MutableCoordinateSample
+import io.bluetape4k.science.exposed.service.internal.NetCdfFileGuard
+import io.bluetape4k.science.exposed.service.internal.NetCdfTileCoordinateSampler
+import io.bluetape4k.science.exposed.service.internal.NetCdfTile
+import io.bluetape4k.science.exposed.service.internal.NetCdfTilePlanner
+import io.bluetape4k.science.exposed.service.internal.TileRow
+import io.bluetape4k.science.exposed.service.internal.UcarCoordinateReader
 import io.bluetape4k.science.exposed.service.internal.VariableAxisMap
+import io.bluetape4k.science.exposed.service.internal.checkedProduct
+import io.bluetape4k.science.exposed.service.internal.serializeAuxiliaryAttributes
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import ucar.ma2.Array as UcarArray
 import ucar.nc2.Attribute
+import ucar.nc2.Group
+import ucar.nc2.NetcdfFile
 import ucar.nc2.NetcdfFiles
 import ucar.nc2.Variable
 import ucar.nc2.dataset.NetcdfDataset
 import ucar.nc2.dataset.NetcdfDatasets
-import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
+import java.util.ArrayDeque
+import java.util.concurrent.CancellationException
+import kotlin.math.abs
 
 /**
- * NetCDF 파일 등록 및 격자 값 임포트를 담당하는 서비스입니다.
+ * NetCDF 파일 등록과 bounded 격자 값 임포트를 담당하는 blocking 서비스입니다.
  *
- * ## 주요 기능
- *
- * - [registerFile] : NetCDF 파일 메타데이터를 DB 에 등록합니다.
- * - [importGridValues] : NetCDF 변수의 격자 값을 슬라이스 단위로 DB 에 임포트합니다.
- *   - rank 1 (시계열) ~ rank 4 (time × level × lat × lon) 지원
- *   - heartbeat lease 기반 동시성 제어 + sliceIdx 기반 재개
- *   - proj4j 기반 비 WGS84 CRS 자동 재투영 (Geographic 1D / Projected 2D pair)
- *   - NaN / `_FillValue` 자동 skip
- *   - 선택적 Micrometer 계측
- *
- * ## 호출 컨텍스트
- *
- * blocking API. 호출자는 Spring Boot Virtual Thread executor 등에서 호출 권장 (VT pinning 위험은 Spec §2.4 R2 참조).
- *
- * ## CoordinateAxis2D 비지원
- *
- * curvilinear / rotated pole / tripolar grid 같은 [ucar.nc2.dataset.CoordinateAxis2D] 좌표축은 본 구현 스코프 외입니다.
- * 1D 가 아닌 lat/lon 축이 발견되면 [NetCdfException.MissingCoordinate] 가 발생합니다.
- *
- * @param fileRepo      파일 메타데이터 Repository
- * @param progressRepo  변수 단위 진행 상태 Repository
- * @param meterRegistry 선택 — null 이면 계측 no-op
+ * 파일 identity를 등록·재개 시점에 확인하고, CF 1D/2D 좌표축을 tile 단위로
+ * 읽습니다. 좌표와 값은 두 번 순회하여 한 slice의 duplicate를 먼저 검증한
+ * 뒤에만 JDBC batch를 실행합니다.
  */
 class NetCdfCatalogService(
     private val fileRepo: NetCdfFileRepository,
@@ -66,478 +76,819 @@ class NetCdfCatalogService(
 
         /** heartbeat 갱신 시간 임계 */
         val HEARTBEAT_INTERVAL: Duration = Duration.ofSeconds(30)
+
+        private val SUPPORTED_RANKS: IntRange = 1..4
+        private const val MAX_SPATIAL_RANK: Int = 4
+        private const val FILL_VALUE_TOLERANCE: Double = 1e-7
     }
 
-    /**
-     * NetCDF 파일을 열어 메타데이터를 DB 에 등록합니다.
-     *
-     * Micrometer `netcdf.register.duration` Timer 로 경과 시간이 계측됩니다 (`status=success|failure` tag).
-     *
-     * 호출자가 [filePath] 의 신뢰성을 검증해야 합니다 (path traversal 등은 호출자 책임 — Spec R11).
-     * 본 메서드는 blocking 으로 동작하므로 향후 `suspend` 변환 시 `runCatching` 대신 try/catch 로
-     * `CancellationException` rethrow 처리 필요 (coding-style 규칙).
-     *
-     * @param filePath NetCDF 파일 전체 경로 (blank 금지)
-     * @return 생성된 파일 레코드 ID
-     * @throws IllegalArgumentException filePath 가 blank 일 때
-     * @throws NetCdfException.FileOpen 파일을 열 수 없을 때
-     */
+    /** NetCDF 파일을 bounded metadata와 identity fingerprint와 함께 등록합니다. */
     fun registerFile(filePath: String): Long {
-        require(filePath.isNotBlank()) { "filePath must not be blank" }
-
         val sample = meterRegistry?.let { Timer.start(it) }
         var success = false
-
         try {
-            val record = runCatching {
-                NetcdfFiles.open(filePath).use { nc ->
-                    val variables = nc.variables.map { v ->
-                        NetCdfVariableInfo(
-                            name = v.fullName,
-                            dataType = v.dataType.name,
-                            shape = v.shape.toList(),
-                            attributes = v.netCdfAttributes().associate { attr ->
-                                attr.shortName to (attr.stringValue ?: attr.numericValue?.toString().orEmpty())
-                            },
-                        )
-                    }
-                    val dimensions = nc.rootGroup.getDimensions().associate { it.shortName to it.length }
-                    val globalAttrs = nc.globalAttributes.associate { attr ->
-                        attr.shortName to (attr.stringValue ?: attr.numericValue?.toString().orEmpty())
-                    }
-
-                    val path = Paths.get(filePath)
-                    NetCdfFileRecord(
-                        filename = path.fileName.toString(),
-                        filePath = filePath,
-                        fileSize = runCatching { Files.size(path) }.getOrDefault(0L),
-                        variables = variables,
-                        dimensions = dimensions,
-                        globalAttrs = globalAttrs,
-                    )
-                }
-            }.getOrElse { throw NetCdfException.FileOpen(filePath, it) }
-
+            val identity = NetCdfFileGuard.validateForRegister(filePath)
+            val record = NetCdfFileGuard.openVerified(
+                fileId = 0L,
+                filePath = identity.path.toString(),
+                expectedFingerprint = identity.fingerprint,
+            ) {
+                NetcdfFiles.open(identity.path.toString())
+            }.use { netcdf ->
+                buildFileRecord(identity.path, identity.fileSize, identity.fingerprint, netcdf)
+            }
             val id = transaction { fileRepo.save(record).id }
             success = true
-            log.info { "NetCDF file registered — id=$id path=$filePath vars=${record.variables.size}" }
+            log.info { "NetCDF file registered — id=$id path=${identity.path} vars=${record.variables.size}" }
             return id
         } finally {
-            sample?.let { sampler ->
-                sampler.stop(
-                    checkNotNull(meterRegistry).timer(
-                        "netcdf.register.duration",
-                        "status", if (success) "success" else "failure",
-                    )
-                )
-            }
+            sample?.stop(
+                checkNotNull(meterRegistry).timer(
+                    "netcdf.register.duration",
+                    "status",
+                    if (success) "success" else "failure",
+                ),
+            )
         }
     }
 
-    /**
-     * NetCDF 파일의 지정된 변수의 격자 값을 DB 에 임포트합니다.
-     *
-     * ## 지원 rank
-     *
-     * - 1D (time)                       : timeIdx=t, levelIdx=0, location=null
-     * - 2D (lat, lon)                   : timeIdx=0, levelIdx=0, location=Point
-     * - 3D (time, lat, lon)             : timeIdx=t, levelIdx=0, location=Point
-     * - 4D (time, level, lat, lon)      : timeIdx=t, levelIdx=k, location=Point
-     *
-     * ## 재개
-     * `(fileId, variableName)` 단위 progress 테이블 + heartbeat lease (5분 TTL).
-     * COMPLETED 면 즉시 no-op. FAILED / 만료된 IN_PROGRESS 면 `lastSliceIdx + 1` 부터 재개.
-     *
-     * ## CRS 재투영
-     * proj4j 화이트리스트 (EPSG:4326/4269/3857/3031/3413/UTM 32601~32660·32701~32760) 외이면 [NetCdfException.UnsupportedProjection].
-     *
-     * ## NaN / `_FillValue`
-     * 자동 skip + `netcdf.import.nan.skipped` counter 증가 + `log.debug`.
-     *
-     * @throws IllegalArgumentException variableName 이 blank 일 때
-     * @throws NetCdfException.FileRecordNotFound DB 에 파일 레코드가 없을 때 (lease 미획득 → metric 미기록)
-     * @throws NetCdfException.VariableNotFound 변수가 없을 때
-     * @throws NetCdfException.UnsupportedVariable rank 가 1~4 외일 때
-     * @throws NetCdfException.MissingCoordinate lat/lon/level 좌표축이 없거나 1D 가 아닐 때
-     * @throws NetCdfException.UnsupportedProjection 화이트리스트 외 CRS 일 때
-     * @throws NetCdfException.ImportAlreadyRunning 다른 프로세스가 활성 lease 보유 중일 때
-     * @throws NetCdfException.ImportLeaseLost lease 만료 후 다른 프로세스가 같은 progress row 를 재획득했을 때
-     */
+    /** 등록된 변수의 값을 slice/tile 단위로 임포트합니다. */
     fun importGridValues(fileId: Long, variableName: String) {
-        require(variableName.isNotBlank()) { "variableName must not be blank" }
+        try {
+            importGridValuesInternal(fileId, variableName)
+        } catch (e: NetCdfException) {
+            if (e !is NetCdfException.FileRecordNotFound) {
+                recordRejection(e)
+            }
+            throw e
+        }
+    }
 
-        // FileRecordNotFound 는 lease 획득 전 → markFailed/counter 호출 없이 raise (Codex Plan v2.1 Medium#4)
+    private fun importGridValuesInternal(fileId: Long, variableName: String) {
+        require(variableName.isNotBlank()) { "variableName must not be blank" }
         val record = transaction { fileRepo.findById(fileId) }
             ?: throw NetCdfException.FileRecordNotFound(fileId)
 
-        val progress = transaction { progressRepo.acquireLease(fileId, variableName, LEASE_TTL) }
-        if (progress.status == NetCdfImportStatus.COMPLETED) {
-            log.info { "import skipped — already completed: fileId=$fileId var=$variableName" }
-            return
-        }
-        val startSliceIdx: Long = (progress.lastSliceIdx ?: -1L) + 1L
-        if (progress.lastSliceIdx != null) {
-            meterRegistry?.counter("netcdf.import.status", "status", "resumed")?.increment()
-            log.info { "resuming import — fileId=$fileId var=$variableName startSliceIdx=$startSliceIdx" }
-        }
-        val initialLeaseToken = checkNotNull(progress.leaseExpiresAt) {
-            "IN_PROGRESS import progress must have leaseExpiresAt"
-        }
-        val lease = ImportLease(initialLeaseToken)
-
-        val dataset = runCatching { NetcdfDatasets.openDataset(record.filePath) }
-            .getOrElse {
-                transaction {
-                    progressRepo.markFailed(progress.id, lease.expiresAt, it.message.orEmpty())
-                }
-                meterRegistry?.counter("netcdf.import.status", "status", "failure")?.increment()
-                throw NetCdfException.FileOpen(record.filePath, it)
+        val expectedFingerprint = record.globalAttrs[NetCdfFileGuard.FINGERPRINT_ATTRIBUTE]
+            ?: run {
+                val actual = NetCdfFileGuard.validateForRegister(record.filePath).fingerprint
+                throw NetCdfException.FileChanged(fileId, "missing-fingerprint", actual)
             }
+        val verifiedIdentity = NetCdfFileGuard.verifyForResume(fileId, record.filePath, expectedFingerprint)
+        val dataset = NetCdfFileGuard.openVerified(
+            fileId = fileId,
+            filePath = record.filePath,
+            expectedFingerprint = expectedFingerprint,
+        ) {
+            NetcdfDatasets.openDataset(verifiedIdentity.path.toString())
+        }
 
         try {
             dataset.use { ncd ->
-                val v = ncd.findVariable(variableName)
+                val variable = ncd.findVariable(variableName)
                     ?: throw NetCdfException.VariableNotFound(fileId, variableName)
-
-                if (v.rank !in 1..4) {
-                    throw NetCdfException.UnsupportedVariable(variableName, v.rank)
+                if (variable.rank !in SUPPORTED_RANKS) {
+                    throw NetCdfException.UnsupportedVariable(variableName, variable.rank)
                 }
-
-                val axisMap = VariableAxisMap.build(v, ncd)
-                val ctx = ImportContext(
+                val axisMap = VariableAxisMap.build(variable, ncd)
+                val layout = ImportLayout.create(variable, axisMap)
+                val prepared = PreparedImport(
                     fileId = fileId,
                     variableName = variableName,
-                    progressId = progress.id,
-                    lease = lease,
-                    variable = v,
+                    variable = variable,
                     axisMap = axisMap,
-                    fillValue = v.findAttribute("_FillValue")?.numericValue?.toDouble(),
+                    layout = layout,
+                    reprojector = if (layout.hasSpatialGrid) {
+                        CoordinateReprojector.from(variable, ncd, axisMap)
+                    } else null,
+                    coordinateReader = UcarCoordinateReader(
+                        buildMap {
+                            (ncd.variables + ncd.coordinateAxes).forEach { candidate ->
+                                put(candidate.fullName, candidate)
+                                putIfAbsent(candidate.shortName, candidate)
+                            }
+                        },
+                        variable.fullName,
+                    ),
+                    fillValue = variable.findAttribute("_FillValue")?.numericValue?.toDouble(),
                 )
-
-                when (v.rank) {
-                    1 -> importRank1(ctx, startSliceIdx)
-                    2 -> importRank2(ctx, ncd, startSliceIdx)
-                    3 -> importRank3(ctx, ncd, startSliceIdx)
-                    4 -> importRank4(ctx, ncd, startSliceIdx)
-                }
-
-                transaction { progressRepo.markCompleted(ctx.progressId, ctx.lease.expiresAt) }
-                meterRegistry?.counter("netcdf.import.status", "status", "success")?.increment()
-                log.info { "import COMPLETED — fileId=$fileId var=$variableName" }
+                runPreparedImport(prepared)
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        }
+    }
+
+    private fun runPreparedImport(prepared: PreparedImport) {
+        val progress = transaction {
+            progressRepo.acquireLease(prepared.fileId, prepared.variableName, LEASE_TTL)
+        }
+        validateProgress(prepared, progress)
+        if (progress.status == NetCdfImportStatus.COMPLETED) {
+            log.info { "import skipped — already completed: fileId=${prepared.fileId} var=${prepared.variableName}" }
+            return
+        }
+
+        val initialExpiry = progress.leaseExpiresAt
+            ?: throw NetCdfException.CorruptProgress(progress.id, "active lease is null")
+        val lease = ImportLease(initialExpiry)
+        val context = ImportContext(prepared, progress.id, lease)
+        val startSlice = (progress.lastSliceIdx ?: -1L) + 1L
+        if (progress.lastSliceIdx != null) {
+            meterRegistry?.counter("netcdf.import.status", "status", "resumed")?.increment()
+            log.info {
+                "resuming import — fileId=${prepared.fileId} var=${prepared.variableName} " +
+                    "startSliceIdx=$startSlice"
+            }
+        }
+
+        try {
+            if (prepared.layout.isRankOne) {
+                importRankOne(context, startSlice)
+            } else {
+                importSpatial(context, startSlice)
+            }
+            meterRegistry?.counter("netcdf.import.status", "status", "success")?.increment()
+            log.info { "import COMPLETED — fileId=${prepared.fileId} var=${prepared.variableName}" }
         } catch (e: NetCdfException.ImportAlreadyRunning) {
-            // 다른 프로세스 소유 — progress 변경 없음, failure counter 미증가 (M4)
             throw e
         } catch (e: NetCdfException.ImportLeaseLost) {
-            // lease 만료 후 다른 프로세스가 재획득 — stale importer 는 progress 를 변경하지 않음.
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
             throw e
         } catch (e: Exception) {
-            transaction { progressRepo.markFailed(progress.id, lease.expiresAt, e.message.orEmpty()) }
+            try {
+                transaction { progressRepo.markFailed(progress.id, lease.expiresAt, e.message.orEmpty()) }
+            } catch (failure: Exception) {
+                e.addSuppressed(failure)
+            }
             meterRegistry?.counter("netcdf.import.status", "status", "failure")?.increment()
             throw e
         }
     }
 
-    /**
-     * rank=1 (time only) — location/level null, timeIdx=t.
-     *
-     * 단일 슬라이스: 모든 time step 을 한 번에 read.
-     */
-    private fun importRank1(ctx: ImportContext, startSliceIdx: Long) {
-        if (startSliceIdx > 0L) return  // sliceIdx 는 0 단일이므로 재시작 무의미
-
-        val data = ctx.variable.read()
+    private fun importRankOne(context: ImportContext, startSlice: Long) {
+        if (startSlice > 0L) {
+            checkNotInterrupted()
+            transaction {
+                checkNotInterrupted()
+                progressRepo.markCompleted(context.progressId, context.lease.expiresAt)
+                checkNotInterrupted()
+            }
+            return
+        }
+        val variable = context.prepared.variable
+        val length = variable.shape.singleOrNull()
+            ?: throw NetCdfException.UnsupportedVariable(variable.fullName, variable.rank)
+        val reader = { origin: IntArray, shape: IntArray -> variable.read(origin, shape) }
+        val writer = JdbcTileBatchWriter()
+        val batchPayloadBytes = checkedProduct(
+            MAX_BATCH_ROWS,
+            io.bluetape4k.science.exposed.service.internal.MAX_FIXED_ROW_BYTES + MAX_AUXILIARY_JSONB_BYTES,
+        )
+        MemoryBudget(
+            tileBufferBytes = checkedProduct(MAX_TILE_CELLS, Double.SIZE_BYTES.toLong()),
+            coordinateBytes = 0L,
+            serializerScratchBytes = maxOf(MAX_AUXILIARY_JSONB_BYTES, batchPayloadBytes),
+            duplicateSetBytes = 0L,
+        ).requireWithinLimit()
         var inserted = 0
         var skipped = 0
-
-        val sql = """
-            INSERT INTO netcdf_grid_values (file_id, variable_name, location, time_idx, level_idx, value)
-            VALUES (?, ?, NULL, ?, 0, ?)
-            ON CONFLICT DO NOTHING
-        """.trimIndent()
-
-        transaction {
-            val conn = connection.connection as java.sql.Connection
-            conn.prepareStatement(sql).use { ps ->
-                val iter = data.indexIterator
-                var t = 0
-                while (iter.hasNext()) {
-                    val raw = iter.getDoubleNext()
-                    if (isMissing(raw, ctx.fillValue)) {
+        var offset = 0
+        while (offset < length) {
+            checkNotInterrupted()
+            val count = minOf(MAX_BATCH_ROWS.toInt(), length - offset)
+            val data = reader(intArrayOf(offset), intArrayOf(count))
+            val index = data.index
+            val result = transaction {
+                context.lease.expiresAt = progressRepo.touchLease(
+                    context.progressId,
+                    context.lease.expiresAt,
+                    leaseTtl = LEASE_TTL,
+                )
+                checkNotInterrupted()
+                val pending = ArrayList<TileRow>(MAX_BATCH_ROWS.toInt())
+                var windowInserted = 0
+                repeat(count) { local ->
+                    checkNotInterrupted()
+                    val value = data.getDouble(index.set(local))
+                    if (isMissing(value, context.prepared.fillValue)) {
                         skipped++
                     } else {
-                        ps.setLong(1, ctx.fileId)
-                        ps.setString(2, ctx.variableName)
-                        ps.setInt(3, t)
-                        ps.setDouble(4, raw)
-                        ps.addBatch()
-                        inserted++
+                        pending += TileRow(
+                            fileId = context.prepared.fileId,
+                            variableName = context.prepared.variableName,
+                            longitude = null,
+                            latitude = null,
+                            timeIdx = offset + local,
+                            levelIdx = 0,
+                            value = value,
+                        )
+                        if (pending.size == MAX_BATCH_ROWS.toInt()) {
+                            windowInserted += writer.write(
+                                connection.connection as java.sql.Connection,
+                                pending,
+                            ).inserted
+                            checkNotInterrupted()
+                            pending.clear()
+                        }
                     }
-                    t++
                 }
-                ps.executeBatch()
+                if (pending.isNotEmpty()) {
+                    checkNotInterrupted()
+                    windowInserted += writer.write(
+                        connection.connection as java.sql.Connection,
+                        pending,
+                    ).inserted
+                    checkNotInterrupted()
+                    pending.clear()
+                }
+                checkNotInterrupted()
+                if (offset + count == length) {
+                    checkNotInterrupted()
+                    context.lease.expiresAt = progressRepo.renewLease(
+                        context.progressId,
+                        context.lease.expiresAt,
+                        lastSliceIdx = 0L,
+                        leaseTtl = LEASE_TTL,
+                    )
+                    checkNotInterrupted()
+                    progressRepo.markCompleted(context.progressId, context.lease.expiresAt)
+                    checkNotInterrupted()
+                } else {
+                    checkNotInterrupted()
+                    context.lease.expiresAt = progressRepo.touchLease(
+                        context.progressId,
+                        context.lease.expiresAt,
+                        leaseTtl = LEASE_TTL,
+                    )
+                    checkNotInterrupted()
+                }
+                windowInserted
             }
-            ctx.lease.expiresAt = progressRepo.renewLease(
-                progressId = ctx.progressId,
-                expectedLeaseExpiresAt = ctx.lease.expiresAt,
-                lastSliceIdx = 0L,
-                leaseTtl = LEASE_TTL,
-            )
+            inserted += result
+            offset += count
         }
-        meterRegistry?.counter("netcdf.import.variable.records", "variable", ctx.variableName)
-            ?.increment(inserted.toDouble())
-        if (skipped > 0) {
-            meterRegistry?.counter("netcdf.import.nan.skipped")?.increment(skipped.toDouble())
-        }
-        log.debug { "rank1 imported — variable=${ctx.variableName} inserted=$inserted skipped=$skipped" }
+        recordMetrics(inserted, skipped)
     }
 
-    /**
-     * rank=2 (lat, lon) — 단일 슬라이스, timeIdx=0/levelIdx=0.
-     */
-    private fun importRank2(ctx: ImportContext, ncd: NetcdfDataset, startSliceIdx: Long) {
-        if (startSliceIdx > 0L) return  // 단일 슬라이스
+    private fun importSpatial(context: ImportContext, startSlice: Long) {
+        val layout = context.prepared.layout
+        val finalSlice = layout.totalSlices - 1L
+        if (startSlice > finalSlice) {
+            checkNotInterrupted()
+            transaction {
+                checkNotInterrupted()
+                progressRepo.markCompleted(context.progressId, context.lease.expiresAt)
+                checkNotInterrupted()
+            }
+            return
+        }
+        var slice = startSlice
+        while (slice <= finalSlice) {
+            checkNotInterrupted()
+            val timeIdx = (slice / layout.levelCount).toInt()
+            val levelIdx = (slice % layout.levelCount).toInt()
+            importSlice(context, timeIdx, levelIdx, slice)
+            slice++
+        }
+    }
 
-        // CoordinateReprojector.from 내부에서 latDim/lonDim 검증되므로 not-null 단정 (M4)
-        val reprojector = CoordinateReprojector.from(ctx.variable, ncd, ctx.axisMap)
-        val origin = IntArray(2)
-        val shape = ctx.variable.shape
-        val data = ctx.variable.read(origin, shape)
+    private fun importSlice(
+        context: ImportContext,
+        timeIdx: Int,
+        levelIdx: Int,
+        sliceIdx: Long,
+    ) {
+        val sample = meterRegistry?.let { Timer.start(it) }
+        var success = false
+        try {
+            importSliceInternal(context, timeIdx, levelIdx, sliceIdx)
+            success = true
+        } finally {
+            sample?.stop(
+                checkNotNull(meterRegistry).timer(
+                    "netcdf.import.slice.duration",
+                    "status",
+                    if (success) "success" else "failure",
+                ),
+            )
+        }
+    }
 
-        val latDim = checkNotNull(ctx.axisMap.latDim) { "axisMap.latDim must not be null after CoordinateReprojector.from" }
-        val lonDim = checkNotNull(ctx.axisMap.lonDim) { "axisMap.lonDim must not be null after CoordinateReprojector.from" }
-        val latN = shape[latDim]
-        val lonN = shape[lonDim]
+    private fun importSliceInternal(
+        context: ImportContext,
+        timeIdx: Int,
+        levelIdx: Int,
+        sliceIdx: Long,
+    ) {
+        val prepared = context.prepared
+        val layout = prepared.layout
+        val tiles = NetCdfTilePlanner.plan(layout.rowCount, layout.columnCount)
+        val sliceCells = checkedProduct(layout.rowCount.toLong(), layout.columnCount.toLong())
+        val duplicateSetBytes = checkedProduct(sliceCells, MAX_DUPLICATE_ENTRY_BYTES)
+        if (duplicateSetBytes > io.bluetape4k.science.exposed.service.internal.MAX_DUPLICATE_SET_BYTES) {
+            throw NetCdfException.ResourceLimitExceeded(
+                "duplicate-coordinate-set",
+                io.bluetape4k.science.exposed.service.internal.MAX_DUPLICATE_SET_BYTES,
+                duplicateSetBytes,
+            )
+        }
+        val duplicateKeys = CoordinateKeySet(
+            expectedSize = sliceCells.toInt(),
+        )
 
-        importSlice2D(
-            ctx = ctx,
-            data = data,
-            reprojector = reprojector,
-            latN = latN,
-            lonN = lonN,
-            timeIdxValue = 0,
-            levelIdxValue = 0,
-            sliceIdx = 0L,
+        // 첫 번째 pass: DB transaction 전에 전체 slice의 canonical coordinate를 검증합니다.
+        tiles.forEach { tile ->
+            checkNotInterrupted()
+            transaction {
+                // duplicate preflight도 NetCDF read 전에 lease fence를 확인합니다.
+                checkNotInterrupted()
+                context.lease.expiresAt = progressRepo.touchLease(
+                    context.progressId,
+                    context.lease.expiresAt,
+                    leaseTtl = LEASE_TTL,
+                )
+                checkNotInterrupted()
+                val data = readTile(prepared.variable, layout, tile, timeIdx, levelIdx)
+                checkNotInterrupted()
+                scanTile(prepared, layout, tile, data) { sample, _ ->
+                    if (sample != null &&
+                        !duplicateKeys.add(timeIdx, levelIdx, sample.longitude, sample.latitude)
+                    ) {
+                        throw NetCdfException.DuplicateCoordinate(
+                            fileId = prepared.fileId,
+                            variableName = prepared.variableName,
+                            timeIdx = timeIdx,
+                            levelIdx = levelIdx,
+                            longitude = sample.longitude,
+                            latitude = sample.latitude,
+                        )
+                    }
+                }
+                checkNotInterrupted()
+            }
+        }
+        val tileCells = MAX_TILE_CELLS
+        val coordinateBytes = checkedProduct(
+            tileCells,
+            (2 + prepared.axisMap.auxiliaryAxes.size).toLong(),
+            Double.SIZE_BYTES.toLong(),
+        )
+        val batchPayloadBytes = checkedProduct(
+            MAX_BATCH_ROWS,
+            io.bluetape4k.science.exposed.service.internal.MAX_FIXED_ROW_BYTES + MAX_AUXILIARY_JSONB_BYTES,
+        )
+        MemoryBudget(
+            tileBufferBytes = checkedProduct(tileCells, Double.SIZE_BYTES.toLong()),
+            coordinateBytes = coordinateBytes,
+            serializerScratchBytes = maxOf(MAX_AUXILIARY_JSONB_BYTES, batchPayloadBytes),
+            duplicateSetBytes = duplicateSetBytes,
+        ).requireWithinLimit()
+
+        // 두 번째 pass: 검증이 끝난 뒤 tile별로 같은 Exposed transaction에서 기록합니다.
+        var inserted = 0
+        var skipped = 0
+        tiles.forEachIndexed { tileIndex, tile ->
+            checkNotInterrupted()
+            val result = transaction {
+                val writer = JdbcTileBatchWriter()
+                val pending = ArrayList<TileRow>(MAX_BATCH_ROWS.toInt())
+                var tileInserted = 0
+                // 첫 read/write 전에 fence하여 만료된 owner가 SQL을 실행한 뒤
+                // lease 손실을 발견하는 경로를 차단합니다.
+                context.lease.expiresAt = progressRepo.touchLease(
+                    context.progressId,
+                    context.lease.expiresAt,
+                    leaseTtl = LEASE_TTL,
+                )
+                checkNotInterrupted()
+                val data = readTile(prepared.variable, layout, tile, timeIdx, levelIdx)
+                checkNotInterrupted()
+                scanTile(prepared, layout, tile, data) { sample, value ->
+                    if (sample == null) {
+                        skipped++
+                    } else {
+                        pending += TileRow(
+                            fileId = prepared.fileId,
+                            variableName = prepared.variableName,
+                            longitude = sample.longitude,
+                            latitude = sample.latitude,
+                            timeIdx = timeIdx,
+                            levelIdx = levelIdx,
+                            value = value,
+                            attrsJson = serializeAuxiliaryAttributes(sample.auxiliary),
+                        )
+                        if (pending.size == MAX_BATCH_ROWS.toInt()) {
+                            checkNotInterrupted()
+                            tileInserted += writer.write(connection.connection as java.sql.Connection, pending).inserted
+                            checkNotInterrupted()
+                            pending.clear()
+                        }
+                    }
+                }
+                checkNotInterrupted()
+                if (pending.isNotEmpty()) {
+                    checkNotInterrupted()
+                    tileInserted += writer.write(connection.connection as java.sql.Connection, pending).inserted
+                    checkNotInterrupted()
+                    pending.clear()
+                }
+                checkNotInterrupted()
+                if (tileIndex == tiles.lastIndex && sliceIdx == layout.totalSlices - 1L) {
+                    checkNotInterrupted()
+                    context.lease.expiresAt = progressRepo.renewLease(
+                        context.progressId,
+                        context.lease.expiresAt,
+                        lastSliceIdx = sliceIdx,
+                        leaseTtl = LEASE_TTL,
+                    )
+                    checkNotInterrupted()
+                    progressRepo.markCompleted(context.progressId, context.lease.expiresAt)
+                    checkNotInterrupted()
+                } else if (tileIndex == tiles.lastIndex) {
+                    checkNotInterrupted()
+                    context.lease.expiresAt = progressRepo.renewLease(
+                        context.progressId,
+                        context.lease.expiresAt,
+                        lastSliceIdx = sliceIdx,
+                        leaseTtl = LEASE_TTL,
+                    )
+                    checkNotInterrupted()
+                } else {
+                    checkNotInterrupted()
+                    context.lease.expiresAt = progressRepo.touchLease(
+                        context.progressId,
+                        context.lease.expiresAt,
+                        leaseTtl = LEASE_TTL,
+                    )
+                    checkNotInterrupted()
+                }
+                tileInserted
+            }
+            inserted += result
+        }
+        recordMetrics(inserted, skipped)
+    }
+
+    private fun scanTile(
+        prepared: PreparedImport,
+        layout: ImportLayout,
+        tile: NetCdfTile,
+        data: UcarArray,
+        consume: (io.bluetape4k.science.exposed.service.internal.CoordinateSample?, Double) -> Unit,
+    ) {
+        val index = data.index
+        val indices = IntArray(prepared.variable.rank)
+        layout.timeDim?.let { indices[it] = 0 }
+        layout.levelDim?.let { indices[it] = 0 }
+        val target = MutableCoordinateSample()
+        val reprojector = prepared.reprojector
+        val pointProvider = reprojector
+            ?.takeUnless { it.sourceCrs == CoordinateReprojector.WGS84 || it.sourceCrs == "EPSG:4269" }
+            ?.tilePointProvider(
+                rowOrigin = tile.rowOrigin,
+                columnOrigin = tile.columnOrigin,
+                rowCount = tile.rowCount,
+                columnCount = tile.columnCount,
+            )
+        val sampler = NetCdfTileCoordinateSampler(
+            prepared.axisMap,
+            prepared.coordinateReader,
+            rowOrigin = tile.rowOrigin,
+            columnOrigin = tile.columnOrigin,
+            rowCount = tile.rowCount,
+            columnCount = tile.columnCount,
+            pointProvider = pointProvider,
+        )
+        repeat(tile.rowCount) { localRow ->
+            repeat(tile.columnCount) { localColumn ->
+                indices[layout.rowDim] = localRow
+                indices[layout.columnDim] = localColumn
+                val value = data.getDouble(index.set(indices))
+                if (isMissing(value, prepared.fillValue)) {
+                    consume(null, value)
+                } else {
+                    sampler.sample(tile.rowOrigin + localRow, tile.columnOrigin + localColumn, target)
+                    consume(target.readOnlyCopy(), value)
+                }
+            }
+        }
+    }
+
+    private fun readTile(
+        variable: Variable,
+        layout: ImportLayout,
+        tile: NetCdfTile,
+        timeIdx: Int,
+        levelIdx: Int,
+    ): UcarArray {
+        val origin = IntArray(variable.rank)
+        val shape = IntArray(variable.rank) { 1 }
+        layout.timeDim?.let { origin[it] = timeIdx }
+        layout.levelDim?.let { origin[it] = levelIdx }
+        origin[layout.rowDim] = tile.rowOrigin
+        origin[layout.columnDim] = tile.columnOrigin
+        shape[layout.rowDim] = tile.rowCount
+        shape[layout.columnDim] = tile.columnCount
+        return variable.read(origin, shape)
+    }
+
+    private fun validateProgress(prepared: PreparedImport, progress: NetCdfImportProgress) {
+        val finalSlice = prepared.layout.totalSlices - 1L
+        val checkpoint = progress.lastSliceIdx
+        val detail = when {
+            progress.status == NetCdfImportStatus.COMPLETED &&
+                (progress.leaseExpiresAt != null || progress.completedAt == null) ->
+                "COMPLETED lease/completedAt invariant"
+            progress.status == NetCdfImportStatus.IN_PROGRESS &&
+                (progress.leaseExpiresAt == null || progress.completedAt != null) ->
+                "IN_PROGRESS lease/completedAt invariant"
+            checkpoint != null && (checkpoint < -1L || checkpoint > finalSlice) ->
+                "lastSliceIdx=$checkpoint finalSlice=$finalSlice"
+            progress.status == NetCdfImportStatus.COMPLETED && checkpoint != finalSlice ->
+                "COMPLETED checkpoint=$checkpoint finalSlice=$finalSlice"
+            else -> null
+        }
+        if (detail != null) {
+            if (progress.status != NetCdfImportStatus.COMPLETED) {
+                transaction { progressRepo.quarantineCorruptProgress(progress.id, detail) }
+            }
+            throw NetCdfException.CorruptProgress(progress.id, detail)
+        }
+    }
+
+    private fun buildFileRecord(
+        path: Path,
+        fileSize: Long,
+        fingerprint: String,
+        netcdf: NetcdfFile,
+    ): NetCdfFileRecord {
+        val budget = MetadataBudget()
+        inspectGroup(netcdf.rootGroup, depth = 0, budget)
+        if (netcdf.variables.size.toLong() > MAX_VARIABLES) {
+            throw NetCdfException.ResourceLimitExceeded("variables", MAX_VARIABLES, netcdf.variables.size.toLong())
+        }
+        val variables = netcdf.variables.map { variable ->
+            val nameBytes = variable.fullName.toByteArray(StandardCharsets.UTF_8).size.toLong()
+            if (nameBytes > MAX_VARIABLE_NAME_BYTES) {
+                throw NetCdfException.ResourceLimitExceeded("variable-name-bytes", MAX_VARIABLE_NAME_BYTES, nameBytes)
+            }
+            NetCdfVariableInfo(
+                name = variable.fullName,
+                dataType = variable.dataType.name,
+                shape = variable.shape.toList(),
+                attributes = variable.attributes().associate { attribute ->
+                    attribute.shortName to attributeValue(attribute)
+                },
+            )
+        }
+        val dimensions = netcdf.rootGroup.dimensions.associate { it.shortName to it.length }
+        val globalAttrs = LinkedHashMap<String, String>()
+        netcdf.globalAttributes.forEach { attribute ->
+            if (attribute.shortName == NetCdfFileGuard.FINGERPRINT_ATTRIBUTE) {
+                throw NetCdfException.ResourceLimitExceeded(
+                    "reserved-fingerprint-key",
+                    0L,
+                    1L,
+                )
+            }
+            globalAttrs[attribute.shortName] = attributeValue(attribute)
+        }
+        globalAttrs[NetCdfFileGuard.FINGERPRINT_ATTRIBUTE] = fingerprint
+        return NetCdfFileRecord(
+            filename = path.fileName.toString(),
+            filePath = path.toString(),
+            fileSize = fileSize,
+            variables = variables,
+            dimensions = dimensions,
+            globalAttrs = globalAttrs,
         )
     }
 
-    /**
-     * rank=3 (time, lat, lon) — time 슬라이스별 1 tx. sliceIdx = timeIdx.
-     */
-    private fun importRank3(ctx: ImportContext, ncd: NetcdfDataset, startSliceIdx: Long) {
-        val reprojector = CoordinateReprojector.from(ctx.variable, ncd, ctx.axisMap)
-        val timeDim = ctx.axisMap.timeDim ?: throw NetCdfException.MissingCoordinate("time")
-        val latDim = ctx.axisMap.latDim ?: throw NetCdfException.MissingCoordinate("lat")
-        val lonDim = ctx.axisMap.lonDim ?: throw NetCdfException.MissingCoordinate("lon")
-        val shape = ctx.variable.shape
-        val timeN = shape[timeDim]
-        val latN = shape[latDim]
-        val lonN = shape[lonDim]
-        var lastHeartbeat = Instant.now()
-        var slicesSinceHeartbeat = 0
-
-        for (t in startSliceIdx.toInt() until timeN) {
-            val origin = IntArray(3).also { it[timeDim] = t }
-            val sliceShape = IntArray(3).also { dims ->
-                dims[timeDim] = 1
-                dims[latDim] = latN
-                dims[lonDim] = lonN
+    private fun inspectGroup(group: Group, depth: Int, budget: MetadataBudget) {
+        val pending = ArrayDeque<Pair<Group, Int>>()
+        pending.addLast(group to depth)
+        while (pending.isNotEmpty()) {
+            val (current, currentDepth) = pending.removeLast()
+            if (currentDepth > MAX_GROUP_DEPTH) {
+                throw NetCdfException.ResourceLimitExceeded("group-depth", MAX_GROUP_DEPTH, currentDepth.toLong())
             }
-            val data = ctx.variable.read(origin, sliceShape)
-            slicesSinceHeartbeat++
-            // heartbeat throttle: 마지막 슬라이스 또는 N 슬라이스마다 또는 30초 경과 시 lease 갱신
-            val shouldRenew = (t == timeN - 1) ||
-                slicesSinceHeartbeat >= HEARTBEAT_EVERY_SLICES ||
-                Duration.between(lastHeartbeat, Instant.now()) >= HEARTBEAT_INTERVAL
-            importSlice2D(
-                ctx = ctx,
-                data = data,
-                reprojector = reprojector,
-                latN = latN,
-                lonN = lonN,
-                timeIdxValue = t,
-                levelIdxValue = 0,
-                sliceIdx = t.toLong(),
-                renewProgress = shouldRenew,
-            )
-            if (shouldRenew) {
-                lastHeartbeat = Instant.now()
-                slicesSinceHeartbeat = 0
+            budget.groupCount++
+            budget.dimensionCount = try {
+                Math.addExact(budget.dimensionCount, current.dimensions.size.toLong())
+            } catch (_: ArithmeticException) {
+                Long.MAX_VALUE
             }
-        }
-    }
-
-    /**
-     * rank=4 (time, level, lat, lon) — (time, level) 슬라이스별 1 tx.
-     *
-     * sliceIdx = timeIdx × levelN + levelIdx (Codex C3 선형화).
-     */
-    private fun importRank4(ctx: ImportContext, ncd: NetcdfDataset, startSliceIdx: Long) {
-        val reprojector = CoordinateReprojector.from(ctx.variable, ncd, ctx.axisMap)
-        val timeDim = ctx.axisMap.timeDim ?: throw NetCdfException.MissingCoordinate("time")
-        val levelDim = ctx.axisMap.levelDim ?: throw NetCdfException.MissingCoordinate("level")
-        val latDim = ctx.axisMap.latDim ?: throw NetCdfException.MissingCoordinate("lat")
-        val lonDim = ctx.axisMap.lonDim ?: throw NetCdfException.MissingCoordinate("lon")
-        val shape = ctx.variable.shape
-        val timeN = shape[timeDim]
-        val levelN = shape[levelDim]
-        val latN = shape[latDim]
-        val lonN = shape[lonDim]
-        val totalSlices = timeN.toLong() * levelN.toLong()
-        var lastHeartbeat = Instant.now()
-        var slicesSinceHeartbeat = 0
-
-        for (sliceIdx in startSliceIdx until totalSlices) {
-            val (t, l) = decomposeSliceIdx(sliceIdx, levelN)
-            val origin = IntArray(4).also {
-                it[timeDim] = t
-                it[levelDim] = l
+            if (budget.groupCount > MAX_GROUP_COUNT) {
+                throw NetCdfException.ResourceLimitExceeded("groups", MAX_GROUP_COUNT, budget.groupCount)
             }
-            val sliceShape = IntArray(4).also { dims ->
-                dims[timeDim] = 1
-                dims[levelDim] = 1
-                dims[latDim] = latN
-                dims[lonDim] = lonN
-            }
-            val data = ctx.variable.read(origin, sliceShape)
-            slicesSinceHeartbeat++
-            val isLast = sliceIdx == totalSlices - 1L
-            val shouldRenew = isLast ||
-                slicesSinceHeartbeat >= HEARTBEAT_EVERY_SLICES ||
-                Duration.between(lastHeartbeat, Instant.now()) >= HEARTBEAT_INTERVAL
-            importSlice2D(
-                ctx = ctx,
-                data = data,
-                reprojector = reprojector,
-                latN = latN,
-                lonN = lonN,
-                timeIdxValue = t,
-                levelIdxValue = l,
-                sliceIdx = sliceIdx,
-                renewProgress = shouldRenew,
-            )
-            if (shouldRenew) {
-                lastHeartbeat = Instant.now()
-                slicesSinceHeartbeat = 0
-            }
-        }
-    }
-
-    /**
-     * 단일 (lat × lon) 슬라이스를 한 트랜잭션에서 insert + progress 갱신.
-     *
-     * 중복 방지: ON CONFLICT DO NOTHING — partial expression unique index 자동 매칭 (Spec §4.1 M4).
-     * `geoPointOf` 헬퍼가 부재하므로 PostGIS `ST_SetSRID(ST_MakePoint(lon, lat), 4326)` 직접 사용.
-     */
-    private fun importSlice2D(
-        ctx: ImportContext,
-        data: UcarArray,
-        reprojector: CoordinateReprojector,
-        latN: Int,
-        lonN: Int,
-        timeIdxValue: Int,
-        levelIdxValue: Int,
-        sliceIdx: Long,
-        renewProgress: Boolean = true,
-    ): Pair<Int, Int> {
-        var inserted = 0
-        var skipped = 0
-        val sliceTimer = meterRegistry?.let { Timer.start(it) }
-
-        val sql = """
-            INSERT INTO netcdf_grid_values (file_id, variable_name, location, time_idx, level_idx, value)
-            VALUES (?, ?, ST_SetSRID(ST_MakePoint(?, ?), 4326), ?, ?, ?)
-            ON CONFLICT DO NOTHING
-        """.trimIndent()
-
-        transaction {
-            val conn = connection.connection as java.sql.Connection
-            conn.prepareStatement(sql).use { ps ->
-                val iter = data.indexIterator
-                for (i in 0 until latN) {
-                    for (j in 0 until lonN) {
-                        if (!iter.hasNext()) break
-                        val raw = iter.getDoubleNext()
-                        if (isMissing(raw, ctx.fillValue)) {
-                            skipped++
-                            continue
-                        }
-                        val (lon, lat) = reprojector.pointAt(i, j)
-                        ps.setLong(1, ctx.fileId)
-                        ps.setString(2, ctx.variableName)
-                        ps.setDouble(3, lon)
-                        ps.setDouble(4, lat)
-                        ps.setInt(5, timeIdxValue)
-                        ps.setInt(6, levelIdxValue)
-                        ps.setDouble(7, raw)
-                        ps.addBatch()
-                        inserted++
-                    }
-                }
-                ps.executeBatch()
-            }
-            if (renewProgress) {
-                ctx.lease.expiresAt = progressRepo.renewLease(
-                    progressId = ctx.progressId,
-                    expectedLeaseExpiresAt = ctx.lease.expiresAt,
-                    lastSliceIdx = sliceIdx,
-                    leaseTtl = LEASE_TTL,
+            if (budget.dimensionCount > MAX_GROUP_DIMENSIONS) {
+                throw NetCdfException.ResourceLimitExceeded(
+                    "group-dimensions",
+                    MAX_GROUP_DIMENSIONS,
+                    budget.dimensionCount,
                 )
             }
+            budget.add(current.fullName)
+            current.dimensions.forEach { dimension ->
+                budget.add(dimension.shortName, dimension.length.toString())
+            }
+            current.variables.forEach { variable ->
+                budget.variableCount++
+                if (budget.variableCount > MAX_VARIABLES) {
+                    throw NetCdfException.ResourceLimitExceeded("variables", MAX_VARIABLES, budget.variableCount)
+                }
+                val nameBytes = variable.fullName.toByteArray(StandardCharsets.UTF_8).size.toLong()
+                if (nameBytes > MAX_VARIABLE_NAME_BYTES) {
+                    throw NetCdfException.ResourceLimitExceeded(
+                        "variable-name-bytes",
+                        MAX_VARIABLE_NAME_BYTES,
+                        nameBytes,
+                    )
+                }
+                budget.add(variable.fullName)
+                variable.attributes().forEach { attribute -> budget.add(attribute.shortName, attributeValue(attribute)) }
+            }
+            current.attributes().forEach { attribute -> budget.add(attribute.shortName, attributeValue(attribute)) }
+            current.groups.forEach { child -> pending.addLast(child to (currentDepth + 1)) }
         }
-
-        sliceTimer?.let { sampler ->
-            sampler.stop(checkNotNull(meterRegistry).timer("netcdf.import.slice.duration"))
-        }
-        meterRegistry?.counter("netcdf.import.variable.records", "variable", ctx.variableName)
-            ?.increment(inserted.toDouble())
-        if (skipped > 0) {
-            meterRegistry?.counter("netcdf.import.nan.skipped")?.increment(skipped.toDouble())
-        }
-        return inserted to skipped
     }
 
-    /**
-     * 선형 sliceIdx 를 (timeIdx, levelIdx) 로 분해. row-major 4D ordering.
-     */
-    private fun decomposeSliceIdx(sliceIdx: Long, levelN: Int): Pair<Int, Int> {
-        val t = (sliceIdx / levelN).toInt()
-        val l = (sliceIdx % levelN).toInt()
-        return t to l
+    private fun attributeValue(attribute: Attribute): String =
+        attribute.stringValue ?: attribute.numericValue?.toString().orEmpty()
+
+    private fun recordMetrics(inserted: Int, skipped: Int) {
+        meterRegistry?.counter("netcdf.import.variable.records")?.increment(inserted.toDouble())
+        if (skipped > 0) meterRegistry?.counter("netcdf.import.nan.skipped")?.increment(skipped.toDouble())
     }
 
-    /**
-     * NaN / `_FillValue` 일치 시 missing 으로 판정.
-     *
-     * `_FillValue` 가 Float 인 경우 Double 변환 시 LSB 차이로 strict equality 가 실패할 수 있어
-     * 절대 오차 (`abs(raw - fillValue) <= max(|fillValue|, 1) * 1e-7`) 로 비교한다 (M1).
-     * Float 의 7 자리 정밀도를 고려한 허용 오차.
-     */
+    private fun recordRejection(exception: NetCdfException) {
+        val reason = when (exception) {
+            is NetCdfException.ResourceLimitExceeded -> "resource"
+            is NetCdfException.UnsupportedCoordinateAxis,
+            is NetCdfException.MissingCoordinate -> "axis"
+            is NetCdfException.DuplicateCoordinate -> "duplicate"
+            is NetCdfException.UnsupportedProjection -> "crs"
+            is NetCdfException.FileChanged,
+            is NetCdfException.FileOpen -> "path"
+            is NetCdfException.CorruptProgress -> "progress"
+            is NetCdfException.VariableNotFound,
+            is NetCdfException.UnsupportedVariable,
+            is NetCdfException.ImportAlreadyRunning,
+            is NetCdfException.ImportLeaseLost,
+            is NetCdfException.FileRecordNotFound -> return
+        }
+        meterRegistry?.counter("netcdf.import.rejected", "reason", reason)?.increment()
+    }
+
+    private fun checkNotInterrupted() {
+        if (Thread.currentThread().isInterrupted) throw InterruptedException("NetCDF import interrupted")
+    }
+
     private fun isMissing(raw: Double, fillValue: Double?): Boolean {
         if (raw.isNaN()) return true
-        if (fillValue != null) {
-            val tolerance = kotlin.math.max(kotlin.math.abs(fillValue), 1.0) * 1e-7
-            if (kotlin.math.abs(raw - fillValue) <= tolerance) return true
-        }
+        if (fillValue != null &&
+            abs(raw - fillValue) <= maxOf(abs(fillValue), 1.0) * FILL_VALUE_TOLERANCE
+        ) return true
         return false
     }
 
-    /**
-     * import 컨텍스트 — slice 함수들에 공통으로 전달되는 immutable 데이터.
-     */
-    private data class ImportContext(
+    private data class PreparedImport(
         val fileId: Long,
         val variableName: String,
-        val progressId: Long,
-        val lease: ImportLease,
         val variable: Variable,
         val axisMap: VariableAxisMap,
+        val layout: ImportLayout,
+        val reprojector: CoordinateReprojector?,
+        val coordinateReader: UcarCoordinateReader,
         val fillValue: Double?,
     )
 
-    private data class ImportLease(
-        var expiresAt: Instant,
+    private data class ImportContext(
+        val prepared: PreparedImport,
+        val progressId: Long,
+        val lease: ImportLease,
     )
 
-    private fun Variable.netCdfAttributes(): Iterable<Attribute> = attributes()
+    private data class ImportLease(var expiresAt: Instant)
+
+    private class MetadataBudget {
+        var bytes: Long = 0L
+        var groupCount: Long = 0L
+        var dimensionCount: Long = 0L
+        var variableCount: Long = 0L
+
+        fun add(vararg values: String) {
+            bytes = try {
+                values.fold(bytes) { total, value ->
+                    Math.addExact(total, value.toByteArray(StandardCharsets.UTF_8).size.toLong())
+                }
+            } catch (_: ArithmeticException) {
+                Long.MAX_VALUE
+            }
+            if (bytes > MAX_METADATA_BYTES) {
+                throw NetCdfException.ResourceLimitExceeded("metadata-bytes", MAX_METADATA_BYTES, bytes)
+            }
+        }
+    }
+
+    private data class ImportLayout(
+        val isRankOne: Boolean,
+        val hasSpatialGrid: Boolean,
+        val timeDim: Int?,
+        val levelDim: Int?,
+        val rowDim: Int,
+        val columnDim: Int,
+        val rowCount: Int,
+        val columnCount: Int,
+        val timeCount: Long,
+        val levelCount: Long,
+        val totalSlices: Long,
+    ) {
+        companion object {
+            fun create(variable: Variable, map: VariableAxisMap): ImportLayout {
+                val shape = variable.shape
+                val hasLat = map.latAxis != null
+                val hasLon = map.lonAxis != null
+                if (hasLat != hasLon) throw NetCdfException.MissingCoordinate(if (hasLat) "lon" else "lat")
+                if (!hasLat) {
+                    val timeDim = map.timeDim
+                    if (variable.rank != 1 || timeDim == null) {
+                        throw NetCdfException.MissingCoordinate("lat/lon")
+                    }
+                    val time = shape[timeDim].toLong()
+                    checkDimension(time, "time")
+                    if (time > MAX_CELLS) {
+                        throw NetCdfException.ResourceLimitExceeded("cells", MAX_CELLS, time)
+                    }
+                    return ImportLayout(true, false, timeDim, null, 0, 0, 1, 1, time, 1L, 1L)
+                }
+                val rowDim = map.gridRowDim ?: throw NetCdfException.MissingCoordinate("lat")
+                val columnDim = map.gridColumnDim ?: throw NetCdfException.MissingCoordinate("lon")
+                if (rowDim == columnDim || rowDim !in shape.indices || columnDim !in shape.indices) {
+                    throw NetCdfException.UnsupportedCoordinateAxis(variable.fullName, "lat/lon", "spatial-dimensions")
+                }
+                val timeDim = map.timeDim
+                val levelDim = map.levelDim
+                if (variable.rank == MAX_SPATIAL_RANK && levelDim == null) {
+                    throw NetCdfException.MissingCoordinate("level")
+                }
+                val used = buildSet {
+                    add(rowDim)
+                    add(columnDim)
+                    timeDim?.let(::add)
+                    levelDim?.let(::add)
+                }
+                if (used.size != variable.rank) {
+                    throw NetCdfException.UnsupportedCoordinateAxis(variable.fullName, null, "unmapped-data-dimension")
+                }
+                val rows = shape[rowDim].toLong()
+                val columns = shape[columnDim].toLong()
+                val time = timeDim?.let { shape[it].toLong() } ?: 1L
+                val level = levelDim?.let { shape[it].toLong() } ?: 1L
+                val cells = checkedProduct(rows, columns)
+                if (cells > MAX_CELLS) throw NetCdfException.ResourceLimitExceeded("cells", MAX_CELLS, cells)
+                checkDimension(time, "time")
+                checkDimension(level, "level")
+                val slices = checkedProduct(time, level)
+                if (slices > MAX_SLICES) throw NetCdfException.ResourceLimitExceeded("slices", MAX_SLICES, slices)
+                val totalCells = checkedProduct(cells, slices)
+                if (totalCells > MAX_CELLS) {
+                    throw NetCdfException.ResourceLimitExceeded("total-cells", MAX_CELLS, totalCells)
+                }
+                return ImportLayout(
+                    false,
+                    true,
+                    timeDim,
+                    levelDim,
+                    rowDim,
+                    columnDim,
+                    rows.toIntExact("rows"),
+                    columns.toIntExact("columns"),
+                    time,
+                    level,
+                    slices,
+                )
+            }
+
+            private fun checkDimension(value: Long, name: String) {
+                if (value <= 0L || value > Int.MAX_VALUE) {
+                    throw NetCdfException.ResourceLimitExceeded(name, Int.MAX_VALUE.toLong(), value)
+                }
+            }
+
+            private fun Long.toIntExact(resource: String): Int = try {
+                Math.toIntExact(this)
+            } catch (_: ArithmeticException) {
+                throw NetCdfException.ResourceLimitExceeded(resource, Int.MAX_VALUE.toLong(), this)
+            }
+        }
+    }
 }

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/CoordinateReprojector.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/CoordinateReprojector.kt
@@ -1,45 +1,32 @@
 package io.bluetape4k.science.exposed.service.internal
 
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.debug
 import io.bluetape4k.science.exposed.NetCdfException
 import org.locationtech.proj4j.CRSFactory
+import org.locationtech.proj4j.CoordinateTransform
 import org.locationtech.proj4j.CoordinateTransformFactory
 import org.locationtech.proj4j.ProjCoordinate
 import ucar.nc2.Variable
-import ucar.nc2.dataset.CoordinateAxis1D
 import ucar.nc2.dataset.NetcdfDataset
 
-/**
- * NetCDF 좌표축을 EPSG:4326 (WGS84) 으로 재투영해 캐싱하는 헬퍼.
- *
- * 파일당 1회 계산, 이후 셀 순회에서 [pointAt] 으로 O(1) 조회.
- *
- * 두 모드:
- * - [Geographic] : EPSG:4326 / 4269 등 lat/lon 분리 가능 CRS. 1D 배열 캐싱 (lonValues × latValues)
- * - [Projected]  : EPSG:3857 / UTM / Polar 등 projected CRS. 격자 cell 단위 (lat, lon) pair 사전 계산 후 flat 배열 캐싱 (Codex C4)
- *
- * Thread-safety: 단일 import 호출 수명 내 단일 스레드 사용 가정. 내부 `DoubleArray` 는 immutable snapshot.
- *
- * @see io.bluetape4k.science.exposed.service.NetCdfCatalogService
- */
+/** 좌표축 값을 필요할 때 bounded window로 읽어 EPSG:4326 좌표를 반환합니다. */
 internal sealed class CoordinateReprojector {
 
-    /**
-     * (latIdx, lonIdx) 격자 좌표를 EPSG:4326 의 (lon, lat) 으로 변환.
-     *
-     * @return `Pair<lon, lat>` — PostGIS POINT 순서 (R4)
-     */
+    /** (row, column) 셀의 `(longitude, latitude)`를 반환합니다. */
     abstract fun pointAt(latIdx: Int, lonIdx: Int): Pair<Double, Double>
+
+    /** 현재 tile의 원본 좌표 window를 한 번 읽어 재사용하는 point provider입니다. */
+    open fun tilePointProvider(
+        rowOrigin: Int,
+        columnOrigin: Int,
+        rowCount: Int,
+        columnCount: Int,
+    ): (Int, Int) -> Pair<Double, Double> = { row, column -> pointAt(row, column) }
 
     /** 진단·로그용 source CRS */
     abstract val sourceCrs: String
 
-    /**
-     * Geographic CRS 전용 (lat/lon 분리 가능 — EPSG:4326 / EPSG:4269).
-     *
-     * lonValues / latValues 를 그대로 캐싱.
-     */
+    /** 기존 직접 배열 주입 호출을 위한 geographic 구현입니다. */
     class Geographic(
         private val lonValues: DoubleArray,
         private val latValues: DoubleArray,
@@ -49,13 +36,7 @@ internal sealed class CoordinateReprojector {
             lonValues[lonIdx] to latValues[latIdx]
     }
 
-    /**
-     * Projected CRS 전용 (UTM / Polar / Web Mercator).
-     *
-     * 격자 cell 단위 `(x[lonIdx], y[latIdx])` 를 EPSG:4326 (lat, lon) 으로 사전 변환해 캐싱.
-     *
-     * @param projected flat 배열 — `[(latIdx * lonCount + lonIdx) * 2]` = lon, `[... + 1]` = lat
-     */
+    /** 기존 직접 배열 주입 호출을 위한 projected 구현입니다. */
     class Projected(
         private val projected: DoubleArray,
         private val lonCount: Int,
@@ -67,26 +48,29 @@ internal sealed class CoordinateReprojector {
         }
     }
 
+    private class ReaderBacked(
+        override val sourceCrs: String,
+        private val pointReader: (Int, Int) -> Pair<Double, Double>,
+        private val tileReader: ((Int, Int, Int, Int) -> (Int, Int) -> Pair<Double, Double>)? = null,
+    ): CoordinateReprojector() {
+        override fun pointAt(latIdx: Int, lonIdx: Int): Pair<Double, Double> = pointReader(latIdx, lonIdx)
+
+        override fun tilePointProvider(
+            rowOrigin: Int,
+            columnOrigin: Int,
+            rowCount: Int,
+            columnCount: Int,
+        ): (Int, Int) -> Pair<Double, Double> =
+            tileReader?.invoke(rowOrigin, columnOrigin, rowCount, columnCount)
+                ?: super.tilePointProvider(rowOrigin, columnOrigin, rowCount, columnCount)
+    }
+
     companion object: KLogging() {
 
-        /** EPSG:4326 (WGS84) — 모든 재투영의 target. */
         const val WGS84: String = "EPSG:4326"
+        private val crsFactory = CRSFactory()
+        private val transformFactory = CoordinateTransformFactory()
 
-        /** proj4j factory — thread-safe, 내부 EPSG hsql DB 캐시 활용 위해 재사용 (M2). */
-        private val crsFactory: CRSFactory = CRSFactory()
-        private val transformFactory: CoordinateTransformFactory = CoordinateTransformFactory()
-
-        /**
-         * 화이트리스트된 source CRS (proj4j-epsg 가 해석 가능한 EPSG 코드).
-         *
-         * - Geographic: 4326 (WGS84), 4269 (NAD83)
-         * - Projected:
-         *   - 3857 (Web Mercator)
-         *   - 32601~32660 (UTM 북반구 zone 1~60)
-         *   - 32701~32760 (UTM 남반구 zone 1~60) — Codex Plan v2 High#3
-         *   - 3413 (NSIDC Polar Stereographic North)
-         *   - 3031 (Antarctic Polar Stereographic)
-         */
         val SUPPORTED_CRS: Set<String> = buildSet {
             add("EPSG:4326")
             add("EPSG:4269")
@@ -97,112 +81,338 @@ internal sealed class CoordinateReprojector {
             add("EPSG:3031")
         }
 
-        /** Geographic CRS 인지 (EPSG:4326 / 4269) */
-        private fun isGeographic(crs: String): Boolean = crs in setOf("EPSG:4326", "EPSG:4269")
+        private val SUPPORTED_GRID_MAPPING_NAMES: Set<String> = setOf(
+            "latitude_longitude",
+            "transverse_mercator",
+            "mercator",
+            "polar_stereographic",
+            "stereographic",
+            "lambert_conformal_conic",
+            "lambert_azimuthal_equal_area",
+            "albers_conical_equal_area",
+        )
 
-        /**
-         * source CRS 를 탐지한다.
-         *
-         * 우선순위:
-         * 1. variable 의 `grid_mapping` 속성 → 참조된 grid_mapping 변수의 `epsg_code` 또는 `grid_mapping_name`
-         * 2. lat/lon axis 가 있으면 EPSG:4326 (default)
-         *
-         * 미지원 CRS 면 [NetCdfException.UnsupportedProjection] throw.
-         */
+        private val SPATIAL_REF_EPSG_PATTERN = Regex(
+            """EPSG:([0-9]+)(?![0-9A-Za-z.+-])""",
+            RegexOption.IGNORE_CASE,
+        )
+        private val SPATIAL_REF_AUTHORITY_EPSG_PATTERN = Regex(
+            """AUTHORITY\s*\[\s*[\"']EPSG[\"']\s*,\s*(?:[\"']([0-9]+)[\"']|([0-9]+))\s*\]""",
+            RegexOption.IGNORE_CASE,
+        )
+        private val SPATIAL_REF_ID_EPSG_PATTERN = Regex(
+            """ID\s*\[\s*[\"']EPSG[\"']\s*,\s*(?:[\"']([0-9]+)[\"']|([0-9]+))\s*\]""",
+            RegexOption.IGNORE_CASE,
+        )
+        private val SPATIAL_REF_EPSG_MARKER_PATTERN = Regex(
+            """(?<![0-9A-Za-z])EPSG:|(?:AUTHORITY|ID)\s*\[\s*[\"']EPSG[\"']\s*,""",
+            RegexOption.IGNORE_CASE,
+        )
+
+        private fun isGeographic(crs: String): Boolean = crs == "EPSG:4326" || crs == "EPSG:4269"
+
+        /** variable/grid_mapping 속성에서 strict ASCII EPSG 코드를 해석합니다. */
         private fun detectSourceCrs(variable: Variable, dataset: NetcdfDataset, axisMap: VariableAxisMap): String {
-            val gridMapping = variable.findAttribute("grid_mapping")?.stringValue
-            if (gridMapping != null) {
-                val mappingVar = dataset.findVariable(gridMapping)
-                val epsgCode = mappingVar?.findAttribute("epsg_code")?.numericValue?.toInt()
-                if (epsgCode != null) return "EPSG:$epsgCode"
-                // grid_mapping_name 이 있으면 보수적으로 latlon 만 인식
-                val name = mappingVar?.findAttribute("grid_mapping_name")?.stringValue
-                if (name == "latitude_longitude") return "EPSG:4326"
-                if (name != null) {
-                    throw NetCdfException.UnsupportedProjection(name)
+            val mappingAttribute = variable.findAttribute("grid_mapping")
+            if (mappingAttribute != null) {
+                val mappingName = mappingAttribute.stringValue?.trim()
+                    ?: throw NetCdfException.UnsupportedProjection("grid_mapping")
+                if (mappingName.isEmpty()) {
+                    throw NetCdfException.UnsupportedProjection("grid_mapping")
                 }
+                val mapping = dataset.findVariable(mappingName)
+                    ?: throw NetCdfException.UnsupportedProjection(mappingName)
+                val gridMappingAttribute = mapping.findAttribute("grid_mapping_name")
+                val gridMappingName = gridMappingAttribute?.stringValue?.trim()
+                    ?: if (gridMappingAttribute == null) null else
+                    throw NetCdfException.UnsupportedProjection("grid_mapping_name")
+                if (gridMappingName.isNullOrEmpty() && gridMappingAttribute != null) {
+                    throw NetCdfException.UnsupportedProjection("grid_mapping_name")
+                }
+                if (gridMappingName != null && gridMappingName !in SUPPORTED_GRID_MAPPING_NAMES) {
+                    throw NetCdfException.UnsupportedProjection(gridMappingName)
+                }
+                if (gridMappingName == null) {
+                    throw NetCdfException.UnsupportedProjection("grid_mapping_name")
+                }
+                val epsgAttribute = mapping.findAttribute("epsg_code")
+                val epsg = epsgAttribute?.let { parseEpsgAttribute(it) }
+                val spatialRefAttribute = mapping.findAttribute("spatial_ref")
+                val spatialRef = if (spatialRefAttribute == null) {
+                    null
+                } else {
+                    val rawSpatialRef = spatialRefAttribute.stringValue?.trim()
+                        ?: throw NetCdfException.UnsupportedProjection("spatial_ref")
+                    if (rawSpatialRef.isEmpty()) {
+                        throw NetCdfException.UnsupportedProjection("spatial_ref")
+                    }
+                    parseSpatialRefEpsg(rawSpatialRef)
+                }
+                if (epsg != null && spatialRef != null && epsg != spatialRef) {
+                    throw NetCdfException.UnsupportedProjection("conflicting:$epsg:$spatialRef")
+                }
+                val resolved = epsg ?: spatialRef
+                if (gridMappingName == "latitude_longitude") {
+                    if (resolved != null && resolved != WGS84) {
+                        throw NetCdfException.UnsupportedProjection("conflicting:latitude_longitude:$resolved")
+                    }
+                    return resolved ?: WGS84
+                }
+                if (resolved != null) return resolved
+                throw NetCdfException.UnsupportedProjection(gridMappingName)
             }
-            // grid_mapping 없으면 axisMap 의 lat/lon 존재 여부로 EPSG:4326 추정
-            return if (axisMap.latDim != null && axisMap.lonDim != null) WGS84
-            else throw NetCdfException.UnsupportedProjection("unknown")
+            val latStandardName = axisMap.latAxis?.axis?.findAttributeString("standard_name", "")?.lowercase()
+            val lonStandardName = axisMap.lonAxis?.axis?.findAttributeString("standard_name", "")?.lowercase()
+            val latUnits = axisMap.latAxis?.axis?.unitsString?.lowercase().orEmpty()
+            val lonUnits = axisMap.lonAxis?.axis?.unitsString?.lowercase().orEmpty()
+            val geographicNames = setOf("latitude", "longitude", "grid_latitude", "grid_longitude")
+            val geographicAxes =
+                (latStandardName in geographicNames || latUnits.contains("degrees_north")) &&
+                    (lonStandardName in geographicNames || lonUnits.contains("degrees_east"))
+            return if (geographicAxes) WGS84 else throw NetCdfException.UnsupportedProjection("missing-grid-mapping")
         }
 
-        /**
-         * Reprojector 를 빌드한다.
-         *
-         * 1. [detectSourceCrs] 로 source CRS 결정
-         * 2. 화이트리스트 검사 → 외이면 [NetCdfException.UnsupportedProjection]
-         * 3. Geographic 이면 lat/lon 1D 배열 그대로 캐싱
-         * 4. Projected 이면 격자 cell 단위 2D pair 변환
-         */
+        private fun parseEpsgAttribute(attribute: ucar.nc2.Attribute): String {
+            val raw = attribute.stringValue ?: attribute.numericValue?.toString()
+                ?: throw NetCdfException.UnsupportedProjection(attribute.shortName)
+            val digits = raw.removePrefix("EPSG:")
+            if (digits.isEmpty() || digits.any { it !in '0'..'9' }) {
+                throw NetCdfException.UnsupportedProjection(raw)
+            }
+            val code = try {
+                digits.toLong()
+            } catch (e: NumberFormatException) {
+                throw NetCdfException.UnsupportedProjection(raw, e)
+            }
+            if (code !in 1L..Int.MAX_VALUE) throw NetCdfException.UnsupportedProjection(raw)
+            return "EPSG:$code"
+        }
+
+        private fun parseSpatialRefEpsg(raw: String): String? {
+            val directMatches = SPATIAL_REF_EPSG_PATTERN.findAll(raw).toList()
+            val structuredMatches = (
+                SPATIAL_REF_AUTHORITY_EPSG_PATTERN.findAll(raw).map { match ->
+                    match to (match.groupValues[1].ifEmpty { match.groupValues[2] })
+                } + SPATIAL_REF_ID_EPSG_PATTERN.findAll(raw).map { match ->
+                    match to (match.groupValues[1].ifEmpty { match.groupValues[2] })
+                }
+                ).sortedBy { it.first.range.first }
+                .toList()
+            val markerCount = SPATIAL_REF_EPSG_MARKER_PATTERN.findAll(raw).count()
+            if (markerCount != directMatches.size + structuredMatches.size) {
+                throw NetCdfException.UnsupportedProjection("invalid-spatial-ref")
+            }
+            val directCodes = directMatches.map { it.groupValues[1].toLongOrNull() }
+            val structuredCodes = structuredMatches.map { it.second.toLongOrNull() }
+            val allCodes = directCodes + structuredCodes
+            if (allCodes.isEmpty() || allCodes.any { it == null || it !in 1L..Int.MAX_VALUE }) {
+                throw NetCdfException.UnsupportedProjection("invalid-spatial-ref")
+            }
+            val rootCode = structuredCodes.lastOrNull() ?: directCodes.singleOrNull()
+            if (rootCode == null) throw NetCdfException.UnsupportedProjection("conflicting-spatial-ref")
+            val directDistinct = directCodes.filterNotNull().distinct()
+            if (directDistinct.size > 1 || (directDistinct.singleOrNull() != null &&
+                    structuredCodes.lastOrNull() != null && directDistinct.single() != structuredCodes.last()
+                )
+            ) {
+                throw NetCdfException.UnsupportedProjection("conflicting-spatial-ref")
+            }
+            return "EPSG:$rootCode"
+        }
+
+        /** variable의 축을 읽는 bounded reprojection 구현을 만듭니다. */
         fun from(
             variable: Variable,
             dataset: NetcdfDataset,
             axisMap: VariableAxisMap,
         ): CoordinateReprojector {
-            // 좌표축 누락은 CRS 미지원 보다 우선 검증 (Spec §3.3 — typed exception 명확성)
-            val latDim = axisMap.latDim ?: throw NetCdfException.MissingCoordinate("lat")
-            val lonDim = axisMap.lonDim ?: throw NetCdfException.MissingCoordinate("lon")
-
-            val srcCrs = detectSourceCrs(variable, dataset, axisMap)
-            if (srcCrs !in SUPPORTED_CRS) {
-                throw NetCdfException.UnsupportedProjection(srcCrs)
+            val latBinding = axisMap.latAxis
+                ?: throw NetCdfException.MissingCoordinate("lat")
+            val lonBinding = axisMap.lonAxis
+                ?: throw NetCdfException.MissingCoordinate("lon")
+            val sourceCrs = detectSourceCrs(variable, dataset, axisMap)
+            if (sourceCrs !in SUPPORTED_CRS) {
+                throw NetCdfException.UnsupportedProjection(sourceCrs)
             }
 
-            val latAxis = dataset.findCoordinateAxis(variable.getDimension(latDim).shortName) as? CoordinateAxis1D
-                ?: throw NetCdfException.MissingCoordinate("lat (CoordinateAxis1D required)")
-            val lonAxis = dataset.findCoordinateAxis(variable.getDimension(lonDim).shortName) as? CoordinateAxis1D
-                ?: throw NetCdfException.MissingCoordinate("lon (CoordinateAxis1D required)")
+            val axes = buildMap {
+                put(latBinding.name, latBinding.axis)
+                put(lonBinding.name, lonBinding.axis)
+            }
+            val reader = UcarCoordinateReader(axes, variable.fullName)
+            val rawPoint: (Int, Int) -> Pair<Double, Double> = { row, column ->
+                val x = readBinding(lonBinding, row, column, axisMap, reader)
+                val y = readBinding(latBinding, row, column, axisMap, reader)
+                if (!x.isFinite() || !y.isFinite()) {
+                    throw NetCdfException.UnsupportedCoordinateAxis(variable.fullName, "lon/lat", "non-finite")
+                }
+                x to y
+            }
 
-            return if (isGeographic(srcCrs)) {
-                Geographic(
-                    lonValues = lonAxis.coordValues.copyOf(),
-                    latValues = latAxis.coordValues.copyOf(),
-                    sourceCrs = srcCrs,
+            if (isGeographic(sourceCrs)) {
+                return ReaderBacked(
+                    sourceCrs = sourceCrs,
+                    pointReader = { row, column ->
+                        val (lon, lat) = rawPoint(row, column)
+                        if (!validateGeographicCoordinate(lon, lat)) {
+                            throw NetCdfException.UnsupportedProjection("$sourceCrs:${variable.fullName}:out-of-range")
+                        }
+                        lon to lat
+                    },
                 )
+            }
+
+            val transform = try {
+                val source = crsFactory.createFromName(sourceCrs)
+                val target = crsFactory.createFromName(WGS84)
+                transformFactory.createTransform(source, target)
+            } catch (e: Exception) {
+                throw NetCdfException.UnsupportedProjection(sourceCrs, e)
+            }
+            return ReaderBacked(
+                sourceCrs = sourceCrs,
+                pointReader = { row, column ->
+                    val (x, y) = rawPoint(row, column)
+                    transformToWgs84(transform, x, y, sourceCrs, variable.fullName)
+                },
+                tileReader = { rowOrigin, columnOrigin, rowCount, columnCount ->
+                    val xWindow = readBindingWindow(
+                        lonBinding,
+                        axisMap,
+                        reader,
+                        rowOrigin,
+                        columnOrigin,
+                        rowCount,
+                        columnCount,
+                    )
+                    val yWindow = readBindingWindow(
+                        latBinding,
+                        axisMap,
+                        reader,
+                        rowOrigin,
+                        columnOrigin,
+                        rowCount,
+                        columnCount,
+                    )
+                    val provider: (Int, Int) -> Pair<Double, Double> = { row, column ->
+                        val localRow = row - rowOrigin
+                        val localColumn = column - columnOrigin
+                        val offset = localRow * columnCount + localColumn
+                        transformToWgs84(
+                            transform,
+                            xWindow[offset],
+                            yWindow[offset],
+                            sourceCrs,
+                            variable.fullName,
+                        )
+                    }
+                    provider
+                },
+            )
+        }
+
+        private fun readBinding(
+            binding: VariableAxisMap.AxisBinding,
+            row: Int,
+            column: Int,
+            axisMap: VariableAxisMap,
+            reader: CoordinateReader,
+        ): Double {
+            return if (binding.isTwoDimensional) {
+                val gridRowDim = axisMap.gridRowDim
+                    ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "missing-row-dimension")
+                val gridColumnDim = axisMap.gridColumnDim
+                    ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "missing-column-dimension")
+                val rowAxis = binding.dimensionIndices.indexOf(gridRowDim)
+                val columnAxis = binding.dimensionIndices.indexOf(gridColumnDim)
+                if (rowAxis < 0 || columnAxis < 0) {
+                    throw NetCdfException.UnsupportedCoordinateAxis(
+                        binding.name,
+                        binding.name,
+                        "grid-dimension-order",
+                    )
+                }
+                val values = if (rowAxis == 0 && columnAxis == 1) {
+                    reader.read2D(binding.name, row, column, 1, 1)
+                } else {
+                    reader.read2D(binding.name, column, row, 1, 1)
+                }
+                values.firstOrNull()
+                    ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "empty-window")
             } else {
-                buildProjected(latAxis, lonAxis, srcCrs)
+                val axisDim = binding.dimensionIndices.singleOrNull()
+                    ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "axis-dimension")
+                val index = if (axisDim == axisMap.gridRowDim) row else column
+                reader.read1D(binding.name, index, 1).firstOrNull()
+                    ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "empty-window")
             }
         }
 
-        /**
-         * Projected CRS 를 격자 cell 단위로 EPSG:4326 으로 변환.
-         *
-         * 메모리 비용: lat × lon × 2 doubles (예: 721 × 1440 × 16B = 16MB).
-         */
-        private fun buildProjected(
-            latAxis: CoordinateAxis1D,
-            lonAxis: CoordinateAxis1D,
-            srcCrs: String,
-        ): Projected {
-            val sourceCrsObj = try {
-                crsFactory.createFromName(srcCrs)
-            } catch (e: Exception) {
-                throw NetCdfException.UnsupportedProjection(srcCrs, e)
-            }
-            val targetCrsObj = crsFactory.createFromName(WGS84)
-            val transform = transformFactory.createTransform(sourceCrsObj, targetCrsObj)
-
-            val latN = latAxis.size.toInt()
-            val lonN = lonAxis.size.toInt()
-            val flat = DoubleArray(latN * lonN * 2)
-
-            val src = ProjCoordinate()
-            val dst = ProjCoordinate()
-            for (i in 0 until latN) {
-                val y = latAxis.getCoordValue(i)
-                for (j in 0 until lonN) {
-                    val x = lonAxis.getCoordValue(j)
-                    src.setValue(x, y)
-                    transform.transform(src, dst)
-                    val base = (i * lonN + j) * 2
-                    flat[base] = dst.x  // lon
-                    flat[base + 1] = dst.y  // lat
+        private fun readBindingWindow(
+            binding: VariableAxisMap.AxisBinding,
+            axisMap: VariableAxisMap,
+            reader: CoordinateReader,
+            rowOrigin: Int,
+            columnOrigin: Int,
+            rowCount: Int,
+            columnCount: Int,
+        ): DoubleArray {
+            if (!binding.isTwoDimensional) {
+                val axisDim = binding.dimensionIndices.singleOrNull()
+                    ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "axis-dimension")
+                val source = if (axisDim == axisMap.gridRowDim) {
+                    reader.read1D(binding.name, rowOrigin, rowCount)
+                } else if (axisDim == axisMap.gridColumnDim) {
+                    reader.read1D(binding.name, columnOrigin, columnCount)
+                } else {
+                    throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "grid-dimension")
+                }
+                return DoubleArray(rowCount * columnCount) { index ->
+                    val row = index / columnCount
+                    val column = index % columnCount
+                    source[if (axisDim == axisMap.gridRowDim) row else column]
                 }
             }
-            log.debug { "Projected reprojection done — srcCrs=$srcCrs gridSize=${latN}x${lonN}" }
+            val rowDim = axisMap.gridRowDim
+                ?: throw NetCdfException.MissingCoordinate("lat")
+            val columnDim = axisMap.gridColumnDim
+                ?: throw NetCdfException.MissingCoordinate("lon")
+            val axisRow = binding.dimensionIndices.indexOf(rowDim)
+            val axisColumn = binding.dimensionIndices.indexOf(columnDim)
+            if (axisRow < 0 || axisColumn < 0) {
+                throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "grid-dimension-order")
+            }
+            if (axisRow == 0 && axisColumn == 1) {
+                return reader.read2D(binding.name, rowOrigin, columnOrigin, rowCount, columnCount)
+            }
+            val source = reader.read2D(binding.name, columnOrigin, rowOrigin, columnCount, rowCount)
+            return DoubleArray(rowCount * columnCount) { index ->
+                val row = index / columnCount
+                val column = index % columnCount
+                source[column * rowCount + row]
+            }
+        }
 
-            return Projected(projected = flat, lonCount = lonN, sourceCrs = srcCrs)
+        private fun transformToWgs84(
+            transform: CoordinateTransform,
+            x: Double,
+            y: Double,
+            sourceCrs: String,
+            variableName: String,
+        ): Pair<Double, Double> {
+            val src = ProjCoordinate(x, y)
+            val dst = ProjCoordinate()
+            return try {
+                transform.transform(src, dst)
+                if (!validateGeographicCoordinate(dst.x, dst.y)) {
+                    throw NetCdfException.UnsupportedProjection(sourceCrs)
+                }
+                dst.x to dst.y
+            } catch (e: NetCdfException) {
+                throw e
+            } catch (e: Exception) {
+                throw NetCdfException.UnsupportedProjection("$sourceCrs:$variableName", e)
+            }
         }
     }
 }

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializer.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializer.kt
@@ -1,0 +1,79 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.bluetape4k.science.exposed.NetCdfException
+import java.nio.charset.StandardCharsets
+import java.text.Normalizer
+
+private val auxiliaryMapper = jacksonObjectMapper()
+
+/**
+ * CF auxiliary 좌표를 JSONB 문자열로 직렬화합니다.
+ *
+ * 위치·시간·레벨 축은 호출자가 제외하고 넘겨야 하며, 비유한 값은 저장하지 않습니다.
+ * 키 순서는 입력 Map 순서를 따르고, UTF-8 크기와 예약 namespace를 검증합니다.
+ */
+internal fun serializeAuxiliaryAttributes(values: Map<String, Double>): String? {
+    if (values.isEmpty()) return null
+    val filtered = LinkedHashMap<String, Double>()
+    values.forEach { (key, value) ->
+        validateAuxiliaryKey(key)
+        if (value.isFinite()) filtered[key] = value
+    }
+    if (filtered.isEmpty()) return null
+
+    val json = auxiliaryMapper.writeValueAsString(filtered)
+    val size = json.toByteArray(StandardCharsets.UTF_8).size.toLong()
+    if (size > MAX_AUXILIARY_JSONB_BYTES) {
+        throw NetCdfException.ResourceLimitExceeded("auxiliary-jsonb", MAX_AUXILIARY_JSONB_BYTES, size)
+    }
+    return json
+}
+
+private fun validateAuxiliaryKey(key: String) {
+    val normalized = Normalizer.normalize(key, Normalizer.Form.NFC)
+    val keyBytes = key.toByteArray(StandardCharsets.UTF_8).size.toLong()
+    val invalid = key.isEmpty() || keyBytes > MAX_VARIABLE_NAME_BYTES || normalized != key ||
+        key.startsWith("__bluetape4k_") ||
+        key.any(Char::isISOControl) || containsUnpairedSurrogate(key)
+    if (invalid) {
+        throw NetCdfException.ResourceLimitExceeded(
+            resource = "auxiliary-key",
+            limit = MAX_VARIABLE_NAME_BYTES,
+            actual = keyBytes,
+        )
+    }
+}
+
+private fun containsUnpairedSurrogate(value: String): Boolean {
+    var index = 0
+    while (index < value.length) {
+        val character = value[index]
+        when {
+            Character.isHighSurrogate(character) -> {
+                if (index + 1 >= value.length || !Character.isLowSurrogate(value[index + 1])) return true
+                index += 2
+            }
+            Character.isLowSurrogate(character) -> return true
+            else -> index++
+        }
+    }
+    return false
+}
+
+/** DB writer가 공통으로 소비하는 하나의 격자 행입니다. */
+internal data class TileRow(
+    val fileId: Long,
+    val variableName: String,
+    val longitude: Double?,
+    val latitude: Double?,
+    val timeIdx: Int,
+    val levelIdx: Int,
+    val value: Double,
+    val attrsJson: String? = null,
+)
+
+internal data class BatchWriteResult(
+    val inserted: Int,
+    val conflicts: Int,
+)

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSampler.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSampler.kt
@@ -1,0 +1,291 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.science.exposed.NetCdfException
+import ucar.ma2.Array as UcarArray
+import ucar.nc2.Variable
+import java.util.concurrent.CancellationException
+
+/** NetCDF variable를 bounded section으로 읽는 추상화입니다. */
+internal fun interface VariableReader {
+    fun read(origin: IntArray, shape: IntArray): UcarArray
+}
+
+/** 1D/2D 좌표축의 tile window만 읽는 추상화입니다. */
+internal interface CoordinateReader {
+    fun read1D(axisName: String, origin: Int, length: Int): DoubleArray
+
+    fun read2D(
+        axisName: String,
+        rowOrigin: Int,
+        columnOrigin: Int,
+        rowCount: Int,
+        columnCount: Int,
+    ): DoubleArray
+}
+
+/** 한 셀을 즉시 소비하기 위한 좌표 샘플러입니다. */
+internal fun interface CoordinateSampler {
+    fun sample(globalRow: Int, globalColumn: Int, target: MutableCoordinateSample)
+}
+
+/** sampler 호출자가 소유하는 재사용 가능한 mutable cell buffer입니다. */
+internal class MutableCoordinateSample {
+    var longitude: Double = 0.0
+    var latitude: Double = 0.0
+    val auxiliary: MutableMap<String, Double> = LinkedHashMap()
+
+    fun clear() {
+        longitude = 0.0
+        latitude = 0.0
+        auxiliary.clear()
+    }
+
+    fun readOnlyCopy(): CoordinateSample = CoordinateSample(longitude, latitude, auxiliary.toMap())
+}
+
+/** tile 밖으로 mutable 상태가 누출되지 않는 immutable cell snapshot입니다. */
+internal data class CoordinateSample(
+    val longitude: Double,
+    val latitude: Double,
+    val auxiliary: Map<String, Double>,
+)
+
+/** 좌표의 finite/bounds 계약을 검사합니다. */
+internal fun validateGeographicCoordinate(longitude: Double, latitude: Double): Boolean =
+    longitude.isFinite() && latitude.isFinite() && longitude in -180.0..180.0 && latitude in -90.0..90.0
+
+/** UCAR [CoordinateAxis]를 요청된 window만큼 읽는 구현입니다. */
+internal class UcarCoordinateReader(
+    private val axes: Map<String, Variable>,
+    private val variableName: String,
+): CoordinateReader {
+
+    override fun read1D(axisName: String, origin: Int, length: Int): DoubleArray {
+        val axis = axis(axisName)
+        if (axis.rank != 1 || origin < 0 || length < 0 ||
+            origin.toLong() + length.toLong() > axis.shape[0].toLong()
+        ) {
+            throw NetCdfException.UnsupportedCoordinateAxis(variableName, axisName, "invalid-1d-window")
+        }
+        return try {
+            val values = axis.read(intArrayOf(origin), intArrayOf(length))
+            values.toDoubleArray()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            throw NetCdfException.UnsupportedCoordinateAxis(variableName, axisName, "read-1d")
+        }
+    }
+
+    override fun read2D(
+        axisName: String,
+        rowOrigin: Int,
+        columnOrigin: Int,
+        rowCount: Int,
+        columnCount: Int,
+    ): DoubleArray {
+        val axis = axis(axisName)
+        val shape = axis.shape
+        if (axis.rank != 2 || rowOrigin < 0 || columnOrigin < 0 || rowCount < 0 || columnCount < 0 ||
+            rowOrigin.toLong() + rowCount.toLong() > shape[0].toLong() ||
+            columnOrigin.toLong() + columnCount.toLong() > shape[1].toLong()
+        ) {
+            throw NetCdfException.UnsupportedCoordinateAxis(variableName, axisName, "invalid-2d-window")
+        }
+        return try {
+            val values = axis.read(
+                intArrayOf(rowOrigin, columnOrigin),
+                intArrayOf(rowCount, columnCount),
+            )
+            values.toDoubleArray()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            throw NetCdfException.UnsupportedCoordinateAxis(variableName, axisName, "read-2d")
+        }
+    }
+
+    private fun axis(name: String): Variable = axes[name]
+        ?: throw NetCdfException.UnsupportedCoordinateAxis(variableName, name, "axis-not-found")
+}
+
+/** axis map에 맞춰 lon/lat과 numeric CF auxiliary를 한 셀씩 채웁니다. */
+internal class NetCdfCoordinateSampler(
+    private val map: VariableAxisMap,
+    private val reader: CoordinateReader,
+    private val pointProvider: ((Int, Int) -> Pair<Double, Double>)? = null,
+) : CoordinateSampler {
+
+    override fun sample(globalRow: Int, globalColumn: Int, target: MutableCoordinateSample) {
+        target.clear()
+        val (longitude, latitude) = pointProvider?.invoke(globalRow, globalColumn)
+            ?: rawPoint(globalRow, globalColumn)
+        if (!validateGeographicCoordinate(longitude, latitude)) {
+            throw NetCdfException.UnsupportedCoordinateAxis(
+                variableName = "coordinate",
+                coordinateName = "lon/lat",
+                reason = "non-finite-or-out-of-range",
+            )
+        }
+        target.longitude = longitude
+        target.latitude = latitude
+        map.auxiliaryAxes.forEach { auxiliary ->
+            val value = readBinding(auxiliary, globalRow, globalColumn)
+            if (value.isFinite()) {
+                target.auxiliary[auxiliary.name] = value
+            }
+        }
+    }
+
+    private fun rawPoint(globalRow: Int, globalColumn: Int): Pair<Double, Double> {
+        val latBinding = map.latAxis
+            ?: throw NetCdfException.MissingCoordinate("lat")
+        val lonBinding = map.lonAxis
+            ?: throw NetCdfException.MissingCoordinate("lon")
+        val longitude = readBinding(lonBinding, globalRow, globalColumn)
+        val latitude = readBinding(latBinding, globalRow, globalColumn)
+        return longitude to latitude
+    }
+
+    private fun readBinding(binding: VariableAxisMap.AxisBinding, row: Int, column: Int): Double {
+        return if (binding.isTwoDimensional) {
+            val rowDim = map.gridRowDim
+                ?: throw NetCdfException.MissingCoordinate("lat")
+            val columnDim = map.gridColumnDim
+                ?: throw NetCdfException.MissingCoordinate("lon")
+            val axisRow = binding.dimensionIndices.indexOf(rowDim)
+            val axisColumn = binding.dimensionIndices.indexOf(columnDim)
+            if (axisRow < 0 || axisColumn < 0) {
+                throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "grid-dimension-order")
+            }
+            val window = if (axisRow == 0 && axisColumn == 1) {
+                reader.read2D(binding.name, row, column, 1, 1)
+            } else {
+                reader.read2D(binding.name, column, row, 1, 1)
+            }
+            window.firstOrNull()
+                ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "empty-window")
+        } else {
+            val axisDim = binding.dimensionIndices.singleOrNull()
+                ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "axis-dimension")
+            val index = if (axisDim == map.gridRowDim) row else column
+            reader.read1D(binding.name, index, 1).firstOrNull()
+                ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "empty-window")
+        }
+    }
+}
+
+/** 현재 tile의 좌표 window만 보유하는 sampler입니다. */
+internal class NetCdfTileCoordinateSampler(
+    private val map: VariableAxisMap,
+    private val reader: CoordinateReader,
+    private val rowOrigin: Int,
+    private val columnOrigin: Int,
+    private val rowCount: Int,
+    private val columnCount: Int,
+    private val pointProvider: ((Int, Int) -> Pair<Double, Double>)? = null,
+) : CoordinateSampler {
+
+    private val longitudeWindow = if (pointProvider == null) map.lonAxis?.let(::readWindow) else null
+    private val latitudeWindow = if (pointProvider == null) map.latAxis?.let(::readWindow) else null
+    private val auxiliaryValues = map.auxiliaryAxes.associate { it.name to readWindow(it) }
+
+    override fun sample(globalRow: Int, globalColumn: Int, target: MutableCoordinateSample) {
+        target.clear()
+        val (longitude, latitude) = pointProvider?.invoke(globalRow, globalColumn)
+            ?: rawPoint(globalRow, globalColumn)
+        if (!validateGeographicCoordinate(longitude, latitude)) {
+            throw NetCdfException.UnsupportedCoordinateAxis(
+                variableName = "coordinate",
+                coordinateName = "lon/lat",
+                reason = "non-finite-or-out-of-range",
+            )
+        }
+        target.longitude = longitude
+        target.latitude = latitude
+        map.auxiliaryAxes.forEach { auxiliary ->
+            val value = valueAt(auxiliaryValues.getValue(auxiliary.name), globalRow, globalColumn)
+            if (value.isFinite()) target.auxiliary[auxiliary.name] = value
+        }
+    }
+
+    private fun rawPoint(globalRow: Int, globalColumn: Int): Pair<Double, Double> {
+        if (map.latAxis == null) throw NetCdfException.MissingCoordinate("lat")
+        if (map.lonAxis == null) throw NetCdfException.MissingCoordinate("lon")
+        val lat = latitudeWindow ?: throw NetCdfException.MissingCoordinate("lat")
+        val lon = longitudeWindow ?: throw NetCdfException.MissingCoordinate("lon")
+        return valueAt(lon, globalRow, globalColumn) to
+            valueAt(lat, globalRow, globalColumn)
+    }
+
+    private fun readWindow(binding: VariableAxisMap.AxisBinding): CoordinateWindow {
+        if (!binding.isTwoDimensional) {
+            val axisDim = binding.dimensionIndices.singleOrNull()
+                ?: throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "axis-dimension")
+            return if (axisDim == map.gridRowDim) {
+                CoordinateWindow(reader.read1D(binding.name, rowOrigin, rowCount), true)
+            } else if (axisDim == map.gridColumnDim) {
+                CoordinateWindow(reader.read1D(binding.name, columnOrigin, columnCount), false)
+            } else {
+                throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "grid-dimension")
+            }
+        }
+        val rowDim = map.gridRowDim
+            ?: throw NetCdfException.MissingCoordinate("lat")
+        val columnDim = map.gridColumnDim
+            ?: throw NetCdfException.MissingCoordinate("lon")
+        val axisRow = binding.dimensionIndices.indexOf(rowDim)
+        val axisColumn = binding.dimensionIndices.indexOf(columnDim)
+        if (axisRow < 0 || axisColumn < 0) {
+            throw NetCdfException.UnsupportedCoordinateAxis(binding.name, binding.name, "grid-dimension-order")
+        }
+        return if (axisRow == 0 && axisColumn == 1) {
+            CoordinateWindow(
+                reader.read2D(binding.name, rowOrigin, columnOrigin, rowCount, columnCount),
+                null,
+            )
+        } else {
+            val source = reader.read2D(binding.name, columnOrigin, rowOrigin, columnCount, rowCount)
+            CoordinateWindow(DoubleArray(rowCount * columnCount) { index ->
+                val row = index / columnCount
+                val column = index % columnCount
+                source[column * rowCount + row]
+            }, null)
+        }
+    }
+
+    private fun valueAt(
+        window: CoordinateWindow,
+        globalRow: Int,
+        globalColumn: Int,
+    ): Double {
+        val localRow = globalRow - rowOrigin
+        val localColumn = globalColumn - columnOrigin
+        if (localRow !in 0 until rowCount || localColumn !in 0 until columnCount) {
+            throw NetCdfException.UnsupportedCoordinateAxis("coordinate", null, "tile-index")
+        }
+        return when (window.rowAxis) {
+            true -> window.values[localRow]
+            false -> window.values[localColumn]
+            null -> window.values[localRow * columnCount + localColumn]
+        }
+    }
+
+    private data class CoordinateWindow(val values: DoubleArray, val rowAxis: Boolean?)
+}
+
+private fun UcarArray.toDoubleArray(): DoubleArray {
+    val values = DoubleArray(size.toInt())
+    val iterator = indexIterator
+    var index = 0
+    while (iterator.hasNext()) {
+        values[index++] = iterator.getDoubleNext()
+    }
+    return values
+}

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuard.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuard.kt
@@ -1,0 +1,198 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.science.exposed.NetCdfException
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.InvalidPathException
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.CancellationException
+import java.util.concurrent.TimeUnit
+
+/** 신뢰된 로컬 NetCDF 파일의 path/identity 경계를 한 곳에서 검증합니다. */
+internal object NetCdfFileGuard {
+
+    /** 등록 레코드의 globalAttrs에 저장하는 identity fingerprint key입니다. */
+    const val FINGERPRINT_ATTRIBUTE: String = "__bluetape4k_source_fingerprint"
+
+    /** 등록·resume 시점의 immutable 파일 identity입니다. */
+    data class Identity(
+        val path: Path,
+        val fingerprint: String,
+        val fileSize: Long,
+    )
+
+    /** 등록 전에 local regular file과 크기를 확인하고 fingerprint를 반환합니다. */
+    fun validateForRegister(filePath: String): Identity {
+        val path = parseLocalPath(filePath)
+        val identity = capture(path, fileId = 0L, expectedFingerprint = null)
+        return identity
+    }
+
+    /** 기존 등록 fingerprint와 현재 파일 identity가 같은지 확인합니다. */
+    fun verifyForResume(fileId: Long, filePath: String, expectedFingerprint: String): Identity {
+        val path = parseLocalPath(filePath)
+        return capture(path, fileId, expectedFingerprint)
+    }
+
+    /** open 전후 stat을 비교하는 generic helper입니다. */
+    fun <T : AutoCloseable> openVerified(
+        fileId: Long,
+        filePath: String,
+        expectedFingerprint: String?,
+        opener: () -> T,
+    ): T {
+        val before = if (expectedFingerprint == null) {
+            validateForRegister(filePath)
+        } else {
+            verifyForResume(fileId, filePath, expectedFingerprint)
+        }
+        val opened = try {
+            opener()
+        } catch (e: NetCdfException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            throw NetCdfException.FileOpen(filePath, e)
+        }
+        val after = try {
+            capture(before.path, fileId, before.fingerprint)
+        } catch (e: Exception) {
+            try {
+                opened.close()
+            } catch (_: Exception) {
+                // 원래 fingerprint 오류를 보존합니다.
+            }
+            throw e
+        }
+        if (before.fingerprint != after.fingerprint) {
+            try {
+                opened.close()
+            } catch (_: Exception) {
+                // 원래 FileChanged를 보존합니다.
+            }
+            throw NetCdfException.FileChanged(fileId, before.fingerprint, after.fingerprint)
+        }
+        return opened
+    }
+
+    private fun parseLocalPath(filePath: String): Path {
+        if (filePath.isBlank()) {
+            throw IllegalArgumentException("filePath must not be blank")
+        }
+        if (filePath.any { it.code < 0x20 || it == '\u007f' || it == '\u0000' }) {
+            throw NetCdfException.FileOpen(filePath, IllegalArgumentException("path contains control characters"))
+        }
+        try {
+            val uri = URI(filePath)
+            if (uri.scheme != null) {
+                throw NetCdfException.FileOpen(filePath, IllegalArgumentException("remote or URI paths are not allowed"))
+            }
+        } catch (e: NetCdfException) {
+            throw e
+        } catch (e: Exception) {
+            throw NetCdfException.FileOpen(filePath, e)
+        }
+        val path = try {
+            Paths.get(filePath).toAbsolutePath().normalize()
+        } catch (e: InvalidPathException) {
+            throw NetCdfException.FileOpen(filePath, e)
+        }
+        return path
+    }
+
+    private fun capture(path: Path, fileId: Long, expectedFingerprint: String?): Identity {
+        val absolute = try {
+            path.toAbsolutePath().normalize()
+        } catch (e: Exception) {
+            throw NetCdfException.FileOpen(path.toString(), e)
+        }
+        val attributes = try {
+            Files.readAttributes(
+                absolute,
+                BasicFileAttributes::class.java,
+                LinkOption.NOFOLLOW_LINKS,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            throw NetCdfException.FileOpen(absolute.toString(), e)
+        }
+        if (Files.isSymbolicLink(absolute)) {
+            if (fileId == 0L) {
+                throw NetCdfException.FileOpen(
+                    absolute.toString(),
+                    IllegalArgumentException("NetCDF path must not be a symbolic link"),
+                )
+            }
+            throw NetCdfException.FileChanged(fileId, "regular-file", "symlink:$absolute")
+        }
+        rejectSymlinkComponents(absolute, fileId)
+        // macOS exposes /var and /tmp as system symlinks. They are the only allowed
+        // aliases; caller-provided parent/final symlinks are rejected above/below.
+        val realPath = try {
+            absolute.toRealPath()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            throw NetCdfException.FileOpen(absolute.toString(), e)
+        }
+        if (!attributes.isRegularFile) {
+            throw NetCdfException.FileOpen(
+                absolute.toString(),
+                IllegalArgumentException("NetCDF path must be a regular file"),
+            )
+        }
+        val size = attributes.size()
+        if (size > MAX_FILE_BYTES) {
+            throw NetCdfException.ResourceLimitExceeded("file-bytes", MAX_FILE_BYTES, size)
+        }
+        val fileKey = attributes.fileKey()?.toString()
+            ?: throw NetCdfException.FileOpen(
+                absolute.toString(),
+                IllegalStateException("file identity key is unavailable"),
+            )
+        val modifiedNanos = attributes.lastModifiedTime().to(TimeUnit.NANOSECONDS)
+        val fingerprint = "$fileKey|$size|$modifiedNanos"
+        if (expectedFingerprint != null && expectedFingerprint != fingerprint) {
+            throw NetCdfException.FileChanged(fileId, expectedFingerprint, fingerprint)
+        }
+        return Identity(realPath, fingerprint, size)
+    }
+
+    private fun rejectSymlinkComponents(path: Path, fileId: Long) {
+        var current = path.root
+        for (component in path) {
+            current = if (current == null) component else current.resolve(component)
+            if (Files.isSymbolicLink(current) && !isAllowedSystemAlias(current)) {
+                if (fileId == 0L) {
+                    throw NetCdfException.FileOpen(
+                        path.toString(),
+                        IllegalArgumentException("NetCDF parent path must not be a symbolic link: $current"),
+                    )
+                } else {
+                    throw NetCdfException.FileChanged(
+                        fileId,
+                        expectedFingerprint = "regular-file",
+                        actualFingerprint = "symlink:$current",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun isAllowedSystemAlias(path: Path): Boolean =
+        path == Paths.get("/tmp") || path == Paths.get("/var")
+}

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimits.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimits.kt
@@ -1,0 +1,208 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.science.exposed.NetCdfException
+
+/** NetCDF import 에 적용하는 bounded resource 계약입니다. */
+internal const val MAX_VARIABLE_NAME_BYTES: Long = 128L
+internal const val MAX_COORDINATE_TOKENS: Long = 32L
+internal const val MAX_AUXILIARY_AXES: Long = 16L
+internal const val MAX_VARIABLES: Long = 1_024L
+internal const val MAX_GROUP_DIMENSIONS: Long = 256L
+internal const val MAX_GROUP_COUNT: Long = 256L
+internal const val MAX_GROUP_DEPTH: Long = 32L
+internal const val MAX_METADATA_BYTES: Long = 1L shl 20
+internal const val MAX_FILE_BYTES: Long = 64L * 1024L * 1024L * 1024L
+internal const val MAX_CELLS: Long = 100_000_000L
+internal const val MAX_SLICES: Long = 1_000_000L
+internal const val MAX_TILE_CELLS: Long = 65_536L
+internal const val MAX_BATCH_ROWS: Long = 1_000L
+internal const val MAX_AUXILIARY_JSONB_BYTES: Long = 8_192L
+internal const val MAX_DUPLICATE_ENTRY_BYTES: Long = 32L
+internal const val MAX_COORDINATE_CACHE_BYTES: Long = 64L * 1024L * 1024L
+internal const val MAX_COORDINATE_WORKING_SET_BYTES: Long = 64L * 1024L * 1024L
+internal const val MAX_DUPLICATE_SET_BYTES: Long = 32L * 1024L * 1024L
+internal const val MAX_OWNED_WORKING_SET_BYTES: Long = 128L * 1024L * 1024L
+internal const val MAX_FIXED_ROW_BYTES: Long = 256L
+internal const val MAX_LEASE_RETRIES: Int = 3
+
+/** checked Long 곱셈을 수행하고 overflow 를 typed resource 오류로 변환합니다. */
+internal fun checkedProduct(vararg factors: Long): Long {
+    if (factors.any { it < 0L }) {
+        val actual = factors.firstOrNull { it < 0L } ?: -1L
+        throw NetCdfException.ResourceLimitExceeded("negative-factor", 0L, actual)
+    }
+    return try {
+        factors.fold(1L) { acc, factor -> Math.multiplyExact(acc, factor) }
+    } catch (e: ArithmeticException) {
+        throw NetCdfException.ResourceLimitExceeded("long-product", Long.MAX_VALUE, Long.MAX_VALUE,)
+    }
+}
+
+/** checked Long 덧셈입니다. */
+internal fun checkedSum(vararg values: Long): Long {
+    if (values.any { it < 0L }) {
+        val actual = values.firstOrNull { it < 0L } ?: -1L
+        throw NetCdfException.ResourceLimitExceeded("negative-value", 0L, actual)
+    }
+    return try {
+        values.fold(0L) { acc, value -> Math.addExact(acc, value) }
+    } catch (e: ArithmeticException) {
+        throw NetCdfException.ResourceLimitExceeded("long-sum", Long.MAX_VALUE, Long.MAX_VALUE)
+    }
+}
+
+/** import 한 번이 소유할 수 있는 working-set byte accounting 입니다. */
+internal data class MemoryBudget(
+    val tileBufferBytes: Long,
+    val coordinateBytes: Long,
+    val serializerScratchBytes: Long,
+    val duplicateSetBytes: Long,
+) {
+    val ownedWorkingSetBytes: Long
+        get() = checkedSum(tileBufferBytes, coordinateBytes, serializerScratchBytes, duplicateSetBytes)
+
+    fun requireWithinLimit() {
+        if (coordinateBytes > MAX_COORDINATE_CACHE_BYTES) {
+            throw NetCdfException.ResourceLimitExceeded(
+                "coordinate-cache",
+                MAX_COORDINATE_CACHE_BYTES,
+                coordinateBytes,
+            )
+        }
+        val coordinateAndDuplicate = checkedSum(coordinateBytes, duplicateSetBytes)
+        if (coordinateAndDuplicate > MAX_COORDINATE_WORKING_SET_BYTES) {
+            throw NetCdfException.ResourceLimitExceeded(
+                "coordinate-working-set",
+                MAX_COORDINATE_WORKING_SET_BYTES,
+                coordinateAndDuplicate,
+            )
+        }
+        val actual = ownedWorkingSetBytes
+        if (actual > MAX_OWNED_WORKING_SET_BYTES) {
+            throw NetCdfException.ResourceLimitExceeded(
+                "owned-working-set",
+                MAX_OWNED_WORKING_SET_BYTES,
+                actual,
+            )
+        }
+    }
+}
+
+/** tile 안에서 duplicate canonical coordinate 를 bounded 하게 추적합니다. */
+internal class CoordinateKeySet(
+    private val byteBudget: Long = MAX_DUPLICATE_SET_BYTES,
+    expectedSize: Int? = null,
+) {
+    private var timeLevels: LongArray
+    private var longitudes: LongArray
+    private var latitudes: LongArray
+    private var used: BooleanArray
+    private var count: Int = 0
+
+    init {
+        val capacity = expectedSize?.let(::capacityFor) ?: INITIAL_CAPACITY
+        requireCapacityWithinBudget(capacity)
+        timeLevels = LongArray(capacity)
+        longitudes = LongArray(capacity)
+        latitudes = LongArray(capacity)
+        used = BooleanArray(capacity)
+    }
+
+    /** open-addressing backing table과 rehash 여유를 반영한 byte estimate 입니다. */
+    val estimatedBytes: Long get() = checkedProduct(used.size.toLong(), BYTES_PER_SLOT)
+
+    fun add(timeIdx: Int, levelIdx: Int, longitude: Double, latitude: Double): Boolean {
+        val longitudeBits = canonicalDoubleBits(longitude)
+        val latitudeBits = canonicalDoubleBits(latitude)
+        if (count + 1 > used.size * LOAD_FACTOR_NUMERATOR / LOAD_FACTOR_DENOMINATOR) {
+            ensureCapacity(count + 1)
+        }
+        val packedTimeLevel = packTimeLevel(timeIdx, levelIdx)
+        val hash = hash(packedTimeLevel, longitudeBits, latitudeBits)
+        var slot = slotFor(hash, used.size)
+        while (used[slot]) {
+            if (timeLevels[slot] == packedTimeLevel &&
+                longitudes[slot] == longitudeBits && latitudes[slot] == latitudeBits
+            ) {
+                return false
+            }
+            slot = (slot + 1) % used.size
+        }
+        used[slot] = true
+        timeLevels[slot] = packedTimeLevel
+        longitudes[slot] = longitudeBits
+        latitudes[slot] = latitudeBits
+        count++
+        return true
+    }
+
+    fun size(): Int = count
+
+    private fun ensureCapacity(required: Int) {
+        if (required * LOAD_FACTOR_DENOMINATOR <= used.size * LOAD_FACTOR_NUMERATOR) return
+        val oldUsed = used
+        val oldTimeLevels = timeLevels
+        val oldLongitudes = longitudes
+        val oldLatitudes = latitudes
+        val newCapacity = capacityFor(required)
+        val rehashBytes = checkedSum(
+            checkedProduct(oldUsed.size.toLong(), BYTES_PER_SLOT),
+            checkedProduct(newCapacity.toLong(), BYTES_PER_SLOT),
+        )
+        if (rehashBytes > byteBudget) {
+            throw NetCdfException.ResourceLimitExceeded("duplicate-coordinate-set", byteBudget, rehashBytes)
+        }
+        used = BooleanArray(newCapacity)
+        timeLevels = LongArray(newCapacity)
+        longitudes = LongArray(newCapacity)
+        latitudes = LongArray(newCapacity)
+        oldUsed.indices.forEach { index ->
+            if (oldUsed[index]) {
+                val hash = hash(oldTimeLevels[index], oldLongitudes[index], oldLatitudes[index])
+                var slot = slotFor(hash, newCapacity)
+                while (used[slot]) slot = (slot + 1) % newCapacity
+                used[slot] = true
+                timeLevels[slot] = oldTimeLevels[index]
+                longitudes[slot] = oldLongitudes[index]
+                latitudes[slot] = oldLatitudes[index]
+            }
+        }
+    }
+
+    private fun slotFor(hash: Long, capacity: Int): Int = Math.floorMod(hash, capacity.toLong()).toInt()
+
+    private fun capacityFor(required: Int): Int {
+        if (required <= 0) return INITIAL_CAPACITY
+        val scaled = checkedProduct(required.toLong(), LOAD_FACTOR_DENOMINATOR.toLong())
+            .let { (it / LOAD_FACTOR_NUMERATOR) + 1L }
+        return scaled.coerceIn(INITIAL_CAPACITY.toLong(), Int.MAX_VALUE.toLong()).toInt()
+    }
+
+    private fun requireCapacityWithinBudget(capacity: Int) {
+        val bytes = checkedProduct(capacity.toLong(), BYTES_PER_SLOT)
+        if (bytes > byteBudget) {
+            throw NetCdfException.ResourceLimitExceeded("duplicate-coordinate-set", byteBudget, bytes)
+        }
+    }
+
+    private companion object {
+        const val INITIAL_CAPACITY: Int = 16
+        const val LOAD_FACTOR_NUMERATOR: Int = 9
+        const val LOAD_FACTOR_DENOMINATOR: Int = 10
+        const val BYTES_PER_SLOT: Long = 25L
+
+        fun canonicalDoubleBits(value: Double): Long =
+            if (value == 0.0) 0L else java.lang.Double.doubleToLongBits(value)
+
+        fun packTimeLevel(timeIdx: Int, levelIdx: Int): Long =
+            (timeIdx.toLong() shl 32) xor (levelIdx.toLong() and 0xffffffffL)
+
+        fun hash(timeLevel: Long, longitudeBits: Long, latitudeBits: Long): Long {
+            var result = longitudeBits * -0x61c8864680b583ebL
+            result = (result xor (result ushr 33)) * -0x3d4d51cb2c7b5a7dL
+            result = (result xor latitudeBits) * -0x61c8864680b583ebL
+            result = (result xor timeLevel) * -0x3d4d51cb2c7b5a7dL
+            return result xor (result ushr 32)
+        }
+    }
+}

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTileBatchWriter.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTileBatchWriter.kt
@@ -1,0 +1,185 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.science.exposed.NetCdfException
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.Types
+
+/** 한 Exposed transaction이 소유하는 현재 JDBC connection으로 tile 행을 기록합니다. */
+internal fun interface TileBatchWriter {
+    fun write(connection: Connection, rows: List<TileRow>): BatchWriteResult
+}
+
+/** PostGIS geometry와 JSONB를 typed placeholder로 기록하는 JDBC 구현입니다. */
+internal class JdbcTileBatchWriter : TileBatchWriter {
+
+    override fun write(connection: Connection, rows: List<TileRow>): BatchWriteResult {
+        if (rows.isEmpty()) return BatchWriteResult(0, 0)
+        if (rows.size.toLong() > MAX_BATCH_ROWS) {
+            throw NetCdfException.ResourceLimitExceeded("batch-rows", MAX_BATCH_ROWS, rows.size.toLong())
+        }
+        val hasNullLocation = rows.any { it.longitude == null || it.latitude == null }
+        val hasSpatialLocation = rows.any { it.longitude != null || it.latitude != null }
+        if (hasNullLocation && hasSpatialLocation) {
+            val first = rows.first()
+            throw NetCdfException.UnsupportedCoordinateAxis(
+                variableName = first.variableName,
+                coordinateName = "location",
+                reason = "mixed-nullability",
+            )
+        }
+        val spatial = hasSpatialLocation
+        val inserted = writeBatch(connection, rows, spatial)
+        return BatchWriteResult(inserted = inserted, conflicts = rows.size - inserted)
+    }
+
+    private fun writeBatch(connection: Connection, rows: List<TileRow>, spatial: Boolean): Int {
+        val sql = if (spatial) SPATIAL_SQL else NULL_LOCATION_SQL
+        return connection.prepareStatement(sql).use { statement ->
+            rows.forEach { row -> bind(statement, row, spatial) }
+            val results = statement.executeBatch()
+            if (results.size != rows.size || results.any { it == PreparedStatement.SUCCESS_NO_INFO || it !in 0..1 }) {
+                // A driver that cannot report one result per row is not allowed to
+                // silently turn an import into a false success. Audit the bounded
+                // canonical keys first, then throw so the enclosing transaction rolls
+                // the batch back even when the audit happens to find identical rows.
+                auditConflicts(connection, rows, rows.indices.toList(), spatial)
+                throw IllegalStateException("JDBC batch result is not fully auditable")
+            }
+            val inserted = countInserted(results, rows.size)
+            val conflicts = results.indices.filter { results[it] == 0 }
+            if (conflicts.isNotEmpty()) {
+                auditConflicts(connection, rows, conflicts, spatial)
+            }
+            inserted
+        }
+    }
+
+    private fun bind(statement: PreparedStatement, row: TileRow, spatial: Boolean) {
+        var index = 1
+        statement.setLong(index++, row.fileId)
+        statement.setString(index++, row.variableName)
+        if (spatial) {
+            statement.setDouble(index++, checkNotNull(row.longitude))
+            statement.setDouble(index++, checkNotNull(row.latitude))
+        }
+        statement.setInt(index++, row.timeIdx)
+        statement.setInt(index++, row.levelIdx)
+        statement.setDouble(index++, row.value)
+        row.attrsJson?.let { statement.setString(index, it) }
+            ?: statement.setNull(index, Types.VARCHAR)
+        statement.addBatch()
+    }
+
+    private fun countInserted(results: IntArray, rowCount: Int): Int {
+        if (results.isEmpty()) return 0
+        if (results.size != rowCount) {
+            throw IllegalStateException("JDBC batch returned an unexpected result count")
+        }
+        var inserted = 0
+        results.forEach { result ->
+            if (result !in 0..1) {
+                throw IllegalStateException("JDBC batch returned an unsupported update count")
+            }
+            inserted += result
+        }
+        return inserted
+    }
+
+    private fun auditConflicts(
+        connection: Connection,
+        rows: List<TileRow>,
+        conflictIndices: List<Int>,
+        spatial: Boolean,
+    ) {
+        val values = conflictIndices.joinToString(",") {
+            "(?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb)"
+        }
+        val sql = """
+            WITH incoming(ordinal, file_id, variable_name, time_idx, level_idx,
+                          longitude, latitude, value, attrs) AS (VALUES $values)
+            SELECT i.ordinal,
+                   COALESCE(
+                       n.value = i.value
+                       AND n.attrs IS NOT DISTINCT FROM i.attrs
+                       AND (
+                           (i.longitude IS NULL AND n.location IS NULL)
+                           OR (i.longitude IS NOT NULL
+                               AND ST_X(n.location) = i.longitude
+                               AND ST_Y(n.location) = i.latitude)
+                       ),
+                       FALSE
+                   ) AS matches
+            FROM incoming i
+            LEFT JOIN netcdf_grid_values n
+              ON n.file_id = i.file_id
+             AND n.variable_name = i.variable_name
+             AND n.time_idx = i.time_idx
+             AND n.level_idx = i.level_idx
+             AND ${if (spatial) {
+            "i.longitude IS NOT NULL AND n.location IS NOT NULL " +
+                "AND ST_X(n.location) = i.longitude AND ST_Y(n.location) = i.latitude"
+        } else {
+            "i.longitude IS NULL AND n.location IS NULL"
+        }}
+            ORDER BY i.ordinal
+        """.trimIndent()
+        connection.prepareStatement(sql).use { statement ->
+            var parameter = 1
+            conflictIndices.forEach { index ->
+                val row = rows[index]
+                statement.setInt(parameter++, index)
+                statement.setLong(parameter++, row.fileId)
+                statement.setString(parameter++, row.variableName)
+                statement.setInt(parameter++, row.timeIdx)
+                statement.setInt(parameter++, row.levelIdx)
+                row.longitude?.let { statement.setDouble(parameter, it) }
+                    ?: statement.setNull(parameter, Types.DOUBLE)
+                parameter++
+                row.latitude?.let { statement.setDouble(parameter, it) }
+                    ?: statement.setNull(parameter, Types.DOUBLE)
+                parameter++
+                statement.setDouble(parameter++, row.value)
+                row.attrsJson?.let { statement.setString(parameter, it) }
+                    ?: statement.setNull(parameter, Types.VARCHAR)
+                parameter++
+            }
+            statement.executeQuery().use { resultSet ->
+                val audited = HashSet<Int>(conflictIndices.size)
+                while (resultSet.next()) {
+                    val ordinal = resultSet.getInt("ordinal")
+                    audited += ordinal
+                    if (!resultSet.getBoolean("matches")) {
+                        val row = rows[ordinal]
+                        throw NetCdfException.DuplicateCoordinate(
+                            fileId = row.fileId,
+                            variableName = row.variableName,
+                            timeIdx = row.timeIdx,
+                            levelIdx = row.levelIdx,
+                            longitude = row.longitude ?: 0.0,
+                            latitude = row.latitude ?: 0.0,
+                        )
+                    }
+                }
+                if (audited.size != conflictIndices.size) {
+                    throw IllegalStateException("JDBC conflict row was not found for audit")
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val NULL_LOCATION_SQL = """
+            INSERT INTO netcdf_grid_values
+                (file_id, variable_name, location, time_idx, level_idx, value, attrs)
+            VALUES (?, ?, NULL::geometry, ?, ?, ?, ?::jsonb)
+            ON CONFLICT DO NOTHING
+        """
+        const val SPATIAL_SQL = """
+            INSERT INTO netcdf_grid_values
+                (file_id, variable_name, location, time_idx, level_idx, value, attrs)
+            VALUES (?, ?, ST_SetSRID(ST_MakePoint(?, ?), 4326), ?, ?, ?, ?::jsonb)
+            ON CONFLICT DO NOTHING
+        """
+    }
+}

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlanner.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlanner.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.science.exposed.NetCdfException
+
+/** 좌표 격자를 bounded row-major tile sequence로 나눕니다. */
+internal data class NetCdfTile(
+    val rowOrigin: Int,
+    val columnOrigin: Int,
+    val rowCount: Int,
+    val columnCount: Int,
+)
+
+internal object NetCdfTilePlanner {
+
+    /**
+     * 입력 순서와 동일한 row-major 순서로 tile을 반환합니다.
+     * 한 tile은 항상 [MAX_TILE_CELLS] 이하이며, 빈 격자는 허용하지 않습니다.
+     */
+    fun plan(rows: Int, columns: Int): List<NetCdfTile> {
+        if (rows <= 0 || columns <= 0) {
+            throw NetCdfException.UnsupportedCoordinateAxis(
+                variableName = "grid",
+                coordinateName = null,
+                reason = "empty-grid-dimension:${maxOf(rows, columns)}",
+            )
+        }
+        val columnTileSize = minOf(columns.toLong(), MAX_TILE_CELLS).toInt()
+        val rowTileSize = maxOf(1L, MAX_TILE_CELLS / columnTileSize).toInt()
+        val tiles = ArrayList<NetCdfTile>()
+        var rowOrigin = 0
+        while (rowOrigin < rows) {
+            val rowCount = minOf(rowTileSize, rows - rowOrigin)
+            var columnOrigin = 0
+            while (columnOrigin < columns) {
+                val columnCount = minOf(columnTileSize, columns - columnOrigin)
+                tiles += NetCdfTile(rowOrigin, columnOrigin, rowCount, columnCount)
+                columnOrigin += columnCount
+            }
+            rowOrigin += rowCount
+        }
+        return tiles
+    }
+}

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/VariableAxisMap.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/internal/VariableAxisMap.kt
@@ -3,110 +3,312 @@ package io.bluetape4k.science.exposed.service.internal
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.science.exposed.NetCdfException
+import ucar.ma2.DataType
 import ucar.nc2.Variable
 import ucar.nc2.constants.AxisType
-import ucar.nc2.dataset.CoordinateAxis1D
+import ucar.nc2.dataset.CoordinateAxis
 import ucar.nc2.dataset.NetcdfDataset
 
-/**
- * NetCDF 변수의 차원 인덱스를 [AxisType] 별로 매핑한 결과.
- *
- * `rank` 가 아니라 dimension 별 의미로 매핑하므로, 비표준 dim order
- * (`[lat, lon, time]` 같은 CF 비준수 변수) 도 정상 처리할 수 있다 (Codex C5).
- *
- * 각 필드는 해당 axis 가 변수의 몇 번째 dimension 인지를 나타낸다 (없으면 null).
- *
- * @param timeDim  time 축 dimension 인덱스
- * @param levelDim level (height/depth/pressure) 축 dimension 인덱스
- * @param latDim   lat 축 dimension 인덱스
- * @param lonDim   lon 축 dimension 인덱스
- */
+private val NUMERIC_DATA_TYPES: Set<DataType> = setOf(
+    DataType.BYTE,
+    DataType.UBYTE,
+    DataType.SHORT,
+    DataType.USHORT,
+    DataType.INT,
+    DataType.UINT,
+    DataType.LONG,
+    DataType.ULONG,
+    DataType.FLOAT,
+    DataType.DOUBLE,
+)
+
+private fun Variable.isNumericCoordinate(): Boolean = dataType in NUMERIC_DATA_TYPES
+
+/** 변수의 데이터 dimension과 CF 좌표축의 의미를 연결한 immutable map입니다. */
 internal data class VariableAxisMap(
-    val timeDim: Int? = null,
-    val levelDim: Int? = null,
-    val latDim: Int? = null,
-    val lonDim: Int? = null,
+    val timeAxis: AxisBinding? = null,
+    val levelAxis: AxisBinding? = null,
+    val latAxis: AxisBinding? = null,
+    val lonAxis: AxisBinding? = null,
+    val auxiliaryAxes: List<AxisBinding> = emptyList(),
+    val gridRowDim: Int? = latAxis?.dimensionIndices?.firstOrNull(),
+    val gridColumnDim: Int? = lonAxis?.dimensionIndices?.lastOrNull(),
 ) {
+
+    /** 기존 rank별 import 코드가 사용하는 의미 dimension index입니다. */
+    val timeDim: Int? get() = timeAxis?.dimensionIndices?.singleOrNull()
+    val levelDim: Int? get() = levelAxis?.dimensionIndices?.singleOrNull()
+    val latDim: Int? get() = gridRowDim
+    val lonDim: Int? get() = gridColumnDim
+
+    /** 축 하나의 이름·원본 axis·변수 dimension 순서입니다. */
+    internal data class AxisBinding(
+        val name: String,
+        val axis: Variable,
+        val dimensionNames: List<String>,
+        val dimensionIndices: IntArray,
+    ) {
+        val isTwoDimensional: Boolean get() = dimensionNames.size == 2
+        val shortName: String get() = axis.shortName
+    }
 
     companion object: KLogging() {
 
-        /** level 축 이름 fallback 리스트 (CF 비준수 파일용 — Spec D4) */
         val LEVEL_AXIS_NAME_FALLBACKS: Set<String> = setOf(
             "level", "lev", "plev", "pressure", "depth", "z", "height",
         )
-
-        /** lat 축 이름 fallback */
         val LAT_AXIS_NAME_FALLBACKS: Set<String> = setOf("lat", "latitude", "y", "rlat")
-
-        /** lon 축 이름 fallback */
         val LON_AXIS_NAME_FALLBACKS: Set<String> = setOf("lon", "longitude", "x", "rlon")
-
-        /** time 축 이름 fallback */
         val TIME_AXIS_NAME_FALLBACKS: Set<String> = setOf("time", "t")
 
         /**
-         * [Variable] 의 각 dimension 을 순회하면서 [AxisType] 1차 + 이름 fallback 으로 매핑한다.
-         *
-         * 1. `dataset.findCoordinateAxis(dimensionName)` 으로 해당 dimension 의 [CoordinateAxis1D] 조회
-         * 2. `axis.axisType` 으로 `Time / Lat / Lon / Pressure|Height|GeoZ` 판별
-         * 3. 판별 실패 시 dimension 이름 기반 fallback
-         * 4. `CoordinateAxis2D` 등 1D 가 아닌 축은 [NetCdfException.MissingCoordinate] throw (curvilinear 비지원)
-         *
-         * @return 매핑 결과. 매핑되지 않은 dimension 은 모든 필드가 null
+         * axis type, CF `standard_name`, units/name fallback 순서로 좌표축을 해석합니다.
+         * 2D 축은 원본 축의 row/column dimension 순서를 그대로 보존합니다.
          */
         fun build(variable: Variable, dataset: NetcdfDataset): VariableAxisMap {
-            var timeDim: Int? = null
-            var levelDim: Int? = null
-            var latDim: Int? = null
-            var lonDim: Int? = null
+            val dimensions = variable.dimensions
+            val dimensionNames = dimensions.map { it.shortName }
+            val tokens = variable.findAttributeString("coordinates", "")
+                .trim()
+                .split(Regex("\\s+"))
+                .filter { it.isNotBlank() }
+            if (tokens.size.toLong() > MAX_COORDINATE_TOKENS) {
+                throw NetCdfException.ResourceLimitExceeded(
+                    "coordinate-tokens",
+                    MAX_COORDINATE_TOKENS,
+                    tokens.size.toLong(),
+                )
+            }
 
-            for (dimIdx in 0 until variable.rank) {
-                val dim = variable.getDimension(dimIdx)
-                val dimName = dim.shortName ?: continue
-                val axis = dataset.findCoordinateAxis(dimName)
+            val allVariables = (dataset.variables + dataset.coordinateAxes)
+                .distinctBy { it.fullName }
+            val tokenVariables = tokens.map { token ->
+                val exactMatches = allVariables.filter { it.fullName == token }
+                val shortMatches = if (exactMatches.isEmpty()) {
+                    allVariables.filter { it.shortName == token }
+                } else {
+                    emptyList()
+                }
+                val matches = exactMatches.ifEmpty { shortMatches }
+                val resolved = when {
+                    matches.size == 1 -> matches.single()
+                    matches.size > 1 -> throw NetCdfException.UnsupportedCoordinateAxis(
+                        variable.fullName,
+                        token,
+                        "ambiguous-coordinate",
+                    )
+                    else -> dataset.findVariable(token)
+                } ?: throw NetCdfException.UnsupportedCoordinateAxis(
+                    variable.fullName,
+                    token,
+                    "unresolved-coordinate",
+                )
+                if (!resolved.isNumericCoordinate()) {
+                    throw NetCdfException.UnsupportedCoordinateAxis(variable.fullName, token, "non-numeric")
+                }
+                resolved
+            }
+            val axes = (dataset.coordinateAxes + tokenVariables)
+                .asSequence()
+                .distinctBy { it.fullName }
+                .toList()
 
-                // Curvilinear (CoordinateAxis2D) 등 1D 가 아닌 축은 비지원
-                if (axis != null && axis !is CoordinateAxis1D) {
-                    log.debug { "non-1D axis detected — dim='$dimName' type=${axis::class.simpleName}" }
-                    throw NetCdfException.MissingCoordinate(
-                        "$dimName (CoordinateAxis2D / curvilinear is not supported)"
+            fun binding(axis: Variable): AxisBinding? {
+                val axisDims = axis.dimensions.map { it.shortName }
+                if (axisDims.isEmpty() || axisDims.size > 2) {
+                    if (tokenVariables.any { it.fullName == axis.fullName }) {
+                        throw NetCdfException.UnsupportedCoordinateAxis(
+                            variable.fullName,
+                            axis.shortName,
+                            "auxiliary-rank",
+                        )
+                    }
+                    return null
+                }
+                val indices = axisDims.map { axisName -> dimensionNames.indexOf(axisName) }
+                if (indices.any { it < 0 }) return null
+                if (axisDims.indices.any { axisIndex ->
+                        axis.shape[axisIndex].toLong() != variable.shape[indices[axisIndex]].toLong()
+                    }
+                ) {
+                    throw NetCdfException.UnsupportedCoordinateAxis(
+                        variable.fullName,
+                        axis.shortName,
+                        "axis-shape-mismatch",
                     )
                 }
+                return AxisBinding(axis.fullName, axis, axisDims, indices.toIntArray())
+            }
 
-                val axisType = axis?.axisType
-                val resolved = when {
-                    axisType == AxisType.Time -> AxisCategory.TIME
-                    axisType == AxisType.Lat || axisType == AxisType.GeoY -> AxisCategory.LAT
-                    axisType == AxisType.Lon || axisType == AxisType.GeoX -> AxisCategory.LON
-                    axisType == AxisType.Pressure ||
-                        axisType == AxisType.Height ||
-                        axisType == AxisType.GeoZ -> AxisCategory.LEVEL
-
-                    dimName.lowercase() in TIME_AXIS_NAME_FALLBACKS -> AxisCategory.TIME
-                    dimName.lowercase() in LAT_AXIS_NAME_FALLBACKS -> AxisCategory.LAT
-                    dimName.lowercase() in LON_AXIS_NAME_FALLBACKS -> AxisCategory.LON
-                    dimName.lowercase() in LEVEL_AXIS_NAME_FALLBACKS -> AxisCategory.LEVEL
-                    else -> null
-                }
-
-                when (resolved) {
-                    AxisCategory.TIME -> timeDim = dimIdx
-                    AxisCategory.LEVEL -> levelDim = dimIdx
-                    AxisCategory.LAT -> latDim = dimIdx
-                    AxisCategory.LON -> lonDim = dimIdx
-                    null -> log.debug { "unmapped dimension: name='$dimName' axisType=$axisType" }
+            val bindings = axes.mapNotNull(::binding)
+            val tokenBindings = tokenVariables.map { tokenVariable ->
+                bindings.firstOrNull { it.axis.fullName == tokenVariable.fullName }
+                    ?: throw NetCdfException.UnsupportedCoordinateAxis(
+                        variable.fullName,
+                        tokenVariable.fullName,
+                        "unsupported-coordinate",
+                    )
+            }
+            fun applicableRoles(binding: AxisBinding): List<AxisRole> {
+                val axis = binding.axis
+                val name = binding.shortName.lowercase()
+                val standardName = axis.findAttributeString("standard_name", "")?.lowercase().orEmpty()
+                val units = axis.findAttributeString("units", "").lowercase()
+                return buildList {
+                    // CF surface altitude is a data auxiliary, not a vertical
+                    // coordinate axis. UCAR may classify it as Height from its
+                    // standard name, so keep it available for `coordinates=`.
+                    if (standardName == "surface_altitude") return@buildList
+                    if ((axis as? CoordinateAxis)?.axisType == AxisType.Time || standardName == "time" ||
+                        name in TIME_AXIS_NAME_FALLBACKS || units.contains(" since ")
+                    ) add(AxisRole.TIME)
+                    if ((axis as? CoordinateAxis)?.axisType == AxisType.Lat ||
+                        (axis as? CoordinateAxis)?.axisType == AxisType.GeoY ||
+                        standardName == "latitude" || standardName == "grid_latitude" ||
+                        units.contains("degrees_north") || name in LAT_AXIS_NAME_FALLBACKS
+                    ) add(AxisRole.LAT)
+                    if ((axis as? CoordinateAxis)?.axisType == AxisType.Lon ||
+                        (axis as? CoordinateAxis)?.axisType == AxisType.GeoX ||
+                        standardName == "longitude" || standardName == "grid_longitude" ||
+                        units.contains("degrees_east") || name in LON_AXIS_NAME_FALLBACKS
+                    ) add(AxisRole.LON)
+                    if ((axis as? CoordinateAxis)?.axisType == AxisType.Pressure ||
+                        (axis as? CoordinateAxis)?.axisType == AxisType.Height ||
+                        (axis as? CoordinateAxis)?.axisType == AxisType.GeoZ ||
+                        name in LEVEL_AXIS_NAME_FALLBACKS
+                    ) add(AxisRole.LEVEL)
                 }
             }
 
-            return VariableAxisMap(
-                timeDim = timeDim,
-                levelDim = levelDim,
-                latDim = latDim,
-                lonDim = lonDim,
-            )
+            fun roleOf(binding: AxisBinding): AxisRole? {
+                val roles = applicableRoles(binding)
+                return when (roles.size) {
+                    0 -> null
+                    1 -> roles.single()
+                    else -> throw NetCdfException.UnsupportedCoordinateAxis(
+                        variable.fullName,
+                        binding.name,
+                        "role-collision:${roles.joinToString(",") { it.name.lowercase() }}",
+                    )
+                }
+            }
+
+            fun candidates(role: AxisRole): List<AxisBinding> = bindings.filter { roleOf(it) == role }
+
+            fun choose(role: AxisRole): AxisBinding? {
+                val roleCandidates = candidates(role)
+                if (roleCandidates.isEmpty()) return null
+                val tokenCandidate = tokenVariables.asSequence()
+                    .mapNotNull { tokenVariable ->
+                        roleCandidates.firstOrNull { it.axis.fullName == tokenVariable.fullName }
+                    }
+                    .distinctBy { it.axis.fullName }
+                    .toList()
+                val chosen = when {
+                    tokenCandidate.size == 1 -> tokenCandidate.single()
+                    tokenCandidate.size > 1 -> throw ambiguous(variable, role, tokenCandidate)
+                    roleCandidates.size == 1 -> roleCandidates.single()
+                    else -> {
+                        val named = roleCandidates.filter { it.shortName.lowercase() in role.fallbacks }
+                        when (named.size) {
+                            1 -> named.single()
+                            else -> throw ambiguous(variable, role, roleCandidates)
+                        }
+                    }
+                }
+                if (!chosen.axis.isNumericCoordinate()) {
+                    throw NetCdfException.UnsupportedCoordinateAxis(variable.fullName, chosen.name, "non-numeric")
+                }
+                return chosen
+            }
+
+            val time = choose(AxisRole.TIME)
+            val level = choose(AxisRole.LEVEL)
+            val lat = choose(AxisRole.LAT)
+            val lon = choose(AxisRole.LON)
+
+            if (time?.isTwoDimensional == true || level?.isTwoDimensional == true) {
+                val offending = time ?: level
+                throw NetCdfException.UnsupportedCoordinateAxis(
+                    variable.fullName,
+                    offending?.name,
+                    "time-level-rank",
+                )
+            }
+
+            if (lat != null && lon != null && lat.isTwoDimensional != lon.isTwoDimensional) {
+                throw NetCdfException.UnsupportedCoordinateAxis(variable.fullName, lat.name, "mixed-rank-spatial-axes")
+            }
+            if (lat != null && lon != null && lat.isTwoDimensional &&
+                lat.dimensionNames != lon.dimensionNames
+            ) {
+                throw NetCdfException.UnsupportedCoordinateAxis(variable.fullName, lon.name, "spatial-dimension-order")
+            }
+
+            val auxiliaries = tokenBindings.asSequence()
+                .filter { candidate ->
+                    candidate.name != lat?.name && candidate.name != lon?.name &&
+                        candidate.name != time?.name && candidate.name != level?.name
+                }
+                .distinctBy { it.name }
+                .onEach { candidate ->
+                    if (candidate.dimensionNames.size !in 1..2) {
+                        throw NetCdfException.UnsupportedCoordinateAxis(
+                            variable.fullName,
+                            candidate.name,
+                            "auxiliary-rank",
+                        )
+                    }
+                    if (lat != null && candidate.dimensionIndices.any { index ->
+                            index != lat.dimensionIndices.firstOrNull() && index != lon?.dimensionIndices?.lastOrNull()
+                        }
+                    ) {
+                        throw NetCdfException.UnsupportedCoordinateAxis(
+                            variable.fullName,
+                            candidate.name,
+                            "auxiliary-dimension-subset",
+                        )
+                    }
+                }
+                .toList()
+
+            if (auxiliaries.size.toLong() > MAX_AUXILIARY_AXES) {
+                throw NetCdfException.ResourceLimitExceeded(
+                    "auxiliary-axes",
+                    MAX_AUXILIARY_AXES,
+                    auxiliaries.size.toLong(),
+                )
+            }
+
+            val rowDim = when {
+                lat?.isTwoDimensional == true -> lat.dimensionIndices.first()
+                lat != null -> lat.dimensionIndices.single()
+                else -> null
+            }
+            val columnDim = when {
+                lon?.isTwoDimensional == true -> lon.dimensionIndices.last()
+                lon != null -> lon.dimensionIndices.single()
+                else -> null
+            }
+            log.debug {
+                "axis map built — variable=${variable.fullName} time=${time?.name} level=${level?.name} " +
+                    "lat=${lat?.name} lon=${lon?.name} auxiliary=${auxiliaries.map { it.name }}"
+            }
+            return VariableAxisMap(time, level, lat, lon, auxiliaries, rowDim, columnDim)
         }
+
+        private fun ambiguous(variable: Variable, role: AxisRole, candidates: List<AxisBinding>): NetCdfException =
+            NetCdfException.UnsupportedCoordinateAxis(
+                variable.fullName,
+                candidates.joinToString(",") { it.name },
+                "ambiguous-${role.name.lowercase()}",
+            )
     }
 
-    /** [build] 내부 분기 라벨 */
-    private enum class AxisCategory { TIME, LEVEL, LAT, LON }
+    private enum class AxisRole(val fallbacks: Set<String>) {
+        TIME(TIME_AXIS_NAME_FALLBACKS),
+        LEVEL(LEVEL_AXIS_NAME_FALLBACKS),
+        LAT(LAT_AXIS_NAME_FALLBACKS),
+        LON(LON_AXIS_NAME_FALLBACKS),
+    }
 }

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/NetCdfExceptionApiCompatibilityTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/NetCdfExceptionApiCompatibilityTest.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.science.exposed
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class NetCdfExceptionApiCompatibilityTest {
+
+    @Test
+    fun `new typed failures retain structured fields`() {
+        val axis = NetCdfException.UnsupportedCoordinateAxis("temperature", "lat", "rank")
+        axis.variableName shouldBeEqualTo "temperature"
+        axis.coordinateName shouldBeEqualTo "lat"
+        axis.reason shouldBeEqualTo "rank"
+
+        val duplicate = NetCdfException.DuplicateCoordinate(1L, "temperature", 2, 3, 120.0, 35.0)
+        duplicate.fileId shouldBeEqualTo 1L
+        duplicate.variableName shouldBeEqualTo "temperature"
+        duplicate.timeIdx shouldBeEqualTo 2
+        duplicate.levelIdx shouldBeEqualTo 3
+
+        val resource = NetCdfException.ResourceLimitExceeded("tile", 10L, 11L)
+        resource.resource shouldBeEqualTo "tile"
+        resource.limit shouldBeEqualTo 10L
+        resource.actual shouldBeEqualTo 11L
+
+        val changed = NetCdfException.FileChanged(1L, "expected", "actual")
+        changed.expectedFingerprint shouldBeEqualTo "expected"
+        changed.actualFingerprint shouldBeEqualTo "actual"
+
+        val corrupt = NetCdfException.CorruptProgress(3L, "checkpoint")
+        corrupt.progressId shouldBeEqualTo 3L
+        corrupt.detail shouldBeEqualTo "checkpoint"
+    }
+
+    @Test
+    fun `base exception handling keeps an explicit default branch`() {
+        val exception: NetCdfException = NetCdfException.UnsupportedCoordinateAxis("v", null, "test")
+        val code = when (exception) {
+            is NetCdfException.FileOpen -> "file-open"
+            is NetCdfException.FileRecordNotFound -> "file-record"
+            is NetCdfException.VariableNotFound -> "variable"
+            is NetCdfException.UnsupportedVariable -> "unsupported-variable"
+            is NetCdfException.MissingCoordinate -> "missing-coordinate"
+            is NetCdfException.UnsupportedProjection -> "projection"
+            is NetCdfException.ImportAlreadyRunning -> "already-running"
+            is NetCdfException.ImportLeaseLost -> "lease-lost"
+            is NetCdfException.UnsupportedCoordinateAxis -> "axis"
+            is NetCdfException.DuplicateCoordinate -> "duplicate"
+            is NetCdfException.ResourceLimitExceeded -> "resource"
+            is NetCdfException.FileChanged -> "changed"
+            is NetCdfException.CorruptProgress -> "corrupt"
+            else -> "unknown"
+        }
+        code shouldBeEqualTo "axis"
+    }
+}

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt
@@ -18,6 +18,7 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteAll
@@ -127,6 +128,11 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
         }
         count shouldBeEqualTo NetCdfSampleWriter.DEFAULT_TIME_N
         anyNullLoc shouldBeEqualTo true
+
+        val progress = transaction { progressRepo.findByFileAndVariable(fileId, "temperature") }
+        progress.shouldNotBeNull()
+        progress.lastSliceIdx shouldBeEqualTo 0L
+        progress.status shouldBeEqualTo NetCdfImportStatus.COMPLETED
     }
 
     @Test
@@ -627,6 +633,105 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
         service.importGridValues(fileId, "temperature")
         val progress = transaction(db) { progressRepo.findByFileAndVariable(fileId, "temperature") }
         progress.shouldNotBeNull()
+    }
+
+    @Test
+    fun `30a - curvilinear 2D axes preserve every cell coordinate and value`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeCurvilinearSample(dir.resolve("curvilinear.nc"))
+        val fileId = service.registerFile(path.absolutePathString())
+        service.importGridValues(fileId, "temperature")
+
+        readSpatialTuples(fileId) shouldBeEqualTo NetCdfSampleWriter.CURVILINEAR_TUPLES
+    }
+
+    @Test
+    fun `31 - CF coordinates stores altitude in attrs and excludes time axis`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeCfAuxiliarySample(dir.resolve("cf-aux.nc"))
+        val fileId = service.registerFile(path.absolutePathString())
+        service.importGridValues(fileId, "temperature")
+
+        val attrs = transaction(db) {
+            NetCdfGridValueTable.selectAll()
+                .where { NetCdfGridValueTable.fileId eq fileId }
+                .mapNotNull { it[NetCdfGridValueTable.attrs] }
+        }
+        attrs.shouldNotBeEmpty()
+        attrs.all { "altitude" in it && "time" !in it && "lat" !in it && "lon" !in it }
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `32 - non standard data dimension order uses full rank index`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeCurvilinearSample(
+            dir.resolve("order.nc"), dataOrder = listOf("time", "x", "y"),
+        )
+        val fileId = service.registerFile(path.absolutePathString())
+        service.importGridValues(fileId, "temperature")
+
+        readSpatialTuples(fileId) shouldBeEqualTo NetCdfSampleWriter.CURVILINEAR_TUPLES
+    }
+
+    @Test
+    fun `33 - duplicate canonical coordinate is rejected before any insert`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeDuplicateCoordinateSample(
+            dir.resolve("duplicate.nc"), duplicateAcrossTiles = true,
+        )
+        val fileId = service.registerFile(path.absolutePathString())
+        assertFailsWith<NetCdfException.DuplicateCoordinate> {
+            service.importGridValues(fileId, "temperature")
+        }
+
+        transaction(db) {
+            NetCdfGridValueTable.selectAll()
+                .where { NetCdfGridValueTable.fileId eq fileId }
+                .count()
+        } shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `34 - unsupported grid mapping and malformed EPSG are typed failures`(@TempDir dir: Path) {
+        val projected = NetCdfSampleWriter.writeProjected2DSample(
+            dir.resolve("bad-crs.nc"), "EPSG:9999999",
+        )
+        val projectedId = service.registerFile(projected.absolutePathString())
+        assertFailsWith<NetCdfException.UnsupportedProjection> {
+            service.importGridValues(projectedId, "temperature")
+        }
+
+        val malformed = NetCdfSampleWriter.writeProjected2DSample(
+            dir.resolve("malformed-crs.nc"), "EPSG:+4326",
+        )
+        val malformedId = service.registerFile(malformed.absolutePathString())
+        assertFailsWith<NetCdfException.UnsupportedProjection> {
+            service.importGridValues(malformedId, "temperature")
+        }
+    }
+
+    private fun readSpatialTuples(fileId: Long): List<NetCdfSampleWriter.SpatialTuple> = transaction(db) {
+        val expected = NetCdfSampleWriter.CURVILINEAR_TUPLES
+        val sql = "SELECT time_idx, level_idx, ST_X(location), ST_Y(location), value " +
+            "FROM netcdf_grid_values WHERE file_id=? AND location IS NOT NULL"
+        val conn = connection.connection as java.sql.Connection
+        conn.prepareStatement(sql).use { ps ->
+            ps.setLong(1, fileId)
+            ps.executeQuery().use { rs ->
+                buildList {
+                    while (rs.next()) {
+                        val timeIdx = rs.getInt(1)
+                        val levelIdx = rs.getInt(2)
+                        val longitude = rs.getDouble(3)
+                        val latitude = rs.getDouble(4)
+                        val fixtureTuple = expected.singleOrNull {
+                            java.lang.Double.doubleToLongBits(it.longitude) ==
+                                java.lang.Double.doubleToLongBits(longitude) &&
+                                java.lang.Double.doubleToLongBits(it.latitude) ==
+                                java.lang.Double.doubleToLongBits(latitude)
+                        } ?: error("Unexpected spatial tuple: time=$timeIdx level=$levelIdx lon=$longitude lat=$latitude")
+                        add(fixtureTuple.copy(timeIdx = timeIdx, levelIdx = levelIdx, value = rs.getDouble(5)))
+                    }
+                }.sortedWith(compareBy({ it.timeIdx }, { it.levelIdx }, { it.row }, { it.column }))
+            }
+        }
     }
 
     private fun forceExpireLease(fileId: Long, variableName: String) {

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializerTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfAuxiliarySerializerTest.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.science.exposed.NetCdfException
+import org.junit.jupiter.api.Test
+
+class NetCdfAuxiliarySerializerTest {
+
+    @Test
+    fun `empty auxiliary map is represented as SQL null`() {
+        serializeAuxiliaryAttributes(emptyMap<String, Double>()) shouldBeEqualTo null
+    }
+
+    @Test
+    fun `numeric auxiliary values use deterministic JSON`() {
+        serializeAuxiliaryAttributes(linkedMapOf("altitude" to 100.0, "pressure" to 850.0))
+            .shouldBeEqualTo("{\"altitude\":100.0,\"pressure\":850.0}")
+    }
+
+    @Test
+    fun `reserved and oversized keys are rejected`() {
+        assertFailsWith<NetCdfException.ResourceLimitExceeded> {
+            serializeAuxiliaryAttributes(mapOf("__bluetape4k_reserved" to 1.0))
+        }
+        assertFailsWith<NetCdfException.ResourceLimitExceeded> {
+            serializeAuxiliaryAttributes(mapOf("x".repeat(8_190) to 1.0))
+        }
+    }
+}

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSamplerTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfCoordinateSamplerTest.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import org.junit.jupiter.api.Test
+
+class NetCdfCoordinateSamplerTest {
+
+    @Test
+    fun `mutable sample is cleared and read-only copy is isolated`() {
+        val target = MutableCoordinateSample()
+        target.longitude = 120.0
+        target.latitude = 35.0
+        target.auxiliary["altitude"] = 100.0
+
+        val copy = target.readOnlyCopy()
+        target.clear()
+        target.auxiliary["altitude"] = 200.0
+
+        copy.longitude shouldBeEqualTo 120.0
+        copy.latitude shouldBeEqualTo 35.0
+        copy.auxiliary["altitude"] shouldBeEqualTo 100.0
+        target.auxiliary["altitude"] shouldBeEqualTo 200.0
+    }
+
+    @Test
+    fun `finite geographic coordinates satisfy WGS84 bounds`() {
+        validateGeographicCoordinate(0.0, 0.0)
+        validateGeographicCoordinate(180.0, 90.0)
+        validateGeographicCoordinate(-180.0, -90.0)
+
+        validateGeographicCoordinate(181.0, 0.0).shouldBeFalse()
+        validateGeographicCoordinate(0.0, 91.0).shouldBeFalse()
+    }
+}

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuardTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuardTest.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.science.exposed.NetCdfException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class NetCdfFileGuardTest {
+
+    @Test
+    fun `final symlink is rejected`(@TempDir dir: Path) {
+        val target = Files.writeString(dir.resolve("target.nc"), "not-netcdf")
+        val link = Files.createSymbolicLink(dir.resolve("link.nc"), target.fileName)
+
+        assertFailsWith<NetCdfException.FileOpen> {
+            NetCdfFileGuard.validateForRegister(link.toString())
+        }
+    }
+
+    @Test
+    fun `parent symlink is rejected`(@TempDir dir: Path) {
+        val targetDir = Files.createDirectory(dir.resolve("target-dir"))
+        Files.writeString(targetDir.resolve("sample.nc"), "not-netcdf")
+        val linkDir = Files.createSymbolicLink(dir.resolve("link-dir"), targetDir.fileName)
+
+        assertFailsWith<NetCdfException.FileOpen> {
+            NetCdfFileGuard.validateForRegister(linkDir.resolve("sample.nc").toString())
+        }
+    }
+}

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimitsTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfImportLimitsTest.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.science.exposed.NetCdfException
+import org.junit.jupiter.api.Test
+
+class NetCdfImportLimitsTest {
+
+    @Test
+    fun `checked product rejects long overflow as typed resource failure`() {
+        assertFailsWith<NetCdfException.ResourceLimitExceeded> {
+            checkedProduct(Long.MAX_VALUE, 2L)
+        }
+    }
+
+    @Test
+    fun `memory budget accounts for owned working set`() {
+        val budget = MemoryBudget(
+            tileBufferBytes = 1L,
+            coordinateBytes = 2L,
+            serializerScratchBytes = 3L,
+            duplicateSetBytes = 4L,
+        )
+
+        budget.ownedWorkingSetBytes shouldBeEqualTo 10L
+    }
+
+    @Test
+    fun `tile and batch limits are explicit bounded contracts`() {
+        MAX_TILE_CELLS shouldBeEqualTo 65_536L
+        MAX_BATCH_ROWS shouldBeEqualTo 1_000L
+        MAX_AUXILIARY_JSONB_BYTES shouldBeEqualTo 8_192L
+    }
+}

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlannerTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfTilePlannerTest.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.science.exposed.service.internal
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class NetCdfTilePlannerTest {
+
+    @Test
+    fun `planner is deterministic and never exceeds tile cell cap`() {
+        val first = NetCdfTilePlanner.plan(rows = 1_024, columns = 1_024)
+        val second = NetCdfTilePlanner.plan(rows = 1_024, columns = 1_024)
+
+        first shouldBeEqualTo second
+        first.all { it.rowCount.toLong() * it.columnCount.toLong() <= MAX_TILE_CELLS }
+            .shouldBeTrue()
+        first.sumOf { it.rowCount.toLong() * it.columnCount.toLong() } shouldBeEqualTo 1_048_576L
+    }
+
+    @Test
+    fun `planner preserves partial edge tiles`() {
+        val tiles = NetCdfTilePlanner.plan(rows = 3, columns = 4)
+
+        tiles.size shouldBeEqualTo 1
+        tiles.single().rowOrigin shouldBeEqualTo 0
+        tiles.single().columnOrigin shouldBeEqualTo 0
+        tiles.single().rowCount shouldBeEqualTo 3
+        tiles.single().columnCount shouldBeEqualTo 4
+    }
+}

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/support/NetCdfSampleWriter.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/support/NetCdfSampleWriter.kt
@@ -24,6 +24,17 @@ import java.nio.file.Path
  */
 internal object NetCdfSampleWriter {
 
+    /** DB read-back helper value used by the curvilinear tests. */
+    data class SpatialTuple(
+        val timeIdx: Int,
+        val levelIdx: Int,
+        val row: Int,
+        val column: Int,
+        val longitude: Double,
+        val latitude: Double,
+        val value: Double,
+    )
+
     const val DEFAULT_TIME_N: Int = 2
     const val DEFAULT_LEVEL_N: Int = 2
     const val DEFAULT_LAT_N: Int = 3
@@ -33,6 +44,46 @@ internal object NetCdfSampleWriter {
     val DEFAULT_LON_VALUES: DoubleArray = doubleArrayOf(-180.0, -90.0, 0.0, 90.0)
 
     const val FILL_VALUE: Double = -9999.0
+
+    const val CURVILINEAR_ROWS: Int = 3
+    const val CURVILINEAR_COLUMNS: Int = 4
+
+    val CURVILINEAR_VALUES: DoubleArray = doubleArrayOf(
+        0.0, 1.0, 2.0, 3.0,
+        4.0, 5.0, 6.0, 7.0,
+        8.0, 9.0, 10.0, 11.0,
+    )
+
+    private val CURVILINEAR_LONGITUDES: DoubleArray = doubleArrayOf(
+        120.0, 121.0, 122.0, 123.0,
+        120.5, 121.5, 122.5, 123.5,
+        121.0, 122.0, 123.0, 124.0,
+    )
+
+    private val CURVILINEAR_LATITUDES: DoubleArray = doubleArrayOf(
+        10.0, 10.25, 10.5, 10.75,
+        15.0, 15.25, 15.5, 15.75,
+        20.0, 20.25, 20.5, 20.75,
+    )
+
+    val CURVILINEAR_TUPLES: List<SpatialTuple> = buildList {
+        repeat(CURVILINEAR_ROWS) { row ->
+            repeat(CURVILINEAR_COLUMNS) { column ->
+                val offset = row * CURVILINEAR_COLUMNS + column
+                add(
+                    SpatialTuple(
+                        timeIdx = 0,
+                        levelIdx = 0,
+                        row = row,
+                        column = column,
+                        longitude = CURVILINEAR_LONGITUDES[offset],
+                        latitude = CURVILINEAR_LATITUDES[offset],
+                        value = CURVILINEAR_VALUES[offset],
+                    ),
+                )
+            }
+        }
+    }
 
     fun writeSample(
         path: Path,
@@ -135,7 +186,10 @@ internal object NetCdfSampleWriter {
             if (latDim != null) {
                 writer.write(writer.findVariable("lat"), Array.factory(DataType.DOUBLE, intArrayOf(DEFAULT_LAT_N), DEFAULT_LAT_VALUES))
             }
-            writer.write(writer.findVariable("lon"), Array.factory(DataType.DOUBLE, intArrayOf(DEFAULT_LON_N), DEFAULT_LON_VALUES))
+            writer.write(
+                writer.findVariable("lon"),
+                Array.factory(DataType.DOUBLE, intArrayOf(DEFAULT_LON_N), DEFAULT_LON_VALUES),
+            )
 
             // temperature data
             val v = writer.findVariable("temperature")
@@ -147,5 +201,235 @@ internal object NetCdfSampleWriter {
             writer.write(v, Array.factory(DataType.DOUBLE, shape, arr))
         }
         return path
+    }
+
+    /**
+     * 2D curvilinear latitude/longitude fixture.
+     *
+     * The two-dimensional axes use `(y, x)` order while the data variable can
+     * deliberately use `(time, x, y)` to expose transposition bugs.
+     */
+    fun writeCurvilinearSample(
+        path: Path,
+        dataOrder: List<String> = listOf("time", "y", "x"),
+    ): Path {
+        require(dataOrder == listOf("time", "y", "x") || dataOrder == listOf("time", "x", "y")) {
+            "dataOrder must be [time, y, x] or [time, x, y]: $dataOrder"
+        }
+
+        return writeCurvilinearGrid(
+            path = path,
+            rows = CURVILINEAR_ROWS,
+            columns = CURVILINEAR_COLUMNS,
+            dataOrder = dataOrder,
+            longitudes = CURVILINEAR_LONGITUDES,
+            latitudes = CURVILINEAR_LATITUDES,
+            valueAt = { row, column -> CURVILINEAR_VALUES[row * CURVILINEAR_COLUMNS + column] },
+        )
+    }
+
+    /** CF `coordinates="time lat lon altitude"` fixture with one numeric auxiliary. */
+    fun writeCfAuxiliarySample(path: Path): Path {
+        val builder = NetcdfFormatWriter.createNewNetcdf3(path.toAbsolutePath().toString())
+        builder.addAttribute(Attribute("Conventions", "CF-1.8"))
+
+        val timeDim = builder.addDimension("time", DEFAULT_TIME_N)
+        val yDim = builder.addDimension("y", 2)
+        val xDim = builder.addDimension("x", 2)
+
+        builder.addVariable("time", DataType.DOUBLE, listOf(timeDim))
+            .addAttribute(Attribute("axis", "T"))
+            .addAttribute(Attribute("units", "hours since 2024-01-01"))
+        builder.addVariable("lat", DataType.DOUBLE, listOf(yDim))
+            .addAttribute(Attribute("axis", "Y"))
+            .addAttribute(Attribute("standard_name", "latitude"))
+            .addAttribute(Attribute("units", "degrees_north"))
+        builder.addVariable("lon", DataType.DOUBLE, listOf(xDim))
+            .addAttribute(Attribute("axis", "X"))
+            .addAttribute(Attribute("standard_name", "longitude"))
+            .addAttribute(Attribute("units", "degrees_east"))
+        builder.addVariable("altitude", DataType.DOUBLE, listOf(yDim, xDim))
+            .addAttribute(Attribute("standard_name", "surface_altitude"))
+            .addAttribute(Attribute("units", "m"))
+        builder.addVariable("temperature", DataType.DOUBLE, listOf(timeDim, yDim, xDim))
+            .addAttribute(Attribute("units", "K"))
+            .addAttribute(Attribute("coordinates", "time lat lon altitude"))
+
+        builder.build().use { writer ->
+            writer.write(
+                writer.findVariable("time"),
+                Array.factory(DataType.DOUBLE, intArrayOf(DEFAULT_TIME_N), doubleArrayOf(0.0, 1.0)),
+            )
+            writer.write(
+                writer.findVariable("lat"),
+                Array.factory(DataType.DOUBLE, intArrayOf(2), doubleArrayOf(30.0, 31.0)),
+            )
+            writer.write(
+                writer.findVariable("lon"),
+                Array.factory(DataType.DOUBLE, intArrayOf(2), doubleArrayOf(120.0, 121.0)),
+            )
+            writer.write(
+                writer.findVariable("altitude"),
+                Array.factory(DataType.DOUBLE, intArrayOf(2, 2), doubleArrayOf(100.0, 101.0, 102.0, 103.0)),
+            )
+            val values = DoubleArray(DEFAULT_TIME_N * 2 * 2) { flat ->
+                val time = flat / 4
+                val cell = flat % 4
+                273.15 + time * 10.0 + cell
+            }
+            writer.write(
+                writer.findVariable("temperature"),
+                Array.factory(DataType.DOUBLE, intArrayOf(DEFAULT_TIME_N, 2, 2), values),
+            )
+        }
+        return path
+    }
+
+    /** 2D projected x/y fixture whose EPSG token remains an unparsed string. */
+    fun writeProjected2DSample(path: Path, sourceCrs: String): Path {
+        val builder = NetcdfFormatWriter.createNewNetcdf3(path.toAbsolutePath().toString())
+        val timeDim = builder.addDimension("time", 1)
+        val yDim = builder.addDimension("y", 2)
+        val xDim = builder.addDimension("x", 2)
+
+        builder.addVariable("time", DataType.DOUBLE, listOf(timeDim))
+            .addAttribute(Attribute("axis", "T"))
+            .addAttribute(Attribute("units", "hours since 2024-01-01"))
+        builder.addVariable("x", DataType.DOUBLE, listOf(yDim, xDim))
+            .addAttribute(Attribute("axis", "X"))
+            .addAttribute(Attribute("standard_name", "projection_x_coordinate"))
+            .addAttribute(Attribute("units", "m"))
+        builder.addVariable("y", DataType.DOUBLE, listOf(yDim, xDim))
+            .addAttribute(Attribute("axis", "Y"))
+            .addAttribute(Attribute("standard_name", "projection_y_coordinate"))
+            .addAttribute(Attribute("units", "m"))
+        builder.addVariable("crs", DataType.INT, emptyList())
+            .addAttribute(Attribute("grid_mapping_name", "transverse_mercator"))
+            .addAttribute(Attribute("epsg_code", sourceCrs.removePrefix("EPSG:")))
+        builder.addVariable("temperature", DataType.DOUBLE, listOf(timeDim, yDim, xDim))
+            .addAttribute(Attribute("units", "K"))
+            .addAttribute(Attribute("grid_mapping", "crs"))
+
+        builder.build().use { writer ->
+            writer.write(
+                writer.findVariable("time"),
+                Array.factory(DataType.DOUBLE, intArrayOf(1), doubleArrayOf(0.0)),
+            )
+            writer.write(
+                writer.findVariable("x"),
+                Array.factory(DataType.DOUBLE, intArrayOf(2, 2), doubleArrayOf(0.0, 1_000.0, 0.0, 1_000.0)),
+            )
+            writer.write(
+                writer.findVariable("y"),
+                Array.factory(DataType.DOUBLE, intArrayOf(2, 2), doubleArrayOf(0.0, 0.0, 1_000.0, 1_000.0)),
+            )
+            writer.write(
+                writer.findVariable("temperature"),
+                Array.factory(DataType.DOUBLE, intArrayOf(1, 2, 2), doubleArrayOf(273.15, 274.15, 275.15, 276.15)),
+            )
+        }
+        return path
+    }
+
+    /**
+     * Curvilinear fixture with an optional duplicate across the planner's row
+     * tile boundary (`257 x 257`, rows 0 and 255).
+     */
+    fun writeDuplicateCoordinateSample(path: Path, duplicateAcrossTiles: Boolean): Path {
+        val rows = if (duplicateAcrossTiles) 257 else CURVILINEAR_ROWS
+        val columns = if (duplicateAcrossTiles) 257 else CURVILINEAR_COLUMNS
+        val size = rows * columns
+        val longitudes = DoubleArray(size) { index ->
+            val row = index / columns
+            val column = index % columns
+            if (duplicateAcrossTiles && row == 255 && column == 0) 100.0 else 100.0 + row * 0.1 + column * 0.001
+        }
+        val latitudes = DoubleArray(size) { index ->
+            val row = index / columns
+            val column = index % columns
+            if (duplicateAcrossTiles && row == 255 && column == 0) 10.0 else 10.0 + row * 0.01 + column * 0.0001
+        }
+        return writeCurvilinearGrid(
+            path = path,
+            rows = rows,
+            columns = columns,
+            dataOrder = listOf("time", "y", "x"),
+            longitudes = longitudes,
+            latitudes = latitudes,
+            valueAt = { row, column -> 200.0 + row * columns + column },
+        )
+    }
+
+    private fun writeCurvilinearGrid(
+        path: Path,
+        rows: Int,
+        columns: Int,
+        dataOrder: List<String>,
+        longitudes: DoubleArray,
+        latitudes: DoubleArray,
+        valueAt: (row: Int, column: Int) -> Double,
+    ): Path {
+        require(longitudes.size == rows * columns) { "longitude size must match grid" }
+        require(latitudes.size == rows * columns) { "latitude size must match grid" }
+
+        val builder = NetcdfFormatWriter.createNewNetcdf3(path.toAbsolutePath().toString())
+        val timeDim = builder.addDimension("time", 1)
+        val yDim = builder.addDimension("y", rows)
+        val xDim = builder.addDimension("x", columns)
+        val dimensions = mapOf("time" to timeDim, "y" to yDim, "x" to xDim)
+
+        builder.addVariable("time", DataType.DOUBLE, listOf(timeDim))
+            .addAttribute(Attribute("axis", "T"))
+            .addAttribute(Attribute("units", "hours since 2024-01-01"))
+        builder.addVariable("lat", DataType.DOUBLE, listOf(yDim, xDim))
+            .addAttribute(Attribute("axis", "Y"))
+            .addAttribute(Attribute("standard_name", "latitude"))
+            .addAttribute(Attribute("units", "degrees_north"))
+        builder.addVariable("lon", DataType.DOUBLE, listOf(yDim, xDim))
+            .addAttribute(Attribute("axis", "X"))
+            .addAttribute(Attribute("standard_name", "longitude"))
+            .addAttribute(Attribute("units", "degrees_east"))
+        val dataDims = dataOrder.map { dimensions.getValue(it) }
+        builder.addVariable("temperature", DataType.DOUBLE, dataDims)
+            .addAttribute(Attribute("units", "K"))
+
+        builder.build().use { writer ->
+            writer.write(
+                writer.findVariable("time"),
+                Array.factory(DataType.DOUBLE, intArrayOf(1), doubleArrayOf(0.0)),
+            )
+            writer.write(
+                writer.findVariable("lat"),
+                Array.factory(DataType.DOUBLE, intArrayOf(rows, columns), latitudes),
+            )
+            writer.write(
+                writer.findVariable("lon"),
+                Array.factory(DataType.DOUBLE, intArrayOf(rows, columns), longitudes),
+            )
+            val shape = dataDims.map { it.length }.toIntArray()
+            val timeIndex = dataOrder.indexOf("time")
+            val rowIndex = dataOrder.indexOf("y")
+            val columnIndex = dataOrder.indexOf("x")
+            val data = DoubleArray(shape.fold(1) { acc, length -> acc * length }) { flatIndex ->
+                val indices = indicesForFlatIndex(flatIndex, shape)
+                valueAt(indices[rowIndex], indices[columnIndex] )
+            }
+            check(timeIndex >= 0) { "temperature must include time dimension" }
+            writer.write(
+                writer.findVariable("temperature"),
+                Array.factory(DataType.DOUBLE, shape, data),
+            )
+        }
+        return path
+    }
+
+    private fun indicesForFlatIndex(flatIndex: Int, shape: IntArray): IntArray {
+        var remaining = flatIndex
+        return IntArray(shape.size) { index ->
+            val stride = shape.drop(index + 1).fold(1) { acc, length -> acc * length }
+            val coordinate = remaining / stride
+            remaining %= stride
+            coordinate
+        }
     }
 }


### PR DESCRIPTION
## 요약
NetCDF science 모듈에 CF 좌표축 기반 1D·2D 격자 임포트를 추가하고, 기존 Exposed schema와 재개 계약을 유지하면서 bounded resource·파일 identity·lease 경계를 고정했습니다.

## 구현 범위
- 1D lat/lon 및 curvilinear 2D lat/lon 좌표축을 row-major tile로 읽습니다.
- `coordinates`의 numeric CF auxiliary를 deterministic JSONB attrs로 저장하고 canonical 위치는 `(longitude, latitude)` 순서를 사용합니다.
- EPSG:4326/4269, Web Mercator, UTM, 극지 CRS whitelist와 strict `epsg_code`·`spatial_ref` 파싱을 적용합니다.
- slice duplicate preflight, PostGIS conflict audit, file fingerprint, malformed progress quarantine, lease/cancellation fence를 추가했습니다.
- rank·tile·batch·metadata·working-set 한도를 typed `NetCdfException`으로 거부합니다.
- README/README.ko.md, 후속 이슈, 설계 검토, benchmark, lesson을 현재 계약과 검증 상태에 맞게 갱신했습니다.

## 스택 순서
- 선행 PR: #1512 (merged; NetCDF contract baseline)
- 현재 PR: #1352
- Epic: #1421

## 검증
- `./gradlew :bluetape4k-science:compileKotlin --no-configuration-cache --console=plain` — PASS
- `./gradlew :bluetape4k-science:test --no-configuration-cache --console=plain` — `SUCCESS: Executed 233 tests`
- `./gradlew :bluetape4k-science:test -PincludeTags=slow-netcdf --no-configuration-cache --console=plain` — `SUCCESS: Executed 1 tests`
- `./gradlew :bluetape4k-science:detekt --rerun-tasks --no-configuration-cache --console=plain` — BUILD SUCCESSFUL (repository `ignoreFailures=true`; findings remain non-blocking)
- Korean terminology audit 5 files — findings=0
- `git diff --check` 및 임시 benchmark harness scan — PASS/clean
- benchmark 문서는 emulated arm64 단일 실행 reference로 기록했으며 최종 median 측정은 pending입니다.
- hosted CI run `33075947761` — 전체 비경로필터 check PASS, 경로 필터 테스트는 SKIPPED

Closes #1352
Relates to #1421

## DoD Status
- 구현·local verification: PASS
- schema migration/dependency 추가: 없음
- PR exact-head hosted CI/review: PASS
- rebase merge: PASS (`5aae135e0d5a6ff66d59809b56905a872c593220`)
- child issue #1352 및 Epic #1421: COMPLETED/CLOSED
- canonical `develop` sync: PASS (`5aae135e0d5a6ff66d59809b56905a872c593220`)
- 반복 median benchmark: PENDING (후속 관찰 항목)
