### PR TITLE
[ci][release] Full Nightly에 중앙 manual 계약을 연결

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -29,6 +29,7 @@ env:
   JAVA_DISTRIBUTION: 'temurin'
   ORG_GRADLE_PROJECT_excludeBenchmarks: 'true'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  BLUETAPE4K_MANUAL_REF: '4e3c00262adb12cd61e4e8a30b6488aa6a287acc'
 
 jobs:
   plan:
@@ -764,8 +765,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, plan]
     if: ${{ needs.plan.outputs.run_standard == 'true' }}
+    env:
+      BLUETAPE4K_MANUAL_ROOT: ${{ github.workspace }}/.manual-site/docs/manual/bluetape4k-projects
     steps:
       - uses: actions/checkout@v7
+
+      - uses: actions/checkout@v7
+        with:
+          repository: bluetape4k/bluetape4k.github.io
+          ref: ${{ env.BLUETAPE4K_MANUAL_REF }}
+          path: .manual-site
+
+      - name: Verify immutable central manual checkout
+        run: |
+          test "$(git -C .manual-site rev-parse HEAD)" = "$BLUETAPE4K_MANUAL_REF"
+          test -f .manual-site/docs/manual/bluetape4k-projects/manifest.yaml
+          echo "central manual commit=$BLUETAPE4K_MANUAL_REF"
 
       - name: Validate mock server Kover isolation
         id: validate-kover-isolation

--- a/scripts/test_central_manual_contract.py
+++ b/scripts/test_central_manual_contract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INVENTORY = REPO_ROOT / "scripts" / "docs-localization-inventory.py"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+NIGHTLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "nightly-tests.yml"
 DOCUMENTATION_TEST = (
     REPO_ROOT
     / "cache/cache-core/src/test/kotlin/io/bluetape4k/cache/nearcache/jcache"
@@ -122,6 +123,18 @@ class CentralManualCiPolicyTest(unittest.TestCase):
             "python3 -m unittest scripts/test_central_manual_contract.py -v",
             workflow,
         )
+
+    def test_full_nightly_misc_job_provides_pinned_central_manual(self) -> None:
+        workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+        misc_job = workflow.split("\n  test-misc:\n", maxsplit=1)[1].split(
+            "\n  test-infra:\n", maxsplit=1
+        )[0]
+
+        self.assertRegex(workflow, r"BLUETAPE4K_MANUAL_REF: '[0-9a-f]{40}'")
+        self.assertIn("repository: bluetape4k/bluetape4k.github.io", misc_job)
+        self.assertIn("ref: ${{ env.BLUETAPE4K_MANUAL_REF }}", misc_job)
+        self.assertIn("BLUETAPE4K_MANUAL_ROOT", misc_job)
+        self.assertIn("docs/manual/bluetape4k-projects/manifest.yaml", misc_job)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 문제

Projects 2.0.0 정식 배포 선행 게이트인 Full Nightly에서 `Test / Misc`가 실패했습니다. `NearJCacheDocumentationTest` 3건이 `BLUETAPE4K_MANUAL_ROOT must point to the central manual checkout`으로 실패해 exact-head Nightly가 release-eligible 상태가 되지 못했습니다.

## 원인

기존 #1588 수정은 PR CI의 `test-key-utils`에 고정 central manual checkout을 제공했지만, 같은 `:bluetape4k-cache-core:test`를 실행하는 `.github/workflows/nightly-tests.yml`의 `test-misc`에는 checkout과 환경 변수를 전달하지 않았습니다.

## 변경

- Nightly 전역에 central manual commit `4e3c00262adb12cd61e4e8a30b6488aa6a287acc`를 고정했습니다.
- `test-misc`가 해당 commit을 checkout하고 `BLUETAPE4K_MANUAL_ROOT`를 job 전체에 제공합니다.
- checkout SHA와 `manifest.yaml` 존재를 테스트 전에 fail-closed로 검증합니다.
- Nightly의 manual checkout, ref, root, manifest 계약을 정책 회귀 테스트로 고정했습니다.

## 검증

- 정책 테스트 RED 확인: Nightly manual ref 누락으로 실패
- `python3 -m unittest scripts/test_central_manual_contract.py -v`: 7/7
- workflow 관련 Python 테스트: 103/103
- `actionlint .github/workflows/nightly-tests.yml`
- `NearJCacheDocumentationTest`: 6/6
- `:bluetape4k-cache-core:test`: 719/719
- `git diff --check`

Fixes #1588

## DoD Status

- 상태: `MERGE READY` — fresh exact-head merge 승인 대기
- exact head: `c44beb061c5992f88a2f11cc4c9f05399ee057e8`
- PR CI: 26/26 성공, failure/skipped/pending 0
- review: P0/P1 0, unresolved thread 0
- 새 develop SHA Full Nightly: 병합 후 재실행 예정
- tag 및 정식 publication: 미실행