### PR TITLE
Nightly 성공 후 Snapshot 자동 배포를 복원한다

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -4,20 +4,11 @@ permissions:
   contents: read
 
 on:
+  workflow_run:
+    workflows: ["Nightly"]
+    types: [completed]
+    branches: [develop]
   workflow_dispatch:
-    inputs:
-      verified_ci_run_id:
-        description: 'Completed full Nightly run ID for the exact develop head'
-        required: true
-        type: string
-      expected_head_sha:
-        description: 'Full develop SHA verified by the Nightly run'
-        required: true
-        type: string
-      handoff_issue_number:
-        description: 'Linked issue that receives the immutable handoff evidence'
-        required: true
-        type: string
 
 concurrency:
   group: publish-snapshot
@@ -29,139 +20,23 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  validate-full-nightly:
-    name: Verify full Nightly validation
-    permissions:
-      actions: read
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      publish_eligible: ${{ steps.validate.outputs.publish_eligible }}
-      head_sha: ${{ steps.validate.outputs.head_sha }}
-      verified_ci_run_id: ${{ steps.validate.outputs.verified_ci_run_id }}
-      handoff_issue_number: ${{ steps.validate.outputs.handoff_issue_number }}
-    steps:
-      - name: Validate exact-head full Nightly run
-        id: validate
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERIFIED_CI_RUN_ID: ${{ inputs.verified_ci_run_id }}
-          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
-          HANDOFF_ISSUE_NUMBER: ${{ inputs.handoff_issue_number }}
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-
-          if ! [[ "$VERIFIED_CI_RUN_ID" =~ ^[0-9]+$ ]]; then
-            echo "::error::verified_ci_run_id must be numeric."
-            exit 1
-          fi
-          if ! [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::expected_head_sha must be a full lowercase Git SHA."
-            exit 1
-          fi
-          if ! [[ "$HANDOFF_ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::handoff_issue_number must be a positive issue number."
-            exit 1
-          fi
-          if [ "$HANDOFF_ISSUE_NUMBER" -ne 1562 ]; then
-            echo "::error::handoff_issue_number must identify TenantContext issue #1562."
-            exit 1
-          fi
-          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
-            echo "::error::Publish Snapshot must be dispatched from refs/heads/develop."
-            exit 1
-          fi
-          if [ "$GITHUB_SHA" != "$EXPECTED_HEAD_SHA" ]; then
-            echo "::error::Dispatch SHA does not match expected_head_sha."
-            exit 1
-          fi
-
-          run_json="$(mktemp)"
-          jobs_json="$(mktemp)"
-          contract_json="$(mktemp)"
-          validator_script="$(mktemp)"
-          develop_ref_json="$(mktemp)"
-          trap 'rm -f "$run_json" "$jobs_json" "$contract_json" "$validator_script" "$develop_ref_json"' EXIT
-
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_CI_RUN_ID}" \
-            --method GET > "$run_json"
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_CI_RUN_ID}/jobs" \
-            --method GET --paginate --slurp > "$jobs_json"
-          gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/develop" \
-            --method GET > "$develop_ref_json"
-
-          validation_head_sha="$(python3 - "$run_json" <<'PY'
-          import json
-          import sys
-          from pathlib import Path
-
-          run = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-          print(run.get("head_sha", ""))
-          PY
-          )"
-          if ! [[ "$validation_head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Nightly validation run has no valid head SHA."
-            exit 1
-          fi
-
-          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/nightly_matrix_contract.json?ref=${validation_head_sha}" \
-            --method GET \
-            --header 'Accept: application/vnd.github.raw' > "$contract_json"
-
-          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/validate_nightly_matrix.py?ref=${validation_head_sha}" \
-            --method GET \
-            --header 'Accept: application/vnd.github.raw' > "$validator_script"
-
-          validation_output="$(python3 "$validator_script" "$run_json" "$jobs_json" "$EXPECTED_HEAD_SHA" "$contract_json")"
-          develop_sha="$(jq -r '.object.sha // empty' "$develop_ref_json")"
-          if [ "$develop_sha" != "$EXPECTED_HEAD_SHA" ]; then
-            echo "::error::Current develop SHA does not match expected_head_sha."
-            exit 1
-          fi
-          if ! grep -qx 'publish_eligible=true' <<< "$validation_output"; then
-            while IFS= read -r line; do
-              case "$line" in
-                validation_error=*) echo "::error::${line#validation_error=}" ;;
-              esac
-            done <<< "$validation_output"
-            exit 1
-          fi
-          while IFS= read -r line; do
-            case "$line" in
-              head_sha=*|publish_eligible=*|validation_error=*) echo "$line" >> "$GITHUB_OUTPUT" ;;
-            esac
-          done <<< "$validation_output"
-          {
-            echo "verified_ci_run_id=$VERIFIED_CI_RUN_ID"
-            echo "handoff_issue_number=$HANDOFF_ISSUE_NUMBER"
-          } >> "$GITHUB_OUTPUT"
-
   publish:
     name: Publish SNAPSHOT to Maven Central
     permissions:
       contents: read
-    needs: validate-full-nightly
-    if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment: maven-central-release
     timeout-minutes: 50
-    outputs:
-      artifact_name: ${{ steps.receipt.outputs.artifact_name }}
-      artifact_id: ${{ steps.handoff-artifact.outputs.artifact-id }}
-      artifact_digest: ${{ steps.handoff-artifact.outputs.artifact-digest }}
-      artifact_url: ${{ steps.handoff-artifact.outputs.artifact-url }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
 
       - name: Verify exact checkout
         env:
-          EXPECTED_HEAD_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
@@ -199,175 +74,10 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
-      - name: Verify public resources and create handoff receipt
-        id: receipt
-        timeout-minutes: 10
-        env:
-          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
-          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
-          PUBLICATION_RUN_ID: ${{ github.run_id }}
-          HANDOFF_ISSUE_NUMBER: ${{ needs.validate-full-nightly.outputs.handoff_issue_number }}
+      - name: Summarize SNAPSHOT publication
         run: |
-          set -euo pipefail
-          receipt_values="$(mktemp)"
-          trap 'rm -f "$receipt_values"' EXIT
-
-          verified=false
-          for attempt in $(seq 1 20); do
-            : > "$receipt_values"
-            rm -f tenant-context-handoff.json
-            set +e
-            python3 scripts/create_snapshot_handoff.py \
-              --repository "$GITHUB_REPOSITORY" \
-              --merge-sha "$MERGE_SHA" \
-              --verified-ci-run-id "$VERIFIED_CI_RUN_ID" \
-              --publication-run-id "$PUBLICATION_RUN_ID" \
-              --handoff-issue-number "$HANDOFF_ISSUE_NUMBER" \
-              --group io.github.bluetape4k \
-              --artifact bluetape4k-bom \
-              --base-version 2.0.0 \
-              --resource bluetape4k-bom:pom \
-              --resource bluetape4k-tenant:pom \
-              --resource bluetape4k-tenant:jar \
-              --resource bluetape4k-tenant-reactor:pom \
-              --resource bluetape4k-tenant-reactor:jar \
-              --resource bluetape4k-ktor-tenant:pom \
-              --resource bluetape4k-ktor-tenant:jar \
-              --output tenant-context-handoff.json > "$receipt_values"
-            receipt_status="$?"
-            set -e
-            if [ "$receipt_status" -eq 0 ]; then
-              verified=true
-              break
-            fi
-            if [ "$receipt_status" -ne 75 ]; then
-              echo "::error::Permanent SNAPSHOT handoff validation failure."
-              exit "$receipt_status"
-            fi
-            echo "::notice::Public SNAPSHOT read-back attempt $attempt is not stable yet."
-            sleep 15
-          done
-          if [ "$verified" != true ]; then
-            echo "::error::Public SNAPSHOT read-back did not stabilize within the retry window."
-            exit 1
-          fi
-
-          jq -e \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg merge_sha "$MERGE_SHA" \
-            --arg verified_ci_run_id "$VERIFIED_CI_RUN_ID" \
-            --arg publication_run_id "$PUBLICATION_RUN_ID" \
-            --arg handoff_issue_number "$HANDOFF_ISSUE_NUMBER" \
-            '.schema == "bluetape.snapshot-handoff/v1" and
-             .status == "verified" and
-             .repository == $repository and
-             .merge_sha == $merge_sha and
-             .verified_ci_run_id == $verified_ci_run_id and
-             .publication_run_id == $publication_run_id and
-             .handoff_issue_number == $handoff_issue_number and
-             .group == "io.github.bluetape4k" and
-             .artifact == "bluetape4k-bom" and
-             .base_version == "2.0.0" and
-             (.resources | length == 7) and
-             ([.resources[].url] | unique | length == 7) and
-             all(.resources[]; (.sha256 | test("^[0-9a-f]{64}$")))' \
-            tenant-context-handoff.json > /dev/null
-          cat "$receipt_values" >> "$GITHUB_OUTPUT"
-          timestamp="$(jq -r '.timestamp' tenant-context-handoff.json)"
-          build_number="$(jq -r '.build_number' tenant-context-handoff.json)"
-          echo "artifact_name=tenant-context-handoff-${MERGE_SHA}-${timestamp}-${build_number}" \
-            >> "$GITHUB_OUTPUT"
-
-      - name: Upload immutable handoff receipt
-        id: handoff-artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: ${{ steps.receipt.outputs.artifact_name }}
-          path: tenant-context-handoff.json
-          if-no-files-found: error
-          retention-days: 90
-
-      - name: Summarize handoff evidence
-        env:
-          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
-          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
-          PUBLICATION_RUN_ID: ${{ github.run_id }}
-          ARTIFACT_NAME: ${{ steps.receipt.outputs.artifact_name }}
-          ARTIFACT_ID: ${{ steps.handoff-artifact.outputs.artifact-id }}
-          ARTIFACT_DIGEST: ${{ steps.handoff-artifact.outputs.artifact-digest }}
-          ARTIFACT_URL: ${{ steps.handoff-artifact.outputs.artifact-url }}
-        run: |
-          set -euo pipefail
           {
-            echo "## TenantContext SNAPSHOT handoff"
-            echo
-            echo "- merge SHA: \`$MERGE_SHA\`"
-            echo "- verified CI run ID: \`$VERIFIED_CI_RUN_ID\`"
-            echo "- publication run ID: \`$PUBLICATION_RUN_ID\`"
-            echo "- artifact: \`$ARTIFACT_NAME\`"
-            echo "- artifact ID: \`$ARTIFACT_ID\`"
-            echo "- artifact digest: \`$ARTIFACT_DIGEST\`"
-            echo "- artifact URL: $ARTIFACT_URL"
-            echo
-            echo "### Public resource SHA-256"
-            jq -r '.resources[] | "- `\(.sha256)` \(.url)"' tenant-context-handoff.json
+            echo "trigger: ${{ github.event_name }}"
+            echo "SOURCE_SHA=${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}"
+            echo "repeated publication allowed"
           } >> "$GITHUB_STEP_SUMMARY"
-
-  record-handoff:
-    name: Record SNAPSHOT handoff on issue
-    permissions:
-      actions: read
-      contents: read
-      issues: write
-    needs: [validate-full-nightly, publish]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Download immutable handoff receipt
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ needs.publish.outputs.artifact_name }}
-
-      - name: Validate and record handoff evidence
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HANDOFF_ISSUE_NUMBER: ${{ needs.validate-full-nightly.outputs.handoff_issue_number }}
-          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
-          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
-          PUBLICATION_RUN_ID: ${{ github.run_id }}
-          ARTIFACT_ID: ${{ needs.publish.outputs.artifact_id }}
-          ARTIFACT_DIGEST: ${{ needs.publish.outputs.artifact_digest }}
-          ARTIFACT_URL: ${{ needs.publish.outputs.artifact_url }}
-        run: |
-          set -euo pipefail
-
-          jq -e \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg merge_sha "$MERGE_SHA" \
-            --arg verified_ci_run_id "$VERIFIED_CI_RUN_ID" \
-            --arg publication_run_id "$PUBLICATION_RUN_ID" \
-            --arg handoff_issue_number "$HANDOFF_ISSUE_NUMBER" \
-            '.schema == "bluetape.snapshot-handoff/v1" and
-             .status == "verified" and
-             .repository == $repository and
-             .merge_sha == $merge_sha and
-             .verified_ci_run_id == $verified_ci_run_id and
-             .publication_run_id == $publication_run_id and
-             .handoff_issue_number == $handoff_issue_number' \
-            tenant-context-handoff.json > /dev/null
-
-          comment="$(mktemp)"
-          trap 'rm -f "$comment"' EXIT
-          {
-            echo "TenantContext SNAPSHOT handoff 검증이 완료되었습니다."
-            echo
-            echo "- merge SHA: \`$MERGE_SHA\`"
-            echo "- 검증 CI run ID: \`$VERIFIED_CI_RUN_ID\`"
-            echo "- 출판 run ID: \`$PUBLICATION_RUN_ID\`"
-            echo "- immutable artifact ID: \`$ARTIFACT_ID\`"
-            echo "- artifact digest: \`$ARTIFACT_DIGEST\`"
-            echo "- artifact: $ARTIFACT_URL"
-            echo
-            echo "downstream은 receipt의 timestamp/build number와 resource SHA-256을 모두 확인해야 합니다."
-          } > "$comment"
-          gh issue comment "$HANDOFF_ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$comment"

--- a/docs/lessons/2026-08-31-issue-1578-snapshot-source-identity.md
+++ b/docs/lessons/2026-08-31-issue-1578-snapshot-source-identity.md
@@ -1,34 +1,49 @@
-# Snapshot publication source identity를 checkout으로 증명하기
+# Nightly 자동 SNAPSHOT의 source identity를 고정하기
 
 ## 맥락
 
-이슈 #1578의 `Publish Snapshot` 대기 실행을 검토하면서 workflow run의
-`headSha`가 곧 publication source라고 판단했다. 그러나 여러 저장소의
-`actions/checkout`은 `ref`를 지정하지 않았고, environment 승인 뒤 runner가
-시작될 때의 기본 branch를 checkout했다.
+이슈 #1578을 진행하면서 반복적인 SNAPSHOT publication이 TenantContext 기능
+handoff 절차에 묶였다. 이 결합 때문에 `Nightly`가 성공해도 별도 run ID와 issue
+번호를 입력해야 했고, routine Snapshot이 자동으로 이어지지 않았다.
 
-## 잘못된 가정과 증거
-
-- 잘못된 가정: `workflow_run`으로 시작한 run의 `headSha`가 checkout source를
-  자동으로 고정한다.
-- 반증: AWS와 Exposed의 triggering Nightly SHA는 대기 중인 Publish Snapshot
-  run이 실제 checkout할 최신 `develop` SHA와 달랐다.
-- 결과: reviewer를 제거하면 Nightly가 검증하지 않은 소스를 배포할 수 있었다.
+자동 실행만 복원하면 source identity가 다시 약해질 수 있다. `workflow_run`으로
+시작한 workflow에서 `github.sha`는 triggering Nightly의 SHA를 뜻하지 않으므로,
+publication source를 `github.event.workflow_run.head_sha`로 명시해야 한다.
 
 ## 결정
 
-- `workflow_run` 경로는 `github.event.workflow_run.head_sha`를 명시적으로
+- `develop`의 `Nightly`가 완료되면 `Publish Snapshot`을 자동으로 시작한다.
+- `publish` job은 Nightly 결론이 `success`일 때만 실행한다. `failure`와
+  `cancelled`는 publication으로 이어지지 않는다.
+- 운영자가 다시 실행할 수 있도록 입력 없는 `workflow_dispatch`도 유지한다.
+- 자동 실행은 `github.event.workflow_run.head_sha`, 수동 실행은 `github.sha`를
   checkout한다.
-- 수동 dispatch는 environment branch policy가 허용한 dispatch SHA를
-  checkout한다.
-- 별도 validation run을 입력받는 workflow는 해당 run의 성공 여부, branch,
-  `head_sha`를 함께 읽고 그 SHA를 publication job으로 전달한다.
-- checkout 직후 `git rev-parse HEAD`를 expected SHA와 비교해 source identity를
-  실행 증적으로 남긴다.
+- checkout 직후 `git rev-parse HEAD`를 같은 조건식의 `EXPECTED_HEAD_SHA`와
+  비교한다.
+- summary에는 trigger와 실제 `SOURCE_SHA`를 기록한다.
+
+## 유지한 경계
+
+- `maven-central-release` environment와 `CENTRAL_USERNAME`,
+  `CENTRAL_PASSWORD`, `SIGNING_KEY_ID`, `SIGNING_KEY`, `SIGNING_PASSWORD`
+  secrets
+- `actions/checkout`, `actions/setup-java`, `gradle/actions/setup-gradle`의
+  immutable commit SHA pins
+- publication metadata validation과 exact Maven Snapshot publication command
+- stable Release workflow의 exact-candidate 검증 경계
+
+environment reviewer 제거는 workflow 변경과 별개의 GitHub 설정 변경이다. 이
+변경이 merge된 뒤 별도 상태 변경 경계에서 처리해야 Nightly 성공 직후 runner가
+대기 없이 publication을 수행한다.
+
+## 제거한 결합
+
+- `verified_ci_run_id`, `expected_head_sha`, `handoff_issue_number` 입력
+- `#1562` 전용 `validate-full-nightly`, `record-handoff` job
+- TenantContext receipt 생성, artifact upload, issue comment
 
 ## 재발 방지
 
-Snapshot 자동화 검토에서는 workflow run metadata만 비교하지 않는다. 반드시
-trigger SHA, checkout `ref`, checkout 이후 SHA 검증, environment 대기 중 branch
-변경 가능성을 한 세트로 확인한다. 이 네 조건이 일치하지 않으면 reviewer 제거와
-publication을 보류한다.
+Snapshot policy test는 두 trigger, 성공 결론 guard, source SHA 조건식, 단일
+`publish` job, 입력과 기능 handoff의 부재를 함께 검사한다. 자동화 여부와 source
+identity를 따로 판단하지 않고 하나의 계약으로 검증한다.

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -49,7 +49,12 @@ REPOSITORY_ACTION_REF = re.compile(
 )
 FULL_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 SNAPSHOT_PUBLISH_JOB_IF = (
-    "${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}"
+    "${{ github.event_name == 'workflow_dispatch' || "
+    "github.event.workflow_run.conclusion == 'success' }}"
+)
+SNAPSHOT_SOURCE_SHA = (
+    "${{ github.event_name == 'workflow_run' && "
+    "github.event.workflow_run.head_sha || github.sha }}"
 )
 PUBLICATION_VALIDATION_COMMANDS = (
     "      - name: Validate publication metadata\n"
@@ -498,10 +503,8 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
         )
     if GITHUB_RELEASE.search(workflow) or ISSUE_RELEASE_MACHINERY.search(workflow):
         errors.append("snapshot workflow must not contain release or issue-specific machinery")
-    if "contents: write" in workflow:
-        errors.append("snapshot workflow must not request write access to repository contents")
-    if job_ids(workflow) != {"validate-full-nightly", "publish", "record-handoff"}:
-        errors.append("snapshot workflow must separate validation, publication, and issue recording")
+    if job_ids(workflow) != {"publish"}:
+        errors.append("snapshot workflow must contain only the publish job")
     errors.extend(
         publication_validation_errors(
             workflow, "publish", SNAPSHOT_PUBLISH_JOB_IF
@@ -509,69 +512,86 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
     )
     if not snapshot_command_valid:
         errors.append("snapshot publication must disable the configuration cache")
-    if "workflow_run:" in workflow or "github.event.workflow_run" in workflow:
-        errors.append("snapshot workflow must not have an automatic workflow_run trigger")
     if "workflow_dispatch:" not in workflow:
         errors.append("snapshot workflow must be manually dispatched")
-    for required_input in (
+    required_trigger = (
+        '  workflow_run:\n'
+        '    workflows: ["Nightly"]\n'
+        '    types: [completed]\n'
+        '    branches: [develop]\n'
+    )
+    if required_trigger not in workflow:
+        errors.append("snapshot workflow must run after completed Nightly on develop")
+    trigger_block = (
+        workflow.split("\non:", 1)[1].split("\n\nconcurrency:", 1)[0]
+        if "\non:" in workflow
+        else ""
+    )
+    trigger_keys = set(
+        re.findall(r"^  ([a-z0-9_-]+):\s*$", trigger_block, re.MULTILINE)
+    )
+    if trigger_keys != {"workflow_run", "workflow_dispatch"}:
+        errors.append("snapshot workflow must use only Nightly and manual triggers")
+    if re.search(r"^ {4}inputs:\s*$", workflow, re.MULTILINE):
+        errors.append("snapshot workflow must not define workflow inputs")
+    removed_markers = (
         "verified_ci_run_id",
         "expected_head_sha",
         "handoff_issue_number",
+        "validation_run_id",
+        "validate-full-nightly",
+        "record-handoff",
+        "TenantContext",
+        "#1562",
+        "create_snapshot_handoff.py",
+        "tenant-context-handoff",
+        "gh issue comment",
+        "actions/upload-artifact",
+        "actions/download-artifact",
+    )
+    if any(marker in workflow for marker in removed_markers):
+        errors.append("snapshot workflow must not contain removed handoff machinery")
+    if re.search(
+        r"^\s+(?:actions|checks|contents|deployments|id-token|issues|packages|pull-requests|security-events|statuses):\s*write\s*$",
+        workflow,
+        re.MULTILINE,
     ):
-        marker = f"      {required_input}:\n"
-        if marker not in workflow:
-            errors.append(f"snapshot workflow must require {required_input}")
-            continue
-        input_tail = workflow.split(marker, 1)[1]
-        next_input = re.search(r"\n      \S", input_tail)
-        input_block = input_tail[: next_input.start()] if next_input else input_tail
-        if "        required: true" not in input_block:
-            errors.append(f"snapshot workflow must require {required_input}")
-    workflow_permissions = workflow.split("\njobs:\n", 1)[0]
-    if "issues: write" in workflow_permissions:
-        errors.append("snapshot workflow must not grant issue write permission globally")
-    if "record-handoff:" not in workflow or "issues: write" not in workflow:
-        errors.append("snapshot handoff job must request issue comment permission")
-    action_refs = workflow_action_refs(workflow)
-    if (
-        not any(action == "actions/upload-artifact" for action, _ in action_refs)
-        or "retention-days: 90" not in workflow
-    ):
-        errors.append("snapshot workflow must retain the immutable handoff artifact for 90 days")
-    if "create_snapshot_handoff.py" not in workflow:
-        errors.append("snapshot workflow must create a public metadata handoff receipt")
-    if "gh issue comment" not in workflow:
-        errors.append("snapshot workflow must record handoff evidence on the linked issue")
+        errors.append("snapshot workflow must not request write permissions")
     if "environment: maven-central-release" not in workflow:
         errors.append("snapshot publication must use the protected Maven Central environment")
-    if "          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}" not in workflow:
-        errors.append("snapshot publication must checkout the validated Nightly head SHA")
+    required_secrets = {
+        "CENTRAL_USERNAME",
+        "CENTRAL_PASSWORD",
+        "SIGNING_KEY_ID",
+        "SIGNING_KEY",
+        "SIGNING_PASSWORD",
+    }
+    secret_refs = set(
+        re.findall(r"\$\{\{ secrets\.([A-Z0-9_]+) \}\}", workflow)
+    )
+    if secret_refs != required_secrets:
+        errors.append("snapshot publication must use only the five Maven Central secrets")
+    if f"          ref: {SNAPSHOT_SOURCE_SHA}" not in workflow:
+        errors.append("snapshot publication must checkout the triggering source SHA")
     exact_checkout_verification = (
         "      - name: Verify exact checkout\n"
         "        env:\n"
-        "          EXPECTED_HEAD_SHA: "
-        "${{ needs.validate-full-nightly.outputs.head_sha }}\n"
+        f"          EXPECTED_HEAD_SHA: {SNAPSHOT_SOURCE_SHA}\n"
         "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\""
     )
     if exact_checkout_verification not in workflow:
         errors.append("snapshot publication must verify the exact checkout SHA")
-    if "GITHUB_REF" not in workflow or "refs/heads/develop" not in workflow:
-        errors.append("snapshot workflow must reject a dispatch ref other than develop")
-    if 'if [ "$HANDOFF_ISSUE_NUMBER" -ne 1562 ]' not in workflow:
-        errors.append("snapshot workflow must pin the TenantContext handoff issue")
-    if "nightly_matrix_contract.json?ref=${validation_head_sha}" not in workflow:
-        errors.append("snapshot workflow must load the exact-head Nightly matrix contract")
-    if "validate_nightly_matrix.py?ref=${validation_head_sha}" not in workflow:
-        errors.append("snapshot workflow must load the exact-head Nightly validator")
-    if 'receipt_status="$?"' not in workflow or 'if [ "$receipt_status" -ne 75 ]' not in workflow:
-        errors.append("snapshot workflow must retry only transient public read-back failures")
-    for receipt_field in (
-        ".repository", ".merge_sha", ".verified_ci_run_id", ".publication_run_id",
-        ".handoff_issue_number", ".group",
-        ".artifact", ".base_version", ".resources",
-    ):
-        if receipt_field not in workflow:
-            errors.append(f"snapshot workflow must verify receipt field {receipt_field}")
+    summary_contract = (
+        "      - name: Summarize SNAPSHOT publication\n",
+        '            echo "trigger: ${{ github.event_name }}"\n',
+        f'            echo "SOURCE_SHA={SNAPSHOT_SOURCE_SHA}"\n',
+        '            echo "repeated publication allowed"\n',
+    )
+    if not all(marker in workflow for marker in summary_contract):
+        errors.append("snapshot workflow must summarize trigger, source SHA, and repeatability")
+    named_steps = re.findall(r"^      - name: (.+)$", workflow, re.MULTILINE)
+    if not named_steps or named_steps[-1] != "Summarize SNAPSHOT publication":
+        errors.append("snapshot workflow must end with the publication summary")
     return errors
 
 
@@ -688,21 +708,20 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
     def test_snapshot_publication_rejects_checkout_source_drift(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
-            "          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}",
+            f"          ref: {SNAPSHOT_SOURCE_SHA}",
             "          ref: develop",
             1,
         )
 
         self.assertIn(
-            "snapshot publication must checkout the validated Nightly head SHA",
+            "snapshot publication must checkout the triggering source SHA",
             snapshot_policy_errors(mutated),
         )
 
     def test_snapshot_publication_rejects_checkout_verification_drift(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
-            "          EXPECTED_HEAD_SHA: "
-            "${{ needs.validate-full-nightly.outputs.head_sha }}\n"
+            f"          EXPECTED_HEAD_SHA: {SNAPSHOT_SOURCE_SHA}\n"
             "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
             "          EXPECTED_HEAD_SHA: ${{ github.sha }}\n"
             "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
@@ -966,7 +985,7 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
             (
                 "snapshot-if",
                 snapshot.replace(
-                    "    if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}\n",
+                    f"    if: {SNAPSHOT_PUBLISH_JOB_IF}\n",
                     "    if: false\n",
                     1,
                 ),
@@ -975,8 +994,8 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
             (
                 "snapshot-continue-on-error",
                 snapshot.replace(
-                    "    if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}\n",
-                    "    if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}\n"
+                    f"    if: {SNAPSHOT_PUBLISH_JOB_IF}\n",
+                    f"    if: {SNAPSHOT_PUBLISH_JOB_IF}\n"
                     "    continue-on-error: true\n",
                     1,
                 ),
@@ -1128,36 +1147,46 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
         self.assertIn("Publish SNAPSHOT to Maven Central", workflow)
         self.assertEqual([], snapshot_policy_errors(workflow))
 
-    def test_snapshot_workflow_requires_full_nightly_validation_before_publish(self) -> None:
+    def test_snapshot_workflow_publishes_only_after_successful_nightly_or_manual_dispatch(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 
-        self.assertIn("actions: read", workflow)
-        self.assertIn("validate-full-nightly:", workflow)
-        self.assertIn("needs: validate-full-nightly", workflow)
-        self.assertIn(
-            "needs.validate-full-nightly.outputs.publish_eligible == 'true'",
-            workflow,
+        self.assertEqual({"publish"}, job_ids(workflow))
+        self.assertIn(f"    if: {SNAPSHOT_PUBLISH_JOB_IF}", workflow)
+        self.assertIn("environment: maven-central-release", workflow)
+        self.assertEqual(
+            {
+                "CENTRAL_USERNAME",
+                "CENTRAL_PASSWORD",
+                "SIGNING_KEY_ID",
+                "SIGNING_KEY",
+                "SIGNING_PASSWORD",
+            },
+            set(re.findall(r"\$\{\{ secrets\.([A-Z0-9_]+) \}\}", workflow)),
         )
-        self.assertIn('verified_ci_run_id:', workflow)
-        self.assertIn('expected_head_sha:', workflow)
-        self.assertIn('handoff_issue_number:', workflow)
-        self.assertIn("required: true", workflow)
-        self.assertIn("gh api", workflow)
-        self.assertIn("actions/runs/${VERIFIED_CI_RUN_ID}", workflow)
-        self.assertIn("actions/runs/${VERIFIED_CI_RUN_ID}/jobs", workflow)
-        self.assertIn(
-            "contents/scripts/nightly_matrix_contract.json?ref=${validation_head_sha}",
-            workflow,
+        self.assertNotIn("needs:", workflow)
+        self.assertNotIn("inputs:", workflow)
+        self.assertEqual([], snapshot_policy_errors(workflow))
+
+        without_success_guard = workflow.replace(
+            "github.event.workflow_run.conclusion == 'success'",
+            "github.event.workflow_run.conclusion != 'cancelled'",
+            1,
         )
         self.assertIn(
-            "contents/scripts/validate_nightly_matrix.py?ref=${validation_head_sha}",
-            workflow,
+            "publication job must use the exact execution guard contract",
+            snapshot_policy_errors(without_success_guard),
         )
-        self.assertIn("Accept: application/vnd.github.raw", workflow)
-        self.assertIn("valid head SHA", workflow)
-        self.assertIn('python3 "$validator_script"', workflow)
-        self.assertIn("publish_eligible=", workflow)
-        self.assertNotIn("override_full_validation", workflow)
+
+        with_extra_secret = workflow.replace(
+            "          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}\n",
+            "          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}\n"
+            "          EXTRA_TOKEN: ${{ secrets.EXTRA_TOKEN }}\n",
+            1,
+        )
+        self.assertIn(
+            "snapshot publication must use only the five Maven Central secrets",
+            snapshot_policy_errors(with_extra_secret),
+        )
 
     def test_nightly_matrix_contract_matches_current_workflow_groups(self) -> None:
         workflow = (WORKFLOWS / "nightly-tests.yml").read_text(encoding="utf-8")
@@ -1268,84 +1297,75 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
                 _, errors = validation_errors(run, jobs, "a" * 40, contract)
                 self.assertIn(expected_error, errors)
 
-    def test_snapshot_workflow_is_manual_only_and_has_no_automatic_fallback(self) -> None:
+    def test_snapshot_workflow_runs_after_successful_nightly_and_keeps_manual_dispatch(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 
-        self.assertNotIn("workflow_run:", workflow)
-        self.assertNotIn("github.event.workflow_run", workflow)
+        self.assertIn(
+            '  workflow_run:\n'
+            '    workflows: ["Nightly"]\n'
+            '    types: [completed]\n'
+            '    branches: [develop]\n',
+            workflow,
+        )
+        self.assertIn("  workflow_dispatch:\n", workflow)
+        self.assertIn(f"    if: {SNAPSHOT_PUBLISH_JOB_IF}", workflow)
+        self.assertGreaterEqual(workflow.count(SNAPSHOT_SOURCE_SHA), 3)
         self.assertEqual([], snapshot_policy_errors(workflow))
 
-        automatic = workflow.replace(
-            "  workflow_dispatch:",
-            '  workflow_run:\n    workflows: ["Nightly"]\n    types: [completed]\n  workflow_dispatch:',
-        )
-        fallback = workflow + "\n# github.event.workflow_run.head_sha\n"
-        self.assertIn(
-            "snapshot workflow must not have an automatic workflow_run trigger",
-            snapshot_policy_errors(automatic),
+        without_develop_filter = workflow.replace(
+            "    branches: [develop]\n",
+            "",
+            1,
         )
         self.assertIn(
-            "snapshot workflow must not have an automatic workflow_run trigger",
-            snapshot_policy_errors(fallback),
+            "snapshot workflow must run after completed Nightly on develop",
+            snapshot_policy_errors(without_develop_filter),
         )
 
-    def test_snapshot_validation_pins_ci_head_and_current_develop_ref(self) -> None:
+    def test_snapshot_source_identity_covers_automatic_and_manual_triggers(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
-        validator = (REPOSITORY / "scripts" / "validate_nightly_matrix.py").read_text(
-            encoding="utf-8"
-        )
 
-        self.assertIn("EXPECTED_HEAD_SHA", workflow)
-        self.assertIn("git/ref/heads/develop", workflow)
-        self.assertIn("run.get(\"path\")", validator)
-        self.assertIn("run.get(\"status\")", validator)
-        self.assertIn("run.get(\"conclusion\")", validator)
-        self.assertIn("run.get(\"head_sha\", \"\")", validator)
-        self.assertIn("develop_sha", workflow)
+        self.assertIn(f"          ref: {SNAPSHOT_SOURCE_SHA}", workflow)
+        self.assertIn(f"          EXPECTED_HEAD_SHA: {SNAPSHOT_SOURCE_SHA}", workflow)
+        self.assertIn(f'            echo "SOURCE_SHA={SNAPSHOT_SOURCE_SHA}"', workflow)
         self.assertIn("environment: maven-central-release", workflow)
-        self.assertIn('GITHUB_REF: ${{ github.ref }}', workflow)
-        self.assertIn('GITHUB_SHA: ${{ github.sha }}', workflow)
+        self.assertEqual([], snapshot_policy_errors(workflow))
 
-    def test_snapshot_receipt_is_immutable_and_linked_to_issue(self) -> None:
+    def test_snapshot_workflow_has_no_completed_tenant_handoff(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 
-        self.assertIn("bluetape.snapshot-handoff/v1", workflow)
-        self.assertIn("tenant-context-handoff-${", workflow)
-        self.assertRegex(
-            workflow,
-            r"uses:\s+actions/upload-artifact@[0-9a-f]{40}\s+# v7",
-        )
-        self.assertIn("retention-days: 90", workflow)
-        self.assertIn("artifact-id", workflow)
-        self.assertIn("artifact-digest", workflow)
-        self.assertIn("gh issue comment", workflow)
-        self.assertIn(
-            'gh issue comment "$HANDOFF_ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" '
-            '--body-file "$comment"',
-            workflow,
-        )
-        self.assertIn("issues: write", workflow)
-        self.assertNotIn("issues: write", workflow.split("\njobs:\n", 1)[0])
-        self.assertIn("record-handoff:", workflow)
-        self.assertIn('--handoff-issue-number "$HANDOFF_ISSUE_NUMBER"', workflow)
-        self.assertIn('receipt_status="$?"', workflow)
-        self.assertIn('if [ "$receipt_status" -ne 75 ]', workflow)
-        for expression in (
-            '.repository == $repository', '.merge_sha == $merge_sha',
-            '.verified_ci_run_id == $verified_ci_run_id',
-            '.publication_run_id == $publication_run_id',
-            '.group == "io.github.bluetape4k"', '.artifact == "bluetape4k-bom"',
-            '.base_version == "2.0.0"', '.resources | length == 7',
+        for marker in (
+            "validate-full-nightly",
+            "record-handoff",
+            "TenantContext",
+            "#1562",
+            "verified_ci_run_id",
+            "expected_head_sha",
+            "handoff_issue_number",
+            "create_snapshot_handoff.py",
+            "tenant-context-handoff",
+            "actions/upload-artifact",
+            "actions/download-artifact",
+            "gh issue comment",
+            "issues: write",
         ):
-            self.assertIn(expression, workflow)
-    def test_snapshot_checkout_uses_validated_nightly_head(self) -> None:
+            self.assertNotIn(marker, workflow)
+        self.assertEqual([], snapshot_policy_errors(workflow))
+
+    def test_snapshot_workflow_has_single_publish_job_and_final_summary(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 
-        self.assertIn("head_sha", workflow)
+        self.assertEqual({"publish"}, job_ids(workflow))
+        self.assertNotIn("needs:", workflow)
         self.assertIn(
-            "ref: ${{ needs.validate-full-nightly.outputs.head_sha }}",
+            "      - name: Summarize SNAPSHOT publication\n",
             workflow,
         )
+        self.assertEqual(
+            "Summarize SNAPSHOT publication",
+            re.findall(r"^      - name: (.+)$", workflow, re.MULTILINE)[-1],
+        )
+        self.assertEqual([], snapshot_policy_errors(workflow))
 
     def test_runtime_surfaces_have_no_renamed_release_machinery(self) -> None:
         self.assertEqual([], runtime_policy_errors())


### PR DESCRIPTION
## Summary

Refs #1578

성공한 `Nightly` 뒤 `Publish Snapshot`이 triggering SHA를 그대로 배포하도록 자동 흐름을 복원합니다. 입력 없는 수동 실행은 복구 경로로 유지하며, 실제 workflow dispatch와 publication은 수행하지 않습니다.

## Background

TenantContext `2.0.0-SNAPSHOT` handoff를 위해 추가한 수동 입력과 issue receipt가 routine Snapshot에도 남았습니다. 그 결과 Nightly가 성공해도 별도 run ID와 issue 번호를 입력해야 했고, 기존 자동 publication 흐름이 중단됐습니다.

## What This Solves

- `develop`의 `Nightly` 성공 후 Snapshot workflow가 자동으로 이어지지 않던 문제
- environment 대기 중 branch가 바뀌어도 Nightly가 검증한 SHA와 publication source가 달라지지 않아야 하는 source identity 위험
- 완료된 TenantContext handoff가 반복 Snapshot에 계속 결합된 운영 복잡도

## Work Done

- `workflow_run`과 `workflow_dispatch`를 함께 지원하고, Nightly 결론이 `success`일 때만 `publish` job이 실행되도록 고정했습니다.
- 자동 실행은 `github.event.workflow_run.head_sha`, 수동 실행은 `github.sha`를 checkout·검증·summary에 동일하게 사용합니다.
- TenantContext 전용 입력, validation, receipt artifact, issue comment job을 제거했습니다.
- immutable action SHA, `maven-central-release` environment, Maven Central secret 5개, publication metadata 검증과 exact Gradle task를 유지했습니다.
- 정책 회귀 테스트와 재사용 가능한 lesson을 현재 자동화 계약에 맞게 갱신했습니다.

## Validation

- `python3 -B -m scripts.test_release_workflow_policy`: PASS (44/44)
- `actionlint`: PASS (전체 workflow)
- `python3 -m py_compile scripts/test_release_workflow_policy.py`: PASS
- `git diff --check origin/develop...HEAD`: PASS
- `node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs docs/lessons/2026-08-31-issue-1578-snapshot-source-identity.md`: PASS (findings=0)

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: exact diff를 대상으로 trigger/guard/source SHA, 권한, immutable action ref, secret scope, concurrency, publication command를 inline review했습니다.
- 독립 리뷰: N/A — `debop` 단독 개발 lane이며 사용자가 반복적으로 독립 리뷰 생략과 inline review를 지시했습니다.
- 남은 외부 경계: 이 PR merge 뒤 `maven-central-release` reviewer 제거를 별도 GitHub 설정 변경으로 검증해야 자동 run이 대기 없이 진행됩니다.

## Metadata

- Issue: #1578, milestone `2.0.0`, assignee `debop`, labels `management`, `security`, `release`
- PR: #1585, head `e244dbaa961063c31cfd1eb3bcb80ea0e11e17ab`, milestone `2.0.0`, assignee `debop`
- CI: PASS — run `33397563693`, exact head `e244dbaa961063c31cfd1eb3bcb80ea0e11e17ab`, 25 success / 0 fail / 0 cancelled / 0 skipped

## DoD Status

Required checks: 17/17; N/A: 3; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-00~WF-05 - 분류·승인·실행 계약 | Type E 분류, GNO/live 상태 확인, 계획 승인, leaf/common gate, receipt, TDD 순서 실행 | PASS | receipt `20260831T130834Z-a06041e7`; RED 후 44/44 GREEN | 없음 |
| WF-06 - 누락 gate 복구 | 누락되거나 약한 gate 확인 | N/A | 건너뛴 required gate 없음 | 없음 |
| E-01~E-03 - 지원 skill·현행 상태·scope | maintenance, Python, TDD, writer, worktree skill 적용과 세 파일 scope 고정 | PASS | exact diff 3 files; no dependency/Kotlin/production source change | 없음 |
| E-04 - managed source parity | chezmoi/source-rendered-live parity | N/A | repo-local workflow·test·lesson이며 user-scope managed surface 아님 | 없음 |
| E-05 - maintenance 검증 | 정책 테스트, actionlint, py_compile, diff, 한국어 용어 검사 | PASS | 모든 명령 PASS; 44 tests; findings=0 | 없음 |
| E-06 - durable pre-PR proof | inline review와 lesson gate 완료 | PASS | P0/P1/P2/P3=0; lesson 갱신 | 없음 |
| CG-11 - PR 권한 | repo/base/head가 포함된 승인 계획 확인 | PASS | `bluetape4k/bluetape4k-projects`, `develop`, `fix/issue-1578-nightly-snapshot` | 없음 |
| CG-12 - exact head push | local/remote SHA 일치 확인 | PASS | `e244dbaa961063c31cfd1eb3bcb80ea0e11e17ab` | 없음 |
| CG-12A - guidance refresh | AGENTS 계층, leaf/common gate, PR template, Issue #1578 재확인 | PASS | current file SHA snapshot과 live Issue metadata 확인 | 없음 |
| CG-13 - PR 생성·metadata | Korean PR 생성 후 assignee/milestone/labels/body read-back | PASS | PR #1585, exact head `e244dbaa961063c31cfd1eb3bcb80ea0e11e17ab` | 없음 |
| CG-14 - exact-head CI·review | exact-head checks와 review/thread read-back | PASS | run `33397563693`: 25 success, 0 fail/cancel/skip; review 0; thread 0; `CLEAN`/`MERGEABLE` | 없음 |
| CG-14 - 독립/추가 인적 리뷰 | 별도 reviewer 수행 | N/A | 단독 개발 lane + 사용자 inline review 지시 | inline review 증거 유지 |

Final status: DONE — PR #1585 exact head `e244dbaa961063c31cfd1eb3bcb80ea0e11e17ab` merge-ready; merge는 fresh approval 대기

Unchecked required items: none
