### PR TITLE
[mongodb][api] 자동 구성의 no-arg ABI와 내부 상수 경계를 복원한다

### DIFF
--- a/spring-boot/mongodb/README.ko.md
+++ b/spring-boot/mongodb/README.ko.md
@@ -27,6 +27,11 @@ Boot가 이미 제공한 `ReactiveMongoOperations` Bean이 항상 우선하며, 
 `ReactiveMongoTemplate`을 생성합니다. operations Bean이 이미 있으면 legacy property
 검사까지 포함한 library auto-configuration 전체가 backoff합니다.
 
+`ReactiveMongoAutoConfiguration`은 Spring framework가 관리하는 구현 클래스이며,
+애플리케이션이 직접 생성하는 public API가 아닙니다. framework 및 binary compatibility를
+위해 public no-arg 생성자를 유지하고, Spring lifecycle callback으로 `Environment`를
+주입합니다. URI 검사 상수는 내부 구현에 속하며 public field로 노출하지 않습니다.
+
 ### `spring.data.mongodb.uri`에서 마이그레이션
 
 | 이전 설정 | 현재 설정 |

--- a/spring-boot/mongodb/README.md
+++ b/spring-boot/mongodb/README.md
@@ -28,6 +28,12 @@ bean exists and both `ReactiveMongoDatabaseFactory` and `MongoConverter` are
 available. The whole library auto-configuration, including its legacy-property
 guard, backs off when an operations bean already exists.
 
+`ReactiveMongoAutoConfiguration` is a framework-managed implementation class,
+not an application-facing API for direct construction. Its public no-arg
+constructor remains available for framework and binary compatibility, while
+Spring injects the `Environment` through its lifecycle callback. The URI guard
+constants are internal implementation details and are not public fields.
+
 ### Migration from `spring.data.mongodb.uri`
 
 | Before | After |

--- a/spring-boot/mongodb/src/main/kotlin/io/bluetape4k/spring/mongodb/config/ReactiveMongoAutoConfiguration.kt
+++ b/spring-boot/mongodb/src/main/kotlin/io/bluetape4k/spring/mongodb/config/ReactiveMongoAutoConfiguration.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
+import org.springframework.context.EnvironmentAware
 import org.springframework.core.env.Environment
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory
 import org.springframework.data.mongodb.core.ReactiveMongoOperations
@@ -22,6 +23,9 @@ import org.springframework.data.mongodb.core.convert.MongoConverter
  *   library fallback이 참여할 때 legacy-only `spring.data.mongodb.uri`는 조용한 localhost
  *   fallback을 막기 위해 fail-fast합니다. 사용자 또는 Spring Boot가 제공한
  *   `ReactiveMongoOperations` Bean이 있으면 이 검사도 함께 backoff합니다.
+ * - Spring framework가 public no-arg 생성자로 인스턴스를 만들고 [setEnvironment]로
+ *   환경을 주입합니다. no-arg 생성자는 framework 및 binary compatibility를 위해
+ *   유지하며, 애플리케이션에서 이 자동 구성 클래스를 직접 생성하는 방식은 지원하지 않습니다.
  *
  * ```yaml
  * spring:
@@ -36,11 +40,9 @@ import org.springframework.data.mongodb.core.convert.MongoConverter
 )
 @ConditionalOnClass(ReactiveMongoOperations::class)
 @ConditionalOnMissingBean(ReactiveMongoOperations::class)
-class ReactiveMongoAutoConfiguration(
-    environment: Environment,
-) {
+class ReactiveMongoAutoConfiguration : EnvironmentAware {
 
-    init {
+    override fun setEnvironment(environment: Environment) {
         if (environment.containsProperty(LEGACY_URI_PROPERTY) &&
             !environment.containsProperty(CURRENT_URI_PROPERTY)
         ) {
@@ -49,9 +51,9 @@ class ReactiveMongoAutoConfiguration(
     }
 
     private companion object {
-        const val CURRENT_URI_PROPERTY = "spring.mongodb.uri"
-        const val LEGACY_URI_PROPERTY = "spring.data.mongodb.uri"
-        const val LEGACY_URI_MESSAGE =
+        private const val CURRENT_URI_PROPERTY = "spring.mongodb.uri"
+        private const val LEGACY_URI_PROPERTY = "spring.data.mongodb.uri"
+        private const val LEGACY_URI_MESSAGE =
             "Unsupported legacy MongoDB property 'spring.data.mongodb.uri'; use 'spring.mongodb.uri' on Spring Boot 4.1+"
     }
 

--- a/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/ReactiveMongoAutoConfigurationTest.kt
+++ b/spring-boot/mongodb/src/test/kotlin/io/bluetape4k/spring/mongodb/ReactiveMongoAutoConfigurationTest.kt
@@ -33,6 +33,20 @@ class ReactiveMongoAutoConfigurationTest {
         .withConfiguration(AutoConfigurations.of(ReactiveMongoAutoConfiguration::class.java))
 
     @Test
+    fun `auto configuration은 public no-arg 생성자 ABI를 유지한다`() {
+        ReactiveMongoAutoConfiguration::class.java.constructors
+            .map { it.parameterCount }
+            .shouldBeEqualTo(listOf(0))
+    }
+
+    @Test
+    fun `auto configuration은 public static field를 노출하지 않는다`() {
+        ReactiveMongoAutoConfiguration::class.java.fields
+            .filter { java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .shouldBeEmpty()
+    }
+
+    @Test
     fun `ReactiveMongoOperations class가 없으면 auto configuration이 비활성화된다`() {
         autoConfigurationRunner
             .withClassLoader(FilteredClassLoader(ReactiveMongoOperations::class.java))


### PR DESCRIPTION
## Summary

Closes #1537

`ReactiveMongoAutoConfiguration`의 기존 public no-arg ABI를 복원하고, URI 진단 상수가 public field로 노출되지 않도록 framework 관리 경계를 고정합니다.

## Background

2.0.0 준비 과정에서 자동 구성 생성자가 `Environment` 인자로 바뀌면서 기존 no-arg bytecode 호환성이 깨졌고, `private companion object`의 `const val` 세 개가 JVM에서는 `public static final` field로 노출됐습니다.

## What This Solves

- Spring lifecycle을 유지하면서 기존 public no-arg constructor descriptor `()V`를 복원합니다.
- URI property와 진단 message 상수를 내부 구현으로 제한하고, 직접 생성이 지원 API가 아님을 문서화합니다.

## Work Done

- `Environment` constructor injection을 `EnvironmentAware.setEnvironment` callback으로 옮겨 legacy URI fail-fast와 operations Bean backoff를 유지했습니다.
- URI 관련 `const val`을 JVM classfile에서도 `private static final`로 만들었습니다.
- public constructor 집합과 public static field 부재를 reflection 회귀 테스트로 고정했습니다.
- KDoc과 README 영문/한글에 framework-managed implementation 및 직접 생성 비지원 경계를 명시했습니다.

## Validation

- `./gradlew :bluetape4k-spring-boot-mongodb:test :bluetape4k-spring-boot-mongodb:detekt`: PASS (96 tests, failures=0, errors=0, skipped=0)
- ABI 회귀 테스트 RED/GREEN: PASS (기존 코드에서 no-arg 부재와 public field 노출 재현, 수정 후 2/2 통과)
- `javap -public -s`: PASS (public constructor descriptor `()V`)
- `javap -p`: PASS (URI 상수 3개 모두 `private static final`)
- exact-head CI: PASS (13 success, 12 path-filtered skipped, pending=0, failed=0)
- `git diff --check`: PASS
- Korean terminology audit: PASS (2 files, findings=0)

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: local inline review에서 code-reviewer `APPROVE`, architect `CLEAR`
- Live PR review: comments=0, reviews=0, unresolved threads=0
- Known gap: precompiled 이전 consumer fixture는 별도로 실행하지 않았으며 reflection contract와 `javap` descriptor로 현재 범위를 검증했습니다.

## Metadata

- Issue: #1537, milestone `2.0.0`, assignee `debop`
- PR: #1575, head `b713aa879efea1647236afc7c27f1fc33531f27d`, base `develop`, milestone `2.0.0`, assignee `debop`
- CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33292903774

## DoD Status

Required checks: 40/46; N/A: 4; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-04 | authority, live issue, isolated worktree, locale 정책 확인 | PASS | repo `bluetape4k-projects`, base `develop`, head `fix/issue-1537-mongodb-abi`; issue #1537 live read-back | 없음 |
| C-01~C-05 / CG-05~CG-07 / KT-01~KT-05 | root cause, RED/GREEN, Kotlin·문서 계약 검증 | PASS | 96 tests, detekt, reflection ABI tests, `javap` | 없음 |
| CG-08 | heavyweight shared-state 검사 직렬화 | N/A | 현재 module test는 외부 MongoDB/Testcontainers를 시작하지 않으며 ABI·context 범위만 변경 | 없음 |
| CG-09 / C-06 | lesson gate 검토 | N/A | 기존 Kotlin public ABI·release convergence 규칙으로 충분하며 신규 복구 실패나 반복 가능한 Projects workflow gap 없음 | 없음 |
| SPW-01~SPW-05 / KO-01~KO-07 | KDoc·README locale parity와 기술 문체 검증 | PASS | README 영문/한글 parity, terminology audit findings=0, final read-back | 없음 |
| CG-10~CG-13 | inline review, commit, exact-head push, guidance refresh, PR 생성 | PASS | `APPROVE` + `CLEAR`; local/remote `b713aa879efea1647236afc7c27f1fc33531f27d`; PR metadata read-back | 없음 |
| C-07 / CG-14 | exact-head CI와 live review/thread 확인 | PASS | 13 success, 12 path-filtered skipped, pending=0, failed=0; comments/reviews/unresolved threads=0; merge state `CLEAN` | 없음 |
| CG-14 human review subgate | single-developer lane의 추가 maintainer review | N/A | owner/assignee `debop`, requested reviewer 없음; 독립 code-reviewer `APPROVE`와 architect `CLEAR` 완료 | 없음 |
| C-08 / CG-15 | merge-ready 보고 | PENDING | 이 사용자 보고에서 exact PR/head와 DoD를 제시 | 보고 후 CG-16 대기 |
| C-09 / CG-16~CG-18 | fresh merge 승인, merge, sync/cleanup | PENDING | merge는 별도 승인 gate | CG-15 이후 사용자 승인 대기 |

Final status: PENDING (CG-15, PR #1575, exact head `b713aa879efea1647236afc7c27f1fc33531f27d`)

Unchecked required items: C-08, C-09, CG-15, CG-16, CG-17, CG-18
