### PR TITLE
docs(release): mutable 후보 SHA를 WIP에서 제거한다

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -2,37 +2,39 @@
 
 - 기준일: 2026-09-01 KST
 - 범위: `2.0.0` 정식 배포 준비
-- milestone: `2.0.0` (열림 0 / 닫힘 261)
-- 열린 release blocker: 없음
+- milestone: `2.0.0` (실시간 상태는 GitHub milestone을 기준으로 확인)
+- release blocker: tag 생성 직전에 GitHub의 열린 이슈와 PR을 다시 확인
 
 ## 현재 상태
 
-`2.0.0` milestone의 이슈와 PR은 모두 닫혔다. PR
-[#1591](https://github.com/bluetape4k/bluetape4k-projects/pull/1591)에서 stable
-tag의 immutable SHA 해석, exact-head Full Nightly 검증, 외부 Central manual의
-fail-closed 계약과 영문/한글 문서 동등성 검증을 통합했다.
+`baseVersion=2.0.0`, `snapshotVersion=` 상태이며 release 준비에 필요한 source
+변경을 모두 마친 뒤 `develop` head를 한 번만 최종 후보로 선택한다. WIP에는
+mutable `develop` SHA나 과거 CI run ID를 현재 기준처럼 기록하지 않는다.
 
-현재 `develop`의 검증 기준 SHA는
-`15c6e640409528d44ec35b580e7d0403cc46448a`이며, 해당 SHA의 post-merge CI
-[run 33503042621](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33503042621)은
-26개 job이 모두 성공했다. `baseVersion=2.0.0`, `snapshotVersion=` 상태이며
-`2.0.0` tag와 stable publication은 아직 생성하거나 실행하지 않았다.
+PR [#1591](https://github.com/bluetape4k/bluetape4k-projects/pull/1591)은 stable
+tag의 immutable SHA 해석, exact-head Full Nightly 검증, 외부 Central manual의
+fail-closed 계약과 영문/한글 문서 동등성 검증을 통합했다. PR
+[#1595](https://github.com/bluetape4k/bluetape4k-projects/pull/1595)는 image gate의
+일시적 `infrastructure_failure`만 최대 두 번 시도하고 `product_failure`는 즉시
+종료하는 bounded retry 경계를 고정했다.
 
 ## 배포 전 준비 상태
 
 | 항목 | 상태 | 근거 / 다음 조치 |
 |---|---|---|
-| `2.0.0` milestone 이슈 | READY | 열린 이슈 0개, 닫힌 이슈 261개다. |
-| release 문서 | IN PROGRESS | 이 문서와 `CHANGELOG.md`를 최종화한 뒤 문서 PR을 병합한다. README/README.ko의 2.0.0, Java 25, 배포 명령은 현재 계약과 일치한다. |
-| `develop` post-merge CI | VERIFIED | SHA `15c6e640409528d44ec35b580e7d0403cc46448a`의 26개 job이 모두 성공했다. |
-| exact-head Full Nightly | PENDING | 문서 PR 병합 후 확정된 최종 `develop` SHA에서 실행한다. |
-| stable tag / publication | HOLD | 최종 Full Nightly 성공과 별도 승인 전에는 `2.0.0` tag를 만들거나 배포하지 않는다. |
-| Central / GitHub Release | HOLD | Maven Central publication 검증 후 별도 권한으로 진행한다. |
+| `2.0.0` milestone 이슈 | GATE | tag 생성 직전에 live GitHub 상태에서 열린 release blocker가 0개인지 확인한다. |
+| release 문서 | READY | WIP, CHANGELOG, README/README.ko의 2.0.0, Java 25, 배포 명령을 source freeze 전에 최종화한다. |
+| `develop` post-merge CI | GATE | source freeze를 만든 마지막 PR의 merge SHA에서 CI와 Dependency Submission 성공을 확인한다. |
+| exact-head Full Nightly | GATE | source freeze 뒤 최종 `develop` head에서 한 번 실행하고 `publish_eligible=true`를 확인한다. |
+| stable tag / publication | GATE | Full Nightly가 증명한 exact head에 signed annotated `2.0.0` tag를 만든다. |
+| Central / GitHub Release | GATE | release workflow 성공 뒤 Maven Central 전체 publication과 GitHub Release를 공개 상태에서 확인한다. |
 
 ## SHA 및 배포 순서 원칙
 
 - 배포 준비 중인 mutable `develop` SHA를 문서나 workflow에 반복해서 고정하지
   않는다. 문서와 이슈 정리가 모두 끝난 뒤의 최종 head만 배포 후보로 삼는다.
+- 최종 후보 SHA와 Full Nightly run ID는 GitHub Actions와 release attestation에
+  남기고, 다음 source 변경을 유발하는 WIP 최신화 대상으로 삼지 않는다.
 - 문서 PR 병합처럼 source tree가 변경되면 이전 Nightly 결과를 재사용하지 않고
   새 exact-head Full Nightly를 실행한다.
 - stable tag가 가리키는 commit은 immutable release source identity다. release
@@ -50,10 +52,11 @@ fail-closed 계약과 영문/한글 문서 동등성 검증을 통합했다.
 
 ## 다음 단계
 
-1. 이 문서와 `CHANGELOG.md`를 포함한 문서 PR을 병합한다.
-2. 최종 `develop` head에서 exact-head Full Nightly를 실행하고 성공 상태를
+1. release 준비 source 변경을 모두 병합하고 source freeze를 선언한다.
+2. 마지막 merge SHA의 post-merge CI와 Dependency Submission을 확인한다.
+3. 같은 SHA에서 exact-head Full Nightly를 실행해 `publish_eligible=true`를
    검증한다.
-3. 별도 승인 후 최종 head에 `2.0.0` tag를 만들고 stable release workflow를
-   실행한다.
-4. Maven Central의 전체 publication 행렬을 검증한 뒤 GitHub Release와
-   `2.0.0` milestone을 별도 권한으로 마무리한다.
+4. 검증된 exact head에 signed annotated `2.0.0` tag를 만들고 release
+   workflow를 실행한다.
+5. Maven Central 전체 publication과 GitHub Release를 공개 상태에서 확인한 뒤
+   `2.0.0` milestone을 마무리하고 downstream handoff를 시작한다.


### PR DESCRIPTION
## 목적

release 준비 문서를 최신화할 때마다 후보 SHA가 바뀌어 Full Nightly를 반복하는 순서 꼬임을 제거합니다.

Closes #1596

## 변경

- WIP에서 mutable develop SHA와 과거 CI run ID를 제거했습니다.
- milestone 고정 집계를 제거하고 tag 직전 live GitHub 확인을 gate로 명시했습니다.
- 이번 release train에 이미 부여된 권한과 충돌하는 별도 승인 대기 문구를 제거했습니다.
- source freeze, post-merge CI, exact-head Full Nightly, signed tag, 공개 artifact 검증 순서를 명시했습니다.
- 최종 SHA와 Nightly run ID는 다음 source 변경을 유발하는 WIP가 아니라 Actions와 release attestation에 남기도록 했습니다.

## 전체 source-freeze audit

- WIP, CHANGELOG, README/README.ko, gradle.properties, release/nightly workflow를 함께 점검했습니다.
- baseVersion=2.0.0, 빈 snapshotVersion, Java 25 및 양 언어 배포 명령이 일치합니다.
- release 정책, immutable target, JVM, central manual 계약 79/79가 성공했습니다.
- actionlint와 README diagram 274/274가 성공했습니다.
- 2.0.0 tag, GitHub Release, active publish run은 없습니다.
- live release blocker는 이 issue/PR 한 쌍뿐이며 추가 source 수정은 0건입니다.

## DoD Status

- 상태: source-freeze 병합 준비 완료
- exact head: d541fdae3cf1f202b3deeb9cbe853a35845434d3
- PR CI: success 11, docs-only path-filter skip 13, failure 0
- 변경 범위: WIP.md 1개
- unchecked: 병합 SHA의 full push CI, exact-head Full Nightly publish_eligible=true