### PR TITLE
[examples][진단] callbackFlow Testcontainers 증거를 cleanup 전에 보존

### DIFF
--- a/.github/scripts/collect-testcontainers-diagnostics.py
+++ b/.github/scripts/collect-testcontainers-diagnostics.py
@@ -20,6 +20,7 @@ MAX_REPORT_FILE_BYTES = 2_000_000
 # The sanitized artifact remains capped by MAX_REPORT_FILE_BYTES.
 MAX_REPORT_SOURCE_BYTES = 32_000_000
 MAX_REPORT_ENTRIES = 50_000
+MAX_ARCHIVED_METADATA_BYTES = 4_096
 ALLOWLIST = {
     "confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130",
     "redis@sha256:4e070415a5713188624f93815e62d6c6a1fcbb416d2e0b578ab3db627db3a93a",
@@ -301,12 +302,50 @@ def collect_container_logs(task_name: str, container_id: str, max_log_bytes: int
 
 
 CONTAINER_ID = re.compile(r"^[0-9a-fA-F]{12,64}$")
+CONTAINER_NAME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
+IMAGE_ID = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+CREATED_AT = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?$")
 
 
 def normalized_path(path: Path) -> Path:
     """Normalize lexical dot segments without following symlinks."""
 
     return Path(os.path.abspath(path))
+
+
+def read_archived_container_metadata(task_name: str, path: Path) -> tuple[dict[str, Any], Path]:
+    """Validate a committed pre-cleanup metadata receipt and its paired log."""
+
+    if path.suffix != ".metadata" or not CONTAINER_ID.fullmatch(path.stem):
+        raise ValueError(f"{task_name}: invalid archived container metadata")
+    with path.open("rb") as handle:
+        encoded = handle.read(MAX_ARCHIVED_METADATA_BYTES + 1)
+    if len(encoded) > MAX_ARCHIVED_METADATA_BYTES:
+        raise ValueError(f"{task_name}: archived container metadata exceeds size limit")
+
+    values: dict[str, str] = {}
+    for line in encoded.decode("utf-8", errors="strict").splitlines():
+        key, separator, value = line.partition("=")
+        if not separator or key in values:
+            raise ValueError(f"{task_name}: invalid archived container metadata")
+        values[key] = value
+    required = {"id", "name", "image", "image_id", "image_digest", "created"}
+    if set(values) != required or values["id"] != path.stem:
+        raise ValueError(f"{task_name}: invalid archived container metadata")
+    if not CONTAINER_NAME.fullmatch(values["name"]):
+        raise ValueError(f"{task_name}: invalid archived container name")
+    if values["image"] != values["image_digest"] or values["image_digest"] not in ALLOWLIST:
+        raise ValueError(f"{task_name}: archived image is outside the diagnostics allowlist")
+    if not IMAGE_ID.fullmatch(values["image_id"]) or not CREATED_AT.fullmatch(values["created"]):
+        raise ValueError(f"{task_name}: invalid archived container metadata")
+
+    log_path = path.with_suffix(".log")
+    if log_path.is_symlink() or not log_path.is_file():
+        raise ValueError(f"{task_name}: archived container log does not exist")
+    return {
+        **values,
+        "source": "pre_cleanup_log",
+    }, log_path
 
 
 def reject_symlink_components(path: Path, stop_at: Path | None = None) -> None:
@@ -439,6 +478,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--workflow-file", required=True, type=Path)
     parser.add_argument("--max-total-bytes", type=int, default=DEFAULT_MAX_BYTES)
     parser.add_argument("--container-id", action="append", default=[])
+    parser.add_argument("--task-exit-code", type=int, default=0)
+    parser.add_argument("--archived-container-metadata", action="append", default=[], type=Path)
     parser.add_argument("--sanitized-report-dir", type=Path)
     parser.add_argument("--report-path", action="append", default=[], type=Path)
     parser.add_argument("--max-report-files", type=int, default=DEFAULT_MAX_REPORT_FILES)
@@ -461,13 +502,21 @@ def write_manifest(path: Path, manifest: dict[str, Any], max_bytes: int, repo_ro
 
 def main() -> int:
     args = parse_args()
-    if args.max_total_bytes <= 0 or args.max_report_files <= 0 or args.max_report_total_bytes <= 0:
+    if (
+        args.max_total_bytes <= 0
+        or args.max_report_files <= 0
+        or args.max_report_total_bytes <= 0
+        or args.task_exit_code < 0
+    ):
         print(f"{args.task_name}: diagnostic limits must be positive", file=sys.stderr)
         return 1
 
     args.workflow_file = normalized_path(args.workflow_file)
     args.output_dir = normalized_path(args.output_dir)
     args.report_path = [normalized_path(path) for path in args.report_path]
+    args.archived_container_metadata = [
+        normalized_path(path) for path in args.archived_container_metadata
+    ]
     if args.sanitized_report_dir is not None:
         args.sanitized_report_dir = normalized_path(args.sanitized_report_dir)
     try:
@@ -482,6 +531,9 @@ def main() -> int:
         for report_path in args.report_path:
             reject_symlink_components(report_path, repo_root)
             require_relative(report_path, repo_root, "report path")
+        for archived_metadata in args.archived_container_metadata:
+            reject_symlink_components(archived_metadata, repo_root)
+            require_relative(archived_metadata, repo_root, "archived container metadata")
         args.output_dir.mkdir(parents=True, exist_ok=True)
     except (OSError, ValueError) as error:
         print(str(error) if str(error).startswith(args.task_name) else f"{args.task_name}: diagnostics failed", file=sys.stderr)
@@ -489,6 +541,8 @@ def main() -> int:
 
     manifest: dict[str, Any] = {
         "task_name": args.task_name,
+        "task_exit_code": args.task_exit_code,
+        "diagnostic_status": "container_not_observed",
         "workflow_action_refs": [],
         "containers": [],
         "truncated": False,
@@ -498,19 +552,41 @@ def main() -> int:
     try:
         manifest["workflow_action_refs"] = workflow_action_refs(args.workflow_file)
         container_ids = sorted(set(args.container_id))
+        archived_metadata = sorted(set(args.archived_container_metadata))
+        archived_records: list[tuple[dict[str, Any], Path]] = []
+        archived_container_ids: set[str] = set()
+        for metadata_path in archived_metadata:
+            record, archived_log = read_archived_container_metadata(args.task_name, metadata_path)
+            container_id = str(record["id"])
+            if container_id in container_ids or container_id in archived_container_ids:
+                raise ValueError(f"{args.task_name}: duplicate container diagnostics")
+            archived_container_ids.add(container_id)
+            archived_records.append((record, archived_log))
         for container_id in container_ids:
             if not CONTAINER_ID.fullmatch(container_id):
                 raise ValueError(f"{args.task_name}: invalid container id")
             manifest["containers"].append(inspect_container(args.task_name, container_id))
+        manifest["containers"].extend(record for record, _ in archived_records)
 
         # Reserve space for the manifest before writing bounded log files.
         provisional = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8") + b"\n"
         log_budget = max(0, args.max_total_bytes - len(provisional))
         log_used = 0
+        collected_logs: list[tuple[str, str, bool]] = []
         for container_id in container_ids:
             logs, logs_truncated = collect_container_logs(
                 args.task_name, container_id, args.max_total_bytes
             )
+            collected_logs.append((container_id, logs, logs_truncated))
+        for record, archived_log in archived_records:
+            container_id = str(record["id"])
+            with archived_log.open("rb") as handle:
+                raw = handle.read(args.max_total_bytes + 1)
+            source_truncated = len(raw) > args.max_total_bytes
+            logs = sanitize(raw[:args.max_total_bytes].decode("utf-8", errors="replace"))
+            collected_logs.append((container_id, logs, source_truncated))
+
+        for container_id, logs, logs_truncated in collected_logs:
             manifest["truncated"] = manifest["truncated"] or logs_truncated
             remaining = log_budget - log_used
             data, was_truncated = bounded_bytes(logs, remaining)
@@ -537,16 +613,25 @@ def main() -> int:
             manifest["sanitized_reports"] = reports
             manifest["report_truncated"] = report_truncated
 
+        if manifest["report_truncated"]:
+            manifest["diagnostic_status"] = "diagnostic_collection_failed"
+        elif manifest["containers"] or manifest["sanitized_reports"]:
+            manifest["diagnostic_status"] = "diagnostic_collection_succeeded"
         write_manifest(args.output_dir / "manifest.json", manifest, args.max_total_bytes, repo_root)
     except (OSError, RuntimeError, ValueError) as error:
         # Do not echo Docker output or report contents; the task name is the only diagnostic detail.
         print(str(error) if str(error).startswith(args.task_name) else f"{args.task_name}: diagnostics failed", file=sys.stderr)
+        manifest["diagnostic_status"] = "diagnostic_collection_failed"
         try:
             write_manifest(args.output_dir / "manifest.json", manifest, args.max_total_bytes, repo_root)
         except (OSError, ValueError):
             pass
         return 1
-    return 1 if manifest["report_truncated"] else 0
+    if manifest["diagnostic_status"] == "diagnostic_collection_failed":
+        return 1
+    if manifest["diagnostic_status"] == "container_not_observed" and args.task_exit_code != 0:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_collect_testcontainers_diagnostics.py
+++ b/.github/scripts/test_collect_testcontainers_diagnostics.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 SCRIPT = Path(__file__).with_name("collect-testcontainers-diagnostics.py")
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SPEC = importlib.util.spec_from_file_location("collect_testcontainers_diagnostics", SCRIPT)
 assert SPEC and SPEC.loader
 diagnostics = importlib.util.module_from_spec(SPEC)
@@ -121,9 +122,31 @@ IllegalStateException: exception-secret
         self.assertEqual(stderr, "")
         manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
         self.assertEqual(manifest["containers"], [])
+        self.assertEqual(manifest["diagnostic_status"], "container_not_observed")
+        self.assertEqual(manifest["task_exit_code"], 0)
         self.assertEqual(manifest["workflow_action_refs"], [
             "actions/checkout@0123456789abcdef0123456789abcdef01234567"
         ])
+
+    def test_failed_task_without_container_is_fail_closed(self):
+        output_dir = self.root / "diagnostics" / "failed-empty"
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "failed-empty-task",
+            "--task-exit-code",
+            "1",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertEqual(stderr, "")
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["diagnostic_status"], "container_not_observed")
+        self.assertEqual(manifest["task_exit_code"], 1)
 
     def test_allowlisted_container_writes_sanitized_log_and_digest(self):
         output_dir = self.root / "diagnostics" / "kafka"
@@ -165,6 +188,7 @@ IllegalStateException: exception-secret
         self.assertEqual(result, 0)
         self.assertEqual(stderr, "")
         manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["diagnostic_status"], "diagnostic_collection_succeeded")
         self.assertEqual(manifest["containers"][0]["image_digest"], image_digest)
         log = (output_dir / f"{CONTAINER_ID}.log").read_text(encoding="utf-8")
         self.assertNotIn("secret", log)
@@ -340,6 +364,93 @@ IllegalStateException: exception-secret
         self.assertIn("log-failure-task", stderr)
         self.assertNotIn("private-docker-error", stderr)
         self.assertNotIn("secret", stderr)
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["diagnostic_status"], "diagnostic_collection_failed")
+
+    def test_archived_container_log_is_sanitized_after_testcontainers_cleanup(self):
+        output_dir = self.root / "diagnostics" / "archived-kafka"
+        raw_dir = self.root / "examples" / "coroutines-demo" / "build" / "testcontainers-raw"
+        raw_dir.mkdir(parents=True)
+        raw_log = raw_dir / f"{CONTAINER_ID}.log"
+        raw_log.write_text("token=secret\nKafkaServer started\n", encoding="utf-8")
+        image_digest = next(
+            digest for digest in diagnostics.ALLOWLIST if digest.startswith("confluentinc/cp-kafka@")
+        )
+        metadata = raw_dir / f"{CONTAINER_ID}.metadata"
+        metadata.write_text(
+            "\n".join(
+                (
+                    f"id={CONTAINER_ID}",
+                    "name=callback-flow-kafka",
+                    f"image={image_digest}",
+                    "image_id=sha256:" + "b" * 64,
+                    f"image_digest={image_digest}",
+                    "created=2026-08-30T00:00:00Z",
+                )
+            ) + "\n",
+            encoding="utf-8",
+        )
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "archived-kafka-task",
+            "--task-exit-code",
+            "1",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--archived-container-metadata",
+            metadata,
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["diagnostic_status"], "diagnostic_collection_succeeded")
+        self.assertEqual(manifest["task_exit_code"], 1)
+        self.assertEqual(manifest["containers"][0]["id"], CONTAINER_ID)
+        self.assertEqual(manifest["containers"][0]["name"], "callback-flow-kafka")
+        self.assertEqual(manifest["containers"][0]["image_id"], "sha256:" + "b" * 64)
+        self.assertEqual(manifest["containers"][0]["created"], "2026-08-30T00:00:00Z")
+        self.assertEqual(manifest["containers"][0]["image_digest"], image_digest)
+        self.assertEqual(manifest["containers"][0]["source"], "pre_cleanup_log")
+        sanitized = (output_dir / f"{CONTAINER_ID}.log").read_text(encoding="utf-8")
+        self.assertNotIn("secret", sanitized)
+        self.assertIn("KafkaServer started", sanitized)
+
+    def test_archived_metadata_without_committed_log_is_fail_closed(self):
+        output_dir = self.root / "diagnostics" / "missing-archived-log"
+        raw_dir = self.root / "examples" / "coroutines-demo" / "build" / "testcontainers-raw"
+        raw_dir.mkdir(parents=True)
+        image_digest = next(
+            digest for digest in diagnostics.ALLOWLIST if digest.startswith("confluentinc/cp-kafka@")
+        )
+        metadata = raw_dir / f"{CONTAINER_ID}.metadata"
+        metadata.write_text(
+            f"id={CONTAINER_ID}\nname=kafka\nimage={image_digest}\n"
+            f"image_id=sha256:{'b' * 64}\nimage_digest={image_digest}\n"
+            "created=2026-08-30T00:00:00Z\n",
+            encoding="utf-8",
+        )
+
+        result, stderr = self.run_main(
+            "--task-name",
+            "missing-archived-log-task",
+            "--task-exit-code",
+            "1",
+            "--output-dir",
+            output_dir,
+            "--workflow-file",
+            self.workflow,
+            "--archived-container-metadata",
+            metadata,
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("missing-archived-log-task", stderr)
+        manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["diagnostic_status"], "diagnostic_collection_failed")
 
     def test_docker_log_truncation_is_preserved_in_manifest(self):
         output_dir = self.root / "diagnostics" / "log-truncated"
@@ -663,6 +774,21 @@ steps:
 
         self.assertEqual(result, 1)
         self.assertIn("mutable-task", stderr)
+
+
+class ExamplesWorkflowDiagnosticsContractTest(unittest.TestCase):
+    def test_callback_flow_task_exports_and_collects_pre_cleanup_logs(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "examples.yml").read_text(encoding="utf-8")
+
+        self.assertIn(
+            'raw_diagnostics_dir="$GITHUB_WORKSPACE/examples/coroutines-demo/build/testcontainers-raw"',
+            workflow,
+        )
+        self.assertIn("-Dbluetape4k.testcontainers.diagnostics.dir=", workflow)
+        self.assertIn('--task-exit-code "$task_exit_code"', workflow)
+        self.assertIn('--archived-container-metadata "$archived_metadata"', workflow)
+        self.assertIn('find "$task_output_dir" -mindepth 1 -maxdepth 1 -delete || status=1', workflow)
+        self.assertIn('rm -f "$archived_metadata" "${archived_metadata%.metadata}.log"', workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -164,7 +164,23 @@ jobs:
               --filter label=org.testcontainers=true \
               --filter label=org.testcontainers.sessionId \
               | sort -u >"$before_ids_file" || status=1
-            ./gradlew "$task" --max-workers=1 || status=1
+            task_exit_code=0
+            raw_diagnostics_dir="$GITHUB_WORKSPACE/examples/coroutines-demo/build/testcontainers-raw"
+            raw_diagnostics_ready=false
+            if [[ "$task" == ':bluetape4k-examples-coroutines-demo:test' ]]; then
+              if mkdir -p "$raw_diagnostics_dir" && \
+                find "$raw_diagnostics_dir" -maxdepth 1 -type f -delete; then
+                raw_diagnostics_ready=true
+                ./gradlew "$task" \
+                  "-Dbluetape4k.testcontainers.diagnostics.dir=$raw_diagnostics_dir" \
+                  --max-workers=1 || task_exit_code=$?
+              else
+                task_exit_code=1
+              fi
+            else
+              ./gradlew "$task" --max-workers=1 || task_exit_code=$?
+            fi
+            (( task_exit_code == 0 )) || status=1
             docker ps -aq \
               --filter label=org.testcontainers=true \
               --filter label=org.testcontainers.sessionId \
@@ -174,14 +190,33 @@ jobs:
             while IFS= read -r container_id; do
               [[ -n "$container_id" ]] && container_args+=(--container-id "$container_id")
             done <<<"$new_ids"
+            archived_metadata_files=()
+            archived_args=()
+            if [[ "$raw_diagnostics_ready" == true ]]; then
+              shopt -s nullglob
+              archived_metadata_files=( "$raw_diagnostics_dir"/*.metadata )
+              shopt -u nullglob
+              for archived_metadata in "${archived_metadata_files[@]}"; do
+                archived_args+=(--archived-container-metadata "$archived_metadata")
+              done
+            fi
             task_output_dir="examples/build/testcontainers-diagnostics/${task//:/_}"
+            mkdir -p "$task_output_dir" || status=1
+            find "$task_output_dir" -mindepth 1 -maxdepth 1 -delete || status=1
             python3 .github/scripts/collect-testcontainers-diagnostics.py \
               --task-name "$task" \
+              --task-exit-code "$task_exit_code" \
               --output-dir "$task_output_dir" \
               --workflow-file .github/workflows/examples.yml \
               --max-total-bytes 2000000 \
-              "${container_args[@]}" || status=1
+              "${container_args[@]}" \
+              "${archived_args[@]}" || status=1
             test -f "$task_output_dir/manifest.json" || status=1
+            for archived_metadata in "${archived_metadata_files[@]}"; do
+              rm -f "$archived_metadata" "${archived_metadata%.metadata}.log" || status=1
+            done
+            [[ "$task" != ':bluetape4k-examples-coroutines-demo:test' ]] || \
+              find "$raw_diagnostics_dir" -maxdepth 1 -type f -delete || status=1
             rm -f "$before_ids_file" "$after_ids_file"
           done
 

--- a/docs/lessons/2026-08-30-testcontainers-pre-cleanup-diagnostics.md
+++ b/docs/lessons/2026-08-30-testcontainers-pre-cleanup-diagnostics.md
@@ -1,0 +1,88 @@
+# Testcontainers 진단은 테스트 JVM 종료 전에 증거를 보존해야 한다
+
+## 배경
+
+`examples.yml`은 각 Gradle test task가 끝난 뒤 Testcontainers label이 붙은 Docker
+container ID를 비교하고 로그를 수집했다. 그러나 callbackFlow의 실제 Kafka 테스트는
+`ShutdownQueue`에 `KafkaServer`를 등록한다. 테스트 JVM이 종료되면 container가 먼저
+정리될 수 있으므로, workflow가 사후 container 목록을 읽을 때는 이미 대상이 사라진다.
+
+GitHub Actions run
+[`32996076207`](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/32996076207)의
+artifact `9616858277`에서는 이 경계가 그대로 드러났다. workflow run은 실패했고
+callbackFlow 테스트 자체는 통과했지만, 해당 task의 `manifest.json`은
+`containers=[]`만 기록했고 collector는 성공을 반환했다. 따라서 이 artifact만으로는
+“container를 관찰하지 못함”과 “진단 수집 성공”을 구분할 수 없었다.
+
+## 근본 원인
+
+Gradle task 종료는 진단 대상 resource가 남아 있다는 보장이 아니다. Testcontainers와
+테스트 fixture가 소유한 container는 JVM shutdown hook이나 명시적 cleanup에서 먼저
+제거될 수 있다. task 전후 `docker ps` 차집합은 남아 있는 container만 찾으므로 transient
+container의 실패 증거를 보존하는 수단이 될 수 없다.
+
+collector도 빈 container 목록을 정상 결과로 처리했고 manifest에 수집 상태를 기록하지
+않았다. 이 때문에 resource lifecycle의 관찰 실패가 성공 상태로 축약됐다.
+
+## 결정
+
+- callbackFlow Kafka 테스트는 실패를 다시 던지기 전에 container ID를 파일명으로 사용해
+  `docker logs --tail 200`의 bounded raw broker log와 선택 metadata receipt를
+  `build/testcontainers-raw`에 기록한다.
+- CI가 export 경로를 지정한 경우 실제 Kafka 테스트는 성공 여부와 관계없이 cleanup 전에
+  raw log를 만든다. 같은 Gradle task의 뒤쪽 테스트가 실패하더라도 이미 종료된 broker의
+  증거를 보존하기 위해서다. 로컬 기본 실행은 임시 디렉터리를 사용하며 `ShutdownQueue`와
+  Testcontainers cleanup 동작을 변경하지 않는다.
+- workflow는 `bluetape4k.testcontainers.diagnostics.dir` system property로 test JVM의
+  export 경로를 정하고, Gradle task의 실제 exit code와 metadata receipt를 collector에
+  전달한다.
+- collector는 raw log를 repository 내부 경로와 allowlist의 immutable image digest로
+  검증하고, 기존 sanitizer와 전체 byte cap을 적용한 결과만 artifact 경로에 쓴다.
+- raw log는 collector 실행 직후 삭제하며 artifact upload 대상에 포함하지 않는다.
+- manifest는 `container_not_observed`, `diagnostic_collection_failed`,
+  `diagnostic_collection_succeeded` 중 하나와 `task_exit_code`를 기록한다.
+- 실패한 task에서 container와 pre-cleanup log를 모두 관찰하지 못하면 collector도
+  실패를 반환해 진단 누락을 fail-closed로 처리한다.
+
+## 결과와 검증
+
+- 기존 artifact 10개의 manifest가 모두 `containers=[]`이고 수집 상태 필드가 없음을
+  확인해 이전 계약의 오판을 재현했다.
+- Python 회귀 테스트는 실패 task의 무관찰, collector 실패, live container 성공,
+  pre-cleanup log sanitize, workflow wiring을 구분한다.
+- Kotlin 회귀 테스트는 raw broker log가 `2_000_000` bytes를 넘지 않고, 실제 Kafka
+  container의 `id`, `image`, `image_id`, `created`가 cleanup 전에 기록됨을 검증한다.
+- 실제 Kafka callbackFlow 테스트에서 cleanup 전 raw log와 metadata receipt가 생성되고,
+  collector가 이를 sanitize한 뒤 workflow가 raw 파일을 제거하는 경계를 확인했다.
+- `py_compile`, `ruff`, `actionlint`, callbackFlow 대상 테스트와 coroutines-demo 전체
+  테스트를 실행했다.
+
+## 놓친 점
+
+사후 진단 수집 코드는 container label과 image allowlist를 엄격히 검사했지만, 검사 시점에
+대상이 살아 있다는 전제를 별도로 검증하지 않았다. 보안 경계가 정확해도 lifecycle 경계가
+틀리면 artifact에는 사용할 수 있는 증거가 남지 않는다.
+
+또한 빈 목록은 합법적인 성공 task에서도 발생할 수 있으므로, `containers=[]`만으로
+collector 실패를 판정할 수도 없다. task exit code와 진단 상태를 함께 기록해야 한다.
+
+## 향후 지침
+
+- process-owned transient resource의 실패 진단은 process 종료 전에 증거를 기록하거나,
+  process가 종료 전에 bounded evidence를 export하도록 한다.
+- 사후 collector는 “관찰하지 못함”, “수집 실패”, “수집 성공”을 서로 다른 상태로 남긴다.
+- 실패 task에서 필수 진단이 없으면 artifact upload의 존재만으로 통과시키지 않는다.
+- raw 진단은 업로드하지 않고 repository 내부 임시 경로, size cap, sanitizer, immutable
+  allowlist를 모두 통과한 결과만 보존한다.
+- cleanup을 비활성화해 진단을 얻는 방식은 기본 선택으로 사용하지 않는다. resource
+  ownership을 바꾸지 않는 pre-cleanup export를 우선한다.
+
+## 문서 SPW 감사
+
+- SPW-01: PASS — CI 유지보수자를 대상으로 issue #1536, workflow, collector, callbackFlow
+  fixture와 기존 artifact를 근거로 범위를 고정했다.
+- SPW-02: PASS — 배경, 근본 원인, 결정, 결과와 검증, 놓친 점, 향후 지침을 기록했다.
+- SPW-03: PASS — 식별자와 상태 token을 보존하고 한국어 기술 문장으로 작성했다.
+- SPW-04: PASS — source, workflow, artifact manifest, 로컬 검증 결과를 문서의 각 주장과
+  대조했다.
+- SPW-05: PASS — 최종 Markdown 구조와 링크, 수치, 명령·상태 token을 다시 확인했다.

--- a/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
+++ b/examples/coroutines-demo/src/test/kotlin/io/bluetape4k/examples/coroutines/flow/CallbackFlowExamples.kt
@@ -56,7 +56,12 @@ import org.apache.kafka.common.header.internals.RecordHeaders
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.testcontainers.utility.DockerImageName
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -73,6 +78,8 @@ import kotlin.time.Duration.Companion.seconds
 class CallbackFlowExamples {
 
     companion object: KLoggingChannel() {
+        private const val DIAGNOSTICS_DIRECTORY_PROPERTY = "bluetape4k.testcontainers.diagnostics.dir"
+        private const val MAX_RAW_LOG_BYTES = 2_000_000
         private const val KAFKA_IMAGE_REF =
             "confluentinc/cp-kafka@sha256:a5040785528b0bce3b146febe9fcacdcf2b9b5acb450307f75170ef0e60ec130"
     }
@@ -693,39 +700,188 @@ class CallbackFlowExamples {
     }
 
     @Test
-    fun `real Kafka producer callbacks become metadata flow`() = runSuspendIO(timeout = 120.seconds) {
+    fun `failure diagnostics export a bounded pre-cleanup broker log`(@TempDir tempDir: Path) {
+        val containerId = "a".repeat(12)
+
+        writeKafkaFailureDiagnostics(
+            containerId = containerId,
+            logs = "x".repeat(2_100_000).toByteArray(),
+            outputDirectory = tempDir,
+            name = "callback-flow-kafka",
+            image = KAFKA_IMAGE_REF,
+            imageId = "sha256:${"b".repeat(64)}",
+            created = "2026-08-30T00:00:00Z",
+        )
+
+        val rawLog = tempDir.resolve("$containerId.log")
+        val metadata = tempDir.resolve("$containerId.metadata")
+        Files.exists(rawLog).shouldBeTrue()
+        Files.size(rawLog) shouldBeEqualTo 2_000_000L
+        Files.readString(metadata).let { receipt ->
+            receipt.contains("id=$containerId").shouldBeTrue()
+            receipt.contains("image_id=sha256:${"b".repeat(64)}").shouldBeTrue()
+            receipt.contains("created=2026-08-30T00:00:00Z").shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `real Kafka producer callbacks become metadata flow`(@TempDir tempDir: Path) = runSuspendIO(timeout = 120.seconds) {
         val topic = "epic-1422-callback-${Base58.randomString(8)}"
         val records = (0 until 8).map { index ->
             ProducerRecord(topic, "key-$index", "value-$index")
         }
 
-        val broker = KafkaServer(DockerImageName.parse(KAFKA_IMAGE_REF)).apply {
-            start()
-            ShutdownQueue.register(this)
-        }
-        val consumer = KafkaServer.Launcher.createStringConsumer(broker)
+        val broker = KafkaServer(DockerImageName.parse(KAFKA_IMAGE_REF))
         try {
-            consumer.subscribe(listOf(topic))
-            val metadata = producerResults(
-                records = records.asFlow(),
-                producerFactory = { KafkaServer.Launcher.createStringProducer(broker) },
-            ).toList()
+            broker.start()
+            ShutdownQueue.register(broker)
+            val consumer = KafkaServer.Launcher.createStringConsumer(broker)
+            try {
+                consumer.subscribe(listOf(topic))
+                val metadata = producerResults(
+                    records = records.asFlow(),
+                    producerFactory = { KafkaServer.Launcher.createStringProducer(broker) },
+                ).toList()
 
-            metadata shouldHaveSize records.size
-            val polled = withTimeout(10.seconds) {
-                buildList {
-                    while (size < records.size) {
-                        addAll(consumer.poll(Duration.ofMillis(250)).toList())
+                metadata shouldHaveSize records.size
+                val polled = withTimeout(10.seconds) {
+                    buildList {
+                        while (size < records.size) {
+                            addAll(consumer.poll(Duration.ofMillis(250)).toList())
+                        }
+                    }
+                }
+                polled shouldHaveSize records.size
+
+                val diagnosticsDirectory = configuredDiagnosticsDirectory() ?: tempDir
+                writeKafkaFailureDiagnostics(broker, diagnosticsDirectory)
+                val containerId = broker.containerId
+                val receipt = Files.readString(diagnosticsDirectory.resolve("$containerId.metadata"))
+                receipt.contains("id=$containerId").shouldBeTrue()
+                receipt.contains("image=${broker.dockerImageName}").shouldBeTrue()
+                receipt.contains("image_id=${broker.containerInfo.imageId}").shouldBeTrue()
+                receipt.contains("created=${broker.containerInfo.created}").shouldBeTrue()
+                Files.size(diagnosticsDirectory.resolve("$containerId.log"))
+                    .let { it in 1..MAX_RAW_LOG_BYTES }.shouldBeTrue()
+            } finally {
+                withContext(NonCancellable + Dispatchers.IO) {
+                    withTimeout(5.seconds) {
+                        runInterruptible { consumer.close(Duration.ofSeconds(5)) }
                     }
                 }
             }
-            polled shouldHaveSize records.size
-        } finally {
-            withContext(NonCancellable + Dispatchers.IO) {
-                withTimeout(5.seconds) {
-                    runInterruptible { consumer.close(Duration.ofSeconds(5)) }
+        } catch (failure: Throwable) {
+            try {
+                val outputDirectory = configuredDiagnosticsDirectory()
+                if (outputDirectory != null && broker.isRunning) {
+                    withContext(NonCancellable) {
+                        writeKafkaFailureDiagnostics(broker, outputDirectory)
+                    }
+                }
+            } catch (diagnosticFailure: Exception) {
+                failure.addSuppressed(diagnosticFailure)
+            }
+            throw failure
+        }
+    }
+
+    private fun configuredDiagnosticsDirectory(): Path? =
+        System.getProperty(DIAGNOSTICS_DIRECTORY_PROPERTY)
+            ?.takeIf { it.isNotBlank() }
+            ?.let(Path::of)
+
+    private suspend fun readBoundedKafkaLogs(containerId: String): ByteArray = withTimeout(10.seconds) {
+        runInterruptible(Dispatchers.IO) {
+            val process = ProcessBuilder("docker", "logs", "--tail", "200", containerId)
+                .redirectErrorStream(true)
+                .start()
+            try {
+                val output = process.inputStream.use { it.readNBytes(MAX_RAW_LOG_BYTES + 1) }
+                val truncated = output.size > MAX_RAW_LOG_BYTES
+                if (truncated) {
+                    process.destroyForcibly()
+                }
+                val exitCode = process.waitFor()
+                check(truncated || exitCode == 0) { "docker logs failed" }
+                output.copyOf(minOf(output.size, MAX_RAW_LOG_BYTES))
+            } finally {
+                if (process.isAlive) {
+                    process.destroyForcibly()
                 }
             }
+        }
+    }
+
+    private suspend fun writeKafkaFailureDiagnostics(broker: KafkaServer, outputDirectory: Path) {
+        val info = broker.containerInfo
+        writeKafkaFailureDiagnostics(
+            containerId = broker.containerId,
+            logs = readBoundedKafkaLogs(broker.containerId),
+            outputDirectory = outputDirectory,
+            name = info.name.orEmpty().removePrefix("/"),
+            image = broker.dockerImageName,
+            imageId = info.imageId,
+            created = info.created,
+        )
+    }
+
+    private fun writeKafkaFailureDiagnostics(
+        containerId: String,
+        logs: ByteArray,
+        outputDirectory: Path,
+        name: String,
+        image: String,
+        imageId: String,
+        created: String,
+    ) {
+        require(containerId.matches(Regex("[0-9a-fA-F]{12,64}"))) { "Invalid container ID" }
+        require(name.matches(Regex("[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}"))) { "Invalid container name" }
+        require(image == KAFKA_IMAGE_REF) { "Unexpected Kafka image" }
+        require(imageId.matches(Regex("sha256:[0-9a-fA-F]{64}"))) { "Invalid image ID" }
+        require(created.matches(Regex("[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?"))) { "Invalid created time" }
+
+        Files.createDirectories(outputDirectory)
+        val logTarget = outputDirectory.resolve("$containerId.log")
+        val metadataTarget = outputDirectory.resolve("$containerId.metadata")
+        val temporarySuffix = ".${ProcessHandle.current().pid()}.${System.nanoTime()}.tmp"
+        val logTemporary = outputDirectory.resolve("$containerId.log$temporarySuffix")
+        val metadataTemporary = outputDirectory.resolve("$containerId.metadata$temporarySuffix")
+        val metadata = """
+            id=$containerId
+            name=$name
+            image=$image
+            image_id=$imageId
+            image_digest=$KAFKA_IMAGE_REF
+            created=$created
+        """.trimIndent() + "\n"
+        require(!Files.exists(logTarget) && !Files.exists(metadataTarget)) {
+            "Diagnostics already exist for container ID"
+        }
+        var logCommitted = false
+        var metadataCommitted = false
+        try {
+            Files.write(
+                logTemporary,
+                logs.copyOf(minOf(logs.size, MAX_RAW_LOG_BYTES)),
+                StandardOpenOption.CREATE_NEW,
+                StandardOpenOption.WRITE,
+            )
+            Files.writeString(
+                metadataTemporary,
+                metadata,
+                StandardOpenOption.CREATE_NEW,
+                StandardOpenOption.WRITE,
+            )
+            Files.move(logTemporary, logTarget, StandardCopyOption.ATOMIC_MOVE)
+            logCommitted = true
+            Files.move(metadataTemporary, metadataTarget, StandardCopyOption.ATOMIC_MOVE)
+            metadataCommitted = true
+        } catch (failure: Exception) {
+            Files.deleteIfExists(logTemporary)
+            Files.deleteIfExists(metadataTemporary)
+            if (logCommitted) Files.deleteIfExists(logTarget)
+            if (metadataCommitted) Files.deleteIfExists(metadataTarget)
+            throw failure
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1536

callbackFlow Kafka 테스트가 종료되며 Testcontainers container가 먼저 정리돼도 broker 로그와 선택 metadata를 cleanup 전에 보존합니다. 빈 관찰, 수집 실패, 수집 성공을 manifest에서 분리해 실패 task의 진단 누락을 fail-closed로 처리합니다.

## Background

기존 `examples.yml`은 Gradle task 전후의 `docker ps` 차집합만 collector에 전달했습니다. Kafka broker는 test JVM의 `ShutdownQueue`가 소유하므로 task 종료 시점에는 container ID와 로그가 이미 사라질 수 있었고, 기존 artifact run `32996076207`은 빈 `containers=[]` manifest를 성공처럼 남겼습니다.

## What This Solves

- transient Kafka container가 cleanup된 뒤에도 bounded broker 로그와 immutable image metadata를 진단 artifact에 보존합니다.
- `container_not_observed`, `diagnostic_collection_failed`, `diagnostic_collection_succeeded`를 구분하고 실패 task의 빈 관찰을 non-zero로 보고합니다.
- stale·partial·duplicate receipt와 allowlist 밖 image, symlink 경로를 fail-closed로 거부합니다.

## Work Done

- callbackFlow 실제 Kafka fixture: `docker logs --tail 200`을 2 MB/10초로 제한해 cleanup 전에 log와 선택 metadata receipt를 atomic commit marker 방식으로 export합니다.
- diagnostics collector: archived receipt의 exact field set, container ID, immutable digest, image ID, paired log를 검증하고 기존 sanitizer/전체 byte cap을 적용합니다.
- examples workflow: Test JVM에 repository-absolute diagnostics 경로와 실제 task exit code를 전달하고, task별 output을 초기화한 뒤 sanitized 결과만 업로드하며 raw cleanup 실패를 job 실패로 전파합니다.
- regression/lesson: Python 계약 테스트와 Kotlin real Kafka·bounded export 테스트를 추가하고 재사용 가능한 lifecycle 교훈을 기록했습니다.

## Validation

- `/opt/homebrew/bin/python3.13 .github/scripts/test_collect_testcontainers_diagnostics.py`: PASS (24/24)
- `ruff check --ignore EXE001 ...`: PASS
- `actionlint .github/workflows/examples.yml`: PASS
- `git diff --check`: PASS
- `./gradlew :bluetape4k-examples-coroutines-demo:cleanTest :bluetape4k-examples-coroutines-demo:test --tests 'io.bluetape4k.examples.coroutines.flow.CallbackFlowExamples' --no-build-cache --no-daemon`: PASS (22/22, skipped=0)
- `./gradlew :bluetape4k-examples-coroutines-demo:cleanTest :bluetape4k-examples-coroutines-demo:test --no-build-cache --no-daemon`: PASS (146 passing, failures/errors=0; 기존 `@Disabled` 3건)
- 실제 Kafka receipt + `--task-exit-code 1` collector smoke: PASS (`diagnostic_collection_succeeded`, `source=pre_cleanup_log`, raw log는 artifact 경로 밖에서 정리)
- 한국어 용어 감사: PASS (findings=0)

## Review Notes

- P0/P1: 0
- P2: stale task output 혼입 가능성을 inline review에서 발견해 collector 실행 전 generation cleanup과 cleanup 실패 전파로 수정했으며 architecture 재검토는 `CLEAR`입니다.
- P3: 없음
- 독립 code/security review: findings 0, recommendation `COMMENT` (LSP 전용 진단은 미실행; fresh Kotlin compile/test로 대체 검증)
- 로컬 Colima ARM64에서 AMD64 Kafka image startup exit 139가 한 차례 발생했으나 원인을 emulation startup flake로 확인했고, 이후 fresh class 22/22와 module 146 passing을 연속 확인했습니다.
- lesson은 branch에 추적했습니다. `bluetape4k-docs` collection이 `.worktrees`를 제외하므로 GNO canonical indexing은 merge 후 canonical sync에서 수행합니다.

## Metadata

- Issue: #1536, milestone `2.0.0`, assignee `debop`, labels `bug`, `test`, `ci`, `tech-debt`
- Base/head: `develop` <- `fix/issue-1536-callbackflow-diagnostics`
- Head: `eef77b1f7145f8fa260a35ca22f0ae22d5d3c334`
- CI: exact-head checks 26/26 PASS — CI run `33271006143` attempt 2, Examples run `33271006218`
- Merge: squash `f1ee1c361a5efdddd2209d93ad97b13d7cd14008`, feature/merge patch-id `63637e2cde085cc809e1c7dafb5bfc936e089213` 일치
- Post-merge: CI `33289818228` 25/25 jobs, Examples `33289818156`, Dependency Submission `33289818188` PASS

## DoD Status

Required checks: 10/10; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - defect/root cause | 기존 artifact와 JVM/container lifecycle 경계를 추적 | PASS | run `32996076207`, artifact `9616858277`, 빈 manifest 10건 | 없음 |
| C-02 - scope/issue | #1536 live metadata와 Type C/P2 범위를 고정 | PASS | assignee `debop`, milestone `2.0.0`, labels 4개 | 없음 |
| C-03 - RED | 빈 관찰·archive receipt·workflow wiring·bounded export 회귀를 먼저 실패시킴 | PASS | Python/Kotlin 의도된 RED 기록 | 없음 |
| C-04 - surgical fix | fixture/workflow/collector 경계만 변경하고 dependency를 추가하지 않음 | PASS | commit `eef77b1f7145f8fa260a35ca22f0ae22d5d3c334` | 없음 |
| C-05 - GREEN/blast radius | Python, workflow, real Kafka, changed class, 전체 module을 fresh 검증 | PASS | 24/24, 22/22, 146 passing, P0/P1=0 | 없음 |
| C-06 - reusable learning | lifecycle 교훈을 tracked lesson으로 작성하고 문서 감사를 수행 | PASS | `docs/lessons/2026-08-30-testcontainers-pre-cleanup-diagnostics.md`; canonical GNO index `#10ed498f` 검색 1위 | 없음 |
| CG-12A - guidance refresh | AGENTS hierarchy, leaf skill, common gates, PR template, linked issue 재확인 | PASS | 2026-08-30 KST hash/readback, metadata/head no drift | 없음 |
| C-07 - PR/CI/review | exact head PR, checks, threads, artifact를 검증 | PASS | head `eef77b1f`; checks 26/26; Redis JUnit 2,135/0/0/0; Examples 352/0/0/4, CallbackFlow 22/22 skipped=0; diagnostics manifest+16,135-byte log; unresolved thread 0; inline review P0/P1=0; human review `N/A (single-developer lane)` | 없음 |
| C-08 - merge readiness | phase-aware exact-head merge-ready 보고 | PASS | PR `#1574`, head `eef77b1f`, checks 26/26, `MERGEABLE`, fresh exact-head 승인 완료 | 없음 |
| C-09 - merge/cleanup | fresh merge 승인 후 merge·sync·cleanup 경계를 검증 | PASS | squash `f1ee1c36`; #1536 CLOSED; canonical `develop` sync; post-merge workflows 3/3; 로컬 worktree/branch와 기존 untracked 4개 보존; remote branch는 저장소 정책으로 자동 삭제 | 별도 cleanup 승인 전 로컬 대상 보존 |

Final status: DONE — PR #1574 merge, #1536 종료, canonical sync와 post-merge 검증 완료

Unchecked required items: 없음


