### PR TITLE
[release] privileged publication action ref를 immutable SHA로 고정

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -154,7 +154,7 @@ jobs:
       artifact_digest: ${{ steps.handoff-artifact.outputs.artifact-digest }}
       artifact_url: ${{ steps.handoff-artifact.outputs.artifact-url }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.validate-full-nightly.outputs.head_sha }}
           fetch-depth: 0
@@ -164,12 +164,12 @@ jobs:
           EXPECTED_HEAD_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
 
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
-      - uses: gradle/actions/setup-gradle@v6.3.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           gradle-version: wrapper
           cache-read-only: true
@@ -280,7 +280,7 @@ jobs:
 
       - name: Upload immutable handoff receipt
         id: handoff-artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.receipt.outputs.artifact_name }}
           path: tenant-context-handoff.json
@@ -324,7 +324,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download immutable handoff receipt
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ needs.publish.outputs.artifact_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,12 @@ jobs:
     needs: resolve-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
 
@@ -90,21 +90,21 @@ jobs:
     env:
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
 
-      - uses: gradle/actions/setup-gradle@v6.3.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           gradle-version: wrapper
           cache-read-only: true
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload image gate evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-testcontainers-image-gate-${{ github.run_id }}-amd64
           path: |
@@ -194,21 +194,21 @@ jobs:
     env:
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
 
-      - uses: gradle/actions/setup-gradle@v6.3.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           gradle-version: wrapper
           cache-read-only: true
@@ -265,7 +265,7 @@ jobs:
 
       - name: Upload Ignite2 arm64 image gate evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-testcontainers-image-gate-${{ github.run_id }}-arm64
           path: |
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: maven-central-release
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
@@ -342,16 +342,16 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.12'
 
-      - uses: gradle/actions/setup-gradle@v6.3.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           gradle-version: wrapper
           cache-read-only: true

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -38,6 +38,16 @@ YAML_EXECUTION_GUARD = re.compile(
     r"'(?P<single>if|continue-on-error)'|"
     r"(?P<plain>if|continue-on-error)):\s*(?P<value>.*?)\s*$"
 )
+WORKFLOW_USES_TARGET = re.compile(
+    r"^\s*(?:-\s*)?(?:\{\s*)?"
+    r"(?:uses|\"uses\"|'uses'):\s+(?P<target>[^\s#},]+)",
+    re.MULTILINE,
+)
+REPOSITORY_ACTION_REF = re.compile(
+    r"(?P<action>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)"
+    r"@(?P<ref>[^\s#]+)"
+)
+FULL_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 SNAPSHOT_PUBLISH_JOB_IF = (
     "${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}"
 )
@@ -389,8 +399,33 @@ def publication_validation_errors(
     return errors
 
 
+def workflow_action_refs(workflow: str) -> list[tuple[str, str]]:
+    refs = []
+    for uses_match in WORKFLOW_USES_TARGET.finditer(workflow):
+        action_match = REPOSITORY_ACTION_REF.fullmatch(uses_match.group("target"))
+        if action_match is not None:
+            refs.append((action_match.group("action"), action_match.group("ref")))
+    return refs
+
+
+def privileged_action_ref_errors(workflow: str) -> list[str]:
+    for uses_match in WORKFLOW_USES_TARGET.finditer(workflow):
+        target = uses_match.group("target")
+        if target.startswith("./"):
+            continue
+        action_match = REPOSITORY_ACTION_REF.fullmatch(target)
+        if (
+            action_match is None
+            or FULL_COMMIT_SHA.fullmatch(action_match.group("ref")) is None
+        ):
+            return [
+                "privileged publication action refs must use full commit SHAs"
+            ]
+    return []
+
+
 def release_policy_errors(workflow: str) -> list[str]:
-    errors = []
+    errors = privileged_action_ref_errors(workflow)
     release_runs = workflow_step_runs(
         workflow, "publish", "Publish to Central Portal"
     )
@@ -449,7 +484,7 @@ def release_policy_errors(workflow: str) -> list[str]:
 
 
 def snapshot_policy_errors(workflow: str) -> list[str]:
-    errors = []
+    errors = privileged_action_ref_errors(workflow)
     snapshot_runs = workflow_step_runs(workflow, "publish", "Publish SNAPSHOT")
     snapshot_command_valid = snapshot_runs == [(SNAPSHOT_PUBLICATION_RUN, False)]
     snapshot_task_count = publication_task_invocation_count(
@@ -497,7 +532,11 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
         errors.append("snapshot workflow must not grant issue write permission globally")
     if "record-handoff:" not in workflow or "issues: write" not in workflow:
         errors.append("snapshot handoff job must request issue comment permission")
-    if "actions/upload-artifact@v7" not in workflow or "retention-days: 90" not in workflow:
+    action_refs = workflow_action_refs(workflow)
+    if (
+        not any(action == "actions/upload-artifact" for action, _ in action_refs)
+        or "retention-days: 90" not in workflow
+    ):
         errors.append("snapshot workflow must retain the immutable handoff artifact for 90 days")
     if "create_snapshot_handoff.py" not in workflow:
         errors.append("snapshot workflow must create a public metadata handoff receipt")
@@ -589,6 +628,51 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
                         workflow, expected_job, expected_if
                     ),
                 )
+
+    def test_privileged_publication_workflows_reject_mutable_action_refs(self) -> None:
+        cases = (
+            ("release.yml", release_policy_errors),
+            ("publish-snapshot.yml", snapshot_policy_errors),
+        )
+
+        for workflow_name, checker in cases:
+            workflow = (WORKFLOWS / workflow_name).read_text(encoding="utf-8")
+            mutable_entries = (
+                "uses: actions/checkout@v7",
+                '"uses": actions/checkout@v7',
+                "'uses': actions/checkout@v7",
+                "{ uses: actions/checkout@v7 }",
+            )
+            for mutable_entry in mutable_entries:
+                with self.subTest(
+                    workflow=workflow_name,
+                    mutable_entry=mutable_entry,
+                ):
+                    mutated = re.sub(
+                        r"uses:\s+actions/checkout@[^\s#]+",
+                        mutable_entry,
+                        workflow,
+                        count=1,
+                    )
+
+                    self.assertIn(
+                        "privileged publication action refs must use full commit SHAs",
+                        checker(mutated),
+                    )
+
+    def test_privileged_publication_workflows_reject_unpinned_external_targets(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        mutated = re.sub(
+            r"uses:\s+actions/checkout@[^\s#]+",
+            "uses: docker://alpine:3.22",
+            workflow,
+            count=1,
+        )
+
+        self.assertIn(
+            "privileged publication action refs must use full commit SHAs",
+            release_policy_errors(mutated),
+        )
 
     def test_publication_validation_rejects_required_task_outside_gradle_invocation(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
@@ -1187,7 +1271,10 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
 
         self.assertIn("bluetape.snapshot-handoff/v1", workflow)
         self.assertIn("tenant-context-handoff-${", workflow)
-        self.assertIn("actions/upload-artifact@v7", workflow)
+        self.assertRegex(
+            workflow,
+            r"uses:\s+actions/upload-artifact@[0-9a-f]{40}\s+# v7",
+        )
         self.assertIn("retention-days: 90", workflow)
         self.assertIn("artifact-id", workflow)
         self.assertIn("artifact-digest", workflow)


### PR DESCRIPTION
## Summary

Refs #1578

Maven Central privileged publication workflow가 이동 가능한 action tag를 직접 실행하지 않도록, 각 action version tag가 가리키는 검증된 full commit SHA로 고정합니다. 저장소 HEAD나 `2.0.0` release tag를 고정하는 변경은 아닙니다.

## Background

`maven-central-release` 운영 경계 점검에서 publication workflow의 third-party action ref가 `@v7`, `@v5.7.0`, `@v6.3.0`처럼 이동 가능한 tag를 사용하고 있음을 확인했습니다. 이 PR은 #1578 중 저장소 정책 범위만 처리하며 environment reviewer·branch/tag policy·secret scope 변경은 포함하지 않습니다.

## What This Solves

- upstream action tag가 이동하더라도 privileged publication 실행 코드가 암묵적으로 바뀌지 않습니다.
- 이후 mutable ref, quoted `uses` key, flow mapping, `docker://` 같은 비-repository external target이 publication workflow에 들어오는 것을 policy test가 fail-closed로 차단합니다.

## Work Done

- `.github/workflows/release.yml`: 외부 action 16개 참조를 검증된 full commit SHA와 같은 줄 version comment로 고정했습니다.
- `.github/workflows/publish-snapshot.yml`: 외부 action 5개 참조를 같은 정책으로 고정했습니다.
- `scripts/test_release_workflow_policy.py`: privileged action ref parser와 mutable/non-repository target 회귀 테스트를 추가했습니다.

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/publish-snapshot.yml`: PASS
- `python3 -m unittest scripts.test_release_workflow_policy -v`: PASS (42 tests)
- `python3 -m unittest scripts.test_jvm_release_contract -v`: PASS (11 tests)
- `./scripts/check-jvm-release-contract.sh`: PASS (`BUILD SUCCESSFUL`, JVM baseline/ABI checks PASS)
- upstream action tag API read-back: PASS (6 action repositories, 21 pinned occurrences, mismatch 0)
- `python3 -m py_compile scripts/test_release_workflow_policy.py`: PASS
- `git diff HEAD^..HEAD --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: quoted `uses` key와 YAML flow mapping 우회 가능성을 local review에서 발견하여 TDD로 보정했습니다.
- Review evidence: exact head `fb07b6e696dec51a1e55d08beb269b60ea9a2a1a` local review 및 hosted CI run `33308605286`. Fresh merge review·승인은 별도 gate입니다.

## Metadata

- Issue: #1578, milestone `2.0.0`, assignee `debop`
- PR: #1579, base `develop`, head `chore/1578-publication-hardening@fb07b6e696dec51a1e55d08beb269b60ea9a2a1a`, milestone `2.0.0`, assignee `debop`
- CI: run `33308605286`, 25 successful, 0 failing, 0 pending, 0 skipped

## DoD Status

Required checks: 9/10; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-01 - 분류 | Type P + Type E repository lane으로 분류 | PASS | #1578 scope와 selected skills 재확인 | 없음 |
| TDD-01 - 정책 계약 | mutable·quoted·flow·non-repository ref RED→GREEN | PASS | targeted failures 후 policy suite 42 tests PASS | 없음 |
| SEC-01 - Immutable refs | privileged workflow action을 full SHA로 고정 | PASS | upstream tag API 6개와 21 occurrences 대조, mismatch 0 | 없음 |
| WF-YAML - Workflow lint | 수정 workflow actionlint 실행 | PASS | actionlint exit 0 | 없음 |
| REL-01 - Release contract | JVM release 정책과 shell contract 검증 | PASS | 11 tests PASS, `BUILD SUCCESSFUL` | 없음 |
| RV-01 - Review | local line-by-line security review | PASS | quoted/flow bypass 발견 후 수정·재검증 | Hosted review 대기 |
| CG-12A - Guidance refresh | AGENTS hierarchy, selected skills, common gates, PR template, linked Issue 재확인 | PASS | 현재 worktree와 #1578 live metadata read-back | 없음 |
| CG-13 - PR metadata | base/head/assignee/labels/milestone live read-back | PASS | PR #1579, exact head `fb07b6e696dec51a1e55d08beb269b60ea9a2a1a`, mergeable | 없음 |
| CI-01 - Hosted exact-head checks | GitHub Actions run 확인 | PASS | run `33308605286`, 25 successful, 실패·대기·skip 0 | 없음 |
| OPS-01 - Environment/secret hardening | repository PR과 분리된 운영 gate | N/A | #1578에 계속 OPEN으로 추적 | PR merge 후 별도 승인·read-back |

Final status: READY FOR REVIEW — exact-head hosted CI와 PR metadata 확인 완료; merge는 별도 승인 gate

Unchecked required items: none



