### PR TITLE
[1320 구현] 공통 TenantContext core와 carrier adapter 제공

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,8 @@ jobs:
               - 'bluetape4k/core/**'
               - 'bluetape4k/coroutines/**'
               - 'bluetape4k/logging/**'
+              - 'bluetape4k/tenant/**'
+              - 'bluetape4k/tenant-reactor/**'
               - 'virtualthread/api/**'
               - 'virtualthread/jdk21/**'
               - 'virtualthread/jdk25/**'
@@ -371,12 +373,18 @@ jobs:
               :bluetape4k-core:test \
               :bluetape4k-coroutines:test \
               :bluetape4k-logging:test \
+              :bluetape4k-tenant:test \
+              :bluetape4k-tenant-reactor:test \
               :bluetape4k-virtualthread-api:test \
               :bluetape4k-virtualthread-jdk21:test \
               :bluetape4k-virtualthread-jdk25:test \
               --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Test TenantContext retention
+        timeout-minutes: 2
+        run: ./gradlew :bluetape4k-tenant:tenantRetentionStress --no-configuration-cache
 
       - name: Generate Kover XML report
         if: always()
@@ -386,6 +394,8 @@ jobs:
             :bluetape4k-core:koverXmlReport \
             :bluetape4k-coroutines:koverXmlReport \
             :bluetape4k-logging:koverXmlReport \
+            :bluetape4k-tenant:koverXmlReport \
+            :bluetape4k-tenant-reactor:koverXmlReport \
             :bluetape4k-virtualthread-api:koverXmlReport \
             :bluetape4k-virtualthread-jdk21:koverXmlReport \
             :bluetape4k-virtualthread-jdk25:koverXmlReport \
@@ -396,7 +406,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results-core
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            bluetape4k/tenant/build/test-results/tenantRetentionStress/*.xml
+            bluetape4k/tenant/build/reports/tests/tenantRetentionStress/**
+            bluetape4k/tenant/build/reports/tenant-retention/**
           retention-days: 30
 
       - name: Upload coverage report
@@ -634,6 +648,7 @@ jobs:
           command: |
             ./gradlew \
               :bluetape4k-ktor-core:test \
+              :bluetape4k-ktor-tenant:test \
               :bluetape4k-ktor-observability:test \
               :bluetape4k-ktor-openapi:test \
               :bluetape4k-ktor-resilience4j:test \
@@ -647,6 +662,7 @@ jobs:
         run: |
           ./gradlew \
             :bluetape4k-ktor-core:koverXmlReport \
+            :bluetape4k-ktor-tenant:koverXmlReport \
             :bluetape4k-ktor-observability:koverXmlReport \
             :bluetape4k-ktor-openapi:koverXmlReport \
             :bluetape4k-ktor-resilience4j:koverXmlReport \

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -426,9 +426,15 @@ jobs:
               :bluetape4k-core:test \
               :bluetape4k-coroutines:test \
               :bluetape4k-logging:test \
+              :bluetape4k-tenant:test \
+              :bluetape4k-tenant-reactor:test \
               --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Test TenantContext retention
+        timeout-minutes: 2
+        run: ./gradlew :bluetape4k-tenant:tenantRetentionStress --no-configuration-cache
 
       - name: Generate Kover XML report
         if: always()
@@ -438,13 +444,19 @@ jobs:
             :bluetape4k-core:koverXmlReport \
             :bluetape4k-coroutines:koverXmlReport \
             :bluetape4k-logging:koverXmlReport \
+            :bluetape4k-tenant:koverXmlReport \
+            :bluetape4k-tenant-reactor:koverXmlReport \
             --parallel
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: nightly-test-results-core
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            bluetape4k/tenant/build/test-results/tenantRetentionStress/*.xml
+            bluetape4k/tenant/build/reports/tests/tenantRetentionStress/**
+            bluetape4k/tenant/build/reports/tenant-retention/**
           retention-days: 14
 
       - name: Upload coverage report
@@ -627,6 +639,7 @@ jobs:
           command: |
             ./gradlew --no-configuration-cache \
               :bluetape4k-ktor-core:test \
+              :bluetape4k-ktor-tenant:test \
               :bluetape4k-ktor-observability:test \
               :bluetape4k-ktor-openapi:test \
               :bluetape4k-ktor-resilience4j:test \
@@ -640,6 +653,7 @@ jobs:
         run: |
           ./gradlew --no-configuration-cache \
             :bluetape4k-ktor-core:koverXmlReport \
+            :bluetape4k-ktor-tenant:koverXmlReport \
             :bluetape4k-ktor-observability:koverXmlReport \
             :bluetape4k-ktor-openapi:koverXmlReport \
             :bluetape4k-ktor-resilience4j:koverXmlReport \

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -2,28 +2,26 @@ name: Publish Snapshot
 
 permissions:
   contents: read
-  actions: read
 
 on:
-  workflow_run:
-    workflows: ["Nightly"]
-    types: [completed]
-    branches: [develop]
   workflow_dispatch:
     inputs:
-      validation_run_id:
-        description: 'Completed full Nightly run ID used for exact-head validation'
+      verified_ci_run_id:
+        description: 'Completed full Nightly run ID for the exact develop head'
         required: true
         type: string
-      diagnoseSigning:
-        description: 'Run signing diagnostics before publishing'
-        required: false
-        default: false
-        type: boolean
+      expected_head_sha:
+        description: 'Full develop SHA verified by the Nightly run'
+        required: true
+        type: string
+      handoff_issue_number:
+        description: 'Linked issue that receives the immutable handoff evidence'
+        required: true
+        type: string
 
 concurrency:
   group: publish-snapshot
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   JAVA_VERSION: '25'
@@ -33,33 +31,51 @@ env:
 jobs:
   validate-full-nightly:
     name: Verify full Nightly validation
+    permissions:
+      actions: read
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       publish_eligible: ${{ steps.validate.outputs.publish_eligible }}
       head_sha: ${{ steps.validate.outputs.head_sha }}
+      verified_ci_run_id: ${{ steps.validate.outputs.verified_ci_run_id }}
+      handoff_issue_number: ${{ steps.validate.outputs.handoff_issue_number }}
     steps:
-      - name: Validate full Nightly run
+      - name: Validate exact-head full Nightly run
         id: validate
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id || '' }}
-          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
-          MANUAL_VALIDATION_RUN_ID: ${{ inputs.validation_run_id || '' }}
+          VERIFIED_CI_RUN_ID: ${{ inputs.verified_ci_run_id }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          HANDOFF_ISSUE_NUMBER: ${{ inputs.handoff_issue_number }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            validation_run_id="$WORKFLOW_RUN_ID"
-            expected_head_sha="$WORKFLOW_RUN_HEAD_SHA"
-          else
-            validation_run_id="$MANUAL_VALIDATION_RUN_ID"
-            expected_head_sha=""
+          if ! [[ "$VERIFIED_CI_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::verified_ci_run_id must be numeric."
+            exit 1
           fi
-
-          if ! [[ "$validation_run_id" =~ ^[0-9]+$ ]]; then
-            echo "::error::A completed Nightly validation_run_id is required."
+          if ! [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::expected_head_sha must be a full lowercase Git SHA."
+            exit 1
+          fi
+          if ! [[ "$HANDOFF_ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::handoff_issue_number must be a positive issue number."
+            exit 1
+          fi
+          if [ "$HANDOFF_ISSUE_NUMBER" -ne 1562 ]; then
+            echo "::error::handoff_issue_number must identify TenantContext issue #1562."
+            exit 1
+          fi
+          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
+            echo "::error::Publish Snapshot must be dispatched from refs/heads/develop."
+            exit 1
+          fi
+          if [ "$GITHUB_SHA" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::Dispatch SHA does not match expected_head_sha."
             exit 1
           fi
 
@@ -67,14 +83,15 @@ jobs:
           jobs_json="$(mktemp)"
           contract_json="$(mktemp)"
           validator_script="$(mktemp)"
-          trap 'rm -f "$run_json" "$jobs_json" "$contract_json" "$validator_script"' EXIT
+          develop_ref_json="$(mktemp)"
+          trap 'rm -f "$run_json" "$jobs_json" "$contract_json" "$validator_script" "$develop_ref_json"' EXIT
 
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${validation_run_id}" \
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_CI_RUN_ID}" \
             --method GET > "$run_json"
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${validation_run_id}/jobs" \
-            --method GET \
-            --paginate \
-            --slurp > "$jobs_json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_CI_RUN_ID}/jobs" \
+            --method GET --paginate --slurp > "$jobs_json"
+          gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/develop" \
+            --method GET > "$develop_ref_json"
 
           validation_head_sha="$(python3 - "$run_json" <<'PY'
           import json
@@ -98,23 +115,54 @@ jobs:
             --method GET \
             --header 'Accept: application/vnd.github.raw' > "$validator_script"
 
-          validation_output="$(python3 "$validator_script" "$run_json" "$jobs_json" "$expected_head_sha" "$contract_json")"
+          validation_output="$(python3 "$validator_script" "$run_json" "$jobs_json" "$EXPECTED_HEAD_SHA" "$contract_json")"
+          develop_sha="$(jq -r '.object.sha // empty' "$develop_ref_json")"
+          if [ "$develop_sha" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::Current develop SHA does not match expected_head_sha."
+            exit 1
+          fi
+          if ! grep -qx 'publish_eligible=true' <<< "$validation_output"; then
+            while IFS= read -r line; do
+              case "$line" in
+                validation_error=*) echo "::error::${line#validation_error=}" ;;
+              esac
+            done <<< "$validation_output"
+            exit 1
+          fi
           while IFS= read -r line; do
             case "$line" in
               head_sha=*|publish_eligible=*|validation_error=*) echo "$line" >> "$GITHUB_OUTPUT" ;;
             esac
           done <<< "$validation_output"
+          {
+            echo "verified_ci_run_id=$VERIFIED_CI_RUN_ID"
+            echo "handoff_issue_number=$HANDOFF_ISSUE_NUMBER"
+          } >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish SNAPSHOT to Maven Central
+    permissions:
+      contents: read
     needs: validate-full-nightly
     if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}
     runs-on: ubuntu-latest
+    environment: maven-central-release
+    timeout-minutes: 50
+    outputs:
+      artifact_name: ${{ steps.receipt.outputs.artifact_name }}
+      artifact_id: ${{ steps.handoff-artifact.outputs.artifact-id }}
+      artifact_digest: ${{ steps.handoff-artifact.outputs.artifact-digest }}
+      artifact_url: ${{ steps.handoff-artifact.outputs.artifact-url }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.validate-full-nightly.outputs.head_sha }}
           fetch-depth: 0
+
+      - name: Verify exact checkout
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
 
       - uses: actions/setup-java@v5.7.0
         with:
@@ -126,22 +174,8 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
-      - name: Diagnose signing inputs
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.diagnoseSigning }}
-        shell: bash
-        env:
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-        run: |
-          python3 - <<'PY'
-          import os
-          for name in ("SIGNING_KEY_ID", "SIGNING_KEY", "SIGNING_PASSWORD"):
-              value = os.environ.get(name, "")
-              print(f"{name} set={bool(value)} length={len(value)}")
-          PY
-
       - name: Validate publication metadata
+        timeout-minutes: 10
         run: |
           ./gradlew generatePomFileForBluetape4kPublication checkPomFileForBluetape4kPublication generateMetadataFileForBluetape4kPublication \
             -PsnapshotVersion=-SNAPSHOT \
@@ -150,6 +184,7 @@ jobs:
           ruby scripts/publication/validate_module_metadata.rb
 
       - name: Publish SNAPSHOT
+        timeout-minutes: 25
         run: >-
           ./gradlew nmcpPublishAggregationToCentralPortalSnapshots
           -PsnapshotVersion=-SNAPSHOT
@@ -163,3 +198,176 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
+      - name: Verify public resources and create handoff receipt
+        id: receipt
+        timeout-minutes: 10
+        env:
+          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
+          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
+          PUBLICATION_RUN_ID: ${{ github.run_id }}
+          HANDOFF_ISSUE_NUMBER: ${{ needs.validate-full-nightly.outputs.handoff_issue_number }}
+        run: |
+          set -euo pipefail
+          receipt_values="$(mktemp)"
+          trap 'rm -f "$receipt_values"' EXIT
+
+          verified=false
+          for attempt in $(seq 1 20); do
+            : > "$receipt_values"
+            rm -f tenant-context-handoff.json
+            set +e
+            python3 scripts/create_snapshot_handoff.py \
+              --repository "$GITHUB_REPOSITORY" \
+              --merge-sha "$MERGE_SHA" \
+              --verified-ci-run-id "$VERIFIED_CI_RUN_ID" \
+              --publication-run-id "$PUBLICATION_RUN_ID" \
+              --handoff-issue-number "$HANDOFF_ISSUE_NUMBER" \
+              --group io.github.bluetape4k \
+              --artifact bluetape4k-bom \
+              --base-version 2.0.0 \
+              --resource bluetape4k-bom:pom \
+              --resource bluetape4k-tenant:pom \
+              --resource bluetape4k-tenant:jar \
+              --resource bluetape4k-tenant-reactor:pom \
+              --resource bluetape4k-tenant-reactor:jar \
+              --resource bluetape4k-ktor-tenant:pom \
+              --resource bluetape4k-ktor-tenant:jar \
+              --output tenant-context-handoff.json > "$receipt_values"
+            receipt_status="$?"
+            set -e
+            if [ "$receipt_status" -eq 0 ]; then
+              verified=true
+              break
+            fi
+            if [ "$receipt_status" -ne 75 ]; then
+              echo "::error::Permanent SNAPSHOT handoff validation failure."
+              exit "$receipt_status"
+            fi
+            echo "::notice::Public SNAPSHOT read-back attempt $attempt is not stable yet."
+            sleep 15
+          done
+          if [ "$verified" != true ]; then
+            echo "::error::Public SNAPSHOT read-back did not stabilize within the retry window."
+            exit 1
+          fi
+
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg merge_sha "$MERGE_SHA" \
+            --arg verified_ci_run_id "$VERIFIED_CI_RUN_ID" \
+            --arg publication_run_id "$PUBLICATION_RUN_ID" \
+            --arg handoff_issue_number "$HANDOFF_ISSUE_NUMBER" \
+            '.schema == "bluetape.snapshot-handoff/v1" and
+             .status == "verified" and
+             .repository == $repository and
+             .merge_sha == $merge_sha and
+             .verified_ci_run_id == $verified_ci_run_id and
+             .publication_run_id == $publication_run_id and
+             .handoff_issue_number == $handoff_issue_number and
+             .group == "io.github.bluetape4k" and
+             .artifact == "bluetape4k-bom" and
+             .base_version == "2.0.0" and
+             (.resources | length == 7) and
+             ([.resources[].url] | unique | length == 7) and
+             all(.resources[]; (.sha256 | test("^[0-9a-f]{64}$")))' \
+            tenant-context-handoff.json > /dev/null
+          cat "$receipt_values" >> "$GITHUB_OUTPUT"
+          timestamp="$(jq -r '.timestamp' tenant-context-handoff.json)"
+          build_number="$(jq -r '.build_number' tenant-context-handoff.json)"
+          echo "artifact_name=tenant-context-handoff-${MERGE_SHA}-${timestamp}-${build_number}" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable handoff receipt
+        id: handoff-artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.receipt.outputs.artifact_name }}
+          path: tenant-context-handoff.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize handoff evidence
+        env:
+          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
+          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
+          PUBLICATION_RUN_ID: ${{ github.run_id }}
+          ARTIFACT_NAME: ${{ steps.receipt.outputs.artifact_name }}
+          ARTIFACT_ID: ${{ steps.handoff-artifact.outputs.artifact-id }}
+          ARTIFACT_DIGEST: ${{ steps.handoff-artifact.outputs.artifact-digest }}
+          ARTIFACT_URL: ${{ steps.handoff-artifact.outputs.artifact-url }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## TenantContext SNAPSHOT handoff"
+            echo
+            echo "- merge SHA: \`$MERGE_SHA\`"
+            echo "- verified CI run ID: \`$VERIFIED_CI_RUN_ID\`"
+            echo "- publication run ID: \`$PUBLICATION_RUN_ID\`"
+            echo "- artifact: \`$ARTIFACT_NAME\`"
+            echo "- artifact ID: \`$ARTIFACT_ID\`"
+            echo "- artifact digest: \`$ARTIFACT_DIGEST\`"
+            echo "- artifact URL: $ARTIFACT_URL"
+            echo
+            echo "### Public resource SHA-256"
+            jq -r '.resources[] | "- `\(.sha256)` \(.url)"' tenant-context-handoff.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  record-handoff:
+    name: Record SNAPSHOT handoff on issue
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    needs: [validate-full-nightly, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download immutable handoff receipt
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.publish.outputs.artifact_name }}
+
+      - name: Validate and record handoff evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HANDOFF_ISSUE_NUMBER: ${{ needs.validate-full-nightly.outputs.handoff_issue_number }}
+          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
+          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
+          PUBLICATION_RUN_ID: ${{ github.run_id }}
+          ARTIFACT_ID: ${{ needs.publish.outputs.artifact_id }}
+          ARTIFACT_DIGEST: ${{ needs.publish.outputs.artifact_digest }}
+          ARTIFACT_URL: ${{ needs.publish.outputs.artifact_url }}
+        run: |
+          set -euo pipefail
+
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg merge_sha "$MERGE_SHA" \
+            --arg verified_ci_run_id "$VERIFIED_CI_RUN_ID" \
+            --arg publication_run_id "$PUBLICATION_RUN_ID" \
+            --arg handoff_issue_number "$HANDOFF_ISSUE_NUMBER" \
+            '.schema == "bluetape.snapshot-handoff/v1" and
+             .status == "verified" and
+             .repository == $repository and
+             .merge_sha == $merge_sha and
+             .verified_ci_run_id == $verified_ci_run_id and
+             .publication_run_id == $publication_run_id and
+             .handoff_issue_number == $handoff_issue_number' \
+            tenant-context-handoff.json > /dev/null
+
+          comment="$(mktemp)"
+          trap 'rm -f "$comment"' EXIT
+          {
+            echo "TenantContext SNAPSHOT handoff 검증이 완료되었습니다."
+            echo
+            echo "- merge SHA: \`$MERGE_SHA\`"
+            echo "- 검증 CI run ID: \`$VERIFIED_CI_RUN_ID\`"
+            echo "- 출판 run ID: \`$PUBLICATION_RUN_ID\`"
+            echo "- immutable artifact ID: \`$ARTIFACT_ID\`"
+            echo "- artifact digest: \`$ARTIFACT_DIGEST\`"
+            echo "- artifact: $ARTIFACT_URL"
+            echo
+            echo "downstream은 receipt의 timestamp/build number와 resource SHA-256을 모두 확인해야 합니다."
+          } > "$comment"
+          gh issue comment "$HANDOFF_ISSUE_NUMBER" --body-file "$comment"

--- a/README.ko.md
+++ b/README.ko.md
@@ -96,6 +96,8 @@ Bluetape4k는 기능별로 분리된 멀티 모듈 Gradle 프로젝트입니다.
 - **[core](./bluetape4k/core/README.ko.md)**: 핵심 유틸리티 (assertions, required, 컬렉션(BoundedStack, RingBuffer, PaginatedList, Permutation), Wildcard 패턴 매칭, XXHasher 등)
 - **[coroutines](./bluetape4k/coroutines/README.ko.md)**: Kotlin Coroutines 확장 (DeferredValue, Flow extensions, AsyncFlow)
 - **[logging](./bluetape4k/logging/README.ko.md)**: 로깅 관련 기능
+- **[tenant](./bluetape4k/tenant/README.ko.md)**: JDK 25 `ThreadLocal`/`ScopedValue` 기반 no-default tenant context
+- **[tenant-reactor](./bluetape4k/tenant-reactor/README.ko.md)**: immutable Reactor subscriber `Context` tenant adapter
 - **[bom](./bluetape4k/bom/README.ko.md)**: Bill of Materials (의존성 관리)
 
 ### I/O 모듈 (`io/`)
@@ -199,6 +201,7 @@ Bluetape4k는 기능별로 분리된 멀티 모듈 Gradle 프로젝트입니다.
 - **[observability](./ktor/observability/README.ko.md)**: Call logging, correlation-id, metrics, Prometheus route helper
 - **[openapi](./ktor/openapi/README.ko.md)**: 명시적인 Ktor OpenAPI 및 Swagger UI 문서 route helper
 - **[resilience4j](./ktor/resilience4j/README.ko.md)**: Route 범위 Resilience4j retry, circuit breaker, rate limiter, timeout helper
+- **[tenant](./ktor/tenant/README.ko.md)**: `ApplicationCall` one-call/one-tenant context adapter
 - **[testing](./ktor/testing/README.ko.md)**: Ktor `testApplication` 및 JSON client 테스트 helper
 
 ### 텍스트 처리 → [bluetape4k-text](https://github.com/bluetape4k/bluetape4k-text)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Bluetape4k is a multi-module Gradle project organized by domain.
 - **[core](./bluetape4k/core/README.md)**: Core utilities — assertions, required helpers, collections (BoundedStack, RingBuffer, PaginatedList, Permutation), wildcard pattern matching, XXHasher, and more
 - **[coroutines](./bluetape4k/coroutines/README.md)**: Kotlin Coroutines extensions — DeferredValue, Flow extensions, AsyncFlow
 - **[logging](./bluetape4k/logging/README.md)**: Logging utilities
+- **[tenant](./bluetape4k/tenant/README.md)**: JDK 25 no-default tenant context backed by `ThreadLocal` or `ScopedValue`
+- **[tenant-reactor](./bluetape4k/tenant-reactor/README.md)**: Immutable Reactor subscriber `Context` tenant adapter
 - **[bom](./bluetape4k/bom/README.md)**: Bill of Materials for dependency management
 
 ### I/O Modules (`io/`)
@@ -197,6 +199,7 @@ auth helpers stay in backlog until their extension points are proven.
 - **[observability](./ktor/observability/README.md)**: Call logging, correlation-id, metrics, and Prometheus route helpers
 - **[openapi](./ktor/openapi/README.md)**: Explicit Ktor OpenAPI and Swagger UI documentation route helpers
 - **[resilience4j](./ktor/resilience4j/README.md)**: Route-scoped Resilience4j retry, circuit breaker, rate limiter, and timeout helpers
+- **[tenant](./ktor/tenant/README.md)**: One-call/one-tenant adapter for Ktor `ApplicationCall`
 - **[testing](./ktor/testing/README.md)**: Ktor `testApplication` and JSON client test helpers
 
 ### Text Processing → [bluetape4k-text](https://github.com/bluetape4k/bluetape4k-text)

--- a/bluetape4k/tenant-reactor/README.ko.md
+++ b/bluetape4k/tenant-reactor/README.ko.md
@@ -1,0 +1,55 @@
+# bluetape4k-tenant-reactor
+
+[English](./README.md) | [한국어](./README.ko.md)
+
+Reactor subscriber `Context`에 `TenantId`를 immutable하게 전달하는 JDK 25 adapter입니다.
+default tenant, global hook, automatic context propagation을 설치하지 않습니다.
+
+## 의존성과 SNAPSHOT repository
+
+```kotlin
+repositories { maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/"); mavenContent { snapshotsOnly() } } }
+configurations.configureEach { resolutionStrategy.cacheChangingModulesFor(0, "seconds") }
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT"))
+    implementation("io.github.bluetape4k:bluetape4k-tenant-reactor:2.0.0-SNAPSHOT") { isChanging = true }
+}
+```
+
+```xml
+<repositories><repository><id>central-snapshots</id><url>https://central.sonatype.com/repository/maven-snapshots/</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots></repository></repositories>
+<dependencyManagement><dependencies><dependency><groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-bom</artifactId><version>2.0.0-SNAPSHOT</version><type>pom</type><scope>import</scope></dependency></dependencies></dependencyManagement>
+<dependencies><dependency><groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-tenant-reactor</artifactId><version>2.0.0-SNAPSHOT</version></dependency></dependencies>
+```
+
+## 사용법과 수명주기
+
+subscription boundary에서 `withTenant`를 한 번 호출하고 downstream은
+`deferContextual`에서 명시적으로 읽습니다. 입력 `Context`는 변경되지 않고 새 derived
+`Context`가 반환됩니다.
+
+```kotlin
+val result = Mono.deferContextual { context ->
+    service.find(ReactorTenantContext.requireCurrent(context))
+}.contextWrite { context ->
+    ReactorTenantContext.withTenant(context, TenantId("clinic-a"))
+}
+```
+
+signal마다 `Context.put`을 호출하지 않습니다. `Hooks`, automatic propagation, coroutine
+`ReactorContext` bridge는 설치하지 않습니다. cancellation 뒤 값은 subscriber lifecycle과 함께
+사라지며 외부 `Context`로 복사되지 않습니다. missing context는 공통
+`MissingTenantContextException`으로 실패하고 fallback은 없습니다.
+
+raw header/token은 application 인증·권한 확인 뒤 canonical enum/domain 값으로 매핑합니다.
+raw tenant 값은 log, exception, MDC, metric tag에 기록하지 않습니다. synthetic fixture만 값을
+출력할 수 있습니다. optional `tenant_context_binding_failures_total{carrier,stage}`는 enum label과
+기존 correlation/trace ID만 사용하며 5분 내 한 건도 wiring alert입니다. workshop maintainer와
+SNAPSHOT train release coordinator가 확인 owner입니다.
+
+## 비지원 경계
+
+- tenant 인증·인가, header parsing, HTTP status mapping
+- default/fallback tenant 또는 global Reactor hook
+- coroutine suspension/dispatcher hop 자동 전파
+- signal별 binding, mutable/global registry, tenant 값 observability

--- a/bluetape4k/tenant-reactor/README.md
+++ b/bluetape4k/tenant-reactor/README.md
@@ -1,0 +1,54 @@
+# bluetape4k-tenant-reactor
+
+[English](./README.md) | [한국어](./README.ko.md)
+
+JDK 25 adapter for immutable `TenantId` propagation in Reactor subscriber `Context`. It installs no
+default tenant, global hook, or automatic context propagation.
+
+## Dependency and snapshot repository
+
+```kotlin
+repositories { maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/"); mavenContent { snapshotsOnly() } } }
+configurations.configureEach { resolutionStrategy.cacheChangingModulesFor(0, "seconds") }
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT"))
+    implementation("io.github.bluetape4k:bluetape4k-tenant-reactor:2.0.0-SNAPSHOT") { isChanging = true }
+}
+```
+
+```xml
+<repositories><repository><id>central-snapshots</id><url>https://central.sonatype.com/repository/maven-snapshots/</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots></repository></repositories>
+<dependencyManagement><dependencies><dependency><groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-bom</artifactId><version>2.0.0-SNAPSHOT</version><type>pom</type><scope>import</scope></dependency></dependencies></dependencyManagement>
+<dependencies><dependency><groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-tenant-reactor</artifactId><version>2.0.0-SNAPSHOT</version></dependency></dependencies>
+```
+
+## Usage and lifecycle
+
+Bind once at the subscription boundary and read explicitly from `deferContextual`. `withTenant` returns
+a derived immutable `Context` and does not mutate its input.
+
+```kotlin
+val result = Mono.deferContextual { context ->
+    service.find(ReactorTenantContext.requireCurrent(context))
+}.contextWrite { context ->
+    ReactorTenantContext.withTenant(context, TenantId("clinic-a"))
+}
+```
+
+Do not call `Context.put` per signal. This adapter installs no Reactor `Hooks`, automatic propagation,
+or coroutine `ReactorContext` bridge. Cancellation ends the subscriber-local lifecycle without copying
+the tenant into an outer context. Missing context throws the common `MissingTenantContextException`;
+there is no fallback.
+
+Authenticate raw headers/tokens and map them to a canonical application enum/domain value first. Never
+put raw tenant data in logs, exceptions, MDC, or metric tags; only synthetic fixtures may print values.
+An optional `tenant_context_binding_failures_total{carrier,stage}` metric uses enum-only labels and
+existing correlation/trace IDs. Any occurrence in five minutes is a wiring alert owned by the workshop
+maintainer and the SNAPSHOT-train release coordinator.
+
+## Unsupported boundaries
+
+- Tenant authentication/authorization, header parsing, and HTTP status mapping
+- Default/fallback tenants or global Reactor hooks
+- Automatic coroutine suspension/dispatcher-hop propagation
+- Per-signal binding, mutable/global registries, or tenant-value observability

--- a/bluetape4k/tenant-reactor/build.gradle.kts
+++ b/bluetape4k/tenant-reactor/build.gradle.kts
@@ -1,0 +1,11 @@
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    api(project(":bluetape4k-tenant"))
+    api(libs.reactor.core)
+
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(libs.reactor.test)
+}

--- a/bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt
+++ b/bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.tenant.reactor
+
+import io.bluetape4k.tenant.MissingTenantContextException
+import io.bluetape4k.tenant.TenantId
+import reactor.util.context.Context
+import reactor.util.context.ContextView
+
+/** immutable Reactor subscriber [Context]에서 tenant를 binding하고 조회합니다. */
+object ReactorTenantContext {
+
+    private object TenantKey
+
+    /** 현재 subscriber tenant를 반환하며 binding이 없으면 `null`을 반환합니다. */
+    fun currentOrNull(context: ContextView): TenantId? =
+        if (context.hasKey(TenantKey)) context.get(TenantKey) else null
+
+    /** 현재 subscriber tenant를 반환하며 binding이 없으면 공통 missing 예외를 던집니다. */
+    fun requireCurrent(context: ContextView): TenantId =
+        currentOrNull(context) ?: throw MissingTenantContextException()
+
+    /** 입력 [context]를 변경하지 않고 [tenantId]를 가진 derived [Context]를 반환합니다. */
+    fun withTenant(context: Context, tenantId: TenantId): Context =
+        context.put(TenantKey, tenantId)
+}

--- a/bluetape4k/tenant-reactor/src/test/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContextTest.kt
+++ b/bluetape4k/tenant-reactor/src/test/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContextTest.kt
@@ -1,0 +1,133 @@
+package io.bluetape4k.tenant.reactor
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeSameInstanceAs
+import io.bluetape4k.tenant.MissingTenantContextException
+import io.bluetape4k.tenant.TenantId
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import reactor.test.StepVerifier
+import reactor.util.context.Context
+import java.time.Duration
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+class ReactorTenantContextTest {
+
+    @Test
+    fun `private key로 원본 Context를 변경하지 않고 tenant를 binding한다`() {
+        val original = Context.of("tenantId", TenantId("collision"))
+        val tenantId = TenantId("clinic-a")
+
+        val derived = ReactorTenantContext.withTenant(original, tenantId)
+
+        derived shouldNotBeSameInstanceAs original
+        ReactorTenantContext.currentOrNull(original).shouldBeNull()
+        ReactorTenantContext.requireCurrent(derived) shouldBeEqualTo tenantId
+    }
+
+    @Test
+    fun `nested derived Context는 outer Context를 변경하지 않는다`() {
+        val outer = ReactorTenantContext.withTenant(Context.empty(), TenantId("clinic-a"))
+        val inner = ReactorTenantContext.withTenant(outer, TenantId("clinic-b"))
+
+        ReactorTenantContext.requireCurrent(outer) shouldBeEqualTo TenantId("clinic-a")
+        ReactorTenantContext.requireCurrent(inner) shouldBeEqualTo TenantId("clinic-b")
+    }
+
+    @Test
+    fun `missing context는 공통 예외로 즉시 실패한다`() {
+        val failure = assertFailsWith<MissingTenantContextException> {
+            ReactorTenantContext.requireCurrent(Context.empty())
+        }
+
+        failure.message shouldBeEqualTo "Tenant context is not bound"
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    fun `single scheduler의 overlapping subscription은 자기 tenant만 읽는다`() {
+        val scheduler = Schedulers.newSingle("tenant-context-test")
+        val executor = Executors.newFixedThreadPool(2)
+        val start = CyclicBarrier(2)
+        val first = TenantId("clinic-a")
+        val second = TenantId("clinic-b")
+
+        try {
+            val firstResult = executor.submit<List<TenantId>> {
+                start.await(5, TimeUnit.SECONDS)
+                tenantSequence(first, scheduler).collectList().block(Duration.ofSeconds(10))!!
+            }
+            val secondResult = executor.submit<List<TenantId>> {
+                start.await(5, TimeUnit.SECONDS)
+                tenantSequence(second, scheduler).collectList().block(Duration.ofSeconds(10))!!
+            }
+
+            firstResult.get(15, TimeUnit.SECONDS).all { it == first }.shouldBeTrue()
+            secondResult.get(15, TimeUnit.SECONDS).all { it == second }.shouldBeTrue()
+        } finally {
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+            scheduler.dispose()
+        }
+        scheduler.isDisposed.shouldBeTrue()
+    }
+
+    @Test
+    fun `subscription 취소 후 외부 Context는 unbound다`() {
+        val cancelled = AtomicBoolean()
+        val tenantId = TenantId("clinic-a")
+        val publisher = Flux.deferContextual { context ->
+            Flux.concat(
+                Mono.just(ReactorTenantContext.requireCurrent(context)),
+                Flux.never<TenantId>(),
+            )
+        }
+            .doOnCancel { cancelled.set(true) }
+            .contextWrite { ReactorTenantContext.withTenant(it, tenantId) }
+
+        StepVerifier.create(publisher)
+            .expectNext(tenantId)
+            .thenCancel()
+            .verify(Duration.ofSeconds(5))
+
+        cancelled.get().shouldBeTrue()
+        ReactorTenantContext.currentOrNull(Context.empty()).shouldBeNull()
+    }
+
+    @Test
+    fun `tenant binding은 subscription boundary에서 한 번만 수행한다`() {
+        val bindingCount = AtomicInteger()
+        val tenantId = TenantId("clinic-a")
+
+        val observed = Flux.deferContextual { context ->
+            Flux.range(0, 100).map { ReactorTenantContext.requireCurrent(context) }
+        }.contextWrite {
+            bindingCount.incrementAndGet()
+            ReactorTenantContext.withTenant(it, tenantId)
+        }.collectList().block(Duration.ofSeconds(5))!!
+
+        bindingCount.get() shouldBeEqualTo 1
+        observed.all { it == tenantId }.shouldBeTrue()
+        ReactorTenantContext.currentOrNull(Context.empty()).shouldBeNull()
+    }
+
+    private fun tenantSequence(
+        tenantId: TenantId,
+        scheduler: reactor.core.scheduler.Scheduler,
+    ): Flux<TenantId> =
+        Flux.deferContextual { context ->
+            Flux.range(0, 32)
+                .delayElements(Duration.ofMillis(1), scheduler)
+                .map { ReactorTenantContext.requireCurrent(context) }
+        }.contextWrite { ReactorTenantContext.withTenant(it, tenantId) }
+}

--- a/bluetape4k/tenant-reactor/src/test/resources/junit-platform.properties
+++ b/bluetape4k/tenant-reactor/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/bluetape4k/tenant-reactor/src/test/resources/logback-test.xml
+++ b/bluetape4k/tenant-reactor/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.tenant.reactor" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/bluetape4k/tenant/README.ko.md
+++ b/bluetape4k/tenant/README.ko.md
@@ -1,0 +1,118 @@
+# bluetape4k-tenant
+
+[English](./README.md) | [한국어](./README.ko.md)
+
+JDK 25 애플리케이션에서 tenant를 명시적으로 binding하는 공통 API와
+`ThreadLocal`/`ScopedValue` carrier를 제공합니다. default tenant와 fallback은 없습니다.
+
+## 의존성
+
+현재 `2.0.0-SNAPSHOT`은 Central snapshots repository에서 받습니다. SNAPSHOT은 changing
+module로 선언하고 Gradle cache를 비활성화해야 새 빌드를 즉시 확인할 수 있습니다.
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent { snapshotsOnly() }
+    }
+}
+
+configurations.configureEach {
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+}
+
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT"))
+    implementation("io.github.bluetape4k:bluetape4k-tenant:2.0.0-SNAPSHOT") {
+        isChanging = true
+    }
+}
+```
+
+```xml
+<repositories>
+  <repository>
+    <id>central-snapshots</id>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    <releases><enabled>false</enabled></releases>
+    <snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots>
+  </repository>
+</repositories>
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.github.bluetape4k</groupId>
+      <artifactId>bluetape4k-bom</artifactId>
+      <version>2.0.0-SNAPSHOT</version>
+      <type>pom</type><scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+<dependencies>
+  <dependency>
+    <groupId>io.github.bluetape4k</groupId>
+    <artifactId>bluetape4k-tenant</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </dependency>
+</dependencies>
+```
+
+## 사용법
+
+MVC/Servlet 요청처럼 같은 실행 thread에서 동기 호출을 이어갈 때는 application singleton
+`ThreadLocalTenantContext`를 filter와 downstream에 같은 identity로 주입합니다. raw
+`set`/`clear` 대신 lexical `withTenant`만 사용합니다.
+
+```kotlin
+val tenantContext: TenantContext = ThreadLocalTenantContext()
+
+tenantContext.withTenant(TenantId("clinic-a")) {
+    repository.findAppointments(tenantContext.requireCurrent())
+}
+```
+
+virtual thread와 structured concurrency에는 application singleton `ScopedValueTenantContext`를
+사용할 수 있습니다. `StructuredTaskScope.fork`는 lexical binding을 상속하지만 독립적으로
+시작한 virtual thread와 coroutine suspension/dispatcher hop에는 자동 전파를 보장하지 않습니다.
+
+```kotlin
+val tenantContext: TenantContext = ScopedValueTenantContext()
+
+tenantContext.withTenant(TenantId("clinic-a")) {
+    service.handle(tenantContext.requireCurrent())
+}
+```
+
+`currentOrNull()`은 미설정 시 `null`, `requireCurrent()`는
+`MissingTenantContextException("Tenant context is not bound")`을 던집니다. default tenant는
+없습니다. carrier instance나 `ScopedValue` key를 request마다 만들지 마세요.
+
+## Application boundary와 운영 안전
+
+raw header/token은 application에서 검증·권한 확인 후 canonical domain 값으로 매핑합니다.
+
+```kotlin
+enum class ClinicTenant(val tenantId: TenantId) {
+    CLINIC_A(TenantId("clinic-a")),
+}
+
+val tenant = authenticateAndResolveClinic(rawHeader).tenantId
+tenantContext.withTenant(tenant) { handleRequest() }
+```
+
+raw header, token, tenant 값은 log, exception, MDC, metric tag에 기록하지 않습니다. synthetic
+test fixture만 expected/observed 값을 사용할 수 있습니다. library는 logging/metric backend를
+설치하지 않습니다. consumer가 선택적으로
+`tenant_context_binding_failures_total{carrier,stage}`를 기록한다면 `carrier`와 `stage`는
+문서화한 enum만 사용하고 기존 correlation/trace ID로 연결합니다. boundary 이후 missing 또는
+duplicate binding이 5분 구간에 한 건이라도 있으면 wiring alert로 취급하며 workshop maintainer와
+SNAPSHOT train의 release coordinator가 확인합니다.
+
+## 비지원 경계
+
+- tenant 인증·존재 확인·권한 부여와 HTTP status mapping
+- default tenant, 라이브러리의 `static` 프로세스 전역 carrier singleton, public `set`/`clear`
+  (애플리케이션 DI scope singleton은 지원)
+- coroutine suspension/dispatcher hop의 암묵적 전파
+- raw tenant 값을 포함한 logging, MDC, metrics, exception

--- a/bluetape4k/tenant/README.md
+++ b/bluetape4k/tenant/README.md
@@ -1,0 +1,95 @@
+# bluetape4k-tenant
+
+[English](./README.md) | [한국어](./README.ko.md)
+
+Common APIs and `ThreadLocal`/`ScopedValue` carriers for explicit tenant binding in JDK 25
+applications. There is no default tenant or fallback.
+
+## Dependency
+
+Resolve the current `2.0.0-SNAPSHOT` from Central snapshots. Mark the artifact as changing and
+disable the Gradle changing-module cache when validating a new snapshot build.
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent { snapshotsOnly() }
+    }
+}
+configurations.configureEach {
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+}
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT"))
+    implementation("io.github.bluetape4k:bluetape4k-tenant:2.0.0-SNAPSHOT") {
+        isChanging = true
+    }
+}
+```
+
+```xml
+<repositories>
+  <repository>
+    <id>central-snapshots</id>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    <releases><enabled>false</enabled></releases>
+    <snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots>
+  </repository>
+</repositories>
+<dependencyManagement><dependencies><dependency>
+  <groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-bom</artifactId>
+  <version>2.0.0-SNAPSHOT</version><type>pom</type><scope>import</scope>
+</dependency></dependencies></dependencyManagement>
+<dependencies><dependency>
+  <groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-tenant</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+</dependency></dependencies>
+```
+
+## Usage and lifecycle
+
+For an MVC/Servlet request that keeps synchronous work on the same execution thread, inject one
+application-singleton `ThreadLocalTenantContext` into the filter and downstream components. Use only
+the lexical `withTenant` API; no raw `set`/`clear` surface exists.
+
+```kotlin
+val tenantContext: TenantContext = ThreadLocalTenantContext()
+tenantContext.withTenant(TenantId("clinic-a")) {
+    repository.findAppointments(tenantContext.requireCurrent())
+}
+```
+
+Use one application-singleton `ScopedValueTenantContext` for virtual-thread and structured-concurrency
+code. `StructuredTaskScope.fork` inherits the lexical binding. An independently started virtual thread,
+coroutine suspension, or dispatcher hop does not receive an automatic propagation guarantee.
+
+`currentOrNull()` returns `null` when unbound; `requireCurrent()` throws
+`MissingTenantContextException("Tenant context is not bound")`. Do not create a carrier or
+`ScopedValue` key per request.
+
+## Application boundary and operational safety
+
+Authenticate and map raw headers/tokens to a canonical application domain value before creating
+`TenantId`; never treat the raw value as an authorized tenant.
+
+```kotlin
+enum class ClinicTenant(val tenantId: TenantId) { CLINIC_A(TenantId("clinic-a")) }
+val tenant = authenticateAndResolveClinic(rawHeader).tenantId
+tenantContext.withTenant(tenant) { handleRequest() }
+```
+
+Never put raw headers, tokens, or tenant values in logs, exceptions, MDC, or metric tags. Only synthetic
+fixtures may print expected/observed tenant values. The library installs no logging or metric backend.
+An optional consumer metric such as `tenant_context_binding_failures_total{carrier,stage}` must use
+documented enum-only labels and existing correlation/trace IDs. Any missing or duplicate binding after
+the boundary in a five-minute window is a wiring alert owned by the workshop maintainer and, during the
+SNAPSHOT train, the release coordinator.
+
+## Unsupported boundaries
+
+- Tenant authentication, existence/authorization checks, and HTTP status mapping
+- Default tenants, a library/static process-global carrier singleton, or public `set`/`clear`
+  (an application DI-scoped singleton is supported)
+- Implicit propagation across coroutine suspension/dispatcher hops
+- Logging, MDC, metrics, or exceptions containing raw tenant values

--- a/bluetape4k/tenant/build.gradle.kts
+++ b/bluetape4k/tenant/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.gradle.api.tasks.testing.Test
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    testImplementation(project(":bluetape4k-junit5"))
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform {
+        excludeTags("tenant-retention-stress")
+    }
+}
+
+tasks.register<Test>("tenantRetentionStress") {
+    description = "Runs TenantContext platform/virtual-thread retention stress tests."
+    group = "verification"
+    maxHeapSize = "256m"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    useJUnitPlatform {
+        includeTags("tenant-retention-stress")
+    }
+    systemProperty(
+        "tenant.retention.reportDir",
+        layout.buildDirectory.dir("reports/tenant-retention").get().asFile.absolutePath,
+    )
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
+    shouldRunAfter(tasks.test)
+}

--- a/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/MissingTenantContextException.kt
+++ b/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/MissingTenantContextException.kt
@@ -1,0 +1,4 @@
+package io.bluetape4k.tenant
+
+/** 필수 tenant context가 binding되지 않았음을 나타냅니다. */
+class MissingTenantContextException: IllegalStateException("Tenant context is not bound")

--- a/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ScopedValueTenantContext.kt
+++ b/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ScopedValueTenantContext.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.tenant
+
+/**
+ * JDK 25 `ScopedValue` 기반 [TenantContext]입니다.
+ *
+ * `StructuredTaskScope.fork`의 lexical 상속 범위를 지원하며 일반 coroutine dispatcher hop의
+ * 자동 전파는 보장하지 않습니다.
+ */
+class ScopedValueTenantContext: TenantContext {
+
+    private val currentTenant = ScopedValue.newInstance<TenantId>()
+
+    override fun currentOrNull(): TenantId? =
+        if (currentTenant.isBound) currentTenant.get() else null
+
+    override fun requireCurrent(): TenantId =
+        currentOrNull() ?: throw MissingTenantContextException()
+
+    override fun <T> withTenant(tenantId: TenantId, block: () -> T): T {
+        var captured: Result<T>? = null
+        ScopedValue.where(currentTenant, tenantId).run {
+            captured = runCatching { block() }
+        }
+        return checkNotNull(captured) { "ScopedValue.Carrier.run did not execute block" }.getOrThrow()
+    }
+}

--- a/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantContext.kt
+++ b/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantContext.kt
@@ -1,0 +1,13 @@
+package io.bluetape4k.tenant
+
+/** tenant를 lexical scope에 binding하고 조회하는 no-default 계약입니다. */
+interface TenantContext {
+    /** 현재 tenant를 반환하며 binding이 없으면 `null`을 반환합니다. */
+    fun currentOrNull(): TenantId?
+
+    /** 현재 tenant를 반환하며 binding이 없으면 [MissingTenantContextException]을 던집니다. */
+    fun requireCurrent(): TenantId
+
+    /** [block]을 [tenantId]가 binding된 lexical scope에서 실행합니다. */
+    fun <T> withTenant(tenantId: TenantId, block: () -> T): T
+}

--- a/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantId.kt
+++ b/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantId.kt
@@ -1,0 +1,13 @@
+package io.bluetape4k.tenant
+
+/**
+ * application boundary에서 검증·정규화된 tenant 식별자입니다.
+ *
+ * blank 값만 거부하며 입력 문자열을 trim하거나 대소문자 변환하지 않습니다.
+ */
+@JvmInline
+value class TenantId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "TenantId must not be blank" }
+    }
+}

--- a/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContext.kt
+++ b/bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContext.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.tenant
+
+/**
+ * 동기 MVC/Servlet 호출을 위한 `ThreadLocal` 기반 [TenantContext]입니다.
+ *
+ * application singleton으로 생성하고 [withTenant] lexical scope만 사용해야 합니다.
+ */
+class ThreadLocalTenantContext: TenantContext {
+
+    private val currentTenant = ThreadLocal<TenantId>()
+
+    override fun currentOrNull(): TenantId? = currentTenant.get()
+
+    override fun requireCurrent(): TenantId =
+        currentOrNull() ?: throw MissingTenantContextException()
+
+    override fun <T> withTenant(tenantId: TenantId, block: () -> T): T {
+        val previous = currentTenant.get()
+        currentTenant.set(tenantId)
+
+        return try {
+            block()
+        } finally {
+            if (previous == null) {
+                currentTenant.remove()
+            } else {
+                currentTenant.set(previous)
+            }
+        }
+    }
+}

--- a/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ScopedValueTenantContextTest.kt
+++ b/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ScopedValueTenantContextTest.kt
@@ -1,0 +1,95 @@
+package io.bluetape4k.tenant
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.Callable
+import java.util.concurrent.StructuredTaskScope
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class ScopedValueTenantContextTest {
+
+    @Test
+    fun `public 기본 생성자와 unbound 계약을 제공한다`() {
+        val context: TenantContext = ScopedValueTenantContext()
+
+        context.currentOrNull().shouldBeNull()
+        val failure = assertFailsWith<MissingTenantContextException> {
+            context.requireCurrent()
+        }
+        failure.message shouldBeEqualTo "Tenant context is not bound"
+    }
+
+    @Test
+    fun `중첩 binding 성공과 실패 후 lexical tenant를 복원한다`() {
+        val context = ScopedValueTenantContext()
+        val outer = TenantId("clinic-a")
+
+        context.withTenant(outer) {
+            context.requireCurrent() shouldBeEqualTo outer
+            context.withTenant(TenantId("clinic-b")) {
+                context.requireCurrent() shouldBeEqualTo TenantId("clinic-b")
+            }
+            context.requireCurrent() shouldBeEqualTo outer
+
+            assertFailsWith<ExpectedFailure> {
+                context.withTenant(TenantId("clinic-c")) {
+                    throw ExpectedFailure()
+                }
+            }
+            context.requireCurrent() shouldBeEqualTo outer
+        }
+
+        context.currentOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `서로 다른 carrier instance는 key를 공유하지 않는다`() {
+        val first = ScopedValueTenantContext()
+        val second = ScopedValueTenantContext()
+
+        first.withTenant(TenantId("clinic-a")) {
+            first.requireCurrent() shouldBeEqualTo TenantId("clinic-a")
+            second.currentOrNull().shouldBeNull()
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    fun `StructuredTaskScope fork는 lexical tenant를 상속한다`() {
+        val context = ScopedValueTenantContext()
+        val tenantId = TenantId("clinic-a")
+
+        val observed = context.withTenant(tenantId) {
+            StructuredTaskScope.open<TenantId, Void>(StructuredTaskScope.Joiner.awaitAll()).use { scope ->
+                val subtask = scope.fork(Callable { context.requireCurrent() })
+                scope.join()
+                subtask.get()
+            }
+        }
+
+        observed shouldBeEqualTo tenantId
+        context.currentOrNull().shouldBeNull()
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    fun `독립적으로 시작한 virtual thread에는 tenant를 전파하지 않는다`() {
+        val context = ScopedValueTenantContext()
+        val observed = AtomicReference<TenantId?>()
+
+        context.withTenant(TenantId("clinic-a")) {
+            Thread.ofVirtual().start {
+                observed.set(context.currentOrNull())
+            }.join()
+        }
+
+        observed.get().shouldBeNull()
+        context.currentOrNull().shouldBeNull()
+    }
+
+    private class ExpectedFailure: RuntimeException()
+}

--- a/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextApiTest.kt
+++ b/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextApiTest.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.tenant
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import org.junit.jupiter.api.Test
+
+class TenantContextApiTest {
+
+    @Test
+    fun `공개 API signature를 제공한다`() {
+        val context = CompileOnlyTenantContext()
+        val tenantId = TenantId("clinic-a")
+
+        context.currentOrNull() shouldBeEqualTo null
+        context.withTenant(tenantId) { tenantId } shouldBeEqualTo tenantId
+    }
+
+    @Test
+    fun `missing context 예외의 type과 message를 고정한다`() {
+        val failure = assertFailsWith<MissingTenantContextException> {
+            CompileOnlyTenantContext().requireCurrent()
+        }
+
+        failure.message shouldBeEqualTo "Tenant context is not bound"
+    }
+
+    @Test
+    fun `withTenant에 default 인자를 제공하지 않는다`() {
+        TenantContext::class.java.declaredMethods
+            .any { it.name == "withTenant\$default" }
+            .shouldBeFalse()
+    }
+
+    private class CompileOnlyTenantContext: TenantContext {
+        override fun currentOrNull(): TenantId? = null
+
+        override fun requireCurrent(): TenantId = throw MissingTenantContextException()
+
+        override fun <T> withTenant(tenantId: TenantId, block: () -> T): T = block()
+    }
+}

--- a/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextRetentionStressTest.kt
+++ b/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextRetentionStressTest.kt
@@ -1,0 +1,206 @@
+package io.bluetape4k.tenant
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+
+@Tag("tenant-retention-stress")
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class TenantContextRetentionStressTest {
+
+    @Test
+    fun `platform과 virtual thread 반복 실행 후 tenant가 남지 않는다`() {
+        verifyPlatformThreadIsolation()
+        verifyVirtualThreadIsolation()
+    }
+
+    @Test
+    fun `binding 종료 후 tenant sentinel을 보존하지 않는다`() {
+        val probes = listOf(
+            createRetentionProbe(ThreadLocalTenantContext()),
+            createRetentionProbe(ScopedValueTenantContext()),
+        )
+
+        probes.forEachIndexed { index, probe ->
+            val collected = awaitCollection(probe, RETENTION_TIMEOUT)
+            if (!collected) {
+                writeRetentionDiagnostics("probe-$index")
+            }
+            collected.shouldBeTrue()
+        }
+    }
+
+    private fun verifyPlatformThreadIsolation() {
+        val context = ThreadLocalTenantContext()
+        val executor = Executors.newFixedThreadPool(PLATFORM_WORKERS)
+        val start = CountDownLatch(1)
+
+        try {
+            val expected = List(TENANT_COUNT) { TenantId("platform-$it") }
+            val futures = expected.mapIndexed { index, tenantId ->
+                executor.submit(Callable {
+                    check(start.await(5, TimeUnit.SECONDS)) { "Platform thread start gate timed out" }
+                    if (index % EXCEPTION_SAMPLE_INTERVAL == 0) {
+                        verifyExceptionalCleanup(context, tenantId)
+                    }
+                    val observed = context.withTenant(tenantId) {
+                        Thread.yield()
+                        context.requireCurrent()
+                    }
+                    context.currentOrNull().shouldBeNull()
+                    observed
+                })
+            }
+            start.countDown()
+
+            collect(futures, Duration.ofSeconds(20)) shouldBeEqualTo expected
+        } finally {
+            shutdown(executor)
+        }
+        context.currentOrNull().shouldBeNull()
+    }
+
+    private fun verifyVirtualThreadIsolation() {
+        val context = ScopedValueTenantContext()
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val start = CountDownLatch(1)
+
+        try {
+            val expected = List(VIRTUAL_TASKS) { TenantId("virtual-$it") }
+            val futures = expected.mapIndexed { index, tenantId ->
+                executor.submit(Callable {
+                    check(start.await(10, TimeUnit.SECONDS)) { "Virtual thread start gate timed out" }
+                    if (index % EXCEPTION_SAMPLE_INTERVAL == 0) {
+                        verifyExceptionalCleanup(context, tenantId)
+                    }
+                    val observed = context.withTenant(tenantId) {
+                        Thread.yield()
+                        context.requireCurrent()
+                    }
+                    context.currentOrNull().shouldBeNull()
+                    observed
+                })
+            }
+            start.countDown()
+
+            collect(futures, Duration.ofSeconds(30)) shouldBeEqualTo expected
+        } finally {
+            shutdown(executor)
+        }
+        context.currentOrNull().shouldBeNull()
+    }
+
+    private fun createRetentionProbe(context: TenantContext): RetentionProbe {
+        val queue = ReferenceQueue<String>()
+        val sentinel = String("tenant-retention-${System.nanoTime()}".toCharArray())
+        val reference = WeakReference(sentinel, queue)
+
+        context.withTenant(TenantId(sentinel)) {
+            context.requireCurrent().value shouldBeEqualTo sentinel
+        }
+        context.currentOrNull().shouldBeNull()
+
+        return RetentionProbe(reference, queue)
+    }
+
+    private fun awaitCollection(probe: RetentionProbe, timeout: Duration): Boolean {
+        val deadline = System.nanoTime() + timeout.toNanos()
+        val pressure = ArrayDeque<ByteArray>()
+        while (System.nanoTime() < deadline) {
+            if (probe.queue.poll() === probe.reference || probe.reference.get() == null) {
+                return true
+            }
+            System.gc()
+            pressure.addLast(ByteArray(GC_PRESSURE_BYTES))
+            if (pressure.size > RETAINED_PRESSURE_BLOCKS) {
+                pressure.removeFirst()
+            }
+            Thread.sleep(GC_POLL_MILLIS)
+        }
+        return probe.queue.poll() === probe.reference || probe.reference.get() == null
+    }
+
+    private fun verifyExceptionalCleanup(context: TenantContext, tenantId: TenantId) {
+        val failure = runCatching<Unit> {
+            context.withTenant(tenantId) {
+                throw ExpectedTenantFailure()
+            }
+        }
+        check(failure.exceptionOrNull() is ExpectedTenantFailure) {
+            "TenantContext did not propagate the expected failure"
+        }
+        context.currentOrNull().shouldBeNull()
+    }
+
+    private fun <T> collect(futures: List<Future<T>>, timeout: Duration): List<T> {
+        val deadline = System.nanoTime() + timeout.toNanos()
+        return futures.map { future ->
+            val remaining = deadline - System.nanoTime()
+            check(remaining > 0) { "TenantContext stress timed out" }
+            future.get(remaining, TimeUnit.NANOSECONDS)
+        }
+    }
+
+    private fun shutdown(executor: ExecutorService) {
+        executor.shutdownNow()
+        check(executor.awaitTermination(5, TimeUnit.SECONDS)) {
+            "TenantContext stress executor did not terminate"
+        }
+    }
+
+    private fun writeRetentionDiagnostics(probeName: String) {
+        val reportDir = Path.of(
+            System.getProperty("tenant.retention.reportDir", "build/reports/tenant-retention")
+        )
+        Files.createDirectories(reportDir)
+        Files.writeString(
+            reportDir.resolve("retention-failure-$probeName.txt"),
+            "TenantContext retention probe was not collected within ${RETENTION_TIMEOUT.seconds} seconds.\n",
+        )
+
+        val jcmd = Path.of(System.getProperty("java.home"), "bin", "jcmd")
+        if (Files.isExecutable(jcmd)) {
+            val histogram = reportDir.resolve("class-histogram-$probeName.txt").toFile()
+            val process = ProcessBuilder(
+                jcmd.toString(),
+                ProcessHandle.current().pid().toString(),
+                "GC.class_histogram",
+            ).redirectErrorStream(true).redirectOutput(histogram).start()
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+            }
+        }
+    }
+
+    private data class RetentionProbe(
+        val reference: WeakReference<String>,
+        val queue: ReferenceQueue<String>,
+    )
+
+    private class ExpectedTenantFailure: RuntimeException()
+
+    companion object {
+        private const val PLATFORM_WORKERS = 8
+        private const val TENANT_COUNT = 100
+        private const val VIRTUAL_TASKS = 10_000
+        private const val EXCEPTION_SAMPLE_INTERVAL = 10
+        private const val GC_PRESSURE_BYTES = 4 * 1024 * 1024
+        private const val RETAINED_PRESSURE_BLOCKS = 16
+        private const val GC_POLL_MILLIS = 50L
+        private val RETENTION_TIMEOUT: Duration = Duration.ofSeconds(30)
+    }
+}

--- a/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantIdTest.kt
+++ b/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantIdTest.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.tenant
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class TenantIdTest {
+
+    @Test
+    fun `빈 tenant id는 거부한다`() {
+        val failure = assertFailsWith<IllegalArgumentException> {
+            TenantId("")
+        }
+
+        failure.message shouldBeEqualTo "TenantId must not be blank"
+    }
+
+    @Test
+    fun `공백뿐인 tenant id는 거부한다`() {
+        val failure = assertFailsWith<IllegalArgumentException> {
+            TenantId("   ")
+        }
+
+        failure.message shouldBeEqualTo "TenantId must not be blank"
+    }
+
+    @Test
+    fun `tenant id 원문을 정규화하지 않는다`() {
+        TenantId(" clinic-a ").value shouldBeEqualTo " clinic-a "
+    }
+}

--- a/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContextTest.kt
+++ b/bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContextTest.kt
@@ -1,0 +1,115 @@
+package io.bluetape4k.tenant
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class ThreadLocalTenantContextTest {
+
+    @Test
+    fun `public 기본 생성자와 unbound 계약을 제공한다`() {
+        val context: TenantContext = ThreadLocalTenantContext()
+
+        context.currentOrNull().shouldBeNull()
+        val failure = assertFailsWith<MissingTenantContextException> {
+            context.requireCurrent()
+        }
+        failure.message shouldBeEqualTo "Tenant context is not bound"
+    }
+
+    @Test
+    fun `중첩 binding 성공 후 outer tenant를 복원한다`() {
+        val context = ThreadLocalTenantContext()
+        val outer = TenantId("clinic-a")
+        val inner = TenantId("clinic-b")
+
+        context.withTenant(outer) {
+            context.requireCurrent() shouldBeEqualTo outer
+            context.withTenant(inner) {
+                context.requireCurrent() shouldBeEqualTo inner
+            }
+            context.requireCurrent() shouldBeEqualTo outer
+        }
+
+        context.currentOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `중첩 binding 실패 후에도 outer tenant를 복원한다`() {
+        val context = ThreadLocalTenantContext()
+        val outer = TenantId("clinic-a")
+
+        context.withTenant(outer) {
+            assertFailsWith<ExpectedFailure> {
+                context.withTenant(TenantId("clinic-b")) {
+                    throw ExpectedFailure()
+                }
+            }
+            context.requireCurrent() shouldBeEqualTo outer
+        }
+
+        context.currentOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `top-level binding 실패 후 tenant를 제거한다`() {
+        val context = ThreadLocalTenantContext()
+
+        assertFailsWith<ExpectedFailure> {
+            context.withTenant(TenantId("clinic-a")) {
+                throw ExpectedFailure()
+            }
+        }
+
+        context.currentOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `서로 다른 carrier instance는 값을 공유하지 않는다`() {
+        val first = ThreadLocalTenantContext()
+        val second = ThreadLocalTenantContext()
+
+        first.withTenant(TenantId("clinic-a")) {
+            first.requireCurrent() shouldBeEqualTo TenantId("clinic-a")
+            second.currentOrNull().shouldBeNull()
+        }
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.SECONDS)
+    fun `고정 thread pool 재사용 중 tenant가 누수되지 않는다`() {
+        val context = ThreadLocalTenantContext()
+        val barrier = CyclicBarrier(WORKERS)
+        val tenantSequence = AtomicInteger()
+
+        MultithreadingTester()
+            .workers(WORKERS)
+            .rounds(ROUNDS)
+            .add {
+                context.currentOrNull().shouldBeNull()
+                val tenantId = TenantId("clinic-${tenantSequence.getAndIncrement() % TENANTS}")
+
+                context.withTenant(tenantId) {
+                    barrier.await(5, TimeUnit.SECONDS)
+                    context.requireCurrent() shouldBeEqualTo tenantId
+                }
+
+                context.currentOrNull().shouldBeNull()
+            }
+            .run()
+    }
+
+    private class ExpectedFailure: RuntimeException()
+
+    companion object {
+        private const val WORKERS = 8
+        private const val ROUNDS = 13
+        private const val TENANTS = 100
+    }
+}

--- a/bluetape4k/tenant/src/test/resources/junit-platform.properties
+++ b/bluetape4k/tenant/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/bluetape4k/tenant/src/test/resources/logback-test.xml
+++ b/bluetape4k/tenant/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.tenant" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/docs/lessons/2026-08-28-issue-1562-tenant-context.md
+++ b/docs/lessons/2026-08-28-issue-1562-tenant-context.md
@@ -1,0 +1,53 @@
+# Issue #1562 TenantContext 구현 lesson
+
+## Maven group은 기억이 아니라 publication source로 확정한다
+
+- 실패한 가정/판단: 초기 설계의 dependency group을 `io.bluetape4k`로 적었다.
+- 발견 증거 또는 교정: `gradle.properties`의 `projectGroup`과 생성 POM은
+  `io.github.bluetape4k`를 사용했다.
+- 수정 결정: spec, plan과 모든 README coordinate를 `io.github.bluetape4k`로 교정하고
+  generated POM/module metadata/BOM 검증을 실행했다.
+- 향후 예방 확인: consumer coordinate를 작성할 때 `projectGroup`, 생성 POM, 공개 metadata의
+  세 source를 대조하고 문자열 fixture가 wrong group을 fail-closed로 거부하게 한다.
+
+## 넓은 review lane의 deadline 초과는 finding closure가 아니다
+
+- 실패한 가정/판단: 전체 파일을 한 번에 맡긴 세 review lane이 5분 안에 끝날 것으로 보았다.
+- 발견 증거 또는 교정: lane이 command deadline 안에 결과를 반환하지 못했고 actionable evidence가
+  없었다.
+- 수정 결정: 초과 lane 결과는 판정에서 제외하고 production, docs/architecture, retention,
+  SNAPSHOT, publication, operations/security의 좁은 read-only 관점으로 다시 배정했다.
+- 향후 예방 확인: review는 파일과 질문을 한 관점으로 제한하고 90초 동안 fresh evidence가 없으면
+  범위를 줄여 회수한다. 완료 메시지가 없는 lane을 P0/P1 closure 증거로 사용하지 않는다.
+
+## matrix prefix 하나는 full validation 증거가 아니다
+
+- 실패한 가정/판단: Infra, Data, Spring Boot, Testcontainers matrix마다 prefix job 하나만 있으면
+  full Nightly를 증명할 수 있다고 보았다.
+- 발견 증거 또는 교정: 한 shard가 누락되어도 같은 prefix의 다른 shard가 있으면 publish validation이
+  통과할 수 있었다.
+- 수정 결정: exact full job set을 모두 요구하고 Nightly source의 matrix group과 required set의 drift를
+  policy test로 연결했다.
+- 향후 예방 확인: matrix 추가·이름 변경은 Nightly source와 SNAPSHOT validation set의 equality
+  검증을 함께 통과해야 한다.
+
+## 재시도는 transport 일시 오류에만 허용한다
+
+- 실패한 가정/판단: public read-back 실패를 모두 같은 propagation delay로 보고 20회 재시도했다.
+- 발견 증거 또는 교정: TLS 인증, 잘못된 metadata identity와 checksum mutation도 재시도되어 원인이
+  최대 5분 늦게 드러날 수 있었다.
+- 수정 결정: 제한된 HTTP/network 오류만 exit `75`로 분류하고 TLS 및 semantic 오류는 exit `1`로
+  즉시 실패한다. metadata identity도 strict format과 timestamped version equality를 검증한다.
+- 향후 예방 확인: retry loop는 명시적 transient exit code만 소비하고 permanent fixture가 한 번에
+  실패하는지 policy/fixture test로 고정한다.
+
+## GC retention 검증은 결정적 cleanup과 보조 신호를 분리한다
+
+- 실패한 가정/판단: `System.gc()`와 사용하지 않는 1 MiB 배열을 10초 반복하면 retention을 충분히
+  증명한다고 보았다.
+- 발견 증거 또는 교정: GC는 강제 계약이 아니며 최적화된 할당은 pressure가 되지 않을 수 있었다.
+- 수정 결정: lexical 종료 직후 `currentOrNull()==null`과 예외 cleanup을 결정적 계약으로 유지하고,
+  별도 nightly task는 256 MiB heap, retained 64 MiB pressure, 30초 bounded WeakReference probe와
+  실패 진단 artifact를 사용한다.
+- 향후 예방 확인: GC probe는 결정적 API test를 대체하지 않으며 bounded stress/diagnostic gate로만
+  사용한다. timeout을 늘리는 것만으로 성공을 만들지 않는다.

--- a/docs/lessons/2026-08-28-issue-1562-tenant-context.md
+++ b/docs/lessons/2026-08-28-issue-1562-tenant-context.md
@@ -51,3 +51,15 @@
   실패 진단 artifact를 사용한다.
 - 향후 예방 확인: GC probe는 결정적 API test를 대체하지 않으며 bounded stress/diagnostic gate로만
   사용한다. timeout을 늘리는 것만으로 성공을 만들지 않는다.
+
+## dependency 문자열 검색은 실제 runtime selection 증거가 아니다
+
+- 실패한 가정/판단: core `runtimeClasspath` 출력에 `reactor` 문자열이 있으면 Reactor runtime
+  dependency가 유입됐다고 판단했다.
+- 발견 증거 또는 교정: 출력의 대상은 실제 `reactor-core`가 아니라 공통 version platform의
+  `reactor-bom` constraint였다. 또한 zsh에서 `$project:check...`는 `:c` parameter modifier로
+  해석되어 잘못된 Gradle task 이름을 만들었다.
+- 수정 결정: `dependencyInsight`로 `reactor-core`, Ktor server, Servlet, Spring artifact의 실제
+  selection 부재를 각각 확인하고, 동적 task 이름은 `${project}`처럼 변수 경계를 명시했다.
+- 향후 예방 확인: dependency leakage는 artifact-level `dependencyInsight`로 판정하고 BOM 이름의
+  문자열 hit를 defect로 승격하지 않는다. zsh 변수 바로 뒤에 `:`가 오면 항상 braces를 사용한다.

--- a/docs/reviews/2026-08-28-issue-1562-tenant-context.md
+++ b/docs/reviews/2026-08-28-issue-1562-tenant-context.md
@@ -1,0 +1,75 @@
+# Issue #1562 TenantContext 구현 6관점 리뷰
+
+## 판정
+
+| 항목 | 결과 |
+| --- | --- |
+| P0 | 0 |
+| source/local P1 | 0 |
+| 외부 운영 P1 | 1 — #1565에서 차단 중 |
+| fixed P2 | 10 |
+| rationale-deferred P2 | 2 |
+| publication 상태 | `PENDING` |
+
+TenantContext source와 local workflow 계약에는 unresolved P0/P1이 없다. 다만 live
+`maven-central-release` environment가 `protection_rules=[]`,
+`deployment_branch_policy=null`, `can_admins_bypass=true`이고 publication/signing secret도
+environment scope로 격리되지 않았다. 이 외부 P1은 #1565에 기록했으며 read-back으로 닫기 전에는
+SNAPSHOT dispatch를 하지 않는다.
+
+## 관점별 결과
+
+| 관점 | 1차 finding | disposition | 근거 |
+| --- | --- | --- | --- |
+| Developer/API | P0=0, P1=0, P2=0 | 변경 없음 | `TenantContext`는 no-default lexical API만 노출하고 carrier raw state를 공개하지 않는다. |
+| Architecture/docs | P2=1 | fixed | application DI singleton과 라이브러리 `static` 프로세스 전역 singleton을 구분했다(`bluetape4k/tenant/README.ko.md:63-76,115-116`). |
+| Stability/retention | P1=3, P2=3 | P1/P2 5건 fixed, P2 1건 deferred | 동시 start gate, 예외 cleanup, 고유 virtual tenant 10,000개, exact sentinel 비교, 256 MiB heap의 retained GC pressure를 적용했다(`TenantContextRetentionStressTest.kt:22-145,198-204`). |
+| SNAPSHOT integrity | P1=2, P2=3 | code finding fixed, environment P1 external | dispatch ref/SHA와 전체 Nightly job을 검증하고 transient exit `75`만 재시도하며 receipt identity를 모두 대조한다(`publish-snapshot.yml:54-151,251-295`). |
+| Dependency/publication | P1=1, P2=1 | P2 fixed, P1 external | Nightly matrix group과 required job set의 drift test를 추가했다(`scripts/test_release_workflow_policy.py`). 세 artifact의 dependency/POM/module metadata/BOM constraint는 검증됐다. |
+| Operations/security | P1=1, P2=5 | P2 4건 fixed, 1건 deferred; P1 external | issue write를 별도 `record-handoff` job으로 격리하고 #1562 identity, Maven snapshot identity, TLS 영구 실패를 fail-fast로 고정했다(`publish-snapshot.yml:336-393`, `create_snapshot_handoff.py:44-132`). |
+
+## Finding disposition
+
+### Fixed
+
+- full Nightly의 matrix prefix 하나만 확인하던 검증을 모든 exact job name 검증으로 교체했다.
+- Nightly matrix group과 SNAPSHOT required set의 drift를 policy test가 검출한다.
+- dispatch ref가 `refs/heads/develop`이고 dispatch SHA, verified Nightly SHA, 현재 develop SHA가
+  모두 같아야 publish job을 시작한다.
+- `404/408/429/500/502/503/504`, timeout과 제한된 연결 오류만 transient exit `75`로 분류한다.
+  TLS 인증 오류와 semantic receipt 오류는 즉시 영구 실패한다.
+- Maven timestamp, build number, `lastUpdated`, timestamped snapshot version을 strict format과
+  동일 identity로 검증한다.
+- receipt와 issue 기록 job이 `handoff_issue_number=1562`를 다시 검증한다.
+- `issues: write`는 publication secret을 사용하는 job과 분리된 `record-handoff` job에만 둔다.
+- retention stress는 platform/virtual task의 동시 시작, 예외 경로 cleanup, 고유 tenant identity,
+  exact sentinel equality와 bounded retained memory pressure를 검증한다.
+- README는 application-scoped singleton과 process-global singleton의 경계를 구분한다.
+
+### Rationale-deferred
+
+- ThreadLocal/platform과 ScopedValue/virtual의 교차 조합 stress는 지원 carrier 선택 계약이 아니므로
+  추가하지 않았다. 각 지원 조합의 isolation과 예외 cleanup은 검증하며 README가 비지원 전파 경계를
+  명시한다.
+- privileged workflow action의 immutable commit SHA pin은 저장소 전체가 version tag 관례이고 live
+  `sha_pinning_required=false`이므로 이 PR에서 일부 action만 바꾸지 않는다. #1565에서 environment
+  보호 및 secret scope와 함께 저장소 publication 정책으로 결정한다. 이 항목이 닫히기 전 publication은
+  외부 P1에 의해 이미 차단된다.
+
+## 검증 증거
+
+- targeted JUnit: core 17, Reactor 6, Ktor 6; 합계 29, failures/errors/skipped=0
+- retention JUnit: 2, failures/errors/skipped=0
+- 세 module `check`, Kover XML, root Detekt, `checkDisabledTests`: 성공
+- workflow/receipt policy: 30 tests, 모두 성공; `actionlint` 성공
+- CI domain policy: 15 tests, 모두 성공
+- module registration, manual inventory, buildSrc tests: 성공
+- publication POM/module metadata: 79 files, failures=0; BOM constraint 세 artifact 각각 1회
+- production logging/MDC/metric/Reactor global hook scan: 0 findings
+- `checkPomFileForBluetape4kPublication`은 신규 tenant와 기존 core 모두 developer
+  `organization`/`organizationUrl` 누락으로 동일 실패하며 #1565의 공통 blocker다.
+
+## 최종 상태
+
+구현과 local 검증은 `DONE`, SNAPSHOT publication은 외부 P1과 #1565 때문에 `PENDING`이다.
+PR exact-head CI와 merge는 이후 별도 gate이며 merge에는 fresh 사용자 승인이 필요하다.

--- a/docs/reviews/2026-08-28-issue-1562-tenant-context.md
+++ b/docs/reviews/2026-08-28-issue-1562-tenant-context.md
@@ -61,8 +61,8 @@ SNAPSHOT dispatch를 하지 않는다.
 - targeted JUnit: core 17, Reactor 6, Ktor 6; 합계 29, failures/errors/skipped=0
 - retention JUnit: 2, failures/errors/skipped=0
 - 세 module `check`, Kover XML, root Detekt, `checkDisabledTests`: 성공
-- workflow/receipt policy: 30 tests, 모두 성공; `actionlint` 성공
-- CI domain policy: 15 tests, 모두 성공
+- workflow/receipt policy: 35 tests, 모두 성공; `actionlint` 성공
+- CI domain policy: 17 tests, 모두 성공
 - module registration, manual inventory, buildSrc tests: 성공
 - publication POM/module metadata: 79 files, failures=0; BOM constraint 세 artifact 각각 1회
 - production logging/MDC/metric/Reactor global hook scan: 0 findings

--- a/docs/superpowers/plans/2026-08-28-issue-1562-tenant-context-plan.md
+++ b/docs/superpowers/plans/2026-08-28-issue-1562-tenant-context-plan.md
@@ -353,14 +353,14 @@ git diff --check
 - [ ] checkout이 validation output SHA만 사용하고 branch 이름/current checkout에 fallback하지
       않는 RED를 추가한다.
 - [ ] receipt schema `bluetape.snapshot-handoff/v1`의 `repository`, `merge_sha`,
-      `verified_ci_run_id`, `publication_run_id`, `group`, `artifact`, `base_version`, `timestamp`,
+      `verified_ci_run_id`, `publication_run_id`, `handoff_issue_number`, `group`, `artifact`, `base_version`, `timestamp`,
       `build_number`, `last_updated`, `resources`, `catalog_commit_sha=null`, `created_at`, `status`,
       `supersedes`를 test로 고정한다. 최초 receipt는 `verified`, 실패 receipt는 기존 파일을
       수정하지 않고 digest로 연결한 append-only `rejected`다.
 - [ ] immutable artifact name, 90일 retention, `actions/upload-artifact@v7`, artifact ID/digest와
-      Korean linked-issue comment를 policy test로 고정한다. 최소 workflow permission은
-      `contents: read`, `actions: read`, issue 기록을 위한 `issues: write`뿐이고 signing/Central
-      secret은 publish step에만 scope한다.
+      Korean linked-issue comment를 policy test로 고정한다. validation은 `contents: read`와
+      `actions: read`, publish는 `contents: read`, 별도 issue 기록 job만 `issues: write`를 가지며
+      signing/Central secret은 publish step에만 scope한다.
 - [ ] `create_snapshot_handoff.py`는 Maven metadata를 두 번 읽고 timestamp/build number/
       `lastUpdated`가 호출 전후 같을 때만 BOM과 세 artifact POM/JAR SHA-256을 계산한다.
 - [ ] fixture HTTP server로 success, missing metadata/resource, checksum mismatch, 호출 중 metadata
@@ -426,7 +426,7 @@ repo-test-summary -- ./gradlew :bluetape4k-tenant:tenantRetentionStress \
   :bluetape4k-ktor-tenant:koverXmlReport \
   --no-daemon --no-configuration-cache --no-build-cache
 
-./gradlew detekt disabledTestReport \
+./gradlew detekt checkDisabledTests \
   --no-daemon --no-configuration-cache --no-build-cache
 
 ./gradlew projects --no-daemon --no-configuration-cache --no-build-cache

--- a/docs/superpowers/plans/2026-08-28-issue-1562-tenant-context-plan.md
+++ b/docs/superpowers/plans/2026-08-28-issue-1562-tenant-context-plan.md
@@ -1,0 +1,514 @@
+# Issue #1562 TenantContext production API 구현 계획
+
+> **실행 agent 필수 skill:** `$test-driven-development`, `$bluetape-kotlin-patterns`,
+> `$bluetape-full-feature`, `$verification-before-completion`을 task 시작 전에 다시 읽는다.
+> 각 production 변경은 해당 task의 RED를 먼저 확인한 뒤 GREEN으로 진행한다.
+
+**목표:** JDK 25 전용 공통 `TenantId`와 no-default `TenantContext`를 제공하고,
+ThreadLocal·ScopedValue·Reactor·Ktor carrier를 framework 의존성 경계에 맞춘 세 artifact로
+발행 가능한 상태까지 구현한다.
+
+**구조:** `bluetape4k-tenant`가 값·예외·JDK carrier를 소유한다.
+`bluetape4k-tenant-reactor`와 `bluetape4k-ktor-tenant`는 core를 `api`로 참조하고 각각
+Reactor `Context`와 Ktor `ApplicationCall`만 adapter 공개 signature에 노출한다. header,
+인증·인가, tenant 존재 확인, routing은 application consumer 소유로 남긴다.
+
+**기술 기준:** Kotlin 2.4, Java/JVM 25, Gradle 9.7.0, Reactor Core, Ktor Server 3.x,
+JUnit 5, bluetape4k assertions/JUnit5, Kover, Detekt, Maven Central SNAPSHOT
+
+**설계:** `docs/superpowers/specs/2026-08-28-issue-1562-tenant-context-design.md`
+
+**Stack:** `develop` (`18472064c594ab2dee835cff6695cd6ef9538ea5`) →
+`feat/issue-1562-tenant-context`; 현재 spec commit
+`9108d0e61e9edc5fce1c61ffb04b708a4d01f222`
+
+---
+
+## 실행 경계
+
+- 세 artifact는 모두 JDK 25 전용이다. `virtualthread/api`, `virtualthread/jdk21`,
+  Java 21 compatibility allowlist는 수정하지 않는다.
+- Maven group은 실제 repository 계약인 `io.github.bluetape4k`다. Kotlin package
+  `io.bluetape4k.*`와 혼동하지 않는다.
+- `bluetape4k-tenant`에는 Reactor, Ktor, Servlet, Spring, coroutine 의존성을 추가하지 않는다.
+- Reactor adapter에는 `kotlinx-coroutines-reactor`, global `Hooks`, automatic context
+  propagation을 추가하지 않는다.
+- Ktor adapter에는 plugin, header parser, status mapping, auth 또는 routing helper를 추가하지
+  않는다.
+- public mutable `set`/`clear`, default tenant, default parameter, global carrier singleton을
+  제공하지 않는다.
+- 새 외부 dependency를 도입하지 않는다. 현재 catalog의 Reactor/Ktor/JUnit dependency만
+  사용한다.
+- `bluetape4k-dependencies`와 두 workshop source는 이 계획에서 수정하지 않는다. 이 PR의
+  산출물은 checksum을 가진 Projects SNAPSHOT handoff receipt까지다.
+- push/PR은 구현·검증·독립 review·lesson 완료 뒤 수행한다. merge는 exact-head 상태를
+  새로 읽고 별도 fresh 승인을 받기 전까지 실행하지 않는다.
+- SNAPSHOT dispatch도 merge 뒤 workflow·target·credential·hold를 새로 확인한 후에만
+  실행한다. stable release는 비범위다.
+
+## 파일 구조와 책임
+
+### Production과 test
+
+| 파일 | 책임 |
+| --- | --- |
+| `bluetape4k/tenant/build.gradle.kts` | framework-free core, JUnit dependency, retention 전용 Test task |
+| `bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantId.kt` | blank 거부 value class |
+| `bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantContext.kt` | no-default 조회와 lexical binding 계약 |
+| `bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/MissingTenantContextException.kt` | 공통 missing 예외와 exact message |
+| `bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContext.kt` | nested restore와 top-level remove |
+| `bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ScopedValueTenantContext.kt` | instance-private JDK 25 ScopedValue key |
+| `bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantIdTest.kt` | blank·non-normalization 계약 |
+| `bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextApiTest.kt` | public signature·missing 예외·default 인자 부재 계약 |
+| `bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContextTest.kt` | missing·nested·exception·same-thread cleanup·identity |
+| `bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ScopedValueTenantContextTest.kt` | dynamic scope·nested·exception·instance isolation |
+| `bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextRetentionStressTest.kt` | platform/virtual-thread overlap와 bounded retention |
+| `bluetape4k/tenant-reactor/build.gradle.kts` | tenant core + Reactor public dependency, JUnit/Reactor Test test dependency |
+| `bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt` | private key와 immutable Context 파생 |
+| `bluetape4k/tenant-reactor/src/test/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContextTest.kt` | missing·interleave·nested·cancel·identity |
+| `ktor/tenant/build.gradle.kts` | tenant core + Ktor server core public dependency, JUnit/Ktor Test Host test dependency |
+| `ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/TenantAlreadyBoundException.kt` | duplicate bind wiring 예외 |
+| `ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt` | private holder/key와 atomic first bind |
+| `ktor/tenant/src/test/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContextTest.kt` | missing·collision·duplicate/concurrent·dispatcher·new/cancelled-call retention |
+| 세 module의 `src/test/resources/junit-platform.properties`, `logback-test.xml` | repository test 실행·logging convention |
+
+### 문서·CI·publication
+
+| 파일 | 책임 |
+| --- | --- |
+| `bluetape4k/tenant/README.md`, `README.ko.md` | core/JDK carrier dependency와 lifecycle |
+| `bluetape4k/tenant-reactor/README.md`, `README.ko.md` | Reactor subscription boundary와 unsupported bridge |
+| `ktor/tenant/README.md`, `README.ko.md` | one-call/one-tenant와 application-owned plugin/auth |
+| `README.md`, `README.ko.md` | Core/Ktor module inventory에 세 artifact 등록 |
+| `.github/workflows/ci.yml` | tenant/tenant-reactor를 Core, ktor/tenant를 Ktor test·Kover에 포함 |
+| `.github/workflows/nightly-tests.yml` | Nightly Core/Ktor test·Kover inventory 동기화 |
+| `scripts/test_release_workflow_policy.py` | manual dispatch exact-head 입력과 receipt upload RED/GREEN |
+| `.github/workflows/publish-snapshot.yml` | validated Nightly SHA checkout, post-publish receipt 생성·업로드 |
+| `scripts/publication/create_snapshot_handoff.py` | Maven metadata/resource checksum을 fail-closed receipt로 생성 |
+| `scripts/test_create_snapshot_handoff.py` | schema, checksum, stale/mutating metadata, receipt lifecycle, last-good manifest test |
+| `docs/release-evidence/issue-1562/last-good-manifest.json` | base SHA와 rollback 가능한 직전 상태를 고정하는 train 중단 증거 |
+| `docs/reviews/2026-08-28-issue-1562-tenant-context.md` | 구현 6관점 review와 finding disposition |
+| `docs/lessons/2026-08-28-issue-1562-tenant-context.md` | 실패한 가정·교정·예방 rule과 검증 증거 |
+
+`settings.gradle.kts`와 `bluetape4k/bom/build.gradle.kts`는 기존 자동 등록·동적 constraint를
+사용하므로 원칙적으로 수정하지 않는다. `./gradlew projects` 또는 generated BOM 검증이
+실패할 때만 원인을 확인하고 최소 변경을 별도 review한다.
+
+## dependency order와 commit 경계
+
+```text
+Task 1 baseline/module routing
+  -> Task 2 core value/API
+  -> Task 3 ThreadLocal carrier
+  -> Task 4 ScopedValue + stress
+  -> Task 5 Reactor adapter
+  -> Task 6 Ktor adapter
+  -> Task 7 bilingual docs
+  -> Task 8 CI + exact-head SNAPSHOT receipt
+  -> Task 9 integration verification/review/lesson/PR
+```
+
+Task 2~6은 각 RED/GREEN 뒤 작은 Korean Lore commit으로 분리할 수 있다. Task 8은 workflow와
+정책 test를 한 commit으로 유지한다. cross-repo consumer는 public SNAPSHOT receipt가 생긴
+뒤에만 시작한다.
+
+---
+
+## Task 1: 기준선과 module routing을 고정한다
+
+**Complexity:** 중간
+
+**Files:** 세 `build.gradle.kts`, `.github/workflows/ci.yml`,
+`.github/workflows/nightly-tests.yml`
+
+- [ ] `git status --short`, `git rev-parse HEAD`, `./gradlew :bluetape4k-core:test` 결과를
+      baseline evidence에 기록한다.
+- [ ] 빈 module directory와 최소 build file을 만든다. core는
+      `testImplementation(project(":bluetape4k-junit5"))`를 가진다. Reactor는
+      `api(project(":bluetape4k-tenant"))`, `api(libs.reactor.core)`,
+      `testImplementation(project(":bluetape4k-junit5"))`,
+      `testImplementation(libs.reactor.test)`를 가진다. Ktor는
+      `api(project(":bluetape4k-tenant"))`, `api(libs.ktor.server.core)`,
+      `testImplementation(project(":bluetape4k-junit5"))`,
+      `testImplementation(libs.ktor.server.test.host)`를 가진다.
+- [ ] CI path filter에 `bluetape4k/tenant/**`, `bluetape4k/tenant-reactor/**`를 Core로
+      포함하고 `ktor/tenant/**`가 기존 Ktor glob에 포함되는지 test/readback한다.
+- [ ] Core/Ktor test와 Kover command에 세 project task를 추가하고 Nightly inventory도
+      같은 project set으로 맞춘다. Core CI와 Nightly는 `tenantRetentionStress`를 required
+      step으로 실행하고 해당 JUnit XML·실패 log·class histogram을 artifact에 포함한다.
+      `Test / Core`가 실패하면 SNAPSHOT eligibility도 실패하는 연결을 policy test로 고정한다.
+
+Run:
+
+```bash
+./gradlew projects --no-daemon --no-configuration-cache --no-build-cache
+./gradlew :bluetape4k-tenant:dependencies \
+  :bluetape4k-tenant-reactor:dependencies \
+  :bluetape4k-ktor-tenant:dependencies \
+  --configuration runtimeClasspath --no-daemon --no-configuration-cache
+./gradlew :bluetape4k-tenant-reactor:dependencies \
+  :bluetape4k-ktor-tenant:dependencies \
+  --configuration testRuntimeClasspath --no-daemon --no-configuration-cache
+python3 .github/scripts/test-ci-domain-parallelization.py -v
+```
+
+Expected: 세 project가 정확한 이름으로 나타나고 core runtime graph에는 Reactor/Ktor/Spring이
+없다. CI domain graph와 YAML parse가 통과한다.
+
+## Task 2: `TenantId`와 no-default API를 TDD로 고정한다
+
+**Complexity:** 중간
+
+**Depends on:** Task 1
+
+- [ ] `TenantIdTest`에 `""`, whitespace-only가 정확한 `IllegalArgumentException`과
+      `TenantId must not be blank`를 내는 RED를 작성한다.
+- [ ] `TenantId(" clinic-a ")`가 원문을 보존해 application normalization을 대신하지
+      않는 RED를 작성한다.
+- [ ] `TenantContextApiTest` compile/behavior test에서 `TenantContext`의 `currentOrNull`,
+      `requireCurrent`, `withTenant(tenantId) {}` signature, `MissingTenantContextException`의 exact
+      type/message와 default 인자 부재를 고정한다. concrete carrier constructor는 해당 carrier의
+      RED를 먼저 쓰는 Tasks 3~4에서 추가한다.
+- [ ] 최소 production type을 구현하고 targeted test를 GREEN으로 만든다.
+
+Run:
+
+```bash
+./gradlew :bluetape4k-tenant:test \
+  --tests 'io.bluetape4k.tenant.TenantIdTest' \
+  --tests 'io.bluetape4k.tenant.TenantContextApiTest' \
+  --rerun-tasks --no-daemon --no-configuration-cache --no-build-cache
+```
+
+## Task 3: ThreadLocal lifecycle을 TDD로 구현한다
+
+**Complexity:** 높음
+
+**Depends on:** Task 2
+
+- [ ] unbound `currentOrNull == null`, `requireCurrent`의 exact 공통 예외 RED를 작성한다.
+- [ ] outer/inner success, inner exception, top-level exception 뒤 outer 복원 또는 remove를
+      검증한다.
+- [ ] 고정 8-thread executor에서 100 tenant의 순차·overlap 실행을 barrier로 섞고 각 block
+      안의 값과 종료 뒤 unbound를 검증한다.
+- [ ] 서로 다른 `ThreadLocalTenantContext` instance가 값을 공유하지 않는 identity RED를
+      작성한다.
+- [ ] public zero-argument `ThreadLocalTenantContext()` construction을 compile test로 고정한다.
+- [ ] private `ThreadLocal<TenantId>`와 `try/finally` restore/remove만으로 GREEN을 만든다.
+      public `set`/`clear`는 만들지 않는다.
+- [ ] barrier test에 hard timeout을 걸고 executor shutdown/awaitTermination과 barrier abort를
+      `finally`에서 수행한다. carrier/key construction count와 source inspection으로 application
+      singleton당 한 instance이며 request마다 새 carrier/key를 만들지 않음을 고정한다.
+
+Run:
+
+```bash
+./gradlew :bluetape4k-tenant:test \
+  --tests 'io.bluetape4k.tenant.ThreadLocalTenantContextTest' \
+  --rerun-tasks --no-daemon --no-configuration-cache --no-build-cache
+```
+
+## Task 4: ScopedValue와 retention stress를 TDD로 구현한다
+
+**Complexity:** 높음
+
+**Depends on:** Task 2
+
+- [ ] unbound, nested success/failure, block 종료 비오염, instance-private key RED를 작성한다.
+- [ ] public zero-argument `ScopedValueTenantContext()` construction을 compile test로 고정한다.
+- [ ] `ScopedValue.where(key, tenantId)`의 JDK 25 lexical scope로 구현한다. raw `get()` 전에는
+      반드시 `isBound`를 확인한다.
+- [ ] JDK 25 `StructuredTaskScope` fork 안에서는 lexical binding이 상속되고, 단순히 새로
+      시작한 unrelated virtual thread에는 자동 전파를 약속하지 않는 positive/negative
+      fixture를 둔다. root의 기존 `--enable-preview` 계약 안에서만 사용한다.
+- [ ] 일반 coroutine dispatcher hop 자동 전파를 API/test 이름으로 약속하지 않는다.
+- [ ] 8 platform thread, 100 tenant, 10,000 virtual-thread task를 60초 안에 완료하고
+      expected/observed tenant가 모두 같으며 종료 뒤 unbound인지 확인한다.
+- [ ] unique non-interned sentinel의 `WeakReference`/`ReferenceQueue`를 최대 10초 확인한다.
+      불안정하거나 sentinel이 남으면 통과 처리하지 않고 log와 class histogram을 blocker
+      evidence로 남긴다.
+- [ ] `TenantContextRetentionStressTest`를 `tenant-retention-stress` JUnit tag로 분리하고
+      `bluetape4k/tenant/build.gradle.kts`에 같은 test source set/classpath를 사용하는
+      `tenantRetentionStress` `Test` task를 등록한다. 일반 `test`에는
+      `excludeTags("tenant-retention-stress")`, custom task에는
+      `includeTags("tenant-retention-stress")`를 명시하며 CI, Nightly, release verification이
+      custom task를 required gate로 실행한다.
+- [ ] 모든 barrier, `StructuredTaskScope`, executor와 virtual thread 실행에 hard timeout을
+      적용하고 `close`/`shutdown`/`join`과 strong reference 해제를 `finally`에서 수행한다.
+
+Run:
+
+```bash
+./gradlew :bluetape4k-tenant:test \
+  --tests 'io.bluetape4k.tenant.ScopedValueTenantContextTest' \
+  --rerun-tasks --no-daemon --no-configuration-cache --no-build-cache
+./gradlew :bluetape4k-tenant:tenantRetentionStress \
+  --rerun-tasks --no-daemon --no-configuration-cache --no-build-cache
+```
+
+## Task 5: Reactor Context adapter를 TDD로 구현한다
+
+**Complexity:** 높음
+
+**Depends on:** Task 2
+
+- [ ] private object key collision, 원본 `Context` identity/비오염, nested derived context,
+      missing 공통 예외 RED를 작성한다.
+- [ ] single-thread scheduler에서 두 subscription을 barrier로 interleave하고 각 subscriber가
+      자기 tenant만 읽는지 검증한다.
+- [ ] cancellation 뒤 외부 context가 unbound이고 global hook이 설치되지 않았음을 검증한다.
+- [ ] `withTenant(Context, TenantId)`가 subscription boundary당 한 번 호출되는 fixture를
+      두고 signal당 `put` 구현을 금지한다.
+- [ ] `ReactorTenantContext` object와 private key만으로 GREEN을 만든다.
+- [ ] barrier에 hard timeout을 적용하고 scheduler/disposable/cancellation을 `finally`에서
+      정리한다. private key가 object 초기화 때 한 번만 만들어지고 request/signal마다 key를
+      만들지 않는지 source와 behavior test로 확인한다.
+
+Run:
+
+```bash
+./gradlew :bluetape4k-tenant-reactor:test \
+  --tests 'io.bluetape4k.tenant.reactor.ReactorTenantContextTest' \
+  --rerun-tasks --no-daemon --no-configuration-cache --no-build-cache
+```
+
+## Task 6: Ktor one-call/one-tenant adapter를 TDD로 구현한다
+
+**Complexity:** 높음
+
+**Depends on:** Task 2
+
+- [ ] unbound 조회가 core `MissingTenantContextException`을 그대로 던지는 RED를 작성한다.
+- [ ] private `TenantBinding` holder와 versioned key name을 사용해 외부
+      `AttributeKey<TenantId>` collision이 값을 읽지 못하는 RED를 작성한다.
+- [ ] 같은 call의 두 번째 bind가 exact `TenantAlreadyBoundException`을 던지고 기존 값을
+      덮어쓰지 않는 RED를 작성한다.
+- [ ] start barrier로 서로 다른 tenant를 같은 call에 동시에 bind해 정확히 한 성공,
+      N-1 exact failure, 최종 winner value를 100회 반복 검증한다.
+- [ ] `ApplicationCall.attributes` monitor 안의 check-and-put으로 최초 binding을 선형화한다.
+- [ ] `testApplication`에서 dispatcher hop, exception, cancellation, 새 call 격리를 검증한다.
+      plugin/header/status API는 추가하지 않는다.
+- [ ] cancelled call의 `WeakReference`/`ReferenceQueue`를 bounded timeout으로 확인하고 adapter가
+      call/global registry를 retain하지 않음을 검증한다. concurrent coroutine은 hard timeout,
+      cancel/join, barrier abort를 `finally`에서 수행하며 lock scope가 attributes의 짧은
+      check-and-put만 포함하는지 inspection한다.
+
+Run:
+
+```bash
+./gradlew :bluetape4k-ktor-tenant:test \
+  --tests 'io.bluetape4k.ktor.tenant.KtorTenantContextTest' \
+  --rerun-tasks --no-daemon --no-configuration-cache --no-build-cache
+```
+
+## Task 7: 양언어 문서와 dependency 좌표를 맞춘다
+
+**Complexity:** 중간
+
+**Depends on:** Tasks 3~6
+
+- [ ] 세 README 쌍에 `io.github.bluetape4k`, `2.0.0-SNAPSHOT`, JDK 25, no-default,
+      carrier lifecycle, 전체 unsupported boundary, 최소 사용 예제를 각각 쓴다. BOM은 exact
+      `platform("io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT")`, 개별 artifact는
+      Gradle Kotlin DSL/Maven 예시를 제공한다.
+- [ ] SNAPSHOT 예시는 Central snapshots repository
+      `https://central.sonatype.com/repository/maven-snapshots/`, changing module 선언과
+      `cacheChangingModulesFor(0, "seconds")` 조건을 포함하고 실제 sample dependency resolution로
+      검증한다.
+- [ ] ThreadLocal singleton + lexical block, ScopedValue coroutine 비보장, Reactor immutable
+      derived context/global hook 미설치, Ktor application-owned plugin/auth를 명시한다.
+- [ ] raw header를 직접 `TenantId`로 만들지 않는 application enum/domain mapping 예시를
+      포함한다. raw header/token/tenant를 log, exception, MDC, metric tag에 기록하지 않고
+      synthetic fixture만 expected/observed 값을 쓸 수 있음을 명시한다. library에는 logging/
+      metric backend를 추가하지 않는다. consumer의 optional metric은 enum-only `carrier`/`stage`,
+      기존 correlation ID, 5분 구간 alert와 workshop maintainer/release coordinator owner를 쓴다.
+- [ ] root README의 Core section에 tenant/tenant-reactor, Ktor section에 tenant를 추가하고
+      EN/KO 의미를 맞춘다.
+- [ ] reader-facing KDoc은 한국어로 작성하고 identifier·coordinate는 원문을 유지한다.
+
+Run:
+
+```bash
+node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  --series clinic-appointment \
+  bluetape4k/tenant/README.ko.md \
+  bluetape4k/tenant-reactor/README.ko.md \
+  ktor/tenant/README.ko.md README.ko.md
+git diff --check
+```
+
+## Task 8: exact-head SNAPSHOT workflow와 handoff receipt를 fail-closed로 만든다
+
+**Complexity:** 높음
+
+**Depends on:** Tasks 1~7
+
+- [ ] `publish-snapshot.yml`의 자동 `workflow_run` publish trigger를 제거하고 승인된
+      `workflow_dispatch`만 남긴다. `scripts/test_release_workflow_policy.py`는 manual dispatch가
+      `verified_ci_run_id`, `expected_head_sha`, `handoff_issue_number`를 모두 요구하고, 승인 없는
+      자동 trigger/fallback이 있으면 실패하는 RED를 가진다.
+- [ ] verified run의 workflow path, completed/success conclusion, `head_sha`와 현재
+      `develop` ref가 모두 `expected_head_sha`와 같은지 검증한다. path/conclusion/head/current-ref
+      mismatch fixture를 각각 둔다. receipt의 `verified_ci_run_id`에는 이 exact run ID만 기록한다.
+- [ ] checkout이 validation output SHA만 사용하고 branch 이름/current checkout에 fallback하지
+      않는 RED를 추가한다.
+- [ ] receipt schema `bluetape.snapshot-handoff/v1`의 `repository`, `merge_sha`,
+      `verified_ci_run_id`, `publication_run_id`, `group`, `artifact`, `base_version`, `timestamp`,
+      `build_number`, `last_updated`, `resources`, `catalog_commit_sha=null`, `created_at`, `status`,
+      `supersedes`를 test로 고정한다. 최초 receipt는 `verified`, 실패 receipt는 기존 파일을
+      수정하지 않고 digest로 연결한 append-only `rejected`다.
+- [ ] immutable artifact name, 90일 retention, `actions/upload-artifact@v7`, artifact ID/digest와
+      Korean linked-issue comment를 policy test로 고정한다. 최소 workflow permission은
+      `contents: read`, `actions: read`, issue 기록을 위한 `issues: write`뿐이고 signing/Central
+      secret은 publish step에만 scope한다.
+- [ ] `create_snapshot_handoff.py`는 Maven metadata를 두 번 읽고 timestamp/build number/
+      `lastUpdated`가 호출 전후 같을 때만 BOM과 세 artifact POM/JAR SHA-256을 계산한다.
+- [ ] fixture HTTP server로 success, missing metadata/resource, checksum mismatch, 호출 중 metadata
+      mutation, wrong group/artifact를 검증한다. network를 사용하는 test는 만들지 않는다.
+- [ ] workflow가 publish 후 bounded retry로 public Central metadata/resource를 확인하고 receipt를
+      생성한다. publish job과 retry에 명시적 hard timeout을 두고 timeout이면 job 자체를
+      실패시키며 downstream issue를 시작하거나 issue에 success를 기록하지 않는다.
+- [ ] immutable artifact name에 merge SHA, timestamp, build number를 넣고 job summary에 run ID,
+      artifact ID/digest, resource checksum을 기록한다. 같은 증거를 linked issue에 Korean
+      comment로 기록하며 raw tenant/secret은 출력하지 않는다.
+- [ ] `last-good-manifest.json`은 base SHA, dependency coordinate, resolved timestamp/build number,
+      catalog commit SHA, resource checksum과 통과한 command/run ID를 기록한다. schema test와
+      read-back을 통과하지 않으면 train을 시작하거나 재개하지 않는다.
+
+Run:
+
+```bash
+python3 -m unittest scripts/test_release_workflow_policy.py -v
+python3 -m unittest scripts/test_create_snapshot_handoff.py -v
+ruby scripts/publication/publication_inventory_audit_test.rb
+ruby scripts/publication/publication_pom_integration_test.rb
+ruby scripts/publication/publication_module_metadata_audit_test.rb
+```
+
+## Task 9: 통합 검증, review, lesson과 PR evidence를 만든다
+
+**Complexity:** 높음
+
+**Depends on:** Tasks 1~8
+
+- [ ] 세 module targeted test에서 실제 JUnit test count와 skipped=0을 기록한다.
+- [ ] module registration, dependency graph, Detekt, Kover, generated POM/module metadata와 BOM
+      constraints를 fresh command로 확인한다.
+- [ ] 6관점 독립 code review를 수행하고 P0/P1=0, P2/P3 fixed 또는 rationale-deferred를
+      `docs/reviews/...`에 기록한다.
+- [ ] lesson을 `실패한 가정/판단 → 발견 증거 또는 교정 → 수정 결정 → 향후 예방 확인`
+      형식으로 기록한다. 최소한 Maven group 오기와 review lane deadline 회수를 포함한다.
+- [ ] exact branch/base, commit list, test evidence, changed-path inventory를 읽고 Korean PR을 만든다.
+      PR은 `Refs #1562`, #1320/#1552 추적 링크와 cross-repo #213/#255/#215 dependency order를
+      포함한다.
+- [ ] production source에 logger/MDC/metric/global hook이 없고 workflow permission이 최소이며
+      publish secret이 step-local인지 source/policy test로 검증한다.
+- [ ] noisy benchmark를 release gate로 추가하지 않는다. per-signal `Context.put`, request별
+      carrier/key 생성 또는 넓은 Ktor lock을 inspection에서 발견하면 구현을 고치고, 안정적인
+      baseline이 필요한 후속 benchmark는 duplicate 확인 뒤 별도 Korean issue로 등록한다.
+
+Run:
+
+```bash
+repo-test-summary -- ./gradlew :bluetape4k-tenant:test \
+  :bluetape4k-tenant-reactor:test \
+  :bluetape4k-ktor-tenant:test \
+  --rerun-tasks --no-daemon --no-configuration-cache --no-build-cache
+
+repo-test-summary -- ./gradlew :bluetape4k-tenant:tenantRetentionStress \
+  --rerun-tasks --no-daemon --no-configuration-cache --no-build-cache
+
+./gradlew :bluetape4k-tenant:check \
+  :bluetape4k-tenant-reactor:check \
+  :bluetape4k-ktor-tenant:check \
+  :bluetape4k-tenant:koverXmlReport \
+  :bluetape4k-tenant-reactor:koverXmlReport \
+  :bluetape4k-ktor-tenant:koverXmlReport \
+  --no-daemon --no-configuration-cache --no-build-cache
+
+./gradlew detekt disabledTestReport \
+  --no-daemon --no-configuration-cache --no-build-cache
+
+./gradlew projects --no-daemon --no-configuration-cache --no-build-cache
+./gradlew exportManualModuleInventory --no-configuration-cache
+./gradlew -p buildSrc test --no-daemon --no-configuration-cache --no-build-cache
+
+./gradlew generatePomFileForBluetape4kPublication \
+  generateMetadataFileForBluetape4kPublication \
+  -PsnapshotVersion=-SNAPSHOT \
+  --no-daemon --no-configuration-cache --no-build-cache
+ruby scripts/publication/validate_poms.rb
+ruby scripts/publication/validate_module_metadata.rb
+
+python3 -m unittest scripts/test_release_workflow_policy.py \
+  scripts/test_create_snapshot_handoff.py -v
+find bluetape4k/tenant bluetape4k/tenant-reactor ktor/tenant \
+  -path '*/build/reports/kover/*.xml' -type f -size +0c
+if rg -n 'LoggerFactory|KotlinLogging|MDC|MeterRegistry|Hooks\.' \
+  bluetape4k/tenant/src/main bluetape4k/tenant-reactor/src/main ktor/tenant/src/main; then
+  exit 1
+fi
+git diff --check
+```
+
+Expected:
+
+- 세 artifact의 targeted test와 check가 fresh 실행되고 JUnit XML의 실제 count가 0보다 크며
+  skipped=0이다. retention custom task도 같은 machine-check를 통과한다.
+- core outgoing/runtime dependency에 Reactor/Ktor/Servlet/Spring이 없다.
+- generated BOM에 `bluetape4k-tenant`, `bluetape4k-tenant-reactor`,
+  `bluetape4k-ktor-tenant` constraint가 정확히 한 번씩 있다.
+- Detekt source coverage에 빈 신규 module이 없고 세 Kover XML이 존재하며 비어 있지 않다.
+- workflow policy와 offline receipt fixture가 fail-closed 경로를 모두 검증한다.
+- PR exact head에서 required CI가 모두 terminal success이기 전에는 merge-ready로 보고하지
+  않는다.
+
+## PR 이후 release train handoff
+
+1. PR exact head, CI, review thread, mergeability를 다시 읽는다.
+2. fresh merge 승인을 받은 뒤에만 rebase merge하고 실제 merge SHA를 확인한다.
+3. merge SHA에서 README/KDoc의 dependency, lifecycle, unsupported boundary, 비노출 계약과
+   `last-good-manifest.json`을 다시 읽는다. manifest 검증이 없으면 train을 중단한다.
+4. merge SHA의 full Nightly exact-head 성공과 manual-only dispatch hold를 확인한다.
+5. 별도 fresh 승인 범위 안에서 `verified_ci_run_id`, `expected_head_sha`,
+   `handoff_issue_number=1562`로 SNAPSHOT workflow를 dispatch한다. immutable artifact를
+   repository/run/artifact ID로 다운로드하고 GitHub artifact digest, schema, merge/CI SHA,
+   public resource checksum을 검증한다.
+6. public BOM POM과 세 artifact의 timestamp/build number/`lastUpdated`/checksum이 receipt와
+   일치할 때만 Dependencies #213을 시작한다. 90일이 지났거나 mutable metadata가 바뀌면 같은
+   coordinate를 재사용하지 않고 새 exact-head CI/publish receipt를 만든다.
+7. Dependencies #213은 별도 최신 base/head, PR, exact-head CI, fresh merge 승인, SNAPSHOT publish,
+   public POM/catalog alias 해석과 append-only handoff receipt를 모두 통과해야 한다. 그 전에는
+   workshop을 시작하지 않는다.
+8. exposed-workshop #255와 exposed-r2dbc-workshop #215는 같은 verified Dependencies build로
+   시작하고 missing/blank/conflicting/unknown/unauthorized tenant가 binding 전에 실패하는
+   consumer fixture를 포함한다. 두 consumer lane은 서로 독립이므로 이 gate 뒤 병렬화한다.
+9. 어느 downstream이 실패하든 기존 receipt를 수정하지 않고 `supersedes`가 원 receipt digest를
+   가리키는 `rejected` receipt를 추가한다. merge 전에는 dependency 변경을 되돌리고 merge 후에는
+   revert PR을 사용하며, last-good manifest 기준 복원 test 증거 전에는 train을 재개하지 않는다.
+
+## 독립 검토 결과
+
+| 관점 | P0 | P1 | P2 | P3 | disposition |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Developer/API | 0 | 1 | 2 | 0 | adapter test dependency, API test inventory, fresh 실행을 계획에 반영 |
+| Operations/release | 0 | 3 | 2 | 0 | manual-only 승인 hold, exact CI identity, rollback/receipt/Dependencies gate 반영 |
+| User/caller docs | 0 | 2 | 2 | 0 | SNAPSHOT repository/cache, observability, README/merged read-back 반영 |
+| Security | 0 | 1 | 2 | 0 | retention release gate, pre-binding negative, permission/non-disclosure check 반영 |
+| Performance | 0 | 1 | 1 | 1 | key lifetime, per-signal 금지, benchmark deferral와 후속 issue 조건 반영 |
+| Stability | 0 | 2 | 2 | 0 | hard timeout/cleanup, tag wiring, CI artifact와 machine count 반영 |
+| 합계 | 0 | 10 | 11 | 1 | 중복 finding을 통합해 모두 fixed; unresolved P0/P1=0 |
+
+초기 전체-file 검토가 5분 command deadline을 넘긴 세 lane은 결과를 사용하지 않고 회수했다.
+같은 agent를 더 좁은 write-scope 없는 계약 검토로 재배정해 위 표의 결과를 얻었다. leader는
+모든 finding을 design line과 대조해 반영했으며, P2/P3도 defer하지 않고 실행 항목으로 승격했다.
+
+## 계획 DoD
+
+- [x] 승인된 spec의 모든 수용 기준이 Task와 fresh 검증 command에 연결됐다.
+- [x] production/test/doc/CI/publication 파일과 write scope가 명시됐다.
+- [x] 각 production task가 RED → GREEN 순서를 가진다.
+- [x] module registration, JDK25, dependency leakage, Ktor concurrency, ThreadLocal retention,
+      Reactor cancellation, SNAPSHOT mutability hazard가 fail-closed test로 배정됐다.
+- [x] 독립 6관점 plan review에서 unresolved P0=0/P1=0이다.
+- [x] 계획과 spec coordinate 교정이 같은 commit으로 고정되고 plan 작성 범위가 clean하다.

--- a/docs/superpowers/specs/2026-08-28-issue-1562-tenant-context-design.md
+++ b/docs/superpowers/specs/2026-08-28-issue-1562-tenant-context-design.md
@@ -1,0 +1,652 @@
+# #1562 공통 TenantContext core와 carrier adapter 설계
+
+- Epic: [#1320](https://github.com/bluetape4k/bluetape4k-projects/issues/1320)
+- 선행 fixture: [#1552](https://github.com/bluetape4k/bluetape4k-projects/issues/1552)
+- 선행 ownership 설계: [#1553](https://github.com/bluetape4k/bluetape4k-projects/issues/1553)
+- 구현 이슈: [#1562](https://github.com/bluetape4k/bluetape4k-projects/issues/1562)
+- catalog/BOM 이슈: [bluetape4k-dependencies #213](https://github.com/bluetape4k/bluetape4k-dependencies/issues/213)
+- MVC·virtual-thread consumer: [exposed-workshop #255](https://github.com/bluetape4k/exposed-workshop/issues/255)
+- Reactor·Ktor consumer: [exposed-r2dbc-workshop #215](https://github.com/bluetape4k/exposed-r2dbc-workshop/issues/215)
+- 기준 브랜치: `develop`의 `18472064c594ab2dee835cff6695cd6ef9538ea5`
+- 작업 브랜치: `feat/issue-1562-tenant-context`
+- 지원 기준: Java/JVM 25, Kotlin 2.4, Spring Boot 4.x, stable release 제외
+
+## 결정 요약
+
+이 문서에서 **tenant 값**은 검증이 끝난 `TenantId`, **carrier**는 tenant 값을 현재 실행
+범위에 보관하는 구현, **binding**은 그 값을 carrier에 연결하는 동작, **consumer**는 공개
+artifact를 사용하는 application 예제를 뜻한다. **unbound**는 현재 실행 범위에 tenant 값이
+연결되지 않은 상태다.
+
+공통 tenant 값과 no-default 조회 계약을 `bluetape4k-tenant`에 두고, 외부 타입을
+공개 API에 노출하는 Reactor와 Ktor 연동은 각각 `bluetape4k-tenant-reactor`,
+`bluetape4k-ktor-tenant`로 분리한다.
+
+`bluetape4k-tenant`는 JDK 25 전용 모듈로 다음을 제공한다.
+
+- 정규화된 tenant 식별자를 담는 `TenantId`
+- `currentOrNull`, `requireCurrent`, `withTenant`의 no-default 계약
+- platform thread와 Spring MVC에서 사용할 `ThreadLocalTenantContext`
+- virtual thread의 동적 범위에서 사용할 `ScopedValueTenantContext`
+
+Reactor adapter는 immutable subscriber `Context`를 파생하고 `ContextView`에서 읽는다.
+Ktor adapter는 `ApplicationCall.attributes`에 값을 저장하고 읽는다. 두 adapter 모두
+header parsing, tenant 존재 확인, 인증·인가, schema/database/connection routing,
+persistence를 수행하지 않는다.
+
+Servlet filter, Spring `WebFilter`, Ktor plugin은 애플리케이션 경계에 남긴다. 각
+consumer는 요청 값을 검증한 뒤 adapter에 `TenantId`만 전달한다. 이 구분으로 공통
+artifact는 transport와 보안 정책을 소유하지 않으면서 carrier 수명주기와 복원 규칙만
+일관되게 제공한다.
+
+## 문제와 현재 증거
+
+멀티테넌트 예제는 같은 책임을 서로 다른 방식으로 반복 구현한다.
+
+- `exposed-workshop` MVC 예제는 `ThreadLocal`에 값을 저장하고 `finally`에서
+  `remove()`한다. 동일 servlet thread의 순차 요청, 중첩, downstream 예외 뒤 cleanup을
+  이미 테스트한다.
+- `exposed-workshop` virtual-thread 예제는 `ScopedValue`를 사용하지만 context가 없을 때
+  default tenant로 돌아가고 `withTenant`의 tenant 인자에도 default가 있다. 이는 #1551의
+  no-default 결정과 맞지 않는다.
+- `exposed-r2dbc-workshop` WebFlux 예제는 문자열 key로 Reactor Context에 tenant를 넣는다.
+  PR #214의 deterministic fixture는 interleaved subscription, nested success/failure,
+  cancellation, 외부 context 비오염을 검증한다.
+- 같은 PR의 Ktor fixture는 `ApplicationCall.attributes`가 dispatcher hop 뒤에도 요청별
+  값을 보존하고 새 요청에 값을 남기지 않는지 검증한다. test-local 중첩 helper는 공통
+  production API의 one-call/one-tenant 계약으로 대체한다.
+- `bluetape4k-projects`에는 tenant 전용 production artifact가 없다. 기존
+  `bluetape4k-core`, `bluetape4k-coroutines`, `bluetape4k-virtualthread-api`의 소유권을
+  tenant 기능 때문에 넓히지 않는다는 #1553 결정이 존재한다.
+
+따라서 이번 변경은 application-local 코드를 그대로 복사하는 작업이 아니다. carrier별
+수명주기를 공통 no-default 의미로 묶고, 기존 deterministic fixture를 실제 독립 consumer
+증거로 전환하는 production API 승격이다.
+
+## 목표
+
+1. 모든 carrier에서 context 부재를 `null` 또는 명시적 예외로 표현하고 default tenant를
+   제공하지 않으며, carrier 수명주기에 맞는 명시적 binding만 허용한다.
+2. ThreadLocal과 ScopedValue의 중첩·예외 복원을 공통 block API로 고정한다.
+3. Reactor Context와 Ktor attributes의 carrier 고유 수명주기를 보존하면서 같은
+   `TenantId`와 조회 의미를 사용한다.
+4. framework 의존성을 선택 artifact에 격리한다.
+5. 기존 네 consumer의 routing·authorization 동작을 보존하면서 application-local
+   carrier 구현을 제거하거나 얇은 application boundary로 축소한다.
+6. 새 artifact를 generated BOM, central SNAPSHOT, 중앙 catalog/aggregator 순서로 공개하고
+   실제 consumer가 `2.0.0-SNAPSHOT`을 해석하도록 증명한다.
+
+## 비목표
+
+- default tenant 선택 또는 fallback 정책
+- tenant header 이름, trim/case 규칙, 중복 header 처리
+- tenant 존재 확인과 registry 조회
+- 인증·인가, schema/database/connection 선택, transaction 또는 persistence
+- Servlet filter, Spring `WebFilter`, Ktor plugin의 범용 구현
+- `ThreadLocal`을 `ScopedValue`로 전면 대체하는 것
+- coroutine suspension을 `ScopedValue`가 자동으로 가로지른다고 보장하는 것
+- JDK 21 compatibility island에 tenant 모듈을 추가하는 것
+- stable `2.0.0` 발행 또는 Maven Central release closeout
+
+## 선택지와 결정
+
+| 선택지 | 장점 | 문제 | 결정 |
+| --- | --- | --- | --- |
+| A. JDK core + Reactor + Ktor의 3-artifact 구조 | 외부 의존성을 격리하고 JDK carrier는 한 계약으로 테스트 가능 | 세 모듈·문서·catalog 등록이 필요 | **선택** |
+| B. core, ThreadLocal, ScopedValue, Reactor, Ktor를 모두 별도 artifact로 분리 | carrier 소유권이 가장 명시적 | JDK 의존성만 가진 작은 artifact가 과도하게 늘고 consumer 설정이 복잡 | 제외 |
+| C. 하나의 artifact에 Reactor/Ktor를 `compileOnly`로 추가 | coordinate가 하나 | 공개 signature의 외부 타입을 소비자가 해석할 수 없고 선택 의존성 실패가 런타임으로 이동 | 제외 |
+| D. 기존 core/coroutines/virtualthread-api/ktor-core에 기능을 분산 | 새 artifact 수가 적음 | #1553의 dedicated owner 결정과 JDK 21 compatibility island를 훼손 | 제외 |
+
+선택안 A에서 JDK carrier를 같은 artifact에 두는 이유는 두 구현이 외부 framework를
+요구하지 않고 저장소 기본 JVM 25 target을 공유하기 때문이다. Reactor와 Ktor는 공개
+signature가 각각 `reactor.util.context.*`, `ApplicationCall`을 사용하므로 별도 artifact의
+`api` 의존성으로 분리한다.
+
+## 모듈과 의존성 경계
+
+### `bluetape4k/tenant` → `bluetape4k-tenant`
+
+- package: `io.bluetape4k.tenant`
+- 외부 framework 의존성 없음
+- 저장소 기본 Java/JVM 25 target 사용
+- `TenantId`, missing-context 예외, `TenantContext` 계약
+- `ThreadLocalTenantContext`, `ScopedValueTenantContext`
+
+### `bluetape4k/tenant-reactor` → `bluetape4k-tenant-reactor`
+
+- package: `io.bluetape4k.tenant.reactor`
+- `api(project(":bluetape4k-tenant"))`
+- `api(libs.reactor.core)`
+- 이번 범위는 coroutine Reactor context bridge를 제공하지 않으므로
+  `kotlinx-coroutines-reactor`를 사용하거나 의존성에 추가하지 않는다.
+
+### `ktor/tenant` → `bluetape4k-ktor-tenant`
+
+- package: `io.bluetape4k.ktor.tenant`
+- `api(project(":bluetape4k-tenant"))`
+- `api(libs.ktor.server.core)`
+- header parser나 installable plugin은 포함하지 않는다.
+
+`settings.gradle.kts`의 기존 `includeModules("bluetape4k", ...)`와
+`includeModules("ktor", withBaseDir = true)` 자동 등록을 사용한다. 수동 `include`를
+추가하지 않는다. BOM은 `isPublishableLibraryProject()`가 반환하는 모든 publishable
+subproject를 동적으로 constraint에 포함하므로 module registration과 generated POM을
+함께 검증한다.
+
+## core API 계약
+
+공개 type과 함수 이름은 다음과 같이 고정한다. 구현 전에 작성하는 API compile test가
+signature와 missing-context 예외 계약을 잠근다.
+
+```kotlin
+@JvmInline
+value class TenantId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "TenantId must not be blank" }
+    }
+}
+
+interface TenantContext {
+    fun currentOrNull(): TenantId?
+    fun requireCurrent(): TenantId
+    fun <T> withTenant(tenantId: TenantId, block: () -> T): T
+}
+
+class MissingTenantContextException : IllegalStateException("Tenant context is not bound")
+
+val threadLocal: TenantContext = ThreadLocalTenantContext()
+val scopedValue: TenantContext = ScopedValueTenantContext()
+```
+
+- `TenantId`는 생성 시 blank 값을 `IllegalArgumentException`과 정확한 메시지
+  `TenantId must not be blank`로 거부하지만 trim, case conversion, tenant existence 확인은
+  하지 않는다. `TenantId(" clinic-a ")`처럼 non-blank 원문은 그대로 보존하므로 원시 요청
+  값의 정규화는 application boundary가 수행한다.
+- `currentOrNull()`은 context가 없으면 `null`이다.
+- `requireCurrent()`는 context가 없으면 정확히 `MissingTenantContextException`을 던진다.
+  예외 메시지 `Tenant context is not bound`도 API compile/behavior test로 고정한다.
+- `withTenant()`는 tenant 인자를 반드시 요구한다. default 인자와 fallback은 없다.
+- 중첩 block은 outer tenant를 복원한다.
+- outer tenant가 없던 block은 성공·예외 모두 종료 후 다시 비어 있어야 한다.
+- carrier instance는 tenant 값을 log하거나 전역 registry에 기록하지 않는다.
+- 두 concrete carrier는 public zero-argument constructor로 application과 test가 독립 instance를
+  만들 수 있다. application configuration이 instance를 한 번 생성해 filter와 downstream에
+  같은 identity로 주입하며, 서로 다른 instance는 값을 공유하지 않는다는 identity test를
+  둔다. global object/default instance는 제공하지 않는다.
+
+`ThreadLocalTenantContext`는 application singleton으로 생성해 filter와 downstream이 같은
+instance를 사용한다. top-level block 종료 시 `ThreadLocal.remove()`를 호출한다. 이전
+값이 있으면 `set(previous)`로 복원한다. 값의 공개 `set`/`clear` API는 제공하지 않아
+application이 `finally`를 빼먹을 수 있는 표면을 줄인다.
+
+`ScopedValueTenantContext`는 instance별 private key를 소유하고
+`ScopedValue.where(key, tenantId).call/run`의 동적 범위를 사용한다. `ScopedValue.get()`을
+unbound 상태에서 직접 호출하지 않고 먼저 `isBound`를 검사한다. 새로운 coroutine
+dispatcher hop 전파를 약속하지 않으며, servlet virtual thread 안의 동기 호출과 JDK가
+보장하는 structured inheritance 범위만 문서화한다.
+
+## Reactor adapter 계약
+
+Reactor Context는 immutable subscriber-local 값이므로 ThreadLocal처럼 set/clear하지 않는다.
+
+```kotlin
+object ReactorTenantContext {
+    fun currentOrNull(context: ContextView): TenantId?
+    fun requireCurrent(context: ContextView): TenantId
+    fun withTenant(context: Context, tenantId: TenantId): Context
+}
+```
+
+- key는 adapter가 소유하는 collision-resistant private object다. application 문자열 key를
+  public contract로 사용하지 않는다.
+- `withTenant`는 입력 `Context`를 수정하지 않고 tenant를 가진 새 `Context`를 반환한다.
+- nested binding은 inner derived context에서만 값을 바꾸고 outer context는 그대로 둔다.
+- subscription cancellation 뒤 외부 subscriber context에 tenant가 나타나지 않아야 한다.
+- `Mono.deferContextual`/`Flux.deferContextual`이 같은 key와 no-default 의미를 사용한다.
+- `requireCurrent`는 core의 `MissingTenantContextException`과 정확한 메시지를 그대로
+  사용하며 Reactor 고유 예외로 감싸지 않는다.
+- coroutine `ReactorContext` bridge는 이번 범위에서 제공하지 않는다. 별도 ambient coroutine
+  API 없이 subscriber `ContextView`를 명시적으로 받는 것이 carrier 경계를 보존한다.
+- adapter는 `Hooks`, automatic context propagation 또는 global hook을 설치하지 않는다.
+
+## Ktor adapter 계약
+
+Ktor adapter는 요청에 이미 존재하는 `ApplicationCall`을 명시적으로 받는다.
+
+```kotlin
+class TenantAlreadyBoundException :
+    IllegalStateException("Tenant context is already bound to this call")
+
+object KtorTenantContext {
+    fun currentOrNull(call: ApplicationCall): TenantId?
+    fun requireCurrent(call: ApplicationCall): TenantId
+    fun bindTenant(call: ApplicationCall, tenantId: TenantId)
+}
+```
+
+- adapter는 private `TenantBinding` holder type과 fully qualified versioned name
+  `io.bluetape4k.ktor.tenant.binding.v1`을 가진 `AttributeKey<TenantBinding>`을 소유한다.
+  외부 code가 같은 holder type을 참조할 수 없으므로 이름/공개 `TenantId` type만 같은 key와
+  충돌하지 않는다. 회귀 test는 같은 이름의 외부 `AttributeKey<TenantId>`가 값을 가로채지
+  못함을 검증한다.
+- application plugin은 header를 검증하고 tenant 존재·권한을 확인한 뒤 request pipeline
+  시작 전에 `bindTenant`를 정확히 한 번 호출한다.
+- 이미 tenant가 bound된 call에 두 번째 `bindTenant`를 호출하면 실패한다. 같은 call에서
+  tenant를 nested rebind하거나 concurrent coroutine마다 바꾸는 API는 제공하지 않는다.
+- `bindTenant`는 non-suspending 함수이며 `ApplicationCall.attributes`를 하나의 monitor로
+  동기화한 check-and-put으로 선형화한다. 먼저 성공한 호출만 값을 기록하고 나머지는 정확히
+  `TenantAlreadyBoundException("Tenant context is already bound to this call")`을 받는다.
+  이 예외는 잘못 구성된 pipeline을 뜻하므로 application의 일반 `500` 처리로 전달하며
+  `400` 또는 `409`로 바꾸거나 기존 값을 덮어쓰지 않는다.
+- dispatcher hop은 같은 `ApplicationCall`을 전달하는 Ktor의 요청 경계를 따른다.
+- `requireCurrent`는 core의 `MissingTenantContextException`과 정확한 메시지를 그대로
+  사용하며 Ktor 고유 예외로 감싸지 않는다.
+- exception·cancellation 뒤 attribute를 별도로 global cleanup할 필요는 없다. 값의 owner가
+  request-local `ApplicationCall`이고 call 자체가 요청 종료와 함께 폐기되기 때문이다. 새
+  call 격리와 cancelled request retention test로 이 전제를 검증한다.
+- adapter는 `createApplicationPlugin`, status mapping, response body를 제공하지 않는다.
+
+따라서 carrier 공통 의미는 no-default 조회와 명시적 binding이지 동일한 mutable block
+형태를 강제하는 것이 아니다. `withTenant`는 lexical JDK carrier와 immutable Reactor
+Context 파생에 사용하고, Ktor는 one-call/one-tenant `bindTenant`만 제공한다.
+
+## application 경계와 데이터 흐름
+
+모든 reference consumer는 context binding 전에 다음 fail-closed 순서를 적용한다.
+
+1. 인증이 있는 consumer는 먼저 principal을 인증한다.
+2. transport boundary가 정확히 하나의 논리 tenant 값을 읽고, 길이 제한을 적용하고,
+   conflicting/blank 값을 거부한다.
+3. 각 application이 문서화한 trim, case, Unicode, 허용 문자 규칙으로 canonical ID를
+   만든다. 공통 `TenantId`는 이 정규화를 대신하지 않는다.
+4. registry/enum에서 tenant 존재를 확인한다.
+5. 인증이 있는 consumer는 principal이 canonical tenant에 접근할 권한이 있는지 확인한다.
+6. 위 검증을 모두 통과한 canonical ID로만 `TenantId`를 생성하고 carrier에 binding한다.
+
+미인증은 기존 security chain의 `401`, 권한 불일치는 `403`, missing/blank/conflicting/unknown
+tenant는 기존 reference consumer 계약의 `400`으로 응답한다. boundary 이후
+`MissingTenantContextException`이 발생하면 application wiring 오류이므로 `500`으로
+종료하며 default tenant로 복구하지 않는다. 인증 기능이 없는 Ktor/WebFlux 예제는
+인증·인가 단계가 N/A임을 README에 명시하되 unknown tenant를 binding 전에 거부한다.
+
+### Spring MVC / platform thread
+
+1. filter가 header와 authentication을 검증한다.
+2. authenticated tenant 권한을 확인한 canonical application enum/domain tenant를 공통
+   `TenantId`로 변환한다.
+3. application singleton `tenantContext: ThreadLocalTenantContext`를 filter에 주입하고
+   `tenantContext.withTenant(tenantId) { chain.doFilter(request, response) }` 안에서 chain을
+   실행한다.
+4. adapter가 nested 복원과 top-level `remove()`를 보장한다.
+
+### Spring MVC / virtual thread
+
+1. filter가 header를 canonicalize하고 tenant 존재를 확인하며 default fallback 없이
+   실패시킨다.
+2. application singleton `tenantContext: ScopedValueTenantContext`를 filter에 주입하고
+   `tenantContext.withTenant(tenantId) { chain.doFilter(request, response) }` 안에서 chain을
+   실행한다.
+3. block 밖에서는 unbound 상태다.
+
+### WebFlux / Reactor
+
+1. `WebFilter`가 header를 canonicalize하고 tenant 존재와 적용 가능한 권한을 검증한다.
+2. `chain.filter(exchange).contextWrite { ReactorTenantContext.withTenant(it, tenantId) }`로
+   subscriber context를 파생한다.
+3. routing connection factory는 `deferContextual`에서 `requireCurrent(contextView)`를
+   사용한다.
+
+### Ktor
+
+1. application plugin이 header 길이·중복·blank·unknown tenant를 검증한다.
+2. 검증된 값만 `TenantId`로 만들어 `bindTenant`로 call attribute에 한 번 바인딩한다.
+3. repository/routing은 `requireCurrent(call)`로 값을 읽고 application enum에 매핑한다.
+
+### carrier 선택표
+
+| application 실행 경계 | 선택할 carrier | 지원 범위 | 지원하지 않는 사용 |
+| --- | --- | --- | --- |
+| Servlet MVC / platform thread | singleton `ThreadLocalTenantContext` | 동일 thread의 동기 filter-chain block | suspend, dispatcher hop, 비동기 callback 자동 전파 |
+| Servlet MVC / virtual thread | singleton `ScopedValueTenantContext` | virtual thread의 동기 lexical block과 JDK structured inheritance | 임의 coroutine suspension·dispatcher hop 자동 전파 |
+| Spring WebFlux | `ReactorTenantContext` | subscription-local Reactor `Context` | ThreadLocal bridge, global hook, coroutine 자동 전파 |
+| Ktor | `KtorTenantContext` | one-call/one-tenant `ApplicationCall` attribute | nested 또는 concurrent rebind |
+
+모든 consumer는 raw header를 직접 `TenantId`로 감싸지 않는다. 예를 들어 application이
+소유한 `TenantKey` enum/domain registry가 다음 순서를 수행한 뒤 공통 API로 넘긴다.
+
+```kotlin
+val canonical = rawHeader.trim().lowercase(Locale.ROOT)
+val tenantKey = TenantKey.entries.singleOrNull { it.externalId == canonical }
+    ?: throw UnknownTenantException()
+authorize(principal, tenantKey)
+val tenantId = TenantId(tenantKey.externalId)
+```
+
+MVC는 이 `tenantId`를 `withTenant` block에, WebFlux는 `contextWrite`에, Ktor는 최초
+`bindTenant`에 전달한다. 예제의 `UnknownTenantException`도 raw 값이나 tenant 값을 메시지,
+로그, metric tag에 기록하지 않는 application-local 예외로 구현한다.
+
+## 호환성과 migration
+
+- 새 artifact 추가이므로 기존 Projects 소비자의 binary/source contract는 바꾸지 않는다.
+- 세 artifact는 모두 JDK 25 전용이다. `bluetape4k-virtualthread-api`와
+  `bluetape4k-virtualthread-jdk21`은 변경하지 않는다.
+- workshop migration은 consumer별 additive 순서로 진행한다. 한 consumer의 local
+  carrier를 제거하기 전에 동일 테스트가 SNAPSHOT artifact를 사용해 통과해야 한다.
+- application-local header/auth/routing 코드는 유지하므로 persistence 또는 data migration은
+  없다.
+- rollback은 dependency와 adapter 사용을 제거하고 직전 local carrier를 복원하는 방식이다.
+  SNAPSHOT artifact가 다른 consumer에 배포됐더라도 각 consumer는 독립적으로 rollback할
+  수 있다.
+- stable version을 요구하는 consumer에는 이번 SNAPSHOT train을 적용하지 않는다.
+
+## 4개 저장소 delivery DAG
+
+| 순서 | 저장소·이슈 | base | head | 산출물 | 다음 단계 gate |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `bluetape4k-projects` #1562 | `develop` | `feat/issue-1562-tenant-context` | 3개 artifact와 generated BOM constraint | exact-head PR merge 후 SNAPSHOT dispatch |
+| 2 | `bluetape4k-dependencies` #213 | `develop` | `feat/issue-213-tenant-context-catalog` | 3개 alias와 aggregator catalog | Projects public SNAPSHOT POM read-back |
+| 3 | `exposed-workshop` #255 | `develop` | `feat/issue-255-tenant-context-consumer` | MVC ThreadLocal·virtual-thread ScopedValue reference consumer | Dependencies public SNAPSHOT read-back |
+| 4 | `exposed-r2dbc-workshop` #215 | `develop` | `feat/issue-215-tenant-context-consumer` | Reactor·Ktor reference consumer | Dependencies public SNAPSHOT read-back |
+
+3과 4는 서로 독립이며 같은 verified Dependencies SNAPSHOT build를 기준으로 병렬 진행할 수 있다.
+각 저장소의 실제 branch는 시작 직전에 최신 `origin/develop`에서 생성하고 표의 base/head를
+PR read-back으로 다시 확인한다.
+
+## SNAPSHOT publish gate
+
+1. Projects PR의 exact head, required CI, review, mergeability를 재확인하고 fresh merge 승인을
+   받는다.
+2. merge SHA에서 성공한 required CI run ID를 고정한다. 수동 publish workflow 입력은
+   `expected_head_sha`와 `verified_ci_run_id`를 필수로 받고, CI conclusion이 `success`이며
+   CI의 `head_sha`와 현재 `develop` head가 모두 `expected_head_sha`와 같을 때만 해당 SHA를
+   checkout한다. branch 이름만 checkout하거나 현재 head를 암묵적으로 사용하면 실패한다.
+3. 그 SHA에서 SNAPSHOT workflow의 version/target/credentials/dispatch hold를 새로 읽고,
+   별도 승인된 workflow dispatch의 publication run ID를 기록한다. Dependencies의 현재
+   `workflow_dispatch`/`workflow_run` checkout도 이 exact-head 계약으로 보강하기 전에는
+   중앙 SNAPSHOT을 발행하지 않는다.
+4. `nmcpPublishAggregationToCentralPortalSnapshots`가 성공한 뒤 공개
+   `bluetape4k-bom:2.0.0-SNAPSHOT` POM에서 세 artifact constraint를 확인한다.
+5. Projects handoff receipt에 repository merge SHA, required CI run ID, publication run ID,
+   Maven metadata의 timestamp/build number와 `lastUpdated`, 공개 BOM POM 및 세 artifact
+   POM/JAR SHA-256을 기록한다. SNAPSHOT coordinate 자체를 immutable로 간주하지 않는다.
+6. Dependencies가 이 immutable handoff receipt로 식별한 Projects BOM build를 참조하도록
+   alias와 generated catalog를 갱신하고 별도 PR/merge/SNAPSHOT gate를 통과한다.
+7. Dependencies handoff에도 merge SHA, required CI run ID, publication run ID, catalog commit
+   SHA, timestamp/build number, `lastUpdated`, 공개 POM/catalog SHA-256을 기록한다.
+8. 공개 `bluetape4k-dependencies:2.0.0-SNAPSHOT` POM/catalog가 세 alias를 해석하는지
+   확인한 뒤에만 workshop dependency version을 `2.0.0-SNAPSHOT`으로 전환한다.
+
+handoff receipt의 schema는 `bluetape.snapshot-handoff/v1`로 고정하고 publish workflow가
+`tenant-context-handoff.json`을 생성한다. 필수 필드는 `repository`, `merge_sha`,
+`verified_ci_run_id`, `publication_run_id`, `group`, `artifact`, `base_version`, `timestamp`,
+`build_number`, `last_updated`, `resources[{url,sha256}]`, `catalog_commit_sha`, `created_at`,
+`status`다. 적용되지 않는 `catalog_commit_sha`는 `null`이고 `status`는 최초 `verified`,
+실패한 downstream이 있으면 새 append-only receipt의 `supersedes`로 연결해 `rejected`로
+표시한다. 기존 receipt 파일은 수정하지 않는다.
+
+publish workflow는 receipt를 GitHub Actions v4 immutable artifact
+`tenant-context-handoff-<merge_sha>-<timestamp>-<build_number>`로 90일 보존하고 artifact ID와
+digest를 job summary 및 연결된 GitHub issue에 기록한다. release coordinator가 owner이며,
+downstream workflow는 repository/run/artifact ID로 receipt를 다운로드하고 artifact digest,
+schema, exact SHA, 모든 resource SHA-256을 검증한다. 90일을 넘겨 재현해야 하면 같은 mutable
+coordinate를 신뢰하지 않고 새 exact-head CI/publish gate로 새 receipt를 만든다.
+
+consumer build는 `--refresh-dependencies`와 changing-module cache 0을 사용한다. build 시작과
+종료에 Maven metadata를 다시 읽어 receipt의 `timestamp`/`build_number`/`last_updated`와
+같은지 확인하고, 실제 다운로드한 BOM/POM/JAR resource의 SHA-256을 receipt와 비교한다.
+중간에 metadata가 바뀌거나 하나라도 다르면 build를 실패시킨다. 즉 Gradle 선언은
+`2.0.0-SNAPSHOT`을 유지하지만 성공 증거는 receipt가 고정한 timestamped resource다.
+
+local Maven publish, Gradle 성공, 이전 SNAPSHOT build 또는 HTTP metadata 존재만으로 다음
+저장소를 시작하지 않는다. 공개 POM/catalog의 실제 constraint와 immutable source SHA가
+handoff 증거다.
+
+각 저장소 작업을 시작하기 전에 `last-good-manifest.json`에 현재 base SHA, dependency
+coordinate, resolved timestamp/build number, catalog commit SHA, resource checksum, 통과한
+test command/run ID를 기록한다. downstream 검증이 실패하면 열차를 즉시 중단하고 실패
+receipt를 `rejected`로 supersede한 뒤, 아직 merge 전이면 branch에서 dependency 변경을
+되돌리고 merge 후면 별도 revert PR을 만든다. 그 다음 manifest가 고정한 catalog/dependency로
+consumer를 복원해 같은 테스트를 재실행한다. 복원 증거가 없으면 train을 재개하지 않는다.
+upstream 수정은 새 merge SHA와 새 timestamped SNAPSHOT receipt를 만들고 실패한 단계부터
+다시 시작한다.
+
+## 테스트 계약
+
+### `bluetape4k-tenant`
+
+1. `TenantId`가 blank를 거부하고 application 정규화를 대신하지 않는다.
+2. ThreadLocal `currentOrNull`은 미설정 시 `null`, `requireCurrent`는 명시적 예외다.
+3. ThreadLocal nested success/failure 뒤 outer tenant가 복원된다.
+4. top-level success/failure 뒤 동일 platform thread에서 값이 없다.
+5. 고정 thread pool의 교차 tenant 순차/병렬 실행에서 값이 섞이지 않는다.
+6. ScopedValue unbound 조회, nested success/failure, block 종료 비오염을 검증한다.
+7. virtual-thread request-shaped 실행에서 각 tenant가 자기 값만 읽는다.
+8. ScopedValue가 coroutine suspension 자동 전파를 보장하지 않는다는 문서와 test 범위를
+   일치시킨다.
+
+### `bluetape4k-tenant-reactor`
+
+1. 서로 다른 tenant의 두 subscription을 single-thread scheduler에서 의도적으로
+   interleave한다.
+2. nested derived context success/failure 뒤 outer context가 유지된다.
+3. cancellation 뒤 외부 context의 `currentOrNull`이 `null`이다.
+4. missing context의 `requireCurrent`가 즉시 실패한다.
+5. 원본 `Context`가 `withTenant` 호출로 변경되지 않는다.
+6. 한 subscription당 boundary binding은 한 번만 수행하며 signal마다 `Context.put`하지
+   않는다.
+
+### `bluetape4k-ktor-tenant`
+
+1. `ApplicationCall.attributes` 미설정 조회와 require failure를 검증한다.
+2. 같은 call의 두 번째 binding을 거부한다. concurrent fixture는 start barrier 뒤 서로 다른
+   tenant로 동시에 bind해 정확히 한 호출만 성공하고 나머지는 모두 정확한
+   `TenantAlreadyBoundException`을 받으며, 이후 조회가 승자의 값이고 overwrite가 없음을
+   검증한다.
+3. dispatcher hop을 포함한 overlapping test에서 expected/observed tenant가 일치한다.
+4. exception·cancellation 뒤 새 call은 이전 요청의 tenant를 볼 수 없다.
+5. cancelled call이 adapter 또는 global registry에 retained되지 않는다.
+
+### reference consumer
+
+- exposed-workshop의 기존 MVC 동일-thread, downstream failure, nested test를 보존한다.
+- virtual-thread 예제의 default fallback을 제거하고 missing tenant failure를 추가한다.
+- exposed-r2dbc-workshop PR #214의 Reactor 35/35, Ktor 11/11 deterministic fixture를
+  SNAPSHOT artifact API로 재실행한다. test-local Ktor nested rebind helper는 production
+  adapter API로 승격하지 않고 one-call/one-tenant 계약에 맞게 조정한다.
+- routing/authorization 결과와 HTTP error semantics가 migration 전과 동일한지 검증한다.
+
+## 문서 계약
+
+- 세 module에 `bluetape4k/tenant/README{,.ko}.md`,
+  `bluetape4k/tenant-reactor/README{,.ko}.md`, `ktor/tenant/README{,.ko}.md`를 두고 정확한
+  group `io.bluetape4k`, version `2.0.0-SNAPSHOT`, JDK 25 requirement, no-default,
+  lifecycle, unsupported boundary, 최소 사용 예제를 맞춘다.
+- 각 README는 `platform("io.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT")`과 해당 artifact
+  `bluetape4k-tenant`, `bluetape4k-tenant-reactor`, `bluetape4k-ktor-tenant`의 Gradle Kotlin
+  DSL 및 Maven 예시를 제공한다. SNAPSHOT 소비 예시는 Maven Central snapshots repository와
+  changing-module cache 정책이 필요하다는 조건을 함께 표시한다.
+- reader-facing KDoc은 한국어로 작성하고 API/identifier는 원문을 유지한다.
+- root README/README.ko의 module 목록에 세 artifact를 같은 의미로 등록한다.
+- ThreadLocal README는 application singleton과 `withTenant` 사용을 강조하고 raw set/clear
+  예제를 제공하지 않는다.
+- ScopedValue README는 coroutine suspension 자동 전파가 아님을 명시한다.
+- Reactor README는 immutable derived context와 global hook 미설치를 명시한다.
+- Ktor README는 header/auth/plugin이 application 소유임을 명시한다.
+- production log, exception, MDC, metric tag에는 raw header, token, tenant 값을 기록하지
+  않는다. synthetic fixture trace만 expected/observed tenant를 사용할 수 있다. 운영 진단은
+  carrier 종류, bound 여부, 실패 단계처럼 값이 아닌 상태만 남긴다.
+- library는 logging/metric backend를 추가하지 않는다. reference consumer가 기존
+  observability stack으로 `tenant_context_binding_failures_total{carrier,stage}`를 선택적으로
+  기록할 때 `carrier`와 `stage`는 문서화한 enum만 사용하고 tenant 값은 label에 넣지 않는다.
+  기존 correlation/trace ID만 log에 연결한다. boundary 이후 missing 또는 duplicate binding이
+  5분 구간에 한 건이라도 있으면 application wiring alert 대상으로 삼고, 각 workshop
+  maintainer가 owner, release coordinator가 SNAPSHOT train 동안 확인 owner다.
+
+## 성능·retention 계약
+
+- `ThreadLocalTenantContext`와 `ScopedValueTenantContext`는 application singleton으로
+  생성한다. request마다 context instance나 key를 만들지 않는다.
+- Reactor binding은 subscription boundary에서 한 번만 수행하며 signal마다 `Context.put`을
+  호출하지 않는다.
+- fixed 8-thread platform executor와 100개 canonical tenant를 round-robin하는 10,000개
+  virtual-thread task의 overlap/retention stress를 60초 timeout으로 실행한다. 모든 task가
+  자기 tenant만 보고 block 종료 직후 unbound인지 확인한다.
+- retention stress는 intern하지 않은 unique tenant 문자열의 `WeakReference`/`ReferenceQueue`를
+  사용한다. task와 executor 종료 후 최대 10초 동안 bounded allocation pressure와 GC를
+  수행해 모든 sentinel이 enqueue되는지 확인한다. 결과와 JUnit XML은 각 module의
+  `build/reports/tests/tenantRetentionStress/`와 `build/test-results/tenantRetentionStress/`에
+  보존한다. 기능 test의 remove/unbound 증거가 우선이며 이 GC 기반 test가 환경상 불안정하면
+  통과로 간주하지 않고 test log와 heap/class histogram을 첨부해 별도 blocker로 판정한다.
+- generic Reactor/Ktor carrier에 저장되는 `TenantId` boxing과 immutable `Context` 파생은
+  boundary당 한 번 허용한다.
+- 이번 PR은 새 benchmark module이나 CI latency threshold를 추가하지 않는다. 작업이 요청
+  경계당 한 번이고 안정적인 기존 baseline이 없어 noisy microbenchmark를 release gate로
+  사용하지 않는다. implementation inspection과 bounded stress에서 per-signal write 또는
+  request별 key 생성이 발견되면 별도 benchmark issue를 등록한다.
+
+## 실패 모드와 대응
+
+| 실패 모드 | 탐지 | 대응 |
+| --- | --- | --- |
+| ThreadLocal이 top-level 종료 뒤 값을 남김 | 동일 thread 순차 요청·예외 test | public set/clear를 숨기고 `finally`에서 `remove()` |
+| nested block이 outer tenant를 지움 | nested success/failure test | 이전 값 기록 후 restore/remove 분기 |
+| ScopedValue unbound `get()`이 실패 | unbound currentOrNull test | `isBound` 확인 뒤 조회 |
+| virtual-thread 지원을 coroutine 전파로 오해 | dispatcher-hop negative scope·README audit | 지원 범위를 동기 servlet/structured JDK scope로 제한 |
+| Reactor 문자열 key가 다른 library와 충돌 | key identity test | adapter private object key 사용 |
+| Reactor binding이 원본 Context를 오염 | identity/outer-context test | immutable derived `Context`만 반환 |
+| cancellation 후 tenant가 외부 subscriber에 노출 | deterministic cancel fixture | global hook과 ThreadLocal bridge를 설치하지 않음 |
+| 같은 Ktor call을 concurrent rebind해 confused tenant가 보임 | duplicate/concurrent bind negative test | one-call/one-tenant를 강제하고 두 번째 bind 실패 |
+| 검증 전에 tenant가 binding됨 | unauthenticated/unknown/unauthorized negative test | canonicalize·existence·authorization 뒤에만 `TenantId` 생성/binding |
+| raw tenant/header/token이 로그로 노출됨 | source/log capture review | production logging 금지, synthetic test trace만 허용 |
+| adapter가 header/auth/routing 정책을 소유 | dependency/source review | filter/plugin을 consumer에 유지하고 adapter API를 carrier 동작으로 제한 |
+| core가 Reactor/Ktor를 transitively 끌어옴 | outgoing dependency/POM audit | 외부 타입 adapter를 별도 artifact로 격리 |
+| 새 module이 자동 등록·Kover·BOM에서 누락 | `projects`, Kover graph, generated POM inventory audit | 기존 auto-registration과 publishable-project predicate 사용 |
+| stale SNAPSHOT으로 workshop이 우연히 성공 | public POM/catalog SHA·timestamp read-back | Projects → Dependencies → consumers 순서와 immutable handoff receipt 고정 |
+| local enum과 공통 TenantId 변환에서 의미가 바뀜 | migration parity test | normalization/existence mapping은 application boundary에 유지 |
+
+## 검증 순서
+
+구현 plan에서 정확한 task 존재를 다시 확인한 뒤 다음 순서로 검증한다.
+
+```bash
+./gradlew :bluetape4k-tenant:test \
+  :bluetape4k-tenant-reactor:test \
+  :bluetape4k-ktor-tenant:test \
+  --no-daemon --no-configuration-cache --no-build-cache
+
+./gradlew :bluetape4k-tenant:check \
+  :bluetape4k-tenant-reactor:check \
+  :bluetape4k-ktor-tenant:check \
+  --no-daemon --no-configuration-cache --no-build-cache
+
+./gradlew projects --no-daemon --no-configuration-cache --no-build-cache
+
+./gradlew -p buildSrc test \
+  --no-daemon --no-configuration-cache --no-build-cache
+
+./gradlew :bluetape4k-bom:generatePomFileForBluetape4kPublication \
+  :bluetape4k-bom:generateMetadataFileForBluetape4kPublication \
+  -PsnapshotVersion=-SNAPSHOT \
+  --no-daemon --no-configuration-cache --no-build-cache
+
+ruby scripts/publication/validate_poms.rb
+ruby scripts/publication/validate_module_metadata.rb
+git diff --check
+```
+
+repository-wide `detekt`, disabled-test gate, CI path filter, root README generation/audit와
+SNAPSHOT workflow policy 검사는 implementation plan에서 module addition hazard로 배정한다.
+Testcontainers나 Docker는 세 Projects module unit test에 필요하지 않는다. workshop의 기존
+database fixture는 각 저장소 규칙에 따라 순차 실행한다.
+
+## 수용 기준
+
+- [ ] 세 artifact가 정확한 project path와 dependency direction으로 자동 등록된다.
+- [ ] public API가 모든 carrier에서 `currentOrNull`/`requireCurrent`의 no-default 의미를
+      유지하고, JDK/Reactor는 `withTenant`, Ktor는 one-call/one-tenant `bindTenant`를
+      제공한다.
+- [ ] ThreadLocal 동일-thread 순차 요청, nested, downstream exception 뒤 누수가 없다.
+- [ ] JDK 25 ScopedValue가 dynamic scope와 nested 복원을 보장한다.
+- [ ] Reactor interleave/nested/cancel과 Ktor dispatcher/duplicate/concurrent/new-call fixture가
+      통과한다.
+- [ ] core artifact POM에 Reactor/Ktor/Servlet/Spring 의존성이 없다.
+- [ ] root/module README와 KDoc이 lifecycle, unsupported boundary, JDK 25를 설명한다.
+- [ ] generated BOM/POM/module metadata가 세 artifact를 포함한다.
+- [ ] 공개 `bluetape4k-bom:2.0.0-SNAPSHOT`에 세 constraint가 존재한다.
+- [ ] 공개 `bluetape4k-dependencies:2.0.0-SNAPSHOT` catalog/aggregator가 세 alias를 제공한다.
+- [ ] 두 workshop reference consumer가 실제 SNAPSHOT artifact로 기존 acceptance를 통과한다.
+- [ ] #1552의 남은 ThreadLocal/Servlet/virtual-thread proof와 #1320의 production consumer
+      acceptance가 live issue에 reconciliation된다.
+
+## DoD
+
+- [ ] spec과 implementation plan이 독립 6-perspective review에서 P0=0/P1=0이다.
+- [ ] TDD RED/GREEN 증거와 module별 fresh test count를 기록한다.
+- [ ] module registration, detekt, Kover, README, CI, publication metadata hazard가 모두
+      PASS 또는 근거 있는 N/A다.
+- [ ] Projects PR은 exact head와 required CI를 확인하고 fresh merge 승인 전에는 병합하지
+      않는다.
+- [ ] 두 SNAPSHOT dispatch는 각각 최신 workflow/target/credential/hold를 확인한 뒤에만
+      실행한다.
+- [ ] Dependencies와 두 workshop PR도 base/head/CI/review를 독립적으로 검증한다.
+- [ ] stable release는 실행하지 않는다.
+- [ ] #1562, #1552, #1320과 세 cross-repo child issue의 live 상태를 acceptance evidence와
+      맞춰 closeout한다.
+
+## 추적성
+
+| 요구 | 설계 위치 | 검증 증거 |
+| --- | --- | --- |
+| no-default core | core API 계약 | missing/blank/require test |
+| MVC ThreadLocal 누수 방지 | application 경계, core test | same-thread·nested·exception fixture |
+| JDK 25 virtual thread | core API, 비목표 | ScopedValue dynamic-scope fixture |
+| WebFlux Reactor | Reactor adapter 계약 | interleave·nested·cancel fixture |
+| Ktor call context | Ktor adapter 계약 | dispatcher·duplicate·concurrent·new-call fixture |
+| auth/routing application ownership | application 경계 | consumer source review·parity test |
+| BOM SNAPSHOT | SNAPSHOT publish gate | public BOM POM constraint read-back |
+| central catalog | delivery DAG | Dependencies generated catalog와 public SNAPSHOT |
+| independent consumers | reference consumer | exposed-workshop #255, r2dbc #215 CI/test evidence |
+| Epic closeout | 수용 기준·DoD | #1552/#1320 live reconciliation comment |
+
+## source ledger
+
+- 2026-08-28 live GitHub: #1320, #1552, #1553, #1562와 cross-repo #213/#255/#215
+- Projects `develop`: `18472064c594ab2dee835cff6695cd6ef9538ea5`
+- Dependencies `develop`: `df64293753a9491b337852a158f89d4a93a1734a`
+- exposed-workshop `develop`: `2728f0543a8077e3b6ced4fbc384d45a21471dea`
+- exposed-r2dbc-workshop `develop`: `a32f9cd47a33dfc857baf32e9e8f53d4534570b2`
+- PR #214 merge SHA: `a32f9cd47a33dfc857baf32e9e8f53d4534570b2`
+- Projects source: `settings.gradle.kts`, root Java 21 compatibility list,
+  `bluetape4k/bom/build.gradle.kts`, `TaskContext`, Reactor/Ktor context examples
+- Workshop source: MVC ThreadLocal/ScopedValue context와 filter, Reactor/Ktor deterministic fixture
+- public SNAPSHOT metadata: `bluetape4k-bom:2.0.0-SNAPSHOT`와
+  `bluetape4k-dependencies:2.0.0-SNAPSHOT`; 현재 BOM에는 tenant constraint 없음
+
+## 독립 검토 결과
+
+| 관점 | 1차 결과 | 반영 결과 |
+| --- | --- | --- |
+| 성능·retention | P0=0, P1=0, P2=3 | singleton·subscription당 1회 binding·10,000 task/60초와 retention evidence를 고정했다. |
+| 안정성 | P0=0, P1=3, P2=2 | Ktor one-call 원자성, 공통 예외/API, coroutine 비보장, immutable SNAPSHOT receipt를 고정했다. |
+| 보안 | P0=0, P1=2, P2=3 | canonicalization·인증·인가 순서, HTTP 상태, duplicate binding, 민감 값 비기록을 고정했다. |
+| 개발자 API | P0=0, P1=1, P2=5 | `TenantId` 검증, carrier 생성·identity, Ktor private holder, 공통 예외, dependency/검증 명령을 고정했다. |
+| 운영·release | P0=0, P1=4, P2=3 | exact-head CI/publish, append-only receipt schema, resolved checksum, rollback manifest, 운영 owner를 고정했다. |
+| 사용자·caller | P0=0, P1=3, P2=3, P3=1 | 정확한 block 호출, carrier 선택표, application mapping 예시, README 좌표와 용어를 고정했다. |
+
+모든 1차 P1과 actionable P2/P3를 본문에 반영했다. main integration readback 결과는
+P0=0/P1=0이며 유예한 finding은 없다. 보안·안정성·성능 재검토 lane은 수정본 검토를 시작했으나
+5분 command deadline 안에 결과를 반환하지 못해 회수했으며, 이를 finding closure 증거로
+사용하지 않는다.
+
+## 작성·검토 게이트
+
+- SPW-01 source ledger: live issue/branch SHA, Projects module/publish source, 네 consumer와
+  deterministic fixture를 확인했다.
+- SPW-02 spec structure: 문제, 목표, 비목표, 대안, 선택, API, lifecycle, migration,
+  failure mode, test, SNAPSHOT DAG, acceptance와 DoD를 포함한다.
+- SPW-03 Korean naturalness: reader-facing prose는 한국어로 쓰고 API, artifact, 명령,
+  URL과 exact identifier는 원문을 보존한다.
+- SPW-04 traceability: #1562 수용 기준과 cross-repo handoff를 설계·검증 표로 연결했다.
+- SPW-05 readback: 독립 review 수정 뒤 전체 파일을 다시 읽고 placeholder, stale SHA,
+  unchecked 설계 결정과 SNAPSHOT 순서 모순이 없는지 확인한다.

--- a/docs/superpowers/specs/2026-08-28-issue-1562-tenant-context-design.md
+++ b/docs/superpowers/specs/2026-08-28-issue-1562-tenant-context-design.md
@@ -460,9 +460,9 @@ upstream 수정은 새 merge SHA와 새 timestamped SNAPSHOT receipt를 만들�
 
 - 세 module에 `bluetape4k/tenant/README{,.ko}.md`,
   `bluetape4k/tenant-reactor/README{,.ko}.md`, `ktor/tenant/README{,.ko}.md`를 두고 정확한
-  group `io.bluetape4k`, version `2.0.0-SNAPSHOT`, JDK 25 requirement, no-default,
+  group `io.github.bluetape4k`, version `2.0.0-SNAPSHOT`, JDK 25 requirement, no-default,
   lifecycle, unsupported boundary, 최소 사용 예제를 맞춘다.
-- 각 README는 `platform("io.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT")`과 해당 artifact
+- 각 README는 `platform("io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT")`과 해당 artifact
   `bluetape4k-tenant`, `bluetape4k-tenant-reactor`, `bluetape4k-ktor-tenant`의 Gradle Kotlin
   DSL 및 Maven 예시를 제공한다. SNAPSHOT 소비 예시는 Maven Central snapshots repository와
   changing-module cache 정책이 필요하다는 조건을 함께 표시한다.

--- a/docs/superpowers/specs/2026-08-28-issue-1562-tenant-context-design.md
+++ b/docs/superpowers/specs/2026-08-28-issue-1562-tenant-context-design.md
@@ -379,7 +379,7 @@ PR read-back으로 다시 확인한다.
 
 handoff receipt의 schema는 `bluetape.snapshot-handoff/v1`로 고정하고 publish workflow가
 `tenant-context-handoff.json`을 생성한다. 필수 필드는 `repository`, `merge_sha`,
-`verified_ci_run_id`, `publication_run_id`, `group`, `artifact`, `base_version`, `timestamp`,
+`verified_ci_run_id`, `publication_run_id`, `handoff_issue_number`, `group`, `artifact`, `base_version`, `timestamp`,
 `build_number`, `last_updated`, `resources[{url,sha256}]`, `catalog_commit_sha`, `created_at`,
 `status`다. 적용되지 않는 `catalog_commit_sha`는 `null`이고 `status`는 최초 `verified`,
 실패한 downstream이 있으면 새 append-only receipt의 `supersedes`로 연결해 `rejected`로

--- a/ktor/tenant/README.ko.md
+++ b/ktor/tenant/README.ko.md
@@ -1,0 +1,55 @@
+# bluetape4k-ktor-tenant
+
+[English](./README.md) | [한국어](./README.ko.md)
+
+Ktor `ApplicationCall.attributes`에 canonical `TenantId`를 one-call/one-tenant로 binding하는
+JDK 25 adapter입니다. plugin, 인증, header parsing, HTTP status mapping은 application이 소유합니다.
+
+## 의존성과 SNAPSHOT repository
+
+```kotlin
+repositories { maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/"); mavenContent { snapshotsOnly() } } }
+configurations.configureEach { resolutionStrategy.cacheChangingModulesFor(0, "seconds") }
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT"))
+    implementation("io.github.bluetape4k:bluetape4k-ktor-tenant:2.0.0-SNAPSHOT") { isChanging = true }
+}
+```
+
+```xml
+<repositories><repository><id>central-snapshots</id><url>https://central.sonatype.com/repository/maven-snapshots/</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots></repository></repositories>
+<dependencyManagement><dependencies><dependency><groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-bom</artifactId><version>2.0.0-SNAPSHOT</version><type>pom</type><scope>import</scope></dependency></dependencies></dependencyManagement>
+<dependencies><dependency><groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-ktor-tenant</artifactId><version>2.0.0-SNAPSHOT</version></dependency></dependencies>
+```
+
+## 사용법과 수명주기
+
+application plugin 또는 인증 pipeline이 raw header/token을 검증하고 canonical domain 값으로
+매핑한 뒤 request pipeline 초기에 정확히 한 번 binding합니다.
+
+```kotlin
+enum class ClinicTenant(val tenantId: TenantId) { CLINIC_A(TenantId("clinic-a")) }
+
+val tenant = authenticateAndResolveClinic(call.request).tenantId
+KtorTenantContext.bindTenant(call, tenant)
+service.find(KtorTenantContext.requireCurrent(call))
+```
+
+dispatcher hop에서도 같은 `ApplicationCall`을 전달하면 값이 유지됩니다. 두 번째 또는 동시
+binding은 `TenantAlreadyBoundException("Tenant context is already bound to this call")`으로
+실패하며 winner를 덮어쓰지 않습니다. call이 request-local owner이므로 exception/cancellation
+종료 후 global cleanup이나 registry가 필요하지 않고 새 call은 unbound입니다. missing context는
+공통 `MissingTenantContextException`으로 실패하며 default/fallback은 없습니다.
+
+raw header, token, tenant 값은 log, exception, MDC, metric tag에 기록하지 않습니다. synthetic
+fixture만 값을 출력할 수 있습니다. optional
+`tenant_context_binding_failures_total{carrier,stage}`는 enum label과 기존 correlation/trace ID만
+사용합니다. 5분 내 한 건도 wiring alert이며 workshop maintainer와 SNAPSHOT train release
+coordinator가 확인합니다.
+
+## 비지원 경계
+
+- application plugin, tenant 인증·인가·존재 확인, header parsing
+- HTTP response/status mapping과 duplicate binding 복구
+- nested rebind, mutable clear API, default tenant, global registry
+- raw tenant 값 observability

--- a/ktor/tenant/README.md
+++ b/ktor/tenant/README.md
@@ -1,0 +1,54 @@
+# bluetape4k-ktor-tenant
+
+[English](./README.md) | [한국어](./README.ko.md)
+
+JDK 25 adapter that binds a canonical `TenantId` to Ktor `ApplicationCall.attributes` with a
+one-call/one-tenant contract. The application owns plugins, authentication, header parsing, and HTTP
+status mapping.
+
+## Dependency and snapshot repository
+
+```kotlin
+repositories { maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/"); mavenContent { snapshotsOnly() } } }
+configurations.configureEach { resolutionStrategy.cacheChangingModulesFor(0, "seconds") }
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT"))
+    implementation("io.github.bluetape4k:bluetape4k-ktor-tenant:2.0.0-SNAPSHOT") { isChanging = true }
+}
+```
+
+```xml
+<repositories><repository><id>central-snapshots</id><url>https://central.sonatype.com/repository/maven-snapshots/</url><releases><enabled>false</enabled></releases><snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots></repository></repositories>
+<dependencyManagement><dependencies><dependency><groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-bom</artifactId><version>2.0.0-SNAPSHOT</version><type>pom</type><scope>import</scope></dependency></dependencies></dependencyManagement>
+<dependencies><dependency><groupId>io.github.bluetape4k</groupId><artifactId>bluetape4k-ktor-tenant</artifactId><version>2.0.0-SNAPSHOT</version></dependency></dependencies>
+```
+
+## Usage and lifecycle
+
+An application plugin or authentication pipeline validates raw headers/tokens, maps them to a canonical
+domain value, and binds exactly once near the start of the request pipeline.
+
+```kotlin
+enum class ClinicTenant(val tenantId: TenantId) { CLINIC_A(TenantId("clinic-a")) }
+val tenant = authenticateAndResolveClinic(call.request).tenantId
+KtorTenantContext.bindTenant(call, tenant)
+service.find(KtorTenantContext.requireCurrent(call))
+```
+
+The value survives dispatcher hops when code passes the same `ApplicationCall`. A second or concurrent
+binding throws `TenantAlreadyBoundException("Tenant context is already bound to this call")` without
+overwriting the winner. The request-local call owns the value, so exception/cancellation completion needs
+no global cleanup or registry and a new call is unbound. Missing context throws the common
+`MissingTenantContextException`; there is no default or fallback.
+
+Never put raw headers, tokens, or tenant values in logs, exceptions, MDC, or metric tags. Only synthetic
+fixtures may print values. An optional `tenant_context_binding_failures_total{carrier,stage}` metric uses
+enum-only labels and existing correlation/trace IDs. Any occurrence in five minutes is a wiring alert
+owned by the workshop maintainer and the SNAPSHOT-train release coordinator.
+
+## Unsupported boundaries
+
+- Application plugins, tenant authentication/authorization/existence checks, and header parsing
+- HTTP response/status mapping or duplicate-binding recovery
+- Nested rebind, mutable clear APIs, default tenants, or global registries
+- Observability containing raw tenant values

--- a/ktor/tenant/build.gradle.kts
+++ b/ktor/tenant/build.gradle.kts
@@ -1,0 +1,11 @@
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    api(project(":bluetape4k-tenant"))
+    api(libs.ktor.server.core)
+
+    testImplementation(project(":bluetape4k-junit5"))
+    testImplementation(libs.ktor.server.test.host)
+}

--- a/ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt
+++ b/ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt
@@ -1,0 +1,33 @@
+package io.bluetape4k.ktor.tenant
+
+import io.bluetape4k.tenant.MissingTenantContextException
+import io.bluetape4k.tenant.TenantId
+import io.ktor.server.application.ApplicationCall
+import io.ktor.util.AttributeKey
+
+/** Ktor [ApplicationCall]에 one-call/one-tenant 계약으로 tenant를 binding하고 조회합니다. */
+object KtorTenantContext {
+
+    private const val BINDING_KEY_NAME = "io.bluetape4k.ktor.tenant.binding.v1"
+    private val tenantBindingKey = AttributeKey<TenantBinding>(BINDING_KEY_NAME)
+
+    /** 현재 call의 tenant를 반환하며 binding이 없으면 `null`을 반환합니다. */
+    fun currentOrNull(call: ApplicationCall): TenantId? =
+        call.attributes.getOrNull(tenantBindingKey)?.tenantId
+
+    /** 현재 call의 tenant를 반환하며 binding이 없으면 공통 missing 예외를 던집니다. */
+    fun requireCurrent(call: ApplicationCall): TenantId =
+        currentOrNull(call) ?: throw MissingTenantContextException()
+
+    /** [call]에 [tenantId]를 최초 한 번만 binding합니다. */
+    fun bindTenant(call: ApplicationCall, tenantId: TenantId) {
+        synchronized(call.attributes) {
+            if (tenantBindingKey in call.attributes) {
+                throw TenantAlreadyBoundException()
+            }
+            call.attributes.put(tenantBindingKey, TenantBinding(tenantId))
+        }
+    }
+
+    private data class TenantBinding(val tenantId: TenantId)
+}

--- a/ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/TenantAlreadyBoundException.kt
+++ b/ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/TenantAlreadyBoundException.kt
@@ -1,0 +1,5 @@
+package io.bluetape4k.ktor.tenant
+
+/** 하나의 `ApplicationCall`에 tenant를 두 번 binding하려 할 때 발생합니다. */
+class TenantAlreadyBoundException:
+    IllegalStateException("Tenant context is already bound to this call")

--- a/ktor/tenant/src/test/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContextTest.kt
+++ b/ktor/tenant/src/test/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContextTest.kt
@@ -1,0 +1,228 @@
+package io.bluetape4k.ktor.tenant
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.tenant.MissingTenantContextException
+import io.bluetape4k.tenant.TenantId
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.ktor.util.AttributeKey
+import io.ktor.util.Attributes
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class KtorTenantContextTest {
+
+    @Test
+    fun `unbound call은 공통 missing 예외를 던진다`() {
+        val call = newCall()
+
+        KtorTenantContext.currentOrNull(call).shouldBeNull()
+        val failure = assertFailsWith<MissingTenantContextException> {
+            KtorTenantContext.requireCurrent(call)
+        }
+        failure.message shouldBeEqualTo "Tenant context is not bound"
+    }
+
+    @Test
+    fun `같은 이름의 외부 TenantId key와 충돌하지 않는다`() {
+        val call = newCall()
+        val externalKey = AttributeKey<TenantId>(BINDING_KEY_NAME)
+        val externalTenant = TenantId("external")
+        val boundTenant = TenantId("clinic-a")
+        call.attributes.put(externalKey, externalTenant)
+
+        KtorTenantContext.currentOrNull(call).shouldBeNull()
+        KtorTenantContext.bindTenant(call, boundTenant)
+
+        call.attributes[externalKey] shouldBeEqualTo externalTenant
+        KtorTenantContext.requireCurrent(call) shouldBeEqualTo boundTenant
+    }
+
+    @Test
+    fun `두 번째 binding은 기존 tenant를 덮어쓰지 않는다`() {
+        val call = newCall()
+        KtorTenantContext.bindTenant(call, TenantId("clinic-a"))
+
+        val failure = assertFailsWith<TenantAlreadyBoundException> {
+            KtorTenantContext.bindTenant(call, TenantId("clinic-b"))
+        }
+
+        failure.message shouldBeEqualTo "Tenant context is already bound to this call"
+        KtorTenantContext.requireCurrent(call) shouldBeEqualTo TenantId("clinic-a")
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    fun `동시 binding은 정확히 한 tenant만 선형화한다`() {
+        val executor = Executors.newFixedThreadPool(CONTENDERS)
+
+        try {
+            repeat(CONCURRENT_ROUNDS) { round ->
+                val call = newCall()
+                val start = CyclicBarrier(CONTENDERS)
+                val attempts = (0 until CONTENDERS).map { contender ->
+                    val tenantId = TenantId("round-$round-contender-$contender")
+                    executor.submit(Callable {
+                        start.await(5, TimeUnit.SECONDS)
+                        runCatching {
+                            KtorTenantContext.bindTenant(call, tenantId)
+                            tenantId
+                        }
+                    })
+                }.map { it.get(10, TimeUnit.SECONDS) }
+
+                val winners = attempts.mapNotNull { it.getOrNull() }
+                val failures = attempts.mapNotNull { it.exceptionOrNull() }
+                winners.size shouldBeEqualTo 1
+                failures.size shouldBeEqualTo CONTENDERS - 1
+                failures.all {
+                    it is TenantAlreadyBoundException &&
+                        it.message == "Tenant context is already bound to this call"
+                }.shouldBeTrue()
+                KtorTenantContext.requireCurrent(call) shouldBeEqualTo winners.single()
+            }
+        } finally {
+            shutdown(executor)
+        }
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    fun `dispatcher hop과 exception cancellation 뒤 새 call은 격리된다`() = testApplication {
+        val dispatcherTenant = AtomicReference<TenantId?>()
+        val exceptionTenant = AtomicReference<TenantId?>()
+        val cancellationTenant = AtomicReference<TenantId?>()
+        val newCallTenant = AtomicReference<TenantId?>()
+
+        application {
+            routing {
+                get("/dispatcher") {
+                    KtorTenantContext.bindTenant(call, TenantId("clinic-dispatcher"))
+                    dispatcherTenant.set(withContext(Dispatchers.Default) {
+                        KtorTenantContext.requireCurrent(call)
+                    })
+                    call.respondText("ok")
+                }
+                get("/exception") {
+                    KtorTenantContext.bindTenant(call, TenantId("clinic-exception"))
+                    runCatching {
+                        withContext(Dispatchers.Default) { throw ExpectedFailure() }
+                    }
+                    exceptionTenant.set(KtorTenantContext.requireCurrent(call))
+                    call.respondText("ok")
+                }
+                get("/cancellation") {
+                    KtorTenantContext.bindTenant(call, TenantId("clinic-cancellation"))
+                    launch { awaitCancellation() }.cancelAndJoin()
+                    cancellationTenant.set(KtorTenantContext.requireCurrent(call))
+                    call.respondText("ok")
+                }
+                get("/new-call") {
+                    newCallTenant.set(KtorTenantContext.currentOrNull(call))
+                    call.respondText("ok")
+                }
+            }
+        }
+
+        client.get("/dispatcher").status shouldBeEqualTo HttpStatusCode.OK
+        client.get("/exception").status shouldBeEqualTo HttpStatusCode.OK
+        client.get("/cancellation").status shouldBeEqualTo HttpStatusCode.OK
+        client.get("/new-call").status shouldBeEqualTo HttpStatusCode.OK
+
+        dispatcherTenant.get() shouldBeEqualTo TenantId("clinic-dispatcher")
+        exceptionTenant.get() shouldBeEqualTo TenantId("clinic-exception")
+        cancellationTenant.get() shouldBeEqualTo TenantId("clinic-cancellation")
+        newCallTenant.get().shouldBeNull()
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    fun `cancelled call을 adapter가 보존하지 않는다`() {
+        val probe = createCancelledCallProbe()
+
+        awaitCollection(probe, Duration.ofSeconds(10)).shouldBeTrue()
+    }
+
+    private fun newCall(): ApplicationCall {
+        val attributes = Attributes(concurrent = false)
+        return mockk<ApplicationCall>().also { call ->
+            every { call.attributes } returns attributes
+        }
+    }
+
+    private fun createCancelledCallProbe(): CallRetentionProbe {
+        val queue = ReferenceQueue<ApplicationCall>()
+        var reference: WeakReference<ApplicationCall>? = null
+
+        testApplication {
+            application {
+                routing {
+                    get("/cancel") {
+                        KtorTenantContext.bindTenant(call, TenantId("clinic-cancelled"))
+                        reference = WeakReference(call, queue)
+                        throw java.util.concurrent.CancellationException("cancelled request")
+                    }
+                }
+            }
+            runCatching { client.get("/cancel") }
+        }
+
+        return CallRetentionProbe(checkNotNull(reference), queue)
+    }
+
+    private fun awaitCollection(probe: CallRetentionProbe, timeout: Duration): Boolean {
+        val deadline = System.nanoTime() + timeout.toNanos()
+        while (System.nanoTime() < deadline) {
+            if (probe.queue.poll() === probe.reference || probe.reference.get() == null) {
+                return true
+            }
+            System.gc()
+            ByteArray(1024 * 1024)
+            Thread.sleep(50)
+        }
+        return probe.queue.poll() === probe.reference || probe.reference.get() == null
+    }
+
+    private fun shutdown(executor: ExecutorService) {
+        executor.shutdownNow()
+        executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+    }
+
+    private data class CallRetentionProbe(
+        val reference: WeakReference<ApplicationCall>,
+        val queue: ReferenceQueue<ApplicationCall>,
+    )
+
+    private class ExpectedFailure: RuntimeException()
+
+    companion object {
+        private const val BINDING_KEY_NAME = "io.bluetape4k.ktor.tenant.binding.v1"
+        private const val CONTENDERS = 8
+        private const val CONCURRENT_ROUNDS = 100
+    }
+}

--- a/ktor/tenant/src/test/resources/junit-platform.properties
+++ b/ktor/tenant/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/ktor/tenant/src/test/resources/logback-test.xml
+++ b/ktor/tenant/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.ktor.tenant" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/scripts/create_snapshot_handoff.py
+++ b/scripts/create_snapshot_handoff.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import errno
+import hashlib
+import json
+import re
+import socket
+import ssl
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCHEMA = "bluetape.snapshot-handoff/v1"
+LAST_GOOD_SCHEMA = "bluetape.last-good-manifest/v1"
+DEFAULT_BASE_URL = "https://central.sonatype.com/repository/maven-snapshots"
+SAFE_TOKEN = re.compile(r"^[A-Za-z0-9_.-]+$")
+TRANSIENT_NETWORK_ERRNOS = {
+    errno.ECONNABORTED,
+    errno.ECONNREFUSED,
+    errno.ECONNRESET,
+    errno.EHOSTUNREACH,
+    errno.ENETDOWN,
+    errno.ENETRESET,
+    errno.ENETUNREACH,
+    errno.ETIMEDOUT,
+}
+
+
+class SnapshotHandoffError(RuntimeError):
+    pass
+
+
+class TransientSnapshotHandoffError(SnapshotHandoffError):
+    pass
+
+
+def is_transient_url_error(error: urllib.error.URLError) -> bool:
+    reason = error.reason
+    if isinstance(reason, ssl.SSLError):
+        return False
+    if isinstance(reason, (TimeoutError, socket.timeout, ConnectionError)):
+        return True
+    if isinstance(reason, socket.gaierror):
+        return reason.errno == socket.EAI_AGAIN
+    return isinstance(reason, OSError) and reason.errno in TRANSIENT_NETWORK_ERRNOS
+
+
+def fetch(url: str, timeout: float = 20.0) -> bytes:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            if response.status != 200:
+                raise SnapshotHandoffError(f"HTTP {response.status} for {url}")
+            return response.read()
+    except urllib.error.HTTPError as error:
+        error_type = (
+            TransientSnapshotHandoffError
+            if error.code in {404, 408, 429, 500, 502, 503, 504}
+            else SnapshotHandoffError
+        )
+        raise error_type(f"Failed to fetch {url}: {error}") from error
+    except urllib.error.URLError as error:
+        error_type = (
+            TransientSnapshotHandoffError
+            if is_transient_url_error(error)
+            else SnapshotHandoffError
+        )
+        raise error_type(f"Failed to fetch {url}: {error}") from error
+    except TimeoutError as error:
+        raise TransientSnapshotHandoffError(f"Failed to fetch {url}: {error}") from error
+
+
+def metadata_url(base_url: str, group: str, artifact: str, base_version: str) -> str:
+    group_path = group.replace(".", "/")
+    return (
+        f"{base_url.rstrip('/')}/{group_path}/{artifact}/"
+        f"{base_version}-SNAPSHOT/maven-metadata.xml"
+    )
+
+
+def parse_metadata(
+    document: bytes,
+    expected_group: str,
+    expected_artifact: str,
+    base_version: str,
+) -> dict:
+    try:
+        root = ET.fromstring(document)
+    except ET.ParseError as error:
+        raise SnapshotHandoffError("Invalid Maven metadata XML") from error
+
+    actual = (
+        root.findtext("groupId"),
+        root.findtext("artifactId"),
+        root.findtext("version"),
+    )
+    expected = (expected_group, expected_artifact, f"{base_version}-SNAPSHOT")
+    if actual != expected:
+        raise SnapshotHandoffError(
+            f"Maven metadata coordinate mismatch: expected={expected}, actual={actual}"
+        )
+
+    timestamp = root.findtext("versioning/snapshot/timestamp")
+    build_number = root.findtext("versioning/snapshot/buildNumber")
+    last_updated = root.findtext("versioning/lastUpdated")
+    if not timestamp or not build_number or not last_updated:
+        raise SnapshotHandoffError("Maven metadata is missing snapshot identity fields")
+    if (
+        not re.fullmatch(r"[0-9]{8}\.[0-9]{6}", timestamp)
+        or not re.fullmatch(r"[1-9][0-9]*", build_number)
+        or not re.fullmatch(r"[0-9]{14}", last_updated)
+    ):
+        raise SnapshotHandoffError("Maven metadata has invalid snapshot identity fields")
+
+    versions = {}
+    expected_snapshot_version = f"{base_version}-{timestamp}-{build_number}"
+    for item in root.findall("versioning/snapshotVersions/snapshotVersion"):
+        extension = item.findtext("extension")
+        classifier = item.findtext("classifier") or ""
+        value = item.findtext("value")
+        if extension and value:
+            if value != expected_snapshot_version:
+                raise SnapshotHandoffError(
+                    "Maven metadata snapshot version mismatch: "
+                    f"expected={expected_snapshot_version}, actual={value}"
+                )
+            versions[(extension, classifier)] = value
+
+    return {
+        "group": expected_group,
+        "artifact": expected_artifact,
+        "base_version": base_version,
+        "timestamp": timestamp,
+        "build_number": build_number,
+        "last_updated": last_updated,
+        "versions": versions,
+    }
+
+
+def read_metadata_set(
+    base_url: str,
+    group: str,
+    base_version: str,
+    artifacts: list[str],
+) -> dict[str, dict]:
+    return {
+        artifact: parse_metadata(
+            fetch(metadata_url(base_url, group, artifact, base_version)),
+            group,
+            artifact,
+            base_version,
+        )
+        for artifact in artifacts
+    }
+
+
+def validate_snapshot_identity(metadata_set: dict[str, dict], receipt_artifact: str) -> dict:
+    canonical = metadata_set.get(receipt_artifact)
+    if canonical is None:
+        raise SnapshotHandoffError("Receipt artifact metadata was not requested")
+    identity = (
+        canonical["timestamp"],
+        canonical["build_number"],
+        canonical["last_updated"],
+    )
+    for artifact, item in metadata_set.items():
+        candidate = (item["timestamp"], item["build_number"], item["last_updated"])
+        if candidate != identity:
+            raise SnapshotHandoffError(
+                f"Snapshot metadata identity mismatch for {artifact}: {candidate} != {identity}"
+            )
+    return canonical
+
+
+def resource_url(
+    base_url: str,
+    group: str,
+    artifact: str,
+    base_version: str,
+    timestamped_version: str,
+    extension: str,
+) -> str:
+    group_path = group.replace(".", "/")
+    return (
+        f"{base_url.rstrip('/')}/{group_path}/{artifact}/{base_version}-SNAPSHOT/"
+        f"{artifact}-{timestamped_version}.{extension}"
+    )
+
+
+def fetch_resources(
+    base_url: str,
+    group: str,
+    base_version: str,
+    resource_specs: list[tuple[str, str]],
+    metadata_set: dict[str, dict],
+) -> list[dict]:
+    resources = []
+    for artifact, extension in resource_specs:
+        timestamped_version = metadata_set[artifact]["versions"].get((extension, ""))
+        if not timestamped_version:
+            raise SnapshotHandoffError(
+                f"Maven metadata has no {extension} snapshot version for {artifact}"
+            )
+        url = resource_url(
+            base_url,
+            group,
+            artifact,
+            base_version,
+            timestamped_version,
+            extension,
+        )
+        content = fetch(url)
+        resources.append({"url": url, "sha256": hashlib.sha256(content).hexdigest()})
+    return resources
+
+
+def validate_tokens(group: str, artifact: str, resource_specs: list[tuple[str, str]]) -> None:
+    if not group or any(not SAFE_TOKEN.fullmatch(part) for part in group.split(".")):
+        raise SnapshotHandoffError("Invalid Maven group")
+    tokens = [artifact]
+    tokens.extend(value for spec in resource_specs for value in spec)
+    if any(not SAFE_TOKEN.fullmatch(token) for token in tokens):
+        raise SnapshotHandoffError("Invalid Maven artifact or extension")
+
+
+def write_json(output: Path, value: dict) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def create_verified_receipt(
+    *,
+    repository: str,
+    merge_sha: str,
+    verified_ci_run_id: str,
+    publication_run_id: str,
+    handoff_issue_number: str,
+    base_url: str,
+    group: str,
+    artifact: str,
+    base_version: str,
+    resource_specs: list[tuple[str, str]],
+    output: Path,
+) -> dict:
+    validate_tokens(group, artifact, resource_specs)
+    if not re.fullmatch(r"[0-9a-f]{40}", merge_sha):
+        raise SnapshotHandoffError("merge_sha must be a full lowercase Git SHA")
+    if not verified_ci_run_id.isdigit() or not publication_run_id.isdigit():
+        raise SnapshotHandoffError("workflow run IDs must be numeric")
+    if not handoff_issue_number.isdigit() or int(handoff_issue_number) < 1:
+        raise SnapshotHandoffError("handoff issue number must be positive")
+    if not resource_specs:
+        raise SnapshotHandoffError("At least one resource is required")
+
+    artifacts = list(dict.fromkeys(item[0] for item in resource_specs))
+    first_metadata = read_metadata_set(base_url, group, base_version, artifacts)
+    canonical = validate_snapshot_identity(first_metadata, artifact)
+    first_resources = fetch_resources(
+        base_url, group, base_version, resource_specs, first_metadata
+    )
+
+    second_metadata = read_metadata_set(base_url, group, base_version, artifacts)
+    if second_metadata != first_metadata:
+        raise SnapshotHandoffError("Maven metadata changed during public read-back")
+    validate_snapshot_identity(second_metadata, artifact)
+    second_resources = fetch_resources(
+        base_url, group, base_version, resource_specs, second_metadata
+    )
+    if second_resources != first_resources:
+        raise SnapshotHandoffError("Public resource checksum changed during read-back")
+
+    receipt = {
+        "schema": SCHEMA,
+        "repository": repository,
+        "merge_sha": merge_sha,
+        "verified_ci_run_id": verified_ci_run_id,
+        "publication_run_id": publication_run_id,
+        "handoff_issue_number": handoff_issue_number,
+        "group": group,
+        "artifact": artifact,
+        "base_version": base_version,
+        "timestamp": canonical["timestamp"],
+        "build_number": canonical["build_number"],
+        "last_updated": canonical["last_updated"],
+        "resources": first_resources,
+        "catalog_commit_sha": None,
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "status": "verified",
+        "supersedes": None,
+    }
+    write_json(output, receipt)
+    return receipt
+
+
+def create_rejected_receipt(source: Path, output: Path) -> dict:
+    if source.resolve() == output.resolve():
+        raise SnapshotHandoffError("Rejected receipt must be append-only")
+    original = source.read_bytes()
+    try:
+        receipt = json.loads(original)
+    except json.JSONDecodeError as error:
+        raise SnapshotHandoffError("Invalid source receipt JSON") from error
+    if receipt.get("schema") != SCHEMA or receipt.get("status") != "verified":
+        raise SnapshotHandoffError("Only a verified handoff receipt can be rejected")
+    receipt["status"] = "rejected"
+    receipt["supersedes"] = hashlib.sha256(original).hexdigest()
+    receipt["created_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    write_json(output, receipt)
+    return receipt
+
+
+def create_last_good_manifest(
+    *,
+    receipt_path: Path,
+    catalog_commit_sha: str | None,
+    validation_command: str,
+    validation_run_id: str,
+    output: Path,
+) -> dict:
+    if receipt_path.resolve() == output.resolve():
+        raise SnapshotHandoffError("Last-good manifest must not replace its receipt")
+    if catalog_commit_sha is not None and not re.fullmatch(
+        r"[0-9a-f]{40}", catalog_commit_sha
+    ):
+        raise SnapshotHandoffError("catalog_commit_sha must be a full lowercase Git SHA")
+    if not validation_command.strip() or not validation_run_id.strip():
+        raise SnapshotHandoffError("Validation command and run ID are required")
+
+    original = receipt_path.read_bytes()
+    try:
+        receipt = json.loads(original)
+    except json.JSONDecodeError as error:
+        raise SnapshotHandoffError("Invalid handoff receipt JSON") from error
+
+    required = (
+        "merge_sha",
+        "handoff_issue_number",
+        "group",
+        "artifact",
+        "base_version",
+        "timestamp",
+        "build_number",
+        "last_updated",
+        "resources",
+    )
+    if receipt.get("schema") != SCHEMA or receipt.get("status") != "verified":
+        raise SnapshotHandoffError("Last-good manifest requires a verified handoff receipt")
+    if any(not receipt.get(field) for field in required):
+        raise SnapshotHandoffError("Verified handoff receipt is incomplete")
+    if not re.fullmatch(r"[0-9a-f]{40}", receipt["merge_sha"]):
+        raise SnapshotHandoffError("Verified handoff receipt has an invalid merge SHA")
+
+    manifest = {
+        "schema": LAST_GOOD_SCHEMA,
+        "base_sha": receipt["merge_sha"],
+        "dependency": {
+            "coordinate": (
+                f"{receipt['group']}:{receipt['artifact']}:"
+                f"{receipt['base_version']}-SNAPSHOT"
+            ),
+            "timestamp": receipt["timestamp"],
+            "build_number": receipt["build_number"],
+            "last_updated": receipt["last_updated"],
+        },
+        "resources": receipt["resources"],
+        "catalog_commit_sha": catalog_commit_sha,
+        "validation": {
+            "command": validation_command,
+            "run_id": validation_run_id,
+        },
+        "receipt_sha256": hashlib.sha256(original).hexdigest(),
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    write_json(output, manifest)
+    return manifest
+
+
+def parse_resource(value: str) -> tuple[str, str]:
+    parts = value.split(":")
+    if len(parts) != 2 or not all(parts):
+        raise argparse.ArgumentTypeError("resource must be ARTIFACT:EXTENSION")
+    return parts[0], parts[1]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create an immutable Maven SNAPSHOT handoff receipt."
+    )
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--merge-sha", required=True)
+    parser.add_argument("--verified-ci-run-id", required=True)
+    parser.add_argument("--publication-run-id", required=True)
+    parser.add_argument("--handoff-issue-number", required=True)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--group", required=True)
+    parser.add_argument("--artifact", required=True)
+    parser.add_argument("--base-version", required=True)
+    parser.add_argument("--resource", action="append", type=parse_resource, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    try:
+        receipt = create_verified_receipt(
+            repository=args.repository,
+            merge_sha=args.merge_sha,
+            verified_ci_run_id=args.verified_ci_run_id,
+            publication_run_id=args.publication_run_id,
+            handoff_issue_number=args.handoff_issue_number,
+            base_url=args.base_url,
+            group=args.group,
+            artifact=args.artifact,
+            base_version=args.base_version,
+            resource_specs=args.resource,
+            output=args.output,
+        )
+    except TransientSnapshotHandoffError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 75
+    except SnapshotHandoffError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"timestamp={receipt['timestamp']}")
+    print(f"build_number={receipt['build_number']}")
+    print(f"last_updated={receipt['last_updated']}")
+    print(f"receipt_sha256={hashlib.sha256(args.output.read_bytes()).hexdigest()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_create_snapshot_handoff.py
+++ b/scripts/test_create_snapshot_handoff.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+
+import hashlib
+import importlib.util
+import json
+import ssl
+import tempfile
+import threading
+import unittest
+import urllib.error
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPOSITORY / "scripts" / "create_snapshot_handoff.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("create_snapshot_handoff", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def metadata(artifact: str, timestamp: str = "20260828.123456", build: str = "7") -> bytes:
+    version = f"2.0.0-{timestamp}-{build}"
+    extensions = ("pom",) if artifact == "bluetape4k-bom" else ("pom", "jar")
+    versions = "".join(
+        f"<snapshotVersion><extension>{extension}</extension><value>{version}</value>"
+        f"<updated>20260828123456</updated></snapshotVersion>"
+        for extension in extensions
+    )
+    return (
+        "<metadata><groupId>io.github.bluetape4k</groupId>"
+        f"<artifactId>{artifact}</artifactId><version>2.0.0-SNAPSHOT</version>"
+        "<versioning><snapshot>"
+        f"<timestamp>{timestamp}</timestamp><buildNumber>{build}</buildNumber>"
+        "</snapshot><lastUpdated>20260828123456</lastUpdated>"
+        f"<snapshotVersions>{versions}</snapshotVersions></versioning></metadata>"
+    ).encode()
+
+
+class FixtureServer:
+    def __init__(self, routes: dict[str, list[tuple[int, bytes]]]):
+        self.routes = routes
+        self.counts: dict[str, int] = {}
+
+        fixture = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                responses = fixture.routes.get(self.path, [(404, b"missing")])
+                index = fixture.counts.get(self.path, 0)
+                fixture.counts[self.path] = index + 1
+                status, body = responses[min(index, len(responses) - 1)]
+                self.send_response(status)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, _format, *_args):
+                return
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    @property
+    def base_url(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_args):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+class SnapshotHandoffTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.module = load_module()
+        self.group_path = "/io/github/bluetape4k"
+        self.timestamped = "2.0.0-20260828.123456-7"
+        self.resources = [
+            ("bluetape4k-bom", "pom"),
+            ("bluetape4k-tenant", "pom"),
+            ("bluetape4k-tenant", "jar"),
+        ]
+
+    def routes(self) -> dict[str, list[tuple[int, bytes]]]:
+        routes = {}
+        for artifact in {artifact for artifact, _ in self.resources}:
+            routes[f"{self.group_path}/{artifact}/2.0.0-SNAPSHOT/maven-metadata.xml"] = [
+                (200, metadata(artifact)),
+            ]
+        for artifact, extension in self.resources:
+            path = (
+                f"{self.group_path}/{artifact}/2.0.0-SNAPSHOT/"
+                f"{artifact}-{self.timestamped}.{extension}"
+            )
+            routes[path] = [(200, f"{artifact}:{extension}".encode())]
+        return routes
+
+    def create(self, base_url: str, output: Path):
+        return self.module.create_verified_receipt(
+            repository="bluetape4k/bluetape4k-projects",
+            merge_sha="a" * 40,
+            verified_ci_run_id="1234",
+            publication_run_id="5678",
+            handoff_issue_number="1562",
+            base_url=base_url,
+            group="io.github.bluetape4k",
+            artifact="bluetape4k-bom",
+            base_version="2.0.0",
+            resource_specs=self.resources,
+            output=output,
+        )
+
+    def test_verified_receipt_reads_metadata_and_resources_twice(self) -> None:
+        with tempfile.TemporaryDirectory() as directory, FixtureServer(self.routes()) as fixture:
+            output = Path(directory) / "tenant-context-handoff.json"
+            receipt = self.create(fixture.base_url, output)
+
+            self.assertEqual("bluetape.snapshot-handoff/v1", receipt["schema"])
+            self.assertEqual("verified", receipt["status"])
+            self.assertIsNone(receipt["catalog_commit_sha"])
+            self.assertIsNone(receipt["supersedes"])
+            self.assertEqual("20260828.123456", receipt["timestamp"])
+            self.assertEqual("7", receipt["build_number"])
+            self.assertEqual("20260828123456", receipt["last_updated"])
+            self.assertEqual("1562", receipt["handoff_issue_number"])
+            self.assertEqual(3, len(receipt["resources"]))
+            self.assertEqual(receipt, json.loads(output.read_text(encoding="utf-8")))
+            self.assertTrue(all(len(item["sha256"]) == 64 for item in receipt["resources"]))
+            self.assertTrue(all(count == 2 for count in fixture.counts.values()))
+
+    def test_missing_metadata_fails_closed(self) -> None:
+        routes = self.routes()
+        metadata_path = f"{self.group_path}/bluetape4k-bom/2.0.0-SNAPSHOT/maven-metadata.xml"
+        routes[metadata_path] = [(404, b"missing")]
+        with tempfile.TemporaryDirectory() as directory, FixtureServer(routes) as fixture:
+            with self.assertRaises(self.module.TransientSnapshotHandoffError):
+                self.create(fixture.base_url, Path(directory) / "receipt.json")
+
+    def test_missing_resource_fails_closed(self) -> None:
+        routes = self.routes()
+        resource_path = (
+            f"{self.group_path}/bluetape4k-tenant/2.0.0-SNAPSHOT/"
+            f"bluetape4k-tenant-{self.timestamped}.jar"
+        )
+        routes[resource_path] = [(404, b"missing")]
+        with tempfile.TemporaryDirectory() as directory, FixtureServer(routes) as fixture:
+            with self.assertRaises(self.module.TransientSnapshotHandoffError):
+                self.create(fixture.base_url, Path(directory) / "receipt.json")
+
+    def test_resource_checksum_mutation_fails_closed(self) -> None:
+        routes = self.routes()
+        resource_path = (
+            f"{self.group_path}/bluetape4k-tenant/2.0.0-SNAPSHOT/"
+            f"bluetape4k-tenant-{self.timestamped}.pom"
+        )
+        routes[resource_path] = [(200, b"first"), (200, b"second")]
+        with tempfile.TemporaryDirectory() as directory, FixtureServer(routes) as fixture:
+            with self.assertRaisesRegex(self.module.SnapshotHandoffError, "checksum changed"):
+                self.create(fixture.base_url, Path(directory) / "receipt.json")
+
+    def test_metadata_mutation_during_readback_fails_closed(self) -> None:
+        routes = self.routes()
+        metadata_path = f"{self.group_path}/bluetape4k-bom/2.0.0-SNAPSHOT/maven-metadata.xml"
+        routes[metadata_path] = [
+            (200, metadata("bluetape4k-bom")),
+            (200, metadata("bluetape4k-bom", timestamp="20260828.123500", build="8")),
+        ]
+        with tempfile.TemporaryDirectory() as directory, FixtureServer(routes) as fixture:
+            with self.assertRaisesRegex(self.module.SnapshotHandoffError, "metadata changed"):
+                self.create(fixture.base_url, Path(directory) / "receipt.json")
+
+    def test_wrong_group_or_artifact_metadata_fails_closed(self) -> None:
+        routes = self.routes()
+        metadata_path = f"{self.group_path}/bluetape4k-tenant/2.0.0-SNAPSHOT/maven-metadata.xml"
+        routes[metadata_path] = [
+            (200, metadata("wrong-artifact")),
+        ]
+        with tempfile.TemporaryDirectory() as directory, FixtureServer(routes) as fixture:
+            with self.assertRaisesRegex(self.module.SnapshotHandoffError, "coordinate mismatch"):
+                self.create(fixture.base_url, Path(directory) / "receipt.json")
+
+    def test_metadata_identity_rejects_control_or_path_characters(self) -> None:
+        fixtures = (
+            (b"20260828.123456", b"20260828/123456"),
+            (b"<buildNumber>7</buildNumber>", b"<buildNumber>7\n8</buildNumber>"),
+            (b"20260828123456", b"2026082812345/"),
+        )
+        for original, replacement in fixtures:
+            with self.subTest(replacement=replacement):
+                document = metadata("bluetape4k-bom").replace(original, replacement)
+                with self.assertRaisesRegex(
+                    self.module.SnapshotHandoffError, "invalid snapshot identity"
+                ):
+                    self.module.parse_metadata(
+                        document,
+                        "io.github.bluetape4k",
+                        "bluetape4k-bom",
+                        "2.0.0",
+                    )
+
+    def test_snapshot_version_value_must_match_metadata_identity(self) -> None:
+        document = metadata("bluetape4k-bom").replace(
+            b"2.0.0-20260828.123456-7",
+            b"2.0.0-20260828.123456-8",
+        )
+        with self.assertRaisesRegex(self.module.SnapshotHandoffError, "version mismatch"):
+            self.module.parse_metadata(
+                document,
+                "io.github.bluetape4k",
+                "bluetape4k-bom",
+                "2.0.0",
+            )
+
+    def test_tls_verification_failure_is_permanent(self) -> None:
+        error = urllib.error.URLError(ssl.SSLCertVerificationError("invalid certificate"))
+        with patch.object(self.module.urllib.request, "urlopen", side_effect=error):
+            with self.assertRaises(self.module.SnapshotHandoffError) as raised:
+                self.module.fetch("https://central.example.invalid/resource")
+        self.assertNotIsInstance(
+            raised.exception, self.module.TransientSnapshotHandoffError
+        )
+
+    def test_connection_failure_is_transient(self) -> None:
+        error = urllib.error.URLError(ConnectionResetError("connection reset"))
+        with patch.object(self.module.urllib.request, "urlopen", side_effect=error):
+            with self.assertRaises(self.module.TransientSnapshotHandoffError):
+                self.module.fetch("https://central.example.invalid/resource")
+
+    def test_rejected_receipt_is_append_only_and_links_source_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "verified.json"
+            source.write_text('{"schema":"bluetape.snapshot-handoff/v1","status":"verified"}\n')
+            original = source.read_bytes()
+            rejected = Path(directory) / "rejected.json"
+
+            receipt = self.module.create_rejected_receipt(source, rejected)
+
+            self.assertEqual(original, source.read_bytes())
+            self.assertEqual("rejected", receipt["status"])
+            self.assertEqual(hashlib.sha256(original).hexdigest(), receipt["supersedes"])
+            self.assertNotEqual(source, rejected)
+
+    def test_last_good_manifest_pins_receipt_identity_and_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory, FixtureServer(self.routes()) as fixture:
+            root = Path(directory)
+            handoff = root / "tenant-context-handoff.json"
+            receipt = self.create(fixture.base_url, handoff)
+            manifest_path = root / "last-good-manifest.json"
+
+            manifest = self.module.create_last_good_manifest(
+                receipt_path=handoff,
+                catalog_commit_sha=None,
+                validation_command="./gradlew test --refresh-dependencies",
+                validation_run_id="local-tenant-consumer",
+                output=manifest_path,
+            )
+
+            self.assertEqual("bluetape.last-good-manifest/v1", manifest["schema"])
+            self.assertEqual(receipt["merge_sha"], manifest["base_sha"])
+            self.assertEqual(
+                "io.github.bluetape4k:bluetape4k-bom:2.0.0-SNAPSHOT",
+                manifest["dependency"]["coordinate"],
+            )
+            self.assertEqual(receipt["timestamp"], manifest["dependency"]["timestamp"])
+            self.assertEqual(receipt["build_number"], manifest["dependency"]["build_number"])
+            self.assertEqual(receipt["resources"], manifest["resources"])
+            self.assertIsNone(manifest["catalog_commit_sha"])
+            self.assertEqual(manifest, json.loads(manifest_path.read_text(encoding="utf-8")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -84,6 +84,7 @@ RELEASE_PUBLICATION_COMMAND = (
 )
 SNAPSHOT_PUBLICATION_COMMAND = (
     "      - name: Publish SNAPSHOT\n"
+    "        timeout-minutes: 25\n"
     "        run: >-\n"
     "          ./gradlew nmcpPublishAggregationToCentralPortalSnapshots\n"
     "          -PsnapshotVersion=-SNAPSHOT\n"
@@ -95,8 +96,9 @@ SNAPSHOT_PUBLICATION_COMMAND = (
 
 def expected_run_contract(step: str) -> tuple[str, tuple[str, ...]]:
     lines = step.splitlines()
-    style = lines[1].split("run:", 1)[1].strip()
-    return style, tuple(line[10:] for line in lines[2:])
+    run_index = next(index for index, line in enumerate(lines) if "run:" in line)
+    style = lines[run_index].split("run:", 1)[1].strip()
+    return style, tuple(line[10:] for line in lines[run_index + 1 :])
 
 
 PUBLICATION_VALIDATION_RUNS = tuple(
@@ -463,8 +465,8 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
         errors.append("snapshot workflow must not contain release or issue-specific machinery")
     if "contents: write" in workflow:
         errors.append("snapshot workflow must not request write access to repository contents")
-    if job_ids(workflow) != {"validate-full-nightly", "publish"}:
-        errors.append("snapshot workflow must contain validation and publish jobs")
+    if job_ids(workflow) != {"validate-full-nightly", "publish", "record-handoff"}:
+        errors.append("snapshot workflow must separate validation, publication, and issue recording")
     errors.extend(
         publication_validation_errors(
             workflow, "publish", SNAPSHOT_PUBLISH_JOB_IF
@@ -472,6 +474,54 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
     )
     if not snapshot_command_valid:
         errors.append("snapshot publication must disable the configuration cache")
+    if "workflow_run:" in workflow or "github.event.workflow_run" in workflow:
+        errors.append("snapshot workflow must not have an automatic workflow_run trigger")
+    if "workflow_dispatch:" not in workflow:
+        errors.append("snapshot workflow must be manually dispatched")
+    for required_input in (
+        "verified_ci_run_id",
+        "expected_head_sha",
+        "handoff_issue_number",
+    ):
+        marker = f"      {required_input}:\n"
+        if marker not in workflow:
+            errors.append(f"snapshot workflow must require {required_input}")
+            continue
+        input_tail = workflow.split(marker, 1)[1]
+        next_input = re.search(r"\n      \S", input_tail)
+        input_block = input_tail[: next_input.start()] if next_input else input_tail
+        if "        required: true" not in input_block:
+            errors.append(f"snapshot workflow must require {required_input}")
+    workflow_permissions = workflow.split("\njobs:\n", 1)[0]
+    if "issues: write" in workflow_permissions:
+        errors.append("snapshot workflow must not grant issue write permission globally")
+    if "record-handoff:" not in workflow or "issues: write" not in workflow:
+        errors.append("snapshot handoff job must request issue comment permission")
+    if "actions/upload-artifact@v7" not in workflow or "retention-days: 90" not in workflow:
+        errors.append("snapshot workflow must retain the immutable handoff artifact for 90 days")
+    if "create_snapshot_handoff.py" not in workflow:
+        errors.append("snapshot workflow must create a public metadata handoff receipt")
+    if "gh issue comment" not in workflow:
+        errors.append("snapshot workflow must record handoff evidence on the linked issue")
+    if "environment: maven-central-release" not in workflow:
+        errors.append("snapshot publication must use the protected Maven Central environment")
+    if "GITHUB_REF" not in workflow or "refs/heads/develop" not in workflow:
+        errors.append("snapshot workflow must reject a dispatch ref other than develop")
+    if 'if [ "$HANDOFF_ISSUE_NUMBER" -ne 1562 ]' not in workflow:
+        errors.append("snapshot workflow must pin the TenantContext handoff issue")
+    if "nightly_matrix_contract.json?ref=${validation_head_sha}" not in workflow:
+        errors.append("snapshot workflow must load the exact-head Nightly matrix contract")
+    if "validate_nightly_matrix.py?ref=${validation_head_sha}" not in workflow:
+        errors.append("snapshot workflow must load the exact-head Nightly validator")
+    if 'receipt_status="$?"' not in workflow or 'if [ "$receipt_status" -ne 75 ]' not in workflow:
+        errors.append("snapshot workflow must retry only transient public read-back failures")
+    for receipt_field in (
+        ".repository", ".merge_sha", ".verified_ci_run_id", ".publication_run_id",
+        ".handoff_issue_number", ".group",
+        ".artifact", ".base_version", ".resources",
+    ):
+        if receipt_field not in workflow:
+            errors.append(f"snapshot workflow must verify receipt field {receipt_field}")
     return errors
 
 
@@ -964,11 +1014,13 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
             "needs.validate-full-nightly.outputs.publish_eligible == 'true'",
             workflow,
         )
-        self.assertIn('validation_run_id:', workflow)
+        self.assertIn('verified_ci_run_id:', workflow)
+        self.assertIn('expected_head_sha:', workflow)
+        self.assertIn('handoff_issue_number:', workflow)
         self.assertIn("required: true", workflow)
         self.assertIn("gh api", workflow)
-        self.assertIn("actions/runs/${validation_run_id}", workflow)
-        self.assertIn("actions/runs/${validation_run_id}/jobs", workflow)
+        self.assertIn("actions/runs/${VERIFIED_CI_RUN_ID}", workflow)
+        self.assertIn("actions/runs/${VERIFIED_CI_RUN_ID}/jobs", workflow)
         self.assertIn(
             "contents/scripts/nightly_matrix_contract.json?ref=${validation_head_sha}",
             workflow,
@@ -1068,6 +1120,92 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
         self.assertEqual("a" * 40, head_sha)
         self.assertEqual([], errors)
 
+    def test_nightly_matrix_validation_rejects_run_identity_mismatches(self) -> None:
+        contract = self._nightly_matrix_contract()
+        jobs = [
+            *({"name": name, "conclusion": "success"} for name in REQUIRED_JOB_NAMES),
+            *self._successful_matrix_jobs(),
+        ]
+        base_run = {
+            "status": "completed",
+            "conclusion": "success",
+            "path": ".github/workflows/nightly-tests.yml",
+            "head_branch": "develop",
+            "head_sha": "a" * 40,
+        }
+        fixtures = (
+            ("path", {**base_run, "path": ".github/workflows/ci.yml"}, "run is not Nightly"),
+            ("conclusion", {**base_run, "conclusion": "failure"}, "run did not succeed"),
+            ("head", {**base_run, "head_sha": "b" * 40}, "head SHA mismatch"),
+        )
+
+        for name, run, expected_error in fixtures:
+            with self.subTest(name=name):
+                _, errors = validation_errors(run, jobs, "a" * 40, contract)
+                self.assertIn(expected_error, errors)
+
+    def test_snapshot_workflow_is_manual_only_and_has_no_automatic_fallback(self) -> None:
+        workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
+
+        self.assertNotIn("workflow_run:", workflow)
+        self.assertNotIn("github.event.workflow_run", workflow)
+        self.assertEqual([], snapshot_policy_errors(workflow))
+
+        automatic = workflow.replace(
+            "  workflow_dispatch:",
+            '  workflow_run:\n    workflows: ["Nightly"]\n    types: [completed]\n  workflow_dispatch:',
+        )
+        fallback = workflow + "\n# github.event.workflow_run.head_sha\n"
+        self.assertIn(
+            "snapshot workflow must not have an automatic workflow_run trigger",
+            snapshot_policy_errors(automatic),
+        )
+        self.assertIn(
+            "snapshot workflow must not have an automatic workflow_run trigger",
+            snapshot_policy_errors(fallback),
+        )
+
+    def test_snapshot_validation_pins_ci_head_and_current_develop_ref(self) -> None:
+        workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
+        validator = (REPOSITORY / "scripts" / "validate_nightly_matrix.py").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("EXPECTED_HEAD_SHA", workflow)
+        self.assertIn("git/ref/heads/develop", workflow)
+        self.assertIn("run.get(\"path\")", validator)
+        self.assertIn("run.get(\"status\")", validator)
+        self.assertIn("run.get(\"conclusion\")", validator)
+        self.assertIn("run.get(\"head_sha\", \"\")", validator)
+        self.assertIn("develop_sha", workflow)
+        self.assertIn("environment: maven-central-release", workflow)
+        self.assertIn('GITHUB_REF: ${{ github.ref }}', workflow)
+        self.assertIn('GITHUB_SHA: ${{ github.sha }}', workflow)
+
+    def test_snapshot_receipt_is_immutable_and_linked_to_issue(self) -> None:
+        workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
+
+        self.assertIn("bluetape.snapshot-handoff/v1", workflow)
+        self.assertIn("tenant-context-handoff-${", workflow)
+        self.assertIn("actions/upload-artifact@v7", workflow)
+        self.assertIn("retention-days: 90", workflow)
+        self.assertIn("artifact-id", workflow)
+        self.assertIn("artifact-digest", workflow)
+        self.assertIn("gh issue comment", workflow)
+        self.assertIn("issues: write", workflow)
+        self.assertNotIn("issues: write", workflow.split("\njobs:\n", 1)[0])
+        self.assertIn("record-handoff:", workflow)
+        self.assertIn('--handoff-issue-number "$HANDOFF_ISSUE_NUMBER"', workflow)
+        self.assertIn('receipt_status="$?"', workflow)
+        self.assertIn('if [ "$receipt_status" -ne 75 ]', workflow)
+        for expression in (
+            '.repository == $repository', '.merge_sha == $merge_sha',
+            '.verified_ci_run_id == $verified_ci_run_id',
+            '.publication_run_id == $publication_run_id',
+            '.group == "io.github.bluetape4k"', '.artifact == "bluetape4k-bom"',
+            '.base_version == "2.0.0"', '.resources | length == 7',
+        ):
+            self.assertIn(expression, workflow)
     def test_snapshot_checkout_uses_validated_nightly_head(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 요약

JDK 25 전용 공통 `TenantId`/`TenantContext`와 framework별 carrier adapter를 제공합니다. MVC platform thread에는 lexical `ThreadLocal`, virtual thread에는 `ScopedValue`, reactive 경계에는 Reactor `Context`, Ktor 요청에는 `ApplicationCall` attribute를 사용합니다.

## 변경 내용

- `bluetape4k-tenant`: no-default API, 공통 missing 예외, `ThreadLocalTenantContext`, `ScopedValueTenantContext`
- `bluetape4k-tenant-reactor`: private key 기반 immutable Reactor `Context` adapter
- `bluetape4k-ktor-tenant`: one-call/one-tenant Ktor attribute adapter
- 세 artifact의 bilingual README, root module inventory, CI/Nightly/Kover wiring
- #1565에서 복구된 exact-head Nightly 검증·manual SNAPSHOT workflow와 immutable public read-back receipt를 신규 TenantContext artifact에 연결
- bounded retention stress, workflow/publication policy, 6관점 review와 lesson

## 검증

- targeted JUnit: core 17, Reactor 6, Ktor 6 — 합계 29, failures/errors/skipped=0
- retention stress JUnit: 2, failures/errors/skipped=0
- workflow/receipt policy와 handoff fixture: 52 tests, failures/errors/skipped=0
- `./gradlew projects`: 세 새 모듈 자동 등록 확인
- publication POM: 79 files, 32,847 dependencies, failures=0
- publication module metadata: 79 files, 163 variants, 1,522 dependencies, failures=0
- `actionlint`, `py_compile`, `git diff --check`: 성공
- exact-head PR CI attempt 2: [33227582587](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33227582587) — 25개 job과 `Coverage Report`/`CI Status` 성공, head `1fabbf864215d90931311eb68a52ac4700d4c8b2`
- 최초 CI attempt 1에서 기존 `LettuceJCacheTest.invoke serializes read modify write across cache instances()`가 `StatusOutput does not support set(long)`로 실패했으나, 동일 head 재실행에서 통과

## 연관 이슈

- Refs #1562
- Epic: #1320
- fixture gate: #1552
- ownership 설계: #1553
- publication gate: #1565 (merged: `3e2781d03087a8cdc464498c65d1bf7578196314`)
- downstream dependency: bluetape4k-dependencies#213
- reference consumer: exposed-workshop#255, exposed-r2dbc-workshop#215

## 알려진 잔여 조건

- `maven-central-release` environment 보호 규칙·secret scope와 공개 SNAPSHOT 실행은 별도 운영 게이트입니다.
- downstream catalog와 두 workshop consumer는 실제 `2.0.0-SNAPSHOT` handoff 이후 검증합니다.
- exact-head 리뷰는 0건이며, fresh gate 검증 후 merge commit `08d451e6f48ad326c13ee1d01e1ddd8ba855f3fa`로 병합되었습니다.

## DoD Status

- 구현·rebase·로컬 검증: `DONE`
- PR exact-head CI: `DONE` — run [33227582587](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33227582587), attempt 2, head `1fabbf864215d90931311eb68a52ac4700d4c8b2`
- 리뷰·mergeability: `DONE` — 리뷰 0건/스레드 0건, `MERGEABLE`, `CLEAN`
- Maven Central SNAPSHOT 및 downstream consumer: `PENDING` — 운영 handoff 이후 검증
- 병합: `DONE` — merge commit `08d451e6f48ad326c13ee1d01e1ddd8ba855f3fa`

