### PR TITLE
[release][ci] 2.0.0 배포 차단 검증을 fail-closed로 전환

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ env:
   ORG_GRADLE_PROJECT_excludeBenchmarks: 'true'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '91f9ea9336b5ea991f5675323a1cf25ccfd6f5ed'
+  BLUETAPE4K_MANUAL_REF: '4e3c00262adb12cd61e4e8a30b6488aa6a287acc'
   GITLEAKS_VERSION: 'v8.30.1'
 
 jobs:
@@ -55,7 +56,36 @@ jobs:
         with:
           python-version: '3.12'
       - name: Verify Maven-only release policy
-        run: python3 -m unittest scripts/test_release_workflow_policy.py -v
+        run: |
+          python3 -m unittest scripts/test_release_workflow_policy.py -v
+          python3 -m unittest scripts/ci/resolve_release_target_test.py -v
+
+  manual-contract:
+    name: Central Manual Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
+        with:
+          repository: bluetape4k/bluetape4k.github.io
+          ref: ${{ env.BLUETAPE4K_MANUAL_REF }}
+          path: .manual-site
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - name: Verify immutable central manual checkout
+        run: |
+          test "$(git -C .manual-site rev-parse HEAD)" = "$BLUETAPE4K_MANUAL_REF"
+          test -f .manual-site/docs/manual/bluetape4k-projects/manifest.yaml
+          echo "central manual commit=$BLUETAPE4K_MANUAL_REF"
+          sha256sum .manual-site/docs/manual/bluetape4k-projects/manifest.yaml
+      - name: Verify central manual inventory contract
+        env:
+          BLUETAPE4K_MANUAL_ROOT: ${{ github.workspace }}/.manual-site/docs/manual/bluetape4k-projects
+        run: |
+          python3 -m unittest scripts/test_central_manual_contract.py -v
+          python3 scripts/docs-localization-inventory.py --check
 
   jvm-release-contract:
     name: JVM Release Contract
@@ -697,8 +727,21 @@ jobs:
     timeout-minutes: 10
     needs: [changes, catalog-governance]
     if: ${{ needs.changes.outputs['key-utils'] == 'true' || needs.changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch' }}
+    env:
+      BLUETAPE4K_MANUAL_ROOT: ${{ github.workspace }}/.manual-site/docs/manual/bluetape4k-projects
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/checkout@v7
+        with:
+          repository: bluetape4k/bluetape4k.github.io
+          ref: ${{ env.BLUETAPE4K_MANUAL_REF }}
+          path: .manual-site
+
+      - name: Verify immutable central manual checkout
+        run: |
+          test "$(git -C .manual-site rev-parse HEAD)" = "$BLUETAPE4K_MANUAL_REF"
+          echo "central manual commit=$BLUETAPE4K_MANUAL_REF"
 
       - uses: actions/setup-java@v6.0.0
         with:
@@ -723,6 +766,27 @@ jobs:
               --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Verify NearJCache documentation contract result
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          from xml.etree import ElementTree
+
+          result = Path(
+              "cache/cache-core/build/test-results/test/"
+              "TEST-io.bluetape4k.cache.nearcache.jcache.NearJCacheDocumentationTest.xml"
+          )
+          suite = ElementTree.parse(result).getroot()
+          actual = {
+              name: int(suite.attrib.get(name, "0"))
+              for name in ("tests", "skipped", "failures", "errors")
+          }
+          expected = {"tests": 6, "skipped": 0, "failures": 0, "errors": 0}
+          if actual != expected:
+              raise SystemExit(f"NearJCache documentation contract mismatch: {actual}")
+          print("NearJCacheDocumentationTest: tests=6, skipped=0, failures=0, errors=0")
+          PY
 
       - name: Generate Kover XML report
         if: always()
@@ -1350,7 +1414,7 @@ jobs:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [release-policy, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, test-ktor, test-key-utils, test-science, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, test-spring-boot, coverage-report]
+    needs: [release-policy, manual-contract, jvm-release-contract, codeql-policy, catalog-governance, gitleaks, validate-wrapper, changes, build, test-core, test-io, test-testcontainers-spring, test-ktor, test-key-utils, test-science, test-infra, test-search-messaging, test-kafka-infra, test-telemetry-infra, test-data, test-spring-boot, coverage-report]
     if: always()
     steps:
       - name: Check all jobs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.resolve.outputs.version }}
-      ref: ${{ steps.resolve.outputs.ref }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      target_sha: ${{ steps.resolve.outputs.target_sha }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.workflow_sha }}
+
       - id: resolve
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
           TAG_NAME: ${{ github.ref_name }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
@@ -58,13 +64,21 @@ jobs:
             VERSION="$INPUT_VERSION"
           fi
 
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
-            echo "::error::Invalid version format: $VERSION"
-            exit 1
-          fi
+          RECEIPT="$RUNNER_TEMP/release-target.txt"
+          python3 scripts/ci/resolve_release_target.py resolve \
+            --version "$VERSION" \
+            --event-name "$EVENT_NAME" \
+            --event-sha "$EVENT_SHA" > "$RECEIPT"
+          cat "$RECEIPT" >> "$GITHUB_OUTPUT"
 
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "ref=refs/tags/$VERSION" >> "$GITHUB_OUTPUT"
+          TARGET_SHA=$(sed -n 's/^target_sha=//p' "$RECEIPT")
+          {
+            echo "### Stable release target"
+            echo
+            echo "- Version: \`$VERSION\`"
+            echo "- Tag: \`refs/tags/$VERSION\`"
+            echo "- Source commit: \`$TARGET_SHA\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   verify-full-nightly:
     name: Verify exact-head Full Nightly
@@ -77,8 +91,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.resolve-version.outputs.ref }}
+          ref: ${{ needs.resolve-version.outputs.target_sha }}
           fetch-depth: 0
+
+      - name: Verify immutable release target
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          TARGET_SHA: ${{ needs.resolve-version.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          python3 scripts/ci/resolve_release_target.py verify \
+            --version "$VERSION" \
+            --expected-sha "$TARGET_SHA"
 
       - name: Validate matching Full Nightly
         id: nightly
@@ -150,14 +176,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.verify-full-nightly.outputs.head_sha }}
+          ref: ${{ needs.resolve-version.outputs.target_sha }}
           fetch-depth: 0
 
-      - name: Verify exact release checkout
+      - name: Verify immutable release target
         shell: bash
         env:
-          EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}
-        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          TARGET_SHA: ${{ needs.resolve-version.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          python3 scripts/ci/resolve_release_target.py verify \
+            --version "$VERSION" \
+            --expected-sha "$TARGET_SHA"
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -176,14 +208,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.verify-full-nightly.outputs.head_sha }}
+          ref: ${{ needs.resolve-version.outputs.target_sha }}
           fetch-depth: 0
 
-      - name: Verify exact release checkout
+      - name: Verify immutable release target
         shell: bash
         env:
-          EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}
-        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          TARGET_SHA: ${{ needs.resolve-version.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          python3 scripts/ci/resolve_release_target.py verify \
+            --version "$VERSION" \
+            --expected-sha "$TARGET_SHA"
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
@@ -286,14 +324,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.verify-full-nightly.outputs.head_sha }}
+          ref: ${{ needs.resolve-version.outputs.target_sha }}
           fetch-depth: 0
 
-      - name: Verify exact release checkout
+      - name: Verify immutable release target
         shell: bash
         env:
-          EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}
-        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          TARGET_SHA: ${{ needs.resolve-version.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          python3 scripts/ci/resolve_release_target.py verify \
+            --version "$VERSION" \
+            --expected-sha "$TARGET_SHA"
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
@@ -377,14 +421,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.verify-full-nightly.outputs.head_sha }}
+          ref: ${{ needs.resolve-version.outputs.target_sha }}
           fetch-depth: 0
 
-      - name: Verify exact release checkout
+      - name: Verify immutable release target
         shell: bash
         env:
-          EXPECTED_HEAD_SHA: ${{ needs.verify-full-nightly.outputs.head_sha }}
-        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          TARGET_SHA: ${{ needs.resolve-version.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          python3 scripts/ci/resolve_release_target.py verify \
+            --version "$VERSION" \
+            --expected-sha "$TARGET_SHA"
 
       - name: Resolve dependencies catalog ref
         shell: bash

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheDocumentationTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache/NearJCacheDocumentationTest.kt
@@ -7,7 +7,6 @@ import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheConfigurationMX
 import io.bluetape4k.cache.nearcache.jcache.management.NearJCacheTierStatisticsMXBean
 import io.bluetape4k.cache.nearcache.jcache.management.registerMBeans
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
@@ -304,7 +303,6 @@ class NearJCacheDocumentationTest {
 
     private fun read(relativePath: String): String {
         if (relativePath.startsWith("docs/manual/")) {
-            assumeTrue(Files.isDirectory(manualRoot), "central manual checkout is not available")
             return Files.readString(manualRoot.resolve(relativePath.removePrefix("docs/manual/")))
         }
         return Files.readString(repositoryRoot.resolve(relativePath))
@@ -498,7 +496,14 @@ class NearJCacheDocumentationTest {
                 .first { Files.exists(it.resolve("settings.gradle.kts")) }
         }
         private val manualRoot: Path by lazy {
-            Path.of(System.getenv("BLUETAPE4K_MANUAL_ROOT") ?: repositoryRoot.resolve("docs/manual").toString())
+            val configuredRoot = checkNotNull(System.getenv("BLUETAPE4K_MANUAL_ROOT")) {
+                "BLUETAPE4K_MANUAL_ROOT must point to the central manual checkout"
+            }
+            Path.of(configuredRoot).also { root ->
+                check(Files.isDirectory(root)) {
+                    "central manual checkout is not available: $root"
+                }
+            }
         }
     }
 }

--- a/docs/localization/korean-docs-kdoc-inventory.md
+++ b/docs/localization/korean-docs-kdoc-inventory.md
@@ -8,19 +8,26 @@ Issue: #1093
 - Korean rewrite target: prose in in-scope docs, public/internal KDoc, and meaningful internal/data-class property contracts.
 - Preserve exactly: code identifiers, API names, commands, URLs, exact error text, external product names, issue/PR numbers, and measured values.
 - Excluded from rewrite: README files, LLM-facing operating guidance, generated workflow state, CHANGELOG, SECURITY, GitHub metadata, release notes, and pushed commit text.
-- Parity-only: `docs/manual/en` and `docs/manual/ko` bilingual manual pairs.
+- Parity-only: `bluetape4k/bluetape4k.github.io`의
+  `docs/manual/bluetape4k-projects/en`과 `ko` bilingual pair.
 
-## Current inventory
+## 현재 inventory
 
-- Git-tracked files scanned: 7425
-- In-scope single-language docs: 728
-- Bilingual manual parity-only docs: 508
-- Excluded docs: 208
-- Kotlin/KTS files for KDoc follow-up: 4492
-- KDoc blocks found in Kotlin/KTS files: 34362
+- Central manual source: `bluetape4k/bluetape4k.github.io`
+- Central manual root: `docs/manual/bluetape4k-projects`
+- Central manual ref: `4e3c00262adb12cd61e4e8a30b6488aa6a287acc`
+- Git-tracked files scanned: 7233
+- In-scope single-language docs: 879
+- Bilingual manual parity-only docs: 516
+- Excluded docs: 214
+- Kotlin/KTS files for KDoc follow-up: 4613
+- KDoc blocks found in Kotlin/KTS files: 34756
 - Manual EN files missing KO pair: 0
 - Manual KO files missing EN pair: 0
 - English-KDoc policy drift findings: 0
+
+아래 bucket 표는 `#1093` 당시 repository-local manual이 존재하던 historical baseline이다.
+현재 CI guardrail은 위 central manual ref를 기준으로 parity를 검증한다.
 
 ### Document Classification
 
@@ -327,6 +334,7 @@ No English-KDoc policy drift was found in the tracked documentation scope.
 ## Reproduction
 
 ```bash
-python3 scripts/docs-localization-inventory.py
+export BLUETAPE4K_MANUAL_ROOT="/path/to/bluetape4k.github.io/docs/manual/bluetape4k-projects"
+export BLUETAPE4K_MANUAL_REF="$(git -C /path/to/bluetape4k.github.io rev-parse HEAD)"
 python3 scripts/docs-localization-inventory.py --check
 ```

--- a/docs/localization/korean-localization-guardrails.md
+++ b/docs/localization/korean-localization-guardrails.md
@@ -6,11 +6,13 @@ Issue: #1094
 
 이 문서는 `#1093`에서 만든 inventory 기준을 검증 가능한 guardrail로 고정한다.
 후속 번역 PR은 이 기준을 사용해 README, 운영 지침, GitHub 공개 메타데이터,
-`docs/manual/en`/`docs/manual/ko` bilingual pair를 잘못 번역 범위에 넣지 않아야 한다.
+central manual의 `en`/`ko` bilingual pair를 잘못 번역 범위에 넣지 않아야 한다.
 
 ## 검사 명령
 
 ```bash
+export BLUETAPE4K_MANUAL_ROOT="/path/to/bluetape4k.github.io/docs/manual/bluetape4k-projects"
+export BLUETAPE4K_MANUAL_REF="$(git -C /path/to/bluetape4k.github.io rev-parse HEAD)"
 python3 scripts/docs-localization-inventory.py --check
 ```
 
@@ -18,6 +20,8 @@ python3 scripts/docs-localization-inventory.py --check
 
 ```text
 Korean localization guardrail
+- central manual root: /path/to/bluetape4k.github.io/docs/manual/bluetape4k-projects
+- central manual ref: 4e3c00262adb12cd61e4e8a30b6488aa6a287acc
 - manual EN missing KO: 0
 - manual KO missing EN: 0
 - English-KDoc policy drift: 0
@@ -25,8 +29,10 @@ Korean localization guardrail
 
 ## 실패 조건
 
-- `docs/manual/en`에 대응되는 `docs/manual/ko` 파일이 없으면 실패한다.
-- `docs/manual/ko`에 대응되는 `docs/manual/en` 파일이 없으면 실패한다.
+- central manual `en`에 대응되는 `ko` 파일이 없으면 실패한다.
+- central manual `ko`에 대응되는 `en` 파일이 없으면 실패한다.
+- `BLUETAPE4K_MANUAL_ROOT`가 없거나 `BLUETAPE4K_MANUAL_REF`가 immutable commit SHA가
+  아니면 0/0 성공으로 처리하지 않고 실패한다.
 - tracked documentation scope 안에 `KDoc in English`, `English KDoc`,
   `Write KDoc in English` 같은 영어 KDoc 정책 문구가 다시 들어오면 실패한다.
 
@@ -37,7 +43,7 @@ Korean localization guardrail
   `.codex` 같은 LLM-facing 또는 generated operating surface는 영어 유지 대상이다.
 - `CHANGELOG.md`, `SECURITY.md`, GitHub issue/PR 본문, release notes,
   pushed commit message는 공개 contributor metadata이므로 영어 유지 대상이다.
-- `docs/manual/en`과 `docs/manual/ko`는 이미 bilingual pair로 관리되므로
+- central manual의 `en`과 `ko`는 이미 bilingual pair로 관리되므로
   rewrite 대상이 아니라 parity 검증 대상이다.
 
 ## 후속 작업 규칙

--- a/docs/process/module-documentation-checklist.md
+++ b/docs/process/module-documentation-checklist.md
@@ -60,9 +60,10 @@ metadata를 같은 변경에서 동기화하는 것이다.
   중앙 원본은 `bluetape4k/bluetape4k.github.io`의
   `docs/manual/bluetape4k-projects`이고, 도구는
   `scripts/manual/repositories/bluetape4k-projects`이다.
-- 소스 repository의 manual workflow는 중앙 사이트를 `.manual-site`에 checkout한 뒤
-  `SITE_ROOT`, `MANUAL_ROOT`, `TOOL_ROOT`, `MANIFEST`를 명시해 검증한다. 로컬 검증도 같은
-  변수와 중앙 경로를 사용한다.
+- 소스 repository의 `Central Manual Contract`와 `Test / Key Utils` CI job은 중앙 사이트를
+  pinned commit으로 `.manual-site`에 checkout한 뒤 `BLUETAPE4K_MANUAL_ROOT`와
+  `BLUETAPE4K_MANUAL_REF`를 명시해 parity와 `NearJCacheDocumentationTest`를 검증한다.
+  로컬 검증도 같은 변수와 중앙 경로를 사용한다.
 - Release 전에는 중앙 manifest의 `publication.contentStatus`를 `in-progress`로 유지하고,
   미래 tag/commit을 기록하지 않는다. 안정 tag와 공개 artifact를 검증한 뒤에만 정확한
   `releaseRef`/`releaseCommit`, generated manifest, validator/build 결과를 갱신한다.

--- a/scripts/ci/resolve_release_target.py
+++ b/scripts/ci/resolve_release_target.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+VERSION_PATTERN = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40,64}$")
+
+
+class ReleaseTargetError(RuntimeError):
+    pass
+
+
+def require_version(version: str) -> str:
+    if not VERSION_PATTERN.fullmatch(version):
+        raise ReleaseTargetError(f"Invalid release version: {version}")
+    return version
+
+
+def require_sha(value: str, *, field: str) -> str:
+    if not SHA_PATTERN.fullmatch(value):
+        raise ReleaseTargetError(f"Invalid {field}: {value or '<empty>'}")
+    return value.lower()
+
+
+def resolve_remote_tag(repository: Path, version: str) -> tuple[str, str]:
+    tag = f"refs/tags/{require_version(version)}"
+    peeled_tag = f"{tag}^{{}}"
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "origin", tag, peeled_tag],
+        cwd=repository,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode == 2:
+        raise ReleaseTargetError(f"Release tag {tag} does not exist on origin")
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "unknown git ls-remote failure"
+        raise ReleaseTargetError(f"Could not read {tag} from origin: {detail}")
+
+    refs = {}
+    for line in result.stdout.splitlines():
+        sha, ref = line.split("\t", 1)
+        refs[ref] = require_sha(sha, field=f"SHA for {ref}")
+
+    target_sha = refs.get(peeled_tag) or refs.get(tag)
+    if target_sha is None:
+        raise ReleaseTargetError(f"Release tag {tag} did not resolve to a commit")
+    return tag, target_sha
+
+
+def resolve_command(args: argparse.Namespace) -> None:
+    tag, target_sha = resolve_remote_tag(args.repository, args.version)
+    if args.event_name == "push":
+        event_sha = require_sha(args.event_sha, field="push event SHA")
+        if target_sha != event_sha:
+            raise ReleaseTargetError(
+                f"Release tag {tag} target {target_sha} does not match push event SHA {event_sha}"
+            )
+    elif args.event_name != "workflow_dispatch":
+        raise ReleaseTargetError(f"Unsupported release event: {args.event_name}")
+
+    print(f"version={args.version}")
+    print(f"tag={tag}")
+    print(f"target_sha={target_sha}")
+
+
+def verify_command(args: argparse.Namespace) -> None:
+    tag, target_sha = resolve_remote_tag(args.repository, args.version)
+    expected_sha = require_sha(args.expected_sha, field="expected release SHA")
+    if target_sha != expected_sha:
+        raise ReleaseTargetError(
+            f"Release tag {tag} moved from expected commit {expected_sha} to {target_sha}"
+        )
+    print(f"Verified {tag} -> {target_sha}")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(
+        description="Resolve and verify an immutable stable release target"
+    )
+    commands = root.add_subparsers(dest="command", required=True)
+
+    resolve = commands.add_parser("resolve")
+    resolve.add_argument("--repository", type=Path, default=Path.cwd())
+    resolve.add_argument("--version", required=True)
+    resolve.add_argument("--event-name", required=True)
+    resolve.add_argument("--event-sha", default="")
+    resolve.set_defaults(handler=resolve_command)
+
+    verify = commands.add_parser("verify")
+    verify.add_argument("--repository", type=Path, default=Path.cwd())
+    verify.add_argument("--version", required=True)
+    verify.add_argument("--expected-sha", required=True)
+    verify.set_defaults(handler=verify_command)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        args.handler(args)
+    except ReleaseTargetError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/resolve_release_target_test.py
+++ b/scripts/ci/resolve_release_target_test.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "resolve_release_target.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class ResolveReleaseTargetCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        root = Path(self.tempdir.name)
+        self.remote = root / "remote.git"
+        self.repository = root / "repository"
+
+        self.run_git(root, "init", "--bare", str(self.remote))
+        self.run_git(root, "init", "-b", "develop", str(self.repository))
+        self.run_git(self.repository, "config", "user.name", "Release Test")
+        self.run_git(self.repository, "config", "user.email", "release@example.com")
+        self.run_git(self.repository, "config", "commit.gpgSign", "false")
+        self.run_git(self.repository, "config", "tag.gpgSign", "false")
+        self.run_git(self.repository, "remote", "add", "origin", str(self.remote))
+        (self.repository / "release.txt").write_text("candidate\n", encoding="utf-8")
+        self.run_git(self.repository, "add", "release.txt")
+        self.run_git(self.repository, "commit", "-m", "release candidate")
+        self.run_git(self.repository, "push", "-u", "origin", "develop")
+        self.candidate_sha = self.git_output(self.repository, "rev-parse", "HEAD")
+
+    def run_git(self, cwd: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def git_output(self, cwd: Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+    def create_tag(self, *, annotated: bool) -> None:
+        args = ["tag"]
+        if annotated:
+            args.extend(["-a", "-m", "2.0.0"])
+        args.append("2.0.0")
+        self.run_git(self.repository, *args)
+        self.run_git(self.repository, "push", "origin", "refs/tags/2.0.0")
+
+    def run_script(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                *args,
+                "--repository",
+                str(self.repository),
+            ],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def assert_resolved_candidate(
+        self, result: subprocess.CompletedProcess[str]
+    ) -> None:
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("version=2.0.0", result.stdout)
+        self.assertIn("tag=refs/tags/2.0.0", result.stdout)
+        self.assertIn(f"target_sha={self.candidate_sha}", result.stdout)
+
+    def test_resolve_peels_annotated_tag_to_commit(self) -> None:
+        self.create_tag(annotated=True)
+
+        result = self.run_script(
+            "resolve",
+            "--version",
+            "2.0.0",
+            "--event-name",
+            "workflow_dispatch",
+        )
+
+        self.assert_resolved_candidate(result)
+
+    def test_resolve_accepts_lightweight_tag(self) -> None:
+        self.create_tag(annotated=False)
+
+        result = self.run_script(
+            "resolve",
+            "--version",
+            "2.0.0",
+            "--event-name",
+            "push",
+            "--event-sha",
+            self.candidate_sha,
+        )
+
+        self.assert_resolved_candidate(result)
+
+    def test_resolve_rejects_push_event_sha_mismatch(self) -> None:
+        self.create_tag(annotated=False)
+
+        result = self.run_script(
+            "resolve",
+            "--version",
+            "2.0.0",
+            "--event-name",
+            "push",
+            "--event-sha",
+            "0" * 40,
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("does not match push event SHA", result.stderr)
+
+    def test_verify_rejects_tag_moved_after_resolution(self) -> None:
+        self.create_tag(annotated=True)
+        (self.repository / "release.txt").write_text("moved\n", encoding="utf-8")
+        self.run_git(self.repository, "add", "release.txt")
+        self.run_git(self.repository, "commit", "-m", "move release tag")
+        self.run_git(self.repository, "tag", "-f", "-a", "2.0.0", "-m", "moved")
+        self.run_git(self.repository, "push", "--force", "origin", "refs/tags/2.0.0")
+
+        result = self.run_script(
+            "verify",
+            "--version",
+            "2.0.0",
+            "--expected-sha",
+            self.candidate_sha,
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("moved from expected commit", result.stderr)
+
+    def test_resolve_rejects_missing_tag(self) -> None:
+        result = self.run_script(
+            "resolve",
+            "--version",
+            "2.0.0",
+            "--event-name",
+            "workflow_dispatch",
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("does not exist on origin", result.stderr)
+
+    def test_resolve_preserves_hyphenated_prerelease_version_support(self) -> None:
+        self.run_git(self.repository, "tag", "2.0.0-rc-build.1")
+        self.run_git(
+            self.repository,
+            "push",
+            "origin",
+            "refs/tags/2.0.0-rc-build.1",
+        )
+
+        result = self.run_script(
+            "resolve",
+            "--version",
+            "2.0.0-rc-build.1",
+            "--event-name",
+            "workflow_dispatch",
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("version=2.0.0-rc-build.1", result.stdout)
+
+
+class ReleaseWorkflowPolicyTest(unittest.TestCase):
+    def test_release_jobs_checkout_and_verify_one_immutable_target(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("target_sha: ${{ steps.resolve.outputs.target_sha }}", workflow)
+        self.assertGreaterEqual(
+            workflow.count("ref: ${{ needs.resolve-version.outputs.target_sha }}"),
+            5,
+        )
+        self.assertNotIn("needs.resolve-version.outputs.ref", workflow)
+        self.assertGreaterEqual(workflow.count("resolve_release_target.py verify"), 5)
+        self.assertIn("Source commit", workflow)
+
+    def test_ci_runs_immutable_release_target_contract(self) -> None:
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "python3 -m unittest scripts/ci/resolve_release_target_test.py -v",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/docs-localization-inventory.py
+++ b/scripts/docs-localization-inventory.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 from collections import Counter
@@ -32,6 +33,7 @@ PUBLIC_ENGLISH_NAMES = {
 }
 MANUAL_EN = Path("docs/manual/en")
 MANUAL_KO = Path("docs/manual/ko")
+MANUAL_REF_PATTERN = re.compile(r"^[0-9a-fA-F]{40,64}$")
 KDOC_BLOCK = re.compile(r"/\\*\\*.*?\\*/", re.DOTALL)
 ENGLISH_KDOC_POLICY = [
     re.compile(r"KDoc\\s+in\\s+English", re.IGNORECASE),
@@ -132,14 +134,29 @@ def find_english_kdoc_policy_drift(root: Path, files: list[Path]) -> list[tuple[
     return findings
 
 
-def manual_relative_set(files: list[Path], root_dir: Path) -> set[Path]:
-    rels: set[Path] = set()
-    for path in files:
-        if path.suffix.lower() not in DOC_SUFFIXES:
-            continue
-        if is_under(path, root_dir):
-            rels.add(path.relative_to(root_dir))
-    return rels
+def central_manual_files(manual_root: Path, locale: str) -> set[Path]:
+    locale_root = manual_root / locale
+    return {
+        path.relative_to(locale_root)
+        for path in locale_root.rglob("*")
+        if path.is_file() and path.suffix.lower() in DOC_SUFFIXES
+    }
+
+
+def require_manual_contract(manual_root: Path, manual_ref: str) -> tuple[Path, str]:
+    resolved_root = manual_root.resolve()
+    if not resolved_root.is_dir():
+        raise ValueError(f"central manual root is not available: {resolved_root}")
+    for locale in ("en", "ko"):
+        if not (resolved_root / locale).is_dir():
+            raise ValueError(
+                f"central manual locale is not available: {resolved_root / locale}"
+            )
+    if not MANUAL_REF_PATTERN.fullmatch(manual_ref):
+        raise ValueError(
+            f"central manual ref must be an immutable commit SHA: {manual_ref or '<empty>'}"
+        )
+    return resolved_root, manual_ref.lower()
 
 
 def render_counter(title: str, counter: Counter[str], limit: int | None = None) -> list[str]:
@@ -159,7 +176,7 @@ def render_sample(title: str, paths: list[Path], limit: int = 40) -> list[str]:
     return lines
 
 
-def inventory(root: Path) -> dict[str, object]:
+def inventory(root: Path, manual_root: Path) -> dict[str, object]:
     files = git_files(root)
     doc_classes = Counter()
     doc_buckets: Counter[str] = Counter()
@@ -186,8 +203,12 @@ def inventory(root: Path) -> dict[str, object]:
     kotlin_buckets = Counter(kotlin_bucket(path) for path in kotlin_files)
     kdoc_buckets = count_kdoc_blocks(root, kotlin_files)
 
-    en_manual = manual_relative_set(files, MANUAL_EN)
-    ko_manual = manual_relative_set(files, MANUAL_KO)
+    en_manual = central_manual_files(manual_root, "en")
+    ko_manual = central_manual_files(manual_root, "ko")
+    parity_only = sorted(
+        {Path("en") / path for path in en_manual}
+        | {Path("ko") / path for path in ko_manual}
+    )
     missing_ko = sorted(en_manual - ko_manual)
     missing_en = sorted(ko_manual - en_manual)
     policy_drift = find_english_kdoc_policy_drift(root, files)
@@ -209,8 +230,8 @@ def inventory(root: Path) -> dict[str, object]:
     }
 
 
-def build_report(root: Path) -> str:
-    data = inventory(root)
+def build_report(root: Path, manual_root: Path, manual_ref: str) -> str:
+    data = inventory(root, manual_root)
     files = data["files"]
     doc_classes = data["doc_classes"]
     doc_buckets = data["doc_buckets"]
@@ -236,10 +257,12 @@ def build_report(root: Path) -> str:
         "- Korean rewrite target: prose in in-scope docs, public/internal KDoc, and meaningful internal/data-class property contracts.",
         "- Preserve exactly: code identifiers, API names, commands, URLs, exact error text, external product names, issue/PR numbers, and measured values.",
         "- Excluded from rewrite: README files, LLM-facing operating guidance, generated workflow state, CHANGELOG, SECURITY, GitHub metadata, release notes, and pushed commit text.",
-        "- Parity-only: `docs/manual/en` and `docs/manual/ko` bilingual manual pairs.",
+        "- Parity-only: central manual `en` and `ko` bilingual pairs.",
         "",
         "## Current Inventory",
         "",
+        f"- Central manual root: `{manual_root}`",
+        f"- Central manual ref: `{manual_ref}`",
         f"- Git-tracked files scanned: {len(files)}",
         f"- In-scope single-language docs: {len(in_scope_docs)}",
         f"- Bilingual manual parity-only docs: {len(parity_only)}",
@@ -274,7 +297,8 @@ def build_report(root: Path) -> str:
         "## Reproduction",
         "",
         "```bash",
-        "python3 scripts/docs-localization-inventory.py",
+        'export BLUETAPE4K_MANUAL_ROOT="/path/to/bluetape4k.github.io/docs/manual/bluetape4k-projects"',
+        'export BLUETAPE4K_MANUAL_REF="$(git -C /path/to/bluetape4k.github.io rev-parse HEAD)"',
         "python3 scripts/docs-localization-inventory.py --check",
         "```",
         "",
@@ -282,12 +306,14 @@ def build_report(root: Path) -> str:
     return "\n".join(lines)
 
 
-def run_check(root: Path) -> int:
-    data = inventory(root)
+def run_check(root: Path, manual_root: Path, manual_ref: str) -> int:
+    data = inventory(root, manual_root)
     missing_ko = data["missing_ko"]
     missing_en = data["missing_en"]
     policy_drift = data["policy_drift"]
     print("Korean localization guardrail")
+    print(f"- central manual root: {manual_root}")
+    print(f"- central manual ref: {manual_ref}")
     print(f"- manual EN missing KO: {len(missing_ko)}")
     print(f"- manual KO missing EN: {len(missing_en)}")
     print(f"- English-KDoc policy drift: {len(policy_drift)}")
@@ -305,14 +331,33 @@ def main() -> None:
         help="Repository root. Defaults to the current directory.",
     )
     parser.add_argument(
+        "--manual-root",
+        type=Path,
+        default=os.environ.get("BLUETAPE4K_MANUAL_ROOT"),
+        help="Central bluetape4k-projects manual root containing en/ and ko/.",
+    )
+    parser.add_argument(
+        "--manual-ref",
+        default=os.environ.get("BLUETAPE4K_MANUAL_REF", ""),
+        help="Immutable central manual commit SHA.",
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help="Fail when manual parity or English-KDoc policy drift is detected.",
     )
     args = parser.parse_args()
+    if args.manual_root is None:
+        parser.error(
+            "central manual root is not available: set --manual-root or BLUETAPE4K_MANUAL_ROOT"
+        )
+    try:
+        manual_root, manual_ref = require_manual_contract(args.manual_root, args.manual_ref)
+    except ValueError as error:
+        parser.error(str(error))
     if args.check:
-        raise SystemExit(run_check(args.root.resolve()))
-    print(build_report(args.root.resolve()))
+        raise SystemExit(run_check(args.root.resolve(), manual_root, manual_ref))
+    print(build_report(args.root.resolve(), manual_root, manual_ref))
 
 
 if __name__ == "__main__":

--- a/scripts/test_central_manual_contract.py
+++ b/scripts/test_central_manual_contract.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INVENTORY = REPO_ROOT / "scripts" / "docs-localization-inventory.py"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DOCUMENTATION_TEST = (
+    REPO_ROOT
+    / "cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache"
+    / "NearJCacheDocumentationTest.kt"
+)
+
+
+class CentralManualInventoryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        root = Path(self.tempdir.name)
+        self.project = root / "project"
+        self.manual = root / "manual"
+        self.project.mkdir()
+        (self.manual / "en").mkdir(parents=True)
+        (self.manual / "ko").mkdir(parents=True)
+        (self.project / "README.md").write_text("fixture\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-b", "develop"], cwd=self.project, check=True, capture_output=True)
+        subprocess.run(["git", "add", "README.md"], cwd=self.project, check=True, capture_output=True)
+
+    def write_manual(self, locale: str, relative_path: str) -> None:
+        target = self.manual / locale / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"# {locale}\n", encoding="utf-8")
+
+    def run_inventory(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "python3",
+                str(INVENTORY),
+                "--root",
+                str(self.project),
+                "--manual-root",
+                str(self.manual),
+                "--manual-ref",
+                "a" * 40,
+                "--check",
+            ],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_external_manual_pair_passes_and_reports_source_identity(self) -> None:
+        self.write_manual("en", "modules/cache.md")
+        self.write_manual("ko", "modules/cache.md")
+
+        result = self.run_inventory()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn(f"central manual root: {self.manual.resolve()}", result.stdout)
+        self.assertIn(f"central manual ref: {'a' * 40}", result.stdout)
+
+    def test_missing_korean_pair_fails(self) -> None:
+        self.write_manual("en", "modules/cache.md")
+
+        result = self.run_inventory()
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("manual EN missing KO: 1", result.stdout)
+
+    def test_missing_english_pair_fails(self) -> None:
+        self.write_manual("ko", "modules/cache.md")
+
+        result = self.run_inventory()
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("manual KO missing EN: 1", result.stdout)
+
+    def test_missing_manual_root_fails_closed(self) -> None:
+        missing = self.manual / "missing"
+        result = subprocess.run(
+            [
+                "python3",
+                str(INVENTORY),
+                "--root",
+                str(self.project),
+                "--manual-root",
+                str(missing),
+                "--manual-ref",
+                "a" * 40,
+                "--check",
+            ],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("central manual root is not available", result.stderr)
+
+
+class CentralManualCiPolicyTest(unittest.TestCase):
+    def test_documentation_test_fails_when_central_manual_is_absent(self) -> None:
+        source = DOCUMENTATION_TEST.read_text(encoding="utf-8")
+
+        self.assertNotIn("assumeTrue", source)
+        self.assertNotIn("repositoryRoot.resolve(\"docs/manual\")", source)
+        self.assertIn("BLUETAPE4K_MANUAL_ROOT", source)
+
+    def test_ci_checks_out_and_records_pinned_central_manual(self) -> None:
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertRegex(workflow, r"BLUETAPE4K_MANUAL_REF: '[0-9a-f]{40}'")
+        self.assertIn("repository: bluetape4k/bluetape4k.github.io", workflow)
+        self.assertIn("ref: ${{ env.BLUETAPE4K_MANUAL_REF }}", workflow)
+        self.assertIn("BLUETAPE4K_MANUAL_ROOT", workflow)
+        self.assertIn("docs/manual/bluetape4k-projects/manifest.yaml", workflow)
+        self.assertIn("tests=6, skipped=0, failures=0, errors=0", workflow)
+        self.assertIn(
+            "python3 -m unittest scripts/test_central_manual_contract.py -v",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -486,7 +486,11 @@ def privileged_action_ref_errors(workflow: str) -> list[str]:
 
 def release_policy_errors(workflow: str) -> list[str]:
     errors = privileged_action_ref_errors(workflow)
-    resolve_runs = workflow_step_runs(workflow, "resolve-version")
+    resolve_runs = [
+        record
+        for record in workflow_step_runs(workflow, "resolve-version")
+        if record[0] is not None
+    ]
     resolve_script = (
         "\n".join(resolve_runs[0][0][1])
         if len(resolve_runs) == 1 and resolve_runs[0][0] is not None
@@ -496,7 +500,10 @@ def release_policy_errors(workflow: str) -> list[str]:
         'if [[ "$EVENT_NAME" == "push" ]]',
         'VERSION="$TAG_NAME"',
         'VERSION="$INPUT_VERSION"',
-        'echo "ref=refs/tags/$VERSION" >> "$GITHUB_OUTPUT"',
+        "scripts/ci/resolve_release_target.py resolve",
+        '--event-name "$EVENT_NAME"',
+        '--event-sha "$EVENT_SHA"',
+        'cat "$RECEIPT" >> "$GITHUB_OUTPUT"',
     )
     if (
         "  push:\n" not in workflow.split("\n\nconcurrency:\n", 1)[0]
@@ -592,6 +599,7 @@ def release_policy_errors(workflow: str) -> list[str]:
     }:
         errors.append("publish must depend on exact-head Full Nightly and the image gates")
     exact_head_jobs = (
+        "verify-full-nightly",
         "testcontainers-manifest-contract",
         "testcontainers-image-gate",
         "testcontainers-ignite2-arm64-image-gate",
@@ -606,19 +614,25 @@ def release_policy_errors(workflow: str) -> list[str]:
             if step[1] is not None
             and step[1].split("@", 1)[0] == "actions/checkout"
         ]
-        verify_steps = [step for step in records if step[0] == "Verify exact release checkout"]
+        verify_steps = [step for step in records if step[0] == "Verify immutable release target"]
+        verify_script = (
+            "\n".join(verify_steps[0][3][1])
+            if len(verify_steps) == 1 and verify_steps[0][3] is not None
+            else ""
+        )
         if not (
             len(checkout_steps) == 1
             and not checkout_steps[0][4]
             and workflow_step_field_values(checkout_steps[0][2], "ref")
-            == ["${{ needs.verify-full-nightly.outputs.head_sha }}"]
+            == ["${{ needs.resolve-version.outputs.target_sha }}"]
             and workflow_step_field_values(checkout_steps[0][2], "fetch-depth") == ["0"]
             and len(verify_steps) == 1
             and not verify_steps[0][4]
-            and workflow_step_field_values(verify_steps[0][2], "EXPECTED_HEAD_SHA")
-            == ["${{ needs.verify-full-nightly.outputs.head_sha }}"]
-            and verify_steps[0][3]
-            == ("inline", ('test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"',))
+            and workflow_step_field_values(verify_steps[0][2], "TARGET_SHA")
+            == ["${{ needs.resolve-version.outputs.target_sha }}"]
+            and 'test "$(git rev-parse HEAD)" = "$TARGET_SHA"' in verify_script
+            and "scripts/ci/resolve_release_target.py verify" in verify_script
+            and '--expected-sha "$TARGET_SHA"' in verify_script
         ):
             exact_head_contract = False
             break
@@ -1343,7 +1357,7 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
     def test_release_publication_rejects_tag_ref_after_nightly_validation(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(
-            "ref: ${{ needs.verify-full-nightly.outputs.head_sha }}",
+            "ref: ${{ needs.resolve-version.outputs.target_sha }}",
             "ref: ${{ needs.resolve-version.outputs.ref }}",
             1,
         )


### PR DESCRIPTION
## 문제

Projects 2.0.0 정식 배포 전에 다음 false-green 및 provenance 공백을 닫아야 합니다.

- 중앙 manual checkout 부재가 NearJCache 문서 계약 테스트의 assumption skip으로 처리됨
- localization inventory가 제거된 repository-local manual을 검사해 0/0으로 통과함
- stable release가 mutable tag를 최초 source identity로 사용해 event/tag 이동을 구분하지 못함

## 변경

- remote stable tag를 commit SHA로 peel하고 push event SHA와 대조하는 resolver를 추가했습니다.
- release의 모든 checkout과 publish 전 검증을 동일한 immutable SHA에 고정했습니다.
- central manual을 commit `4e3c00262adb12cd61e4e8a30b6488aa6a287acc`로 checkout하고 manifest와 source identity를 기록합니다.
- NearJCache 문서 계약은 central manual이 없으면 fail-closed하고 JUnit `tests=6, skipped=0, failures=0, errors=0`을 요구합니다.
- localization inventory를 external manual root/ref 입력으로 전환하고 missing EN/KO 및 source 부재 회귀 테스트를 추가했습니다.
- 관련 운영 문서와 재현 명령을 실제 central manual 계약에 맞췄습니다.

## 검증

- Python 정책 및 회귀 테스트: `66/66`
- central manual parity: missing KO `0`, missing EN `0`, policy drift `0`
- `NearJCacheDocumentationTest`: `6/6`, skipped `0`
- `:bluetape4k-cache-core:test`: `719/719`, skipped `0`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`

## 운영 경계

live ruleset에는 tag target 보호가 없으므로 workflow가 tag를 최초 resolve한 SHA와 각 job 직전 remote tag identity를 재검증하는 fail-closed 경계를 제공합니다. 이 PR에서는 tag 생성, Maven Central publication, GitHub Release를 실행하지 않습니다.

Closes #1588
Closes #1589
Closes #1590

## DoD Status

- 상태: `PENDING` — PR CI 및 exact-head merge 승인 대기
- 구현/로컬 검증: 완료
- stable tag/publication: 미실행
