### PR TITLE
[release] 반복 SNAPSHOT을 기능 handoff에서 분리한다

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -5,19 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-    inputs:
-      verified_ci_run_id:
-        description: 'Completed full Nightly run ID for the exact develop head'
-        required: true
-        type: string
-      expected_head_sha:
-        description: 'Full develop SHA verified by the Nightly run'
-        required: true
-        type: string
-      handoff_issue_number:
-        description: 'Linked issue that receives the immutable handoff evidence'
-        required: true
-        type: string
 
 concurrency:
   group: publish-snapshot
@@ -29,139 +16,22 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  validate-full-nightly:
-    name: Verify full Nightly validation
-    permissions:
-      actions: read
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      publish_eligible: ${{ steps.validate.outputs.publish_eligible }}
-      head_sha: ${{ steps.validate.outputs.head_sha }}
-      verified_ci_run_id: ${{ steps.validate.outputs.verified_ci_run_id }}
-      handoff_issue_number: ${{ steps.validate.outputs.handoff_issue_number }}
-    steps:
-      - name: Validate exact-head full Nightly run
-        id: validate
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERIFIED_CI_RUN_ID: ${{ inputs.verified_ci_run_id }}
-          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
-          HANDOFF_ISSUE_NUMBER: ${{ inputs.handoff_issue_number }}
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-
-          if ! [[ "$VERIFIED_CI_RUN_ID" =~ ^[0-9]+$ ]]; then
-            echo "::error::verified_ci_run_id must be numeric."
-            exit 1
-          fi
-          if ! [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::expected_head_sha must be a full lowercase Git SHA."
-            exit 1
-          fi
-          if ! [[ "$HANDOFF_ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::handoff_issue_number must be a positive issue number."
-            exit 1
-          fi
-          if [ "$HANDOFF_ISSUE_NUMBER" -ne 1562 ]; then
-            echo "::error::handoff_issue_number must identify TenantContext issue #1562."
-            exit 1
-          fi
-          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
-            echo "::error::Publish Snapshot must be dispatched from refs/heads/develop."
-            exit 1
-          fi
-          if [ "$GITHUB_SHA" != "$EXPECTED_HEAD_SHA" ]; then
-            echo "::error::Dispatch SHA does not match expected_head_sha."
-            exit 1
-          fi
-
-          run_json="$(mktemp)"
-          jobs_json="$(mktemp)"
-          contract_json="$(mktemp)"
-          validator_script="$(mktemp)"
-          develop_ref_json="$(mktemp)"
-          trap 'rm -f "$run_json" "$jobs_json" "$contract_json" "$validator_script" "$develop_ref_json"' EXIT
-
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_CI_RUN_ID}" \
-            --method GET > "$run_json"
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${VERIFIED_CI_RUN_ID}/jobs" \
-            --method GET --paginate --slurp > "$jobs_json"
-          gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/develop" \
-            --method GET > "$develop_ref_json"
-
-          validation_head_sha="$(python3 - "$run_json" <<'PY'
-          import json
-          import sys
-          from pathlib import Path
-
-          run = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-          print(run.get("head_sha", ""))
-          PY
-          )"
-          if ! [[ "$validation_head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Nightly validation run has no valid head SHA."
-            exit 1
-          fi
-
-          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/nightly_matrix_contract.json?ref=${validation_head_sha}" \
-            --method GET \
-            --header 'Accept: application/vnd.github.raw' > "$contract_json"
-
-          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/validate_nightly_matrix.py?ref=${validation_head_sha}" \
-            --method GET \
-            --header 'Accept: application/vnd.github.raw' > "$validator_script"
-
-          validation_output="$(python3 "$validator_script" "$run_json" "$jobs_json" "$EXPECTED_HEAD_SHA" "$contract_json")"
-          develop_sha="$(jq -r '.object.sha // empty' "$develop_ref_json")"
-          if [ "$develop_sha" != "$EXPECTED_HEAD_SHA" ]; then
-            echo "::error::Current develop SHA does not match expected_head_sha."
-            exit 1
-          fi
-          if ! grep -qx 'publish_eligible=true' <<< "$validation_output"; then
-            while IFS= read -r line; do
-              case "$line" in
-                validation_error=*) echo "::error::${line#validation_error=}" ;;
-              esac
-            done <<< "$validation_output"
-            exit 1
-          fi
-          while IFS= read -r line; do
-            case "$line" in
-              head_sha=*|publish_eligible=*|validation_error=*) echo "$line" >> "$GITHUB_OUTPUT" ;;
-            esac
-          done <<< "$validation_output"
-          {
-            echo "verified_ci_run_id=$VERIFIED_CI_RUN_ID"
-            echo "handoff_issue_number=$HANDOFF_ISSUE_NUMBER"
-          } >> "$GITHUB_OUTPUT"
-
   publish:
     name: Publish SNAPSHOT to Maven Central
     permissions:
       contents: read
-    needs: validate-full-nightly
-    if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}
     runs-on: ubuntu-latest
     environment: maven-central-release
     timeout-minutes: 50
-    outputs:
-      artifact_name: ${{ steps.receipt.outputs.artifact_name }}
-      artifact_id: ${{ steps.handoff-artifact.outputs.artifact-id }}
-      artifact_digest: ${{ steps.handoff-artifact.outputs.artifact-digest }}
-      artifact_url: ${{ steps.handoff-artifact.outputs.artifact-url }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Verify exact checkout
         env:
-          EXPECTED_HEAD_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
+          EXPECTED_HEAD_SHA: ${{ github.sha }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
@@ -199,175 +69,10 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
-      - name: Verify public resources and create handoff receipt
-        id: receipt
-        timeout-minutes: 10
-        env:
-          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
-          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
-          PUBLICATION_RUN_ID: ${{ github.run_id }}
-          HANDOFF_ISSUE_NUMBER: ${{ needs.validate-full-nightly.outputs.handoff_issue_number }}
+      - name: Summarize SNAPSHOT publication
         run: |
-          set -euo pipefail
-          receipt_values="$(mktemp)"
-          trap 'rm -f "$receipt_values"' EXIT
-
-          verified=false
-          for attempt in $(seq 1 20); do
-            : > "$receipt_values"
-            rm -f tenant-context-handoff.json
-            set +e
-            python3 scripts/create_snapshot_handoff.py \
-              --repository "$GITHUB_REPOSITORY" \
-              --merge-sha "$MERGE_SHA" \
-              --verified-ci-run-id "$VERIFIED_CI_RUN_ID" \
-              --publication-run-id "$PUBLICATION_RUN_ID" \
-              --handoff-issue-number "$HANDOFF_ISSUE_NUMBER" \
-              --group io.github.bluetape4k \
-              --artifact bluetape4k-bom \
-              --base-version 2.0.0 \
-              --resource bluetape4k-bom:pom \
-              --resource bluetape4k-tenant:pom \
-              --resource bluetape4k-tenant:jar \
-              --resource bluetape4k-tenant-reactor:pom \
-              --resource bluetape4k-tenant-reactor:jar \
-              --resource bluetape4k-ktor-tenant:pom \
-              --resource bluetape4k-ktor-tenant:jar \
-              --output tenant-context-handoff.json > "$receipt_values"
-            receipt_status="$?"
-            set -e
-            if [ "$receipt_status" -eq 0 ]; then
-              verified=true
-              break
-            fi
-            if [ "$receipt_status" -ne 75 ]; then
-              echo "::error::Permanent SNAPSHOT handoff validation failure."
-              exit "$receipt_status"
-            fi
-            echo "::notice::Public SNAPSHOT read-back attempt $attempt is not stable yet."
-            sleep 15
-          done
-          if [ "$verified" != true ]; then
-            echo "::error::Public SNAPSHOT read-back did not stabilize within the retry window."
-            exit 1
-          fi
-
-          jq -e \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg merge_sha "$MERGE_SHA" \
-            --arg verified_ci_run_id "$VERIFIED_CI_RUN_ID" \
-            --arg publication_run_id "$PUBLICATION_RUN_ID" \
-            --arg handoff_issue_number "$HANDOFF_ISSUE_NUMBER" \
-            '.schema == "bluetape.snapshot-handoff/v1" and
-             .status == "verified" and
-             .repository == $repository and
-             .merge_sha == $merge_sha and
-             .verified_ci_run_id == $verified_ci_run_id and
-             .publication_run_id == $publication_run_id and
-             .handoff_issue_number == $handoff_issue_number and
-             .group == "io.github.bluetape4k" and
-             .artifact == "bluetape4k-bom" and
-             .base_version == "2.0.0" and
-             (.resources | length == 7) and
-             ([.resources[].url] | unique | length == 7) and
-             all(.resources[]; (.sha256 | test("^[0-9a-f]{64}$")))' \
-            tenant-context-handoff.json > /dev/null
-          cat "$receipt_values" >> "$GITHUB_OUTPUT"
-          timestamp="$(jq -r '.timestamp' tenant-context-handoff.json)"
-          build_number="$(jq -r '.build_number' tenant-context-handoff.json)"
-          echo "artifact_name=tenant-context-handoff-${MERGE_SHA}-${timestamp}-${build_number}" \
-            >> "$GITHUB_OUTPUT"
-
-      - name: Upload immutable handoff receipt
-        id: handoff-artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: ${{ steps.receipt.outputs.artifact_name }}
-          path: tenant-context-handoff.json
-          if-no-files-found: error
-          retention-days: 90
-
-      - name: Summarize handoff evidence
-        env:
-          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
-          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
-          PUBLICATION_RUN_ID: ${{ github.run_id }}
-          ARTIFACT_NAME: ${{ steps.receipt.outputs.artifact_name }}
-          ARTIFACT_ID: ${{ steps.handoff-artifact.outputs.artifact-id }}
-          ARTIFACT_DIGEST: ${{ steps.handoff-artifact.outputs.artifact-digest }}
-          ARTIFACT_URL: ${{ steps.handoff-artifact.outputs.artifact-url }}
-        run: |
-          set -euo pipefail
           {
-            echo "## TenantContext SNAPSHOT handoff"
-            echo
-            echo "- merge SHA: \`$MERGE_SHA\`"
-            echo "- verified CI run ID: \`$VERIFIED_CI_RUN_ID\`"
-            echo "- publication run ID: \`$PUBLICATION_RUN_ID\`"
-            echo "- artifact: \`$ARTIFACT_NAME\`"
-            echo "- artifact ID: \`$ARTIFACT_ID\`"
-            echo "- artifact digest: \`$ARTIFACT_DIGEST\`"
-            echo "- artifact URL: $ARTIFACT_URL"
-            echo
-            echo "### Public resource SHA-256"
-            jq -r '.resources[] | "- `\(.sha256)` \(.url)"' tenant-context-handoff.json
+            echo "trigger: workflow_dispatch"
+            echo "SOURCE_SHA=${{ github.sha }}"
+            echo "repeated publication allowed"
           } >> "$GITHUB_STEP_SUMMARY"
-
-  record-handoff:
-    name: Record SNAPSHOT handoff on issue
-    permissions:
-      actions: read
-      contents: read
-      issues: write
-    needs: [validate-full-nightly, publish]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Download immutable handoff receipt
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ needs.publish.outputs.artifact_name }}
-
-      - name: Validate and record handoff evidence
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HANDOFF_ISSUE_NUMBER: ${{ needs.validate-full-nightly.outputs.handoff_issue_number }}
-          MERGE_SHA: ${{ needs.validate-full-nightly.outputs.head_sha }}
-          VERIFIED_CI_RUN_ID: ${{ needs.validate-full-nightly.outputs.verified_ci_run_id }}
-          PUBLICATION_RUN_ID: ${{ github.run_id }}
-          ARTIFACT_ID: ${{ needs.publish.outputs.artifact_id }}
-          ARTIFACT_DIGEST: ${{ needs.publish.outputs.artifact_digest }}
-          ARTIFACT_URL: ${{ needs.publish.outputs.artifact_url }}
-        run: |
-          set -euo pipefail
-
-          jq -e \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg merge_sha "$MERGE_SHA" \
-            --arg verified_ci_run_id "$VERIFIED_CI_RUN_ID" \
-            --arg publication_run_id "$PUBLICATION_RUN_ID" \
-            --arg handoff_issue_number "$HANDOFF_ISSUE_NUMBER" \
-            '.schema == "bluetape.snapshot-handoff/v1" and
-             .status == "verified" and
-             .repository == $repository and
-             .merge_sha == $merge_sha and
-             .verified_ci_run_id == $verified_ci_run_id and
-             .publication_run_id == $publication_run_id and
-             .handoff_issue_number == $handoff_issue_number' \
-            tenant-context-handoff.json > /dev/null
-
-          comment="$(mktemp)"
-          trap 'rm -f "$comment"' EXIT
-          {
-            echo "TenantContext SNAPSHOT handoff 검증이 완료되었습니다."
-            echo
-            echo "- merge SHA: \`$MERGE_SHA\`"
-            echo "- 검증 CI run ID: \`$VERIFIED_CI_RUN_ID\`"
-            echo "- 출판 run ID: \`$PUBLICATION_RUN_ID\`"
-            echo "- immutable artifact ID: \`$ARTIFACT_ID\`"
-            echo "- artifact digest: \`$ARTIFACT_DIGEST\`"
-            echo "- artifact: $ARTIFACT_URL"
-            echo
-            echo "downstream은 receipt의 timestamp/build number와 resource SHA-256을 모두 확인해야 합니다."
-          } > "$comment"
-          gh issue comment "$HANDOFF_ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$comment"

--- a/docs/lessons/2026-08-31-issue-1578-snapshot-source-identity.md
+++ b/docs/lessons/2026-08-31-issue-1578-snapshot-source-identity.md
@@ -1,34 +1,44 @@
-# Snapshot publication source identity를 checkout으로 증명하기
+# 반복 SNAPSHOT publication을 기능 handoff에서 분리하기
 
 ## 맥락
 
-이슈 #1578의 `Publish Snapshot` 대기 실행을 검토하면서 workflow run의
-`headSha`가 곧 publication source라고 판단했다. 그러나 여러 저장소의
-`actions/checkout`은 `ref`를 지정하지 않았고, environment 승인 뒤 runner가
-시작될 때의 기본 branch를 checkout했다.
-
-## 잘못된 가정과 증거
-
-- 잘못된 가정: `workflow_run`으로 시작한 run의 `headSha`가 checkout source를
-  자동으로 고정한다.
-- 반증: AWS와 Exposed의 triggering Nightly SHA는 대기 중인 Publish Snapshot
-  run이 실제 checkout할 최신 `develop` SHA와 달랐다.
-- 결과: reviewer를 제거하면 Nightly가 검증하지 않은 소스를 배포할 수 있었다.
+이슈 #1578의 Snapshot source identity 검토에서 반복적인 SNAPSHOT publication과
+기능 handoff를 같은 workflow에 묶어 두었던 경계를 재평가했다. 반복 publication은
+검증된 기능을 다음 담당자에게 넘기는 단계가 아니라, 사용자가 실행을 승인한
+`workflow_dispatch`의 source를 그대로 배포하는 운영 동작이어야 한다.
 
 ## 결정
 
-- `workflow_run` 경로는 `github.event.workflow_run.head_sha`를 명시적으로
+- `Publish Snapshot`은 입력이 없는 `workflow_dispatch` 전용 workflow로 유지한다.
+- 단일 `publish` job이 `ref: ${{ github.sha }}`와 `fetch-depth: 0`으로 dispatch SHA를
   checkout한다.
-- 수동 dispatch는 environment branch policy가 허용한 dispatch SHA를
-  checkout한다.
-- 별도 validation run을 입력받는 workflow는 해당 run의 성공 여부, branch,
-  `head_sha`를 함께 읽고 그 SHA를 publication job으로 전달한다.
-- checkout 직후 `git rev-parse HEAD`를 expected SHA와 비교해 source identity를
-  실행 증적으로 남긴다.
+- publication 직전에 `git rev-parse HEAD`를
+  `EXPECTED_HEAD_SHA=${{ github.sha }}`와 비교해 실제 source identity를 증명한다.
+- 마지막 summary에는 `workflow_dispatch`, `SOURCE_SHA=${{ github.sha }}`,
+  `repeated publication allowed`를 기록한다.
+- 따라서 routine repeated Snapshot은 dispatch SHA를 사용하며 feature handoff가
+  아니다.
+
+## 유지한 경계
+
+- 보호된 `maven-central-release` environment와
+  `CENTRAL_USERNAME`, `CENTRAL_PASSWORD`, `SIGNING_KEY_ID`, `SIGNING_KEY`,
+  `SIGNING_PASSWORD` secrets
+- `actions/checkout`, `actions/setup-java`, `gradle/actions/setup-gradle`의
+  immutable commit SHA pins
+- 기존 publication metadata validation과 exact Maven Snapshot publication command
+- stable Release workflow의 exact-candidate 검증 경계
+
+## 제거한 결합
+
+- 수동 `verified_ci_run_id`, `expected_head_sha`, `handoff_issue_number`,
+  `validation_run_id` 입력과 validation run/current `develop` SHA 전달
+- `#1562` issue handoff와 `validate-full-nightly`, `record-handoff` job
+- TenantContext receipt 생성·artifact upload·issue comment machinery
 
 ## 재발 방지
 
-Snapshot 자동화 검토에서는 workflow run metadata만 비교하지 않는다. 반드시
-trigger SHA, checkout `ref`, checkout 이후 SHA 검증, environment 대기 중 branch
-변경 가능성을 한 세트로 확인한다. 이 네 조건이 일치하지 않으면 reviewer 제거와
-publication을 보류한다.
+Snapshot policy test는 job이 `publish` 하나인지, trigger가 `workflow_dispatch`만인지,
+입력·issue handoff·receipt machinery가 없는지, checkout과 검증·summary가 같은
+dispatch SHA를 가리키는지를 검사한다. 안정 release의 exact-candidate 검증과
+Snapshot의 반복 publication은 각각의 목적과 승인 경계를 유지한다.

--- a/docs/lessons/2026-08-31-issue-1578-snapshot-source-identity.md
+++ b/docs/lessons/2026-08-31-issue-1578-snapshot-source-identity.md
@@ -1,0 +1,34 @@
+# Snapshot publication source identity를 checkout으로 증명하기
+
+## 맥락
+
+이슈 #1578의 `Publish Snapshot` 대기 실행을 검토하면서 workflow run의
+`headSha`가 곧 publication source라고 판단했다. 그러나 여러 저장소의
+`actions/checkout`은 `ref`를 지정하지 않았고, environment 승인 뒤 runner가
+시작될 때의 기본 branch를 checkout했다.
+
+## 잘못된 가정과 증거
+
+- 잘못된 가정: `workflow_run`으로 시작한 run의 `headSha`가 checkout source를
+  자동으로 고정한다.
+- 반증: AWS와 Exposed의 triggering Nightly SHA는 대기 중인 Publish Snapshot
+  run이 실제 checkout할 최신 `develop` SHA와 달랐다.
+- 결과: reviewer를 제거하면 Nightly가 검증하지 않은 소스를 배포할 수 있었다.
+
+## 결정
+
+- `workflow_run` 경로는 `github.event.workflow_run.head_sha`를 명시적으로
+  checkout한다.
+- 수동 dispatch는 environment branch policy가 허용한 dispatch SHA를
+  checkout한다.
+- 별도 validation run을 입력받는 workflow는 해당 run의 성공 여부, branch,
+  `head_sha`를 함께 읽고 그 SHA를 publication job으로 전달한다.
+- checkout 직후 `git rev-parse HEAD`를 expected SHA와 비교해 source identity를
+  실행 증적으로 남긴다.
+
+## 재발 방지
+
+Snapshot 자동화 검토에서는 workflow run metadata만 비교하지 않는다. 반드시
+trigger SHA, checkout `ref`, checkout 이후 SHA 검증, environment 대기 중 branch
+변경 가능성을 한 세트로 확인한다. 이 네 조건이 일치하지 않으면 reviewer 제거와
+publication을 보류한다.

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -48,9 +48,6 @@ REPOSITORY_ACTION_REF = re.compile(
     r"@(?P<ref>[^\s#]+)"
 )
 FULL_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
-SNAPSHOT_PUBLISH_JOB_IF = (
-    "${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}"
-)
 PUBLICATION_VALIDATION_COMMANDS = (
     "      - name: Validate publication metadata\n"
     "        run: |\n"
@@ -498,80 +495,74 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
         )
     if GITHUB_RELEASE.search(workflow) or ISSUE_RELEASE_MACHINERY.search(workflow):
         errors.append("snapshot workflow must not contain release or issue-specific machinery")
-    if "contents: write" in workflow:
-        errors.append("snapshot workflow must not request write access to repository contents")
-    if job_ids(workflow) != {"validate-full-nightly", "publish", "record-handoff"}:
-        errors.append("snapshot workflow must separate validation, publication, and issue recording")
-    errors.extend(
-        publication_validation_errors(
-            workflow, "publish", SNAPSHOT_PUBLISH_JOB_IF
-        )
-    )
+    if job_ids(workflow) != {"publish"}:
+        errors.append("snapshot workflow must contain only the publish job")
+    errors.extend(publication_validation_errors(workflow, "publish"))
     if not snapshot_command_valid:
         errors.append("snapshot publication must disable the configuration cache")
-    if "workflow_run:" in workflow or "github.event.workflow_run" in workflow:
-        errors.append("snapshot workflow must not have an automatic workflow_run trigger")
     if "workflow_dispatch:" not in workflow:
         errors.append("snapshot workflow must be manually dispatched")
-    for required_input in (
+    trigger_block = (
+        workflow.split("\non:", 1)[1].split("\n\nconcurrency:", 1)[0]
+        if "\non:" in workflow
+        else ""
+    )
+    trigger_keys = set(
+        re.findall(r"^  ([a-z0-9_-]+):\s*$", trigger_block, re.MULTILINE)
+    )
+    if trigger_keys != {"workflow_dispatch"}:
+        errors.append("snapshot workflow must use only the workflow_dispatch trigger")
+    if re.search(r"^ {4}inputs:\s*$", workflow, re.MULTILINE):
+        errors.append("snapshot workflow must not define workflow inputs")
+    removed_markers = (
         "verified_ci_run_id",
         "expected_head_sha",
         "handoff_issue_number",
+        "validation_run_id",
+        "validate-full-nightly",
+        "record-handoff",
+        "TenantContext",
+        "#1562",
+        "1562",
+        "handoff",
+        "receipt",
+        "create_snapshot_handoff.py",
+        "tenant-context-handoff",
+        "gh issue comment",
+        "actions/upload-artifact",
+        "actions/download-artifact",
+    )
+    if any(marker in workflow for marker in removed_markers):
+        errors.append("snapshot workflow must not contain removed handoff machinery")
+    if re.search(
+        r"^\s+(?:actions|checks|contents|deployments|id-token|issues|packages|pull-requests|security-events|statuses):\s*write\s*$",
+        workflow,
+        re.MULTILINE,
     ):
-        marker = f"      {required_input}:\n"
-        if marker not in workflow:
-            errors.append(f"snapshot workflow must require {required_input}")
-            continue
-        input_tail = workflow.split(marker, 1)[1]
-        next_input = re.search(r"\n      \S", input_tail)
-        input_block = input_tail[: next_input.start()] if next_input else input_tail
-        if "        required: true" not in input_block:
-            errors.append(f"snapshot workflow must require {required_input}")
-    workflow_permissions = workflow.split("\njobs:\n", 1)[0]
-    if "issues: write" in workflow_permissions:
-        errors.append("snapshot workflow must not grant issue write permission globally")
-    if "record-handoff:" not in workflow or "issues: write" not in workflow:
-        errors.append("snapshot handoff job must request issue comment permission")
-    action_refs = workflow_action_refs(workflow)
-    if (
-        not any(action == "actions/upload-artifact" for action, _ in action_refs)
-        or "retention-days: 90" not in workflow
-    ):
-        errors.append("snapshot workflow must retain the immutable handoff artifact for 90 days")
-    if "create_snapshot_handoff.py" not in workflow:
-        errors.append("snapshot workflow must create a public metadata handoff receipt")
-    if "gh issue comment" not in workflow:
-        errors.append("snapshot workflow must record handoff evidence on the linked issue")
+        errors.append("snapshot workflow must not request write permissions")
     if "environment: maven-central-release" not in workflow:
         errors.append("snapshot publication must use the protected Maven Central environment")
-    if "          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}" not in workflow:
-        errors.append("snapshot publication must checkout the validated Nightly head SHA")
+    if "          ref: ${{ github.sha }}" not in workflow:
+        errors.append("snapshot publication must checkout the dispatch SHA")
     exact_checkout_verification = (
         "      - name: Verify exact checkout\n"
         "        env:\n"
-        "          EXPECTED_HEAD_SHA: "
-        "${{ needs.validate-full-nightly.outputs.head_sha }}\n"
+        "          EXPECTED_HEAD_SHA: ${{ github.sha }}\n"
         "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\""
     )
     if exact_checkout_verification not in workflow:
         errors.append("snapshot publication must verify the exact checkout SHA")
-    if "GITHUB_REF" not in workflow or "refs/heads/develop" not in workflow:
-        errors.append("snapshot workflow must reject a dispatch ref other than develop")
-    if 'if [ "$HANDOFF_ISSUE_NUMBER" -ne 1562 ]' not in workflow:
-        errors.append("snapshot workflow must pin the TenantContext handoff issue")
-    if "nightly_matrix_contract.json?ref=${validation_head_sha}" not in workflow:
-        errors.append("snapshot workflow must load the exact-head Nightly matrix contract")
-    if "validate_nightly_matrix.py?ref=${validation_head_sha}" not in workflow:
-        errors.append("snapshot workflow must load the exact-head Nightly validator")
-    if 'receipt_status="$?"' not in workflow or 'if [ "$receipt_status" -ne 75 ]' not in workflow:
-        errors.append("snapshot workflow must retry only transient public read-back failures")
-    for receipt_field in (
-        ".repository", ".merge_sha", ".verified_ci_run_id", ".publication_run_id",
-        ".handoff_issue_number", ".group",
-        ".artifact", ".base_version", ".resources",
-    ):
-        if receipt_field not in workflow:
-            errors.append(f"snapshot workflow must verify receipt field {receipt_field}")
+    summary_contract = (
+        "      - name: Summarize SNAPSHOT publication\n",
+        '            echo "trigger: workflow_dispatch"\n',
+        '            echo "SOURCE_SHA=${{ github.sha }}"\n',
+        '            echo "repeated publication allowed"\n',
+    )
+    if not all(marker in workflow for marker in summary_contract):
+        errors.append("snapshot workflow must summarize dispatch, source SHA, and repeatability")
+    named_steps = re.findall(r"^      - name: (.+)$", workflow, re.MULTILINE)
+    if not named_steps or named_steps[-1] != "Summarize SNAPSHOT publication":
+        errors.append("snapshot workflow must end with the publication summary")
     return errors
 
 
@@ -628,7 +619,7 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
         workflow_jobs = {
             "ci.yml": ("build", None),
             "release.yml": ("publish", None),
-            "publish-snapshot.yml": ("publish", SNAPSHOT_PUBLISH_JOB_IF),
+            "publish-snapshot.yml": ("publish", None),
         }
         for workflow_name, (expected_job, expected_if) in workflow_jobs.items():
             with self.subTest(workflow=workflow_name):
@@ -688,23 +679,22 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
     def test_snapshot_publication_rejects_checkout_source_drift(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
-            "          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}",
+            "          ref: ${{ github.sha }}",
             "          ref: develop",
             1,
         )
 
         self.assertIn(
-            "snapshot publication must checkout the validated Nightly head SHA",
+            "snapshot publication must checkout the dispatch SHA",
             snapshot_policy_errors(mutated),
         )
 
     def test_snapshot_publication_rejects_checkout_verification_drift(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
-            "          EXPECTED_HEAD_SHA: "
-            "${{ needs.validate-full-nightly.outputs.head_sha }}\n"
-            "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
             "          EXPECTED_HEAD_SHA: ${{ github.sha }}\n"
+            "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
+            "          EXPECTED_HEAD_SHA: ${{ github.ref }}\n"
             "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
             1,
         )
@@ -965,19 +955,14 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
             ),
             (
                 "snapshot-if",
-                snapshot.replace(
-                    "    if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}\n",
-                    "    if: false\n",
-                    1,
-                ),
+                snapshot.replace("  publish:\n", "  publish:\n    if: false\n", 1),
                 snapshot_policy_errors,
             ),
             (
                 "snapshot-continue-on-error",
                 snapshot.replace(
-                    "    if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}\n",
-                    "    if: ${{ needs.validate-full-nightly.outputs.publish_eligible == 'true' }}\n"
-                    "    continue-on-error: true\n",
+                    "  publish:\n",
+                    "  publish:\n    continue-on-error: true\n",
                     1,
                 ),
                 snapshot_policy_errors,
@@ -1128,36 +1113,34 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
         self.assertIn("Publish SNAPSHOT to Maven Central", workflow)
         self.assertEqual([], snapshot_policy_errors(workflow))
 
-    def test_snapshot_workflow_requires_full_nightly_validation_before_publish(self) -> None:
+    def test_snapshot_workflow_is_input_free_manual_dispatch(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 
-        self.assertIn("actions: read", workflow)
-        self.assertIn("validate-full-nightly:", workflow)
-        self.assertIn("needs: validate-full-nightly", workflow)
-        self.assertIn(
-            "needs.validate-full-nightly.outputs.publish_eligible == 'true'",
-            workflow,
-        )
-        self.assertIn('verified_ci_run_id:', workflow)
-        self.assertIn('expected_head_sha:', workflow)
-        self.assertIn('handoff_issue_number:', workflow)
-        self.assertIn("required: true", workflow)
-        self.assertIn("gh api", workflow)
-        self.assertIn("actions/runs/${VERIFIED_CI_RUN_ID}", workflow)
-        self.assertIn("actions/runs/${VERIFIED_CI_RUN_ID}/jobs", workflow)
-        self.assertIn(
-            "contents/scripts/nightly_matrix_contract.json?ref=${validation_head_sha}",
-            workflow,
+        self.assertEqual({"publish"}, job_ids(workflow))
+        self.assertIn("on:\n  workflow_dispatch:\n", workflow)
+        self.assertNotIn("workflow_run:", workflow)
+        self.assertNotIn("inputs:", workflow)
+        self.assertEqual([], snapshot_policy_errors(workflow))
+
+        with_inputs = workflow.replace(
+            "  workflow_dispatch:\n",
+            "  workflow_dispatch:\n    inputs:\n      source:\n        required: false\n",
+            1,
         )
         self.assertIn(
-            "contents/scripts/validate_nightly_matrix.py?ref=${validation_head_sha}",
-            workflow,
+            "snapshot workflow must not define workflow inputs",
+            snapshot_policy_errors(with_inputs),
         )
-        self.assertIn("Accept: application/vnd.github.raw", workflow)
-        self.assertIn("valid head SHA", workflow)
-        self.assertIn('python3 "$validator_script"', workflow)
-        self.assertIn("publish_eligible=", workflow)
-        self.assertNotIn("override_full_validation", workflow)
+
+        automatic = workflow.replace(
+            "  workflow_dispatch:\n",
+            '  workflow_run:\n    workflows: ["Nightly"]\n    types: [completed]\n  workflow_dispatch:\n',
+            1,
+        )
+        self.assertIn(
+            "snapshot workflow must use only the workflow_dispatch trigger",
+            snapshot_policy_errors(automatic),
+        )
 
     def test_nightly_matrix_contract_matches_current_workflow_groups(self) -> None:
         workflow = (WORKFLOWS / "nightly-tests.yml").read_text(encoding="utf-8")
@@ -1268,84 +1251,97 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
                 _, errors = validation_errors(run, jobs, "a" * 40, contract)
                 self.assertIn(expected_error, errors)
 
-    def test_snapshot_workflow_is_manual_only_and_has_no_automatic_fallback(self) -> None:
+    def test_snapshot_workflow_records_dispatch_sha_and_summary(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 
-        self.assertNotIn("workflow_run:", workflow)
-        self.assertNotIn("github.event.workflow_run", workflow)
+        self.assertIn("          ref: ${{ github.sha }}", workflow)
+        self.assertIn(
+            "          EXPECTED_HEAD_SHA: ${{ github.sha }}\n"
+            "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
+            workflow,
+        )
+        self.assertIn('echo "trigger: workflow_dispatch"', workflow)
+        self.assertIn('echo "SOURCE_SHA=${{ github.sha }}"', workflow)
+        self.assertIn('echo "repeated publication allowed"', workflow)
+        self.assertIn(
+            '            echo "repeated publication allowed"\n'
+            '          } >> "$GITHUB_STEP_SUMMARY"',
+            workflow,
+        )
         self.assertEqual([], snapshot_policy_errors(workflow))
 
-        automatic = workflow.replace(
-            "  workflow_dispatch:",
-            '  workflow_run:\n    workflows: ["Nightly"]\n    types: [completed]\n  workflow_dispatch:',
-        )
-        fallback = workflow + "\n# github.event.workflow_run.head_sha\n"
-        self.assertIn(
-            "snapshot workflow must not have an automatic workflow_run trigger",
-            snapshot_policy_errors(automatic),
-        )
-        self.assertIn(
-            "snapshot workflow must not have an automatic workflow_run trigger",
-            snapshot_policy_errors(fallback),
-        )
-
-    def test_snapshot_validation_pins_ci_head_and_current_develop_ref(self) -> None:
+    def test_snapshot_dispatch_sha_contract_rejects_drift(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
-        validator = (REPOSITORY / "scripts" / "validate_nightly_matrix.py").read_text(
-            encoding="utf-8"
+        mutations = (
+            (
+                workflow.replace(
+                    "          ref: ${{ github.sha }}",
+                    "          ref: develop",
+                    1,
+                ),
+                "snapshot publication must checkout the dispatch SHA",
+            ),
+            (
+                workflow.replace(
+                    "          EXPECTED_HEAD_SHA: ${{ github.sha }}",
+                    "          EXPECTED_HEAD_SHA: ${{ github.ref }}",
+                    1,
+                ),
+                "snapshot publication must verify the exact checkout SHA",
+            ),
+            (
+                workflow.replace(
+                    '            echo "SOURCE_SHA=${{ github.sha }}"',
+                    '            echo "SOURCE_SHA=${{ github.ref }}"',
+                    1,
+                ),
+                "snapshot workflow must summarize dispatch, source SHA, and repeatability",
+            ),
         )
+        for mutated, expected_error in mutations:
+            with self.subTest(expected_error=expected_error):
+                self.assertIn(expected_error, snapshot_policy_errors(mutated))
 
-        self.assertIn("EXPECTED_HEAD_SHA", workflow)
-        self.assertIn("git/ref/heads/develop", workflow)
-        self.assertIn("run.get(\"path\")", validator)
-        self.assertIn("run.get(\"status\")", validator)
-        self.assertIn("run.get(\"conclusion\")", validator)
-        self.assertIn("run.get(\"head_sha\", \"\")", validator)
-        self.assertIn("develop_sha", workflow)
-        self.assertIn("environment: maven-central-release", workflow)
-        self.assertIn('GITHUB_REF: ${{ github.ref }}', workflow)
-        self.assertIn('GITHUB_SHA: ${{ github.sha }}', workflow)
-
-    def test_snapshot_receipt_is_immutable_and_linked_to_issue(self) -> None:
+    def test_snapshot_workflow_has_no_issue_handoff(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 
-        self.assertIn("bluetape.snapshot-handoff/v1", workflow)
-        self.assertIn("tenant-context-handoff-${", workflow)
-        self.assertRegex(
-            workflow,
-            r"uses:\s+actions/upload-artifact@[0-9a-f]{40}\s+# v7",
-        )
-        self.assertIn("retention-days: 90", workflow)
-        self.assertIn("artifact-id", workflow)
-        self.assertIn("artifact-digest", workflow)
-        self.assertIn("gh issue comment", workflow)
-        self.assertIn(
-            'gh issue comment "$HANDOFF_ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" '
-            '--body-file "$comment"',
-            workflow,
-        )
-        self.assertIn("issues: write", workflow)
-        self.assertNotIn("issues: write", workflow.split("\njobs:\n", 1)[0])
-        self.assertIn("record-handoff:", workflow)
-        self.assertIn('--handoff-issue-number "$HANDOFF_ISSUE_NUMBER"', workflow)
-        self.assertIn('receipt_status="$?"', workflow)
-        self.assertIn('if [ "$receipt_status" -ne 75 ]', workflow)
-        for expression in (
-            '.repository == $repository', '.merge_sha == $merge_sha',
-            '.verified_ci_run_id == $verified_ci_run_id',
-            '.publication_run_id == $publication_run_id',
-            '.group == "io.github.bluetape4k"', '.artifact == "bluetape4k-bom"',
-            '.base_version == "2.0.0"', '.resources | length == 7',
+        for marker in (
+            "validate-full-nightly",
+            "record-handoff",
+            "TenantContext",
+            "#1562",
+            "verified_ci_run_id",
+            "expected_head_sha",
+            "handoff_issue_number",
+            "validation_run_id",
+            "create_snapshot_handoff.py",
+            "tenant-context-handoff",
+            "actions/upload-artifact",
+            "actions/download-artifact",
+            "gh issue comment",
+            "issues: write",
         ):
-            self.assertIn(expression, workflow)
-    def test_snapshot_checkout_uses_validated_nightly_head(self) -> None:
+            self.assertNotIn(marker, workflow)
+        self.assertEqual([], snapshot_policy_errors(workflow))
+
+        handoff = workflow + "\n  record-handoff:\n    permissions:\n      issues: write\n"
+        errors = snapshot_policy_errors(handoff)
+        self.assertIn("snapshot workflow must contain only the publish job", errors)
+        self.assertIn("snapshot workflow must not contain removed handoff machinery", errors)
+    def test_snapshot_workflow_has_single_publish_job_and_final_summary(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
 
-        self.assertIn("head_sha", workflow)
+        self.assertEqual({"publish"}, job_ids(workflow))
+        self.assertNotIn("needs:", workflow)
         self.assertIn(
-            "ref: ${{ needs.validate-full-nightly.outputs.head_sha }}",
+            "      - name: Summarize SNAPSHOT publication\n",
             workflow,
         )
+        self.assertEqual(
+            "Summarize SNAPSHOT publication",
+            re.findall(r"^      - name: (.+)$", workflow, re.MULTILINE)[-1],
+        )
+        self.assertEqual([], snapshot_policy_errors(workflow))
 
     def test_runtime_surfaces_have_no_renamed_release_machinery(self) -> None:
         self.assertEqual([], runtime_policy_errors())

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -546,7 +546,14 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
         errors.append("snapshot publication must use the protected Maven Central environment")
     if "          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}" not in workflow:
         errors.append("snapshot publication must checkout the validated Nightly head SHA")
-    if "Verify exact checkout" not in workflow or "git rev-parse HEAD" not in workflow:
+    exact_checkout_verification = (
+        "      - name: Verify exact checkout\n"
+        "        env:\n"
+        "          EXPECTED_HEAD_SHA: "
+        "${{ needs.validate-full-nightly.outputs.head_sha }}\n"
+        "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\""
+    )
+    if exact_checkout_verification not in workflow:
         errors.append("snapshot publication must verify the exact checkout SHA")
     if "GITHUB_REF" not in workflow or "refs/heads/develop" not in workflow:
         errors.append("snapshot workflow must reject a dispatch ref other than develop")
@@ -688,6 +695,22 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
 
         self.assertIn(
             "snapshot publication must checkout the validated Nightly head SHA",
+            snapshot_policy_errors(mutated),
+        )
+
+    def test_snapshot_publication_rejects_checkout_verification_drift(self) -> None:
+        workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace(
+            "          EXPECTED_HEAD_SHA: "
+            "${{ needs.validate-full-nightly.outputs.head_sha }}\n"
+            "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
+            "          EXPECTED_HEAD_SHA: ${{ github.sha }}\n"
+            "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
+            1,
+        )
+
+        self.assertIn(
+            "snapshot publication must verify the exact checkout SHA",
             snapshot_policy_errors(mutated),
         )
 

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -173,13 +173,20 @@ def yaml_run_contract(
     return (style, tuple(content)), end
 
 
-def workflow_step_runs(
+def workflow_step_records(
     workflow: str,
     expected_job: Optional[str] = None,
-    expected_name: Optional[str] = None,
-) -> list[tuple[Optional[tuple[str, tuple[str, ...]]], bool]]:
+) -> list[
+    tuple[
+        Optional[str],
+        Optional[str],
+        tuple[str, ...],
+        Optional[tuple[str, tuple[str, ...]]],
+        bool,
+    ]
+]:
     lines = workflow.splitlines()
-    runs = []
+    records = []
     in_jobs = False
     current_job = None
     index = 0
@@ -228,6 +235,11 @@ def workflow_step_runs(
 
             name_match = re.match(r"^ {6}- name:\s*(?P<name>.+?)\s*$", step_line)
             step_name = name_match.group("name") if name_match else None
+            uses_match = re.match(
+                r"^ {6}- uses:\s*(?P<uses>[^\s#]+)", step_line
+            )
+            step_uses = uses_match.group("uses") if uses_match else None
+            fields = []
             run = None
             guarded = False
             index += 1
@@ -240,6 +252,7 @@ def workflow_step_runs(
                 if field_indent == 6 and field_stripped.startswith("- "):
                     break
 
+                fields.append(field_line)
                 run_match = re.match(
                     r"^ {8}run:\s*(?P<header>.*)$", field_line
                 )
@@ -267,12 +280,40 @@ def workflow_step_runs(
                 else:
                     index += 1
 
-            if (expected_job is None or current_job == expected_job) and (
-                expected_name is None or step_name == expected_name
-            ):
-                runs.append((run, guarded))
+            if expected_job is None or current_job == expected_job:
+                records.append(
+                    (step_name, step_uses, tuple(fields), run, guarded)
+                )
 
-    return runs
+    return records
+
+
+def workflow_step_runs(
+    workflow: str,
+    expected_job: Optional[str] = None,
+    expected_name: Optional[str] = None,
+) -> list[tuple[Optional[tuple[str, tuple[str, ...]]], bool]]:
+    return [
+        (run, guarded)
+        for step_name, _, _, run, guarded in workflow_step_records(
+            workflow, expected_job
+        )
+        if expected_name is None or step_name == expected_name
+    ]
+
+
+def workflow_step_field_values(
+    fields: tuple[str, ...], expected_key: str
+) -> list[str]:
+    key = re.escape(expected_key)
+    pattern = re.compile(
+        rf"""^ {{10}}(?:"{key}"|'{key}'|{key}):\s*(?P<value>.*?)\s*$"""
+    )
+    return [
+        match.group("value")
+        for line in fields
+        if (match := pattern.fullmatch(line)) is not None
+    ]
 
 
 def publication_job_guard_errors(
@@ -542,25 +583,69 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
         errors.append("snapshot workflow must not request write permissions")
     if "environment: maven-central-release" not in workflow:
         errors.append("snapshot publication must use the protected Maven Central environment")
-    if "          ref: ${{ github.sha }}" not in workflow:
+
+    publish_steps = workflow_step_records(workflow, "publish")
+    checkout_steps = [
+        step
+        for step in publish_steps
+        if step[1] is not None
+        and step[1].split("@", 1)[0] == "actions/checkout"
+    ]
+    checkout_contract = (
+        len(checkout_steps) == 1
+        and not checkout_steps[0][4]
+        and workflow_step_field_values(checkout_steps[0][2], "ref")
+        == ["${{ github.sha }}"]
+        and workflow_step_field_values(checkout_steps[0][2], "fetch-depth")
+        == ["0"]
+    )
+    if not checkout_contract:
         errors.append("snapshot publication must checkout the dispatch SHA")
-    exact_checkout_verification = (
-        "      - name: Verify exact checkout\n"
-        "        env:\n"
-        "          EXPECTED_HEAD_SHA: ${{ github.sha }}\n"
-        "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\""
+
+    exact_checkout_runs = workflow_step_runs(
+        workflow, "publish", "Verify exact checkout"
     )
-    if exact_checkout_verification not in workflow:
+    exact_checkout_steps = [
+        step
+        for step in publish_steps
+        if step[0] == "Verify exact checkout"
+    ]
+    if exact_checkout_runs != [
+        (
+            (
+                "inline",
+                ('test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"',),
+            ),
+            False,
+        )
+    ] or (
+        len(exact_checkout_steps) != 1
+        or workflow_step_field_values(
+            exact_checkout_steps[0][2], "EXPECTED_HEAD_SHA"
+        )
+        != ["${{ github.sha }}"]
+    ):
         errors.append("snapshot publication must verify the exact checkout SHA")
-    summary_contract = (
-        "      - name: Summarize SNAPSHOT publication\n",
-        '            echo "trigger: workflow_dispatch"\n',
-        '            echo "SOURCE_SHA=${{ github.sha }}"\n',
-        '            echo "repeated publication allowed"\n',
+
+    summary_runs = workflow_step_runs(
+        workflow, "publish", "Summarize SNAPSHOT publication"
     )
-    if not all(marker in workflow for marker in summary_contract):
+    summary_run_valid = (
+        len(summary_runs) == 1
+        and summary_runs[0][0] is not None
+        and not summary_runs[0][1]
+        and all(
+            marker in "\n".join(summary_runs[0][0][1])
+            for marker in (
+                'echo "trigger: workflow_dispatch"',
+                'echo "SOURCE_SHA=${{ github.sha }}"',
+                'echo "repeated publication allowed"',
+            )
+        )
+    )
+    if not summary_run_valid:
         errors.append("snapshot workflow must summarize dispatch, source SHA, and repeatability")
-    named_steps = re.findall(r"^      - name: (.+)$", workflow, re.MULTILINE)
+    named_steps = [step[0] for step in publish_steps if step[0] is not None]
     if not named_steps or named_steps[-1] != "Summarize SNAPSHOT publication":
         errors.append("snapshot workflow must end with the publication summary")
     return errors
@@ -696,6 +781,20 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
             "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
             "          EXPECTED_HEAD_SHA: ${{ github.ref }}\n"
             "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"",
+            1,
+        )
+
+        self.assertIn(
+            "snapshot publication must verify the exact checkout SHA",
+            snapshot_policy_errors(mutated),
+        )
+
+    def test_snapshot_publication_rejects_disabled_checkout_verification(self) -> None:
+        workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace(
+            "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"\n",
+            "        run: test \"$(git rev-parse HEAD)\" = \"$EXPECTED_HEAD_SHA\"\n"
+            "        if: false\n",
             1,
         )
 

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -544,6 +544,10 @@ def snapshot_policy_errors(workflow: str) -> list[str]:
         errors.append("snapshot workflow must record handoff evidence on the linked issue")
     if "environment: maven-central-release" not in workflow:
         errors.append("snapshot publication must use the protected Maven Central environment")
+    if "          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}" not in workflow:
+        errors.append("snapshot publication must checkout the validated Nightly head SHA")
+    if "Verify exact checkout" not in workflow or "git rev-parse HEAD" not in workflow:
+        errors.append("snapshot publication must verify the exact checkout SHA")
     if "GITHUB_REF" not in workflow or "refs/heads/develop" not in workflow:
         errors.append("snapshot workflow must reject a dispatch ref other than develop")
     if 'if [ "$HANDOFF_ISSUE_NUMBER" -ne 1562 ]' not in workflow:
@@ -672,6 +676,19 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
         self.assertIn(
             "privileged publication action refs must use full commit SHAs",
             release_policy_errors(mutated),
+        )
+
+    def test_snapshot_publication_rejects_checkout_source_drift(self) -> None:
+        workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace(
+            "          ref: ${{ needs.validate-full-nightly.outputs.head_sha }}",
+            "          ref: develop",
+            1,
+        )
+
+        self.assertIn(
+            "snapshot publication must checkout the validated Nightly head SHA",
+            snapshot_policy_errors(mutated),
         )
 
     def test_publication_validation_rejects_required_task_outside_gradle_invocation(self) -> None:


### PR DESCRIPTION
## 요약

Refs #1578

routine SNAPSHOT을 Full Nightly와 기능 handoff에서 분리합니다. 수동 배포는 입력 없이 현재 `develop` commit을 반복 발행할 수 있습니다.

## 변경

- `Publish Snapshot`의 `workflow_dispatch` 입력을 제거했습니다.
- Full Nightly run ID, override, TenantContext handoff를 routine SNAPSHOT에서 제거했습니다.
- checkout과 배포 대상은 모두 `github.sha`를 사용하며 exact SHA를 확인합니다.
- `maven-central-release` 환경의 required reviewer를 제거했습니다.
- `develop` branch policy, `can_admins_bypass=false`, 기존 secret 5개는 유지했습니다.

## 검증

- `actionlint`: PASS
- release workflow policy: **45/45 PASS**
- `git diff --check`: PASS
- 통합 검토: 지적 사항 없음

## DoD Status

- 구현 및 로컬 검증: **PASS**
- 환경 정책 read-back: **PASS**
- exact-head hosted CI: **PASS**
- merge: **PENDING** — 현재 head에 대한 별도 승인 필요
