### PR TITLE
[release][ci] stable Release를 exact-head Full Nightly 뒤로 잠근다

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
   packages: read
 
@@ -64,6 +65,83 @@ jobs:
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "ref=refs/tags/$VERSION" >> "$GITHUB_OUTPUT"
+
+  verify-full-nightly:
+    name: Verify exact-head Full Nightly
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.nightly.outputs.head_sha }}
+      run_id: ${{ steps.nightly.outputs.run_id }}
+      run_url: ${{ steps.nightly.outputs.run_url }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.resolve-version.outputs.ref }}
+          fetch-depth: 0
+
+      - id: nightly
+        name: Validate matching Full Nightly
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TARGET_SHA="$(git rev-parse HEAD)"
+          run_pages="$RUNNER_TEMP/nightly-runs.json"
+          run_json="$RUNNER_TEMP/nightly-run.json"
+          jobs_json="$RUNNER_TEMP/nightly-jobs.json"
+          validation_output="$RUNNER_TEMP/nightly-validation.txt"
+
+          gh api --paginate --slurp \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/nightly-tests.yml/runs?branch=develop&status=completed&per_page=100" \
+            > "$run_pages"
+          NIGHTLY_RUN_ID="$(jq -r --arg sha "$TARGET_SHA" '
+            [.[].workflow_runs[]
+              | select(
+                  .head_sha == $sha
+                  and .status == "completed"
+                  and .conclusion == "success"
+                  and .path == ".github/workflows/nightly-tests.yml"
+                )]
+            | sort_by(.run_number)
+            | last
+            | .id // empty
+          ' "$run_pages")"
+
+          if [[ -z "$NIGHTLY_RUN_ID" ]]; then
+            echo "::error::No successful Full Nightly candidate found for tag SHA $TARGET_SHA"
+            exit 1
+          fi
+
+          gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${NIGHTLY_RUN_ID}" > "$run_json"
+          gh api --paginate --slurp \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${NIGHTLY_RUN_ID}/jobs?per_page=100" \
+            > "$jobs_json"
+
+          python3 scripts/validate_nightly_matrix.py \
+            "$run_json" \
+            "$jobs_json" \
+            "$TARGET_SHA" \
+            scripts/nightly_matrix_contract.json \
+            | tee "$validation_output"
+          if ! grep -qx 'publish_eligible=true' "$validation_output"; then
+            echo "::error::Full Nightly validation rejected run $NIGHTLY_RUN_ID"
+            exit 1
+          fi
+
+          NIGHTLY_RUN_URL="$(jq -r '.html_url' "$run_json")"
+          {
+            echo "head_sha=$TARGET_SHA"
+            echo "run_id=$NIGHTLY_RUN_ID"
+            echo "run_url=$NIGHTLY_RUN_URL"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Stable Release Full Nightly attestation"
+            echo "- tag SHA: \`$TARGET_SHA\`"
+            echo "- Nightly run: [$NIGHTLY_RUN_ID]($NIGHTLY_RUN_URL)"
+            echo "- publish eligible: \`true\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   testcontainers-manifest-contract:
     name: Verify Testcontainers manifest contract
@@ -275,14 +353,20 @@ jobs:
 
   publish:
     name: Publish RELEASE to Maven Central Portal
-    needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]
+    needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]
     runs-on: ubuntu-latest
     environment: maven-central-release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.resolve-version.outputs.ref }}
+          ref: ${{ needs.verify-full-nightly.outputs.head_sha }}
           fetch-depth: 0
+
+      - name: Verify exact release checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
 
       - name: Resolve dependencies catalog ref
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,8 @@ jobs:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
 
-      - id: nightly
-        name: Validate matching Full Nightly
+      - name: Validate matching Full Nightly
+        id: nightly
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -145,13 +145,19 @@ jobs:
 
   testcontainers-manifest-contract:
     name: Verify Testcontainers manifest contract
-    needs: resolve-version
+    needs: [resolve-version, verify-full-nightly]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.resolve-version.outputs.ref }}
+          ref: ${{ needs.verify-full-nightly.outputs.head_sha }}
           fetch-depth: 0
+
+      - name: Verify exact release checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -162,7 +168,7 @@ jobs:
 
   testcontainers-image-gate:
     name: Verify Testcontainers image gate
-    needs: [resolve-version, testcontainers-manifest-contract]
+    needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract]
     runs-on: ubuntu-24.04
     timeout-minutes: 360
     env:
@@ -170,8 +176,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.resolve-version.outputs.ref }}
+          ref: ${{ needs.verify-full-nightly.outputs.head_sha }}
           fetch-depth: 0
+
+      - name: Verify exact release checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
@@ -266,7 +278,7 @@ jobs:
 
   testcontainers-ignite2-arm64-image-gate:
     name: Verify Testcontainers Ignite2 arm64 image gate
-    needs: [resolve-version, testcontainers-manifest-contract]
+    needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract]
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
     env:
@@ -274,8 +286,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.resolve-version.outputs.ref }}
+          ref: ${{ needs.verify-full-nightly.outputs.head_sha }}
           fetch-depth: 0
+
+      - name: Verify exact release checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -122,6 +122,28 @@ def job_ids(workflow: str) -> set[str]:
     return set(re.findall(r"^  ([a-z0-9_-]+):\s*$", jobs[1], re.MULTILINE))
 
 
+def workflow_job_block(workflow: str, job_id: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_id)}:\s*$\n(?P<body>.*?)(?=^  [a-z0-9_-]+:\s*$|\Z)",
+        workflow,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group("body") if match is not None else ""
+
+
+def workflow_job_needs(workflow: str, job_id: str) -> set[str]:
+    block = workflow_job_block(workflow, job_id)
+    inline = re.search(r"^    needs:\s*\[(?P<needs>[^]]*)]\s*$", block, re.MULTILINE)
+    if inline is not None:
+        return {
+            item.strip()
+            for item in inline.group("needs").split(",")
+            if item.strip()
+        }
+    scalar = re.search(r"^    needs:\s*(?P<need>[a-z0-9_-]+)\s*$", block, re.MULTILINE)
+    return {scalar.group("need")} if scalar is not None else set()
+
+
 def line_indent(line: str) -> int:
     return len(line) - len(line.lstrip())
 
@@ -464,6 +486,26 @@ def privileged_action_ref_errors(workflow: str) -> list[str]:
 
 def release_policy_errors(workflow: str) -> list[str]:
     errors = privileged_action_ref_errors(workflow)
+    resolve_runs = workflow_step_runs(workflow, "resolve-version")
+    resolve_script = (
+        "\n".join(resolve_runs[0][0][1])
+        if len(resolve_runs) == 1 and resolve_runs[0][0] is not None
+        else ""
+    )
+    release_source_markers = (
+        'if [[ "$EVENT_NAME" == "push" ]]',
+        'VERSION="$TAG_NAME"',
+        'VERSION="$INPUT_VERSION"',
+        'echo "ref=refs/tags/$VERSION" >> "$GITHUB_OUTPUT"',
+    )
+    if (
+        "  push:\n" not in workflow.split("\n\nconcurrency:\n", 1)[0]
+        or "  workflow_dispatch:\n" not in workflow.split("\n\nconcurrency:\n", 1)[0]
+        or len(resolve_runs) != 1
+        or resolve_runs[0][1]
+        or any(marker not in resolve_script for marker in release_source_markers)
+    ):
+        errors.append("release workflow must resolve push and dispatch to the requested tag")
     release_runs = workflow_step_runs(
         workflow, "publish", "Publish to Central Portal"
     )
@@ -496,35 +538,91 @@ def release_policy_errors(workflow: str) -> list[str]:
             "release workflow must contain resolve-version, verify-full-nightly, testcontainers-manifest-contract, "
             "testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate, and publish jobs"
         )
+    verify_block = workflow_job_block(workflow, "verify-full-nightly")
+    verify_runs = workflow_step_runs(
+        workflow, "verify-full-nightly", "Validate matching Full Nightly"
+    )
+    verify_script = (
+        "\n".join(verify_runs[0][0][1])
+        if len(verify_runs) == 1 and verify_runs[0][0] is not None
+        else ""
+    )
     nightly_attestation_markers = (
-        "actions: read",
-        "  verify-full-nightly:\n",
-        "name: Verify exact-head Full Nightly",
         "actions/workflows/nightly-tests.yml/runs",
         "actions/runs/${NIGHTLY_RUN_ID}/jobs",
         "scripts/validate_nightly_matrix.py",
         "scripts/nightly_matrix_contract.json",
         "grep -qx 'publish_eligible=true'",
-        "head_sha: ${{ steps.nightly.outputs.head_sha }}",
-        "run_id: ${{ steps.nightly.outputs.run_id }}",
-        "run_url: ${{ steps.nightly.outputs.run_url }}",
+        "sort_by(.run_number)",
     )
-    if any(marker not in workflow for marker in nightly_attestation_markers):
+    verify_contract = (
+        "actions: read" in workflow.split("\njobs:\n", 1)[0]
+        and workflow_job_needs(workflow, "verify-full-nightly") == {"resolve-version"}
+        and "name: Verify exact-head Full Nightly" in verify_block
+        and "head_sha: ${{ steps.nightly.outputs.head_sha }}" in verify_block
+        and "run_id: ${{ steps.nightly.outputs.run_id }}" in verify_block
+        and "run_url: ${{ steps.nightly.outputs.run_url }}" in verify_block
+        and len(verify_runs) == 1
+        and not verify_runs[0][1]
+        and verify_script.count("--paginate --slurp") == 2
+        and all(marker in verify_script for marker in nightly_attestation_markers)
+    )
+    if not verify_contract:
         errors.append("release workflow must fail closed on exact-head Full Nightly evidence")
-    if "needs: [resolve-version, testcontainers-manifest-contract]" not in workflow:
-        errors.append("full Testcontainers image gate must wait for the manifest contract")
-    if (
-        "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]"
-        not in workflow
+    if not all(
+        workflow_job_needs(workflow, job_id)
+        == {"resolve-version", "verify-full-nightly", "testcontainers-manifest-contract"}
+        for job_id in (
+            "testcontainers-image-gate",
+            "testcontainers-ignite2-arm64-image-gate",
+        )
     ):
+        errors.append("full Testcontainers image gate must wait for the manifest contract")
+    if workflow_job_needs(workflow, "testcontainers-manifest-contract") != {
+        "resolve-version",
+        "verify-full-nightly",
+    }:
+        errors.append("release validation gates must wait for exact-head Full Nightly")
+    if workflow_job_needs(workflow, "publish") != {
+        "resolve-version",
+        "verify-full-nightly",
+        "testcontainers-manifest-contract",
+        "testcontainers-image-gate",
+        "testcontainers-ignite2-arm64-image-gate",
+    }:
         errors.append("publish must depend on exact-head Full Nightly and the image gates")
-    exact_release_source_markers = (
-        "ref: ${{ needs.verify-full-nightly.outputs.head_sha }}",
-        "name: Verify exact release checkout",
-        "EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}",
-        'test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"',
+    exact_head_jobs = (
+        "testcontainers-manifest-contract",
+        "testcontainers-image-gate",
+        "testcontainers-ignite2-arm64-image-gate",
+        "publish",
     )
-    if any(marker not in workflow for marker in exact_release_source_markers):
+    exact_head_contract = True
+    for job_id in exact_head_jobs:
+        records = workflow_step_records(workflow, job_id)
+        checkout_steps = [
+            step
+            for step in records
+            if step[1] is not None
+            and step[1].split("@", 1)[0] == "actions/checkout"
+        ]
+        verify_steps = [step for step in records if step[0] == "Verify exact release checkout"]
+        if not (
+            len(checkout_steps) == 1
+            and not checkout_steps[0][4]
+            and workflow_step_field_values(checkout_steps[0][2], "ref")
+            == ["${{ needs.verify-full-nightly.outputs.head_sha }}"]
+            and workflow_step_field_values(checkout_steps[0][2], "fetch-depth") == ["0"]
+            and len(verify_steps) == 1
+            and not verify_steps[0][4]
+            and workflow_step_field_values(verify_steps[0][2], "EXPECTED_HEAD_SHA")
+            == ["${{ needs.verify-full-nightly.outputs.head_sha }}"]
+            and verify_steps[0][3]
+            == ("inline", ('test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"',))
+        ):
+            exact_head_contract = False
+            break
+    if not exact_head_contract:
         errors.append("release publication must use the exact validated Nightly SHA")
     if "--scope full" not in workflow or not (
         "coverage=48/48" in workflow or "expected_coverage=\"48/48\"" in workflow
@@ -1224,6 +1322,24 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
             release_policy_errors(mutated),
         )
 
+    def test_release_workflow_requires_paginated_nightly_selection(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace("gh api --paginate --slurp", "gh api", 1)
+
+        self.assertIn(
+            "release workflow must fail closed on exact-head Full Nightly evidence",
+            release_policy_errors(mutated),
+        )
+
+    def test_release_workflow_keeps_push_and_dispatch_tag_resolution(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace('VERSION="$TAG_NAME"', 'VERSION="$INPUT_VERSION"', 1)
+
+        self.assertIn(
+            "release workflow must resolve push and dispatch to the requested tag",
+            release_policy_errors(mutated),
+        )
+
     def test_release_publication_rejects_tag_ref_after_nightly_validation(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
@@ -1240,11 +1356,24 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
     def test_release_workflow_blocks_image_gate_without_manifest_contract(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
-            "needs: [resolve-version, testcontainers-manifest-contract]",
+            "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract]",
             "needs: resolve-version",
         )
         errors = release_policy_errors(mutated)
         self.assertIn("full Testcontainers image gate must wait for the manifest contract", errors)
+
+    def test_release_validation_gates_wait_for_full_nightly(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace(
+            "needs: [resolve-version, verify-full-nightly]",
+            "needs: resolve-version",
+            1,
+        )
+
+        self.assertIn(
+            "release validation gates must wait for exact-head Full Nightly",
+            release_policy_errors(mutated),
+        )
 
     def test_release_workflow_blocks_arm_gate_without_exact_selector(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -485,6 +485,7 @@ def release_policy_errors(workflow: str) -> list[str]:
         errors.append("release workflow must not contain issue-specific release machinery")
     expected_jobs = {
         "resolve-version",
+        "verify-full-nightly",
         "testcontainers-manifest-contract",
         "testcontainers-image-gate",
         "testcontainers-ignite2-arm64-image-gate",
@@ -492,16 +493,39 @@ def release_policy_errors(workflow: str) -> list[str]:
     }
     if job_ids(workflow) != expected_jobs:
         errors.append(
-            "release workflow must contain resolve-version, testcontainers-manifest-contract, "
+            "release workflow must contain resolve-version, verify-full-nightly, testcontainers-manifest-contract, "
             "testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate, and publish jobs"
         )
+    nightly_attestation_markers = (
+        "actions: read",
+        "  verify-full-nightly:\n",
+        "name: Verify exact-head Full Nightly",
+        "actions/workflows/nightly-tests.yml/runs",
+        "actions/runs/${NIGHTLY_RUN_ID}/jobs",
+        "scripts/validate_nightly_matrix.py",
+        "scripts/nightly_matrix_contract.json",
+        "grep -qx 'publish_eligible=true'",
+        "head_sha: ${{ steps.nightly.outputs.head_sha }}",
+        "run_id: ${{ steps.nightly.outputs.run_id }}",
+        "run_url: ${{ steps.nightly.outputs.run_url }}",
+    )
+    if any(marker not in workflow for marker in nightly_attestation_markers):
+        errors.append("release workflow must fail closed on exact-head Full Nightly evidence")
     if "needs: [resolve-version, testcontainers-manifest-contract]" not in workflow:
         errors.append("full Testcontainers image gate must wait for the manifest contract")
     if (
-        "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]"
+        "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]"
         not in workflow
     ):
-        errors.append("publish must depend on the manifest contract and full image gate")
+        errors.append("publish must depend on exact-head Full Nightly and the image gates")
+    exact_release_source_markers = (
+        "ref: ${{ needs.verify-full-nightly.outputs.head_sha }}",
+        "name: Verify exact release checkout",
+        "EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}",
+        'test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"',
+    )
+    if any(marker not in workflow for marker in exact_release_source_markers):
+        errors.append("release publication must use the exact validated Nightly SHA")
     if "--scope full" not in workflow or not (
         "coverage=48/48" in workflow or "expected_coverage=\"48/48\"" in workflow
     ):
@@ -1185,11 +1209,33 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
     def test_release_workflow_blocks_publish_without_full_image_gate(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
-            "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
+            "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
             "needs: resolve-version",
         )
         errors = release_policy_errors(mutated)
-        self.assertIn("publish must depend on the manifest contract and full image gate", errors)
+        self.assertIn("publish must depend on exact-head Full Nightly and the image gates", errors)
+
+    def test_release_workflow_fails_closed_without_nightly_eligibility_check(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace("grep -qx 'publish_eligible=true'", "cat")
+
+        self.assertIn(
+            "release workflow must fail closed on exact-head Full Nightly evidence",
+            release_policy_errors(mutated),
+        )
+
+    def test_release_publication_rejects_tag_ref_after_nightly_validation(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        mutated = workflow.replace(
+            "ref: ${{ needs.verify-full-nightly.outputs.head_sha }}",
+            "ref: ${{ needs.resolve-version.outputs.ref }}",
+            1,
+        )
+
+        self.assertIn(
+            "release publication must use the exact validated Nightly SHA",
+            release_policy_errors(mutated),
+        )
 
     def test_release_workflow_blocks_image_gate_without_manifest_contract(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
@@ -1349,6 +1395,42 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
             with self.subTest(name=name):
                 _, errors = validation_errors(run, jobs, "a" * 40, contract)
                 self.assertIn(expected_error, errors)
+
+    def test_nightly_matrix_validation_rejects_missing_run_identity(self) -> None:
+        contract = self._nightly_matrix_contract()
+        jobs = [
+            *({"name": name, "conclusion": "success"} for name in REQUIRED_JOB_NAMES),
+            *self._successful_matrix_jobs(),
+        ]
+
+        _, errors = validation_errors({}, jobs, "a" * 40, contract)
+
+        self.assertIn("run is not completed", errors)
+        self.assertIn("run has no head SHA", errors)
+        self.assertIn("head SHA mismatch", errors)
+
+    def test_nightly_matrix_validation_rejects_skipped_job(self) -> None:
+        contract = self._nightly_matrix_contract()
+        jobs = [
+            *({"name": name, "conclusion": "success"} for name in REQUIRED_JOB_NAMES),
+            *self._successful_matrix_jobs(),
+        ]
+        jobs[0]["conclusion"] = "skipped"
+
+        _, errors = validation_errors(
+            {
+                "status": "completed",
+                "conclusion": "success",
+                "path": ".github/workflows/nightly-tests.yml",
+                "head_branch": "develop",
+                "head_sha": "a" * 40,
+            },
+            jobs,
+            "a" * 40,
+            contract,
+        )
+
+        self.assertIn(f"non-success job: {jobs[0]['name']}", errors)
 
     def test_snapshot_workflow_records_dispatch_sha_and_summary(self) -> None:
         workflow = (WORKFLOWS / "publish-snapshot.yml").read_text(encoding="utf-8")

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -243,17 +243,17 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertNotIn("jibDockerBuild", manifest_match.group(0))
         self.assertNotIn("run_testcontainers_image_gate.py", manifest_match.group(0))
         self.assertIn(
-            "needs: [resolve-version, testcontainers-manifest-contract]",
+            "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract]",
             release_workflow,
         )
         if "testcontainers-ignite2-arm64-image-gate:" in release_workflow:
             self.assertIn(
-                "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
+                "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
                 release_workflow,
             )
         else:
             self.assertIn(
-                "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]",
+                "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract, testcontainers-image-gate]",
                 release_workflow,
             )
 
@@ -344,12 +344,12 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertIn("testcontainers-image-gate:", workflow)
         if "testcontainers-ignite2-arm64-image-gate:" in workflow:
             self.assertIn(
-                "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
+                "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract, testcontainers-image-gate, testcontainers-ignite2-arm64-image-gate]",
                 workflow,
             )
         else:
             self.assertIn(
-                "needs: [resolve-version, testcontainers-manifest-contract, testcontainers-image-gate]",
+                "needs: [resolve-version, verify-full-nightly, testcontainers-manifest-contract, testcontainers-image-gate]",
                 workflow,
             )
         self.assertIn("--scope full", workflow)


### PR DESCRIPTION
## 요약

Closes #1582

정식 `Publish Release`가 tag commit과 동일한 Full Nightly 증명을 통과한 경우에만 Maven Central publication으로 진행하도록 잠급니다.

## 변경 사항

- `verify-full-nightly` job이 release tag의 commit SHA와 일치하는 성공한 `Nightly` run을 GitHub Actions API에서 찾습니다.
- 기존 `validate_nightly_matrix.py`와 `nightly_matrix_contract.json`으로 workflow identity, `develop`, exact `head_sha`, required jobs, 29개 matrix job, skipped/non-success를 검증합니다.
- validator가 오류에도 exit code 0을 반환하는 계약을 고려해 `publish_eligible=true`를 명시적으로 확인합니다.
- manifest, amd64 image gate, arm64 image gate, publication이 모두 검증 job output의 exact SHA를 checkout하고 `git rev-parse HEAD`를 다시 대조합니다.
- 정책 테스트가 Nightly 증명 누락, eligibility 확인 제거, tag ref 회귀, SHA 불일치, run identity 누락, skipped job을 거부합니다.

## 검증

- `actionlint .github/workflows/release.yml .github/workflows/nightly-tests.yml`: PASS
- `python3 -B -m unittest scripts/test_release_workflow_policy.py scripts/test_jvm_release_contract.py scripts/test_testcontainers_contract.py scripts/test_testcontainers_image_gate.py -v`: PASS, 92 tests
- independent review: P0 0, P1 0, `APPROVE`
- live API 재현: Nightly run `33334520984`, head `cdf6a8cfe14230c80fa84d743173ae61c2776a78`, `publish_eligible=true`
- `git diff --check`: PASS

## 범위

- 실제 stable tag, `Publish Release` dispatch, Maven Central publication은 실행하지 않습니다.
- routine SNAPSHOT의 반복 발행 단순화는 변경하지 않습니다.
- 병합 후 canonical `develop` exact head에서 Full Nightly `scope=full` 증명을 새로 만들고 #1582를 종료합니다.

## DoD Status

- 구현 및 로컬 정책 검증: **PASS**
- live API selector/validator 재현: **PASS**
- hosted exact-head PR CI: **PASS** — run `33413510858`, head `429f7447215ac90d71b0424f7369472ee4e57081`, 25/25 jobs 성공
- 병합: **PENDING — 별도 exact-head 승인 필요**
- post-merge Full Nightly 및 #1582 종료: **PENDING**
