### PR TITLE
fix(ci): image gate 인프라 실패를 bounded retry한다

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1276,7 +1276,7 @@ jobs:
           --shard-count 4
           --report-dir build/reports/testcontainers-image-gate
           --default-platform-id amd64
-          --max-attempts 1
+          --max-attempts 2
           --pull-timeout-seconds 60
           --timeout-minutes 4
           --diagnostic-timeout-seconds 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
           --scope full
           --report-dir build/reports/testcontainers-image-gate
           --default-platform-id amd64
-          --max-attempts 1
+          --max-attempts 2
           --pull-timeout-seconds 60
           --timeout-minutes 4
           --diagnostic-timeout-seconds 30

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -824,6 +824,31 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
             for name in sorted(expected_names)
         ]
 
+    def test_generic_image_gates_retry_only_transient_infrastructure_failures(self) -> None:
+        cases = (
+            (
+                "nightly-tests.yml",
+                "test-testcontainers-image-gate-shard",
+                "Run image family gate shard sequentially",
+            ),
+            (
+                "release.yml",
+                "testcontainers-image-gate",
+                "Run full image family gate",
+            ),
+        )
+
+        for workflow_name, job_id, step_name in cases:
+            with self.subTest(workflow=workflow_name):
+                workflow = (WORKFLOWS / workflow_name).read_text(encoding="utf-8")
+                runs = workflow_step_runs(workflow, job_id, step_name)
+
+                self.assertEqual(1, len(runs))
+                self.assertIsNotNone(runs[0][0])
+                command = "\n".join(runs[0][0][1])
+                self.assertIn("--max-attempts 2", command)
+                self.assertNotIn("--max-attempts 1", command)
+
     def test_semantic_checker_rejects_snapshot_task_and_release_action(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
         mutated = workflow.replace(

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -300,6 +300,30 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
         self.assertEqual("infrastructure_failure", classify_failure(1, "connection refused", ""))
         self.assertEqual("infrastructure_failure", classify_failure(None, "", "timeout"))
 
+    def test_product_failure_does_not_retry(self) -> None:
+        calls: list[list[str]] = []
+
+        def command_runner(command: list[str], timeout_seconds: int) -> SimpleNamespace:
+            calls.append(command)
+            return SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="AssertionError: expected 200",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            summary = GateRunner(
+                [entry()],
+                Path(directory),
+                command_runner=command_runner,
+                max_attempts=2,
+            ).run()
+
+        self.assertEqual("product_failure", summary["results"][0]["status"])
+        self.assertEqual(1, len(summary["results"][0]["attempts"]))
+        gradle_calls = [command for command in calls if command[0] == "./gradlew"]
+        self.assertEqual(1, len(gradle_calls))
+
     def test_test_discovery_failure_wins_over_unrelated_docker_output(self) -> None:
         stdout = "building image to Docker daemon\ntimeout while preparing unrelated diagnostics\n"
         stderr = (


### PR DESCRIPTION
## 목적

Projects 2.0.0 Full Nightly에서 서로 다른 runner의 Elasticsearch와 PostgreSQL image family가 각각 한 번의 infrastructure_failure로 종료되어 전체 publish gate가 차단된 문제를 바로잡습니다.

Closes #1594

## 변경

- Nightly의 4개 generic image gate shard를 --max-attempts 2로 실행합니다.
- stable Release의 full generic image gate도 --max-attempts 2로 맞춥니다.
- workflow policy가 두 값의 drift를 거부하도록 고정합니다.
- runner가 infrastructure_failure는 재시도하지만 product_failure는 한 번만 실행하는 경계를 unit test로 고정합니다.
- Ignite2 arm64 exact-platform gate, exact-head Full Nightly 검증, manifest/digest/platform 검증은 변경하지 않습니다.

## 검증

- RED: 새 workflow policy test가 Nightly/Release의 기존 --max-attempts 1에서 2건 실패
- GREEN: workflow policy 및 image gate runner 84/84
- actionlint .github/workflows/nightly-tests.yml .github/workflows/release.yml
- git diff --check
- PR CI: exact head 23aadf9f0801221b04e7afcc9773c89e84590f6b, 26/26 성공
- 미해결 review thread: 0

## DoD Status

- 상태: 병합 준비 완료
- exact head: 23aadf9f0801221b04e7afcc9773c89e84590f6b
- 변경 범위: workflow 2개, 회귀 테스트 2개
- unchecked: 병합 후 develop CI, 새 develop Full Nightly publish_eligible=true