### PR TITLE
[redisson][bug] withSuspendedTransaction 취소·rollback 시 주 예외와 cancellation을 보존한다

### DIFF
--- a/docs/lessons/2026-09-04-issue-1615-redisson-transaction-rollback.md
+++ b/docs/lessons/2026-09-04-issue-1615-redisson-transaction-rollback.md
@@ -1,0 +1,44 @@
+# Issue #1615: 취소 가능한 본문과 트랜잭션 정리를 분리한다
+
+## 맥락
+
+`withSuspendedTransaction`은 action 또는 commit 실패를 잡은 뒤 같은 coroutine
+context에서 `rollbackAsync().await()`를 실행했다. caller가 이미 취소된 경우 rollback
+대기가 즉시 취소되고 그 `CancellationException`이 주 예외를 덮을 수 있었다. 일반
+rollback 실패도 `runCatching` 안에서 버려져 장애 진단 정보가 사라졌다.
+
+## 결정
+
+- action과 commit은 기존 caller context에서 실행해 정상적인 취소 전파를 유지한다.
+- 실패 후 rollback만 `NonCancellable` context로 분리해 caller 취소와 관계없이 정리를
+  시도한다.
+- rollback 대기는 `withTimeout(5_000L)`로 제한해 응답 없는 Redis 때문에 무한히
+  정지하지 않도록 한다.
+- action, commit, caller cancellation을 항상 주 예외로 다시 던진다.
+- rollback 실패와 timeout은 주 예외의 suppressed 예외로 연결한다. 동일한 예외
+  인스턴스는 self-suppression을 피하기 위해 다시 추가하지 않는다.
+
+## 결과
+
+caller가 취소된 뒤에도 rollback future의 완료를 기다릴 수 있으며, 정리가 끝나면
+원래 cancellation을 그대로 관찰한다. action 또는 commit이 실패한 경우에도 그 원인이
+유지되고 rollback 장애 정보는 suppressed chain에서 확인할 수 있다. 정상 commit 경로와
+public API signature는 변경하지 않았다.
+
+## 검증
+
+- 수정 전 회귀: rollback 실패가 suppressed에 남지 않아 1 test failed.
+- contract test: action 실패, caller cancellation, commit 실패, rollback 실패/timeout
+  4건 통과.
+- 실제 Redis Testcontainers transaction/batch 검증: 3건 통과.
+- `:bluetape4k-redisson:test`: 320 passing, failure/error/skipped 0.
+- `:bluetape4k-redisson:detekt`: `BUILD SUCCESSFUL`; 변경 전부터 존재한
+  `TooGenericExceptionCaught`를 포함한 baseline 진단만 보고됨.
+- `git diff --check`: 통과.
+
+## 향후 지침
+
+coroutine transaction helper는 취소 가능한 업무 본문과 반드시 시도해야 하는 정리
+단계를 분리한다. 정리는 `NonCancellable`만으로 무제한 보호하지 말고 timeout을 함께
+설정한다. 정리 실패는 주 예외를 교체하지 말고 suppressed 또는 별도 diagnostic으로
+남겨 원인과 cleanup 상태를 동시에 보존한다.

--- a/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/coroutines/RedissonClientCoroutine.kt
+++ b/infra/redisson/src/main/kotlin/io/bluetape4k/redis/redisson/coroutines/RedissonClientCoroutine.kt
@@ -2,8 +2,10 @@ package io.bluetape4k.redis.redisson.coroutines
 
 import io.bluetape4k.idgenerators.snowflake.Snowflakers
 import io.bluetape4k.support.requireNotBlank
-import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.redisson.api.BatchOptions
 import org.redisson.api.BatchResult
 import org.redisson.api.RBatch
@@ -42,7 +44,8 @@ suspend inline fun RedissonClient.withSuspendedBatch(
  * 예외가 발생하면 롤백을 시도한 후 원래 예외를 다시 던집니다.
  *
  * ## 주의사항
- * - 롤백 실패 시 롤백 예외는 무시되고 원래 예외만 전파됩니다 ([runCatching] 처리).
+ * - 롤백은 취소되지 않는 문맥에서 최대 5초 동안 수행합니다.
+ * - 롤백 실패나 제한 시간 초과는 원래 예외를 덮지 않고 suppressed 예외로 보존됩니다.
  * - Redisson 트랜잭션은 낙관적 잠금 방식이므로 충돌 시 재시도 로직이 필요할 수 있습니다.
  *
  * ## 사용 예
@@ -55,8 +58,9 @@ suspend inline fun RedissonClient.withSuspendedBatch(
  *
  * @param options 트랜잭션 옵션 (기본값: [TransactionOptions.defaults])
  * @param action [RTransaction] 수신 객체로 Redis 커맨드를 등록하는 블록
- * @throws Throwable [action] 블록에서 발생한 예외
+ * @throws Throwable [action] 또는 commit에서 발생한 주 예외
  */
+@Suppress("TooGenericExceptionCaught")
 suspend inline fun RedissonClient.withSuspendedTransaction(
     options: TransactionOptions = TransactionOptions.defaults(),
     action: RTransaction.() -> Unit,
@@ -65,10 +69,21 @@ suspend inline fun RedissonClient.withSuspendedTransaction(
     try {
         action(tx)
         tx.commitAsync().await()
-    } catch (e: Throwable) {
-        runCatching { tx.rollbackAsync().await() }
-            .onFailure { if (it is CancellationException) throw it }
-        throw e
+    } catch (primaryFailure: Throwable) {
+        val rollbackFailure = withContext(NonCancellable) {
+            try {
+                withTimeout(5_000L) {
+                    tx.rollbackAsync().await()
+                }
+                null
+            } catch (failure: Throwable) {
+                failure
+            }
+        }
+        if (rollbackFailure != null && rollbackFailure !== primaryFailure) {
+            primaryFailure.addSuppressed(rollbackFailure)
+        }
+        throw primaryFailure
     }
 }
 

--- a/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/coroutines/RedissonClientCoroutineContractTest.kt
+++ b/infra/redisson/src/test/kotlin/io/bluetape4k/redis/redisson/coroutines/RedissonClientCoroutineContractTest.kt
@@ -1,0 +1,125 @@
+package io.bluetape4k.redis.redisson.coroutines
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.redisson.api.RFuture
+import org.redisson.api.RTransaction
+import org.redisson.api.RedissonClient
+import org.redisson.misc.CompletableFutureWrapper
+import java.util.concurrent.CompletableFuture
+
+class RedissonClientCoroutineContractTest {
+
+    @Test
+    fun `action 실패가 주 예외이고 rollback 실패는 suppressed로 보존한다`() = runTest {
+        val (client, transaction) = transactionFixture()
+        val actionFailure = IllegalStateException("action failed")
+        val rollbackFailure = IllegalArgumentException("rollback failed")
+        every { transaction.rollbackAsync() } returns failedFuture(rollbackFailure)
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            client.withSuspendedTransaction {
+                throw actionFailure
+            }
+        }
+
+        thrown shouldBeSameInstanceAs actionFailure
+        thrown.suppressed.single()
+            .shouldBeInstanceOf<IllegalArgumentException>()
+            .message shouldBeEqualTo rollbackFailure.message
+        verify(exactly = 0) { transaction.commitAsync() }
+        verify(exactly = 1) { transaction.rollbackAsync() }
+    }
+
+    @Test
+    fun `caller cancellation 동안 rollback 완료를 기다리고 원래 cancellation을 보존한다`() = runTest {
+        val (client, transaction) = transactionFixture()
+        val callerCancellation = CancellationException("caller cancelled")
+        val rollback = CompletableFuture<Void>()
+        val observed = CompletableDeferred<Throwable>()
+        every { transaction.rollbackAsync() } returns CompletableFutureWrapper(rollback)
+
+        val job = launch {
+            try {
+                client.withSuspendedTransaction {
+                    currentCoroutineContext().cancel(callerCancellation)
+                    throw callerCancellation
+                }
+            } catch (failure: Throwable) {
+                observed.complete(failure)
+            }
+        }
+
+        runCurrent()
+        observed.isCompleted.shouldBeFalse()
+
+        rollback.complete(null)
+        runCurrent()
+
+        observed.await() shouldBeSameInstanceAs callerCancellation
+        job.isCancelled.shouldBeTrue()
+        verify(exactly = 1) { transaction.rollbackAsync() }
+    }
+
+    @Test
+    fun `commit 실패가 주 예외이고 rollback을 수행한다`() = runTest {
+        val (client, transaction) = transactionFixture()
+        val commitFailure = IllegalStateException("commit failed")
+        every { transaction.commitAsync() } returns failedFuture(commitFailure)
+        every { transaction.rollbackAsync() } returns completedFuture()
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            client.withSuspendedTransaction {}
+        }
+
+        thrown shouldBeSameInstanceAs commitFailure
+        thrown.suppressed.isEmpty().shouldBeTrue()
+        verify(exactly = 1) { transaction.commitAsync() }
+        verify(exactly = 1) { transaction.rollbackAsync() }
+    }
+
+    @Test
+    fun `rollback이 완료되지 않으면 제한 시간 후 주 예외에 timeout을 suppress한다`() = runTest {
+        val (client, transaction) = transactionFixture()
+        val actionFailure = IllegalStateException("action failed")
+        every { transaction.rollbackAsync() } returns CompletableFutureWrapper(CompletableFuture<Void>())
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            client.withSuspendedTransaction {
+                throw actionFailure
+            }
+        }
+
+        thrown shouldBeSameInstanceAs actionFailure
+        (thrown.suppressed.single() is TimeoutCancellationException).shouldBeTrue()
+    }
+
+    private fun transactionFixture(): Pair<RedissonClient, RTransaction> {
+        val client = mockk<RedissonClient>()
+        val transaction = mockk<RTransaction>()
+        every { client.createTransaction(any()) } returns transaction
+        return client to transaction
+    }
+
+    private fun completedFuture(): RFuture<Void> =
+        CompletableFutureWrapper.completedNull()
+
+    private fun failedFuture(failure: Throwable): RFuture<Void> =
+        CompletableFutureWrapper(failure)
+}


### PR DESCRIPTION
## Summary

Fixes #1615

`withSuspendedTransaction`의 rollback을 bounded `NonCancellable` 경계에서 수행하고, action/commit/caller cancellation의 주 예외를 그대로 보존합니다.

## Background

milestone `2.1.0`의 #1615에서 취소 가능한 caller context의 rollback `await()`가 cleanup cancellation으로 주 실패를 덮고 rollback 진단도 잃는 결함을 확인했습니다.

## What This Solves

- caller cancellation 중에도 bounded rollback cleanup 수행
- rollback 실패 또는 timeout을 주 예외의 suppressed 정보로 보존

## Work Done

- rollback을 `NonCancellable`과 5초 timeout 경계에서 수행하고 주 예외를 다시 던지도록 했습니다.
- action 실패, caller cancellation, commit 실패, rollback 실패/timeout contract test를 추가했습니다.
- pre-PR review에서 suspend `runCatching`과 assertion import를 교정하고 exact head를 재검증했습니다.

## Validation

- `RedissonClientCoroutineContractTest`: PASS (4건)
- `:bluetape4k-redisson:test`: PASS (320건, failures/errors/skipped 0)
- `:bluetape4k-redisson:detekt`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: pre-PR Kotlin 규칙 finding 2건 교정 완료
- Review evidence: independent native `code-reviewer` exact-head review; repair receipt `20260903T204902Z-47360298`

## Metadata

- Issue: #1615, milestone `2.1.0`, assignee `debop`
- PR: #1626, head `4316eac0afd11a24f7637a67e8fffe375ac07751`, milestone `2.1.0`, assignee `debop`
- CI: https://github.com/bluetape4k/bluetape4k-projects/pull/1626/checks

## DoD Status

Required checks: 8/8; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - 사전 검증 | RED/GREEN, sequential Testcontainers, review repair, exact diff 수렴 | PASS | head `4316eac0afd11a24f7637a67e8fffe375ac07751`; 320 tests; P0/P1=0 | 없음 |
| CG-12A - Guidance refresh | 현재 guidance, Type C/Kotlin/coroutine skill, PR template, #1615 metadata 재확인 | PASS | live issue OPEN, milestone `2.1.0`, assignee/labels 일치 | 없음 |
| CG-13 - PR 전달 | exact head publish와 한국어 PR metadata 확인 | PASS | #1626 `4316eac0afd11a24f7637a67e8fffe375ac07751` | 없음 |
| CG-14 - CI 및 독립 검토 | exact-head CI와 review/thread read-back | PASS | head `4316eac0afd11a24f7637a67e8fffe375ac07751`; [CI run 33811687895](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33811687895) 12 SUCCESS/12 SKIPPED; independent review P0/P1/P2/P3=0; unresolved thread 0 | 없음 |
| CG-14 - human review | single-developer lane | N/A | 저장소 관리자 `debop` 단독 범위 | 없음 |
| CG-15 - merge-ready 보고 | exact PR/head와 CI/review 증거 보고 | PASS | PR #1626 head `4316eac0afd11a24f7637a67e8fffe375ac07751` merge-ready 보고 완료 | 없음 |
| CG-16 - fresh merge 승인 | CG-15 이후 exact head 승인 확인 | PASS | 사용자의 후속 `승인`을 PR #1626 exact head에 귀속 | 없음 |
| CG-17 - 병합 및 live 확인 | `--rebase --match-head-commit` 병합 | PASS | `2026-09-04T03:59:59Z`; merge commit `a18374fbe8af1e6595383ff59c6f8334a488e3af`; Issue #1615 CLOSED | 없음 |
| CG-18 - 동기화 및 보존 | `develop` fast-forward, 통합 테스트, 비승인 cleanup 보존 | PASS | local/`origin/develop` `611aa2fabaffe610df8ee242e64b3cb51372686f`; Core/Coroutines/VirtualThread BUILD SUCCESSFUL; Redisson 320 tests PASS | worktree/local branch 보존 |

Final status: DONE

Unchecked required items: none
