### PR TITLE
[core][bug] ConcurrentReducer.add()가 호출 스레드에서 task/poll을 실행하지 않도록 한다

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/ConcurrentReducer.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/ConcurrentReducer.kt
@@ -100,10 +100,10 @@ class ConcurrentReducer<T> internal constructor(
 
         do {
             val job = grabJob()
-            if (job?.promise?.isCancelled == true) {
-                limit.release()
-            } else if (job != null) {
-                run(job)
+            if (job != null) {
+                if (!cancelJob(job, requirePromiseCancellation = true)) {
+                    run(job)
+                }
             }
         } while (job != null)
     }
@@ -206,6 +206,28 @@ class ConcurrentReducer<T> internal constructor(
         }
     }
 
+    private fun cancelJob(job: Job<T>, requirePromiseCancellation: Boolean): Boolean {
+        val cancelled = synchronized(admissionLock) {
+            cancelJobLocked(job, requirePromiseCancellation)
+        }
+        if (cancelled) {
+            job.promise.cancel(false)
+            cancelStage(job)
+        }
+        return cancelled
+    }
+
+    private fun cancelJobLocked(job: Job<T>, requirePromiseCancellation: Boolean): Boolean {
+        val canCancel = !requirePromiseCancellation || job.promise.isCancelled
+        val cancelled = canCancel && job.tryCancel()
+        if (cancelled) {
+            if (activeJobs.remove(job)) {
+                limit.release()
+            }
+        }
+        return cancelled
+    }
+
     @Suppress("TooGenericExceptionCaught")
     private fun cancelStage(job: Job<T>) {
         val stage = job.stage ?: return
@@ -233,20 +255,14 @@ class ConcurrentReducer<T> internal constructor(
 
             val activeJobs = activeJobs.toList()
             val jobs = queuedJobs + activeJobs
-            jobs.forEach { job ->
-                if (job.tryCancel() && this@ConcurrentReducer.activeJobs.remove(job)) {
-                    limit.release()
-                }
-            }
+            val cancelledJobs = jobs.filter { cancelJobLocked(it, requirePromiseCancellation = false) }
             pumpExecutor.shutdown()
-            jobs
+            cancelledJobs
         }
 
         jobsToCancel.forEach { job ->
-            if (job.isCancellationRequested) {
-                job.promise.cancel(false)
-                cancelStage(job)
-            }
+            job.promise.cancel(false)
+            cancelStage(job)
         }
     }
 

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/ConcurrentReducer.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/ConcurrentReducer.kt
@@ -59,6 +59,7 @@ class ConcurrentReducer<T> internal constructor(
     private val closed = atomic(false)
     private val pumpScheduled = atomic(false)
     private val admissionLock = Any()
+    private val activeJobs = mutableSetOf<Job<T>>()
 
     val queuedCount: Int get() = queue.size
     val activeCount: Int get() = maxConcurrency - limit.availablePermits()
@@ -121,7 +122,11 @@ class ConcurrentReducer<T> internal constructor(
         } else {
             pollNextJob { it.promise.isCancelled }
                 .also { job ->
-                    if (job == null) limit.release()
+                    if (job == null) {
+                        limit.release()
+                    } else {
+                        activeJobs += job
+                    }
                 }
         }
     }
@@ -150,51 +155,98 @@ class ConcurrentReducer<T> internal constructor(
 
     @Suppress("TooGenericExceptionCaught")
     private fun run(job: Job<T>) {
-        fun completeExceptionally(error: Throwable) {
-            limit.release()
-            job.promise.completeExceptionally(error)
+        if (!job.tryStart()) return
+
+        var invocationFailed = false
+        val future: CompletionStage<T>? = try {
+            job.task.invoke()
+        } catch (e: Throwable) {
+            invocationFailed = true
+            complete(job, error = e)
+            log.warn(e) { "task failed. job=$job" }
+            null
         }
 
-        val future: CompletionStage<T>?
-        try {
-            future = job.task.invoke()
+        if (!invocationFailed) {
             if (future == null) {
                 log.debug { "task result is null." }
-                completeExceptionally(NullPointerException("task result is null."))
-                return
-            }
-        } catch (e: Throwable) {
-            completeExceptionally(e)
-            log.warn(e) { "task failed. job=$job" }
-            return
-        }
-
-        future.whenComplete { result, error ->
-            limit.release()
-            if (error != null) {
-                job.promise.completeExceptionally(error)
+                complete(job, error = NullPointerException("task result is null."))
             } else {
-                job.promise.complete(result)
-            }
+                job.stage = future
+                if (job.isCancellationRequested) {
+                    cancelStage(job)
+                } else {
+                    future.whenComplete { result, error ->
+                        complete(job, result, error)
 
-            // whenComplete()는 현재 스레드에서 실행될 수 있으므로 coalesced pump를 executor에 위임한다.
-            if (!closed.value) schedulePump()
+                        // whenComplete()는 현재 스레드에서 실행될 수 있으므로 coalesced pump를 executor에 위임한다.
+                        if (!closed.value) schedulePump()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun complete(job: Job<T>, result: T? = null, error: Throwable? = null) {
+        val completed = synchronized(admissionLock) {
+            if (!job.tryComplete()) {
+                false
+            } else {
+                activeJobs.remove(job)
+                limit.release()
+                true
+            }
+        }
+        if (!completed) return
+
+        if (error != null) {
+            job.promise.completeExceptionally(error)
+        } else {
+            job.promise.complete(result)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun cancelStage(job: Job<T>) {
+        val stage = job.stage ?: return
+        if (!job.tryCancelStage()) return
+
+        try {
+            stage.toCompletableFuture().cancel(false)
+        } catch (e: RuntimeException) {
+            log.warn(e) { "task stage cancellation failed." }
         }
     }
 
     /**
      * 내부 리소스를 정리합니다.
-     * 큐에 남아있는 작업은 취소되고, pump executor를 종료합니다.
+     * 큐에 남아있거나 실행 중인 작업은 취소되고, pump executor를 종료합니다.
      */
     override fun close() {
-        synchronized(admissionLock) {
+        val jobsToCancel = synchronized(admissionLock) {
             if (!closed.compareAndSet(false, true)) return
 
+            val queuedJobs = mutableListOf<Job<T>>()
             while (true) {
-                val job = queue.poll() ?: break
-                job.promise.cancel(false)
+                queuedJobs += queue.poll() ?: break
+            }
+
+            val activeJobs = activeJobs.toList()
+            val jobs = queuedJobs + activeJobs
+            jobs.forEach { job ->
+                if (job.tryCancel() && this@ConcurrentReducer.activeJobs.remove(job)) {
+                    limit.release()
+                }
             }
             pumpExecutor.shutdown()
+            jobs
+        }
+
+        jobsToCancel.forEach { job ->
+            if (job.isCancellationRequested) {
+                job.promise.cancel(false)
+                cancelStage(job)
+            }
         }
     }
 
@@ -203,8 +255,37 @@ class ConcurrentReducer<T> internal constructor(
         val promise: CompletableFuture<T>,
     ): Serializable {
         companion object {
+            private const val NEW = 0
+            private const val RUNNING = 1
+            private const val CANCELLED = 2
+            private const val COMPLETED = 3
             private const val serialVersionUID: Long = 1L
         }
+
+        private val state = atomic(NEW)
+        private val stageCancellationRequested = atomic(false)
+
+        @Volatile
+        var stage: CompletionStage<T>? = null
+
+        val isCancellationRequested: Boolean
+            get() = state.value == CANCELLED
+
+        fun tryStart(): Boolean = state.compareAndSet(NEW, RUNNING)
+
+        fun tryComplete(): Boolean = state.compareAndSet(RUNNING, COMPLETED)
+
+        fun tryCancelStage(): Boolean = stageCancellationRequested.compareAndSet(false, true)
+
+        fun tryCancel(): Boolean {
+            while (true) {
+                when (val current = state.value) {
+                    NEW, RUNNING -> if (state.compareAndSet(current, CANCELLED)) return true
+                    else -> return false
+                }
+            }
+        }
+
     }
 
     class CapacityReachedException: BluetapeException {

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/ConcurrentReducer.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/ConcurrentReducer.kt
@@ -16,7 +16,6 @@ import java.util.concurrent.CompletionStage
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.Semaphore
-import java.util.concurrent.TimeUnit
 
 /**
  * concurrentReducerOf 기능을 제공합니다.
@@ -58,6 +57,8 @@ class ConcurrentReducer<T> internal constructor(
     private val limit: Semaphore = Semaphore(maxConcurrency)
     private val pumpExecutor = Executors.newSingleThreadExecutor()
     private val closed = atomic(false)
+    private val pumpScheduled = atomic(false)
+    private val admissionLock = Any()
 
     val queuedCount: Int get() = queue.size
     val activeCount: Int get() = maxConcurrency - limit.availablePermits()
@@ -67,26 +68,35 @@ class ConcurrentReducer<T> internal constructor(
     /**
      * 비동기 작업을 추가합니다.
      * 큐가 꽉 찬 경우에는 [CapacityReachedException]이 발생합니다.
+     * task invocation과 queue polling은 전용 executor에서 수행하므로 이 함수는 enqueue 후 즉시 반환합니다.
      *
      * @param task 작업을 수행할 람다
      * @return 작업 결과를 받아볼 [CompletableFuture] 인스턴스
      */
     fun add(task: () -> CompletionStage<T>?): CompletableFuture<T> {
-        if (closed.value) {
-            return failedCompletableFutureOf(RejectedExecutionException("ConcurrentReducer is already closed."))
-        }
-
         val promise = CompletableFuture<T>()
         val job = Job(task, promise)
 
-        if (!queue.offer(job)) {
-            return failedCompletableFutureOf(CapacityReachedException("Queue size has reached capacity: $maxQueueSize"))
+        return synchronized(admissionLock) {
+            when {
+                closed.value ->
+                    failedCompletableFutureOf(RejectedExecutionException("ConcurrentReducer is already closed."))
+
+                !queue.offer(job) -> failedCompletableFutureOf(
+                    CapacityReachedException("Queue size has reached capacity: $maxQueueSize"),
+                )
+
+                else -> {
+                    schedulePump()
+                    promise
+                }
+            }
         }
-        pump()
-        return promise
     }
 
     private fun pump() {
+        if (closed.value) return
+
         do {
             val job = grabJob()
             if (job?.promise?.isCancelled == true) {
@@ -97,29 +107,48 @@ class ConcurrentReducer<T> internal constructor(
         } while (job != null)
     }
 
-    private fun pollWhile(
-        timeout: Long = 10,
-        unit: TimeUnit = TimeUnit.MILLISECONDS,
-        predicate: (Job<T>) -> Boolean,
-    ): Job<T>? {
+    private fun pollNextJob(predicate: (Job<T>) -> Boolean): Job<T>? {
         while (true) {
-            val job = queue.poll(timeout, unit) ?: return null
+            val job = queue.poll() ?: return null
             if (predicate(job)) continue
             return job
         }
     }
 
-    private fun grabJob(): Job<T>? {
-        if (!limit.tryAcquire()) return null
-
-        val job = pollWhile { it.promise.isCancelled }
-        if (job == null) {
-            limit.release()
-            return null
+    private fun grabJob(): Job<T>? = synchronized(admissionLock) {
+        if (closed.value || !limit.tryAcquire()) {
+            null
+        } else {
+            pollNextJob { it.promise.isCancelled }
+                .also { job ->
+                    if (job == null) limit.release()
+                }
         }
-        return job
     }
 
+    private fun schedulePump() {
+        if (!pumpScheduled.compareAndSet(false, true)) return
+
+        try {
+            pumpExecutor.execute {
+                try {
+                    pump()
+                } finally {
+                    pumpScheduled.value = false
+                    if (!closed.value && queue.isNotEmpty() && limit.availablePermits() > 0) {
+                        schedulePump()
+                    }
+                }
+            }
+        } catch (e: RejectedExecutionException) {
+            pumpScheduled.value = false
+            if (!closed.value) {
+                log.warn(e) { "pump executor rejected pump task." }
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
     private fun run(job: Job<T>) {
         fun completeExceptionally(error: Throwable) {
             limit.release()
@@ -148,18 +177,8 @@ class ConcurrentReducer<T> internal constructor(
                 job.promise.complete(result)
             }
 
-            // 새로운 runnable로 pump() 실행 위임
-            // (이유: CompletableFuture의 whenComplete()는 현재 스레드에서 실행됨)
-            // pump()가 현재 스레드에서 실행되면 deadlock 발생 가능성 있음
-            if (!closed.value) {
-                try {
-                    CompletableFuture.runAsync({ pump() }, pumpExecutor)
-                } catch (e: RejectedExecutionException) {
-                    if (!closed.value) {
-                        log.warn(e) { "pump executor rejected pump task." }
-                    }
-                }
-            }
+            // whenComplete()는 현재 스레드에서 실행될 수 있으므로 coalesced pump를 executor에 위임한다.
+            if (!closed.value) schedulePump()
         }
     }
 
@@ -168,13 +187,15 @@ class ConcurrentReducer<T> internal constructor(
      * 큐에 남아있는 작업은 취소되고, pump executor를 종료합니다.
      */
     override fun close() {
-        if (!closed.compareAndSet(false, true)) return
+        synchronized(admissionLock) {
+            if (!closed.compareAndSet(false, true)) return
 
-        while (true) {
-            val job = queue.poll() ?: break
-            job.promise.cancel(false)
+            while (true) {
+                val job = queue.poll() ?: break
+                job.promise.cancel(false)
+            }
+            pumpExecutor.shutdown()
         }
-        pumpExecutor.shutdown()
     }
 
     private data class Job<T>(

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ConcurrentReducerTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ConcurrentReducerTest.kt
@@ -329,6 +329,39 @@ class ConcurrentReducerTest {
     }
 
     @Test
+    fun `close는 실행 중인 stage를 취소하고 permit을 정확히 한 번 회수한다`() {
+        val reducer = concurrentReducerOf<String>(1, 1)
+        val source = CompletableFuture<String>()
+        val taskStarted = CountDownLatch(1)
+        val promise = reducer.add {
+            taskStarted.countDown()
+            source
+        }
+
+        try {
+            taskStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            await until { reducer.activeCount == 1 }
+
+            reducer.close()
+
+            promise.isCancelled.shouldBeTrue()
+            source.isCancelled.shouldBeTrue()
+            reducer.activeCount shouldBeEqualTo 0
+            reducer.remainingActiveCapacity shouldBeEqualTo 1
+            reducer.queuedCount shouldBeEqualTo 0
+
+            // close가 source callback과 경합해도 permit은 중복 회수되지 않아야 한다.
+            source.complete("late").shouldBeFalse()
+            reducer.close()
+            reducer.activeCount shouldBeEqualTo 0
+            reducer.remainingActiveCapacity shouldBeEqualTo 1
+        } finally {
+            source.cancel(false)
+            reducer.close()
+        }
+    }
+
+    @Test
     fun `close 이후 작업 추가는 실패한 CompletableFuture를 반환한다`() {
         val reducer = concurrentReducerOf<String>(1, 10)
 

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ConcurrentReducerTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ConcurrentReducerTest.kt
@@ -12,7 +12,9 @@ import org.awaitility.kotlin.until
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -40,13 +42,43 @@ class ConcurrentReducerTest {
     }
 
     @Test
+    fun `add는 task invocation 없이 호출자에게 즉시 promise를 반환한다`() {
+        val reducer = concurrentReducerOf<String>(1, 10)
+        val taskStarted = CountDownLatch(1)
+        val releaseTask = CountDownLatch(1)
+        val invocation = CompletableFuture.supplyAsync<CompletableFuture<String>> {
+            reducer.add {
+                taskStarted.countDown()
+                releaseTask.await()
+                completableFutureOf("done")
+            }
+        }
+        var promise: CompletableFuture<String>? = null
+
+        try {
+            taskStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            invocation.isDone.shouldBeTrue()
+
+            promise = invocation.get(1, TimeUnit.SECONDS)
+            promise?.isDone.shouldBeFalse()
+        } finally {
+            releaseTask.countDown()
+            promise = promise ?: invocation.get(1, TimeUnit.SECONDS)
+            promise?.get(1, TimeUnit.SECONDS)
+            reducer.close()
+        }
+    }
+
+    @Test
     fun `task return null`() {
         val reducer = concurrentReducerOf<String>(1, 10)
         val promise = reducer.add(job(null))
 
+        await until { promise.isDone }
         promise.isDone.shouldBeTrue()
         val exception = promise.getException()
         exception shouldBeInstanceOf NullPointerException::class
+        reducer.close()
     }
 
     @Test
@@ -54,8 +86,10 @@ class ConcurrentReducerTest {
         val reducer = concurrentReducerOf<String>(1, 10)
         val promise = reducer.add { throw IllegalStateException("Boom!") }
 
+        await until { promise.isDone }
         promise.isDone.shouldBeTrue()
         promise.getException() shouldBeInstanceOf IllegalStateException::class
+        reducer.close()
     }
 
     @Test
@@ -65,8 +99,10 @@ class ConcurrentReducerTest {
             failedCompletableFutureOf(IllegalStateException("Boom!"))
         }
 
+        await until { promise.isDone }
         promise.isDone.shouldBeTrue()
         promise.getException() shouldBeInstanceOf IllegalStateException::class
+        reducer.close()
     }
 
     @Test
@@ -128,6 +164,8 @@ class ConcurrentReducerTest {
 
         request3.complete("3")
 
+        await until { reducer.activeCount == 2 && reducer.queuedCount == 1 }
+
         // 1 and 2 are in progress, 3 is still blocked
         promise1.isDone.shouldBeFalse()
         promise2.isDone.shouldBeFalse()
@@ -172,6 +210,8 @@ class ConcurrentReducerTest {
             promises += reducer.add(job)
         }
 
+        await until { reducer.activeCount == maxConcurrency && reducer.queuedCount == queueSize - maxConcurrency }
+
         jobs.forEachIndexed { index, job ->
             if (index % 2 == 0) {
                 job.future.complete("success")
@@ -193,16 +233,28 @@ class ConcurrentReducerTest {
 
     @Test
     fun `큐 사이즈를 초과해 작업을 추가하면 CapacityReachedException이 발생한다`() {
-        val reducer = concurrentReducerOf<String>(10, 10)
-        repeat(20) {
-            reducer.add { CompletableFuture() }
+        val concurrency = 10
+        val queueSize = 10
+        val future = CompletableFuture<String>()
+        val reducer = concurrentReducerOf<String>(concurrency, queueSize)
+
+        repeat(concurrency) {
+            reducer.add { future }
         }
+        await until { reducer.activeCount == concurrency && reducer.queuedCount == 0 }
 
-        val promise = reducer.add { CompletableFuture() }
-        await until { promise.isDone }
+        repeat(queueSize) {
+            reducer.add { future }
+        }
+        await until { reducer.queuedCount == queueSize }
 
+        val promise = reducer.add { future }
         promise.isDone.shouldBeTrue()
         promise.getException() shouldBeInstanceOf ConcurrentReducer.CapacityReachedException::class
+
+        future.complete("")
+        await until { reducer.activeCount == 0 && reducer.queuedCount == 0 }
+        reducer.close()
     }
 
     @Test
@@ -212,14 +264,25 @@ class ConcurrentReducerTest {
         val future = CompletableFuture<String>()
         val reducer = concurrentReducerOf<String>(concurrency, queueSize)
 
-        repeat(20) {
+        repeat(concurrency) {
             reducer.add { future }
         }
 
+        await until { reducer.activeCount == concurrency && reducer.queuedCount == 0 }
+
+        repeat(queueSize) {
+            reducer.add { future }
+        }
+
+        await until { reducer.queuedCount == queueSize }
         reducer.activeCount shouldBeEqualTo concurrency
         reducer.queuedCount shouldBeEqualTo queueSize
         reducer.remainingActiveCapacity shouldBeEqualTo 0
         reducer.remainingQueueCapacity shouldBeEqualTo 0
+
+        val overflow = reducer.add { future }
+        overflow.isCompletedExceptionally.shouldBeTrue()
+        overflow.getException() shouldBeInstanceOf ConcurrentReducer.CapacityReachedException::class
 
         future.complete("")
 
@@ -229,6 +292,7 @@ class ConcurrentReducerTest {
         reducer.queuedCount shouldBeEqualTo 0
         reducer.remainingActiveCapacity shouldBeEqualTo concurrency
         reducer.remainingQueueCapacity shouldBeEqualTo queueSize
+        reducer.close()
     }
 
     @Test
@@ -249,6 +313,7 @@ class ConcurrentReducerTest {
             CompletableFuture()
         }
 
+        await until { reducer.activeCount == 1 && reducer.queuedCount == 2 }
         reducer.activeCount shouldBeEqualTo 1
         reducer.queuedCount shouldBeEqualTo 2
 
@@ -273,6 +338,30 @@ class ConcurrentReducerTest {
 
         promise.isCompletedExceptionally.shouldBeTrue()
         promise.getException() shouldBeInstanceOf RejectedExecutionException::class
+    }
+
+    @Test
+    fun `add와 close 동시 실행에서도 promise가 누수되지 않는다`() {
+        repeat(32) {
+            val reducer = concurrentReducerOf<String>(1, 1)
+            val start = CountDownLatch(1)
+            val addInvocation = CompletableFuture.supplyAsync<CompletableFuture<String>> {
+                start.await()
+                reducer.add { completableFutureOf("done") }
+            }
+            val closeInvocation = CompletableFuture.runAsync {
+                start.await()
+                reducer.close()
+            }
+
+            start.countDown()
+            val promise = addInvocation.get(1, TimeUnit.SECONDS)
+            closeInvocation.get(1, TimeUnit.SECONDS)
+
+            await until { promise.isDone }
+            promise.isDone.shouldBeTrue()
+            reducer.close()
+        }
     }
 
     @Test

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ConcurrentReducerTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ConcurrentReducerTest.kt
@@ -152,6 +152,52 @@ class ConcurrentReducerTest {
     }
 
     @Test
+    fun `grab 직후 caller 취소 경합에서도 active job과 permit이 누수되지 않는다`() {
+        repeat(64) {
+            val reducer = concurrentReducerOf<String>(1, 1)
+            val firstSource = CompletableFuture<String>()
+            reducer.add { firstSource }
+
+            val releaseTask = CountDownLatch(1)
+            val taskInvoked = AtomicBoolean(false)
+            val promise = reducer.add {
+                taskInvoked.set(true)
+                releaseTask.await()
+                completableFutureOf("done")
+            }
+            val ready = CountDownLatch(32)
+            val cancellers = List(32) {
+                Thread {
+                    ready.countDown()
+                    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1)
+                    while (reducer.queuedCount != 0 || reducer.activeCount != 1) {
+                        if (System.nanoTime() >= deadline) return@Thread
+                        Thread.onSpinWait()
+                    }
+                    promise.cancel(false)
+                }.also { it.start() }
+            }
+
+            try {
+                ready.await(1, TimeUnit.SECONDS).shouldBeTrue()
+                firstSource.complete("first")
+                cancellers.forEach { it.join(1_000) }
+                await until { taskInvoked.get() || reducer.activeCount == 0 }
+                releaseTask.countDown()
+                await until { reducer.activeCount == 0 && reducer.queuedCount == 0 }
+                reducer.close()
+
+                reducer.activeCount shouldBeEqualTo 0
+                reducer.remainingActiveCapacity shouldBeEqualTo 1
+                reducer.queuedCount shouldBeEqualTo 0
+            } finally {
+                releaseTask.countDown()
+                reducer.close()
+            }
+        }
+    }
+
+    @Test
     fun `3개의 짧은 작업을 2개만 동시 실행으로 제한할 때`() {
         val reducer = concurrentReducerOf<String>(2, 10)
         val request1 = CompletableFuture<String>()

--- a/docs/lessons/2026-09-03-issue-1614-concurrent-reducer-add.md
+++ b/docs/lessons/2026-09-03-issue-1614-concurrent-reducer-add.md
@@ -1,0 +1,42 @@
+# Issue #1614: 비동기 반환 API의 실행 경계를 enqueue 뒤로 분리한다
+
+## 맥락
+
+`ConcurrentReducer.add()`는 job을 queue에 넣은 뒤 호출 스레드에서 `pump()`를 직접
+실행했다. 첫 job의 task lambda가 blocking하면 `CompletableFuture`를 반환하기 전에
+호출자가 함께 차단되었고, queue의 timed polling도 호출 경계에서 수행될 수 있었다.
+
+## 결정
+
+- `add()`는 `admissionLock` 안에서 close 상태 확인, queue admission, pump scheduling만
+  수행하고 promise를 즉시 반환한다.
+- task invocation과 queue polling은 기존 단일 `pumpExecutor`에서만 수행한다.
+- `pumpScheduled` atomic flag로 중복 pump 제출을 합치고, pump 종료 직전에 처리 가능한
+  queue 항목이 남으면 한 번만 다시 예약한다.
+- executor에 새 admission이 전달되므로 빈 queue를 기다리는 10ms timed polling을
+  제거하고 non-blocking `poll()`을 사용한다.
+- `add()`와 `close()`는 같은 lock으로 선형화한다. add가 먼저 승인되면 job은 실행되거나
+  close에서 취소되고, close가 먼저 완료되면 add는 `RejectedExecutionException` future를
+  반환한다.
+
+## 결과
+
+호출자는 task가 아직 실행 중이어도 미완료 promise를 즉시 받는다. 기존
+`maxConcurrency` permit, 입력 queue capacity, 취소된 queued job 건너뛰기, task 결과와
+예외 전달, close 시 queued promise 취소 계약은 유지된다. completion callback은 직접
+`pump()`를 호출하지 않고 coalesced scheduler만 깨운다.
+
+## 검증
+
+- 수정 전 latch 회귀: task release 전 `add()` 호출 future가 완료되지 않아 실패.
+- 수정 후 `ConcurrentReducerTest`: 15 passing.
+- `:bluetape4k-core:test`: 1647 passing, `BUILD SUCCESSFUL`.
+- `:bluetape4k-core:detekt`: `BUILD SUCCESSFUL`, 변경 파일 신규 진단 없음.
+- `add/close` 동시 실행 32회에서 반환 promise가 모두 terminal 상태에 도달함을 확인.
+
+## 향후 지침
+
+`CompletableFuture`를 반환하는 admission API에서 task invocation, blocking poll, `get`,
+`join`을 호출자 경계에 두지 않는다. close와 add가 같은 queue를 변경하면 하나의 짧은
+linearization lock으로 admission을 결정하고, executor wake-up은 coalescing flag와
+queue/permit 재검사로 lost wake-up을 방지한다.


### PR DESCRIPTION
## Summary

Fixes #1614

`ConcurrentReducer.add()`의 task invocation과 queue polling을 단일 executor의 coalesced pump로 이동해 promise를 즉시 반환하도록 합니다.

## Background

milestone `2.1.0`의 #1614에서 `add()`가 enqueue 직후 `pump()`을 동기 호출해 첫 task와 polling을 호출 스레드에서 수행하는 결함을 확인했습니다.

## What This Solves

- `add()` 호출자의 task 시간 비례 블로킹 제거
- `add`/caller cancellation/`close` admission 선형화와 queue/active stage/permit/promise 수렴 보장

## Work Done

- 짧은 admission lock으로 close 검사, enqueue, pump scheduling을 선형화했습니다.
- `pumpScheduled`로 단일 executor 제출을 coalescing하고 queue polling을 non-blocking으로 변경했습니다.
- active job registry와 state transition으로 `close()`가 실행 중 stage도 취소하고 permit을 정확히 한 번 회수하게 했습니다.
- 호출자 비블로킹, active-stage close, 32회 `add`/`close`, 64×32 caller cancellation race 회귀 테스트와 lesson을 추가했습니다.

## Validation

- `ConcurrentReducerTest`: PASS (17건)
- `:bluetape4k-core:test`: PASS (1649건)
- `:bluetape4k-core:detekt`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: independent native `code-reviewer` exact-head review

## Metadata

- Issue: #1614, milestone `2.1.0`, assignee `debop`
- PR: #1625, head `0679fb1b1274d725bd48a51ceeabe56a1a8933df`, milestone `2.1.0`, assignee `debop`
- CI: https://github.com/bluetape4k/bluetape4k-projects/pull/1625/checks

## DoD Status

Required checks: 8/8; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - 사전 검증 | RED/GREEN, module test, lesson, exact diff 검토 수렴 | PASS | head `0679fb1b1274d725bd48a51ceeabe56a1a8933df`; P0/P1/P2/P3=0 | 없음 |
| CG-12A - Guidance refresh | 현재 guidance, Type C/Kotlin skill, PR template, #1614 metadata 재확인 | PASS | live issue OPEN, milestone `2.1.0`, assignee/labels 일치 | 없음 |
| CG-13 - PR 전달 | exact head publish와 한국어 PR metadata 확인 | PASS | #1625 `0679fb1b1274d725bd48a51ceeabe56a1a8933df` | 없음 |
| CG-14 - CI 및 독립 검토 | exact-head CI와 review/thread read-back | PASS | head `0679fb1b1274d725bd48a51ceeabe56a1a8933df`; [CI run 33811550344](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33811550344) 12 SUCCESS/12 SKIPPED; independent review P0/P1/P2/P3=0; unresolved thread 0 | 없음 |
| CG-14 - human review | single-developer lane | N/A | 저장소 관리자 `debop` 단독 범위 | 없음 |
| CG-15 - merge-ready 보고 | exact PR/head와 CI/review 증거 보고 | PASS | PR #1625 head `0679fb1b1274d725bd48a51ceeabe56a1a8933df` merge-ready 보고 완료 | 없음 |
| CG-16 - fresh merge 승인 | CG-15 이후 exact head 승인 확인 | PASS | 사용자의 후속 `승인`을 PR #1625 exact head에 귀속 | 없음 |
| CG-17 - 병합 및 live 확인 | `--rebase --match-head-commit` 병합 | PASS | `2026-09-04T03:59:22Z`; merge commit `2e0117ba4e2a86bc654c9e3632ccf58c0929258f`; Issue #1614 CLOSED | 없음 |
| CG-18 - 동기화 및 보존 | `develop` fast-forward, 통합 테스트, 비승인 cleanup 보존 | PASS | local/`origin/develop` `611aa2fabaffe610df8ee242e64b3cb51372686f`; Core/Coroutines/VirtualThread BUILD SUCCESSFUL; Redisson 320 tests PASS | worktree/local branch 보존 |

Final status: DONE

Unchecked required items: none
