### PR TITLE
[cache][성능] #1554 rejected callback snapshot 비용 제거

### DIFF
--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListener.kt
@@ -28,7 +28,9 @@ private const val DEFAULT_MAX_IN_FLIGHT_CALLBACKS = 64
  * `launch`를 사용하여 스레드 풀 고갈과 데드락을 방지합니다.
  * callback admission은 non-blocking `tryAcquire()`로 선형화하며, 기본적으로
  * listener마다 최대 64개의 in-flight callback job만 허용합니다. 상한에 도달한
- * callback은 내부 queue 없이 즉시 거부하고 sanitized debug log를 남깁니다.
+ * callback은 이벤트 snapshot을 만들기 전에 내부 queue 없이 즉시 거부하고
+ * sanitized debug log를 남깁니다. permit을 확보한 callback만 JCache event의
+ * key/value를 immutable snapshot으로 복사합니다.
  * [close]는 취소를 요청하지만 callback 완료를 기다리지 않습니다.
  *
  * ```kotlin
@@ -96,10 +98,12 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onCreated(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        val eventCopies = events.map { EventCopy(it.key, it.value) }
-        log.trace { "BackCache cache entry created. cache=$cacheIdentifier count=${eventCopies.size}" }
         submit("put all created cache entries") {
-            targetCache.putAll(eventCopies.associate { it.key to it.value })
+            val eventCopies = events.map { EventCopy(it.key, it.value) }
+            log.trace { "BackCache cache entry created. cache=$cacheIdentifier count=${eventCopies.size}" }
+            suspend {
+                targetCache.putAll(eventCopies.associate { it.key to it.value })
+            }
         }
     }
 
@@ -110,10 +114,12 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onUpdated(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        val eventCopies = events.map { EventCopy(it.key, it.value) }
-        log.trace { "BackCache cache entry updated. cache=$cacheIdentifier count=${eventCopies.size}" }
         submit("put all updated cache entries") {
-            targetCache.putAll(eventCopies.associate { it.key to it.value })
+            val eventCopies = events.map { EventCopy(it.key, it.value) }
+            log.trace { "BackCache cache entry updated. cache=$cacheIdentifier count=${eventCopies.size}" }
+            suspend {
+                targetCache.putAll(eventCopies.associate { it.key to it.value })
+            }
         }
     }
 
@@ -125,10 +131,12 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onRemoved(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        val eventKeys = events.map { it.key }
-        log.trace { "BackCache cache entry removed. cache=$cacheIdentifier count=${eventKeys.size}" }
         submit("remove all removed cache entries") {
-            targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
+            val eventKeys = events.map { it.key }
+            log.trace { "BackCache cache entry removed. cache=$cacheIdentifier count=${eventKeys.size}" }
+            suspend {
+                targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
+            }
         }
     }
 
@@ -140,14 +148,17 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
      * @throws CacheEntryListenerException if there is problem executing the listener
      */
     override fun onExpired(events: MutableIterable<CacheEntryEvent<out K, out V>>) {
-        val eventKeys = events.map { it.key }
-        log.trace { "BackCache cache entry expired. cache=$cacheIdentifier count=${eventKeys.size}" }
         submit("remove all expired cache entries") {
-            targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
+            val eventKeys = events.map { it.key }
+            log.trace { "BackCache cache entry expired. cache=$cacheIdentifier count=${eventKeys.size}" }
+            suspend {
+                targetCache.removeAll(eventKeys.toCollection(LinkedHashSet()))
+            }
         }
     }
 
-    private fun submit(operation: String, block: suspend () -> Unit) {
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    private fun submit(operation: String, blockFactory: () -> (suspend () -> Unit)) {
         if (!shouldAcceptCallback()) return
         if (!admission.tryAcquire()) {
             log.debug {
@@ -156,9 +167,11 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
             }
             return
         }
-        if (!shouldAcceptCallback()) {
-            admission.release()
-        } else {
+        var permitTransferred = false
+        try {
+            if (!shouldAcceptCallback()) return
+            val block = blockFactory()
+            if (!shouldAcceptCallback()) return
             val job = scope.launch(start = CoroutineStart.LAZY) {
                 try {
                     if (!closed.get()) {
@@ -169,6 +182,11 @@ class SuspendJCacheEntryEventListener<K: Any, V: Any> private constructor(
                 }
             }
             if (!job.start()) {
+                admission.release()
+            }
+            permitTransferred = true
+        } finally {
+            if (!permitTransferred) {
                 admission.release()
             }
         }

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/jcache/SuspendJCacheEntryEventListenerTest.kt
@@ -306,6 +306,127 @@ class SuspendJCacheEntryEventListenerTest {
     }
 
     @Test
+    fun `admission overflow는 event snapshot을 만들지 않는다`() = runTest {
+        val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+        every { targetCache.isClosed() } returns false
+        val started = CompletableDeferred<Unit>()
+        coEvery { targetCache.putAll(any()) } coAnswers {
+            started.complete(Unit)
+            awaitCancellation()
+        }
+
+        val reads = AtomicInteger()
+        val overflowEvent = mockk<CacheEntryEvent<String, String>>()
+        every { overflowEvent.key } answers {
+            reads.incrementAndGet()
+            "overflow-key"
+        }
+        every { overflowEvent.value } answers {
+            reads.incrementAndGet()
+            "overflow-value"
+        }
+
+        val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val listener = SuspendJCacheEntryEventListener.forTest(
+            targetCache,
+            listenerScope,
+            maxInFlightCallbacks = 1,
+        )
+        try {
+            listener.onCreated(mutableListOf(mockEvent("first", "value", EventType.CREATED)))
+            runCurrent()
+            started.await()
+
+            listener.onCreated(mutableListOf(overflowEvent))
+            runCurrent()
+
+            reads.get().shouldBeEqualTo(0)
+        } finally {
+            listener.close()
+            runCurrent()
+        }
+    }
+
+    @Test
+    fun `rejected burst snapshot work는 고정 matrix에서 최소 20퍼센트 개선된다`() = runTest {
+        // Gradle Wrapper 9.7.0/JVM 25 기준: warm-up 2회 후 5회 측정, cap/burst 3개 조합.
+        // 기준선은 거부된 event마다 key/value를 2회 읽는 eager EventCopy 경로이며,
+        // 측정값은 실제 listener의 거부된 event getter 접근 횟수입니다.
+        val warmupRounds = 2
+        val measurementRounds = 5
+        val burstAndCapMatrix = listOf(
+            1 to 4,
+            2 to 8,
+            4 to 16,
+        )
+        var baselineSnapshotReads = 0
+        var measuredSnapshotReads = 0
+
+        suspend fun measureRejectedSnapshotReads(maxInFlight: Int, burstSize: Int): Int {
+            val targetCache = mockk<SuspendJCache<String, String>>(relaxed = true)
+            every { targetCache.isClosed() } returns false
+            val startedCount = AtomicInteger()
+            val allStarted = CompletableDeferred<Unit>()
+            coEvery { targetCache.putAll(any()) } coAnswers {
+                if (startedCount.incrementAndGet() == maxInFlight) {
+                    allStarted.complete(Unit)
+                }
+                awaitCancellation()
+            }
+
+            val reads = AtomicInteger()
+            val listenerScope = CoroutineScope(coroutineContext + SupervisorJob())
+            val listenerJob = listenerScope.coroutineContext[Job]!!
+            val listener = SuspendJCacheEntryEventListener.forTest(
+                targetCache,
+                listenerScope,
+                maxInFlightCallbacks = maxInFlight,
+            )
+            try {
+                repeat(maxInFlight) { index ->
+                    listener.onCreated(mutableListOf(mockEvent("accepted-$index", "value", EventType.CREATED)))
+                }
+                runCurrent()
+                allStarted.await()
+
+                repeat(burstSize - maxInFlight) { index ->
+                    val overflowEvent = mockk<CacheEntryEvent<String, String>>()
+                    every { overflowEvent.key } answers {
+                        reads.incrementAndGet()
+                        "overflow-key-$index"
+                    }
+                    every { overflowEvent.value } answers {
+                        reads.incrementAndGet()
+                        "overflow-value-$index"
+                    }
+                    listener.onCreated(mutableListOf(overflowEvent))
+                }
+                runCurrent()
+                return reads.get()
+            } finally {
+                listener.close()
+                runCurrent()
+                listenerJob.join()
+            }
+        }
+
+        repeat(warmupRounds + measurementRounds) { round ->
+            burstAndCapMatrix.forEach { (maxInFlight, burstSize) ->
+                val rejectedCount = burstSize - maxInFlight
+                if (round >= warmupRounds) {
+                    baselineSnapshotReads += rejectedCount * 2
+                }
+                measuredSnapshotReads += measureRejectedSnapshotReads(maxInFlight, burstSize)
+            }
+        }
+
+        val improvement =
+            (baselineSnapshotReads - measuredSnapshotReads).toDouble() / baselineSnapshotReads
+        measuredSnapshotReads.shouldBeEqualTo(0)
+        (improvement >= 0.20).shouldBeTrue()
+    }
+
+    @Test
     fun `close는 bounded cooperative callback burst를 모두 취소한다`() = runTest {
         val maxInFlight = 2
         val callbackCount = 8


### PR DESCRIPTION
## Summary

Closes #1554

admission 포화로 거부되는 JCache callback이 불필요한 immutable event snapshot을 만들지 않도록 비용 경계를 정렬합니다.

## Background

#1474에서 listener callback fan-out에 bounded non-blocking admission을 적용했지만, 기존 `onCreated`/`onUpdated` 경로는 permit 확보 전에 `EventCopy` batch를 생성했습니다.

## What This Solves

- rejected burst의 key/value snapshot allocation 및 getter 비용을 제거합니다.
- accepted callback의 immutable snapshot, event 반영 의미, close/cancellation 동작을 유지합니다.

## Work Done

- admission permit을 먼저 확보한 callback만 event snapshot과 trace 정보를 생성하도록 `submit` 경계를 변경했습니다.
- permit 소유권과 예외·취소·close 경로의 release를 보강했습니다.
- rejected snapshot getter 접근, deterministic cap/burst matrix, 기존 listener lifecycle 및 cache contract 회귀 테스트를 추가했습니다.

## Validation

- `./gradlew :bluetape4k-cache-core:test --tests 'io.bluetape4k.cache.jcache.SuspendJCacheEntryEventListenerTest' --rerun-tasks`: PASS (19 passing)
- `./gradlew :bluetape4k-cache-core:test --rerun-tasks`: PASS (713 passing)
- `./gradlew :bluetape4k-cache-core:detekt --rerun-tasks`: PASS (변경 listener 신규 finding 없음)
- `./gradlew :bluetape4k-cache-core:build -x test --rerun-tasks`: PASS
- `git diff --check`: PASS
- deterministic matrix: warm-up 2회, 측정 5회, cap/burst 3조합, Gradle 9.7.0/JVM 25; rejected getter work 100% 감소

## Review Notes

- P0/P1: 없음
- P2/P3: 실제 JMH wall-clock 및 provider별 장시간 부하는 후속 성능 검증으로 유지
- Review evidence: single-developer lane N/A (사용자가 1인 개발자임을 확인했고 추가 maintainer/reviewer 범위 없음); independent final review 완료, unresolved review/comment 0

## Metadata

- Issue: #1554, milestone `2.0.0`, assignee `debop`
- PR: #1556, head `809a64a59b9cdbae70a54cd175bc61b25518f93b`, milestone `2.0.0`, assignee `debop`
- CI: [CI run 33103222538](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33103222538) exact-head `809a64a59b9cdbae70a54cd175bc61b25518f93b` 성공 (required jobs pass; path-filtered jobs skipped)

## DoD Status

Required checks: 18/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 to CG-05 | authority, GNO/live evidence, worktree isolation, policy, Kotlin reuse | PASS | current guidance, GNO fallback, isolated `feat/issue-1554-snapshot-cost`, scoped 2-file diff | none |
| CG-06 to CG-10 | docs/API scope, RED-GREEN, sequential validation, lesson, final convergence | PASS | internal KDoc, 19/713 tests, detekt/build, Lore commit `809a64a`, P0/P1=0 | none |
| CG-11 - PR delivery authority | create PR for bluetape4k/bluetape4k-projects `develop <- feat/issue-1554-snapshot-cost` | PASS | user request “다음 단계 진행해” and approved next-step plan | none |
| CG-12 - Exact head publication | push exact branch without force | PASS | local/remote HEAD `809a64a59b9cdbae70a54cd175bc61b25518f93b` match | none |
| CG-12A - Guidance refresh | reread current guidance, leaf, common gates, PR template, issue metadata | PASS | current hashes and #1554 live metadata; no drift | none |
| CG-13 - Create and verify PR | create Korean PR, mirror metadata, keep DoD last | PASS | live PR metadata/body/head and CI link verified | none |
| CG-14 - CI and human review | PASS | CI run 33103222538 exact-head success; reviews/threads 0; single-developer lane human-review subgate N/A; independent final review P0/P1=0 | none |
| CG-15 - Merge-ready report | PASS | exact PR #1556/head `809a64a59b9cdbae70a54cd175bc61b25518f93b`, CI/review/lesson evidence reconciled | none |
| CG-16 - Fresh merge approval | PASS | current user approval "1인 개발자야. 승인, 다음 단계 진행해" for PR #1556 exact head `809a64a59b9cdbae70a54cd175bc61b25518f93b` | none |
| CG-17 - Merge | merge approved PR | PASS | squash merge completed as `4b48095901dc49415908ae4c40e40b86cd0608ed` after exact-head approval | none |
| CG-18 - Sync/cleanup | sync and proof-gated cleanup | PASS | canonical `develop` fast-forwarded to `18472064c594ab2dee835cff6695cd6ef9538ea5`; unrelated flow evidence preserved; local worktrees/branches retained under proof-gated cleanup policy | none |
| CG-X01 - Release/publish | no tag, release, publish, or dispatch in scope | N/A | issue explicitly excludes BOM/release/tag/publish | none |

Final status: DONE

Unchecked required items: none





