### PR TITLE
checkout 없는 Snapshot handoff의 저장소 추론을 고정한다

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -370,4 +370,4 @@ jobs:
             echo
             echo "downstream은 receipt의 timestamp/build number와 resource SHA-256을 모두 확인해야 합니다."
           } > "$comment"
-          gh issue comment "$HANDOFF_ISSUE_NUMBER" --body-file "$comment"
+          gh issue comment "$HANDOFF_ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$comment"

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -1192,6 +1192,11 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
         self.assertIn("artifact-id", workflow)
         self.assertIn("artifact-digest", workflow)
         self.assertIn("gh issue comment", workflow)
+        self.assertIn(
+            'gh issue comment "$HANDOFF_ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" '
+            '--body-file "$comment"',
+            workflow,
+        )
         self.assertIn("issues: write", workflow)
         self.assertNotIn("issues: write", workflow.split("\njobs:\n", 1)[0])
         self.assertIn("record-handoff:", workflow)


### PR DESCRIPTION
## 요약
`Publish Snapshot`의 checkout 없는 `record-handoff` job에서 GitHub CLI issue comment 대상 저장소를 명시합니다.

## 원인
기존 호출이 `gh issue comment`에 repository를 전달하지 않아 checkout이 없는 runner에서 `fatal: not a git repository`로 종료되었습니다. Snapshot publish와 immutable receipt 생성은 성공했지만 workflow 전체가 실패했습니다.

## 변경
- `gh issue comment "$HANDOFF_ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$comment"`로 대상 저장소 고정
- release workflow policy 회귀 assertion 추가

## 검증
- `actionlint .github/workflows/publish-snapshot.yml`
- `python3 -m unittest scripts.test_release_workflow_policy` (40 tests)
- `git diff --check`
- RED에서 회귀 assertion 실패 확인 후 수정 뒤 GREEN 확인
- exact-head CI run #33266780115 전체 성공
- 독립 최종 리뷰: P0/P1/P2/P3 모두 0, APPROVE

## 영향 범위
workflow handoff 대상 저장소 해석만 수정하며 Maven artifact 내용은 변경하지 않습니다. 예외적인 Nightly 재사용 로직은 추가하지 않고, 머지된 develop exact head에서 Full Nightly 후 Publish Snapshot을 실행합니다.

## DoD Status
- [x] 명시적 repository 인자 적용
- [x] 회귀 테스트 및 workflow lint 통과
- [x] exact-head PR CI 전체 성공
- [x] 독립 최종 리뷰 APPROVE, P0/P1=0
- 상태: MERGE-READY (`fdf020a7c43f01b4877727706643a585dd815596`)