### PR TITLE
Maven SNAPSHOT handoff가 artifact별 build number를 허용하도록 수정

### DIFF
--- a/scripts/create_snapshot_handoff.py
+++ b/scripts/create_snapshot_handoff.py
@@ -166,14 +166,17 @@ def validate_snapshot_identity(metadata_set: dict[str, dict], receipt_artifact: 
         raise SnapshotHandoffError("Receipt artifact metadata was not requested")
     identity = (
         canonical["timestamp"],
-        canonical["build_number"],
         canonical["last_updated"],
     )
     for artifact, item in metadata_set.items():
-        candidate = (item["timestamp"], item["build_number"], item["last_updated"])
+        # Maven Central은 artifact별로 SNAPSHOT build number를 독립적으로 부여한다.
+        # receipt identity는 BOM에 두고, 각 resource URL은 artifact별
+        # timestamp/build-number 조합으로 고정한다.
+        candidate = (item["timestamp"], item["last_updated"])
         if candidate != identity:
             raise SnapshotHandoffError(
-                f"Snapshot metadata identity mismatch for {artifact}: {candidate} != {identity}"
+                "Snapshot publication timestamp mismatch for "
+                f"{artifact}: {candidate} != {identity}"
             )
     return canonical
 

--- a/scripts/test_create_snapshot_handoff.py
+++ b/scripts/test_create_snapshot_handoff.py
@@ -141,6 +141,30 @@ class SnapshotHandoffTest(unittest.TestCase):
             self.assertTrue(all(len(item["sha256"]) == 64 for item in receipt["resources"]))
             self.assertTrue(all(count == 2 for count in fixture.counts.values()))
 
+    def test_verified_receipt_allows_artifact_specific_build_numbers(self) -> None:
+        routes = self.routes()
+        tenant_metadata_path = (
+            f"{self.group_path}/bluetape4k-tenant/2.0.0-SNAPSHOT/maven-metadata.xml"
+        )
+        routes[tenant_metadata_path] = [(200, metadata("bluetape4k-tenant", build="1"))]
+        tenant_resource_path = (
+            f"{self.group_path}/bluetape4k-tenant/2.0.0-SNAPSHOT/"
+            f"bluetape4k-tenant-2.0.0-20260828.123456-1.jar"
+        )
+        routes[tenant_resource_path] = [(200, b"bluetape4k-tenant:jar-build-1")]
+        tenant_pom_path = (
+            f"{self.group_path}/bluetape4k-tenant/2.0.0-SNAPSHOT/"
+            f"bluetape4k-tenant-2.0.0-20260828.123456-1.pom"
+        )
+        routes[tenant_pom_path] = [(200, b"bluetape4k-tenant:pom-build-1")]
+        with tempfile.TemporaryDirectory() as directory, FixtureServer(routes) as fixture:
+            output = Path(directory) / "tenant-context-handoff.json"
+            receipt = self.create(fixture.base_url, output)
+
+            self.assertEqual("20260828.123456", receipt["timestamp"])
+            self.assertEqual("7", receipt["build_number"])
+            self.assertEqual(3, len(receipt["resources"]))
+
     def test_missing_metadata_fails_closed(self) -> None:
         routes = self.routes()
         metadata_path = f"{self.group_path}/bluetape4k-bom/2.0.0-SNAPSHOT/maven-metadata.xml"
@@ -181,6 +205,26 @@ class SnapshotHandoffTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory, FixtureServer(routes) as fixture:
             with self.assertRaisesRegex(self.module.SnapshotHandoffError, "metadata changed"):
                 self.create(fixture.base_url, Path(directory) / "receipt.json")
+
+    def test_artifact_publication_timestamp_mismatch_fails_closed(self) -> None:
+        metadata_set = {
+            "bluetape4k-bom": self.module.parse_metadata(
+                metadata("bluetape4k-bom"),
+                "io.github.bluetape4k",
+                "bluetape4k-bom",
+                "2.0.0",
+            ),
+            "bluetape4k-tenant": self.module.parse_metadata(
+                metadata("bluetape4k-tenant", timestamp="20260828.123457"),
+                "io.github.bluetape4k",
+                "bluetape4k-tenant",
+                "2.0.0",
+            ),
+        }
+        with self.assertRaisesRegex(
+            self.module.SnapshotHandoffError, "publication timestamp mismatch"
+        ):
+            self.module.validate_snapshot_identity(metadata_set, "bluetape4k-bom")
 
     def test_wrong_group_or_artifact_metadata_fails_closed(self) -> None:
         routes = self.routes()


### PR DESCRIPTION
## 변경 목적

Refs #1562

Maven Central은 SNAPSHOT metadata의 buildNumber를 artifact별로 독립 부여합니다. 기존 handoff 검증기는 모든 artifact가 동일한 buildNumber를 가져야 한다고 가정해, bluetape4k-bom=14와 신규 Tenant artifact=1이 함께 게시된 정상 상태를 영구 실패로 판정했습니다.

이번 변경은 BOM을 receipt의 canonical identity로 유지하면서 각 resource URL이 artifact별 timestamp/buildNumber를 사용하도록 검증 범위를 바로잡습니다. artifact 간 timestamp/lastUpdated 불일치는 계속 fail-closed로 거부합니다.

## 검증

- RED: artifact별 buildNumber fixture가 기존 identity mismatch로 실패함을 확인
- GREEN: artifact별 build number 허용 및 timestamp 불일치 거부 테스트 추가
- python3 -m unittest scripts.test_create_snapshot_handoff scripts.test_release_workflow_policy — 54개 통과
- 실제 Maven Central 2.0.0-SNAPSHOT read-back — BOM 14, Tenant/Reactor/Ktor 1, 7개 resource 및 SHA-256 receipt 생성 성공
- python3 -m py_compile ..., git diff --check 통과
- 실패했던 publish run: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33240708605

## 영향 범위

- scripts/create_snapshot_handoff.py
- scripts/test_create_snapshot_handoff.py
- 새 dependency 또는 runtime API 변경 없음

## DoD Status

- [x] artifact별 Maven Central SNAPSHOT build number를 정상 처리
- [x] resource URL은 각 artifact metadata의 timestamped version에 고정
- [x] artifact 간 publication timestamp 불일치는 계속 차단
- [x] 자동화 테스트 및 실제 Central read-back 증거 확보
- [ ] exact-head PR CI 및 후속 Publish Snapshot handoff 재실행
