### PR TITLE
[docs] tenant 모듈 3개를 manual publication contract에 등록

### DIFF
--- a/docs/manual/en/modules/bluetape4k-ktor-tenant.md
+++ b/docs/manual/en/modules/bluetape4k-ktor-tenant.md
@@ -1,0 +1,110 @@
+---
+manualId: bluetape4k-ktor-tenant
+title: "Ktor Tenant Context Adapter"
+description: "JDK 25 adapter that binds a canonical TenantId to Ktor ApplicationCall.attributes with a one-call/one-tenant contract. The application owns plugins, authentication, header parsing, and HTTP status mapping."
+kind: library
+group: web
+learningOrder: 850
+---
+
+# Ktor Tenant Context Adapter
+
+## Problem {#problem}
+
+JDK 25 adapter that binds a canonical TenantId to Ktor ApplicationCall.attributes with a one-call/one-tenant contract. The application owns plugins, authentication, header parsing, and HTTP status mapping. This manual connects that purpose to the current build, source entry points, tests, configuration resources, and lifecycle evidence instead of duplicating the README feature list.
+
+## When to use {#when-to-use}
+
+Use `bluetape4k-ktor-tenant` when an application must attach one authorized `TenantId` to each Ktor `ApplicationCall` and make it available across dispatcher hops that keep the same call. The application plugin or authentication pipeline remains responsible for parsing, authentication, authorization, and HTTP status mapping.
+
+## Coordinates {#coordinates}
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-dependencies:<version>"))
+    implementation("io.github.bluetape4k:bluetape4k-ktor-tenant")
+}
+```
+
+Gradle project path: `:bluetape4k-ktor-tenant`. Source directory: `ktor/tenant`.
+
+## Concepts {#concepts}
+
+The first source-level concepts to inspect are `KtorTenantContext`, and `TenantAlreadyBoundException`. File names are navigation anchors; read each declaration and its tests before treating it as a public contract.
+
+## Quick start {#quick-start}
+
+Bind once near the start of the request pipeline after the raw input has been validated:
+
+```kotlin
+val tenant = authenticateAndResolveClinic(call.request).tenantId
+KtorTenantContext.bindTenant(call, tenant)
+
+service.find(KtorTenantContext.requireCurrent(call))
+```
+
+Pass the same `ApplicationCall` to downstream code that needs the request-local binding.
+
+## API by task {#api-by-task}
+
+| Entry point | What to verify |
+| --- | --- |
+| [`KtorTenantContext.bindTenant`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt) | Bind the first canonical tenant to the call without exposing a mutable clear or overwrite API. |
+| [`KtorTenantContext.currentOrNull`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt) | Read the optional request-local binding. |
+| [`KtorTenantContext.requireCurrent`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt) | Require the binding and fail with the common missing-context exception when absent. |
+| [`TenantAlreadyBoundException`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/TenantAlreadyBoundException.kt) | Reject a second or concurrent binding without overwriting the first tenant. |
+
+## Patterns {#patterns}
+
+Authenticate and resolve the canonical tenant before calling `bindTenant`, then bind exactly once per call. The `ApplicationCall.attributes` owner provides request-local lifecycle cleanup; do not add a global registry, mutable clear operation, nested rebind, or duplicate-binding recovery.
+
+## Integrations {#integrations}
+
+The current build declares these integration edges:
+
+```kotlin
+api(project(":bluetape4k-tenant"))
+api(libs.ktor.server.core)
+```
+
+Both dependencies are public API edges: consumers receive the common tenant contract and Ktor server core types with this adapter.
+
+## Configuration {#configuration}
+
+The adapter has no configuration properties or installed Ktor plugin. Applications decide where authentication, canonicalization, binding, and error mapping occur in their own pipeline.
+
+## Failures {#failures}
+
+`currentOrNull` returns `null` for an unbound call and `requireCurrent` throws the common `MissingTenantContextException`. A second or concurrent `bindTenant` call throws `TenantAlreadyBoundException("Tenant context is already bound to this call")` and preserves the first value.
+
+## Operations {#operations}
+
+Do not include tenant values in logs, exceptions, MDC, or metric tags. Keep binding-failure telemetry bounded to carrier/stage labels and correlate it through existing trace or request identifiers.
+
+## Testing {#testing}
+
+Run the module test task:
+
+```bash
+./gradlew :bluetape4k-ktor-tenant:test --no-configuration-cache
+```
+
+Representative test anchors:
+
+- [`KtorTenantContextTest`](../../../../ktor/tenant/src/test/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContextTest.kt)
+
+## Workshops {#workshops}
+
+No dedicated workshop path is registered in the manual manifest. Use the module README and the representative tests above as runnable evidence.
+
+## Limitations {#limitations}
+
+The module does not install an application plugin, authenticate or authorize tenants, parse headers, map exceptions to HTTP responses, or recover from duplicate binding. It provides no default tenant or process-global registry.
+
+## Sources {#sources}
+
+- [Module README](../../../../ktor/tenant/README.md)
+- [Module build](../../../../ktor/tenant/build.gradle.kts)
+- [`KtorTenantContext`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt)
+- [`TenantAlreadyBoundException`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/TenantAlreadyBoundException.kt)
+- [`KtorTenantContextTest`](../../../../ktor/tenant/src/test/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContextTest.kt)

--- a/docs/manual/en/modules/bluetape4k-tenant-reactor.md
+++ b/docs/manual/en/modules/bluetape4k-tenant-reactor.md
@@ -1,0 +1,109 @@
+---
+manualId: bluetape4k-tenant-reactor
+title: "Reactor Tenant Context Adapter"
+description: "JDK 25 adapter for immutable TenantId propagation in Reactor subscriber Context. It installs no default tenant, global hook, or automatic context propagation."
+kind: library
+group: concurrency
+learningOrder: 260
+---
+
+# Reactor Tenant Context Adapter
+
+## Problem {#problem}
+
+JDK 25 adapter for immutable TenantId propagation in Reactor subscriber Context. It installs no default tenant, global hook, or automatic context propagation. This manual connects that purpose to the current build, source entry points, tests, configuration resources, and lifecycle evidence instead of duplicating the README feature list.
+
+## When to use {#when-to-use}
+
+Use `bluetape4k-tenant-reactor` when a reactive pipeline must carry an authorized `TenantId` in Reactor subscriber `Context`. Bind once at the subscription boundary and read through `ContextView` downstream. The adapter is appropriate when explicit propagation is preferred over global hooks or automatic context propagation.
+
+## Coordinates {#coordinates}
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-dependencies:<version>"))
+    implementation("io.github.bluetape4k:bluetape4k-tenant-reactor")
+}
+```
+
+Gradle project path: `:bluetape4k-tenant-reactor`. Source directory: `bluetape4k/tenant-reactor`.
+
+## Concepts {#concepts}
+
+The first source-level concepts to inspect are `ReactorTenantContext`. File names are navigation anchors; read each declaration and its tests before treating it as a public contract.
+
+## Quick start {#quick-start}
+
+Bind at `contextWrite` and read lazily with `deferContextual`:
+
+```kotlin
+val result = Mono.deferContextual { context ->
+    service.find(ReactorTenantContext.requireCurrent(context))
+}.contextWrite { context ->
+    ReactorTenantContext.withTenant(context, TenantId("clinic-a"))
+}
+```
+
+`withTenant` returns a derived immutable `Context`; it does not mutate the input context.
+
+## API by task {#api-by-task}
+
+| Entry point | What to verify |
+| --- | --- |
+| [`ReactorTenantContext.currentOrNull`](../../../../bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt) | Read an optional `TenantId` from a `ContextView`. |
+| [`ReactorTenantContext.requireCurrent`](../../../../bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt) | Require the binding and fail with the common missing-context exception when absent. |
+| [`ReactorTenantContext.withTenant`](../../../../bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt) | Derive a new `Context` containing the canonical `TenantId`. |
+
+## Patterns {#patterns}
+
+Call `withTenant` once near the subscription boundary and use `deferContextual` where a downstream component needs the tenant. Do not call `Context.put` for every signal, install a global `Hooks` bridge, or copy the tenant into a mutable registry.
+
+## Integrations {#integrations}
+
+The current build declares these integration edges:
+
+```kotlin
+api(project(":bluetape4k-tenant"))
+api(libs.reactor.core)
+```
+
+Both dependencies are public API edges: consumers receive the common tenant contract and Reactor `Context` types with this adapter.
+
+## Configuration {#configuration}
+
+The adapter has no configuration properties, global registration, or automatic-propagation switch. The application chooses the subscription boundary explicitly in the pipeline.
+
+## Failures {#failures}
+
+`currentOrNull` returns `null` for an unbound `ContextView`; `requireCurrent` throws the common `MissingTenantContextException`. Cancellation ends the subscriber lifecycle together with its context. The adapter provides no default, fallback, or duplicate-recovery policy.
+
+## Operations {#operations}
+
+Do not expose tenant values through logs, exceptions, MDC, or metric tags. Binding-failure telemetry should use bounded carrier/stage labels and existing correlation or trace identifiers.
+
+## Testing {#testing}
+
+Run the module test task:
+
+```bash
+./gradlew :bluetape4k-tenant-reactor:test --no-configuration-cache
+```
+
+Representative test anchors:
+
+- [`ReactorTenantContextTest`](../../../../bluetape4k/tenant-reactor/src/test/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContextTest.kt)
+
+## Workshops {#workshops}
+
+No dedicated workshop path is registered in the manual manifest. Use the module README and the representative tests above as runnable evidence.
+
+## Limitations {#limitations}
+
+The adapter does not authenticate tenants, parse headers, map HTTP errors, install Reactor hooks, or bridge automatically to coroutine `ReactorContext`. Each boundary must opt into propagation explicitly.
+
+## Sources {#sources}
+
+- [Module README](../../../../bluetape4k/tenant-reactor/README.md)
+- [Module build](../../../../bluetape4k/tenant-reactor/build.gradle.kts)
+- [`ReactorTenantContext`](../../../../bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt)
+- [`ReactorTenantContextTest`](../../../../bluetape4k/tenant-reactor/src/test/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContextTest.kt)

--- a/docs/manual/en/modules/bluetape4k-tenant.md
+++ b/docs/manual/en/modules/bluetape4k-tenant.md
@@ -1,0 +1,116 @@
+---
+manualId: bluetape4k-tenant
+title: "Tenant Context Core"
+description: "Common APIs and ThreadLocal/ScopedValue carriers for explicit tenant binding in JDK 25 applications. There is no default tenant or fallback."
+kind: library
+group: concurrency
+learningOrder: 250
+---
+
+# Tenant Context Core
+
+## Problem {#problem}
+
+Common APIs and ThreadLocal/ScopedValue carriers for explicit tenant binding in JDK 25 applications. There is no default tenant or fallback. This manual connects that purpose to the current build, source entry points, tests, configuration resources, and lifecycle evidence instead of duplicating the README feature list.
+
+## When to use {#when-to-use}
+
+Use `bluetape4k-tenant` when an application must carry an authenticated, canonical `TenantId` through a lexical scope without inventing a default tenant. Choose `ThreadLocalTenantContext` for synchronous work that remains on one platform thread and `ScopedValueTenantContext` for virtual-thread or structured-concurrency code. Use a carrier-specific adapter for Reactor, Ktor, or coroutine boundaries instead of assuming automatic propagation.
+
+## Coordinates {#coordinates}
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-dependencies:<version>"))
+    implementation("io.github.bluetape4k:bluetape4k-tenant")
+}
+```
+
+Gradle project path: `:bluetape4k-tenant`. Source directory: `bluetape4k/tenant`.
+
+## Concepts {#concepts}
+
+The first source-level concepts to inspect are `MissingTenantContextException`, `ScopedValueTenantContext`, `TenantContext`, `TenantId`, and `ThreadLocalTenantContext`. File names are navigation anchors; read each declaration and its tests before treating it as a public contract.
+
+## Quick start {#quick-start}
+
+Create one application-scoped carrier and use only the lexical `withTenant` API:
+
+```kotlin
+val tenantContext: TenantContext = ThreadLocalTenantContext()
+
+tenantContext.withTenant(TenantId("clinic-a")) {
+    repository.findAppointments(tenantContext.requireCurrent())
+}
+```
+
+Map raw headers or tokens to an authorized domain value before constructing `TenantId`.
+
+## API by task {#api-by-task}
+
+| Entry point | What to verify |
+| --- | --- |
+| [`TenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantContext.kt) | Bind with `withTenant`, query optionally with `currentOrNull`, or require a binding with `requireCurrent`. |
+| [`ThreadLocalTenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContext.kt) | Keep synchronous platform-thread bindings lexical; nested scopes restore the previous value in `finally`. |
+| [`ScopedValueTenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ScopedValueTenantContext.kt) | Use JDK 25 `ScopedValue` lexical inheritance with virtual threads and `StructuredTaskScope`. |
+| [`TenantId`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantId.kt) | Carry only a canonical application value after authentication and authorization. |
+| [`MissingTenantContextException`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/MissingTenantContextException.kt) | Handle a missing required binding at the application boundary that owns status or error mapping. |
+
+## Patterns {#patterns}
+
+Inject one carrier instance into the boundary and downstream components that share the binding. Keep authentication, authorization, tenant existence checks, schema or connection routing, and persistence outside this module. Do not expose mutable `set` or `clear` operations or create a carrier per request.
+
+## Integrations {#integrations}
+
+The module build declares no direct `api`, `implementation`, `compileOnly`, or `runtimeOnly` dependency line. Inspect plugins and generated metadata in the build file.
+
+## Configuration {#configuration}
+
+The module has no configuration properties or resources. Carrier choice and lifecycle are explicit application decisions made when the `TenantContext` instance is constructed and injected.
+
+## Failures {#failures}
+
+`currentOrNull()` returns `null` when unbound, while `requireCurrent()` throws `MissingTenantContextException("Tenant context is not bound")`. `ThreadLocalTenantContext` restores a nested previous value and removes the binding in `finally`; `ScopedValueTenantContext` keeps the binding inside its lexical carrier. There is no fallback tenant.
+
+## Operations {#operations}
+
+Do not put raw headers, tokens, or tenant values in logs, exceptions, MDC, or metric labels. If a consumer records binding failures, use bounded carrier/stage labels and existing correlation or trace identifiers without exposing tenant identity.
+
+## Testing {#testing}
+
+Run the module test task:
+
+```bash
+./gradlew :bluetape4k-tenant:test --no-configuration-cache
+```
+
+Representative test anchors:
+
+- [`ScopedValueTenantContextTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ScopedValueTenantContextTest.kt)
+- [`TenantContextApiTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextApiTest.kt)
+- [`TenantContextRetentionStressTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextRetentionStressTest.kt)
+- [`TenantIdTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantIdTest.kt)
+- [`ThreadLocalTenantContextTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContextTest.kt)
+
+## Workshops {#workshops}
+
+No dedicated workshop path is registered in the manual manifest. Use the module README and the representative tests above as runnable evidence.
+
+## Limitations {#limitations}
+
+The module does not authenticate tenants, authorize access, select schemas or connections, or propagate bindings across coroutine suspension and dispatcher hops. Independently started virtual threads also do not inherit a binding automatically. Applications must select the correct adapter at each asynchronous or framework boundary.
+
+## Sources {#sources}
+
+- [Module README](../../../../bluetape4k/tenant/README.md)
+- [Module build](../../../../bluetape4k/tenant/build.gradle.kts)
+- [`MissingTenantContextException`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/MissingTenantContextException.kt)
+- [`ScopedValueTenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ScopedValueTenantContext.kt)
+- [`TenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantContext.kt)
+- [`TenantId`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantId.kt)
+- [`ThreadLocalTenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContext.kt)
+- [`ScopedValueTenantContextTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ScopedValueTenantContextTest.kt)
+- [`TenantContextApiTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextApiTest.kt)
+- [`TenantContextRetentionStressTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextRetentionStressTest.kt)
+- [`TenantIdTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantIdTest.kt)
+- [`ThreadLocalTenantContextTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContextTest.kt)

--- a/docs/manual/generated/manifest.json
+++ b/docs/manual/generated/manifest.json
@@ -1456,6 +1456,31 @@
       ]
     },
     {
+      "artifact": "io.github.bluetape4k:bluetape4k-ktor-tenant",
+      "en": "en/modules/bluetape4k-ktor-tenant.md",
+      "gradlePath": ":bluetape4k-ktor-tenant",
+      "group": "web",
+      "id": "bluetape4k-ktor-tenant",
+      "kind": "library",
+      "ko": "ko/modules/bluetape4k-ktor-tenant.md",
+      "learningOrder": 850,
+      "sourceDir": "ktor/tenant",
+      "sourcePaths": [
+        "ktor/tenant/src/main/kotlin"
+      ],
+      "testPaths": [
+        "ktor/tenant/src/test/kotlin",
+        "ktor/tenant/src/test/resources"
+      ],
+      "title": {
+        "en": "Ktor Tenant Context Adapter",
+        "ko": "Ktor Tenant Context 어댑터"
+      },
+      "workshops": [
+
+      ]
+    },
+    {
       "artifact": "io.github.bluetape4k:bluetape4k-ktor-testing",
       "en": "en/modules/bluetape4k-ktor-testing.md",
       "gradlePath": ":bluetape4k-ktor-testing",
@@ -2537,6 +2562,56 @@
       "title": {
         "en": "State Machine Utilities",
         "ko": "상태 머신 유틸리티"
+      },
+      "workshops": [
+
+      ]
+    },
+    {
+      "artifact": "io.github.bluetape4k:bluetape4k-tenant",
+      "en": "en/modules/bluetape4k-tenant.md",
+      "gradlePath": ":bluetape4k-tenant",
+      "group": "concurrency",
+      "id": "bluetape4k-tenant",
+      "kind": "library",
+      "ko": "ko/modules/bluetape4k-tenant.md",
+      "learningOrder": 250,
+      "sourceDir": "bluetape4k/tenant",
+      "sourcePaths": [
+        "bluetape4k/tenant/src/main/kotlin"
+      ],
+      "testPaths": [
+        "bluetape4k/tenant/src/test/kotlin",
+        "bluetape4k/tenant/src/test/resources"
+      ],
+      "title": {
+        "en": "Tenant Context Core",
+        "ko": "Tenant Context 공통 API"
+      },
+      "workshops": [
+
+      ]
+    },
+    {
+      "artifact": "io.github.bluetape4k:bluetape4k-tenant-reactor",
+      "en": "en/modules/bluetape4k-tenant-reactor.md",
+      "gradlePath": ":bluetape4k-tenant-reactor",
+      "group": "concurrency",
+      "id": "bluetape4k-tenant-reactor",
+      "kind": "library",
+      "ko": "ko/modules/bluetape4k-tenant-reactor.md",
+      "learningOrder": 260,
+      "sourceDir": "bluetape4k/tenant-reactor",
+      "sourcePaths": [
+        "bluetape4k/tenant-reactor/src/main/kotlin"
+      ],
+      "testPaths": [
+        "bluetape4k/tenant-reactor/src/test/kotlin",
+        "bluetape4k/tenant-reactor/src/test/resources"
+      ],
+      "title": {
+        "en": "Reactor Tenant Context Adapter",
+        "ko": "Reactor Tenant Context 어댑터"
       },
       "workshops": [
 

--- a/docs/manual/ko/modules/bluetape4k-ktor-tenant.md
+++ b/docs/manual/ko/modules/bluetape4k-ktor-tenant.md
@@ -1,0 +1,110 @@
+---
+manualId: bluetape4k-ktor-tenant
+title: "Ktor Tenant Context 어댑터"
+description: "Ktor ApplicationCall.attributes에 canonical TenantId를 one-call/one-tenant로 binding하는 JDK 25 adapter입니다. plugin, 인증, header parsing, HTTP status mapping은 application이 소유합니다."
+kind: library
+group: web
+learningOrder: 850
+---
+
+# Ktor Tenant Context 어댑터
+
+## 해결하는 문제 {#problem}
+
+Ktor ApplicationCall.attributes에 canonical TenantId를 one-call/one-tenant로 binding하는 JDK 25 adapter입니다. plugin, 인증, header parsing, HTTP status mapping은 application이 소유합니다. 이 매뉴얼은 README의 기능 목록을 반복하지 않고 현재 build, source entry point, test, 설정 resource, lifecycle 근거를 연결합니다.
+
+## 사용 시점 {#when-to-use}
+
+Ktor `ApplicationCall`마다 인증을 마친 `TenantId` 하나를 연결하고 같은 call을 유지하는 dispatcher hop에서도 조회해야 할 때 `bluetape4k-ktor-tenant`를 사용합니다. parsing, 인증·인가, HTTP status mapping은 application plugin 또는 authentication pipeline이 계속 소유합니다.
+
+## 의존성 좌표 {#coordinates}
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-dependencies:<version>"))
+    implementation("io.github.bluetape4k:bluetape4k-ktor-tenant")
+}
+```
+
+Gradle project path는 `:bluetape4k-ktor-tenant`, source directory는 `ktor/tenant`입니다.
+
+## 핵심 개념 {#concepts}
+
+먼저 확인할 source 개념은 `KtorTenantContext`, `TenantAlreadyBoundException`입니다. 파일 이름은 탐색 anchor일 뿐이므로 public 계약으로 사용하기 전에 선언과 test를 함께 읽습니다.
+
+## 빠른 시작 {#quick-start}
+
+raw input을 검증한 다음 request pipeline 앞부분에서 한 번 binding합니다.
+
+```kotlin
+val tenant = authenticateAndResolveClinic(call.request).tenantId
+KtorTenantContext.bindTenant(call, tenant)
+
+service.find(KtorTenantContext.requireCurrent(call))
+```
+
+request-local binding이 필요한 downstream code에는 같은 `ApplicationCall`을 전달합니다.
+
+## 작업별 API {#api-by-task}
+
+| Entry point | 확인할 내용 |
+| --- | --- |
+| [`KtorTenantContext.bindTenant`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt) | mutable clear나 overwrite API 없이 첫 canonical tenant를 call에 binding합니다. |
+| [`KtorTenantContext.currentOrNull`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt) | optional request-local binding을 읽습니다. |
+| [`KtorTenantContext.requireCurrent`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt) | binding을 요구하고 누락 시 공통 missing-context exception으로 실패합니다. |
+| [`TenantAlreadyBoundException`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/TenantAlreadyBoundException.kt) | 두 번째 또는 concurrent binding을 거부하고 첫 tenant를 보존합니다. |
+
+## 권장 패턴 {#patterns}
+
+`bindTenant` 호출 전에 canonical tenant를 인증·확정하고 call마다 정확히 한 번 binding합니다. `ApplicationCall.attributes`가 request-local lifecycle을 소유하므로 global registry, mutable clear, nested rebind, duplicate-binding recovery를 추가하지 않습니다.
+
+## 연동 {#integrations}
+
+현재 build에 선언된 integration edge는 다음과 같습니다.
+
+```kotlin
+api(project(":bluetape4k-tenant"))
+api(libs.ktor.server.core)
+```
+
+두 dependency 모두 public API edge이므로 consumer는 이 adapter와 함께 공통 tenant 계약과 Ktor server core type을 전달받습니다.
+
+## 설정 {#configuration}
+
+이 adapter에는 configuration property나 자동 설치되는 Ktor plugin이 없습니다. 인증, canonicalization, binding, error mapping 위치는 application pipeline이 결정합니다.
+
+## 실패 동작 {#failures}
+
+binding이 없으면 `currentOrNull`은 `null`, `requireCurrent`는 공통 `MissingTenantContextException`을 던집니다. 두 번째 또는 concurrent `bindTenant` 호출은 `TenantAlreadyBoundException("Tenant context is already bound to this call")`으로 실패하며 첫 값을 보존합니다.
+
+## 운영 {#operations}
+
+tenant 값은 log, exception, MDC, metric tag에 넣지 않습니다. binding failure telemetry는 bounded carrier/stage label을 사용하고 기존 trace 또는 request identifier로 연결합니다.
+
+## 테스트 {#testing}
+
+모듈 test task는 다음과 같습니다.
+
+```bash
+./gradlew :bluetape4k-ktor-tenant:test --no-configuration-cache
+```
+
+대표 test anchor는 다음과 같습니다.
+
+- [`KtorTenantContextTest`](../../../../ktor/tenant/src/test/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContextTest.kt)
+
+## 워크숍 {#workshops}
+
+manual manifest에 등록된 전용 workshop path가 없습니다. 모듈 README와 위 representative test를 실행 근거로 사용합니다.
+
+## 제한 사항 {#limitations}
+
+이 모듈은 application plugin 설치, tenant 인증·인가, header parsing, HTTP response mapping, duplicate binding 복구를 제공하지 않습니다. default tenant나 process-global registry도 없습니다.
+
+## 근거 {#sources}
+
+- [모듈 README](../../../../ktor/tenant/README.ko.md)
+- [모듈 build](../../../../ktor/tenant/build.gradle.kts)
+- [`KtorTenantContext`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContext.kt)
+- [`TenantAlreadyBoundException`](../../../../ktor/tenant/src/main/kotlin/io/bluetape4k/ktor/tenant/TenantAlreadyBoundException.kt)
+- [`KtorTenantContextTest`](../../../../ktor/tenant/src/test/kotlin/io/bluetape4k/ktor/tenant/KtorTenantContextTest.kt)

--- a/docs/manual/ko/modules/bluetape4k-tenant-reactor.md
+++ b/docs/manual/ko/modules/bluetape4k-tenant-reactor.md
@@ -1,0 +1,109 @@
+---
+manualId: bluetape4k-tenant-reactor
+title: "Reactor Tenant Context 어댑터"
+description: "Reactor subscriber Context에 TenantId를 immutable하게 전달하는 JDK 25 adapter입니다. default tenant, global hook, automatic context propagation을 설치하지 않습니다."
+kind: library
+group: concurrency
+learningOrder: 260
+---
+
+# Reactor Tenant Context 어댑터
+
+## 해결하는 문제 {#problem}
+
+Reactor subscriber Context에 TenantId를 immutable하게 전달하는 JDK 25 adapter입니다. default tenant, global hook, automatic context propagation을 설치하지 않습니다. 이 매뉴얼은 README의 기능 목록을 반복하지 않고 현재 build, source entry point, test, 설정 resource, lifecycle 근거를 연결합니다.
+
+## 사용 시점 {#when-to-use}
+
+reactive pipeline이 인증을 마친 `TenantId`를 Reactor subscriber `Context`로 전달해야 할 때 `bluetape4k-tenant-reactor`를 사용합니다. subscription boundary에서 한 번 binding하고 downstream은 `ContextView`로 읽습니다. global hook이나 automatic context propagation보다 명시적 전파가 필요할 때 적합합니다.
+
+## 의존성 좌표 {#coordinates}
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-dependencies:<version>"))
+    implementation("io.github.bluetape4k:bluetape4k-tenant-reactor")
+}
+```
+
+Gradle project path는 `:bluetape4k-tenant-reactor`, source directory는 `bluetape4k/tenant-reactor`입니다.
+
+## 핵심 개념 {#concepts}
+
+먼저 확인할 source 개념은 `ReactorTenantContext`입니다. 파일 이름은 탐색 anchor일 뿐이므로 public 계약으로 사용하기 전에 선언과 test를 함께 읽습니다.
+
+## 빠른 시작 {#quick-start}
+
+`contextWrite`에서 binding하고 `deferContextual`에서 지연 조회합니다.
+
+```kotlin
+val result = Mono.deferContextual { context ->
+    service.find(ReactorTenantContext.requireCurrent(context))
+}.contextWrite { context ->
+    ReactorTenantContext.withTenant(context, TenantId("clinic-a"))
+}
+```
+
+`withTenant`는 입력 `Context`를 변경하지 않고 새 immutable `Context`를 반환합니다.
+
+## 작업별 API {#api-by-task}
+
+| Entry point | 확인할 내용 |
+| --- | --- |
+| [`ReactorTenantContext.currentOrNull`](../../../../bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt) | `ContextView`에서 optional `TenantId`를 읽습니다. |
+| [`ReactorTenantContext.requireCurrent`](../../../../bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt) | binding을 요구하고 누락 시 공통 missing-context exception으로 실패합니다. |
+| [`ReactorTenantContext.withTenant`](../../../../bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt) | canonical `TenantId`를 포함한 새 `Context`를 만듭니다. |
+
+## 권장 패턴 {#patterns}
+
+subscription boundary 가까이에서 `withTenant`를 한 번 호출하고 tenant가 필요한 downstream component에서 `deferContextual`을 사용합니다. signal마다 `Context.put`을 호출하거나 global `Hooks` bridge, mutable registry를 설치하지 않습니다.
+
+## 연동 {#integrations}
+
+현재 build에 선언된 integration edge는 다음과 같습니다.
+
+```kotlin
+api(project(":bluetape4k-tenant"))
+api(libs.reactor.core)
+```
+
+두 dependency 모두 public API edge이므로 consumer는 이 adapter와 함께 공통 tenant 계약과 Reactor `Context` type을 전달받습니다.
+
+## 설정 {#configuration}
+
+이 adapter에는 configuration property, global registration, automatic-propagation switch가 없습니다. application이 pipeline 안에서 subscription boundary를 명시적으로 선택합니다.
+
+## 실패 동작 {#failures}
+
+binding이 없으면 `currentOrNull`은 `null`, `requireCurrent`는 공통 `MissingTenantContextException`을 던집니다. cancellation이 발생하면 subscriber lifecycle과 함께 context도 끝납니다. default, fallback, duplicate recovery 정책은 제공하지 않습니다.
+
+## 운영 {#operations}
+
+tenant 값은 log, exception, MDC, metric tag에 노출하지 않습니다. binding failure telemetry에는 bounded carrier/stage label과 기존 correlation 또는 trace identifier를 사용합니다.
+
+## 테스트 {#testing}
+
+모듈 test task는 다음과 같습니다.
+
+```bash
+./gradlew :bluetape4k-tenant-reactor:test --no-configuration-cache
+```
+
+대표 test anchor는 다음과 같습니다.
+
+- [`ReactorTenantContextTest`](../../../../bluetape4k/tenant-reactor/src/test/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContextTest.kt)
+
+## 워크숍 {#workshops}
+
+manual manifest에 등록된 전용 workshop path가 없습니다. 모듈 README와 위 representative test를 실행 근거로 사용합니다.
+
+## 제한 사항 {#limitations}
+
+이 adapter는 tenant 인증, header parsing, HTTP error mapping, Reactor hook, coroutine `ReactorContext` 자동 bridge를 제공하지 않습니다. 각 boundary가 전파를 명시적으로 선택해야 합니다.
+
+## 근거 {#sources}
+
+- [모듈 README](../../../../bluetape4k/tenant-reactor/README.ko.md)
+- [모듈 build](../../../../bluetape4k/tenant-reactor/build.gradle.kts)
+- [`ReactorTenantContext`](../../../../bluetape4k/tenant-reactor/src/main/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContext.kt)
+- [`ReactorTenantContextTest`](../../../../bluetape4k/tenant-reactor/src/test/kotlin/io/bluetape4k/tenant/reactor/ReactorTenantContextTest.kt)

--- a/docs/manual/ko/modules/bluetape4k-tenant.md
+++ b/docs/manual/ko/modules/bluetape4k-tenant.md
@@ -1,0 +1,116 @@
+---
+manualId: bluetape4k-tenant
+title: "Tenant Context 공통 API"
+description: "JDK 25 애플리케이션에서 tenant를 명시적으로 binding하는 공통 API와 ThreadLocal/ScopedValue carrier를 제공합니다. default tenant와 fallback은 없습니다."
+kind: library
+group: concurrency
+learningOrder: 250
+---
+
+# Tenant Context 공통 API
+
+## 해결하는 문제 {#problem}
+
+JDK 25 애플리케이션에서 tenant를 명시적으로 binding하는 공통 API와 ThreadLocal/ScopedValue carrier를 제공합니다. default tenant와 fallback은 없습니다. 이 매뉴얼은 README의 기능 목록을 반복하지 않고 현재 build, source entry point, test, 설정 resource, lifecycle 근거를 연결합니다.
+
+## 사용 시점 {#when-to-use}
+
+인증을 마친 canonical `TenantId`를 default 없이 lexical scope에 전달해야 할 때 `bluetape4k-tenant`를 사용합니다. 같은 platform thread에서 동기 작업을 이어가면 `ThreadLocalTenantContext`, virtual thread나 structured concurrency를 사용하면 `ScopedValueTenantContext`를 선택합니다. Reactor, Ktor, coroutine 경계에서는 자동 전파를 가정하지 말고 해당 carrier adapter를 사용합니다.
+
+## 의존성 좌표 {#coordinates}
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k:bluetape4k-dependencies:<version>"))
+    implementation("io.github.bluetape4k:bluetape4k-tenant")
+}
+```
+
+Gradle project path는 `:bluetape4k-tenant`, source directory는 `bluetape4k/tenant`입니다.
+
+## 핵심 개념 {#concepts}
+
+먼저 확인할 source 개념은 `MissingTenantContextException`, `ScopedValueTenantContext`, `TenantContext`, `TenantId`, `ThreadLocalTenantContext`입니다. 파일 이름은 탐색 anchor일 뿐이므로 public 계약으로 사용하기 전에 선언과 test를 함께 읽습니다.
+
+## 빠른 시작 {#quick-start}
+
+application scope carrier 하나를 만들고 lexical `withTenant` API만 사용합니다.
+
+```kotlin
+val tenantContext: TenantContext = ThreadLocalTenantContext()
+
+tenantContext.withTenant(TenantId("clinic-a")) {
+    repository.findAppointments(tenantContext.requireCurrent())
+}
+```
+
+raw header나 token은 인증과 권한 확인을 거쳐 canonical domain 값으로 바꾼 다음 `TenantId`를 생성합니다.
+
+## 작업별 API {#api-by-task}
+
+| Entry point | 확인할 내용 |
+| --- | --- |
+| [`TenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantContext.kt) | `withTenant`로 binding하고 `currentOrNull` 또는 `requireCurrent`로 조회합니다. |
+| [`ThreadLocalTenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContext.kt) | platform thread의 동기 binding을 lexical scope로 제한하며 nested scope 종료 시 이전 값을 복원합니다. |
+| [`ScopedValueTenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ScopedValueTenantContext.kt) | JDK 25 `ScopedValue`를 사용해 virtual thread와 `StructuredTaskScope`의 lexical 상속을 지원합니다. |
+| [`TenantId`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantId.kt) | 인증과 권한 확인을 마친 canonical application 값만 전달합니다. |
+| [`MissingTenantContextException`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/MissingTenantContextException.kt) | 필수 binding 누락은 status 또는 error mapping을 소유한 application boundary에서 처리합니다. |
+
+## 권장 패턴 {#patterns}
+
+binding을 공유하는 application boundary와 downstream component에 같은 carrier instance를 주입합니다. 인증, 권한 확인, tenant 존재 확인, schema 또는 connection routing, persistence는 이 모듈 밖에 둡니다. mutable `set`/`clear` API를 추가하거나 request마다 carrier를 만들지 않습니다.
+
+## 연동 {#integrations}
+
+모듈 build에 직접적인 `api`, `implementation`, `compileOnly`, `runtimeOnly` dependency line이 없습니다. build file의 plugin과 generated metadata를 확인합니다.
+
+## 설정 {#configuration}
+
+이 모듈에는 configuration property나 resource가 없습니다. application이 `TenantContext` instance를 만들고 주입할 때 carrier 종류와 lifecycle을 명시적으로 결정합니다.
+
+## 실패 동작 {#failures}
+
+binding이 없으면 `currentOrNull()`은 `null`, `requireCurrent()`는 `MissingTenantContextException("Tenant context is not bound")`을 던집니다. `ThreadLocalTenantContext`는 nested 이전 값을 복원하고 `finally`에서 binding을 제거하며, `ScopedValueTenantContext`는 lexical carrier 안에서만 값을 유지합니다. fallback tenant는 없습니다.
+
+## 운영 {#operations}
+
+raw header, token, tenant 값은 log, exception, MDC, metric label에 넣지 않습니다. consumer가 binding failure를 기록한다면 tenant identity 대신 bounded carrier/stage label과 기존 correlation 또는 trace identifier를 사용합니다.
+
+## 테스트 {#testing}
+
+모듈 test task는 다음과 같습니다.
+
+```bash
+./gradlew :bluetape4k-tenant:test --no-configuration-cache
+```
+
+대표 test anchor는 다음과 같습니다.
+
+- [`ScopedValueTenantContextTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ScopedValueTenantContextTest.kt)
+- [`TenantContextApiTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextApiTest.kt)
+- [`TenantContextRetentionStressTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextRetentionStressTest.kt)
+- [`TenantIdTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantIdTest.kt)
+- [`ThreadLocalTenantContextTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContextTest.kt)
+
+## 워크숍 {#workshops}
+
+manual manifest에 등록된 전용 workshop path가 없습니다. 모듈 README와 위 representative test를 실행 근거로 사용합니다.
+
+## 제한 사항 {#limitations}
+
+이 모듈은 tenant 인증·인가, schema/connection 선택, coroutine suspension/dispatcher hop 전파를 제공하지 않습니다. 독립적으로 시작한 virtual thread도 binding을 자동 상속하지 않습니다. 비동기 또는 framework 경계마다 알맞은 adapter를 application이 선택해야 합니다.
+
+## 근거 {#sources}
+
+- [모듈 README](../../../../bluetape4k/tenant/README.ko.md)
+- [모듈 build](../../../../bluetape4k/tenant/build.gradle.kts)
+- [`MissingTenantContextException`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/MissingTenantContextException.kt)
+- [`ScopedValueTenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ScopedValueTenantContext.kt)
+- [`TenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantContext.kt)
+- [`TenantId`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/TenantId.kt)
+- [`ThreadLocalTenantContext`](../../../../bluetape4k/tenant/src/main/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContext.kt)
+- [`ScopedValueTenantContextTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ScopedValueTenantContextTest.kt)
+- [`TenantContextApiTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextApiTest.kt)
+- [`TenantContextRetentionStressTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantContextRetentionStressTest.kt)
+- [`TenantIdTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/TenantIdTest.kt)
+- [`ThreadLocalTenantContextTest`](../../../../bluetape4k/tenant/src/test/kotlin/io/bluetape4k/tenant/ThreadLocalTenantContextTest.kt)

--- a/docs/manual/manifest.yaml
+++ b/docs/manual/manifest.yaml
@@ -1022,6 +1022,24 @@ modules:
   - ktor/resilience4j/src/test/kotlin
   - ktor/resilience4j/src/test/resources
   workshops: []
+- id: bluetape4k-ktor-tenant
+  title:
+    en: "Ktor Tenant Context Adapter"
+    ko: "Ktor Tenant Context 어댑터"
+  learningOrder: 850
+  gradlePath: ":bluetape4k-ktor-tenant"
+  sourceDir: ktor/tenant
+  kind: library
+  group: web
+  artifact: io.github.bluetape4k:bluetape4k-ktor-tenant
+  en: en/modules/bluetape4k-ktor-tenant.md
+  ko: ko/modules/bluetape4k-ktor-tenant.md
+  sourcePaths:
+  - ktor/tenant/src/main/kotlin
+  testPaths:
+  - ktor/tenant/src/test/kotlin
+  - ktor/tenant/src/test/resources
+  workshops: []
 - id: bluetape4k-ktor-testing
   title:
     en: "Ktor Test Support"
@@ -1775,6 +1793,42 @@ modules:
   testPaths:
   - utils/states/src/test/kotlin
   - utils/states/src/test/resources
+  workshops: []
+- id: bluetape4k-tenant
+  title:
+    en: "Tenant Context Core"
+    ko: "Tenant Context 공통 API"
+  learningOrder: 250
+  gradlePath: ":bluetape4k-tenant"
+  sourceDir: bluetape4k/tenant
+  kind: library
+  group: concurrency
+  artifact: io.github.bluetape4k:bluetape4k-tenant
+  en: en/modules/bluetape4k-tenant.md
+  ko: ko/modules/bluetape4k-tenant.md
+  sourcePaths:
+  - bluetape4k/tenant/src/main/kotlin
+  testPaths:
+  - bluetape4k/tenant/src/test/kotlin
+  - bluetape4k/tenant/src/test/resources
+  workshops: []
+- id: bluetape4k-tenant-reactor
+  title:
+    en: "Reactor Tenant Context Adapter"
+    ko: "Reactor Tenant Context 어댑터"
+  learningOrder: 260
+  gradlePath: ":bluetape4k-tenant-reactor"
+  sourceDir: bluetape4k/tenant-reactor
+  kind: library
+  group: concurrency
+  artifact: io.github.bluetape4k:bluetape4k-tenant-reactor
+  en: en/modules/bluetape4k-tenant-reactor.md
+  ko: ko/modules/bluetape4k-tenant-reactor.md
+  sourcePaths:
+  - bluetape4k/tenant-reactor/src/main/kotlin
+  testPaths:
+  - bluetape4k/tenant-reactor/src/test/kotlin
+  - bluetape4k/tenant-reactor/src/test/resources
   workshops: []
 - id: bluetape4k-testcontainers
   title:


### PR DESCRIPTION
## 변경 요약

Refs #1562

PR #1566에서 추가된 tenant 모듈 3개를 manual publication contract에 등록합니다. 이 변경으로 `develop` 기준 manual 검증 실패를 해소하고, 후속 문서 PR #1576이 자체 변경 범위에 대한 검증을 계속할 수 있게 합니다.

## 배경

- `bluetape4k-tenant`, `bluetape4k-tenant-reactor`, `bluetape4k-ktor-tenant`는 PR #1566에서 추가됐지만 manual manifest와 영문/한글 모듈 문서에는 등록되지 않았습니다.
- 그 결과 PR #1576의 `Validate manual source and release contract`가 해당 3개 모듈을 `missing from manifest`로 보고했으며, 같은 실패가 깨끗한 `develop`에서도 재현됐습니다.
- 이 PR은 #1562의 남은 SNAPSHOT/downstream 작업을 자동 종료하지 않는 선행 문서 정합성 변경입니다.

## 해결 내용

- publishable module inventory와 manual manifest의 불일치를 제거합니다.
- 현재 Kotlin source와 module README를 기준으로 tenant core, Reactor, Ktor 사용 계약을 영문/한글 문서에 함께 제공합니다.
- 기존 `1.12.1` release manual 호환성을 유지하도록 신규 모듈을 snapshot-only 문서로 처리합니다.

## 작업 내역

- `docs/manual/manifest.yaml`, `docs/manual/generated/manifest.json`: tenant 모듈 3개의 group, learning order, source/test path, artifact, locale 경로를 등록했습니다.
- `docs/manual/{en,ko}/modules/bluetape4k-tenant.md`: no-default tenant contract, `ThreadLocal`/`ScopedValue`, lexical restore와 application boundary를 문서화했습니다.
- `docs/manual/{en,ko}/modules/bluetape4k-tenant-reactor.md`: immutable subscriber `Context`, `contextWrite`, `deferContextual` 사용 계약을 문서화했습니다.
- `docs/manual/{en,ko}/modules/bluetape4k-ktor-tenant.md`: `ApplicationCall.attributes`, one-call/one-tenant, duplicate binding 예외와 application ownership을 문서화했습니다.

## 검증

- `./gradlew exportManualModuleInventory --no-configuration-cache`: PASS (`BUILD SUCCESSFUL`)
- manual Ruby tests: PASS (44 runs, 170 assertions, failures/errors/skips 0)
- `ruby scripts/manual/validate_manuals.rb`: PASS (`Manuals are aligned.`)
- release contract validator: PASS (5069 checked, 0 missing, snapshot-only manuals 8개 제외)
- localization inventory: PASS (양방향 누락 0, English-KDoc drift 0)
- terminology audit: PASS (3 files, findings 0)
- `./gradlew :bluetape4k-tenant:test :bluetape4k-tenant-reactor:test :bluetape4k-ktor-tenant:test`: PASS (29 tests, failures/errors/skips 0)
- `git diff --cached --check`: PASS

## 리뷰

- 독립 inline review: `APPROVE`
- P0/P1/P2/P3: 0/0/0/0
- 확인 범위: YAML/JSON parity, group/learningOrder, 링크, source/API 주장, 영문/한글 parity, release snapshot 호환성

## 메타데이터

- Issue: #1562, milestone `2.0.0`, assignee `debop`, labels `enhancement`, `dependencies`, `coroutines`
- PR: #1577, base `develop`, head `docs/issue-1562-tenant-manual-registration`, exact head `cf5400ea228d4c61a41e0703f1f7ada90c49367b`
- CI: `Validate manual source and release contract` SUCCESS ([run 33302372389 / job 99232767709](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33302372389/job/99232767709))

## DoD Status

Required checks: 25/25; N/A: 2; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-04 - 권한·경계 | 지침, 승인 범위, worktree, 언어 정책 재확인 | PASS | 독립 worktree와 승인된 8개 문서 파일만 변경 | 없음 |
| CG-05~CG-07 - 계약·검증 | 기존 source/README 패턴 재사용, manual 등록 및 targeted proof | PASS | manual 44/170, tenant 29 tests, 정합성·현지화·용어 검사 통과 | 없음 |
| CG-08 - heavyweight 직렬화 | Testcontainers/DB/native/shared-state 검사 적용성 확인 | N/A | 문서 및 비컨테이너 tenant unit test 범위 | 없음 |
| CG-09 - lesson gate | 기존 module documentation checklist 재사용 여부 검토 | PASS | `docs/process/module-documentation-checklist.md`가 inventory export와 manual validation을 이미 규정; 신규 반복 실패/복구/설계 수정 없음 | 없음 |
| CG-10 - pre-PR proof | 최종 diff, independent inline review, commit 수렴 | PASS | P0~P3 0, commit `cf5400ea228d4c61a41e0703f1f7ada90c49367b` | 없음 |
| CG-11~CG-12 - PR 권한·publish | 승인된 repo/base/head 확인 후 force 없이 push, remote head readback | PASS | `bluetape4k/bluetape4k-projects`, `develop` ← `docs/issue-1562-tenant-manual-registration`; local=remote=`cf5400ea228d4c61a41e0703f1f7ada90c49367b` | 없음 |
| CG-12A - Guidance refresh | 현재 AGENTS hierarchy, leaf skill, common gates, PR template, issue #1562 재확인 | PASS | preflight 해시와 동일; issue metadata live readback 완료 | 없음 |
| CG-13 - PR 생성·검증 | assignee, milestone, labels, body final heading을 설정하고 live readback | PASS | 이 PR의 live metadata 및 exact head 확인 | 불일치 시 즉시 수정 |
| CG-14 - CI·review | exact-head CI 및 live reviews/threads 확인 | PASS | `cf5400ea228d4c61a41e0703f1f7ada90c49367b`에서 manual check SUCCESS; GitHub reviews 0, threads 0, unresolved 0; 독립 inline review APPROVE 및 P0~P3 0; live human review는 N/A (single-developer lane) | 없음 |
| CG-15 - merge-ready 보고 | exact PR/head 기준 CI·review·lesson·artifact DoD 보고 | PASS | 이 PR의 현재 `## DoD Status`, mergeable `MERGEABLE`, exact head `cf5400ea228d4c61a41e0703f1f7ada90c49367b` | fresh merge 승인 대기 |
| CG-16 - fresh merge 승인 | merge-ready 보고 후 exact-head 및 자동 원격 branch 삭제 승인 획득 | PASS | 사용자가 PR #1577 exact head `cf5400ea228d4c61a41e0703f1f7ada90c49367b` merge와 `deleteBranchOnMerge=true` side effect를 각각 승인 | 없음 |
| CG-17 - merge | `--match-head-commit`을 사용한 squash merge 및 live 검증 | PASS | 2026-08-30T08:59:37Z MERGED, merge commit `fb89f8821390bfdf5e709f00708deddb32194a01`, merged by `debop` | 없음 |
| CG-18 - sync·cleanup | canonical `develop` fast-forward와 보존 범위 검증 | PASS | local/upstream `develop`=`fb89f8821390bfdf5e709f00708deddb32194a01`; 승인된 원격 head 삭제 확인; 로컬 worktree/branch와 기존 untracked 파일 보존 | 없음 |
| E-01~E-03 - maintenance 경로·소유권 | workflow/writer 지원 경로와 문서-only 범위 적용 | PASS | production code 및 사용자-scope 운영 surface 변경 없음 | 없음 |
| E-04 - chezmoi parity | managed user-scope resource 적용성 확인 | N/A | repository manual 문서만 변경 | 없음 |
| E-05~E-06 - maintenance proof | diff, reference, manual, release, locale, terminology 검증 수렴 | PASS | 모든 triggered check PASS, P0/P1 0 | 없음 |
| E-07 - common PR gates | CG-11~CG-15 수행 | PASS | PR #1577 exact-head CI/review readback 및 merge-ready DoD 완료 | 없음 |
| E-08 - merge closeout | CG-16~CG-18 수행 | PASS | exact-head 승인, squash merge, live merged-state 검증, canonical sync 완료 | 없음 |

Final status: DONE — PR #1577을 merge commit `fb89f8821390bfdf5e709f00708deddb32194a01`로 병합하고 canonical `develop` 동기화 완료

Unchecked required items: none
