### PR TITLE
2.0.0 정식 배포 문서와 최종 SHA 순서를 정리한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 <!-- issue-1335-java25-semver:start -->
 ## [Unreleased]
 
+## [2.0.0] — 2026-09-01
+
 ### 호환성 변경
 
 - `bluetape4k-virtualthread-api`의 Java 21 호환 API 타입을
@@ -397,14 +399,6 @@
 - Fory-backed Kafka and Kafka4 codecs now carry `@BluetapeDelicateApi` and
   explicit trust-boundary documentation so callers are warned about the default
   Fory deserialization risk for shared or external topics ([#580](https://github.com/bluetape4k/bluetape4k-projects/issues/580)).
-
----
-
-## [Unreleased]
-
-### 변경
-
-- Opened the `1.11.0` development line after the `1.10.0` stable release.
 
 ### 추가
 

--- a/WIP.md
+++ b/WIP.md
@@ -1,55 +1,59 @@
 # WIP - bluetape4k-projects
 
-- 2026-08-26: `bluetape4k-virtualthread-api`의 API package ownership 경계를
-  `io.bluetape4k.concurrent.virtualthread.api`로 분리하는
-  [bluetape4k-graph #563](https://github.com/bluetape4k/bluetape4k-graph/issues/563)
-  지원 PR을 준비했다. core/JDK21/JDK25/API 테스트와 JAR
-  `java --validate-modules`가 통과했으며, 기존 API import는 재컴파일이
-  필요하다. upstream PR merge와 새 snapshot 소비 검증 전까지 graph 후속
-  PR은 대기한다.
-
-- 스냅샷: 2026-08-06 KST
-- 범위: `1.12.1` BOM publication inventory 복구 릴리스
-- 열린 release blocker: [#1313](https://github.com/bluetape4k/bluetape4k-projects/issues/1313)
+- 기준일: 2026-09-01 KST
+- 범위: `2.0.0` 정식 배포 준비
+- milestone: `2.0.0` (열림 0 / 닫힘 261)
+- 열린 release blocker: 없음
 
 ## 현재 상태
 
-`1.12.0`은 Maven Central에 게시됐지만 BOM에 실제로 게시되지 않는 benchmark와
-application-only 모듈 제약이 포함됐다. Central artifact는 불변이므로 #1313에서
-공통 publication 분류기와 생성 POM 인벤토리 검증을 추가하고 `1.12.1`로 복구한다.
+`2.0.0` milestone의 이슈와 PR은 모두 닫혔다. PR
+[#1591](https://github.com/bluetape4k/bluetape4k-projects/pull/1591)에서 stable
+tag의 immutable SHA 해석, exact-head Full Nightly 검증, 외부 Central manual의
+fail-closed 계약과 영문/한글 문서 동등성 검증을 통합했다.
+
+현재 `develop`의 검증 기준 SHA는
+`15c6e640409528d44ec35b580e7d0403cc46448a`이며, 해당 SHA의 post-merge CI
+[run 33503042621](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33503042621)은
+26개 job이 모두 성공했다. `baseVersion=2.0.0`, `snapshotVersion=` 상태이며
+`2.0.0` tag와 stable publication은 아직 생성하거나 실행하지 않았다.
 
 ## 배포 전 준비 상태
 
 | 항목 | 상태 | 근거 / 다음 조치 |
 |---|---|---|
-| `1.12.1` 이슈 | IN PROGRESS | #1313 구현과 전체 검증을 진행한다. |
-| publication inventory | VERIFIED LOCALLY | 생성된 75개 POM과 BOM 제약 집합이 일치한다. |
-| `CHANGELOG.md` | PREPARED | `1.12.1` 복구 사유와 검증 게이트를 기록한다. |
-| milestone 종료 | HOLD | Central의 전체 아티팩트 행렬이 HTTP 200이 된 뒤 닫는다. |
-| release / publish | HOLD | PR merge, Nightly, snapshot 검증 후 `1.12.1`을 게시한다. |
+| `2.0.0` milestone 이슈 | READY | 열린 이슈 0개, 닫힌 이슈 261개다. |
+| release 문서 | IN PROGRESS | 이 문서와 `CHANGELOG.md`를 최종화한 뒤 문서 PR을 병합한다. README/README.ko의 2.0.0, Java 25, 배포 명령은 현재 계약과 일치한다. |
+| `develop` post-merge CI | VERIFIED | SHA `15c6e640409528d44ec35b580e7d0403cc46448a`의 26개 job이 모두 성공했다. |
+| exact-head Full Nightly | PENDING | 문서 PR 병합 후 확정된 최종 `develop` SHA에서 실행한다. |
+| stable tag / publication | HOLD | 최종 Full Nightly 성공과 별도 승인 전에는 `2.0.0` tag를 만들거나 배포하지 않는다. |
+| Central / GitHub Release | HOLD | Maven Central publication 검증 후 별도 권한으로 진행한다. |
 
-## 신규 이슈 처리 원칙
+## SHA 및 배포 순서 원칙
 
-- 배포 전 검증에서 재현 가능한 결함, 문서 누락, 호환성 위험이 확인되면
-  `1.12.1` milestone에 추가하고 이 문서의 상태를 다시 갱신한다.
-- caller evidence가 없는 API 후보나 장기 설계 항목은 release blocker로
-  승격하지 않는다. 구체적인 production caller와 검증 가능한 계약이 생기면
-  별도 이슈로 재개한다.
-- milestone을 닫는 행위는 전체 Bluetape 배포 준비가 끝난 뒤 별도 판단한다.
+- 배포 준비 중인 mutable `develop` SHA를 문서나 workflow에 반복해서 고정하지
+  않는다. 문서와 이슈 정리가 모두 끝난 뒤의 최종 head만 배포 후보로 삼는다.
+- 문서 PR 병합처럼 source tree가 변경되면 이전 Nightly 결과를 재사용하지 않고
+  새 exact-head Full Nightly를 실행한다.
+- stable tag가 가리키는 commit은 immutable release source identity다. release
+  workflow는 tag를 실행 시점에 SHA로 해석하고 publication 전 다시 검증한다.
+- `2.0.0` tag 생성, publication, GitHub Release, milestone 종료는 각각의 검증과
+  권한 경계를 유지한다.
 
 ## Backlog
 
 | 이슈 | 상태 | 메모 |
 |---|---|---|
 | [#767](https://github.com/bluetape4k/bluetape4k-projects/issues/767) | HOLD | Owned money API 도입과 Moneta compatibility 경계는 별도 설계·마이그레이션 작업이다. |
-| [#1070](https://github.com/bluetape4k/bluetape4k-projects/issues/1070) | HOLD | Event Sourcing 및 projection primitive 수요를 검증하는 장기 설계 항목이다. |
 
-두 backlog 이슈는 현재 `1.12.1` release blocker가 아니다.
+#767은 현재 `2.0.0` release blocker가 아니다.
 
 ## 다음 단계
 
-1. 전체 Bluetape repository의 배포 준비 상태를 확인한다.
-2. #1313 PR을 merge하고 exact-head Nightly를 통과시킨다.
-3. `1.12.1-SNAPSHOT`의 전체 POM 행렬을 검증한 뒤 stable을 게시한다.
-4. Central 전체 행렬과 GitHub Release를 확인한 뒤 `1.12.0`, `1.12.1`
-   milestone을 정리한다.
+1. 이 문서와 `CHANGELOG.md`를 포함한 문서 PR을 병합한다.
+2. 최종 `develop` head에서 exact-head Full Nightly를 실행하고 성공 상태를
+   검증한다.
+3. 별도 승인 후 최종 head에 `2.0.0` tag를 만들고 stable release workflow를
+   실행한다.
+4. Maven Central의 전체 publication 행렬을 검증한 뒤 GitHub Release와
+   `2.0.0` milestone을 별도 권한으로 마무리한다.


### PR DESCRIPTION
## 목적

`bluetape4k-projects` 2.0.0 정식 배포 전에 release 문서의 기준과 실제 GitHub 상태를 일치시킵니다.

## 변경 사항

- `CHANGELOG.md`의 현재 변경분을 `2.0.0`으로 cut하고 빈 `Unreleased` 섹션을 유지했습니다.
- 1.9.0 아래에 남아 있던 역사적 중복 `Unreleased` heading과 이미 완료된 1.11.0 개발 시작 문구를 제거하되 기존 변경 기록은 보존했습니다.
- `WIP.md`를 2.0.0 milestone 열림 0개, PR #1591 병합, post-merge CI 26/26 성공 상태로 갱신했습니다.
- 배포 준비 중에는 mutable `develop` SHA를 반복 고정하지 않고, 이 PR 병합 후 확정된 final head에서 exact-head Full Nightly를 새로 실행하도록 순서를 명시했습니다.
- README/README.ko는 2.0.0, Java 25, stable/SNAPSHOT 명령이 이미 일치해 변경하지 않았습니다.

## 검증

- JVM release contract: 11/11 성공
- release workflow policy: 52/52 성공
- immutable release target resolver: 8/8 성공
- Central manual contract: 6/6 성공
- 실제 central manual EN/KO 누락: 0/0
- English-KDoc policy drift: 0
- `git diff --check`: 성공

## 배포 경계

이 PR은 문서만 정리합니다. `2.0.0` tag 생성, Full Nightly dispatch, Maven Central publication, GitHub Release, milestone 종료는 수행하지 않습니다.

## DoD Status

- DONE: 2.0.0 CHANGELOG cut 및 WIP 최신화
- DONE: README/README.ko 현행 계약 확인
- DONE: 로컬 release 문서·workflow 정책 검증
- PENDING: 이 PR의 exact-head CI
- PENDING: 병합 후 final `develop` exact-head Full Nightly
