### PR TITLE
Nightly image gate를 4개 shard로 병렬화한다

### DIFF
--- a/.github/scripts/test-ci-domain-parallelization.py
+++ b/.github/scripts/test-ci-domain-parallelization.py
@@ -277,10 +277,12 @@ class CiDomainParallelizationTest(unittest.TestCase):
         nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
         image_gate = job_block(nightly, "test-testcontainers-image-gate")
         self.assertIn(
-            "if: ${{ needs.plan.outputs.scope == 'full' }}",
+            "needs.plan.outputs.scope == 'full'",
             image_gate,
         )
-        self.assertIn("--scope full", image_gate)
+        shard_gate = job_block(nightly, "test-testcontainers-image-gate-shard")
+        self.assertIn("--scope full", shard_gate)
+        self.assertIn("max-parallel: 4", shard_gate)
         self.assertIn("test-testcontainers:", nightly)
         self.assertIn("test-testcontainers-spring:", nightly)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         run: python3 -m unittest scripts/test_testcontainers_image_gate.py -v
       - name: Verify Testcontainers image-gate runner contract
         run: python3 -m unittest scripts/test_run_testcontainers_image_gate.py -v
+      - name: Verify Testcontainers image-gate aggregate contract
+        run: python3 -m unittest scripts/test_aggregate_testcontainers_image_gate.py -v
       - name: Verify compiled classfile contract
         run: ./scripts/check-jvm-release-contract.sh
 
@@ -171,6 +173,8 @@ jobs:
               - 'scripts/validate-ci-*.rb'
               - 'scripts/run_testcontainers_image_gate.py'
               - 'scripts/test_run_testcontainers_image_gate.py'
+              - 'scripts/aggregate_testcontainers_image_gate.py'
+              - 'scripts/test_aggregate_testcontainers_image_gate.py'
               - 'scripts/testcontainers_image_gate.py'
               - 'scripts/testcontainers_image_gate_manifest.json'
             core:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1214,12 +1214,17 @@ jobs:
           retention-days: 14
 
   # ── Testcontainers image startup/workload gate — full Nightly 전용 ────────
-  test-testcontainers-image-gate:
-    name: Test / Testcontainers image startup-workload gate
+  test-testcontainers-image-gate-shard:
+    name: Test / Testcontainers image startup-workload gate shard ${{ matrix.shard }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 360
+    timeout-minutes: 180
     needs: [build, plan]
     if: ${{ needs.plan.outputs.scope == 'full' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        shard: [0, 1, 2, 3]
     env:
       TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -1246,39 +1251,38 @@ jobs:
       - name: Build mock-webflux-server Docker image
         run: ./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache
 
-      - name: Run full image family gate sequentially
+      - name: Run image family gate shard sequentially
         env:
           DOCKER_AUTH_CONFIG: ${{ secrets.TESTCONTAINERS_DOCKER_AUTH_CONFIG }}
         run: >-
           python3 scripts/run_testcontainers_image_gate.py
           --scope full
+          --shard-index ${{ matrix.shard }}
+          --shard-count 4
           --report-dir build/reports/testcontainers-image-gate
           --default-platform-id amd64
           --max-attempts 1
           --pull-timeout-seconds 60
           --timeout-minutes 4
           --diagnostic-timeout-seconds 30
-          --job-budget-minutes 360
+          --job-budget-minutes 120
 
-      - name: Verify nightly image gate summary
+      - name: Verify image gate shard summary
         if: always()
         run: |
           python3 - <<'PY'
           import json
           from pathlib import Path
-          from scripts.run_testcontainers_image_gate import verify_release_summary
 
           summary = json.loads(Path("build/reports/testcontainers-image-gate/summary.json").read_text(encoding="utf-8"))
-          errors = verify_release_summary(
-              summary,
-              expected_coverage="48/48",
-              platform_id="amd64",
-              expected_tag="2.18.0",
-              expected_architecture="amd64",
-              report_dir=Path("build/reports/testcontainers-image-gate"),
-          )
-          if errors:
-              raise SystemExit("; ".join(errors))
+          expected_index = int("${{ matrix.shard }}")
+          shard = summary.get("shard")
+          if summary.get("schema_version") != 2 or summary.get("scope") != "full":
+              raise SystemExit("invalid image-gate shard summary")
+          if not isinstance(shard, dict) or shard.get("index") != expected_index or shard.get("count") != 4:
+              raise SystemExit("image-gate shard identity mismatch")
+          if summary.get("selected", 0) <= 0 or summary.get("status") != "success":
+              raise SystemExit("image-gate shard is incomplete or failed")
           PY
 
       - name: Publish image gate summary
@@ -1297,6 +1301,92 @@ jobs:
           python3 - <<'PY'
           import shutil
           from pathlib import Path
+          from scripts.testcontainers_image_gate import load_manifest, select_shard_entries
+
+          report = Path("build/reports/testcontainers-image-gate")
+          stage = Path("build/reports/testcontainers-image-gate-artifact")
+
+          selected = select_shard_entries(
+              load_manifest(),
+              shard_index=int("${{ matrix.shard }}"),
+              shard_count=4,
+          )
+          names = [f"{entry['id']}.json" for entry in selected]
+          names.extend(("summary.json", "summary.md"))
+          for name in names:
+              source = report / name
+              if source.is_symlink() or not source.is_file():
+                  raise SystemExit(f"missing exact image-gate artifact: {source}")
+              shutil.copy2(source, stage / name)
+          PY
+
+      - name: Upload image gate evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-testcontainers-image-gate-${{ github.run_id }}-amd64-shard-${{ matrix.shard }}
+          path: |
+            build/reports/testcontainers-image-gate-artifact
+          if-no-files-found: error
+          retention-days: 14
+
+  # Keep one canonical job/artifact for publication validators while executing
+  # the release-required manifest in four independent amd64 shards above.
+  test-testcontainers-image-gate:
+    name: Test / Testcontainers image startup-workload gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: [build, plan, test-testcontainers-image-gate-shard]
+    if: ${{ always() && needs.plan.outputs.scope == 'full' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Download image gate shard evidence
+        if: always()
+        uses: actions/download-artifact@v8
+        with:
+          pattern: nightly-testcontainers-image-gate-${{ github.run_id }}-amd64-shard-*
+          path: shard-artifacts
+          merge-multiple: false
+
+      - name: Aggregate and verify image gate evidence
+        if: always()
+        env:
+          SHARD_RESULT: ${{ needs.test-testcontainers-image-gate-shard.result }}
+        run: |
+          set +e
+          python3 scripts/aggregate_testcontainers_image_gate.py \
+            --input-dir shard-artifacts \
+            --output-dir build/reports/testcontainers-image-gate \
+            --manifest scripts/testcontainers_image_gate_manifest.json \
+            --expected-shards 4 \
+            --platform-id amd64 \
+            --expected-tag 2.18.0 \
+            --expected-architecture amd64
+          aggregate_exit=$?
+          set -e
+          test "$SHARD_RESULT" = success
+          test "$aggregate_exit" -eq 0
+
+      - name: Publish aggregate image gate summary
+        if: always()
+        run: |
+          if [ -f build/reports/testcontainers-image-gate/summary.md ]; then
+            cat build/reports/testcontainers-image-gate/summary.md
+          fi
+
+      - name: Stage exact aggregate image gate evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p build/reports/testcontainers-image-gate-artifact
+          python3 - <<'PY'
+          import shutil
+          from pathlib import Path
           from scripts.testcontainers_image_gate import load_manifest
 
           report = Path("build/reports/testcontainers-image-gate")
@@ -1310,7 +1400,7 @@ jobs:
               shutil.copy2(source, stage / name)
           PY
 
-      - name: Upload image gate evidence
+      - name: Upload aggregate image gate evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:

--- a/scripts/aggregate_testcontainers_image_gate.py
+++ b/scripts/aggregate_testcontainers_image_gate.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Aggregate fail-closed Testcontainers image-gate shard evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from collections.abc import Iterable, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from scripts.run_testcontainers_image_gate import verify_release_summary
+from scripts.testcontainers_image_gate import (
+    MANIFEST,
+    load_manifest,
+    validate_manifest,
+)
+
+
+class AggregationError(ValueError):
+    """Raised when shard evidence cannot form one canonical release summary."""
+
+
+def _manifest_digest(manifest_path: Path) -> str:
+    return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+
+def _metadata(summary: dict[str, Any], key: str) -> str:
+    value = summary.get(key)
+    if not isinstance(value, str) or not value:
+        raise AggregationError(f"shard summary is missing {key}")
+    return value
+
+
+def aggregate_summaries(
+    shard_summaries: Iterable[dict[str, Any]],
+    manifest_entries: Sequence[dict[str, Any]],
+    *,
+    expected_shard_count: int,
+    expected_manifest_digest: str | None = None,
+) -> dict[str, Any]:
+    """Merge shard summaries while rejecting overlap, omission, and drift."""
+
+    if expected_shard_count < 1:
+        raise AggregationError("expected shard count must be positive")
+    expected_by_id = {str(entry["id"]): entry for entry in manifest_entries}
+    if len(expected_by_id) != len(manifest_entries):
+        raise AggregationError("manifest contains duplicate family ids")
+
+    summaries = list(shard_summaries)
+    if len(summaries) != expected_shard_count:
+        raise AggregationError(
+            f"expected {expected_shard_count} shard summaries, found {len(summaries)}"
+        )
+
+    seen_shards: set[int] = set()
+    results_by_id: dict[str, dict[str, Any]] = {}
+    platforms: list[dict[str, Any]] = []
+    shard_rows: list[dict[str, Any]] = []
+    shared_metadata: dict[str, str] | None = None
+
+    for summary in summaries:
+        if summary.get("schema_version") != 2:
+            raise AggregationError("shard summary schema_version must be 2")
+        if summary.get("scope") != "full":
+            raise AggregationError("shard summary scope must be full")
+        shard = summary.get("shard")
+        if not isinstance(shard, dict):
+            raise AggregationError("shard identity is required")
+        index = shard.get("index")
+        count = shard.get("count")
+        if (
+            not isinstance(index, int)
+            or isinstance(index, bool)
+            or not isinstance(count, int)
+            or isinstance(count, bool)
+            or count != expected_shard_count
+            or index < 0
+            or index >= expected_shard_count
+        ):
+            raise AggregationError("invalid shard identity")
+        if index in seen_shards:
+            raise AggregationError(f"duplicate shard index: {index}")
+        seen_shards.add(index)
+
+        metadata = {
+            key: _metadata(summary, key)
+            for key in ("manifest_digest", "workflow_run_id", "commit", "ref")
+        }
+        if (
+            expected_manifest_digest is not None
+            and metadata["manifest_digest"] != expected_manifest_digest
+        ):
+            raise AggregationError("manifest digest mismatch")
+        if shared_metadata is None:
+            shared_metadata = metadata
+        elif metadata != shared_metadata:
+            raise AggregationError("shard metadata mismatch")
+
+        results = summary.get("results")
+        if not isinstance(results, list) or not results:
+            raise AggregationError(f"shard {index} has no family results")
+        family_ids = shard.get("family_ids")
+        result_ids = [
+            result.get("id") for result in results if isinstance(result, dict)
+        ]
+        if family_ids != result_ids:
+            raise AggregationError(
+                f"shard {index} family identity does not match results"
+            )
+        for result in results:
+            if not isinstance(result, dict):
+                raise AggregationError(f"shard {index} contains a non-object result")
+            family_id = result.get("id")
+            if not isinstance(family_id, str) or family_id not in expected_by_id:
+                raise AggregationError(f"unknown family id: {family_id}")
+            if family_id in results_by_id:
+                raise AggregationError(f"duplicate family id: {family_id}")
+            expected_release = bool(expected_by_id[family_id].get("releaseRequired"))
+            if result.get("release_required") is not expected_release:
+                raise AggregationError(f"releaseRequired drift: {family_id}")
+            results_by_id[family_id] = result
+
+        allowed_statuses = (
+            "success",
+            "product_failure",
+            "infrastructure_failure",
+            "blocked",
+        )
+        if any(result.get("status") not in allowed_statuses for result in results):
+            raise AggregationError(f"shard {index} contains an unknown result status")
+        shard_counts = {
+            status: sum(result.get("status") == status for result in results)
+            for status in allowed_statuses
+        }
+        release_results = [
+            result for result in results if result.get("release_required") is True
+        ]
+        release_success = sum(
+            result.get("status") == "success" for result in release_results
+        )
+        expected_summary = {
+            "selected": len(results),
+            "success": shard_counts["success"],
+            "product_failure": shard_counts["product_failure"],
+            "infrastructure_failure": shard_counts["infrastructure_failure"],
+            "blocked": shard_counts["blocked"],
+            "coverage": f"{release_success}/{len(release_results)}",
+            "release_coverage": f"{release_success}/{len(release_results)}",
+            "selected_coverage": f"{shard_counts['success']}/{len(results)}",
+            "release_required_selected": len(release_results),
+            "release_required_success": release_success,
+            "release_gate": bool(release_results)
+            and release_success == len(release_results),
+            "status": "success"
+            if shard_counts["success"] == len(results)
+            else "failed",
+        }
+        for key, expected in expected_summary.items():
+            if summary.get(key) != expected:
+                raise AggregationError(f"shard {index} counter mismatch: {key}")
+
+        shard_platforms = summary.get("platforms")
+        if not isinstance(shard_platforms, list):
+            raise AggregationError(f"shard {index} platforms must be a list")
+        if not all(isinstance(item, dict) for item in shard_platforms):
+            raise AggregationError(f"shard {index} contains an invalid platform record")
+        platforms.extend(shard_platforms)
+        shard_rows.append(
+            {
+                "index": index,
+                "count": count,
+                "family_ids": list(result_ids),
+            }
+        )
+
+    missing_shards = set(range(expected_shard_count)) - seen_shards
+    if missing_shards:
+        values = ", ".join(str(index) for index in sorted(missing_shards))
+        raise AggregationError(f"missing shard indexes: {values}")
+    missing_ids = set(expected_by_id) - set(results_by_id)
+    if missing_ids:
+        raise AggregationError(f"missing family ids: {', '.join(sorted(missing_ids))}")
+
+    ordered_results = [results_by_id[str(entry["id"])] for entry in manifest_entries]
+    counts = {
+        status: sum(result.get("status") == status for result in ordered_results)
+        for status in (
+            "success",
+            "product_failure",
+            "infrastructure_failure",
+            "blocked",
+        )
+    }
+    release_results = [
+        result for result in ordered_results if result.get("release_required") is True
+    ]
+    release_success = sum(
+        result.get("status") == "success" for result in release_results
+    )
+    selected = len(ordered_results)
+    release_selected = len(release_results)
+    if shared_metadata is None:
+        raise AggregationError("no shard metadata found")
+    return {
+        "schema_version": 2,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "manifest_digest": shared_metadata["manifest_digest"],
+        "workflow_run_id": shared_metadata["workflow_run_id"],
+        "commit": shared_metadata["commit"],
+        "ref": shared_metadata["ref"],
+        "scope": "full",
+        "selected": selected,
+        "success": counts["success"],
+        "product_failure": counts["product_failure"],
+        "infrastructure_failure": counts["infrastructure_failure"],
+        "blocked": counts["blocked"],
+        "coverage": f"{release_success}/{release_selected}",
+        "release_coverage": f"{release_success}/{release_selected}",
+        "selected_coverage": f"{counts['success']}/{selected}",
+        "release_required_selected": release_selected,
+        "release_required_success": release_success,
+        "release_gate": release_selected > 0 and release_success == release_selected,
+        "status": "success"
+        if selected > 0 and counts["success"] == selected
+        else "failed",
+        "results": ordered_results,
+        "platforms": platforms,
+        "shards": sorted(shard_rows, key=lambda item: item["index"]),
+    }
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise AggregationError(f"invalid JSON: {path}") from error
+    if not isinstance(value, dict):
+        raise AggregationError(f"JSON object required: {path}")
+    return value
+
+
+def _regular(path: Path) -> bool:
+    return path.is_file() and not path.is_symlink()
+
+
+def _write_markdown(path: Path, summary: dict[str, Any]) -> None:
+    lines = [
+        "# Testcontainers image gate",
+        "",
+        f"- 상태: `{summary['status']}`",
+        f"- release 증거 coverage: `{summary['coverage']}`",
+        f"- 전체 선택/성공: `{summary['selected_coverage']}`",
+        f"- 제품 실패: `{summary['product_failure']}`",
+        f"- 인프라 실패: `{summary['infrastructure_failure']}`",
+        f"- 차단: `{summary['blocked']}`",
+        f"- stable release gate: `{str(summary['release_gate']).lower()}`",
+        f"- manifest digest: `{summary['manifest_digest']}`",
+        "",
+        "| family | image | tag | status | attempts |",
+        "|---|---|---|---|---:|",
+    ]
+    lines.extend(
+        f"| `{result.get('server', result.get('id'))}` | `{result.get('image', '')}` | "
+        f"`{result.get('tag', '')}` | `{result.get('status')}` | "
+        f"{len(result.get('attempts', []))} |"
+        for result in summary["results"]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def aggregate_reports(
+    input_dir: Path,
+    output_dir: Path,
+    *,
+    manifest_path: Path = MANIFEST,
+    expected_shard_count: int,
+    platform_id: str,
+    expected_tag: str,
+    expected_architecture: str,
+) -> dict[str, Any]:
+    """Load shard artifacts, create canonical artifacts, and verify the release gate."""
+
+    manifest_entries = load_manifest(manifest_path)
+    errors = validate_manifest(manifest_entries, REPOSITORY_ROOT)
+    if errors:
+        raise AggregationError("manifest contract drift: " + "; ".join(errors))
+    if not input_dir.is_dir() or input_dir.is_symlink():
+        raise AggregationError(f"shard artifact directory is missing: {input_dir}")
+    shard_dirs = [
+        path
+        for path in sorted(input_dir.iterdir())
+        if path.is_dir() and not path.is_symlink()
+    ]
+    if len(shard_dirs) != expected_shard_count:
+        raise AggregationError(
+            f"expected {expected_shard_count} shard artifact directories, found {len(shard_dirs)}"
+        )
+
+    shard_summaries: list[dict[str, Any]] = []
+    family_sources: dict[str, Path] = {}
+    expected_ids = {str(entry["id"]) for entry in manifest_entries}
+    for shard_dir in shard_dirs:
+        summary_path = shard_dir / "summary.json"
+        if not _regular(summary_path):
+            raise AggregationError(f"missing shard summary: {summary_path}")
+        summary = _load_json(summary_path)
+        shard_summaries.append(summary)
+        results = summary.get("results")
+        if not isinstance(results, list):
+            raise AggregationError(f"shard results must be a list: {summary_path}")
+        for result in results:
+            if not isinstance(result, dict):
+                raise AggregationError(
+                    f"shard result must be an object: {summary_path}"
+                )
+            family_id = result.get("id")
+            if family_id not in expected_ids:
+                raise AggregationError(f"unknown family artifact: {family_id}")
+            source = shard_dir / f"{family_id}.json"
+            if not _regular(source):
+                raise AggregationError(f"missing family artifact: {source}")
+            payload = _load_json(source)
+            if payload.get("id") != family_id:
+                raise AggregationError(f"family artifact identity mismatch: {source}")
+            if payload.get("status") != result.get("status"):
+                raise AggregationError(f"family artifact status mismatch: {source}")
+            if family_id in family_sources:
+                raise AggregationError(f"duplicate family artifact: {family_id}")
+            family_sources[family_id] = source
+
+    summary = aggregate_summaries(
+        shard_summaries,
+        manifest_entries,
+        expected_shard_count=expected_shard_count,
+        expected_manifest_digest=_manifest_digest(manifest_path),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if any(output_dir.iterdir()):
+        raise AggregationError(f"aggregate output directory is not empty: {output_dir}")
+    for entry in manifest_entries:
+        family_id = str(entry["id"])
+        source = family_sources.get(family_id)
+        if source is None:
+            raise AggregationError(f"missing family ids: {family_id}")
+        shutil.copy2(source, output_dir / source.name)
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    _write_markdown(output_dir / "summary.md", summary)
+
+    expected_release_count = sum(
+        bool(entry.get("releaseRequired")) for entry in manifest_entries
+    )
+    verification_errors = verify_release_summary(
+        summary,
+        expected_coverage=f"{expected_release_count}/{expected_release_count}",
+        platform_id=platform_id,
+        expected_tag=expected_tag,
+        expected_architecture=expected_architecture,
+        report_dir=output_dir,
+    )
+    if verification_errors:
+        raise AggregationError("; ".join(verification_errors))
+    return summary
+
+
+def _write_blocked_summary(
+    output_dir: Path, errors: Sequence[str], manifest_path: Path
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "schema_version": 2,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "manifest_digest": _manifest_digest(manifest_path)
+        if manifest_path.is_file()
+        else "",
+        "workflow_run_id": "local",
+        "commit": "local",
+        "ref": "local",
+        "scope": "full",
+        "selected": 0,
+        "success": 0,
+        "product_failure": 0,
+        "infrastructure_failure": 0,
+        "blocked": 1,
+        "coverage": "0/0",
+        "release_coverage": "0/0",
+        "selected_coverage": "0/0",
+        "release_required_selected": 0,
+        "release_required_success": 0,
+        "release_gate": False,
+        "status": "blocked",
+        "errors": list(errors),
+        "results": [],
+        "platforms": [],
+        "shards": [],
+    }
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    _write_markdown(output_dir / "summary.md", summary)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, default=MANIFEST)
+    parser.add_argument("--expected-shards", type=int, required=True)
+    parser.add_argument("--platform-id", default="amd64")
+    parser.add_argument("--expected-tag", default="2.18.0")
+    parser.add_argument("--expected-architecture", default="amd64")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        summary = aggregate_reports(
+            args.input_dir,
+            args.output_dir,
+            manifest_path=args.manifest,
+            expected_shard_count=args.expected_shards,
+            platform_id=args.platform_id,
+            expected_tag=args.expected_tag,
+            expected_architecture=args.expected_architecture,
+        )
+    except (AggregationError, OSError, ValueError) as error:
+        _write_blocked_summary(args.output_dir, [str(error)], args.manifest)
+        print(f"BLOCKED: {error}", file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                key: summary[key]
+                for key in (
+                    "status",
+                    "coverage",
+                    "selected_coverage",
+                    "product_failure",
+                    "infrastructure_failure",
+                    "blocked",
+                    "release_gate",
+                )
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -34,6 +34,7 @@ from scripts.testcontainers_image_gate import (
     load_manifest,
     platform_for_entry,
     select_entries,
+    select_shard_entries,
     validate_manifest,
 )
 
@@ -503,7 +504,16 @@ class GateRunner:
         workflow_run_id: str | None = None,
         commit: str | None = None,
         ref: str | None = None,
+        shard_index: int | None = None,
+        shard_count: int | None = None,
     ) -> None:
+        if (shard_index is None) != (shard_count is None):
+            raise ValueError("shard index and count must be provided together")
+        if shard_index is not None and shard_count is not None:
+            if shard_count < 1:
+                raise ValueError("shard count must be positive")
+            if shard_index < 0 or shard_index >= shard_count:
+                raise ValueError("shard index must be within shard count")
         self.entries = [dict(entry) for entry in entries]
         self.report_dir = report_dir
         self.command_runner = command_runner
@@ -518,6 +528,8 @@ class GateRunner:
         self.workflow_run_id = workflow_run_id or os.environ.get("GITHUB_RUN_ID", "local")
         self.commit = commit or os.environ.get("GITHUB_SHA", "local")
         self.ref = ref or os.environ.get("GITHUB_REF", "local")
+        self.shard_index = shard_index
+        self.shard_count = shard_count
         self.manifest_digest = self._digest(manifest_path)
         self._staging_root: Path | None = None
         self._elapsed_seconds = 0.0
@@ -1359,6 +1371,12 @@ class GateRunner:
                 for result in results
             ],
         }
+        if self.shard_index is not None and self.shard_count is not None:
+            summary["shard"] = {
+                "index": self.shard_index,
+                "count": self.shard_count,
+                "family_ids": [result.get("id") for result in results],
+            }
         summary_text = json.dumps(summary, ensure_ascii=False, indent=2) + "\n"
         if len(summary_text.encode("utf-8")) > MAX_SUMMARY_BYTES:
             summary["status"] = "blocked"
@@ -1451,6 +1469,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--timeout-minutes", type=int, default=30)
     parser.add_argument("--diagnostic-timeout-seconds", type=int, default=30)
     parser.add_argument("--job-budget-minutes", type=int)
+    parser.add_argument("--shard-index", type=int)
+    parser.add_argument("--shard-count", type=int)
     return parser.parse_args(argv)
 
 
@@ -1484,6 +1504,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             require_selection=args.require_selection,
             default_platform_id=args.default_platform_id,
         )
+        if args.shard_index is not None or args.shard_count is not None:
+            if args.scope != "full":
+                raise SelectionError("shards require full scope")
+            if args.shard_index is None or args.shard_count is None:
+                raise SelectionError("shard index and count must be provided together")
+            selected = select_shard_entries(
+                selected,
+                shard_index=args.shard_index,
+                shard_count=args.shard_count,
+            )
     except (ValueError, SelectionError) as error:
         _blocked_summary(args.report_dir, [str(error)], args.manifest)
         print(f"BLOCKED: {error}", file=sys.stderr)
@@ -1500,6 +1530,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             diagnostic_timeout_seconds=args.diagnostic_timeout_seconds,
             job_budget_minutes=args.job_budget_minutes,
             scope=args.scope,
+            shard_index=args.shard_index,
+            shard_count=args.shard_count,
         ).run()
     except (OSError, RuntimeError, ValueError) as error:
         _blocked_summary(args.report_dir, [str(error)], args.manifest)

--- a/scripts/test_aggregate_testcontainers_image_gate.py
+++ b/scripts/test_aggregate_testcontainers_image_gate.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Unit tests for the Nightly image-gate shard aggregate contract."""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts.aggregate_testcontainers_image_gate import (
+    AggregationError,
+    aggregate_summaries,
+)
+
+
+def _result(family_id: str, *, release_required: bool = True) -> dict[str, object]:
+    return {
+        "id": family_id,
+        "server": f"{family_id.title()}Server",
+        "release_required": release_required,
+        "status": "success",
+        "attempts": [],
+    }
+
+
+def _summary(
+    index: int, results: list[dict[str, object]], *, count: int = 2
+) -> dict[str, object]:
+    release_results = [
+        result for result in results if result.get("release_required") is True
+    ]
+    release_success = sum(
+        result.get("status") == "success" for result in release_results
+    )
+    success = sum(result.get("status") == "success" for result in results)
+    product_failure = sum(
+        result.get("status") == "product_failure" for result in results
+    )
+    infrastructure_failure = sum(
+        result.get("status") == "infrastructure_failure" for result in results
+    )
+    blocked = sum(result.get("status") == "blocked" for result in results)
+    return {
+        "schema_version": 2,
+        "generated_at": "2026-08-29T00:00:00+00:00",
+        "manifest_digest": "manifest-digest",
+        "workflow_run_id": "123",
+        "commit": "a" * 40,
+        "ref": "refs/heads/develop",
+        "scope": "full",
+        "status": "success" if success == len(results) else "failed",
+        "selected": len(results),
+        "success": success,
+        "product_failure": product_failure,
+        "infrastructure_failure": infrastructure_failure,
+        "blocked": blocked,
+        "coverage": f"{release_success}/{len(release_results)}",
+        "release_coverage": f"{release_success}/{len(release_results)}",
+        "selected_coverage": f"{success}/{len(results)}",
+        "release_required_selected": len(release_results),
+        "release_required_success": release_success,
+        "release_gate": bool(release_results)
+        and release_success == len(release_results),
+        "results": results,
+        "platforms": [],
+        "shard": {
+            "index": index,
+            "count": count,
+            "family_ids": [result["id"] for result in results],
+        },
+    }
+
+
+class TestAggregateTestcontainersImageGate(unittest.TestCase):
+    def test_aggregate_preserves_all_families_and_release_coverage(self) -> None:
+        entries = [
+            {"id": "alpha", "releaseRequired": True},
+            {"id": "beta", "releaseRequired": True},
+            {"id": "support", "releaseRequired": False},
+        ]
+        aggregate = aggregate_summaries(
+            [
+                _summary(0, [_result("alpha")]),
+                _summary(
+                    1, [_result("beta"), _result("support", release_required=False)]
+                ),
+            ],
+            entries,
+            expected_shard_count=2,
+        )
+        self.assertEqual("3/3", aggregate["selected_coverage"])
+        self.assertEqual("2/2", aggregate["coverage"])
+        self.assertTrue(aggregate["release_gate"])
+        self.assertEqual(
+            ["alpha", "beta", "support"], [item["id"] for item in aggregate["results"]]
+        )
+        self.assertEqual([0, 1], [item["index"] for item in aggregate["shards"]])
+
+    def test_aggregate_rejects_missing_or_duplicate_family(self) -> None:
+        entries = [
+            {"id": "alpha", "releaseRequired": True},
+            {"id": "beta", "releaseRequired": True},
+        ]
+        with self.assertRaisesRegex(AggregationError, "missing family ids"):
+            aggregate_summaries(
+                [_summary(0, [_result("alpha")], count=1)],
+                entries,
+                expected_shard_count=1,
+            )
+        with self.assertRaisesRegex(AggregationError, "duplicate family id"):
+            aggregate_summaries(
+                [_summary(0, [_result("alpha")]), _summary(1, [_result("alpha")])],
+                entries,
+                expected_shard_count=2,
+            )
+
+    def test_aggregate_rejects_shard_counter_drift(self) -> None:
+        entries = [{"id": "alpha", "releaseRequired": True}]
+        summary = _summary(0, [_result("alpha")], count=1)
+        summary["blocked"] = 1
+        with self.assertRaisesRegex(AggregationError, "counter mismatch"):
+            aggregate_summaries([summary], entries, expected_shard_count=1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -499,6 +499,18 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             read_back = json.loads((Path(directory) / "summary.json").read_text())
             self.assertEqual(summary["manifest_digest"], read_back["manifest_digest"])
 
+    def test_shard_summary_records_partition_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [entry("AlphaServer"), entry("BetaServer")],
+                Path(directory),
+                command_runner=_generic_success,
+                max_attempts=1,
+                shard_index=1,
+                shard_count=4,
+            ).run()
+        self.assertEqual({"index": 1, "count": 4, "family_ids": ["alphaserver", "betaserver"]}, summary["shard"])
+
     def test_strict_family_requires_pull_platform_and_workload_evidence(self) -> None:
         calls: list[list[str]] = []
 

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -14,6 +14,7 @@ from scripts.testcontainers_image_gate import (
     SelectionError,
     load_manifest,
     select_entries,
+    select_shard_entries,
     validate_manifest,
 )
 
@@ -97,6 +98,25 @@ class TestTestcontainersImageGate(unittest.TestCase):
 
         shared = select_entries(self.entries, {"scripts/run_testcontainers_image_gate.py"})
         self.assertEqual(EXPECTED_FAMILY_COUNT, len(shared))
+
+    def test_full_manifest_shards_are_disjoint_and_complete(self) -> None:
+        shards = [
+            select_shard_entries(self.entries, shard_index=index, shard_count=4)
+            for index in range(4)
+        ]
+        shard_ids = [[entry["id"] for entry in shard] for shard in shards]
+        self.assertEqual([13, 13, 13, 13], [len(ids) for ids in shard_ids])
+        self.assertCountEqual(
+            [entry["id"] for entry in self.entries],
+            [family_id for ids in shard_ids for family_id in ids],
+        )
+        self.assertEqual(EXPECTED_FAMILY_COUNT, len({family_id for ids in shard_ids for family_id in ids}))
+
+    def test_shard_selection_rejects_invalid_bounds(self) -> None:
+        with self.assertRaises(SelectionError):
+            select_shard_entries(self.entries, shard_index=0, shard_count=0)
+        with self.assertRaises(SelectionError):
+            select_shard_entries(self.entries, shard_index=4, shard_count=4)
 
     def test_family_selector_is_exact_and_requires_platform_when_requested(self) -> None:
         ignite = dict(self.entries[0])
@@ -257,6 +277,10 @@ class TestTestcontainersImageGate(unittest.TestCase):
             "python3 -m unittest scripts/test_run_testcontainers_image_gate.py -v",
             ci_match.group(0),
         )
+        self.assertIn(
+            "python3 -m unittest scripts/test_aggregate_testcontainers_image_gate.py -v",
+            ci_match.group(0),
+        )
         shared_match = re.search(
             r"^            shared:\n.*?(?=^            [a-z0-9-]+:\n)",
             workflow,
@@ -266,6 +290,8 @@ class TestTestcontainersImageGate(unittest.TestCase):
         for path in (
             "scripts/run_testcontainers_image_gate.py",
             "scripts/test_run_testcontainers_image_gate.py",
+            "scripts/aggregate_testcontainers_image_gate.py",
+            "scripts/test_aggregate_testcontainers_image_gate.py",
             "scripts/testcontainers_image_gate.py",
             "scripts/testcontainers_image_gate_manifest.json",
         ):
@@ -274,14 +300,27 @@ class TestTestcontainersImageGate(unittest.TestCase):
     def test_nightly_runs_full_gate_only_before_spring_bridge(self) -> None:
         workflow = (self.root / ".github/workflows/nightly-tests.yml").read_text(encoding="utf-8")
         self.assertIn("test-testcontainers-image-gate:", workflow)
+        self.assertIn("test-testcontainers-image-gate-shard:", workflow)
         self.assertIn("if: ${{ needs.plan.outputs.scope == 'full' }}", workflow)
         self.assertIn("--scope full", workflow)
         self.assertIn("TESTCONTAINERS_IMAGE_GATE_MAX_PARALLEL: '1'", workflow)
+        self.assertIn("max-parallel: 4", workflow)
+        self.assertIn("--shard-index", workflow)
+        self.assertIn("--shard-count 4", workflow)
+        self.assertIn("scripts/aggregate_testcontainers_image_gate.py", workflow)
+        self.assertIn(
+            "name: nightly-testcontainers-image-gate-${{ github.run_id }}-amd64-shard-${{ matrix.shard }}",
+            workflow,
+        )
         if "test-testcontainers-ignite2-arm64-image-gate:" in workflow:
             self.assertIn("runs-on: ubuntu-24.04", workflow)
             self.assertIn("runs-on: ubuntu-24.04-arm", workflow)
             self.assertIn("--default-platform-id amd64", workflow)
-            self.assertIn("--job-budget-minutes 360", workflow)
+            self.assertIn("--job-budget-minutes 120", workflow)
+            self.assertIn(
+                "needs: [build, plan, test-testcontainers-image-gate-shard]",
+                workflow,
+            )
             self.assertIn("--family-id ignite2", workflow)
             self.assertIn("--platform-id arm64", workflow)
             self.assertIn("--job-budget-minutes 90", workflow)

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -394,4 +395,26 @@ def select_entries(
         )
         if selected_platform is not None:
             entry["_selected_platform_id"] = selected_platform["id"]
+    return selected
+
+
+def select_shard_entries(
+    entries: Iterable[dict[str, Any]],
+    *,
+    shard_index: int,
+    shard_count: int,
+) -> list[dict[str, Any]]:
+    """Select a deterministic manifest shard without overlap or omission."""
+
+    if shard_count < 1:
+        raise SelectionError("shard count must be positive")
+    if shard_index < 0 or shard_index >= shard_count:
+        raise SelectionError("shard index must be within shard count")
+    selected = [
+        dict(entry)
+        for index, entry in enumerate(entries)
+        if index % shard_count == shard_index
+    ]
+    if not selected:
+        raise SelectionError("shard selection is empty")
     return selected


### PR DESCRIPTION
## 요약

Full Nightly의 52개 Testcontainers image startup-workload family를 네 개의 독립 shard로 나눠 전체 gate 소요 시간이 단일 직렬 실행에 묶이지 않도록 합니다. 기존 release validator가 소비하는 canonical aggregate job과 artifact 계약은 그대로 유지합니다.

## 배경

기존 x64 image startup-workload gate는 image pull timeout이 각 pull당 60초여도 52개 family를 직렬로 처리해 한 실행이 1시간 33분 이상 걸렸습니다. 이 지연은 Full Nightly 완료와 이후 별도 승인 대상인 Snapshot publication 판단을 늦춥니다.

## 해결하는 문제

- 52개 family를 4개 shard로 분산해 wall-clock 시간을 shard 경계로 제한합니다.
- shard 누락, 중복, catalog drift를 aggregate 단계에서 fail-closed로 차단합니다.
- `coverage=48/48`, `selected_coverage=52/52`, `release_gate=true`의 기존 release evidence 계약을 보존합니다.

## 작업 내용

- `.github/workflows/nightly-tests.yml`: x64 image gate를 4-way matrix로 분리하고 canonical aggregate job을 추가했습니다.
- `scripts/testcontainers_image_gate.py`: deterministic shard selection 계약을 추가했습니다.
- `scripts/run_testcontainers_image_gate.py`: shard 인자를 runner에 연결했습니다.
- `scripts/aggregate_testcontainers_image_gate.py`: shard 결과를 검증하고 canonical summary를 생성합니다.
- Python unit test와 CI policy test에 shard/aggregate 회귀 검증을 추가했습니다.

## 검증

- `python3 -B -m unittest scripts/test_testcontainers_image_gate.py scripts/test_run_testcontainers_image_gate.py scripts/test_aggregate_testcontainers_image_gate.py scripts/test_release_workflow_policy.py scripts/test_testcontainers_contract.py scripts/test_jvm_release_contract.py -v`: PASS (112 tests)
- `python3 -B .github/scripts/test-ci-domain-parallelization.py`: PASS (17 tests)
- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml .github/workflows/publish-snapshot.yml`: PASS
- `python3 -m py_compile ...`: PASS
- `ruff check --select E9,F821 ...`: PASS
- `git diff --check origin/develop...HEAD`: PASS

## 리뷰 참고

- P0/P1: 0/0
- 독립 최종 리뷰: PASS
- hosted exact-head Full Nightly wall time은 PR CI 이후 별도 Nightly 실행에서 확인해야 합니다.
- Snapshot publication은 현재의 manual-only 및 exact-head 승인 경계를 유지하며 이 PR에서 자동 실행으로 변경하지 않습니다.

## 메타데이터

- Milestone: `2.0.0`
- Assignee: `debop`
- Base/head: `develop` ← `feat/nightly-image-gate-shards`
- Exact head: `6c3c6a896268774f4af62f6f4633100f67b1c1f4`

## DoD Status

Required checks: 11/16; N/A: 4; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|---|---|---|---|---|
| CG-10 - Pre-PR proof | 대상 테스트, 정적 검사, 최종 리뷰와 exact head를 수렴 | PASS | Python 129 tests, actionlint, py_compile, ruff, diff-check; P0=0/P1=0; `6c3c6a8` | 없음 |
| CG-12 - Exact head publish | 승인된 feature branch를 force 없이 push하고 remote SHA 확인 | PASS | local/remote `6c3c6a896268774f4af62f6f4633100f67b1c1f4` | 없음 |
| CG-12A - Guidance refresh | 현재 user/workspace/worktree `AGENTS.md`, Type E leaf, common gates, PR template 재확인 | PASS | current content hashes 확인, target metadata drift 없음 | 없음 |
| CG-13 - PR metadata | 한국어 PR, assignee, milestone, labels, base/head를 live 확인 | PASS | PR #1571, `develop` ← `feat/nightly-image-gate-shards`, head `6c3c6a8`, assignee `debop`, milestone `2.0.0` | 없음 |
| CG-14 - CI/review | exact-head 자동 CI, live review/thread, 독립 최종 리뷰와 hosted Full Nightly 동작 확인 | PENDING | 자동 CI 25/25 jobs + Examples 성공, PR checks 26/26 성공, thread/request 0, P0=0/P1=0; hosted Full Nightly 미실행 | CG-X01에서 exact-head Full Nightly dispatch 승인 필요 |
| CG-15 - Merge-ready | CI/review/lesson/artifact 상태를 종합해 exact PR/head merge-ready 확정 | PENDING | GitHub 상태는 `MERGEABLE`/`CLEAN`; hosted Full Nightly wall-time 및 aggregate 증거 미확인 | Full Nightly 성공 후 merge-ready 재판정 |
| CG-16 - Fresh merge approval | exact PR/head에 대한 별도 merge 승인 확보 | PENDING | PR 생성 승인은 merge 승인과 별개 | auto-merge 금지 |
| CG-17 - Merge | 승인된 전략으로 merge 후 live 상태 확인 | PENDING | CG-16 이후 | 승인 전 실행 금지 |
| CG-18 - Sync/cleanup | canonical checkout 동기화와 안전한 정리 | PENDING | merge 이후 | 사용자 dirty/untracked work 보존 |

Final status: PENDING (CG-X01 exact-head Full Nightly dispatch authority, then CG-14)

Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18



