### PR TITLE
[coroutines][bug] groupBy 미수집 그룹을 terminal 상태로 닫고 late collector 영구 대기를 제거한다

### DIFF
--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/Resumable.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/Resumable.kt
@@ -90,6 +90,13 @@ open class Resumable {
         continuationRef.getAndSet(READY)?.resumeWith(RESULT_SUCCESS)
     }
 
+    /**
+     * 이미 기록된 READY 신호를 대기 없이 소비합니다.
+     *
+     * 대기 없이 신호를 확인해야 하는 내부 handshake 경로에서만 사용합니다.
+     */
+    internal fun tryAcquireReady(): Boolean = continuationRef.compareAndSet(READY, null)
+
     private class ReadyContinuation: Continuation<Any> {
         override val context: CoroutineContext
             get() = EmptyCoroutineContext

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/groupBy.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/groupBy.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.withTimeout
 import org.eclipse.collections.api.multimap.list.ListMultimap
 import org.eclipse.collections.api.multimap.list.MutableListMultimap
@@ -249,9 +250,16 @@ internal fun <T, K: Any, V> groupByInternal(
                         emit(group)
                     } catch (e: CancellationException) {
                         state.mainStopped.value = true
-                        if (map.isEmpty()) {
-                            throw e
+                        // flatMapMerge가 이미 받은 그룹의 collector를 시작할 기회를
+                        // 한 번 양보한 뒤, 준비된 경우에만 첫 값을 전달합니다.
+                        yield()
+                        if (!group.tryNext { valueSelector(it) }) {
+                            group.abandon()
+                            if (map.isEmpty()) {
+                                throw e
+                            }
                         }
+                        return@collect
                     }
                     group.next(valueSelector(it))
                 } else {
@@ -354,7 +362,16 @@ private class FlowGroup<K: Any, V>(
         valueReady.resume()
     }
 
-    private fun abandon() {
+    fun tryNext(valueProvider: () -> V): Boolean {
+        if (cancelled.value || !consumerReady.tryAcquireReady()) return false
+
+        this.value = valueProvider()
+        this.hasValue.value = true
+        valueReady.resume()
+        return true
+    }
+
+    fun abandon() {
         map.remove(this.key, this)
         cancelled.value = true
         done.value = true

--- a/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/groupBy.kt
+++ b/bluetape4k/coroutines/src/main/kotlin/io/bluetape4k/coroutines/flow/extensions/groupBy.kt
@@ -183,6 +183,8 @@ suspend fun <K: Any, V> Flow<GroupedFlow<K, V>>.toListMultiMap(
  * ## 동작/계약
  * - 새 키가 등장하면 새로운 [GroupedFlow]를 방출하고, 이후 같은 키 값은 해당 그룹으로 전달합니다.
  * - 그룹 Flow는 최대 한 번만 수집할 수 있습니다.
+ * - 그룹이 consumer 대기 시간 안에 수집되지 않으면 해당 그룹을 포기하며,
+ *   이후 late collector는 빈 Flow로 종료됩니다.
  * - 업스트림 오류는 [FlowOperationException]으로 감싸 전파됩니다.
  * - 다운스트림 취소 시 남은 그룹이 없으면 수집을 조기 종료합니다.
  *
@@ -342,13 +344,20 @@ private class FlowGroup<K: Any, V>(
                 consumerReady.await()
             }
         } catch (e: TimeoutCancellationException) {
-            // 그룹이 타임아웃 내에 수집되지 않음 — upstream에 전파하지 않고 해당 그룹만 포기
-            map.remove(this.key)
-            cancelled.value = true
+            // 그룹이 타임아웃 내에 수집되지 않음 — upstream에 전파하지 않고
+            // 해당 그룹만 종료
+            abandon()
             return
         }
         this.value = value
         this.hasValue.value = true
+        valueReady.resume()
+    }
+
+    private fun abandon() {
+        map.remove(this.key, this)
+        cancelled.value = true
+        done.value = true
         valueReady.resume()
     }
 

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/GroupByTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/GroupByTest.kt
@@ -10,13 +10,23 @@ import io.bluetape4k.coroutines.flow.exceptions.FlowOperationException
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.trace
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.eclipse.collections.api.multimap.list.ListMultimap
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 class GroupByTest: AbstractFlowTest() {
 
@@ -92,6 +102,30 @@ class GroupByTest: AbstractFlowTest() {
             .flatMapMerge { it }
             .take(2)
             .assertResult(1, 2)
+    }
+
+    @Test
+    fun `late collector after abandoned group completes`() = runTest {
+        val groupReady = CompletableDeferred<GroupedFlow<Int, Int>>()
+        val producer = launch {
+            flow {
+                emit(1)
+                awaitCancellation()
+            }
+                .groupBy { it }
+                .collect { groupReady.complete(it) }
+        }
+
+        try {
+            val group = groupReady.await()
+            advanceTimeBy(5_001)
+            runCurrent()
+
+            val values = withTimeout(100.milliseconds) { group.toList() }
+            values shouldBeEqualTo emptyList()
+        } finally {
+            producer.cancelAndJoin()
+        }
     }
 
     @Test

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/GroupByTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/GroupByTest.kt
@@ -13,6 +13,7 @@ import io.bluetape4k.logging.trace
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -102,6 +103,36 @@ class GroupByTest: AbstractFlowTest() {
             .flatMapMerge { it }
             .take(2)
             .assertResult(1, 2)
+    }
+
+    @Test
+    fun `outer cancellation delivers one value to active flatMapMerge collector`() = runTest {
+        val innerStarted = CompletableDeferred<Unit>()
+        val result = CompletableDeferred<List<Int>>()
+        val collection = launch {
+            val values = flow {
+                emit(1)
+            }
+                .groupBy { it }
+                .take(1)
+                .flatMapMerge { group ->
+                    flow {
+                        innerStarted.complete(Unit)
+                        emitAll(group)
+                    }
+                }
+                .toList()
+            result.complete(values)
+        }
+
+        try {
+            withTimeout(100.milliseconds) { innerStarted.await() }
+            withTimeout(100.milliseconds) {
+                result.await() shouldBeEqualTo listOf(1)
+            }
+        } finally {
+            collection.cancelAndJoin()
+        }
     }
 
     @Test

--- a/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/GroupByTest.kt
+++ b/bluetape4k/coroutines/src/test/kotlin/io/bluetape4k/coroutines/flow/extensions/GroupByTest.kt
@@ -129,6 +129,36 @@ class GroupByTest: AbstractFlowTest() {
     }
 
     @Test
+    fun `outer cancellation closes emitted group without waiting for consumer`() = runTest {
+        val groupReady = CompletableDeferred<GroupedFlow<Int, Int>>()
+        val upstreamFinished = CompletableDeferred<Unit>()
+        val collection = launch {
+            flow {
+                try {
+                    emit(1)
+                    awaitCancellation()
+                } finally {
+                    upstreamFinished.complete(Unit)
+                }
+            }
+                .groupBy { it }
+                .take(1)
+                .collect { groupReady.complete(it) }
+        }
+
+        try {
+            val group = groupReady.await()
+            withTimeout(100.milliseconds) { upstreamFinished.await() }
+            withTimeout(100.milliseconds) {
+                group.toList() shouldBeEqualTo emptyList()
+            }
+            collection.join()
+        } finally {
+            collection.cancelAndJoin()
+        }
+    }
+
+    @Test
     fun `main errors no items`() = runTest {
         flowRangeOf(1, 10)
             .map { if (it < 5) error("oops") else it }

--- a/docs/lessons/2026-09-03-issue-1612-groupby-abandoned-group.md
+++ b/docs/lessons/2026-09-03-issue-1612-groupby-abandoned-group.md
@@ -1,0 +1,40 @@
+# Issue #1612: 미수집 groupBy 그룹은 terminal 상태로 닫아야 한다
+
+## 맥락
+
+`groupBy`는 새 그룹을 방출한 뒤 `FlowGroup.next()`에서 consumer가 준비될 때까지
+대기한다. consumer가 준비되지 않으면 기존 5초 timeout 경로가 그룹을 map에서
+제거하고 `cancelled`만 설정했다. 이미 방출된 `GroupedFlow`를 나중에 수집하면
+`collectSafely()`가 `valueReady.await()`에서 영구 대기할 수 있었다.
+
+## 결정
+
+- consumer timeout을 단순 취소가 아니라 그룹의 terminal 전이로 취급한다.
+- `map.remove(key, group)`으로 동일 키의 새 그룹을 실수로 제거하지 않도록 조건부
+  삭제한다.
+- `done = true`를 설정한 뒤 `valueReady.resume()`으로 현재 또는 late collector를
+  깨운다. late collector는 빈 Flow로 정상 종료하며 업스트림에는 timeout을 전파하지
+  않는다.
+- 이 계약을 `groupBy` KDoc에 명시하고, virtual time 회귀 테스트로 고정한다.
+
+## 결과
+
+포기된 그룹은 map에서 제거되고 terminal 상태를 관찰할 수 있다. late collector는
+bounded time 안에 빈 목록을 받고, 기존 그룹 수집·오류·다운스트림 취소 동작은
+그대로 유지된다.
+
+## 검증
+
+- 수정 전 회귀 테스트: 100ms timeout으로 실패(미수집 그룹의 `valueReady.await()` 영구 대기).
+- 수정 후 targeted regression: 1 passing.
+- `GroupByTest`: 13 passing.
+- `:bluetape4k-coroutines:test`: 631 passing, `BUILD SUCCESSFUL`.
+- `:bluetape4k-coroutines:detekt`: 기존 `groupBy.kt` 포함 저장소 전반의 사전 존재 위반으로
+  실패했으며, 변경으로 새 진단을 추가하지 않았다.
+
+## 향후 지침
+
+bounded wait가 producer를 포기시키는 모든 Flow 그룹/collector 구현은 취소 플래그만
+설정하지 말고 terminal 상태와 waiter wake-up을 함께 선형화해야 한다. map 정리와
+terminal 신호가 경합할 때는 조건부 삭제와 늦게 도착한 collector의 종료 증거를 각각
+테스트한다.


### PR DESCRIPTION
## Summary

Fixes #1612

미수집 상태로 timeout된 `GroupedFlow`를 terminal 상태로 닫아, 이후 시작한 late collector가 영구 대기하지 않고 빈 Flow로 종료되게 합니다.

## Background

milestone `2.1.0`의 #1612에서 `next()` timeout 경로가 map 제거와 `cancelled=true`만 수행해 `valueReady.await()` waiter를 깨우지 못하는 lifecycle 결함을 확인했습니다.

## What This Solves

- 포기된 그룹의 late collector 영구 대기 제거
- timeout·outer cancellation 뒤 남는 map entry와 waiter lifecycle의 명시적 종료
- active collector에는 첫 값을 정확히 한 번 전달하고 미수집 그룹만 즉시 abandon

## Work Done

- `FlowGroup.abandon()`을 추가해 조건부 map 제거, `cancelled`/`done` terminal 전이, `valueReady` wake-up을 한 경로로 묶었습니다.
- outer cancellation에서 active collector READY 신호만 비블로킹으로 소비하고, 미수집 그룹은 대기 없이 닫도록 했습니다.
- virtual time 기반 late collector·미수집 그룹·active collector handshake 회귀 테스트와 재발 방지 lesson을 추가했습니다.

## Validation

- active collector handshake targeted test: PASS (5회 반복)
- `GroupByTest`: PASS (15건)
- `:bluetape4k-coroutines:test`: PASS (633건)
- `git diff --check`: PASS
- `:bluetape4k-coroutines:detekt`: 기존 module findings로 실패, 추가된 `abandon()`에서 신규 finding 없음

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: independent native `code-reviewer` exact-head review

## Metadata

- Issue: #1612, milestone `2.1.0`, assignee `debop`
- PR: #1623, head `5cd3275d3c3dd725bb8a1b601a23ba899fccd5f4`, milestone `2.1.0`, assignee `debop`
- CI: https://github.com/bluetape4k/bluetape4k-projects/pull/1623/checks

## DoD Status

Required checks: 8/8; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - 사전 검증 | RED/GREEN, module test, lesson, exact diff 검토 수렴 | PASS | head `5cd3275d3c3dd725bb8a1b601a23ba899fccd5f4`; P0/P1/P2/P3=0 | 없음 |
| CG-12A - Guidance refresh | 현재 `AGENTS.md` 계층, Type C/Kotlin skill, common gates, PR template, #1612 metadata 재확인 | PASS | live issue OPEN, milestone `2.1.0`, assignee/labels 일치 | 없음 |
| CG-13 - PR 전달 | exact head publish와 한국어 PR metadata 확인 | PASS | #1623 `5cd3275d3c3dd725bb8a1b601a23ba899fccd5f4` | 없음 |
| CG-14 - CI 및 독립 검토 | exact-head CI와 review/thread read-back | PASS | head `5cd3275d3c3dd725bb8a1b601a23ba899fccd5f4`; [CI run 33810176152](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33810176152) 12 SUCCESS/12 SKIPPED; independent review P0/P1/P2/P3=0; unresolved thread 0 | 없음 |
| CG-14 - human review | single-developer lane | N/A | 저장소 관리자 `debop` 단독 범위 | 없음 |
| CG-15 - merge-ready 보고 | exact PR/head와 CI/review 증거 보고 | PASS | PR #1623 head `5cd3275d3c3dd725bb8a1b601a23ba899fccd5f4` merge-ready 보고 완료 | 없음 |
| CG-16 - fresh merge 승인 | CG-15 이후 exact head 승인 확인 | PASS | 사용자의 후속 `승인`을 PR #1623 exact head에 귀속 | 없음 |
| CG-17 - 병합 및 live 확인 | `--rebase --match-head-commit` 병합 | PASS | `2026-09-04T03:56:04Z`; merge commit `eb72706aa3eadbbe2eaebbe41580711c0dd31183`; Issue #1612 CLOSED | 없음 |
| CG-18 - 동기화 및 보존 | `develop` fast-forward, 통합 테스트, 비승인 cleanup 보존 | PASS | local/`origin/develop` `611aa2fabaffe610df8ee242e64b3cb51372686f`; Core/Coroutines/VirtualThread BUILD SUCCESSFUL; Redisson 320 tests PASS | worktree/local branch 보존 |

Final status: DONE

Unchecked required items: none
