### PR TITLE
[docs][testcontainers] Ignite2Server 2.0 migration 계약을 고정한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@
 
 <!-- issue-1335-java25-semver:end -->
 
+<!-- issue-1520-ignite2-migration:start -->
+- `Ignite2Server`의 2.0.0 custom image 계약을 fail-fast로 확정했다.
+  `Ignite2Server(image = "custom/ignite")`는 더 이상 canonical tag를
+  적용하지 않고 `IllegalArgumentException`과
+  `Custom Ignite2 image requires an explicit tag` 메시지로 실패한다.
+  Tag가 없는 `DockerImageName` custom 경로도 `IllegalArgumentException`과
+  `Custom Ignite2 DockerImageName must include an explicit tag` 메시지로
+  실패한다. Custom image는
+  `Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom")`처럼 tag를
+  명시해야 한다. 지원하지 않는 아키텍처에서 canonical tag를 생략하면
+  `IllegalStateException`과
+  `Unsupported Ignite2 default image architecture: <architecture>` 메시지로
+  실패하며, backward-compatible fallback은 제공하지 않는다. Public
+  callable JVM descriptor는 published `1.12.1` baseline과 동일하게 유지한다
+  ([#1520](https://github.com/bluetape4k/bluetape4k-projects/issues/1520)).
+<!-- issue-1520-ignite2-migration:end -->
+
 - QueryDSL Kotlin codegen은 Kotlin 2.4/JDK 25 환경에서 clean annotation
   processing을 통과하지 못하는 upstream `NullPointerException`으로 인해
   기본 지원 경로에서 제외했다. Java APT 생성 Q 타입과 QueryDSL association

--- a/docs/lessons/2026-08-30-issue-1520-ignite2-migration-contract.md
+++ b/docs/lessons/2026-08-30-issue-1520-ignite2-migration-contract.md
@@ -1,0 +1,39 @@
+# Issue #1520 Ignite2 마이그레이션 계약 보강 교훈
+
+## 맥락
+
+`Ignite2Server`의 production 동작은 유지하면서 custom image tag와 unknown
+architecture fail-fast 동작을 문서·테스트·JVM descriptor 계약으로 고정했다.
+
+## 잘못된 가정과 확인 증거
+
+Custom tag가 canonical architecture resolver를 우회하는지 확인하려고
+`GenericContainer.dockerImageName`을 단순 metadata 조회로 사용했다. 그러나 이
+프로퍼티는 `RemoteDockerImage` 해석을 시작했고, 존재하지 않는
+`custom/ignite:2.18.0-custom`을 pull하려다 404로 실패했다.
+
+KDoc에 고정된 custom tag literal을 추가한 뒤에는
+`scripts.test_testcontainers_contract`가 이를 stale default tag로 판정했다.
+공개 예제가 정확해도 기존 문서 drift 계약을 함께 통과해야 한다는 점을 확인했다.
+
+## 결정
+
+- Architecture resolver 우회는 unknown architecture에서 명시적인 custom tag로
+  `Ignite2Server`를 생성한 뒤, test-only reflection으로 아직 해석하지 않은
+  `RemoteDockerImage.imageNameFuture`의 `DockerImageName`을 확인한다. 실제 image
+  pull을 시작하는 `dockerImageName` 프로퍼티는 이 계약의 증거로 사용하지 않는다.
+- Published JVM baseline은 descriptor literal만 기록하지 않는다. Maven Central의
+  1.12.1 JAR을 내려받아 SHA-256을 검증하고, 해당 artifact에서 추출한 descriptor와
+  현재 compile output을 직접 비교한다.
+- Custom image KDoc은 `customTag` 같은 symbolic value를 사용하고, 실제 migration
+  예시는 EN/KO README와 release 문서에서 `custom/ignite:2.18.0-custom`으로
+  제공한다.
+- KDoc을 변경하면 Kotlin test보다 먼저
+  `python3 -m unittest scripts.test_testcontainers_contract -v`를 실행해 기존
+  tag drift 규칙과 충돌하는지 확인한다.
+
+## 결과와 검증
+
+Network-triggering assertion을 제거한 뒤 targeted test 2개와
+`Ignite2ServerTest` 전체 6개가 통과했다. Testcontainers 문서 계약 6개,
+JVM release 계약 11개, public `invoke` descriptor 4개도 모두 통과했다.

--- a/docs/release/2.0.0-ignite2-migration.md
+++ b/docs/release/2.0.0-ignite2-migration.md
@@ -1,0 +1,67 @@
+# Ignite2Server 2.0.0 마이그레이션
+
+<!-- issue-1520-ignite2-migration:start -->
+## 변경 요약
+
+`Ignite2Server`의 public callable JVM descriptor는 유지되지만 custom image와
+기본 image tag를 해석하는 런타임 계약이 2.0.0에서 바뀝니다.
+
+- `Ignite2Server(image = "custom/ignite")`는 더 이상 canonical tag를
+  자동으로 적용하지 않고 `IllegalArgumentException`으로 실패합니다.
+- String image와 `DockerImageName` custom 경로는 모두 명시적인 tag가
+  필요합니다.
+- canonical `apacheignite/ignite`의 tag를 생략하면 `x86_64`/`amd64`에서는
+  `2.18.0`, `aarch64`/`arm64`에서는 `2.18.0-arm64`를 선택합니다.
+- 지원하지 않는 아키텍처에서는 `IllegalStateException`과
+  `Unsupported Ignite2 default image architecture: <architecture>` 메시지로
+  즉시 실패합니다.
+
+## 소비자 코드 변경
+
+기존 호출은 컴파일 가능한 형태를 유지하지만 2.0.0 런타임에서는 실패합니다.
+
+```kotlin
+// 2.0.0에서 실패: Custom Ignite2 image requires an explicit tag
+Ignite2Server(image = "custom/ignite")
+```
+
+Custom image tag를 다음과 같이 명시하세요.
+
+```kotlin
+val byName = Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom")
+val byDockerName = Ignite2Server(DockerImageName.parse("custom/ignite:2.18.0-custom"))
+```
+
+Tag가 없는 `DockerImageName.parse("custom/ignite")` 경로는
+`Custom Ignite2 DockerImageName must include an explicit tag` 메시지와 함께
+`IllegalArgumentException`으로 실패합니다.
+
+## 호환성 결정
+
+Backward-compatible fallback은 제공하지 않습니다. Custom image에 canonical
+tag를 자동 적용하면 image 소유자가 의도한 version이 아닐 수 있고 실행 결과의
+재현성이 낮아집니다. 2.0.0에서는 이 동작을 의도된 breaking behavior로
+취급하고, 명시적인 custom tag만 canonical 아키텍처 해석을 우회하도록
+fail-fast 계약을 유지합니다.
+
+## JVM descriptor 기준선
+
+Maven Central에 게시된
+`io.github.bluetape4k:bluetape4k-testcontainers:1.12.1`을 비교 기준으로
+사용했습니다. 해당 JAR의 SHA-256은
+`525f21ea6addeece8cb9d9eded2e9461aeda8693e2a2617e82e2357a476d99ee`입니다.
+
+`javap -public -s`로 확인한 두 public `invoke` overload의 descriptor는
+2.0.0에서도 동일해야 합니다.
+
+```text
+(Lorg/testcontainers/utility/DockerImageName;ZZ)Lio/bluetape4k/testcontainers/storage/Ignite2Server;
+(Ljava/lang/String;Ljava/lang/String;ZZ)Lio/bluetape4k/testcontainers/storage/Ignite2Server;
+```
+
+CI의 `scripts/check-jvm-release-contract.sh`는 Maven Central의 1.12.1 JAR을
+내려받아 위 SHA-256을 확인하고, published artifact와 현재 compile output의
+static `invoke` 및 companion `invoke` descriptor를 직접 비교합니다. 따라서 이
+변경은 binary callable signature 변경이 아니라 명시적으로 문서화한 런타임 의미
+변경입니다.
+<!-- issue-1520-ignite2-migration:end -->

--- a/docs/testlogs/2026-08.md
+++ b/docs/testlogs/2026-08.md
@@ -22,3 +22,6 @@
 | 2026-08-29 | #1534 | 사용자/Boot 제공 `ReactiveMongoOperations` + legacy-only URI 회귀 | RED → GREEN — 각 1 failed 후 1 passing | method-level 조건에서는 auto-configuration 생성자 예외를 재현하고 class-level 조건 복원 뒤 backoff를 확인 |
 | 2026-08-29 | #1534 | `:bluetape4k-spring-boot-mongodb:test` | PASS — 94 passing | JUnit `failures=0`, `errors=0`, `skipped=0`; auto-configuration 12개 포함 |
 | 2026-08-29 | #1534 | `:bluetape4k-spring-boot-mongodb:detekt`, 문서·diff 감사 | PASS — task 완료 | 변경 밖의 기존 `TooManyFunctions` 2건만 출력; 한국어 용어 감사 4개 파일과 `git diff --check` 통과 |
+| 2026-08-30 | #1520 | Ignite2 migration marker 계약 | RED → GREEN — 1 failed 후 1 passing | EN/KO README, CHANGELOG, release 문서의 동기화 marker와 필수 예외 타입·메시지를 고정 |
+| 2026-08-30 | #1520 | `Ignite2ServerTest` | PASS — 6 passing | Testcontainers 직렬 실행; 대표 Ignite startup/workload, custom String/`DockerImageName` tag, unknown architecture fail-fast 검증 |
+| 2026-08-30 | #1520 | JVM·문서 계약, `:bluetape4k-testcontainers:detekt`, shell·diff 감사 | PASS — Python 17 passing, JVM descriptor 4개 일치 | Maven Central 1.12.1 JAR SHA-256 검증 후 current descriptor와 직접 비교; 변경 파일 신규 Detekt finding 없음 |

--- a/scripts/check-jvm-release-contract.sh
+++ b/scripts/check-jvm-release-contract.sh
@@ -5,6 +5,14 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 
 readonly GENERAL_CLASS="$ROOT/testing/testcontainers/build/classes/kotlin/main/io/bluetape4k/testcontainers/PropertyExportingServer.class"
+readonly TESTCONTAINERS_CLASSES="$ROOT/testing/testcontainers/build/classes/kotlin/main"
+readonly IGNITE2_CLASS="io.bluetape4k.testcontainers.storage.Ignite2Server"
+readonly IGNITE2_COMPANION_CLASS='io.bluetape4k.testcontainers.storage.Ignite2Server$Companion'
+readonly IGNITE2_BASELINE_VERSION="1.12.1"
+readonly IGNITE2_BASELINE_SHA256="525f21ea6addeece8cb9d9eded2e9461aeda8693e2a2617e82e2357a476d99ee"
+readonly IGNITE2_BASELINE_URL="https://repo.maven.apache.org/maven2/io/github/bluetape4k/bluetape4k-testcontainers/$IGNITE2_BASELINE_VERSION/bluetape4k-testcontainers-$IGNITE2_BASELINE_VERSION.jar"
+readonly IGNITE2_BASELINE_DIR="$ROOT/testing/testcontainers/build/jvm-release-contract"
+readonly IGNITE2_BASELINE_JAR="$IGNITE2_BASELINE_DIR/bluetape4k-testcontainers-$IGNITE2_BASELINE_VERSION.jar"
 readonly JAVA21_CLASS="$ROOT/virtualthread/jdk21/build/classes/kotlin/main/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.class"
 readonly JAVA25_CLASS="$ROOT/virtualthread/jdk25/build/classes/kotlin/main/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.class"
 
@@ -24,6 +32,49 @@ assert_major() {
   printf 'OK: %s major=%s\n' "${class_file#"$ROOT"/}" "$actual"
 }
 
+descriptor_for() {
+  local classpath="$1"
+  local class_name="$2"
+  local signature="$3"
+  local report
+  report="$(javap -classpath "$classpath" -public -s "$class_name")"
+  printf '%s\n' "$report" |
+    grep -F -A1 -- "$signature" |
+    awk '/descriptor:/{print $2; exit}'
+}
+
+assert_descriptor_matches_baseline() {
+  local class_name="$1"
+  local signature="$2"
+  local expected_descriptor="$3"
+  local baseline_descriptor
+  local current_descriptor
+  baseline_descriptor="$(descriptor_for "$IGNITE2_BASELINE_JAR" "$class_name" "$signature")"
+  current_descriptor="$(descriptor_for "$TESTCONTAINERS_CLASSES" "$class_name" "$signature")"
+  [[ "$baseline_descriptor" == "$expected_descriptor" ]] ||
+    fail "published baseline descriptor mismatch: class=$class_name expected=$expected_descriptor actual=$baseline_descriptor"
+  [[ "$current_descriptor" == "$baseline_descriptor" ]] ||
+    fail "JVM descriptor drift: class=$class_name baseline=$baseline_descriptor current=$current_descriptor"
+  printf 'OK: %s baseline=%s current=%s\n' "$class_name" "$baseline_descriptor" "$current_descriptor"
+}
+
+download_ignite2_baseline() {
+  mkdir -p "$IGNITE2_BASELINE_DIR"
+  local baseline_tmp
+  local actual_sha256
+  baseline_tmp="$(mktemp "$IGNITE2_BASELINE_DIR/.ignite2-baseline.XXXXXX")"
+  trap 'rm -f "$baseline_tmp"' EXIT
+  curl --fail --location --silent --show-error \
+    --output "$baseline_tmp" \
+    "$IGNITE2_BASELINE_URL"
+  actual_sha256="$(shasum -a 256 "$baseline_tmp" | awk '{print $1}')"
+  [[ "$actual_sha256" == "$IGNITE2_BASELINE_SHA256" ]] ||
+    fail "published baseline checksum mismatch: expected=$IGNITE2_BASELINE_SHA256 actual=$actual_sha256"
+  mv "$baseline_tmp" "$IGNITE2_BASELINE_JAR"
+  trap - EXIT
+  printf 'OK: published baseline %s sha256=%s\n' "$IGNITE2_BASELINE_VERSION" "$actual_sha256"
+}
+
 "$ROOT/gradlew" \
   :bluetape4k-testcontainers:compileKotlin \
   :bluetape4k-virtualthread-jdk21:compileKotlin \
@@ -33,3 +84,23 @@ assert_major() {
 assert_major "$GENERAL_CLASS" 69
 assert_major "$JAVA21_CLASS" 65
 assert_major "$JAVA25_CLASS" 69
+download_ignite2_baseline
+
+# Published baseline:
+# io.github.bluetape4k:bluetape4k-testcontainers:1.12.1
+# SHA-256: 525f21ea6addeece8cb9d9eded2e9461aeda8693e2a2617e82e2357a476d99ee
+readonly DOCKER_IMAGE_DESCRIPTOR='(Lorg/testcontainers/utility/DockerImageName;ZZ)Lio/bluetape4k/testcontainers/storage/Ignite2Server;'
+readonly STRING_IMAGE_DESCRIPTOR='(Ljava/lang/String;Ljava/lang/String;ZZ)Lio/bluetape4k/testcontainers/storage/Ignite2Server;'
+
+assert_descriptor_matches_baseline "$IGNITE2_CLASS" \
+  'public static final io.bluetape4k.testcontainers.storage.Ignite2Server invoke(org.testcontainers.utility.DockerImageName, boolean, boolean);' \
+  "$DOCKER_IMAGE_DESCRIPTOR"
+assert_descriptor_matches_baseline "$IGNITE2_CLASS" \
+  'public static final io.bluetape4k.testcontainers.storage.Ignite2Server invoke(java.lang.String, java.lang.String, boolean, boolean);' \
+  "$STRING_IMAGE_DESCRIPTOR"
+assert_descriptor_matches_baseline "$IGNITE2_COMPANION_CLASS" \
+  'public final io.bluetape4k.testcontainers.storage.Ignite2Server invoke(org.testcontainers.utility.DockerImageName, boolean, boolean);' \
+  "$DOCKER_IMAGE_DESCRIPTOR"
+assert_descriptor_matches_baseline "$IGNITE2_COMPANION_CLASS" \
+  'public final io.bluetape4k.testcontainers.storage.Ignite2Server invoke(java.lang.String, java.lang.String, boolean, boolean);' \
+  "$STRING_IMAGE_DESCRIPTOR"

--- a/scripts/test_jvm_release_contract.py
+++ b/scripts/test_jvm_release_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MARKER = "issue-1335-java25-semver"
+IGNITE2_MARKER = "issue-1520-ignite2-migration"
 EXPECTED_ISLAND = {
     "bluetape4k-assertions",
     "bluetape4k-junit5",
@@ -16,6 +17,22 @@ EXPECTED_ISLAND = {
 }
 COMMON_TOKENS = ("2.0.0", "1.13.x", "Java 25", "Java 21")
 HTTP_READMES = ("io/http/README.md", "io/http/README.ko.md")
+IGNITE2_MIGRATION_DOCS = (
+    "testing/testcontainers/README.md",
+    "testing/testcontainers/README.ko.md",
+    "CHANGELOG.md",
+    "docs/release/2.0.0-ignite2-migration.md",
+)
+IGNITE2_MIGRATION_TOKENS = (
+    "Ignite2Server",
+    "custom/ignite",
+    "2.18.0-custom",
+    "IllegalArgumentException",
+    "IllegalStateException",
+    "Custom Ignite2 image requires an explicit tag",
+    "Custom Ignite2 DockerImageName must include an explicit tag",
+    "Unsupported Ignite2 default image architecture: <architecture>",
+)
 
 
 def read(relative: str) -> str:
@@ -24,10 +41,10 @@ def read(relative: str) -> str:
 
 def block(text: str, marker: str = MARKER) -> str:
     pattern = rf"<!-- {re.escape(marker)}:start -->(.*?)<!-- {re.escape(marker)}:end -->"
-    match = re.search(pattern, text, re.DOTALL)
-    if match is None:
-        raise AssertionError(f"missing marker block: {marker}")
-    return match.group(1)
+    matches = re.findall(pattern, text, re.DOTALL)
+    if len(matches) != 1:
+        raise AssertionError(f"expected exactly one marker block: {marker}; actual={len(matches)}")
+    return matches[0]
 
 
 class JvmReleaseContractTest(unittest.TestCase):
@@ -123,6 +140,14 @@ class JvmReleaseContractTest(unittest.TestCase):
         self.assertIn("#1335", changelog)
         for token in COMMON_TOKENS:
             self.assertIn(token, changelog)
+
+    def test_ignite2_migration_contract_is_synchronized(self) -> None:
+        for relative in IGNITE2_MIGRATION_DOCS:
+            path = ROOT / relative
+            self.assertTrue(path.is_file(), msg=f"missing Ignite2 migration document: {relative}")
+            migration = block(read(relative), IGNITE2_MARKER)
+            for token in IGNITE2_MIGRATION_TOKENS:
+                self.assertIn(token, migration, msg=f"missing {token!r} in {relative}")
 
     def test_ci_and_release_workflows_run_both_contract_checks(self) -> None:
         for workflow in (read(".github/workflows/ci.yml"), read(".github/workflows/release.yml")):

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -100,12 +100,37 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 재현 가능한 로컬·CI 실행을 위해 변경 가능한 `latest`, major-only, rolling minor
 태그는 사용하지 않습니다.
 
+<!-- issue-1520-ignite2-migration:start -->
+### 2.0.0 `Ignite2Server` 마이그레이션 계약
+
 `Ignite2Server`는 canonical `apacheignite/ignite` 이미지를 지연 해석합니다.
 `x86_64`/`amd64`에서는 `2.18.0`, `aarch64`/`arm64`에서는
 `2.18.0-arm64`를 사용합니다. canonical tag를 생략한 상태에서 지원하지 않는
-아키텍처를 만나면 즉시 실패합니다. Custom image는 명시적인 tag가 필요하고,
-명시한 custom tag는 모든 아키텍처에서 허용됩니다. 아래처럼 서버와
-`IgniteClient`를 `use`/`close`로 함께 정리하세요.
+아키텍처를 만나면 `IllegalStateException`과
+`Unsupported Ignite2 default image architecture: <architecture>` 메시지로
+즉시 실패합니다.
+
+Custom image에는 이제 명시적인 tag가 필요합니다. 이전에 canonical 기본 tag에
+의존하던 `Ignite2Server(image = "custom/ignite")` 호출은 다음 중 하나로
+변경해야 합니다.
+
+```kotlin
+val byName = Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom")
+val byDockerName = Ignite2Server(DockerImageName.parse("custom/ignite:2.18.0-custom"))
+```
+
+Tag가 없는 String 호출은 `IllegalArgumentException`과
+`Custom Ignite2 image requires an explicit tag` 메시지로 실패합니다.
+Tag가 없는 `DockerImageName` 호출은 `IllegalArgumentException`과
+`Custom Ignite2 DockerImageName must include an explicit tag` 메시지로
+실패합니다. 2.0.0에서는 canonical tag fallback을 제공하지 않습니다. 이
+fail-fast 계약으로 custom image 선택의 재현성을 유지하며, 명시적인 custom
+tag는 canonical 아키텍처 해석을 우회합니다. 호환성과 JVM descriptor 결정은
+[`docs/release/2.0.0-ignite2-migration.md`](../../docs/release/2.0.0-ignite2-migration.md)를
+참고하세요.
+<!-- issue-1520-ignite2-migration:end -->
+
+아래처럼 서버와 `IgniteClient`를 `use`/`close`로 함께 정리하세요.
 
 Java 25+에서 Ignite 2 thin-client 테스트에 필요한 JVM 옵션은
 `--add-opens=java.base/java.nio=ALL-UNNAMED`와

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -95,12 +95,37 @@ The defaults below are pinned to the latest stable image tag verified on
 2026-08-10. Mutable `latest`, major-only, and rolling minor tags are avoided so
 that Testcontainers runs remain reproducible across local machines and CI.
 
+<!-- issue-1520-ignite2-migration:start -->
+### `Ignite2Server` migration contract for 2.0.0
+
 `Ignite2Server` resolves the canonical `apacheignite/ignite` image lazily:
 `x86_64`/`amd64` uses `2.18.0`, while `aarch64`/`arm64` uses
-`2.18.0-arm64`. An unknown architecture fails fast when the canonical tag is
-omitted. Custom images must provide an explicit tag; an explicit custom tag is
-accepted on any architecture. Start the server and close both the server and
-the `IgniteClient` with `use`/`close` as shown below.
+`2.18.0-arm64`. Omitting the canonical tag on an unknown architecture fails
+with `IllegalStateException` and the message
+`Unsupported Ignite2 default image architecture: <architecture>`.
+
+Custom images must now provide an explicit tag. Code that previously relied on
+`Ignite2Server(image = "custom/ignite")` compiling to a canonical default tag
+must migrate to one of these forms:
+
+```kotlin
+val byName = Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom")
+val byDockerName = Ignite2Server(DockerImageName.parse("custom/ignite:2.18.0-custom"))
+```
+
+The tagless String call fails with `IllegalArgumentException` and
+`Custom Ignite2 image requires an explicit tag`. The tagless
+`DockerImageName` call fails with `IllegalArgumentException` and
+`Custom Ignite2 DockerImageName must include an explicit tag`. There is no
+fallback to the canonical tag in 2.0.0: the fail-fast behavior keeps custom
+image selection reproducible, while an explicit custom tag bypasses canonical
+architecture resolution. See
+[`docs/release/2.0.0-ignite2-migration.md`](../../docs/release/2.0.0-ignite2-migration.md)
+for the compatibility and JVM descriptor decision.
+<!-- issue-1520-ignite2-migration:end -->
+
+Start the server and close both the server and the `IgniteClient` with
+`use`/`close` as shown below.
 
 On Java 25+, the Ignite 2 thin-client tests use only
 `--add-opens=java.base/java.nio=ALL-UNNAMED` and

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
@@ -35,6 +35,15 @@ import java.time.Duration
  * 않는 아키텍처를 만나면 즉시 실패합니다. Custom image는 명시적인 tag가
  * 필요하며, 명시한 custom tag는 canonical resolver를 우회합니다.
  *
+ * ```kotlin
+ * val customTag = "your-pinned-tag"
+ * val byName = Ignite2Server(image = "custom/ignite", tag = customTag)
+ * val byDockerName = Ignite2Server(DockerImageName.parse("custom/ignite:$customTag"))
+ * ```
+ *
+ * `Ignite2Server(image = "custom/ignite")`는 `IllegalArgumentException`으로
+ * 실패하며 canonical tag fallback을 제공하지 않습니다.
+ *
  * @param imageName Docker 이미지 이름 ([DockerImageName])
  * @param useDefaultPort 기본 포트(10800)를 그대로 사용할지 여부. `false`이면 임의 포트가 할당됩니다.
  * @param reuse 컨테이너 재사용 여부
@@ -116,8 +125,8 @@ class Ignite2Server private constructor(
          * ```
          *
          * @param image          Docker 이미지 이름, blank이면 [IllegalArgumentException]이 발생합니다.
-         * @param tag            Docker 이미지 태그, blank이면 [IllegalArgumentException]이 발생합니다 (기본: [DEFAULT_TAG];
-         *                       aarch64에서는 [TAG]-arm64).
+         * @param tag            Docker 이미지 태그 (기본: [DEFAULT_TAG]; aarch64 canonical image는 [TAG]-arm64).
+         *                       blank이면 [IllegalArgumentException]이 발생하며, custom image는 tag를 명시해야 합니다.
          * @param useDefaultPort `true`면 10800 포트를 고정 바인딩합니다.
          * @param reuse          컨테이너 재사용 여부입니다.
          */

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt
@@ -1,15 +1,16 @@
 package io.bluetape4k.testcontainers.storage
 
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.testcontainers.AbstractContainerTest
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.AbstractContainerTest
 import org.apache.ignite.Ignition
 import org.apache.ignite.configuration.ClientConfiguration
-import org.testcontainers.utility.DockerImageName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
-import io.bluetape4k.assertions.assertFailsWith
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
@@ -17,6 +18,18 @@ import java.util.concurrent.TimeUnit
 class Ignite2ServerTest: AbstractContainerTest() {
 
     companion object: KLogging()
+
+    private fun Ignite2Server.configuredImageName(): DockerImageName {
+        val imageField = GenericContainer::class.java.getDeclaredField("image").apply {
+            isAccessible = true
+        }
+        val remoteImage = imageField.get(this)
+        val imageNameFutureField = remoteImage.javaClass.getDeclaredField("imageNameFuture").apply {
+            isAccessible = true
+        }
+        val imageNameFuture = imageNameFutureField.get(remoteImage) as java.util.concurrent.Future<*>
+        return imageNameFuture.get() as DockerImageName
+    }
 
     @Test
     @Timeout(value = 30, unit = TimeUnit.MINUTES)
@@ -79,11 +92,24 @@ class Ignite2ServerTest: AbstractContainerTest() {
 
             System.setProperty("os.arch", "arm64")
             Ignite2Server.DEFAULT_TAG shouldBeEqualTo "${Ignite2Server.TAG}-arm64"
-            assertFailsWith<IllegalArgumentException> { Ignite2Server(image = "custom/ignite") }
-            Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom").use { }
+            val customImageFailure = assertFailsWith<IllegalArgumentException> {
+                Ignite2Server(image = "custom/ignite")
+            }
+            customImageFailure.message shouldBeEqualTo
+                "Custom Ignite2 image requires an explicit tag"
+            Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom").use { server ->
+                server.configuredImageName().getUnversionedPart() shouldBeEqualTo "custom/ignite"
+                server.configuredImageName().getVersionPart() shouldBeEqualTo "2.18.0-custom"
+            }
 
             System.setProperty("os.arch", "mips64")
-            assertFailsWith<IllegalStateException> { Ignite2Server() }
+            Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom").use { server ->
+                server.configuredImageName().getUnversionedPart() shouldBeEqualTo "custom/ignite"
+                server.configuredImageName().getVersionPart() shouldBeEqualTo "2.18.0-custom"
+            }
+            val architectureFailure = assertFailsWith<IllegalStateException> { Ignite2Server() }
+            architectureFailure.message shouldBeEqualTo
+                "Unsupported Ignite2 default image architecture: mips64"
         } finally {
             if (originalArchitecture == null) {
                 System.clearProperty("os.arch")
@@ -98,8 +124,25 @@ class Ignite2ServerTest: AbstractContainerTest() {
         val canonical = Ignite2Server(DockerImageName.parse(Ignite2Server.IMAGE))
         canonical.dockerImageName shouldBeEqualTo
             "${Ignite2Server.IMAGE}:${Ignite2Server.DEFAULT_TAG}"
-        assertFailsWith<IllegalArgumentException> {
+        val customImageFailure = assertFailsWith<IllegalArgumentException> {
             Ignite2Server(DockerImageName.parse("custom/ignite"))
+        }
+        customImageFailure.message shouldBeEqualTo
+            "Custom Ignite2 DockerImageName must include an explicit tag"
+
+        val originalArchitecture = System.getProperty("os.arch")
+        try {
+            System.setProperty("os.arch", "mips64")
+            Ignite2Server(DockerImageName.parse("custom/ignite:2.18.0-custom")).use { server ->
+                server.configuredImageName().getUnversionedPart() shouldBeEqualTo "custom/ignite"
+                server.configuredImageName().getVersionPart() shouldBeEqualTo "2.18.0-custom"
+            }
+        } finally {
+            if (originalArchitecture == null) {
+                System.clearProperty("os.arch")
+            } else {
+                System.setProperty("os.arch", originalArchitecture)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1520

`Ignite2Server`의 2.0.0 custom image fail-fast 동작을 소비자 migration 계약으로 명시하고, published 1.12.1 JVM descriptor와의 호환성을 CI에서 직접 검증합니다.

## Background

2.0.0 milestone에서 tag가 없는 custom image와 지원하지 않는 아키텍처의 실패 동작은 이미 결정됐지만, EN/KO 사용법·정확한 예외 메시지·binary callable 기준선이 하나의 배포 계약으로 고정되지 않았습니다.

## What This Solves

- custom image는 명시적인 tag가 필요하며 canonical tag fallback을 제공하지 않는다는 2.0.0 계약을 소비자에게 제공합니다.
- Maven Central 1.12.1 JAR의 SHA-256과 public `invoke` descriptor를 현재 compile output과 직접 비교해 binary drift를 차단합니다.

## Work Done

- EN/KO README, CHANGELOG, release migration 문서, KDoc에 custom String/`DockerImageName` 사용법과 정확한 예외 타입·메시지를 동기화했습니다.
- marker exact-one 문서 계약과 String/`DockerImageName` custom tag·unknown architecture 회귀 테스트를 보강했습니다.
- Maven Central 1.12.1 artifact의 SHA-256을 검증한 뒤 static/Companion descriptor 4개를 현재 output과 비교하도록 JVM release contract를 강화했습니다.
- 재현 중 확인한 network-triggering image 조회와 published baseline 검증 교훈을 lesson 및 testlog에 기록했습니다.

## Validation

- `./gradlew :bluetape4k-testcontainers:cleanTest :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.storage.Ignite2ServerTest' --no-build-cache --no-parallel --max-workers=1`: PASS (6 passing, 대표 Ignite startup/workload 포함)
- `python3 -m unittest scripts.test_jvm_release_contract scripts.test_testcontainers_contract`: PASS (17/17)
- `./scripts/check-jvm-release-contract.sh`: PASS (1.12.1 SHA-256 일치, static/Companion descriptor 4개 일치)
- `./gradlew :bluetape4k-testcontainers:detekt --rerun-tasks --no-parallel --max-workers=1`: PASS (변경 파일 신규 finding 0)
- `shellcheck -e SC2016 scripts/check-jvm-release-contract.sh` 및 `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: 독립 read-only exact-diff 재검토 `APPROVE`; production 동작 변경·dependency 추가·scope creep 없음

## Metadata

- Issue: #1520, milestone `2.0.0`, assignee `debop`
- PR: #1572, head `8b87f57f6a443d6453f24e82e105b274391610f4`, milestone `2.0.0`, assignee `debop`
- CI: exact head `8b87f57f6a443d6453f24e82e105b274391610f4`, run `33261097545` terminal green

## DoD Status

Required checks: 27/27; N/A: 2; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 | authority 재확인 | PASS | AGENTS hierarchy, Type E plan, staged diff readback | 없음 |
| CG-02 | historical/current evidence 조회 | PASS | GNO GitHub/docs 및 live Issue #1520 조회 | 없음 |
| CG-03 | 사용자 작업·경계 보호 | PASS | isolated worktree와 `docs/issue-1520-ignite2-migration-contract`; canonical dirty files 보존 | 없음 |
| CG-04 | 정책·audience 적용 | PASS | GitHub/사용자 문서 한국어, EN/KO README locale 유지 | 없음 |
| CG-05 | ecosystem pattern 재사용 | PASS | 기존 JVM/Python contract와 Kotlin test pattern 확장; dependency 추가 없음 | 없음 |
| CG-06 | public·documentation contract | PASS | README 2종, KDoc, CHANGELOG, release migration 문서 | 없음 |
| CG-07 | RED/GREEN·targeted proof | PASS | marker RED→GREEN, Python 17/17, Kotlin 6/6, descriptor 4개 | 없음 |
| CG-08 | heavyweight check 직렬화 | PASS | Testcontainers `--no-parallel --max-workers=1` 순차 실행 | 없음 |
| CG-09 | lesson gate | PASS | `docs/lessons/2026-08-30-issue-1520-ignite2-migration-contract.md`; GNO update 완료 | 없음 |
| CG-10 | pre-PR proof 수렴 | PASS | 독립 review P0/P1/P2/P3=0, local head `8b87f57f6a443d6453f24e82e105b274391610f4` | 없음 |
| CG-11 | PR delivery authority | PASS | 승인된 repo `bluetape4k/bluetape4k-projects`, base `develop`, named head | 없음 |
| CG-12 | exact head publish | PASS | local/remote head `8b87f57f6a443d6453f24e82e105b274391610f4` 일치 | 없음 |
| CG-12A | guidance refresh | PASS | AGENTS 3종, maintenance skill, common gates, PR templates hash no-drift; Issue #1520 live readback | 없음 |
| CG-13 | PR 생성·검증 | PASS | PR #1572 생성; metadata/body/head live readback | 없음 |
| CG-14 | exact-head CI·review | PASS | run `33261097545`: 11 success, 12 path-filter skipped, terminal failure 0; reviews/threads 0; 독립 review P0/P1=0; human review `N/A (single-developer lane, required approvals=0)` | 없음 |
| CG-15 | merge-ready 보고 | PASS | PR #1572, exact head `8b87f57f6a443d6453f24e82e105b274391610f4`, mergeable, Blocked=0 | CG-16 fresh merge 승인 대기 |
| E-01 | support skill route | PASS | bluetape-kotlin-patterns, bluetape-writer 적용 | 없음 |
| E-02 | current guidance 발견 | PASS | GNO, live issue, source/docs/contracts readback | 없음 |
| E-03 | behavior·ownership 보존 | PASS | production Kotlin diff KDoc-only; repo-local scope | 없음 |
| E-04 | chezmoi parity | N/A | repo 코드·문서 변경이며 user-scope managed config 변경 없음 | 없음 |
| E-05 | maintenance verification | PASS | diff, links, marker, shellcheck, Detekt, Korean audit | 없음 |
| E-06 | durable pre-PR proof | PASS | staged 10-file diff, duplicate marker 0, locale contract·lesson 검증 | 없음 |
| E-07 | common PR gates delivery | PASS | CG-11~CG-15 및 live PR/CI/review readback 완료 | 없음 |

| CG-16 | fresh exact-head merge 승인 | PASS | merge-ready 보고 이후 사용자 `승인`; PR #1572, head `8b87f57f6a443d6453f24e82e105b274391610f4` | 없음 |
| CG-17 | rebase merge 실행·검증 | PASS | `MERGED` at `2026-08-29T16:06:48Z`; merge SHA `b9b7fb08e1ce80048d0be0841a61c1facb7fb2f5` | 없음 |
| CG-18 | canonical sync·cleanup | PASS | `develop == origin/develop == b9b7fb08...`; patch-id `4398673d...`·10 changed path 일치; 기존 untracked 4개 보존; target worktree와 local/stale tracking branch 제거 | 없음 |
| E-08 | fresh merge closeout | PASS | CG-16~CG-18 live proof 완료; Issue #1520 자동 종료 | 없음 |

Final status: DONE — PR #1572 rebase merge 및 local closeout 완료

Unchecked required items: 없음