### PR TITLE
NetCDF timeout 이후 진행 상태 진단 경계를 추가한다

### DIFF
--- a/docs/lessons/2026-08-30-issue-1561-netcdf-operation-boundary.md
+++ b/docs/lessons/2026-08-30-issue-1561-netcdf-operation-boundary.md
@@ -1,0 +1,92 @@
+# Issue #1561 NetCDF 작업 경계 보강 교훈
+
+## 맥락
+
+기존 NetCDF import는 blocking API였지만 timeout 뒤 caller가 progress를 조회할 `fileId`를
+보존하는 흐름, worker 종료와 retry의 순서, trusted path와 tenant/job 책임, fingerprint 한계,
+sealed exception migration 계약이 한 흐름으로 연결되지 않았다.
+
+## 결정
+
+- `registerFile()`을 import deadline 밖에서 완료하고 worker에는 `importGridValues()`만 제출한다.
+- read-only progress API를 추가하되 `fileId`를 권한 토큰으로 취급하지 않는다.
+- timeout 뒤 `cancel(true)`, `shutdownNow()`, bounded `awaitTermination()`, progress/failure 분류,
+  운영 검토 순서를 고정하고 자동 retry는 0회로 둔다.
+- active lease는 caller clock이 아니라 DB 결과와 `ImportAlreadyRunning`으로 판정한다.
+- private typed checkpoint를 첫 spatial preflight의 `touchLease()` 직후에 한 번 호출한다.
+  production 기본값은 no-op이며 test만 private constructor를 dynamic proxy로 호출한다.
+- caller fixture는 authoritative `fileId → tenant/job/path` binding을 사용하고 raw progress를
+  3-field allowlist DTO로 변환한다.
+- fingerprint를 content integrity로 표현하지 않고 `fileKey|size|lastModifiedTime` 휴리스틱으로
+  한정한다.
+
+## 구현 중 놓쳤던 점
+
+### Kotlin `internal`은 JVM private이 아니다
+
+초기 설계는 `internal ImportCheckpoint`와 internal 4-arg constructor를 사용했다. Kotlin
+caller에게는 감춰지지만 `javap`에서는 public constructor와 interface로 보였다. 테스트 편의를
+위해 새 accidental ABI를 만드는 셈이었다.
+
+public 3-arg constructor는 유지하고 typed 4-arg constructor를 private으로 바꿨다. test가
+reflection을 쓰는 불편보다 production artifact의 공개 표면을 좁히는 편이 안전했다. private
+interface method에는 `@Throws(InterruptedException::class)`를 붙여 dynamic proxy가 checked
+interruption을 `UndeclaredThrowableException`으로 감싸지 않도록 했다.
+
+### correlation ID는 bounded metric label이 아니다
+
+초기 문서와 fixture는 `correlation_id`를 metric tag 예시로 넣었다. 요청이나 job마다 달라지는
+값은 시계열 cardinality와 관측 비용을 폭증시킬 수 있다. metric은 `operation`과 `outcome`만
+사용하고 correlation ID는 구조화 로그나 trace 필드로 옮겼다.
+
+### timeout 예제는 모든 종료 경로를 합류시켜야 한다
+
+처음 예제는 `ExecutionException`만 보완했고 `CancellationException`, `awaitTermination()`의
+interruption, 실제 outcome 재분류를 빠뜨렸다. unchecked cancellation도 bounded termination과
+progress 조회 경로로 합류시켰고, 예상하지 못한 worker failure는 fail-closed 처리했다.
+
+### caller가 보낸 path로 caller authorization을 증명할 수 없다
+
+초기 fixture는 요청의 tenant/path를 서로 비교했다. 이는 `fileId`가 가리키는 authoritative
+record와 다른 값을 caller가 함께 위조하는 경우를 막지 못한다. non-register operation은
+caller path를 무시하고 file binding에서 tenant/job/path를 읽도록 바꿨다.
+
+### 파일 permission test에는 실행 사용자 전제가 있다
+
+POSIX read bit를 제거해도 root는 파일을 읽을 수 있다. permission 변경 직후
+`Files.isReadable()`을 확인해 재현 가능한 환경에서만 denial을 검증하고 permissions는
+`finally`에서 복원했다. 현재 로컬 uid `501`과 hosted runner에서는 skipped 없이 실행된다.
+
+### 최신 base와의 단순 diff는 역차이를 만들 수 있다
+
+reviewer가 최신 `origin/develop`의 workflow hardening을 feature branch가 되돌렸다고 판단했지만,
+이는 two-dot 비교에서 upstream-only 변경을 역차이로 본 결과였다. feature delta 판정은
+`git merge-base origin/develop HEAD`를 기준으로 하고 status를 함께 확인해야 한다.
+
+## 왜 JDK latch와 executor를 직접 사용했는가
+
+검증해야 할 지점은 Exposed transaction 안에서 `touchLease()`가 성공한 직후, NetCDF tile read
+전이다. 기존 test helper에는 이 정확한 경계에서 worker를 멈추는 수단이 없었다. 따라서
+`CountDownLatch`, single-thread executor, private checkpoint를 사용했다. 모든 wait와 join은
+5초로 제한하고 `Thread.sleep()`은 사용하지 않았다. 테스트는 interruption 뒤 worker 종료,
+transaction rollback, 초기 lease 보존, grid row 0개, active retry 거부, DB lease 강제 만료 뒤
+완료까지 검증한다.
+
+## 결과와 검증
+
+- 전체 science test `275`개가 failures/errors/skipped 없이 통과했다.
+- consumer fixture `30`개가 public API, sealed fallback, authoritative authorization,
+  fail-closed lifecycle, bounded metric/log field를 검증한다.
+- public 3-arg JVM descriptor는 유지되고 typed 4-arg constructor는 private이다.
+- EN/KO timeout marker는 byte-identical하며 Korean terminology findings는 0건이다.
+- 독립 6관점 재검토와 main inline 검토의 최종 결과는 `P0=0`, `P1=0`, `P2=0`, `P3=0`이다.
+
+## 앞으로의 guard
+
+- timeout/retry 문서를 바꾸면 `CancellationException`, caller interruption 복구, bounded worker
+  termination, progress/failure 재분류, zero-auto-retry가 모두 남아 있는지 확인한다.
+- operation handle이나 progress DTO를 외부 endpoint에 연결할 때 authorization과 redaction을
+  실제 adapter integration test로 승격한다.
+- fingerprint를 강화하려면 기존 heuristic을 content hash라고 재명명하지 말고 비용·TOCTOU·
+  immutable storage 계약을 별도 설계한다.
+- test seam 변경은 Kotlin visibility와 JVM descriptor를 함께 검증한다.

--- a/docs/review/issue-1561-netcdf-operation-boundary-review.md
+++ b/docs/review/issue-1561-netcdf-operation-boundary-review.md
@@ -1,0 +1,101 @@
+# Issue #1561 NetCDF 작업 경계 검토
+
+## 검토 기준
+
+- 이슈: `#1561 [science][api] NetCDF timeout progress·trusted path·sealed exception 2.0 경계 명시`
+- 기준 commit: `9831a513f9b81e53f505fadd2e4546b8ea8cf6a8`
+- 검토 시점의 `origin/develop`: `d59f7002469bc6596e0f487768468594e7bc08dc`
+- 구현 delta SHA-256: `2c5aae4d0d5f94049d1060da793b01187aa9b8d402b8d56363fc67f3409afb07`
+- 구현 범위: `utils/science` production 1개, service/guard test 2개, 외부 caller fixture 1개,
+  EN/KO README 2개.
+- 중단 조건: inline 검토와 독립 6관점 검토에서 `P0=0`, `P1=0`이고 전체 science
+  test, compile, Detekt, JVM descriptor, 문서 parity 검증이 통과할 것.
+
+구현 delta hash는 `utils/science`의 binary diff와 untracked consumer fixture의 경로·내용을
+결합해 계산했다. 최신 `origin/develop`과의 two-dot 역차이는 feature 변경으로 간주하지 않았다.
+
+## 최종 판정
+
+최종 통합 판정은 **APPROVE**이다. inline 검토와 독립 6관점 재검토의 최종 합계는
+`P0=0`, `P1=0`, `P2=0`, `P3=0`이다.
+
+| 관점 | 최종 판정 | 근거 |
+|---|---|---|
+| Performance/resource | CLEAR | progress lookup은 indexed read transaction과 bounded `status` tag만 사용한다. `correlation_id`는 metric tag에서 제거하고 구조화 로그·trace 필드로 이동했다. |
+| Stability/cancellation | APPROVE | post-lease interruption이 transaction을 rollback하고 worker 종료 뒤에만 retry한다. POSIX permission test는 non-root 전제를 명시하며 모든 latch/join은 bounded이다. |
+| Security/trust boundary | CLEAR | `fileId`를 권한 토큰으로 취급하지 않고 tenant/job/path를 매 operation 재검증한다. checkpoint type과 4-arg constructor는 JVM public surface가 아니다. |
+| Operator/Ops | CLEAR | timeout, cancellation, stuck worker, progress, alert, zero-auto-retry, recovery 순서가 EN/KO에서 일치한다. workflow 변경 경보는 merge-base 대조로 역차이 오탐임을 확인했다. |
+| Developer/API | APPROVE | 기존 public 3-arg constructor와 method descriptor를 유지하고 `findImportProgress()`만 additive하게 추가했다. private typed checkpoint가 deterministic test seam을 제공한다. |
+| User/caller | APPROVE | timeout 전에 `fileId`를 보존하고 worker termination과 progress를 함께 분류한다. fingerprint·sealed subtype·caller DTO·authoritative binding 한계가 명시됐다. |
+
+## 해결된 주요 발견
+
+1. **P1 — 고카디널리티 metric tag**
+   `correlation_id`를 caller metric tag 예시와 fixture에서 제거했다. metric은 bounded
+   `operation`/`outcome`만 사용하고 correlation ID는 구조화 로그나 trace에 둔다.
+2. **P1 — fingerprint 보장 범위 누락**
+   fingerprint가 `fileKey|size|lastModifiedTime` 휴리스틱이며 content hash나 TOCTOU
+   증명이 아니라는 점을 public KDoc와 EN/KO README에 추가했다. 동일 metadata를 보존한
+   hostile change는 탐지하지 못할 수 있으므로 immutable quarantine 책임을 유지한다.
+3. **P2 — JVM public test seam**
+   Kotlin `internal` 4-arg constructor가 JVM에서 public으로 노출되는 문제를 확인했다.
+   checkpoint를 private typed interface와 private primary constructor로 축소하고, test만
+   dynamic proxy로 private constructor를 호출한다. public non-synthetic constructor는 3-arg
+   하나다.
+4. **P2 — cancellation과 unknown failure 분류**
+   README 예제가 `CancellationException`과 `awaitTermination()` interruption을 처리하고,
+   종료 후 progress와 worker failure를 실제 outcome으로 매핑하도록 수정했다. 예상하지 못한
+   worker failure는 `RECOVERY_REQUIRED`로 fail-closed한다.
+5. **P2 — caller binding fixture의 자기신고 값 의존**
+   fixture가 authoritative `fileId → tenant/job/path` map을 조회하도록 변경했다. non-register
+   operation은 caller가 보낸 path를 신뢰하지 않으며 cross-tenant, cross-job, unauthorized,
+   outside-root를 register/import/progress/retry 각각에서 service invocation 전에 거부한다.
+6. **P2 — POSIX permission test의 root 환경**
+   permission 변경 뒤 `Files.isReadable()`을 확인하고 root처럼 denial을 재현할 수 없는 환경은
+   명시적으로 abort한다. 현재 검증 환경은 uid `501`이며 최종 전체 suite의 skipped는 0이다.
+7. **오탐 — release workflow rollback**
+   최신 `origin/develop`과 working tree의 two-dot 비교에서 upstream 변경이 역차이로 보였다.
+   merge-base `9831a513` 기준 `.github/workflows`와 release policy script delta 및 status는
+   모두 비어 있어 Issue #1561 범위 변경이 아님을 확인했다.
+
+## 공개 계약과 운영 경계
+
+- `registerFile()`은 import deadline 밖에서 완료해 caller가 `fileId`를 보존한다.
+- `findImportProgress(fileId, variableName)`는 진행 row를 조회할 뿐 lease나 cursor를 변경하지
+  않는다. `fileId` 자체는 authorization 근거가 아니다.
+- timeout은 cooperative cancellation 요청이다. worker termination을 bounded하게 확인하지
+  못하면 `RECOVERY_REQUIRED`이며 자동 retry는 0회다.
+- application host clock으로 `leaseExpiresAt`을 판정하지 않는다. 활성 lease 여부와 재획득은
+  DB 결과와 `ImportAlreadyRunning`을 기준으로 한다.
+- raw progress model을 HTTP/RPC 응답으로 직접 직렬화하지 않는다. caller DTO는 status,
+  last committed slice, coarse outcome만 allowlist한다.
+- sealed `NetCdfException` 소비자는 integration 경계의 `when`에 `else` fallback을 둔다.
+
+## 검증 근거
+
+- `./gradlew :bluetape4k-science:test`: `275` passed, failures `0`, errors `0`, skipped `0`.
+- consumer fixture: `30` passed, failures `0`, errors `0`, skipped `0`.
+- post-lease interruption, private constructor ABI, checkpoint cardinality, POSIX unreadable targeted
+  test: PASS.
+- `./gradlew :bluetape4k-science:detekt :bluetape4k-science:compileKotlin
+  :bluetape4k-science:compileTestKotlin`: BUILD SUCCESSFUL.
+- Detekt는 기존 `NetCdfCatalogService` complexity/size와 test `LargeClass` 경고를 계속 보고하지만,
+  이번에 추가한 private checkpoint와 consumer fixture의 신규 경고는 없다.
+- `javap -public -s`: 기존 3-arg constructor descriptor와 세 public method를 확인했다.
+- `javap -private -s`: typed 4-arg constructor가 private임을 확인했다.
+- EN/KO `netcdf-timeout-example` marker byte parity: PASS.
+- Korean terminology audit: findings `0`.
+- `git diff --check`: PASS.
+- `.github/workflows`, dependency, catalog, schema, module registration delta: 없음.
+
+## 잔여 공백과 후속 gate
+
+- 실제 HTTP/RPC adapter의 tenant/job authorization과 DTO redaction은 caller 구현 책임이며 이
+  repository에는 해당 adapter가 없다. consumer fixture는 source/decision-table 계약이지 실제
+  endpoint integration proof가 아니다.
+- fingerprint는 hostile writer를 막지 않는다. 운영 환경은 immutable quarantine과 별도 access
+  control을 제공해야 한다.
+- remote exact-head CI와 GitHub review thread 상태는 PR 생성 뒤 확인해야 한다.
+- 병합, release, publication, branch/worktree 정리는 별도 승인 gate다.
+
+최종 결론은 `P0=0`, `P1=0`이다. 현재 구현 범위에서 해결되지 않은 차단 finding은 없다.

--- a/docs/superpowers/plans/2026-08-30-issue-1561-netcdf-operation-boundary-plan.md
+++ b/docs/superpowers/plans/2026-08-30-issue-1561-netcdf-operation-boundary-plan.md
@@ -1,0 +1,788 @@
+# NetCDF 작업 경계와 진행 상태 조회 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** timeout 이후에도 보존한 `fileId`로 progress를 진단하고, lease 취득 뒤 cancellation·파일 교체·권한 경계를 결정적으로 검증하는 additive NetCDF 2.0 API를 제공한다.
+
+**Architecture:** 기존 `registerFile()`과 `importGridValues()`를 유지하고 `findImportProgress()`만 추가한다. public 3-인자 constructor는 그대로 두며, spatial 첫 preflight transaction의 lease fence 뒤에 internal checkpoint를 주입해 cancellation rollback을 테스트한다. allowed-root·인증·인가·tenant 정책과 executor lifecycle은 caller 책임으로 두고 KDoc/README EN/KO와 consumer fixture에서 계약을 고정한다.
+
+**Tech Stack:** Kotlin 2.4, Java 25 virtual threads, Exposed JDBC, PostgreSQL/PostGIS Testcontainers, NetCDF-Java, Micrometer, JUnit 5, Kluent/bluetape assertions, Gradle 9.7
+
+---
+
+- **이슈**: [#1561](https://github.com/bluetape4k/bluetape4k-projects/issues/1561)
+- **승인된 사양**: `docs/superpowers/specs/2026-08-30-issue-1561-netcdf-operation-boundary-design.md`
+- **브랜치**: `feat/issue-1561-netcdf-operation-boundary`
+- **기준**: `origin/develop@9831a513f9b81e53f505fadd2e4546b8ea8cf6a8`
+- **작업 방식**: 이 세션에서 inline execution, Testcontainers 명령은 한 번에 하나씩 순차 실행
+- **외부 side effect**: 승인된 branch push와 PR 생성만 허용, merge·release·publish·cleanup 금지
+
+## 1. 파일 구조와 책임
+
+| 파일 | 작업 | 책임 |
+|---|---|---|
+| `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt` | 수정 | progress 조회·metric, 기존 public constructor 보존, checkpoint 호출 |
+| `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/ImportCheckpoint.kt` | 생성 | spatial cancellation용 internal fun interface와 no-op |
+| `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt` | 수정 | progress, timeout, post-lease cancel/resume, replacement, unreadable-file 통합 검증 |
+| `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuardTest.kt` | 수정 | URI, control, directory, symlink path 회귀 검증 |
+| `utils/science/src/test/kotlin/consumer/fixture/NetCdfPublicApiSourceCompatibilityTest.kt` | 생성 | 외부 package public API compile, sealed `else`, caller timeout 정책 |
+| `utils/science/README.md` | 수정 | English timeout lifecycle, trust, metric, migration, quarantine |
+| `utils/science/README.ko.md` | 수정 | 한국어 locale parity |
+| `docs/lessons/2026-08-30-issue-1561-netcdf-operation-boundary.md` | 생성 | 구현·검증·review에서 얻은 재사용 가능한 교훈 |
+| `docs/review/issue-1561-netcdf-operation-boundary-review.md` | 생성 | 최종 inline·독립 review의 P0-P3 통합 결과 |
+
+`NetCdfImportProgressRepository`, schema, model, `NetCdfException`, Gradle 설정은 변경하지 않는다.
+
+## 2. 수용 기준 추적
+
+| 수용 기준 | 구현 task | 검증 |
+|---|---|---|
+| timeout 후 progress 식별자 보존 | Task 2, Task 4 | pre/post-admission tests, README example |
+| progress service API | Task 1 | null/status/blank/metric tests |
+| path/auth/tenant/fingerprint 책임 | Task 3, Task 4 | path tests, unreadable test, KDoc/README parity |
+| 2.0 sealed subtype migration | Task 4 | external-package `else` fixture, docs |
+| timeout/resume | Task 2 | cancel/rollback/active lease/expiry/resume |
+| file replacement | Task 3 | atomic inode replacement → `FileChanged`, no progress |
+| permission boundary | Task 3, Task 4 | POSIX unreadable `FileOpen`, consumer auth negative-test 책임 |
+| 진단 개선 | Task 1, Task 4 | low-cardinality lookup metric and caller alert contract |
+
+## 3. 위험 예측과 대응
+
+| 위험 | 신호 | 완화 | rollback/rerun |
+|---|---|---|---|
+| constructor ABI 파손 | reflection/`javap`에 3-인자 descriptor 없음 | primary constructor 수정 금지, internal 4-인자 secondary만 추가 | Task 2 revert, compile/ABI 재실행 |
+| checkpoint가 production 의미 변경 | 두 번 이상 호출, rank-1 영향, write 뒤 block | 첫 spatial preflight `touchLease` 뒤·`readTile` 전 1회 | checkpoint diff revert, cancellation tests 재실행 |
+| cancellation test hang | latch 또는 executor 5초 초과 | 모든 대기 bounded, `finally`에서 release·`shutdownNow` | 타깃 단일 테스트로 원인 확인 후 전체 재실행 |
+| unreadable test 환경 의존 | root 실행, POSIX 미지원 | Ubuntu/macOS non-root 계약, permission `finally` 복구 | 환경 증거를 PENDING으로 보고; skip을 PASS로 사용 금지 |
+| metric cardinality 증가 | tag에 ID/path/tenant 포함 | status allowlist 5개만 사용 | metric test와 source review 재실행 |
+| 자동 retry storm | `FAILED`/local clock만 보고 반복 | 기본 자동 retry 0회, `ImportAlreadyRunning` authoritative, `RECOVERY_REQUIRED` | consumer fixture와 README review 재실행 |
+| 파일 교체 테스트 flake | inode/size/mtime 동일 | 새 inode + atomic move + 크기 차이 | 타깃 파일 테스트 재실행 |
+| raw progress 외부 노출 | response DTO에 lease/error/timestamp 존재 | caller-owned DTO allowlist와 민감 필드 부재를 fixture로 고정 | consumer fixture와 README review 재실행 |
+| `fileId` 권한 토큰 오용 | authorization 전에 service 호출 | register/import/progress/retry별 authorize-first negative test | consumer fixture 단일 테스트 재실행 |
+
+## Task 0: 승인된 사양과 계획 checkpoint
+
+**Complexity:** 낮음
+**Dependency:** 구현 전 필수
+**Files:**
+- Add: `docs/superpowers/specs/2026-08-30-issue-1561-netcdf-operation-boundary-design.md`
+- Add: `docs/superpowers/plans/2026-08-30-issue-1561-netcdf-operation-boundary-plan.md`
+
+- [ ] **Step 1: 문서 무결성을 검사한다**
+
+Run:
+
+```bash
+node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  docs/superpowers/specs/2026-08-30-issue-1561-netcdf-operation-boundary-design.md \
+  docs/superpowers/plans/2026-08-30-issue-1561-netcdf-operation-boundary-plan.md
+git diff --check
+```
+
+Expected: terminology findings 0, whitespace error 0.
+
+- [ ] **Step 2: 사용자 계획 승인 뒤 사양과 계획만 Lore commit한다**
+
+```bash
+git add \
+  docs/superpowers/specs/2026-08-30-issue-1561-netcdf-operation-boundary-design.md \
+  docs/superpowers/plans/2026-08-30-issue-1561-netcdf-operation-boundary-plan.md
+git commit -m "NetCDF 작업 경계를 구현 전에 고정한다
+
+Constraint: 기존 public constructor와 blocking API를 유지한다
+Rejected: 작업 handle 추가 | 기존 fileId와 variableName으로 충분하다
+Confidence: high
+Scope-risk: moderate
+Directive: 등록은 deadline 밖에서 완료하고 import만 취소 대상으로 둔다
+Tested: 문서 terminology audit와 git diff --check
+Not-tested: 구현과 Gradle 검증은 후속 task에서 수행한다"
+```
+
+Expected: spec/plan 두 파일만 포함한 commit.
+
+## Task 1: Progress 조회 API와 low-cardinality metric
+
+**Complexity:** 중간
+**Dependency:** Task 0
+**Pattern skills:** `bluetape-kotlin-patterns`, `test-driven-development`
+**Files:**
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+
+- [ ] **Step 1: 존재하지 않는 progress API를 호출하는 RED tests를 추가한다**
+
+추가할 핵심 형태:
+
+```kotlin
+@Test
+fun `findImportProgress returns null before import`(@TempDir dir: Path) {
+    val path = NetCdfSampleWriter.writeSample(dir.resolve("progress-missing.nc"), rank = 2)
+    val fileId = service.registerFile(path.absolutePathString())
+
+    service.findImportProgress(fileId, "temperature").shouldBeNull()
+    meterRegistry.find("netcdf.import.progress.lookup")
+        .tag("status", "missing")
+        .counter()
+        .shouldNotBeNull()
+}
+
+@Test
+fun `findImportProgress returns completed row without mutation`(@TempDir dir: Path) {
+    val path = NetCdfSampleWriter.writeSample(dir.resolve("progress-completed.nc"), rank = 2)
+    val fileId = service.registerFile(path.absolutePathString())
+    service.importGridValues(fileId, "temperature")
+    val before = transaction(db) { progressRepo.findByFileAndVariable(fileId, "temperature") }
+
+    val found = service.findImportProgress(fileId, "temperature")
+
+    found shouldBeEqualTo before
+    meterRegistry.find("netcdf.import.progress.lookup")
+        .tag("status", "completed")
+        .counter()
+        .shouldNotBeNull()
+}
+
+@Test
+fun `findImportProgress rejects blank variable name`() {
+    assertFailsWith<IllegalArgumentException> {
+        service.findImportProgress(1L, " ")
+    }
+}
+```
+
+- [ ] **Step 2: compile RED를 확인한다**
+
+Run:
+
+```bash
+./gradlew :bluetape4k-science:compileTestKotlin
+```
+
+Expected: `Unresolved reference 'findImportProgress'`로 FAIL.
+
+- [ ] **Step 3: 최소 API와 metric을 구현한다**
+
+`NetCdfCatalogService`에 추가:
+
+```kotlin
+/**
+ * `(fileId, variableName)` 임포트 진행 상태를 조회합니다.
+ *
+ * 조회는 lease나 상태를 변경하지 않습니다. [fileId]는 권한 토큰이 아니므로 caller는
+ * 호출 전에 파일 소유권과 tenant/job binding을 다시 검증해야 합니다.
+ */
+fun findImportProgress(fileId: Long, variableName: String): NetCdfImportProgress? {
+    require(variableName.isNotBlank()) { "variableName must not be blank" }
+    val progress = transaction { progressRepo.findByFileAndVariable(fileId, variableName) }
+    meterRegistry?.counter(
+        "netcdf.import.progress.lookup",
+        "status",
+        when (progress?.status) {
+            null -> "missing"
+            NetCdfImportStatus.PENDING -> "pending"
+            NetCdfImportStatus.IN_PROGRESS -> "in-progress"
+            NetCdfImportStatus.COMPLETED -> "completed"
+            NetCdfImportStatus.FAILED -> "failed"
+        },
+    )?.increment()
+    return progress
+}
+```
+
+- [ ] **Step 4: 타깃 tests GREEN을 확인한다**
+
+Run sequentially:
+
+```bash
+repo-test-summary -- ./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest'
+```
+
+Expected: all selected tests PASS, skipped=0.
+
+- [ ] **Step 5: Task 1 diff를 review한다**
+
+```bash
+git diff -- \
+  utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt \
+  utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt
+```
+
+Expected: repository/schema/public model 변경 없음, metric tag allowlist만 존재.
+
+## Task 2: 실제 lease 취득 뒤 cancellation과 resume
+
+**Complexity:** 높음
+**Dependency:** Task 1
+**Pattern skills:** `bluetape-kotlin-patterns`, `test-driven-development`
+**Files:**
+- Create: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/ImportCheckpoint.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+
+- [ ] **Step 1: public constructor ABI와 checkpoint lifecycle RED tests를 추가한다**
+
+핵심 ABI assertion:
+
+```kotlin
+@Test
+fun `public three argument constructor remains available`() {
+    NetCdfCatalogService::class.java.getConstructor(
+        NetCdfFileRepository::class.java,
+        NetCdfImportProgressRepository::class.java,
+        MeterRegistry::class.java,
+    ).shouldNotBeNull()
+}
+```
+
+핵심 post-admission test 흐름:
+
+```kotlin
+val leaseTouched = CountDownLatch(1)
+val releaseCheckpoint = CountDownLatch(1)
+val workerFailure = AtomicReference<Throwable?>()
+val checkpointThread = AtomicReference<Thread?>()
+val cancellableService = NetCdfCatalogService(
+    fileRepo,
+    progressRepo,
+    meterRegistry,
+    ImportCheckpoint {
+        checkpointThread.set(Thread.currentThread())
+        leaseTouched.countDown()
+        check(releaseCheckpoint.await(5, TimeUnit.SECONDS)) {
+            "netcdf post-lease checkpoint timed out"
+        }
+    },
+)
+val executor = Executors.newSingleThreadExecutor { task ->
+    Thread(task, "netcdf-post-lease-cancel")
+}
+val task = executor.submit {
+    try {
+        cancellableService.importGridValues(fileId, "temperature")
+    } catch (failure: Throwable) {
+        workerFailure.set(failure)
+        throw failure
+    }
+}
+try {
+    leaseTouched.await(5, TimeUnit.SECONDS).shouldBeTrue()
+    val committedBeforeCancel = transaction(db) {
+        progressRepo.findByFileAndVariable(fileId, "temperature")
+    }.shouldNotBeNull()
+    task.cancel(true).shouldBeTrue()
+    executor.shutdownNow()
+    executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+    (workerFailure.get() is InterruptedException).shouldBeTrue()
+
+    val afterCancel = service.findImportProgress(fileId, "temperature").shouldNotBeNull()
+    afterCancel.status shouldBeEqualTo NetCdfImportStatus.IN_PROGRESS
+    afterCancel.leaseExpiresAt shouldBeEqualTo committedBeforeCancel.leaseExpiresAt
+    afterCancel.updatedAt shouldBeEqualTo committedBeforeCancel.updatedAt
+    afterCancel.lastSliceIdx shouldBeEqualTo committedBeforeCancel.lastSliceIdx
+    countGridRows(fileId) shouldBeEqualTo 0L
+    assertFailsWith<NetCdfException.ImportAlreadyRunning> {
+        service.importGridValues(fileId, "temperature")
+    }
+    forceExpireLease(fileId, "temperature")
+    service.importGridValues(fileId, "temperature")
+    service.findImportProgress(fileId, "temperature")?.status
+        .shouldBeEqualTo(NetCdfImportStatus.COMPLETED)
+} finally {
+    releaseCheckpoint.countDown()
+    task.cancel(true)
+    executor.shutdownNow()
+    executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+    checkpointThread.get()?.isAlive.shouldBeFalse()
+}
+```
+
+pre-admission test는 import 호출 전 latch에서 task를 막아 `Future.get(... )`의
+`TimeoutException`, cancel, 종료, progress `null`, 동일 `fileId` 정상 import를 검증한다.
+모든 latch 대기는 5초 bounded이며 `finally`에서 release, cancel, `shutdownNow`, 두 번째
+bounded `awaitTermination`, captured thread `isAlive=false`를 공통으로 확인한다.
+
+- [ ] **Step 2: compile RED를 확인한다**
+
+```bash
+./gradlew :bluetape4k-science:compileTestKotlin
+```
+
+Expected: `ImportCheckpoint`와 4-인자 internal constructor가 없어 FAIL.
+
+- [ ] **Step 3: internal checkpoint를 최소 구현한다**
+
+`ImportCheckpoint.kt`:
+
+```kotlin
+package io.bluetape4k.science.exposed.service
+
+internal fun interface ImportCheckpoint {
+    fun afterLeaseTouched()
+
+    companion object {
+        val NONE: ImportCheckpoint = ImportCheckpoint {}
+    }
+}
+```
+
+`NetCdfCatalogService`의 public primary constructor는 그대로 두고 다음 property와 secondary
+constructor만 추가한다.
+
+```kotlin
+private var importCheckpoint: ImportCheckpoint = ImportCheckpoint.NONE
+
+internal constructor(
+    fileRepo: NetCdfFileRepository,
+    progressRepo: NetCdfImportProgressRepository,
+    meterRegistry: MeterRegistry?,
+    importCheckpoint: ImportCheckpoint,
+): this(fileRepo, progressRepo, meterRegistry) {
+    this.importCheckpoint = importCheckpoint
+}
+```
+
+spatial preflight loop를 `forEachIndexed`로 바꾸고 첫 tile에서만 호출한다.
+
+```kotlin
+tiles.forEachIndexed { tileIndex, tile ->
+    checkNotInterrupted()
+    transaction {
+        checkNotInterrupted()
+        context.lease.expiresAt = progressRepo.touchLease(
+            context.progressId,
+            context.lease.expiresAt,
+            leaseTtl = LEASE_TTL,
+        )
+        if (tileIndex == 0) {
+            importCheckpoint.afterLeaseTouched()
+        }
+        checkNotInterrupted()
+        val data = readTile(prepared.variable, layout, tile, timeIdx, levelIdx)
+        // 기존 scan 유지
+    }
+}
+```
+
+- [ ] **Step 4: cancellation tests GREEN을 확인한다**
+
+```bash
+repo-test-summary -- ./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest'
+```
+
+Expected: timeout/cancel/resume와 기존 service tests PASS, skipped=0, executor leak 없음.
+
+- [ ] **Step 5: JVM constructor descriptor를 확인한다**
+
+```bash
+./gradlew :bluetape4k-science:compileKotlin
+javap -classpath utils/science/build/classes/kotlin/main \
+  io.bluetape4k.science.exposed.service.NetCdfCatalogService
+```
+
+Expected: 기존 3-인자 public constructor가 출력되고 새 public primary replacement가 없음.
+
+## Task 3: 파일 교체와 path/permission 경계 회귀
+
+**Complexity:** 중간
+**Dependency:** Task 2
+**Pattern skills:** `bluetape-kotlin-patterns`, `test-driven-development`
+**Files:**
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt`
+- Modify: `utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuardTest.kt`
+
+- [ ] **Step 1: 기존 동작을 잠그는 regression tests를 먼저 추가한다**
+
+파일 교체 test:
+
+```kotlin
+@Test
+fun `registered file replacement is rejected before progress creation`(@TempDir dir: Path) {
+    val original = NetCdfSampleWriter.writeSample(dir.resolve("replace.nc"), rank = 2)
+    val fileId = service.registerFile(original.absolutePathString())
+    val replacement = NetCdfSampleWriter.writeSample(dir.resolve("replacement.nc"), rank = 3)
+    Files.move(
+        replacement,
+        original,
+        StandardCopyOption.ATOMIC_MOVE,
+        StandardCopyOption.REPLACE_EXISTING,
+    )
+
+    assertFailsWith<NetCdfException.FileChanged> {
+        service.importGridValues(fileId, "temperature")
+    }
+    service.findImportProgress(fileId, "temperature").shouldBeNull()
+}
+```
+
+POSIX unreadable test:
+
+```kotlin
+@Test
+fun `registerFile rejects unreadable POSIX file`(@TempDir dir: Path) {
+    val path = NetCdfSampleWriter.writeSample(dir.resolve("unreadable.nc"), rank = 2)
+    val original = Files.getPosixFilePermissions(path)
+    try {
+        Files.setPosixFilePermissions(path, setOf(PosixFilePermission.OWNER_WRITE))
+        assertFailsWith<NetCdfException.FileOpen> {
+            service.registerFile(path.absolutePathString())
+        }
+    } finally {
+        Files.setPosixFilePermissions(path, original)
+    }
+}
+```
+
+guard tests에는 URI, control 문자, directory 거부를 추가하고 기존 final/parent symlink
+검증을 유지한다.
+
+- [ ] **Step 2: regression tests를 실행한다**
+
+```bash
+repo-test-summary -- ./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest' \
+  --tests 'io.bluetape4k.science.exposed.service.internal.NetCdfFileGuardTest'
+```
+
+Expected: 새 tests와 기존 tests PASS, skipped=0. 기존 production guard가 이미 계약을
+충족하면 test-only diff를 유지하고 불필요한 source 수정을 추가하지 않는다.
+
+- [ ] **Step 3: 환경과 cleanup을 확인한다**
+
+```bash
+id -u
+git status --short
+```
+
+Expected: uid 0이 아님, permission이 복구돼 temp cleanup 성공, 의도한 파일만 변경.
+
+## Task 4: 외부 caller compile fixture와 KDoc/README EN/KO
+
+**Complexity:** 중간
+**Dependency:** Task 1~3 GREEN
+**Pattern skills:** `bluetape-kotlin-patterns`, `bluetape-writer`
+**Files:**
+- Create: `utils/science/src/test/kotlin/consumer/fixture/NetCdfPublicApiSourceCompatibilityTest.kt`
+- Modify: `utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt`
+- Modify: `utils/science/README.md`
+- Modify: `utils/science/README.ko.md`
+
+- [ ] **Step 1: external-package public-only fixture를 추가한다**
+
+핵심 compile contract:
+
+```kotlin
+package consumer.fixture
+
+internal fun readProgress(
+    catalog: NetCdfCatalogService,
+    fileId: Long,
+    variableName: String,
+): NetCdfImportProgress? = catalog.findImportProgress(fileId, variableName)
+
+internal fun classify(exception: NetCdfException): String = when (exception) {
+    is NetCdfException.FileChanged -> "file-changed"
+    is NetCdfException.CorruptProgress -> "corrupt-progress"
+    is NetCdfException.ImportAlreadyRunning -> "running"
+    else -> "unhandled-netcdf"
+}
+```
+
+같은 fixture에 library public API로 추가하지 않는 caller-owned DTO를 둔다.
+
+```kotlin
+private data class NetCdfImportStatusResponse(
+    val status: String,
+    val lastCommittedSlice: Long?,
+    val outcome: String,
+)
+```
+
+변환 함수는 상태 allowlist, `lastSliceIdx`, outcome만 복사한다. reflection으로 response의
+property 이름이 정확히 세 개인지 확인하고 `errorMessage`, `leaseExpiresAt`, `startedAt`,
+`completedAt`, `updatedAt`이 없음을 검증한다. raw `NetCdfImportProgress`를 HTTP/RPC serializer로
+전달하는 example은 두 README와 fixture 어디에도 두지 않는다.
+
+test-only caller adapter는 `authorize(operation, actor, tenant, job, fileIdOrPath)`가 성공한
+뒤에만 service lambda를 호출한다. register/import/progress/retry 네 operation 각각에서
+cross-tenant, unauthorized, allowed-root 밖 path를 거부했을 때 service lambda invocation
+count가 0인지 negative test로 고정한다. 이 adapter는 library public API가 아니라 consumer
+integration pattern의 compile/runtime fixture이며, 실제 application identity store와 정책은
+이 저장소 범위 밖이다.
+
+caller lifecycle policy는 다음 표를 exact parameterized test로 고정한다.
+
+| worker/progress/authoritative signal | outcome | caller action |
+|---|---|---|
+| `terminated=false` | `RECOVERY_REQUIRED` | worker 격리, stuck alert, retry 금지 |
+| progress `COMPLETED` | `COMPLETED` | 완료 처리 |
+| 첫 `ImportAlreadyRunning` | `RUNNING` | DB clock 결과를 신뢰하고 retry 금지 |
+| `PENDING`, `FAILED`, row 없음, 판정 불가능한 `IN_PROGRESS` | `RETRY_REVIEW` | 자동 retry 0회, 운영 검토 |
+| 반복 `ImportAlreadyRunning` 또는 attempt 상한 소진 | `RECOVERY_REQUIRED` | retry 중지와 alert |
+| non-transient typed failure | `RECOVERY_REQUIRED` | 입력/운영 조건 수정 전 retry 금지 |
+
+각 분기는 retry invocation count, `netcdf.import.timeout`,
+`netcdf.import.worker.stuck`, `netcdf.import.retry.exhausted` alert 이름과 correlation ID 존재,
+raw path/tenant/error의 metric tag 부재를 함께 검증한다. `FAILED`만으로 자동 retry하지 않으며,
+local clock의 lease 비교는 어느 fixture에도 넣지 않는다.
+
+- [ ] **Step 2: public KDoc을 사양과 맞춘다**
+
+class KDoc과 세 public 메서드는 다음을 설명한다.
+
+- 모두 blocking이며 등록은 deadline 밖에서 완료
+- timeout은 cooperative cancellation이고 worker 종료 확인 전 retry 금지
+- progress는 진단용이며 local clock만으로 lease 만료 판정 금지
+- `fileId`는 권한 토큰이 아니며 매 작업/retry authorization 필요
+- service guard와 caller-owned allowed-root/authn/authz/tenant/immutable-file 경계
+- progress model 직접 외부 반환 금지, caller-owned DTO allowlist와 redaction
+
+- [ ] **Step 3: README EN/KO를 같은 순서로 갱신한다**
+
+두 locale에 다음 구조를 동일하게 둔다.
+
+1. 등록을 task 밖에서 수행하는 code example
+2. import-only future, failure `AtomicReference`, timeout cancel, 30초 bounded termination
+3. `awaitTermination=false => RECOVERY_REQUIRED`, 자동 retry 0회
+4. progress/worker exception 상태표
+5. trust boundary와 매 작업 authorization
+6. fingerprint/hostile-writer/quarantine
+7. metric allowlist와 caller alerts
+8. sealed subtype `else` migration
+9. API 표의 `findImportProgress()`
+
+timeout code example은 두 README에서
+`<!-- netcdf-timeout-example:start -->`/`<!-- netcdf-timeout-example:end -->` marker로 감싼다.
+marker 내부는 `registerFile()`을 `submit` 전에 실행해 `fileId`를 보존하고, import-only future,
+`AtomicReference` failure capture, timeout `cancel(true)`, 30초 bounded termination,
+termination 실패의 `RECOVERY_REQUIRED`, worker 종료 후 progress 조회를 모두 포함한다.
+두 locale의 marker 내부 code는 byte-for-byte 같고 설명과 상태표만 각 언어로 작성한다.
+기존 “stable sealed-exception contract” 표현은 source-compatible `else` migration 안내로 교체한다.
+
+두 README의 operator checklist는 stop retry → worker 격리 → progress/partial rows 보존 →
+correlation ID 기반 alert → 입력·권한·tenant 확인 → 승인된 수동 cleanup 순서를 포함한다.
+
+- [ ] **Step 4: compile과 locale token parity를 검증한다**
+
+```bash
+./gradlew :bluetape4k-science:compileTestKotlin
+for readme in utils/science/README.md utils/science/README.ko.md; do
+  rg -n 'findImportProgress|RECOVERY_REQUIRED|ImportAlreadyRunning|FileChanged|CorruptProgress|netcdf.import.progress.lookup|allowed[- ]root|tenant|else' "$readme"
+done
+awk '/<!-- netcdf-timeout-example:start -->/{capture=1;next}/<!-- netcdf-timeout-example:end -->/{capture=0}capture' \
+  utils/science/README.md > /private/tmp/issue-1561-timeout-en.txt
+awk '/<!-- netcdf-timeout-example:start -->/{capture=1;next}/<!-- netcdf-timeout-example:end -->/{capture=0}capture' \
+  utils/science/README.ko.md > /private/tmp/issue-1561-timeout-ko.txt
+test -s /private/tmp/issue-1561-timeout-en.txt
+diff -u /private/tmp/issue-1561-timeout-en.txt /private/tmp/issue-1561-timeout-ko.txt
+! rg -ni 'stable sealed[- ]exception contract' utils/science/README.md utils/science/README.ko.md
+node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  utils/science/README.ko.md \
+  docs/superpowers/specs/2026-08-30-issue-1561-netcdf-operation-boundary-design.md \
+  docs/superpowers/plans/2026-08-30-issue-1561-netcdf-operation-boundary-plan.md
+git diff --check
+```
+
+Expected: compile PASS, marker code parity PASS, deprecated sealed 표현 0건, 두 locale 필수 token
+존재, terminology findings 0, whitespace error 0.
+consumer fixture는 네 operation의 authorize-first negative test와 response 민감 필드 부재를 PASS해야 한다.
+
+## Task 5: 비례 검증과 spec/plan verifier
+
+**Complexity:** 중간
+**Dependency:** Task 1~4 GREEN
+**Files:** all changed files
+
+- [ ] **Step 1: 변경 test subset을 순차 실행한다**
+
+```bash
+repo-test-summary -- ./gradlew :bluetape4k-science:test \
+  --tests 'io.bluetape4k.science.exposed.service.NetCdfCatalogServiceTest' \
+  --tests 'io.bluetape4k.science.exposed.service.internal.NetCdfFileGuardTest' \
+  --tests 'consumer.fixture.NetCdfPublicApiSourceCompatibilityTest'
+```
+
+Expected: selected tests PASS, skipped=0.
+
+- [ ] **Step 2: 전체 science module test를 한 번 실행한다**
+
+```bash
+repo-test-summary -- ./gradlew :bluetape4k-science:test
+```
+
+Expected: all tests PASS, failed=0, skipped=0. Testcontainers invocation은 다른 module/worktree와
+동시에 실행하지 않는다.
+
+- [ ] **Step 3: static validation을 실행한다**
+
+```bash
+./gradlew :bluetape4k-science:detekt :bluetape4k-science:compileKotlin \
+  :bluetape4k-science:compileTestKotlin
+git diff --check
+```
+
+Expected: all tasks PASS, diagnostics 0, whitespace error 0.
+
+- [ ] **Step 4: repository hazard N/A를 증명한다**
+
+```bash
+{
+  git diff --name-only origin/develop...HEAD
+  git diff --name-only
+  git ls-files --others --exclude-standard
+} | sort -u
+git status --short
+```
+
+Expected: `utils/science` source/test/docs와 승인된 spec/plan/review/lesson만 변경. module move,
+settings/BOM/catalog/schema/workflow/dependency가 없어 registration·catalog·Nightly hazard N/A.
+
+- [ ] **Step 5: verifier traceability를 완료한다**
+
+사양 §11의 여섯 수용 기준과 이 계획 §2의 task/test를 대조한다. 누락, stale command,
+unexpected public ABI, skipped test가 있으면 구현 task로 돌아가고 Step 5를 처음부터 재실행한다.
+
+## Task 6: inline review, 독립 review, lesson, commit과 PR
+
+**Complexity:** 높음
+**Dependency:** Task 5 PASS
+**Skills:** `verification-before-completion`, `requesting-code-review`, `bluetape-writer`
+**Files:**
+- Create: `docs/review/issue-1561-netcdf-operation-boundary-review.md`
+- Create: `docs/lessons/2026-08-30-issue-1561-netcdf-operation-boundary.md`
+- Modify: PR body only after local evidence PASS
+
+- [ ] **Step 1: inline review를 먼저 수행한다**
+
+다음 관점으로 exact diff를 직접 읽는다.
+
+- cancellation/transaction rollback과 dataset/executor lifecycle
+- path/auth/tenant/redaction과 metric cardinality
+- public constructor/method ABI와 sealed fallback
+- README EN/KO example correctness와 상태표 parity
+- flaky timing, POSIX cleanup, atomic replacement
+
+P0/P1을 발견하면 코드와 test를 수정하고 Task 5를 처음부터 재실행한다.
+
+- [ ] **Step 2: 6개 독립 code-review perspective와 통합 review를 수행한다**
+
+performance, stability, security, Ops, developer/API, user/caller lane을 read-only로 실행한다.
+최신 P0=0/P1=0까지 affected lane만 재실행하고, 통합 결과를
+`docs/review/issue-1561-netcdf-operation-boundary-review.md`에 기록한다.
+
+- [ ] **Step 3: lesson을 작성하고 writer gate를 통과한다**
+
+lesson은 context, decision, outcome, verification, review miss, future guard를 포함한다.
+
+```bash
+node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  docs/review/issue-1561-netcdf-operation-boundary-review.md \
+  docs/lessons/2026-08-30-issue-1561-netcdf-operation-boundary.md
+git diff --check
+```
+
+Expected: findings 0, writer SPW-01~05 PASS.
+
+- [ ] **Step 4: 구현 commit을 만든다**
+
+```bash
+git add \
+  utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt \
+  utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/ImportCheckpoint.kt \
+  utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt \
+  utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuardTest.kt \
+  utils/science/src/test/kotlin/consumer/fixture/NetCdfPublicApiSourceCompatibilityTest.kt \
+  utils/science/README.md \
+  utils/science/README.ko.md \
+  docs/review/issue-1561-netcdf-operation-boundary-review.md \
+  docs/lessons/2026-08-30-issue-1561-netcdf-operation-boundary.md
+git commit -m "NetCDF timeout 뒤 진단 가능한 경계를 제공한다
+
+Constraint: 기존 blocking API와 3-인자 constructor ABI를 유지한다
+Rejected: public 작업 handle 추가 | 기존 fileId와 variableName으로 충분하다
+Confidence: high
+Scope-risk: moderate
+Directive: worker 종료와 authorization을 확인하기 전에는 같은 import를 재시도하지 않는다
+Tested: science 전체 test, detekt, compile, ABI, locale parity, inline 및 독립 review
+Not-tested: 실제 consumer별 authN/authZ와 tenant 정책은 caller 책임이다"
+```
+
+- [ ] **Step 5: exact head를 push하고 승인된 PR을 생성한다**
+
+```bash
+pr_body=/private/tmp/issue-1561-pr-body.md
+# 바로 아래 계약을 충족하는 한국어 본문을 이 파일에 작성하고 readback한 뒤 사용한다.
+git push -u origin feat/issue-1561-netcdf-operation-boundary
+gh pr create \
+  --repo bluetape4k/bluetape4k-projects \
+  --base develop \
+  --head feat/issue-1561-netcdf-operation-boundary \
+  --title "NetCDF timeout 이후 진행 상태 진단 경계를 추가한다" \
+  --body-file "$pr_body"
+
+head_sha=$(git rev-parse HEAD)
+remote_sha=$(git ls-remote origin refs/heads/feat/issue-1561-netcdf-operation-boundary | awk '{print $1}')
+test "$head_sha" = "$remote_sha"
+gh pr checks --repo bluetape4k/bluetape4k-projects --watch
+gh pr view --repo bluetape4k/bluetape4k-projects \
+  --json url,headRefOid,baseRefName,mergeStateStatus,statusCheckRollup
+```
+
+PR body는 문제, 변경, timeout/trust/migration 계약, 검증, risk, `Refs #1561`, 마지막
+`## DoD Status`를 포함한다. 생성 직후 live metadata와 remote exact head를 확인하고 regular CI의
+모든 required job이 exact head에서 terminal PASS인지 읽는다. local JUnit summary의 failed=0,
+skipped=0과 hosted check URL을 review 문서/PR DoD에 연결한다. `slow-netcdf` Nightly와 release
+matrix receipt는 이 PR merge 증거로 대체하지 않고 2.0.0 release gate의 별도 handoff로 명시한다.
+merge와 branch/worktree cleanup은 별도 승인 전까지 수행하지 않는다.
+
+## 10. Step 3-R 통합 검토
+
+| 관점 | 최초 결과 | 계획 반영 | 최종 결과 |
+|---|---|---|---|
+| Performance | P0=0, P1=0 | 단일 indexed 조회, 5값 metric allowlist, 자동 retry 0회 확인 | CLEAR |
+| Stability | P1=2 | 모든 latch/termination bounded, 취소 전후 lease 필드와 grid row rollback 비교 | P0=0, P1=0 CLEAR |
+| Security | P1=2 | 3-field redacted DTO, 민감 필드 부재, 네 operation authorize-first negative test | P0=0, P1=0 CLEAR |
+| Operator/Ops | P0=0, P1=0, P2=2, P3=1 | operator checklist, exact-head CI handoff, stop-retry부터 재검증까지 rollback 순서 | P0=0, P1=0 CLEAR; P2/P3 integrated |
+| Developer/API | P0=0, P1=0 | 3-인자 JVM descriptor, checkpoint 위치, fixture/Gradle 명령 실행 가능성 확인 | CLEAR |
+| User/caller | P1=2 | outcome decision table과 marker 기반 EN/KO 실행 예제·byte parity | P0=0, P1=0 CLEAR |
+| Main integration | 중복·충돌·범위 검토 | 승인된 API A 유지, library/caller/release gate 책임을 분리 | PASS |
+
+Security의 실제 application identity store/policy와 Ops의 `slow-netcdf` Nightly receipt는 이
+library PR이 대신 증명하지 않는다. 전자는 caller integration 책임으로 명시하고 fixture로 안전한
+호출 순서를 고정하며, 후자는 2.0.0 release gate의 별도 exact-head handoff로 남긴다. 두 항목은
+현재 implementation/PR 범위의 P0/P1 blocker가 아니다.
+
+### Writer DoD
+
+| 항목 | 결과 | 근거 |
+|---|---|---|
+| SPW-01 audience/goal | PASS | 구현자와 reviewer가 Issue #1561을 순차 실행하는 목표가 첫 문단에 명확함 |
+| SPW-02 structure | PASS | 파일 책임, 추적표, 위험, RED/GREEN, 검증, review, delivery 순서 |
+| SPW-03 executable detail | PASS | exact path, signature, command, expected result, rollback/rerun 포함 |
+| SPW-04 terminology/locale | PASS | 한국어 본문과 보존할 API·command token을 분리하고 EN/KO parity gate 포함 |
+| SPW-05 completion/risk | PASS | P0/P1 0, caller/release 책임과 별도 승인 gate를 명시 |
+
+## 11. Plan self-review
+
+- **Spec coverage:** 사양 §11 여섯 기준과 §12 DoD가 Task 1~6에 모두 매핑된다.
+- **Placeholder scan:** `TBD`, `TODO`, “적절한 처리”, 후속 구현 placeholder 없음.
+- **Type consistency:** `findImportProgress`, `ImportCheckpoint.afterLeaseTouched`,
+  `NetCdfImportStatus`, metric status allowlist가 전 task에서 동일하다.
+- **Ordering:** spec/plan commit → RED/GREEN API → cancellation → regression → docs/fixture →
+  full verification → review/lesson → commit/push/PR 순서이며 later artifact 의존이 없다.
+- **Rollback:** schema/dependency가 없어 commit 단위 revert가 가능하다. cancellation seam이나
+  metric이 회귀하면 stop retry → worker 격리 → progress/partial rows 보존 → 해당 commit revert →
+  타깃/full science 검증 → authorization·quarantine 재확인 순서로 복구한다. public 조회 API와
+  docs를 유지한 채 internal 변경만 되돌리는 경우에도 사양/계획을 재검토한다.
+
+## 12. Plan DoD
+
+- 모든 public behavior는 RED 또는 기존 동작 regression 증거를 가진다.
+- Testcontainers tests는 순차 실행하고 `skipped=0`을 요구한다.
+- 기존 3-인자 constructor와 두 public 메서드는 유지된다.
+- locale, KDoc, metric, trust, migration, quarantine가 exact task에 배정된다.
+- library boundary는 실제 consumer 정책을 소유하지 않으며, authorize-first와 redacted response를
+  외부-package fixture로 증명하고 실제 application integration은 caller 책임으로 명시한다.
+- module/schema/dependency/workflow hazards는 changed-path 증거로만 N/A 처리한다.
+- PR 생성까지만 승인 범위이며 merge·release·cleanup은 계획에 포함하지 않는다.

--- a/docs/superpowers/specs/2026-08-30-issue-1561-netcdf-operation-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-30-issue-1561-netcdf-operation-boundary-design.md
@@ -1,0 +1,395 @@
+# NetCDF 작업 경계와 진행 상태 조회 설계
+
+- **일자**: 2026-08-30
+- **이슈**: [#1561](https://github.com/bluetape4k/bluetape4k-projects/issues/1561)
+- **대상 모듈**: `bluetape4k-science` (`utils/science`)
+- **기준**: `origin/develop@9831a513f9b81e53f505fadd2e4546b8ea8cf6a8`
+- **브랜치**: `feat/issue-1561-netcdf-operation-boundary`
+- **상태**: 사용자 설계안 A 승인, Step 2-R 통합 PASS
+
+## 1. 문제와 목표
+
+현재 `NetCdfCatalogService`의 README timeout 예시는 `registerFile()`과
+`importGridValues()`를 같은 작업에 넣는다. timeout이 발생하면 호출자가 작업 내부에서
+생성된 `fileId`를 받지 못하므로 `(fileId, variableName)` 진행 상태를 조회하거나 같은
+작업을 안전하게 재개할 수 없다. Repository에는 이미 진행 상태 조회 기능이 있지만,
+서비스 사용자가 직접 Exposed transaction을 열어야 한다.
+
+이번 변경의 목표는 다음과 같다.
+
+1. 등록과 장시간 import의 수명주기를 분리해 timeout 이후에도 `fileId`를 보존한다.
+2. `NetCdfCatalogService`에서 `(fileId, variableName)` 진행 상태를 직접 조회한다.
+3. local path 검증과 호출 계층의 허용 경로·인증·인가·tenant 책임을 구분한다.
+4. 2.0에서 sealed exception 하위 타입이 추가될 수 있음을 설명하고 안전한 호출자
+   분기 패턴을 source-compile fixture로 고정한다.
+5. timeout, 재시도, 파일 교체, 경로 거부 경계를 회귀 테스트로 고정한다.
+
+## 2. 현재 근거
+
+- `NetCdfCatalogService.registerFile(filePath)`는 등록이 끝난 뒤에만 `Long fileId`를
+  반환한다.
+- `NetCdfCatalogService.importGridValues(fileId, variableName)`는 blocking API이며,
+  `CancellationException`과 `InterruptedException`을 실패 상태로 바꾸지 않고 다시
+  던진다.
+- 취소된 import가 이미 lease를 얻었다면 진행 상태는 lease 만료 전까지
+  `IN_PROGRESS`일 수 있다.
+- `NetCdfImportProgressRepository.findByFileAndVariable()`는 필요한 조회를 제공하지만
+  호출자가 transaction을 열어야 한다.
+- `NetCdfFileGuard`는 control 문자, URI, non-regular file, symlink를 거부하고
+  `fileKey|size|lastModifiedTime`으로 identity를 확인한다. 허용 root, 인증·인가,
+  tenant 소유권은 검사하지 않는다.
+- 현재 `NetCdfExceptionApiCompatibilityTest`의 `else` 분기는 안전한 기본 처리 패턴을
+  보여 주지만, 외부 package의 source-compile 계약으로 명시돼 있지 않다.
+
+## 3. 범위와 비범위
+
+### 3.1 포함 범위
+
+- `NetCdfCatalogService.findImportProgress(fileId, variableName)` 추가
+- 공개 서비스 KDoc에 blocking, timeout, cooperative cancellation, progress, lease 계약 추가
+- README EN/KO timeout 예제와 신뢰 경계 설명 교정
+- `utils/science/src/test/kotlin/consumer/fixture/NetCdfPublicApiSourceCompatibilityTest.kt`
+  외부 package source-compile fixture 추가
+- timeout 후 동일 `fileId` 재사용, 파일 교체, path 거부 회귀 테스트
+- public constructor는 유지하면서 transaction 내 cancellation을 결정적으로 검증하는
+  internal test checkpoint 추가
+- POSIX unreadable local file 거부 테스트와 기존 path 거부 테스트 보강
+
+### 3.2 제외 범위
+
+- 새 작업 handle 타입이나 async/coroutine API
+- Repository, table, schema, lease TTL 정책 변경
+- allowed-root 설정, 인증·인가, tenant 정책 구현
+- 콘텐츠 hash 계산 또는 fingerprint 형식 변경
+- 취소 시 진행 상태를 즉시 `FAILED`로 변경하는 동작
+- 새 `NetCdfException` 하위 타입 추가
+- dependency, Gradle catalog, module registration, workflow 변경
+
+## 4. 대안과 결정
+
+### 대안 A — 기존 `fileId`와 `variableName`을 작업 식별자로 유지하고 조회 API만 추가
+
+`registerFile()`을 deadline 밖에서 먼저 호출하고, `importGridValues()`만 deadline이 있는
+worker에 제출한다. timeout 후 호출자는 보존한 `fileId`와 `variableName`으로
+`findImportProgress()`를 호출한다.
+
+- 장점: 기존 API와 저장 모델을 유지하며 public ABI 추가가 메서드 하나로 제한된다.
+- 비용: 두 값을 함께 전달해야 하며, caller가 executor 종료와 재시도 정책을 소유한다.
+- **결정**: 채택. 사용자가 2026-08-30 승인했다.
+
+### 대안 B — `NetCdfImportOperation(fileId, variableName)` public handle 추가
+
+- 장점: 작업 식별자를 하나의 값으로 전달할 수 있다.
+- 거부 이유: 기존 tuple을 감싸는 public Serializable 타입과 overload가 늘지만, 이번
+  수용 기준에는 별도 상태나 동작이 필요하지 않다.
+
+### 대안 C — `registerFile()` 반환형 변경 또는 등록과 import를 하나의 task로 결합
+
+- 장점: 겉보기 호출 단계가 줄어든다.
+- 거부 이유: 반환형 변경은 source/binary compatibility를 깨뜨리고, 결합 task는 timeout
+  시 `fileId` 유실 문제를 그대로 남긴다.
+
+## 5. 공개 API 계약
+
+다음 메서드를 `NetCdfCatalogService`에 추가한다.
+
+```kotlin
+fun findImportProgress(fileId: Long, variableName: String): NetCdfImportProgress?
+```
+
+계약은 다음과 같다.
+
+- `(fileId, variableName)` 진행 row가 없으면 `null`을 반환한다.
+- `variableName`이 blank면 `IllegalArgumentException`을 발생시킨다.
+- 조회는 서비스가 Exposed transaction 안에서 수행한다.
+- 파일 레코드의 존재 여부는 별도로 검증하지 않는다. Repository의 현재 조회 의미를
+  그대로 노출해 timeout 직후에도 부수 효과 없이 상태만 읽는다.
+- 반환 모델은 현재의 `NetCdfImportProgress`를 재사용한다.
+- 조회는 lease를 획득·연장·만료시키거나 progress 상태를 변경하지 않는다.
+- 조회 결과마다 `netcdf.import.progress.lookup{status}` counter를 1회 증가시킨다.
+  `status` allowlist는 `missing`, `pending`, `in-progress`, `completed`, `failed`이며
+  `fileId`, `variableName`, path, tenant는 metric tag에 넣지 않는다.
+- `fileId`는 어떤 경우에도 외부 권한 토큰이 아니다. caller는 `registerFile()`,
+  `importGridValues()`, `findImportProgress()`, 모든 retry 직전에 canonical path의
+  allowed-root 포함 여부, 인증·인가, 파일 소유권, tenant/job binding을 다시 검증한다.
+- `NetCdfImportProgress`는 내부 운영 모델이다. HTTP/RPC 응답으로 직접 직렬화하지 않고,
+  caller가 허용한 상태·cursor만 담는 redacted DTO로 변환한다. `errorMessage`, lease
+  token 역할을 하는 시각, 내부 timestamp는 외부 응답에서 기본적으로 제외한다.
+
+서비스 KDoc은 다음 작업 경계를 명시한다.
+
+1. `registerFile()`과 `importGridValues()`는 blocking이다.
+2. timeout이 필요한 호출자는 먼저 `registerFile()`로 `fileId`를 확보한다.
+3. deadline은 `importGridValues()` 작업에만 적용한다.
+4. timeout은 cooperative cancellation 요청이다. `Future.cancel(true)`가 반환됐다고
+   worker 종료나 transaction rollback이 끝났다고 간주하지 않는다.
+5. caller는 executor를 종료하고 bounded `awaitTermination`으로 worker 종료를 확인한 뒤
+   진행 상태를 조회한다.
+6. `awaitTermination`이 `false`면 worker가 살아 있다고 보고 재시도하지 않는다. executor를
+   격리하고 운영 결과를 `RECOVERY_REQUIRED`로 전환해 alert하며 progress는 진단에만
+   사용한다.
+7. worker가 종료되면 task wrapper가 기록한 최종 예외와 progress를 함께 확인한다.
+   진행 row가 `COMPLETED`면 성공으로 처리하고, 활성 lease의 `IN_PROGRESS`면 재시도하지
+   않는다. `PENDING`, `FAILED`, row 없음, 만료된 `IN_PROGRESS`는 조사 대상이지만,
+   상태만으로 자동 재시도를 결정하지 않는다. `FileChanged`, `CorruptProgress`,
+   `FileOpen`, variable/coordinate/CRS/shape/resource/duplicate 관련 typed failure는 입력이나
+   운영 조건을 수정하기 전까지 자동 재시도하지 않는다. 정책상 transient로 분류한
+   failure만 별도 승인된 bounded backoff와 retry budget 안에서 재시도한다. 이 모듈의
+   README 예제와 기본 권장 정책은 자동 재시도 0회다. application이 자동 재시도를
+   도입하면 job별 attempt 상한을 설정하고, `ImportAlreadyRunning` 또는 상한 소진 시
+   `RECOVERY_REQUIRED`로 중지·alert해야 한다.
+8. 재시도를 허용한 경우에도
+   `leaseExpiresAt`을 caller clock으로 비교해 단독 판정하지 않는다. worker 종료 후
+   import를 다시 요청하고 `ImportAlreadyRunning`을 DB clock 기반 authoritative 결과로
+   처리한다. malformed `IN_PROGRESS`의 null lease는 Repository가 복구하며, 일관되지 않은
+   cursor/status는 `CorruptProgress`로 격리될 수 있다. 실제 backoff와 재시도 상한은
+   caller가 소유한다.
+
+## 6. 신뢰 경계와 파일 identity
+
+`NetCdfCatalogService`는 외부 요청을 직접 받는 sandbox나 authorization 계층이 아니라
+신뢰된 운영 호출자를 위한 local-file API다.
+
+- 서비스가 검사하는 경계: blank/control 문자, URI scheme, symlink 구성요소,
+  non-regular file, 파일 크기 상한, 등록 시점과 재개 시점의 identity 변화
+- 호출 계층이 검사할 경계: allowed root, canonical path가 허용 root 아래인지,
+  인증·인가, tenant 또는 job 소유권, 파일 생성·배포 주체, 보존·삭제 정책
+- `fileKey|size|lastModifiedTime` fingerprint는 같은 경로의 파일 교체와 일반적인 변경을
+  탐지하기 위한 identity 휴리스틱이다. 콘텐츠 hash나 악의적 동일 metadata 변경에 대한
+  증명이 아니다.
+- guard의 path stat과 path-based open은 sandbox나 hostile-writer에 대한 완전한 TOCTOU
+  방어가 아니다. caller는 서비스 계정만 쓸 수 있는 private/quarantined directory를
+  사용하고, import 수명 동안 untrusted writer의 rename·replacement·metadata 변경을
+  차단해야 한다. hostile writer를 지원해야 한다면 file descriptor/handle 기반 open과
+  별도 threat-model 설계가 필요하며 이번 범위에는 포함하지 않는다.
+- caller는 등록된 파일을 import 완료까지 immutable하게 유지해야 한다. 교체가 감지되면
+  기존 `fileId` import는 `NetCdfException.FileChanged`로 실패한다.
+- caller는 최초 등록 결과를 신뢰해 권한 검사를 생략하지 않는다. 등록·import·progress
+  조회·retry마다 authorization 결과와 tenant/job binding을 다시 확정하며, stale
+  `fileId`만으로 권한을 부여해서는 안 된다.
+
+외부 응답은 서비스 모델을 직접 사용하지 않고 다음 최소 의미만 가진 caller-owned DTO로
+변환한다. 이름은 예시이며 library public API로 추가하지 않는다.
+
+```kotlin
+data class NetCdfImportStatusResponse(
+    val status: String,
+    val lastCommittedSlice: Long?,
+    val outcome: String,
+)
+```
+
+`status`는 allowlist 상태만, `outcome`은 `COMPLETED`, `RUNNING`, `RETRY_REVIEW`,
+`RECOVERY_REQUIRED` 중 하나만 사용한다. raw `errorMessage`, path, lease 시각, 내부
+timestamp는 운영 저장소와 접근 통제된 log에만 남기며 외부 DTO에는 포함하지 않는다.
+
+## 7. Sealed exception 2.0 호환성
+
+이번 변경은 `NetCdfException` 하위 타입을 추가하지 않는다. 다만 2.0 계열에서 typed
+failure가 확장될 수 있으므로 다음 migration 계약을 문서화한다.
+
+- 기존 public 메서드의 descriptor는 변경하지 않는다. 조회 메서드 추가는 기존 binary와
+  source caller에 additive compatibility를 제공한다.
+- Kotlin caller가 다른 module에서 `NetCdfException`을 exhaustive `when`으로 분기하면,
+  새 subtype이 추가된 버전으로 source recompilation할 때 새 분기를 요구할 수 있다.
+- 모든 subtype을 업무 의미로 구분할 필요가 없는 caller는 `else` fallback을 둔다.
+- 특정 subtype만 복구 가능한 caller는 해당 subtype을 먼저 처리하고 나머지는 base
+  handler로 전달하는 `else` 분기를 둔다.
+- 외부 package fixture는
+  `utils/science/src/test/kotlin/consumer/fixture/NetCdfPublicApiSourceCompatibilityTest.kt`에
+  두고 public API만 사용한다. `else` fallback이 있는 분기와 새 progress 조회 호출이
+  함께 source-compile되는지 확인한다. 이는 미래 subtype 자체를 합성하는 proof가 아니라,
+  현재 권장 fallback 패턴의 compile proof다. sealed direct subtype은 같은 package/module
+  제약이 있으므로 외부 consumer fixture에서 가짜 future subtype을 추가하지 않는다.
+
+## 8. 실패 모드와 동작
+
+| 실패 모드 | 예상 동작 | 호출자 조치 |
+|---|---|---|
+| 등록 전에 timeout을 적용해 `fileId`를 잃음 | 수정된 예제에서는 발생하지 않음 | 등록을 deadline 밖에서 완료 |
+| import timeout 후 worker가 아직 실행 중 | `awaitTermination=false`, 활성 작업 가능 | executor 격리, 운영 알림, 재시도 금지; progress는 진단에만 사용 |
+| 취소가 slice commit 뒤 관찰됨 | progress가 `COMPLETED`일 수 있음 | 상태를 최종 결과로 사용 |
+| 진행 row가 생성되기 전 취소됨 | 조회 결과 `null` | worker 종료 확인 후 같은 `fileId`로 재시도 가능 |
+| `PENDING` 또는 null lease의 `IN_PROGRESS` | Repository가 재획득 또는 malformed lease 복구 | worker 종료 확인 후 bounded 재호출 |
+| status/cursor 조합이 일관되지 않음 | `CorruptProgress`로 격리될 수 있음 | 자동 반복을 중지하고 운영 진단 |
+| `FAILED`이지만 원인이 영구 오류임 | 같은 입력으로 반복 실패 | typed failure와 worker 최종 예외를 분류하고 입력 수정 전 자동 재시도 금지 |
+| `ImportAlreadyRunning` 반복 또는 attempt 상한 소진 | 중복 작업이나 무한 retry 위험 | 자동 반복 중지, `RECOVERY_REQUIRED`, low-cardinality alert |
+| 등록된 경로의 파일이 교체됨 | `FileChanged`, progress row 미생성 또는 기존 row 불변 | 새 파일을 새 `fileId`로 등록 |
+| URI·symlink·directory 경로 전달 | `FileOpen` 또는 등록 거부 | caller 입력 검증과 allowed-root 정책 점검 |
+| caller가 다른 tenant의 `fileId` 사용 | 서비스 자체는 식별하지 못함 | 호출 계층에서 tenant 소유권 검증 |
+| sealed subtype 추가 뒤 exhaustive caller 재컴파일 | 새 branch가 없으면 compile 실패 가능 | base fallback 또는 새 subtype branch 추가 |
+
+## 9. 테스트 전략
+
+### 9.1 Progress API
+
+- row가 없으면 `null`
+- 저장된 `IN_PROGRESS`/`COMPLETED` row의 필드를 그대로 반환
+- blank `variableName` 거부
+- 조회가 상태와 lease를 변경하지 않음
+
+### 9.2 Timeout과 재시도
+
+- pre-admission 테스트는 임시 NetCDF를 먼저 등록해 `fileId`를 확보하고, worker를
+  import 호출 전 latch에서 대기시켜 timeout과 interrupt를 결정적으로 만든다.
+- pre-admission worker 종료 후 `findImportProgress()`가 `null`임을 확인하고, 같은
+  `fileId`로 import를 다시 실행해 `COMPLETED`를 확인한다.
+- post-admission 테스트를 위해 기존 public primary constructor
+  `(NetCdfFileRepository, NetCdfImportProgressRepository, MeterRegistry?)`를 그대로 두고,
+  네 번째 `internal ImportCheckpoint`를 받는 internal secondary constructor를 추가한다.
+  primary constructor에 default parameter를 추가하지 않는다. reflection과 `javap`로 기존
+  3-인자 JVM descriptor가 남는지 검증한다.
+- `ImportCheckpoint`는 internal fun interface이고 production 기본 구현은 no-op이다.
+  spatial import의 첫 preflight tile transaction에서 최초 `touchLease()` 성공 직후,
+  `readTile()` 전에 정확히 한 번 호출한다. rank-1과 두 번째 write pass에는 호출하지 않는다.
+- post-admission worker는 checkpoint에서 lease 획득을 알리고 latch를 기다린다. 테스트는
+  `Future.cancel(true)`와 `shutdownNow()`를 호출하고 bounded `awaitTermination` 성공을
+  확인한다.
+- checkpoint의 interrupt는 현재 Exposed transaction을 rollback한다. 테스트는 grid row가
+  없고, worker 종료 뒤 heartbeat가 더 갱신되지 않으며, progress가 초기 lease의
+  `IN_PROGRESS`로 남는지 확인한다. dataset은 기존 `use` 경계에서 닫힌다.
+- 활성 lease 중 즉시 재호출은 `ImportAlreadyRunning`이어야 한다. DB에서 lease를
+  결정적으로 만료한 뒤 같은 `fileId`로 재호출해 `COMPLETED`를 확인한다.
+- 별도 lifecycle fixture는 `awaitTermination=false` 분기에서 retry가 호출되지 않는지,
+  task wrapper가 기록한 최종 예외와 progress를 함께 분류하는지 검증한다.
+- 기존 partial progress/expired lease resume 테스트와 함께 timeout 이후 재개 의미를
+  검증한다.
+- checkpoint는 internal 테스트 seam이며 외부 caller, public constructor, 정상 import
+  의미에는 노출되지 않는다.
+- 테스트의 latch 대기와 worker 종료 상한은 각각 5초로 고정한다. 상한을 넘기면
+  `shutdownNow()`를 다시 요청하고 thread 이름을 assertion에 포함한 뒤 테스트를 실패시킨다.
+  기다림을 무제한으로 두지 않는다.
+
+### 9.3 파일 교체
+
+- 임시 복사본을 등록한 뒤 같은 path의 파일 내용을 교체한다.
+- 교체는 새 inode를 같은 path로 atomic move하고 크기 또는 mtime 차이를 강제해
+  fingerprint 변화가 파일시스템 timestamp 정밀도에 의존하지 않게 한다.
+- 기존 `fileId` import가 `NetCdfException.FileChanged`를 발생시키는지 확인한다.
+- 교체 감지 시 새 progress row가 생기지 않는지 확인한다.
+
+### 9.4 경로와 권한 경계
+
+- URI, control 문자, final/parent symlink, directory를 거부하는 기존 guard 테스트를
+  유지·보강한다.
+- allowed-root, 인증·인가, tenant 정책은 서비스 테스트 대상이 아님을 README/KDoc
+  parity 검사로 확인한다.
+- 이 모듈은 tenant authorization을 보장하지 않는다. 서비스 테스트는 local path의
+  구조·identity·현재 process의 read permission 거부를 증명하며, consumer는
+  등록·import·조회·retry마다 authorization을 검증하는 negative test를 자체 경계에 둔다.
+- 저장소의 `test-science` CI는 `ubuntu-latest`이고 로컬 기준 환경은 macOS이므로 POSIX
+  unreadable-file 검증을 지원 범위로 고정한다. 테스트는 정상 NetCDF를 생성한 뒤 read
+  permission을 제거하고 `registerFile()`이 `FileOpen`을 발생시키는지 확인하며 `finally`에서
+  permission을 복구한다. CI/로컬 실행 사용자는 root가 아니어야 하며, root 실행은 이
+  acceptance의 유효한 증거로 인정하지 않는다.
+
+### 9.5 Source compatibility
+
+- `utils/science/src/test/kotlin/consumer/fixture/NetCdfPublicApiSourceCompatibilityTest.kt`의
+  `consumer.fixture` package에서 public API만으로 기존 두 메서드와 새 조회 메서드를
+  참조한다.
+- `NetCdfException` 분기는 `else` fallback을 포함해 새 subtype 추가에도 source-compile
+  가능한 현재 권장 패턴을 고정한다. 미래 subtype 추가 자체를 시뮬레이션한다고 주장하지
+  않는다.
+
+### 9.6 운영 진단과 보존
+
+- 서비스는 progress 조회에만 `netcdf.import.progress.lookup{status}`를 기록한다.
+  timeout, worker stuck, retry exhausted는 서비스 밖 executor lifecycle이므로 caller가
+  `netcdf.import.timeout`, `netcdf.import.worker.stuck`, `netcdf.import.retry.exhausted`에
+  해당하는 low-cardinality metric/log를 기록한다.
+- log correlation은 application job/correlation ID를 사용한다. raw path, tenant,
+  `errorMessage`를 metric tag에 넣지 않는다. 접근 통제된 운영 log의 보존 기간은
+  application 정책을 따른다.
+- `FileChanged` 전에 이미 commit된 grid row와 progress는 자동 삭제하지 않는다. 기존
+  `fileId`를 quarantine 상태로 다루고 새 파일은 새 `fileId`로 등록한다. 수동 정리는
+  보존 기간, 참조 여부, tenant 소유권, 삭제 권한을 확인한 운영자만 수행한다.
+- 이번 변경은 destructive cleanup API나 schema를 추가하지 않는다. 정리 자동화가
+  필요하면 별도 이슈와 migration/runbook 검토가 필요하다.
+
+## 10. 문서 계약
+
+README EN/KO는 같은 순서와 의미를 유지한다.
+
+- 등록 예제에서 `fileId`를 deadline task 밖에서 생성
+- 등록 → import-only task → timeout cancel → bounded worker 종료 결과 → task wrapper의
+  최종 예외 → progress 조회 → 상태와 오류 종류별 처리 순서
+- `awaitTermination=false`이면 재시도 금지, `FAILED`만으로 자동 재시도 금지,
+  영구 typed failure와 정책상 transient failure 구분
+- trusted local path와 caller-owned allowed-root/authn/authz/tenant 경계
+- 등록·import·조회·모든 retry마다 authorization과 tenant/job binding 재검증
+- fingerprint 한계와 immutable file 책임
+- progress 모델 직접 외부 노출 금지, 상태 중심 redacted DTO와 오류 정보 제거
+- private/quarantined directory와 untrusted writer 차단 전제
+- sealed exception subtype 추가 시 source migration 안내
+- API 표에 `findImportProgress()` 추가
+- progress lookup metric allowlist, caller timeout/stuck/retry alert, partial row quarantine
+
+두 README의 parity 검사는 다음 항목을 같은 순서로 읽어 확인한다.
+
+1. `NetCdfCatalogService` API 표의 세 메서드
+2. timeout lifecycle 7단계와 `awaitTermination=false` 처리
+3. progress 상태·worker 예외·영구/일시 오류 분류표
+4. allowed-root/authn/authz/tenant 재검증과 redacted DTO
+5. fingerprint/hostile-writer 한계
+6. sealed subtype `else` migration 안내
+7. progress lookup metric과 caller alert, partial row quarantine
+
+검증은 각 locale에서 위 identifier와 상태 토큰을 `rg`로 확인하고, 최종 inline review에서
+문단 순서와 의미 parity를 함께 판정한다.
+
+KDoc은 한국어 reader-facing 정책을 따르며, API 이름과 상태 enum은 그대로 보존한다.
+
+## 11. 수용 기준 추적
+
+| 이슈 수용 기준 | 설계 충족 방식 | 검증 |
+|---|---|---|
+| timeout 경로에서 progress 조회용 식별자 보존 | 등록을 deadline 밖으로 이동, `fileId` 유지 | timeout/retry 통합 테스트, README 예제 |
+| path/auth/tenant/fingerprint 책임 명시 | 서비스 KDoc과 EN/KO trust boundary | 문서 parity와 source review |
+| 2.0 sealed subtype migration 안내 | base fallback 권장, additive API 명시 | 외부 package source-compile fixture |
+| timeout/resume 검증 | timeout 전 row 없음과 동일 `fileId` 재시도, 기존 partial resume 유지 | 타깃 Testcontainers 테스트 |
+| file replacement 검증 | import 전 fingerprint 재검증 유지 | `FileChanged` 통합 테스트 |
+| permission boundary 검증 | POSIX unreadable local file 거부, tenant authorization은 consumer가 매 작업·retry에서 검증 | unreadable/guard 테스트, KDoc/README review, consumer negative-test 책임 명시 |
+
+## 12. 완료 정의
+
+- 기존 `registerFile()`과 `importGridValues()` descriptor가 유지된다.
+- reflection/`javap`가 기존 3-인자 public constructor descriptor를 확인한다.
+- `findImportProgress()`가 transaction 경계를 숨기고 읽기 전용 조회를 제공한다.
+- timeout 후 동일 `fileId` 재시도와 파일 교체 거부 테스트가 통과한다.
+- 외부 package source-compile fixture가 통과한다.
+- README EN/KO와 KDoc이 timeout·trust·migration 계약을 같은 의미로 설명한다.
+- `:bluetape4k-science:test`, 관련 정적 검사, `git diff --check`가 통과한다.
+- inline review와 독립 review의 최신 결과가 P0=0/P1=0이다.
+- PR은 승인된 `develop <- feat/issue-1561-netcdf-operation-boundary`로 생성하고 merge는
+  별도 승인 전까지 수행하지 않는다.
+
+## 13. Step 2-R 통합 검토
+
+검토 범위는 이 사양과 현재 `utils/science`의 service, repository, guard, model, test,
+README EN/KO다. 각 lane은 읽기 전용으로 한 관점만 검토했고, 수정은 main session이
+통합했다.
+
+| 관점 | 최초 결과 | 반영한 수정 | 최종 결과 |
+|---|---|---|---|
+| 성능 | P0=0, P1=0 | indexed single-row 조회라 별도 benchmark N/A | CLEAR |
+| 안정성 | P1=1, P2=2 | post-lease cancellation checkpoint, DB-clock retry, atomic replacement | CLEAR |
+| 보안 | P2=2 | redacted DTO, 매 작업 authorization, hostile-writer 경계 | CLEAR |
+| Operator/Ops | P1=1, P2=3 | `RECOVERY_REQUIRED`, 자동 retry 0회, metric allowlist, quarantine | CLEAR |
+| Developer/API | P1=2, P2=3 | POSIX unreadable test, 3-인자 constructor ABI와 checkpoint 위치 | CLEAR |
+| User/caller | P1=2, P2=3 | 규범적 timeout 순서, 영구/일시 오류 분류, locale parity | CLEAR |
+| Main integration | 중복·충돌·근거 검토 | public API 최소화, 책임 경계와 수용 기준 재추적 | PASS |
+
+최신 통합 결과는 **P0=0, P1=0, P2=0, P3=0**이다. public 설계안 A는 유지됐고,
+internal test seam과 운영 계약만 구체화됐으므로 사용자 재승인이 필요한 material design
+변경은 없다.
+
+### Writer DoD
+
+| 항목 | 결과 | 근거 |
+|---|---|---|
+| SPW-01 | PASS | 독자는 library 개발자·운영 caller, 언어는 한국어, source/issue/ref 고정 |
+| SPW-02 | PASS | 문제, 대안, API, 신뢰 경계, 실패 모드, 호환성, 테스트, 수용 기준, DoD 포함 |
+| SPW-03 | PASS | Korean naturalness KO-01~KO-07 검토, identifier와 상태 토큰 보존 |
+| SPW-04 | PASS | source-to-claim과 issue-to-acceptance 표, 6개 관점 재검토로 의미 추적 |
+| SPW-05 | PASS | 최종 Markdown read-back, terminology audit findings=0, `git diff --check` PASS |

--- a/docs/testlogs/2026-08.md
+++ b/docs/testlogs/2026-08.md
@@ -25,3 +25,6 @@
 | 2026-08-30 | #1520 | Ignite2 migration marker 계약 | RED → GREEN — 1 failed 후 1 passing | EN/KO README, CHANGELOG, release 문서의 동기화 marker와 필수 예외 타입·메시지를 고정 |
 | 2026-08-30 | #1520 | `Ignite2ServerTest` | PASS — 6 passing | Testcontainers 직렬 실행; 대표 Ignite startup/workload, custom String/`DockerImageName` tag, unknown architecture fail-fast 검증 |
 | 2026-08-30 | #1520 | JVM·문서 계약, `:bluetape4k-testcontainers:detekt`, shell·diff 감사 | PASS — Python 17 passing, JVM descriptor 4개 일치 | Maven Central 1.12.1 JAR SHA-256 검증 후 current descriptor와 직접 비교; 변경 파일 신규 Detekt finding 없음 |
+| 2026-08-30 | #1561 | progress·timeout·cancellation·resume·path boundary RED → GREEN | PASS — targeted regression 모두 복원 후 통과 | pre-admission timeout, post-lease interruption rollback, active lease 거부, 강제 만료 뒤 resume, atomic replacement, POSIX unreadable, authoritative tenant/job/path binding을 검증 |
+| 2026-08-30 | #1561 | `:bluetape4k-science:test` | PASS — 275 passing | JUnit failures 0, errors 0, skipped 0; consumer source compatibility fixture 30개 포함 |
+| 2026-08-30 | #1561 | `:bluetape4k-science:detekt :bluetape4k-science:compileKotlin :bluetape4k-science:compileTestKotlin`, ABI·문서 감사 | PASS — task 완료 | 기존 3-인자 public constructor 유지, typed 4-인자 constructor private, EN/KO marker parity, 한국어 용어 findings 0, `git diff --check` 통과 |

--- a/utils/science/README.ko.md
+++ b/utils/science/README.ko.md
@@ -117,6 +117,7 @@ io.bluetape4k.science/
 | | NetCDF 격자 값 저장 스키마 | `NetCdfGridValueTable` ✅ |
 | | `.nc` 파일 등록 | `NetCdfCatalogService.registerFile()` ✅ |
 | | rank 1~4 격자 임포트 | `NetCdfCatalogService.importGridValues()` ✅ |
+| | 임포트 progress 진단 | `NetCdfCatalogService.findImportProgress()` ✅ |
 | | CoordinateAxis2D / CF auxiliary 좌표 | `NetCdfCatalogService.importGridValues()` ✅ |
 
 ---
@@ -299,31 +300,122 @@ val fileId = catalog.registerFile("/data/era5/ERA5_2024_01.nc")
 catalog.importGridValues(fileId, variableName = "temperature")
 ```
 
-두 호출은 blocking이므로 호출자가 virtual-thread의 deadline과 취소 수명주기를
-소유해야 합니다. timeout은 cooperative cancel일 뿐 import 완료를 의미하지 않으므로,
-재시도하기 전에 progress row를 조회하세요.
+두 호출은 blocking입니다. 호출자가 `fileId`를 보존할 수 있도록 등록을 import deadline
+밖에서 완료하고, worker에는 `importGridValues()`만 제출하세요. timeout은 cooperative
+cancellation을 요청할 뿐 worker나 데이터베이스 transaction 종료를 보장하지 않습니다.
 
+<!-- netcdf-timeout-example:start -->
 ```kotlin
+import io.bluetape4k.science.exposed.NetCdfException
+import io.bluetape4k.science.exposed.model.NetCdfImportStatus
+import java.util.concurrent.CancellationException
 import java.util.concurrent.Executors
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
 
+val fileId = catalog.registerFile("/srv/netcdf/quarantine/grid.nc")
+val workerFailure = AtomicReference<Throwable?>()
 val executor = Executors.newVirtualThreadPerTaskExecutor()
 val task = executor.submit {
-    val fileId = catalog.registerFile("/srv/netcdf/grid.nc") // trusted-admin 경로
-    catalog.importGridValues(fileId, "temperature")
-    fileId
+    try {
+        catalog.importGridValues(fileId, "temperature")
+    } catch (failure: Throwable) {
+        workerFailure.set(failure)
+        throw failure
+    }
 }
+var outcome = "RUNNING"
+var callerInterrupted = false
 try {
     task.get(30, TimeUnit.MINUTES)
+    outcome = "COMPLETED"
 } catch (timeout: TimeoutException) {
     task.cancel(true)
-    throw timeout
+    outcome = "TIMED_OUT"
+} catch (cancelled: CancellationException) {
+    outcome = "CANCELLED"
+} catch (failure: ExecutionException) {
+    outcome = "FAILED"
+} catch (interrupted: InterruptedException) {
+    task.cancel(true)
+    callerInterrupted = true
+    outcome = "INTERRUPTED"
 } finally {
     executor.shutdownNow()
-    check(executor.awaitTermination(30, TimeUnit.SECONDS)) { "import worker did not stop" }
 }
+
+var workerTerminated = false
+try {
+    workerTerminated = executor.awaitTermination(30, TimeUnit.SECONDS)
+} catch (interrupted: InterruptedException) {
+    callerInterrupted = true
+}
+if (!workerTerminated) {
+    outcome = "RECOVERY_REQUIRED"
+    // Isolate the worker, alert, and do not retry.
+} else {
+    val progress = catalog.findImportProgress(fileId, "temperature")
+    val failure = workerFailure.get()
+    outcome = when {
+        outcome == "COMPLETED" || progress?.status == NetCdfImportStatus.COMPLETED -> "COMPLETED"
+        failure is NetCdfException.ImportAlreadyRunning -> "RUNNING"
+        failure is NetCdfException -> "RECOVERY_REQUIRED"
+        failure != null -> "RECOVERY_REQUIRED"
+        else -> "RETRY_REVIEW"
+    }
+}
+if (callerInterrupted) Thread.currentThread().interrupt()
 ```
+<!-- netcdf-timeout-example:end -->
+
+`awaitTermination=false`는 항상 `RECOVERY_REQUIRED`입니다. worker를 격리하고
+`netcdf.import.worker.stuck` 경보를 보낸 뒤 자동 재시도를 0회로 유지하세요. worker 종료를
+확인한 뒤에는 worker 예외와 progress를 함께 분류합니다.
+
+| Worker/progress/기준 신호 | Outcome | Caller 조치 |
+|--------------------------|---------|-------------|
+| `terminated=false` | `RECOVERY_REQUIRED` | worker 격리, stuck 경보, 재시도 금지 |
+| progress `COMPLETED` | `COMPLETED` | 작업 완료 처리 |
+| 첫 `ImportAlreadyRunning` | `RUNNING` | DB lease 결과를 신뢰하고 재시도 금지 |
+| `PENDING`, `FAILED`, row 없음, 판정할 수 없는 `IN_PROGRESS` | `RETRY_REVIEW` | 자동 재시도 0회, 운영 검토 |
+| 반복 `ImportAlreadyRunning` 또는 attempt 상한 소진 | `RECOVERY_REQUIRED` | 재시도 중단과 경보 |
+| non-transient typed failure | `RECOVERY_REQUIRED` | 입력이나 운영 조건을 수정하기 전 재시도 금지 |
+| 예상하지 못한 worker failure | `RECOVERY_REQUIRED` | fail-closed, 진단 보존, 경보 |
+
+`leaseExpiresAt`과 application host clock을 비교하지 마세요. 만료된 lease의 재획득 가능 여부는
+데이터베이스가 판정하며, `ImportAlreadyRunning`이 활성 lease의 기준 신호입니다. `fileId`는
+권한 토큰이 아닙니다. register, import, progress, retry를 각각 인증·인가하고, 매 호출에서
+tenant/job 소유권을 확인하며, caller-owned allowed-root 정책에 속한 경로만 허용하세요.
+
+서비스는 symlink, 일반 파일이 아닌 경로, identity 변경, open 중 파일 변경을 거부하지만 이
+guard가 sandbox를 대신하지는 않습니다. 업로드 파일은 hostile writer가 접근할 수 없는 immutable
+quarantine directory에 보관하세요. fingerprint는 content hash나 TOCTOU 증명이 아닌
+`fileKey|size|lastModifiedTime` 휴리스틱입니다. 값이 다르면 `FileChanged`가 발생하지만 공격자가
+동일 metadata를 보존할 수 있습니다. fingerprint나 파일 이름이 같다는 이유로 content integrity가
+증명됐거나 등록된 path를 교체해도 안전하다고 가정하면 안 됩니다.
+
+`findImportProgress()`는 운영용 model을 반환합니다. caller-owned DTO에는 status, 마지막 commit
+slice, coarse outcome만 allowlist로 복사하세요. `errorMessage`, `leaseExpiresAt`, timestamp, raw path,
+tenant identifier, fingerprint를 직렬화하면 안 됩니다. library metric
+`netcdf.import.progress.lookup`은 고정 `status` tag를 사용합니다. caller 경보는
+`netcdf.import.timeout`, `netcdf.import.worker.stuck`, `netcdf.import.retry.exhausted`를 사용할 수
+있으며 metric tag는 `operation`, `outcome`처럼 cardinality가 제한된 값만 둡니다. correlation ID는
+metric tag가 아니라 구조화 로그나 trace 필드에 기록하세요.
+
+`NetCdfException`은 sealed 타입이므로 subtype이 추가되면 exhaustive consumer `when`의 source
+migration이 필요할 수 있습니다. integration 경계에는 `else` fallback을 두고 caller가 정책을
+소유한 subtype만 명시적으로 매핑하세요.
+
+운영 복구 순서는 다음과 같습니다.
+
+1. 자동 재시도를 중단합니다.
+2. worker를 격리하고 종료를 확인합니다.
+3. 진단을 위해 progress와 partial grid row를 보존합니다.
+4. raw path, tenant, 예외 text를 tag에 넣지 않고 correlation ID로 경보를 보냅니다.
+5. 입력 identity, 권한, tenant/job binding을 확인합니다.
+6. 명시적인 운영 승인을 받은 뒤에만 수동 cleanup을 수행합니다.
 
 지원 rank의 저장 좌표는 다음과 같습니다.
 
@@ -410,10 +502,12 @@ typed `NetCdfException` 하위 타입으로 보고합니다.
 | `NetCdfFileRepository` | ✅ | 파일 메타데이터 CRUD (`save`, `findById`, `findAll`, `deleteById`) |
 | `NetCdfFileTable` | ✅ | JSONB 컬럼 + PostGIS bbox + 시간 범위 |
 | `NetCdfGridValueTable` | ✅ | 격자 값 테이블 (location: PostGIS POINT, value, timeIdx, levelIdx) |
-| `NetCdfCatalogService` | ✅ | 동기 `registerFile()`·`importGridValues()`; rank 1~4, 1D/2D 축, CF numeric auxiliary, bounded tile, lease/resume, CRS 화이트리스트, NaN/`_FillValue` 처리 |
+| `NetCdfCatalogService` | ✅ | 동기 `registerFile()`·`importGridValues()`와 read-only `findImportProgress()`; rank 1~4, 1D/2D 축, CF numeric auxiliary, bounded tile, lease/resume, CRS 화이트리스트, NaN/`_FillValue` 처리 |
 
-`NetCdfCatalogService`는 안정적인 sealed 예외 계약을 제공합니다. 빈 경로와
-변수명은 `IllegalArgumentException`을 발생시키며, 파일·변수·좌표 누락,
+`NetCdfCatalogService`는 sealed `NetCdfException` subtype으로 typed failure를 보고합니다.
+새 subtype이 추가되면 exhaustive `when`의 source migration이 필요할 수 있으므로 consumer
+code에는 `else` fallback을 유지하세요. 빈 경로와 변수명은 `IllegalArgumentException`을
+발생시키며, 파일·변수·좌표 누락,
 지원하지 않는 rank/축/CRS, 활성 lease, lease 손실, 파일 변경, 손상된 progress,
 좌표 중복, 자원 한도 초과는 각각의 `NetCdfException` 하위 타입으로 보고합니다.
 기존 schema를 재사용해 `location`에는 canonical `(lon, lat)`, `attrs`에는

--- a/utils/science/README.md
+++ b/utils/science/README.md
@@ -117,6 +117,7 @@ io.bluetape4k.science/
 | | NetCDF grid value storage schema | `NetCdfGridValueTable` ✅ |
 | | `.nc` file registration | `NetCdfCatalogService.registerFile()` ✅ |
 | | Rank 1–4 grid import | `NetCdfCatalogService.importGridValues()` ✅ |
+| | Import progress diagnostics | `NetCdfCatalogService.findImportProgress()` ✅ |
 | | CoordinateAxis2D / CF auxiliary coordinates | `NetCdfCatalogService.importGridValues()` ✅ |
 
 ---
@@ -299,31 +300,124 @@ val fileId = catalog.registerFile("/data/era5/ERA5_2024_01.nc")
 catalog.importGridValues(fileId, variableName = "temperature")
 ```
 
-Because both calls are blocking, a virtual-thread caller should own its deadline
-and cancellation lifecycle. A timeout cancels cooperatively; it does not imply
-that an import completed, so callers should read the progress row before retrying.
+Both calls are blocking. Complete registration outside the import deadline so the
+caller retains `fileId`, then submit only `importGridValues()` to the worker. A
+timeout requests cooperative cancellation; it does not prove that the worker or
+database transaction stopped.
 
+<!-- netcdf-timeout-example:start -->
 ```kotlin
+import io.bluetape4k.science.exposed.NetCdfException
+import io.bluetape4k.science.exposed.model.NetCdfImportStatus
+import java.util.concurrent.CancellationException
 import java.util.concurrent.Executors
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
 
+val fileId = catalog.registerFile("/srv/netcdf/quarantine/grid.nc")
+val workerFailure = AtomicReference<Throwable?>()
 val executor = Executors.newVirtualThreadPerTaskExecutor()
 val task = executor.submit {
-    val fileId = catalog.registerFile("/srv/netcdf/grid.nc") // trusted-admin path
-    catalog.importGridValues(fileId, "temperature")
-    fileId
+    try {
+        catalog.importGridValues(fileId, "temperature")
+    } catch (failure: Throwable) {
+        workerFailure.set(failure)
+        throw failure
+    }
 }
+var outcome = "RUNNING"
+var callerInterrupted = false
 try {
     task.get(30, TimeUnit.MINUTES)
+    outcome = "COMPLETED"
 } catch (timeout: TimeoutException) {
     task.cancel(true)
-    throw timeout
+    outcome = "TIMED_OUT"
+} catch (cancelled: CancellationException) {
+    outcome = "CANCELLED"
+} catch (failure: ExecutionException) {
+    outcome = "FAILED"
+} catch (interrupted: InterruptedException) {
+    task.cancel(true)
+    callerInterrupted = true
+    outcome = "INTERRUPTED"
 } finally {
     executor.shutdownNow()
-    check(executor.awaitTermination(30, TimeUnit.SECONDS)) { "import worker did not stop" }
 }
+
+var workerTerminated = false
+try {
+    workerTerminated = executor.awaitTermination(30, TimeUnit.SECONDS)
+} catch (interrupted: InterruptedException) {
+    callerInterrupted = true
+}
+if (!workerTerminated) {
+    outcome = "RECOVERY_REQUIRED"
+    // Isolate the worker, alert, and do not retry.
+} else {
+    val progress = catalog.findImportProgress(fileId, "temperature")
+    val failure = workerFailure.get()
+    outcome = when {
+        outcome == "COMPLETED" || progress?.status == NetCdfImportStatus.COMPLETED -> "COMPLETED"
+        failure is NetCdfException.ImportAlreadyRunning -> "RUNNING"
+        failure is NetCdfException -> "RECOVERY_REQUIRED"
+        failure != null -> "RECOVERY_REQUIRED"
+        else -> "RETRY_REVIEW"
+    }
+}
+if (callerInterrupted) Thread.currentThread().interrupt()
 ```
+<!-- netcdf-timeout-example:end -->
+
+`awaitTermination=false` is always `RECOVERY_REQUIRED`: isolate the worker, emit
+`netcdf.import.worker.stuck`, and perform zero automatic retries. After a confirmed
+worker exit, classify the worker exception and progress together:
+
+| Worker/progress/authoritative signal | Outcome | Caller action |
+|--------------------------------------|---------|---------------|
+| `terminated=false` | `RECOVERY_REQUIRED` | Isolate worker, emit stuck alert, do not retry |
+| Progress `COMPLETED` | `COMPLETED` | Finish the job |
+| First `ImportAlreadyRunning` | `RUNNING` | Trust the DB lease result; do not retry |
+| `PENDING`, `FAILED`, no row, or indeterminate `IN_PROGRESS` | `RETRY_REVIEW` | Zero automatic retries; require operational review |
+| Repeated `ImportAlreadyRunning` or exhausted attempt limit | `RECOVERY_REQUIRED` | Stop retries and alert |
+| Non-transient typed failure | `RECOVERY_REQUIRED` | Repair input or operating conditions before retrying |
+| Unexpected worker failure | `RECOVERY_REQUIRED` | Fail closed, preserve diagnostics, and alert |
+
+Do not compare `leaseExpiresAt` with the application host clock. The database decides
+whether an expired lease can be reacquired; `ImportAlreadyRunning` is the authoritative
+active-lease signal. `fileId` is not an authorization token. Authenticate and authorize
+register, import, progress, and retry independently, verify tenant/job ownership each time,
+and accept paths only from a caller-owned allowed-root policy.
+
+The service rejects symlinks, non-regular files, identity changes, and files that change
+during open, but this guard is not a sandbox. Stage uploads in an immutable quarantine
+directory and protect them from hostile writers. The fingerprint is only a
+`fileKey|size|lastModifiedTime` heuristic, not a content hash or TOCTOU proof. A mismatch raises
+`FileChanged`, but an attacker may preserve the same metadata; do not replace the registered path
+and assume a matching fingerprint or filename proves content integrity.
+
+`findImportProgress()` returns an operational model. Convert it to a caller-owned DTO that
+allowlists only status, the last committed slice, and a coarse outcome. Do not serialize
+`errorMessage`, `leaseExpiresAt`, timestamps, raw paths, tenant identifiers, or fingerprints.
+The library metric `netcdf.import.progress.lookup` uses a fixed `status` tag. Caller alerts
+may use `netcdf.import.timeout`, `netcdf.import.worker.stuck`, and
+`netcdf.import.retry.exhausted`; keep metric tags to bounded values such as `operation` and
+`outcome`. Put the correlation ID in a structured log or trace field, never in a metric tag.
+
+`NetCdfException` is sealed, so adding a subtype can require source migration for exhaustive
+consumer `when` expressions. Keep an `else` fallback at integration boundaries and map only
+the subtypes whose policy the caller owns.
+
+Operator recovery order:
+
+1. Stop automatic retries.
+2. Isolate the worker and confirm termination.
+3. Preserve progress and partial grid rows for diagnosis.
+4. Alert with a correlation ID, without raw path, tenant, or exception text tags.
+5. Verify input identity, authorization, and tenant/job binding.
+6. Perform manual cleanup only after explicit operational approval.
 
 The importer maps the supported ranks as follows:
 
@@ -411,10 +505,12 @@ and counted by `netcdf.import.nan.skipped`.
 | `NetCdfFileRepository` | ✅ | File metadata CRUD (`save`, `findById`, `findAll`, `deleteById`) |
 | `NetCdfFileTable` | ✅ | Exposed table — JSONB columns + PostGIS bbox + time range |
 | `NetCdfGridValueTable` | ✅ | Grid value table (location: PostGIS POINT, value, timeIdx, levelIdx) |
-| `NetCdfCatalogService` | ✅ | Blocking `registerFile()` and `importGridValues()`; rank 1–4, 1D/2D axes, CF numeric auxiliary coordinates, bounded tiles, lease/resume, CRS whitelist, NaN/`_FillValue` handling |
+| `NetCdfCatalogService` | ✅ | Blocking `registerFile()`, `importGridValues()`, and read-only `findImportProgress()`; rank 1–4, 1D/2D axes, CF numeric auxiliary coordinates, bounded tiles, lease/resume, CRS whitelist, NaN/`_FillValue` handling |
 
-`NetCdfCatalogService` exposes a stable sealed-exception contract. Blank paths or
-variable names raise `IllegalArgumentException`; missing files, variables,
+`NetCdfCatalogService` reports typed failures through sealed `NetCdfException` subtypes.
+Consumer code should retain an `else` fallback because a new subtype can require source
+migration for an exhaustive `when`. Blank paths or variable names raise
+`IllegalArgumentException`; missing files, variables,
 coordinates, unsupported ranks/axes/CRS, active leases, lost leases, changed
 files, corrupt progress, duplicates, and resource-limit violations are reported
 as the corresponding `NetCdfException` subtype. Existing schema columns are reused:

--- a/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt
+++ b/utils/science/src/main/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogService.kt
@@ -35,6 +35,7 @@ import io.bluetape4k.science.exposed.service.internal.UcarCoordinateReader
 import io.bluetape4k.science.exposed.service.internal.VariableAxisMap
 import io.bluetape4k.science.exposed.service.internal.checkedProduct
 import io.bluetape4k.science.exposed.service.internal.serializeAuxiliaryAttributes
+import io.bluetape4k.support.requireNotBlank
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -54,18 +55,44 @@ import java.util.ArrayDeque
 import java.util.concurrent.CancellationException
 import kotlin.math.abs
 
+private fun interface ImportCheckpoint {
+
+    @Throws(InterruptedException::class)
+    fun afterLeaseTouched()
+
+    companion object {
+        val NONE: ImportCheckpoint = ImportCheckpoint {}
+    }
+}
+
 /**
  * NetCDF 파일 등록과 bounded 격자 값 임포트를 담당하는 blocking 서비스입니다.
  *
- * 파일 identity를 등록·재개 시점에 확인하고, CF 1D/2D 좌표축을 tile 단위로
- * 읽습니다. 좌표와 값은 두 번 순회하여 한 slice의 duplicate를 먼저 검증한
- * 뒤에만 JDBC batch를 실행합니다.
+ * [registerFile]은 import worker의 deadline 밖에서 먼저 완료해야 합니다. [importGridValues]의
+ * timeout은 cooperative cancellation이므로 worker 종료를 확인하기 전에는 재시도하면 안 됩니다.
+ * 파일 identity를 등록·재개 시점에 확인하고, CF 1D/2D 좌표축을 tile 단위로 읽습니다.
+ * identity fingerprint는 `fileKey|size|lastModifiedTime` 휴리스틱이며 content hash가 아닙니다.
+ * 동일 metadata를 보존한 변경이나 hostile writer와의 TOCTOU를 탐지한다고 보장하지 않습니다.
+ * 좌표와 값은 두 번 순회하여 한 slice의 duplicate를 먼저 검증한 뒤에만 JDBC batch를 실행합니다.
+ *
+ * 이 서비스의 local-file guard는 authentication, authorization, tenant/job binding 또는
+ * allowed-root 정책을 대신하지 않습니다. caller는 register/import/progress/retry마다 권한을
+ * 다시 확인하고, 승인된 immutable/quarantine 경로만 전달해야 합니다. `fileId`는 권한 토큰이
+ * 아니며 progress의 lease 만료 여부는 caller의 local clock으로 판정하지 않습니다. progress를
+ * 외부에 반환할 때는 caller-owned DTO의 allowlist로 상태와 cursor만 복사해야 합니다.
  */
-class NetCdfCatalogService(
+class NetCdfCatalogService private constructor(
     private val fileRepo: NetCdfFileRepository,
     private val progressRepo: NetCdfImportProgressRepository,
-    private val meterRegistry: MeterRegistry? = null,
+    private val meterRegistry: MeterRegistry?,
+    private val importCheckpoint: ImportCheckpoint,
 ) {
+
+    constructor(
+        fileRepo: NetCdfFileRepository,
+        progressRepo: NetCdfImportProgressRepository,
+        meterRegistry: MeterRegistry? = null,
+    ): this(fileRepo, progressRepo, meterRegistry, ImportCheckpoint.NONE)
 
     companion object: KLogging() {
         /** heartbeat lease TTL — 5분 */
@@ -82,7 +109,14 @@ class NetCdfCatalogService(
         private const val FILL_VALUE_TOLERANCE: Double = 1e-7
     }
 
-    /** NetCDF 파일을 bounded metadata와 identity fingerprint와 함께 등록합니다. */
+    /**
+     * NetCDF 파일을 bounded metadata와 identity fingerprint와 함께 등록합니다.
+     *
+     * blocking 호출이며 import task를 제출하기 전에 완료해 `fileId`를 보존해야 합니다. 경로가
+     * local regular file인지와 identity가 안정적인지는 검증하지만, caller-owned allowed-root,
+     * authentication, authorization, tenant 정책은 검증하지 않습니다.
+     * fingerprint는 content integrity 증명이 아니므로 immutable/quarantine source가 별도로 필요합니다.
+     */
     fun registerFile(filePath: String): Long {
         val sample = meterRegistry?.let { Timer.start(it) }
         var success = false
@@ -112,7 +146,44 @@ class NetCdfCatalogService(
         }
     }
 
-    /** 등록된 변수의 값을 slice/tile 단위로 임포트합니다. */
+    /**
+     * `(fileId, variableName)`에 대응하는 임포트 진행 상태를 조회합니다.
+     *
+     * 조회는 lease나 진행 상태를 변경하지 않습니다. [fileId]는 권한 토큰이 아니므로 caller는
+     * 호출 전에 파일 소유권과 tenant/job binding을 다시 검증해야 합니다. 반환 모델은 내부
+     * 운영 정보이므로 HTTP/RPC 응답에서는 허용한 상태와 cursor만 담은 DTO로 변환해야 합니다.
+     * `leaseExpiresAt`과 caller의 local clock만으로 retry 가능 여부를 판정하지 말고, DB가 반환한
+     * [NetCdfException.ImportAlreadyRunning]과 worker 종료 상태를 함께 사용해야 합니다.
+     *
+     * @return 진행 row가 없으면 `null`
+     * @throws IllegalArgumentException [variableName]이 blank인 경우
+     */
+    fun findImportProgress(fileId: Long, variableName: String): NetCdfImportProgress? {
+        variableName.requireNotBlank("variableName")
+        val progress = transaction { progressRepo.findByFileAndVariable(fileId, variableName) }
+        val metricStatus = when (progress?.status) {
+            null -> "missing"
+            NetCdfImportStatus.PENDING -> "pending"
+            NetCdfImportStatus.IN_PROGRESS -> "in-progress"
+            NetCdfImportStatus.COMPLETED -> "completed"
+            NetCdfImportStatus.FAILED -> "failed"
+        }
+        meterRegistry?.counter(
+            "netcdf.import.progress.lookup",
+            "status",
+            metricStatus,
+        )?.increment()
+        return progress
+    }
+
+    /**
+     * 등록된 변수의 값을 slice/tile 단위로 임포트합니다.
+     *
+     * blocking 호출이며 interrupt는 cooperative cancellation입니다. timeout 뒤에는 executor 종료를
+     * bounded하게 확인하고 [findImportProgress]로 상태를 조회한 다음에만 재시도를 검토해야 합니다.
+     * worker가 종료되지 않았거나 활성 lease가 남아 있으면 격리·경보 후 자동 재시도를 중단합니다.
+     * 호출과 재시도마다 [fileId], tenant/job, 변수 접근 권한을 다시 검증해야 합니다.
+     */
     fun importGridValues(fileId: Long, variableName: String) {
         try {
             importGridValuesInternal(fileId, variableName)
@@ -405,7 +476,7 @@ class NetCdfCatalogService(
         )
 
         // 첫 번째 pass: DB transaction 전에 전체 slice의 canonical coordinate를 검증합니다.
-        tiles.forEach { tile ->
+        tiles.forEachIndexed { tileIndex, tile ->
             checkNotInterrupted()
             transaction {
                 // duplicate preflight도 NetCDF read 전에 lease fence를 확인합니다.
@@ -415,6 +486,10 @@ class NetCdfCatalogService(
                     context.lease.expiresAt,
                     leaseTtl = LEASE_TTL,
                 )
+                if (tileIndex == 0 && !context.checkpointReached) {
+                    importCheckpoint.afterLeaseTouched()
+                    context.checkpointReached = true
+                }
                 checkNotInterrupted()
                 val data = readTile(prepared.variable, layout, tile, timeIdx, levelIdx)
                 checkNotInterrupted()
@@ -775,6 +850,7 @@ class NetCdfCatalogService(
         val prepared: PreparedImport,
         val progressId: Long,
         val lease: ImportLease,
+        var checkpointReached: Boolean = false,
     )
 
     private data class ImportLease(var expiresAt: Instant)

--- a/utils/science/src/test/kotlin/consumer/fixture/NetCdfPublicApiSourceCompatibilityTest.kt
+++ b/utils/science/src/test/kotlin/consumer/fixture/NetCdfPublicApiSourceCompatibilityTest.kt
@@ -1,0 +1,414 @@
+package consumer.fixture
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.science.exposed.NetCdfException
+import io.bluetape4k.science.exposed.model.NetCdfImportProgress
+import io.bluetape4k.science.exposed.model.NetCdfImportStatus
+import io.bluetape4k.science.exposed.service.NetCdfCatalogService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.nio.file.Path
+import java.util.stream.Stream
+
+/**
+ * 외부 package에서 public NetCDF API의 source compatibility와 caller 책임 예제를 검증합니다.
+ *
+ * authorize/lifecycle helper는 실제 HTTP/RPC adapter나 worker 통합을 증명하지 않습니다. 공개 API와
+ * caller-owned 정책 예제가 함께 compile되고 기대한 결정표를 실행하는지 고정하는 consumer fixture입니다.
+ */
+class NetCdfPublicApiSourceCompatibilityTest {
+
+    @Test
+    fun `public progress API compiles and response allowlist excludes operational fields`() {
+        val progress = NetCdfImportProgress(
+            fileId = 41L,
+            variableName = "temperature",
+            status = NetCdfImportStatus.IN_PROGRESS,
+            lastSliceIdx = 7L,
+            errorMessage = "must-not-leak",
+        )
+
+        progress.toCallerResponse(ImportOutcome.RUNNING) shouldBeEqualTo NetCdfImportStatusResponse(
+            status = "IN_PROGRESS",
+            lastCommittedSlice = 7L,
+            outcome = "RUNNING",
+        )
+        NetCdfImportStatusResponse::class.java.declaredFields
+            .filterNot { it.isSynthetic }
+            .map { it.name }
+            .toSet() shouldBeEqualTo setOf("status", "lastCommittedSlice", "outcome")
+    }
+
+    @Test
+    fun `sealed exception migration keeps an else fallback`() {
+        classify(NetCdfException.FileChanged(1L, "expected", "actual")) shouldBeEqualTo "file-changed"
+        classify(NetCdfException.CorruptProgress(2L, "invalid")) shouldBeEqualTo "corrupt-progress"
+        classify(NetCdfException.ImportAlreadyRunning(3L, "temperature")) shouldBeEqualTo "running"
+        classify(NetCdfException.FileRecordNotFound(4L)) shouldBeEqualTo "unhandled-netcdf"
+    }
+
+    @Test
+    fun `non-register authorization resolves tenant job and path from the file binding`() {
+        var invocations = 0
+        val adapter = AuthorizedNetCdfCaller(::authorize)
+        val spoofedRequestPath = allowedRequest().copy(registeredPath = "/tmp/caller-supplied.nc")
+
+        listOf(CallerOperation.IMPORT, CallerOperation.PROGRESS, CallerOperation.RETRY).forEach { operation ->
+            adapter.execute(operation, spoofedRequestPath) { invocations++ }
+        }
+
+        invocations shouldBeEqualTo 3
+    }
+
+    @ParameterizedTest(name = "{0} rejects {1} before invoking service")
+    @MethodSource("deniedOperations")
+    internal fun `authorization precedes every service operation`(
+        operation: CallerOperation,
+        reason: DenialReason,
+        request: CallerRequest,
+    ) {
+        var invocations = 0
+        val adapter = AuthorizedNetCdfCaller(::authorize)
+
+        reason.matches(operation, request).shouldBeTrue()
+        assertFailsWith<SecurityException> {
+            adapter.execute(operation, request) {
+                invocations++
+            }
+        }
+        invocations shouldBeEqualTo 0
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("lifecycleCases")
+    internal fun `caller lifecycle policy never retries automatically`(
+        name: String,
+        input: LifecycleInput,
+        expectedOutcome: ImportOutcome,
+        expectedAlerts: Set<String>,
+    ) {
+        val decision = decideLifecycle(input)
+
+        name.isNotBlank().shouldBeTrue()
+        decision.outcome shouldBeEqualTo expectedOutcome
+        decision.retryInvocations shouldBeEqualTo 0
+        decision.alerts shouldBeEqualTo expectedAlerts
+        decision.metricTags.keys shouldBeEqualTo setOf("operation", "outcome")
+        decision.metricTags.values.none {
+            it.contains(input.rawPath) || it.contains(input.tenant) || it.contains(input.rawError)
+        }.shouldBeTrue()
+        decision.structuredLogFields.keys shouldBeEqualTo setOf("operation", "outcome", "correlation_id")
+        decision.structuredLogFields.values.none {
+            it.contains(input.rawPath) || it.contains(input.tenant) || it.contains(input.rawError)
+        }.shouldBeTrue()
+        decision.structuredLogFields.getValue("correlation_id").isNotBlank().shouldBeTrue()
+    }
+
+    companion object {
+        @JvmStatic
+        fun deniedOperations(): Stream<Arguments> = CallerOperation.entries.flatMap { operation ->
+            val outsideRootRequest = if (operation == CallerOperation.REGISTER) {
+                allowedRequest().copy(registeredPath = "/srv/netcdf/quarantine/../outside.nc")
+            } else {
+                allowedRequest().copy(fileId = 99L)
+            }
+            listOf(
+                Arguments.of(
+                    operation,
+                    DenialReason.CROSS_TENANT,
+                    allowedRequest().copy(targetTenant = "tenant-b"),
+                ),
+                Arguments.of(
+                    operation,
+                    DenialReason.UNAUTHORIZED,
+                    allowedRequest().copy(allowedOperations = emptySet()),
+                ),
+                Arguments.of(
+                    operation,
+                    DenialReason.CROSS_JOB,
+                    allowedRequest().copy(actorJob = "job-b"),
+                ),
+                Arguments.of(
+                    operation,
+                    DenialReason.OUTSIDE_ALLOWED_ROOT,
+                    outsideRootRequest,
+                ),
+            )
+        }.stream()
+
+        @JvmStatic
+        fun lifecycleCases(): Stream<Arguments> = (terminalLifecycleCases() + reviewLifecycleCases()).stream()
+
+        private fun terminalLifecycleCases(): List<Arguments> = listOf(
+            Arguments.of(
+                "unterminated worker requires isolation",
+                lifecycleInput(terminated = false),
+                ImportOutcome.RECOVERY_REQUIRED,
+                setOf("netcdf.import.timeout", "netcdf.import.worker.stuck"),
+            ),
+            Arguments.of(
+                "completed progress is authoritative after worker exit",
+                lifecycleInput(progressStatus = NetCdfImportStatus.COMPLETED),
+                ImportOutcome.COMPLETED,
+                emptySet<String>(),
+            ),
+            Arguments.of(
+                "first ImportAlreadyRunning trusts the DB lease result",
+                lifecycleInput(signal = LifecycleSignal.ALREADY_RUNNING),
+                ImportOutcome.RUNNING,
+                emptySet<String>(),
+            ),
+            Arguments.of(
+                "repeated ImportAlreadyRunning stops retry",
+                lifecycleInput(signal = LifecycleSignal.REPEATED_ALREADY_RUNNING),
+                ImportOutcome.RECOVERY_REQUIRED,
+                setOf("netcdf.import.retry.exhausted"),
+            ),
+            Arguments.of(
+                "attempt exhaustion stops retry",
+                lifecycleInput(attempt = 3, maxAttempts = 3),
+                ImportOutcome.RECOVERY_REQUIRED,
+                setOf("netcdf.import.retry.exhausted"),
+            ),
+            Arguments.of(
+                "non-transient typed failure requires repair",
+                lifecycleInput(signal = LifecycleSignal.NON_TRANSIENT_FAILURE),
+                ImportOutcome.RECOVERY_REQUIRED,
+                setOf("netcdf.import.retry.exhausted"),
+            ),
+            Arguments.of(
+                "unknown worker failure fails closed",
+                lifecycleInput(signal = LifecycleSignal.UNKNOWN_FAILURE),
+                ImportOutcome.RECOVERY_REQUIRED,
+                setOf("netcdf.import.retry.exhausted"),
+            ),
+        )
+
+        private fun reviewLifecycleCases(): List<Arguments> = listOf(
+            Arguments.of(
+                "pending progress needs review",
+                lifecycleInput(progressStatus = NetCdfImportStatus.PENDING),
+                ImportOutcome.RETRY_REVIEW,
+                setOf("netcdf.import.timeout"),
+            ),
+            Arguments.of(
+                "failed progress needs review",
+                lifecycleInput(progressStatus = NetCdfImportStatus.FAILED),
+                ImportOutcome.RETRY_REVIEW,
+                setOf("netcdf.import.timeout"),
+            ),
+            Arguments.of(
+                "missing progress needs review",
+                lifecycleInput(progressStatus = null),
+                ImportOutcome.RETRY_REVIEW,
+                setOf("netcdf.import.timeout"),
+            ),
+            Arguments.of(
+                "in-progress row is not judged by the caller clock",
+                lifecycleInput(progressStatus = NetCdfImportStatus.IN_PROGRESS),
+                ImportOutcome.RETRY_REVIEW,
+                setOf("netcdf.import.timeout"),
+            ),
+        )
+
+        private fun allowedRequest(): CallerRequest = CallerRequest(
+            actor = "operator-1",
+            actorTenant = "tenant-a",
+            actorJob = "job-a",
+            targetTenant = "tenant-a",
+            targetJob = "job-a",
+            allowedOperations = CallerOperation.entries.toSet(),
+            fileId = 41L,
+            registeredPath = "/srv/netcdf/quarantine/grid.nc",
+        )
+
+        private fun lifecycleInput(
+            terminated: Boolean = true,
+            progressStatus: NetCdfImportStatus? = null,
+            signal: LifecycleSignal = LifecycleSignal.TIMEOUT,
+            attempt: Int = 1,
+            maxAttempts: Int = 3,
+        ): LifecycleInput = LifecycleInput(
+            terminated = terminated,
+            progressStatus = progressStatus,
+            signal = signal,
+            attempt = attempt,
+            maxAttempts = maxAttempts,
+            correlationId = "job-1561",
+            rawPath = "/srv/netcdf/quarantine/customer-grid.nc",
+            tenant = "tenant-secret",
+            rawError = "database detail must not be a tag",
+        )
+    }
+}
+
+internal fun readProgress(
+    catalog: NetCdfCatalogService,
+    fileId: Long,
+    variableName: String,
+): NetCdfImportProgress? = catalog.findImportProgress(fileId, variableName)
+
+internal fun classify(exception: NetCdfException): String = when (exception) {
+    is NetCdfException.FileChanged -> "file-changed"
+    is NetCdfException.CorruptProgress -> "corrupt-progress"
+    is NetCdfException.ImportAlreadyRunning -> "running"
+    else -> "unhandled-netcdf"
+}
+
+private data class NetCdfImportStatusResponse(
+    val status: String,
+    val lastCommittedSlice: Long?,
+    val outcome: String,
+)
+
+private fun NetCdfImportProgress.toCallerResponse(outcome: ImportOutcome): NetCdfImportStatusResponse =
+    NetCdfImportStatusResponse(
+        status = status.name,
+        lastCommittedSlice = lastSliceIdx,
+        outcome = outcome.name,
+    )
+
+internal enum class CallerOperation { REGISTER, IMPORT, PROGRESS, RETRY }
+
+internal enum class DenialReason { CROSS_TENANT, CROSS_JOB, UNAUTHORIZED, OUTSIDE_ALLOWED_ROOT }
+
+internal data class CallerRequest(
+    val actor: String,
+    val actorTenant: String,
+    val actorJob: String,
+    val targetTenant: String,
+    val targetJob: String,
+    val allowedOperations: Set<CallerOperation>,
+    val fileId: Long,
+    val registeredPath: String,
+)
+
+private data class RegisteredTarget(
+    val tenant: String,
+    val job: String,
+    val path: String,
+)
+
+private val targetsByFileId = mapOf(
+    41L to RegisteredTarget("tenant-a", "job-a", "/srv/netcdf/quarantine/grid.nc"),
+    99L to RegisteredTarget("tenant-a", "job-a", "/srv/netcdf/outside.nc"),
+)
+
+private fun resolveTarget(operation: CallerOperation, request: CallerRequest): RegisteredTarget? =
+    if (operation == CallerOperation.REGISTER) {
+        RegisteredTarget(request.targetTenant, request.targetJob, request.registeredPath)
+    } else {
+        targetsByFileId[request.fileId]
+    }
+
+private fun DenialReason.matches(operation: CallerOperation, request: CallerRequest): Boolean = when (this) {
+    DenialReason.CROSS_TENANT -> resolveTarget(operation, request)?.let { target ->
+        request.actorTenant != target.tenant || request.targetTenant != target.tenant
+    } ?: true
+    DenialReason.CROSS_JOB -> resolveTarget(operation, request)?.let { target ->
+        request.actorJob != target.job || request.targetJob != target.job
+    } ?: true
+    DenialReason.UNAUTHORIZED -> operation !in request.allowedOperations
+    DenialReason.OUTSIDE_ALLOWED_ROOT -> resolveTarget(operation, request)?.let { target ->
+        !isWithinAllowedRoot(target.path)
+    } ?: true
+}
+
+private class AuthorizedNetCdfCaller(
+    private val authorize: (CallerOperation, CallerRequest) -> Boolean,
+) {
+    fun execute(operation: CallerOperation, request: CallerRequest, serviceCall: () -> Unit) {
+        if (!authorize(operation, request)) throw SecurityException("NetCDF operation is not authorized")
+        serviceCall()
+    }
+}
+
+private fun authorize(operation: CallerOperation, request: CallerRequest): Boolean {
+    val target = resolveTarget(operation, request) ?: return false
+    return request.actor.isNotBlank() &&
+        request.actorTenant == target.tenant &&
+        request.actorJob == target.job &&
+        request.targetTenant == target.tenant &&
+        request.targetJob == target.job &&
+        operation in request.allowedOperations &&
+        isWithinAllowedRoot(target.path)
+}
+
+private fun isWithinAllowedRoot(rawPath: String): Boolean {
+    val allowedRoot = Path.of("/srv/netcdf/quarantine").normalize()
+    val candidate = runCatching { Path.of(rawPath).normalize() }.getOrElse { return false }
+    return candidate.isAbsolute && candidate != allowedRoot && candidate.startsWith(allowedRoot)
+}
+
+internal enum class LifecycleSignal {
+    TIMEOUT,
+    ALREADY_RUNNING,
+    REPEATED_ALREADY_RUNNING,
+    NON_TRANSIENT_FAILURE,
+    UNKNOWN_FAILURE,
+}
+
+internal enum class ImportOutcome { COMPLETED, RUNNING, RETRY_REVIEW, RECOVERY_REQUIRED }
+
+internal data class LifecycleInput(
+    val terminated: Boolean,
+    val progressStatus: NetCdfImportStatus?,
+    val signal: LifecycleSignal,
+    val attempt: Int,
+    val maxAttempts: Int,
+    val correlationId: String,
+    val rawPath: String,
+    val tenant: String,
+    val rawError: String,
+)
+
+private data class LifecycleDecision(
+    val outcome: ImportOutcome,
+    val retryInvocations: Int,
+    val alerts: Set<String>,
+    val metricTags: Map<String, String>,
+    val structuredLogFields: Map<String, String>,
+)
+
+private fun decideLifecycle(input: LifecycleInput): LifecycleDecision {
+    val outcome = decideOutcome(input)
+    return LifecycleDecision(
+        outcome = outcome,
+        retryInvocations = 0,
+        alerts = alertsFor(input, outcome),
+        metricTags = mapOf(
+            "operation" to "netcdf-import",
+            "outcome" to outcome.name.lowercase(),
+        ),
+        structuredLogFields = mapOf(
+            "operation" to "netcdf-import",
+            "outcome" to outcome.name.lowercase(),
+            "correlation_id" to input.correlationId,
+        ),
+    )
+}
+
+private fun decideOutcome(input: LifecycleInput): ImportOutcome = when {
+    !input.terminated -> ImportOutcome.RECOVERY_REQUIRED
+    input.progressStatus == NetCdfImportStatus.COMPLETED -> ImportOutcome.COMPLETED
+    input.signal == LifecycleSignal.ALREADY_RUNNING -> ImportOutcome.RUNNING
+    input.signal == LifecycleSignal.REPEATED_ALREADY_RUNNING -> ImportOutcome.RECOVERY_REQUIRED
+    input.attempt >= input.maxAttempts -> ImportOutcome.RECOVERY_REQUIRED
+    input.signal == LifecycleSignal.NON_TRANSIENT_FAILURE -> ImportOutcome.RECOVERY_REQUIRED
+    input.signal == LifecycleSignal.UNKNOWN_FAILURE -> ImportOutcome.RECOVERY_REQUIRED
+    else -> ImportOutcome.RETRY_REVIEW
+}
+
+private fun alertsFor(input: LifecycleInput, outcome: ImportOutcome): Set<String> = when {
+    !input.terminated -> setOf("netcdf.import.timeout", "netcdf.import.worker.stuck")
+    input.signal == LifecycleSignal.REPEATED_ALREADY_RUNNING ||
+        input.attempt >= input.maxAttempts ||
+        input.signal == LifecycleSignal.NON_TRANSIENT_FAILURE ||
+        input.signal == LifecycleSignal.UNKNOWN_FAILURE -> setOf("netcdf.import.retry.exhausted")
+    outcome == ImportOutcome.RETRY_REVIEW -> setOf("netcdf.import.timeout")
+    else -> emptySet()
+}

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/NetCdfCatalogServiceTest.kt
@@ -1,18 +1,6 @@
 package io.bluetape4k.science.exposed.service
 
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.debug
-import io.bluetape4k.logging.info
-import io.bluetape4k.science.exposed.AbstractPostgisTest
-import io.bluetape4k.science.exposed.NetCdfException
-import io.bluetape4k.science.exposed.model.NetCdfImportStatus
-import io.bluetape4k.science.exposed.repository.NetCdfFileRepository
-import io.bluetape4k.science.exposed.repository.NetCdfImportProgressRepository
-import io.bluetape4k.science.exposed.schema.NetCdfFileTable
-import io.bluetape4k.science.exposed.schema.NetCdfGridValueTable
-import io.bluetape4k.science.exposed.schema.NetCdfImportProgressTable
-import io.bluetape4k.science.exposed.service.support.NetCdfSampleWriter
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
@@ -20,22 +8,44 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.science.exposed.AbstractPostgisTest
+import io.bluetape4k.science.exposed.NetCdfException
+import io.bluetape4k.science.exposed.model.NetCdfImportProgress
+import io.bluetape4k.science.exposed.model.NetCdfImportStatus
+import io.bluetape4k.science.exposed.repository.NetCdfFileRepository
+import io.bluetape4k.science.exposed.repository.NetCdfImportProgressRepository
+import io.bluetape4k.science.exposed.schema.NetCdfFileTable
+import io.bluetape4k.science.exposed.schema.NetCdfGridValueTable
+import io.bluetape4k.science.exposed.schema.NetCdfImportProgressTable
+import io.bluetape4k.science.exposed.service.support.NetCdfSampleWriter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteAll
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import io.bluetape4k.assertions.assertFailsWith
 import org.junit.jupiter.api.io.TempDir
 import java.io.IOException
+import java.lang.reflect.Modifier
+import java.lang.reflect.Proxy
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.PosixFilePermission
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.absolutePathString
 
@@ -109,6 +119,54 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
         val timer = meterRegistry.find("netcdf.register.duration").tag("status", "success").timer()
         timer.shouldNotBeNull()
         timer.count() shouldBeEqualTo 1L
+    }
+
+    // -------------------------------------------------------------------------
+    // findImportProgress
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `findImportProgress returns null before import`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeSample(dir.resolve("progress-missing.nc"), rank = 2)
+        val fileId = service.registerFile(path.absolutePathString())
+
+        service.findImportProgress(fileId, "temperature").shouldBeNull()
+
+        val counter = meterRegistry.find("netcdf.import.progress.lookup")
+            .tag("status", "missing")
+            .counter()
+        counter.shouldNotBeNull()
+        counter.count() shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `findImportProgress returns completed row without mutation`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeSample(dir.resolve("progress-completed.nc"), rank = 2)
+        val fileId = service.registerFile(path.absolutePathString())
+        service.importGridValues(fileId, "temperature")
+        val before = transaction(db) {
+            progressRepo.findByFileAndVariable(fileId, "temperature")
+        }.shouldNotBeNull()
+
+        val found = service.findImportProgress(fileId, "temperature")
+
+        found shouldBeEqualTo before
+        val after = transaction(db) {
+            progressRepo.findByFileAndVariable(fileId, "temperature")
+        }
+        after shouldBeEqualTo before
+        val counter = meterRegistry.find("netcdf.import.progress.lookup")
+            .tag("status", "completed")
+            .counter()
+        counter.shouldNotBeNull()
+        counter.count() shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `findImportProgress rejects blank variable name`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.findImportProgress(1L, " ")
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -386,6 +444,140 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
     // -------------------------------------------------------------------------
 
     @Test
+    fun `public three argument constructor remains available`() {
+        NetCdfCatalogService::class.java.getConstructor(
+            NetCdfFileRepository::class.java,
+            NetCdfImportProgressRepository::class.java,
+            MeterRegistry::class.java,
+        ).shouldNotBeNull()
+        NetCdfCatalogService::class.java.constructors
+            .filterNot { it.isSynthetic }
+            .map { it.parameterCount } shouldBeEqualTo listOf(3)
+        NetCdfCatalogService::class.java.declaredConstructors
+            .single { !it.isSynthetic && it.parameterCount == 4 }
+            .let { constructor ->
+                Modifier.isPrivate(constructor.modifiers).shouldBeTrue()
+                constructor.parameterTypes.last().simpleName shouldBeEqualTo "ImportCheckpoint"
+            }
+    }
+
+    @Test
+    fun `timeout before import admission leaves no progress and permits retry`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeSample(dir.resolve("pre-admission-timeout.nc"), rank = 2)
+        val fileId = service.registerFile(path.absolutePathString())
+        val entered = CountDownLatch(1)
+        val releaseAdmission = CountDownLatch(1)
+        val workerThread = AtomicReference<Thread?>()
+        val executor = Executors.newSingleThreadExecutor { task ->
+            Thread(task, "netcdf-pre-admission-timeout")
+        }
+        val future = executor.submit {
+            workerThread.set(Thread.currentThread())
+            entered.countDown()
+            check(releaseAdmission.await(5, TimeUnit.SECONDS)) {
+                "pre-admission timeout test did not release the worker"
+            }
+            service.importGridValues(fileId, "temperature")
+        }
+
+        try {
+            entered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            assertFailsWith<TimeoutException> {
+                future.get(20, TimeUnit.MILLISECONDS)
+            }
+
+            future.cancel(true).shouldBeTrue()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            service.findImportProgress(fileId, "temperature").shouldBeNull()
+            service.importGridValues(fileId, "temperature")
+            service.findImportProgress(fileId, "temperature")
+                .shouldNotBeNull()
+                .status shouldBeEqualTo NetCdfImportStatus.COMPLETED
+        } finally {
+            releaseAdmission.countDown()
+            future.cancel(true)
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+            workerThread.get()?.isAlive.shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `post lease interruption rolls back and expired lease resumes`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeSample(dir.resolve("post-lease-cancel.nc"), rank = 2)
+        val fileId = service.registerFile(path.absolutePathString())
+        val leaseTouched = CountDownLatch(1)
+        val releaseCheckpoint = CountDownLatch(1)
+        val checkpointCalls = AtomicInteger()
+        val workerFailure = AtomicReference<Throwable?>()
+        val workerThread = AtomicReference<Thread?>()
+        val cancellableService = newCatalogWithCheckpoint {
+            workerThread.set(Thread.currentThread())
+            checkpointCalls.incrementAndGet()
+            leaseTouched.countDown()
+            check(releaseCheckpoint.await(5, TimeUnit.SECONDS)) {
+                "post-lease cancellation test did not release the worker"
+            }
+        }
+        val executor = Executors.newSingleThreadExecutor { task ->
+            Thread(task, "netcdf-post-lease-cancel")
+        }
+        val future = executor.submit {
+            try {
+                cancellableService.importGridValues(fileId, "temperature")
+            } catch (failure: Throwable) {
+                workerFailure.set(failure)
+                throw failure
+            }
+        }
+
+        try {
+            leaseTouched.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            val committedBeforeCancel = transaction(db) {
+                progressRepo.findByFileAndVariable(fileId, "temperature")
+            }.shouldNotBeNull()
+
+            future.cancel(true).shouldBeTrue()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            assertCancelledImportState(fileId, committedBeforeCancel, workerFailure, checkpointCalls)
+
+            assertFailsWith<NetCdfException.ImportAlreadyRunning> {
+                service.importGridValues(fileId, "temperature")
+            }
+            forceExpireLease(fileId, "temperature")
+            service.importGridValues(fileId, "temperature")
+            service.findImportProgress(fileId, "temperature")
+                .shouldNotBeNull()
+                .status shouldBeEqualTo NetCdfImportStatus.COMPLETED
+        } finally {
+            releaseCheckpoint.countDown()
+            future.cancel(true)
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+            workerThread.get()?.isAlive.shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `import checkpoint runs once for spatial preflight and never for rank one`(@TempDir dir: Path) {
+        val checkpointCalls = AtomicInteger()
+        val checkpointService = newCatalogWithCheckpoint { checkpointCalls.incrementAndGet() }
+        val rankOne = NetCdfSampleWriter.writeSample(dir.resolve("checkpoint-rank1.nc"), rank = 1)
+        val rankOneFileId = checkpointService.registerFile(rankOne.absolutePathString())
+        checkpointService.importGridValues(rankOneFileId, "temperature")
+        checkpointCalls.get() shouldBeEqualTo 0
+
+        val spatial = NetCdfSampleWriter.writeSample(dir.resolve("checkpoint-rank3.nc"), rank = 3)
+        val spatialFileId = checkpointService.registerFile(spatial.absolutePathString())
+        checkpointService.importGridValues(spatialFileId, "temperature")
+        checkpointCalls.get() shouldBeEqualTo 1
+    }
+
+    @Test
     fun `22 - importGridValues throws ImportAlreadyRunning on concurrent call`(@TempDir dir: Path) {
         val path = NetCdfSampleWriter.writeSample(dir.resolve("conc.nc"), rank = 2)
         val fileId = service.registerFile(path.absolutePathString())
@@ -490,6 +682,39 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
     // -------------------------------------------------------------------------
     // tx 독립성 / 비표준 dim order / 캐시 / upsert dedup (#24 ~ #28)
     // -------------------------------------------------------------------------
+
+    @Test
+    fun `registered file replacement is rejected before progress creation`(@TempDir dir: Path) {
+        val original = NetCdfSampleWriter.writeSample(dir.resolve("replace.nc"), rank = 2)
+        val fileId = service.registerFile(original.absolutePathString())
+        val replacement = NetCdfSampleWriter.writeSample(dir.resolve("replacement.nc"), rank = 3)
+        Files.move(
+            replacement,
+            original,
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING,
+        )
+
+        assertFailsWith<NetCdfException.FileChanged> {
+            service.importGridValues(fileId, "temperature")
+        }
+        service.findImportProgress(fileId, "temperature").shouldBeNull()
+    }
+
+    @Test
+    fun `registerFile rejects unreadable POSIX file`(@TempDir dir: Path) {
+        val path = NetCdfSampleWriter.writeSample(dir.resolve("unreadable.nc"), rank = 2)
+        val originalPermissions = Files.getPosixFilePermissions(path)
+        try {
+            Files.setPosixFilePermissions(path, setOf(PosixFilePermission.OWNER_WRITE))
+            assumeFalse(Files.isReadable(path), "POSIX unreadable-file test requires a non-root user")
+            assertFailsWith<NetCdfException.FileOpen> {
+                service.registerFile(path.absolutePathString())
+            }
+        } finally {
+            Files.setPosixFilePermissions(path, originalPermissions)
+        }
+    }
 
     @Test
     fun `24 - importGridValues commits per slice independently`(@TempDir dir: Path) {
@@ -726,8 +951,13 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
                                 java.lang.Double.doubleToLongBits(longitude) &&
                                 java.lang.Double.doubleToLongBits(it.latitude) ==
                                 java.lang.Double.doubleToLongBits(latitude)
-                        } ?: error("Unexpected spatial tuple: time=$timeIdx level=$levelIdx lon=$longitude lat=$latitude")
-                        add(fixtureTuple.copy(timeIdx = timeIdx, levelIdx = levelIdx, value = rs.getDouble(5)))
+                        } ?: error(
+                            "Unexpected spatial tuple: time=$timeIdx level=$levelIdx " +
+                                "lon=$longitude lat=$latitude",
+                        )
+                        add(
+                            fixtureTuple.copy(timeIdx = timeIdx, levelIdx = levelIdx, value = rs.getDouble(5)),
+                        )
                     }
                 }.sortedWith(compareBy({ it.timeIdx }, { it.levelIdx }, { it.row }, { it.column }))
             }
@@ -745,5 +975,43 @@ class NetCdfCatalogServiceTest: AbstractPostgisTest() {
                 ps.executeUpdate()
             }
         }
+    }
+
+    private fun newCatalogWithCheckpoint(
+        checkpoint: () -> Unit,
+    ): NetCdfCatalogService {
+        val constructor = NetCdfCatalogService::class.java.declaredConstructors
+            .single { !it.isSynthetic && it.parameterCount == 4 }
+        constructor.trySetAccessible().shouldBeTrue()
+        val checkpointType = constructor.parameterTypes.last()
+        val checkpointProxy = Proxy.newProxyInstance(
+            checkpointType.classLoader,
+            arrayOf(checkpointType),
+        ) { _, method, _ ->
+            if (method.name == "afterLeaseTouched") checkpoint()
+            null
+        }
+        return constructor.newInstance(fileRepo, progressRepo, meterRegistry, checkpointProxy)
+            as NetCdfCatalogService
+    }
+
+    private fun assertCancelledImportState(
+        fileId: Long,
+        committedBeforeCancel: NetCdfImportProgress,
+        workerFailure: AtomicReference<Throwable?>,
+        checkpointCalls: AtomicInteger,
+    ) {
+        (workerFailure.get() is InterruptedException).shouldBeTrue()
+        checkpointCalls.get() shouldBeEqualTo 1
+        val afterCancel = service.findImportProgress(fileId, "temperature").shouldNotBeNull()
+        afterCancel.status shouldBeEqualTo committedBeforeCancel.status
+        afterCancel.lastSliceIdx shouldBeEqualTo committedBeforeCancel.lastSliceIdx
+        afterCancel.leaseExpiresAt shouldBeEqualTo committedBeforeCancel.leaseExpiresAt
+        afterCancel.updatedAt shouldBeEqualTo committedBeforeCancel.updatedAt
+        transaction(db) {
+            NetCdfGridValueTable.selectAll()
+                .where { NetCdfGridValueTable.fileId eq fileId }
+                .count()
+        } shouldBeEqualTo 0L
     }
 }

--- a/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuardTest.kt
+++ b/utils/science/src/test/kotlin/io/bluetape4k/science/exposed/service/internal/NetCdfFileGuardTest.kt
@@ -10,6 +10,29 @@ import java.nio.file.Path
 class NetCdfFileGuardTest {
 
     @Test
+    fun `URI path is rejected`() {
+        assertFailsWith<NetCdfException.FileOpen> {
+            NetCdfFileGuard.validateForRegister("file:///tmp/sample.nc")
+        }
+    }
+
+    @Test
+    fun `path containing control character is rejected`(@TempDir dir: Path) {
+        assertFailsWith<NetCdfException.FileOpen> {
+            NetCdfFileGuard.validateForRegister(dir.resolve("sample\n.nc").toString())
+        }
+    }
+
+    @Test
+    fun `directory is rejected`(@TempDir dir: Path) {
+        val directory = Files.createDirectory(dir.resolve("sample.nc"))
+
+        assertFailsWith<NetCdfException.FileOpen> {
+            NetCdfFileGuard.validateForRegister(directory.toString())
+        }
+    }
+
+    @Test
     fun `final symlink is rejected`(@TempDir dir: Path) {
         val target = Files.writeString(dir.resolve("target.nc"), "not-netcdf")
         val link = Files.createSymbolicLink(dir.resolve("link.nc"), target.fileName)


### PR DESCRIPTION
## 변경 요약

NetCDF import timeout 뒤에도 caller가 보존한 `fileId`와 `variableName`으로 진행 상태를 진단할 수 있도록 additive `findImportProgress()` API를 추가합니다. 기존 blocking API와 public 3-인자 constructor ABI는 유지하고, lease 취득 뒤 cancellation rollback·worker 종료·재시도 경계를 결정적으로 검증했습니다.

caller가 담당해야 하는 authN/authZ, tenant/job binding, allowed-root, executor lifecycle, DTO redaction과 fingerprint 한계를 KDoc, EN/KO README, 외부 package source fixture에 함께 고정했습니다.

Closes #1561

## 변경 유형

- [x] `feat` — 새 기능
- [ ] `fix` — 버그 수정
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `perf` — 성능 개선
- [x] `test` — 테스트 추가/수정
- [ ] `docs` — 문서만 변경
- [ ] `chore` — 빌드/설정/의존성

## 주요 계약

- `registerFile()`은 import deadline 밖에서 완료해 `fileId`를 보존합니다.
- timeout은 cooperative cancellation 요청이며, worker 종료를 확인하지 못하면 `RECOVERY_REQUIRED`로 fail-closed합니다.
- 자동 retry는 0회이고 active lease 및 재획득 여부는 DB 결과를 authoritative하게 사용합니다.
- `fileId`는 권한 토큰이 아니며 tenant/job/path authorization은 매 operation 전에 caller가 수행합니다.
- fingerprint는 `fileKey|size|lastModifiedTime` 휴리스틱이며 content hash나 TOCTOU 증명이 아닙니다.
- raw progress model 대신 3-field allowlist caller DTO를 사용하고 sealed subtype 소비자는 `else` fallback을 둡니다.

## 테스트

- [x] `./gradlew :bluetape4k-science:test` — 275 passing, failures 0, errors 0, skipped 0
- [x] consumer source compatibility fixture — 30 passing, failures 0, errors 0, skipped 0
- [x] `./gradlew :bluetape4k-science:detekt :bluetape4k-science:compileKotlin :bluetape4k-science:compileTestKotlin` — `BUILD SUCCESSFUL`
- [x] `javap -public -s` / `javap -private -s` — 기존 public 3-arg constructor 유지, typed 4-arg constructor private
- [x] EN/KO marker byte parity, 한국어 용어 audit findings 0, `git diff --check`
- [x] `docs/testlogs/2026-08.md`에 결과 기록

## Code Review

- [x] inline review 완료 — `P0=0`, `P1=0`
- [x] performance, stability, security, Ops, developer/API, user/caller 독립 review 완료 — `P0=0`, `P1=0`, `P2=0`, `P3=0`
- [x] 최종 구현 verifier — `CLEAR`

## 체크리스트

- [x] `utils/science/README.md` + `README.ko.md` 업데이트 및 locale parity 확인
- [x] 공개 API KDoc 추가
- [x] consumer source/decision-table fixture 추가
- [x] 별도 worktree에서 작업 후 PR 생성
- [x] `.github/workflows`, dependency, catalog, schema, module registration 변경 없음
- [x] superpowers index 경로가 저장소에 존재하지 않음을 확인함

## 위험과 후속 gate

- 실제 HTTP/RPC adapter의 tenant/job authorization과 DTO redaction은 caller 구현 책임이며 이 저장소에는 해당 adapter가 없습니다.
- hostile writer 방지는 immutable quarantine과 별도 access control이 필요합니다.
- merge, release, publication, branch/worktree 정리는 별도 승인 gate입니다.

## DoD Status

- **로컬 구현·검증:** DONE
- **리뷰:** DONE — 전 등급 finding 0
- **exact-head GitHub CI:** DONE — `68d4f04d106f5c42aeef116602bfdefc77883131`, [CI run 33312542219](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33312542219), 11 success / 0 failure / 0 cancelled / 0 pending, 비관련 matrix 12개 path-filter skip
- **merge:** DONE — squash merge `cdf6a8cfe14230c80fa84d743173ae61c2776a78`, Issue #1561 `COMPLETED`
- **release/publication/cleanup:** 별도 승인 전 미수행
