### PR TITLE
docs: Actions gate 단순화 결과를 배포 후 상태로 닫는다

### DIFF
--- a/docs/operations/ecosystem-actions-gate-contract.md
+++ b/docs/operations/ecosystem-actions-gate-contract.md
@@ -29,18 +29,38 @@ terminal success, required matrix, `publish_eligible=true`를 fail-closed로 검
 
 | 저장소 | PR/develop CI | Full Nightly | SNAPSHOT/stable release |
 |---|---|---|---|
-| Projects | path-filtered module tests와 일부 container tests | 전체 module, 52-family image gate, Ignite 2 arm64 | Nightly attestation 재사용, runtime gate 없음 |
+| Projects | path-filtered module tests와 일부 container tests | 전체 module과 현재 지원 image family gate | Nightly attestation 재사용, runtime gate 없음 |
 | AWS | emulator별 module tests | AWS backend 전체 | runtime gate 없음 |
 | Exposed | H2 중심 + 변경 영향 DB/cache module | JDBC/R2DBC/Redis/DB 전체 | runtime gate 없음 |
-| Graph | backend tests, benchmark, image gate가 과다 결합 | backend와 image gate 전체 | runtime gate 없음 |
+| Graph | path router가 선택한 backend tests만 실행 | backend와 image gate 전체 | Nightly attestation 재사용, runtime gate 없음 |
 | Image | image/native/OCR 영향 module | 전체 image/native matrix | Nightly attestation 또는 runtime gate 없음 |
 | Javers | Redis/Kafka/Exposed 영향 module | persistence backend 전체 | runtime gate 없음 |
 | Leader | backend 영향 module | 전체 leader backend matrix | runtime gate 없음 |
 | Text | tokenizer/search unit 중심 | 전체 module | runtime gate 없음 |
 
-Graph의 workflow·문서-only PR 과다 실행은 Graph #602에서 path routing과 fail-fast를
-직접 수정한다. Projects release의 중복 image gate는 Projects #1598/PR #1599에서
-제거했다.
+Graph의 workflow·문서-only PR 과다 실행은 Graph #602/PR #608에서 path routing과
+fail-fast로 제거했다. Projects release의 중복 image gate는 Projects #1598/PR #1599에서
+제거했고, Ignite 2 전용 image/arm64 gate는 Projects #1600/PR #1607에서 지원 코드와
+함께 제거했다.
+
+## 배포 후 ecosystem audit
+
+2026-09-02의 최종 `origin/develop`을 다시 확인했다. Projects, AWS, Exposed,
+Graph, Image, Javers, Leader, Text의 stable release 및 SNAPSHOT publication workflow는
+Testcontainers runtime suite나 image startup gate를 새로 실행하지 않는다. release
+workflow에 남은 `Testcontainers` 문자열은 contract 검증이나 catalog alias 확인이며
+container 기동이 아니다.
+
+PR/develop CI와 Full Nightly에 같은 backend 이름이 존재하는 것은 중복 배포 gate가
+아니다. CI는 path-filtered 변경 영향 범위를 빠르게 확인하고, Nightly는 전체 backend
+matrix와 image compatibility의 canonical 증거를 만든다. Text는 두 경로 모두 별도
+container job이 없다. 따라서 배포 후 추가로 runtime 검증을 제거하면 안전 경계를
+약화시키며, 현재 최소 경계는 다음과 같다.
+
+- 변경 영향 검증: PR/develop CI에서 한 번
+- 전체 호환성 검증: exact-head Full Nightly에서 한 번
+- SNAPSHOT/stable publication: 위 증거를 재사용하고 container 0개
+- 문서/workflow-only PR: Graph path router처럼 heavy/container 0개
 
 ## catalog 전환 계약
 
@@ -64,9 +84,12 @@ GitHub Actions API의 run/job timestamp를 사용했다. runner 시간은 각 jo
 | Projects 중복 release run `33527449585` | cancelled | 68분 | 6 | 74분 | 3 |
 | Projects attestation-only run `33537327623` | success | 8분 | 3 | 8분 | 0 |
 | Graph 과다 PR run `33537634192` | failure | 6분 | 21 | 37분 | 9 |
+| Graph path-routed PR run `33616285791` | success | 68초 | 18 | 약 1분 | 0 |
 
 Projects stable release 경로는 job 6→3, container job 3→0, 관측 runner 시간
 74→8분으로 줄었다. 첫 run은 68분에 취소됐으므로 절감치는 보수적인 하한이다.
+Graph의 workflow-only PR은 heavy job 11개를 명시적으로 skip하고 container job을
+9→0으로 줄였으며, 전체 경과 시간은 6분→68초로 줄었다.
 
 ## 유지할 안전 경계
 


### PR DESCRIPTION
## 변경 사항

- Projects #1600/PR #1607의 Ignite 2 image/arm64 gate 제거를 inventory에 반영했습니다.
- Graph #602/PR #608의 path routing 결과와 실제 run 33616285791 지표를 추가했습니다.
- 8개 JVM 소비자 저장소의 최종 CI/Nightly/release/SNAPSHOT workflow를 다시 점검했습니다.
- stable/SNAPSHOT publication은 container 0개, PR CI는 변경 영향, Full Nightly는 전체 호환성이라는 최소 책임을 명시했습니다.
- catalog repository variable은 8개 저장소에서 모두 삭제되어 hidden fallback이 남지 않습니다.
- Image/Javers/Text CodeQL은 `--no-build-cache` compile을 사용함을 확인했습니다.

## 검증

- 8개 저장소 `origin/develop` workflow read-back
- release/SNAPSHOT runtime container job: 0
- `BLUETAPE4K_DEPENDENCIES_CATALOG_REF` live repository variable: 8/8 absent
- Graph run 33616285791: 68초, heavy 11 skipped, container 0
- `git diff --check`: PASS

Closes #1605
Refs #1451
Refs bluetape4k/bluetape4k-graph#602

## DoD Status

- [x] ecosystem inventory 최신화
- [x] canonical gate/재사용 계약
- [x] release container 중복 제거 확인
- [x] catalog hidden variable 제거
- [x] CodeQL cache-safe build 확인
- [x] 변경 전후 지표 기록
- [ ] PR CI와 exact-head 병합
