### PR TITLE
[virtualthread][bug] JDK25 public join에서 owner interrupt를 즉시 전파한다 (#953 후속)

### DIFF
--- a/docs/lessons/2026-09-04-issue-1616-jdk25-owner-interrupt.md
+++ b/docs/lessons/2026-09-04-issue-1616-jdk25-owner-interrupt.md
@@ -1,0 +1,48 @@
+# Issue #1616: owner interrupt와 subtask failure를 같은 실패 슬롯에 넣지 않는다
+
+## 맥락
+
+JDK25 `StructuredTaskScope` adapter는 JDK21의 직접 위임 방식과 달리
+`FailedException`을 저장했다가 기존 bluetape4k API의 `throwIfFailed` 또는 `result`
+mapper 경계에서 처리한다. 이때 `runCatching`이나 `catch (Throwable)`로 `join()` 전체를
+감싸면 owner thread의 `InterruptedException`까지 subtask 실패로 분류된다. 그 결과
+`withAll.join()`은 취소 신호를 즉시 던지지 않고, `withAny.result()`는 cancellation을
+업무 실패 mapper로 변환할 수 있었다.
+
+## 결정
+
+- JDK25 `withAll`의 `join`과 `joinUntil`은 `InterruptedException`을 failure slot에
+  저장하지 않고 즉시 다시 던진다.
+- `withAll`은 `StructuredTaskScope.FailedException`만 잡아 cause를 기존 방식대로
+  `throwIfFailed`에 보관한다.
+- JDK25 `withAny`의 `join`과 `result` 직접 호출은 하나의 `joinResult` 경계를 공유한다.
+- `joinResult`는 owner `InterruptedException`을 즉시 던지고, subtask
+  `FailedException`만 `Result.failure`로 저장해 mapper에 전달한다.
+- timeout scheduler가 만든 interrupt를 `TimeoutException`으로 변환하는 기존
+  `interruptJoinUntil` 계약은 유지한다.
+
+## 결과
+
+pre-interrupt와 외부 interrupt는 `withAll.join`, `withAll.joinUntil`,
+`withAny.join().result`, `withAny.result` 직접 호출에서 raw `InterruptedException`으로
+관찰된다. mapper는 owner interrupt에 호출되지 않는다. subtask 실패는 계속 cause가
+unwrap되고 fail-fast 또는 mapper 계약에 따라 처리된다. public API와 JDK21 provider
+구현은 변경하지 않았다.
+
+## 검증
+
+- 수정 전 회귀: pre-interrupted `withAll.join()`이 예외 없이 반환해 1 test failed.
+- `Jdk25StructuredTaskScopeProviderExtTest`: 27 passing. pre/external interrupt,
+  `join`/`result`/`joinUntil`, subtask failure와 timeout을 포함한다.
+- `:bluetape4k-virtualthread-jdk25:test`: 43 passing, failure/error/skipped 0.
+- `:bluetape4k-virtualthread-jdk21:test`: 26 passing, failure/error/skipped 0.
+- `:bluetape4k-virtualthread-jdk25:detekt`: `BUILD SUCCESSFUL`; 변경 경로의 generic
+  catch 진단은 제거됐고 기존 baseline 진단만 남았다.
+- `git diff --check`: 통과.
+
+## 향후 지침
+
+structured concurrency adapter에서 owner control-flow 예외와 subtask 결과 예외를 먼저
+분류한다. `InterruptedException`은 저장, 래핑, mapper 변환 전에 즉시 전파한다.
+`Result`나 failure slot에는 API가 명시한 subtask failure만 넣고, timeout처럼 별도
+control-flow 의미가 있는 예외는 해당 public 경계에서 보존한다.

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderExtTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderExtTest.kt
@@ -1,7 +1,6 @@
 package io.bluetape4k.concurrent.virtualthread.jdk21
 
-import io.bluetape4k.logging.coroutines.KLoggingChannel
-import io.bluetape4k.logging.debug
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeInstanceOf
@@ -9,12 +8,15 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeBlank
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
-import java.util.concurrent.StructuredTaskScope
+import org.junit.jupiter.api.condition.EnabledForJreRange
 import java.time.Instant
-import io.bluetape4k.assertions.assertFailsWith
+import java.util.concurrent.Executors
+import java.util.concurrent.StructuredTaskScope
+import java.util.concurrent.TimeUnit
 
 /**
  * [Jdk21StructuredTaskScopeProvider] 추가 커버리지 테스트입니다.
@@ -81,6 +83,39 @@ class Jdk21StructuredTaskScopeProviderExtTest {
     }
 
     @Test
+    fun `withAll join은 기존 owner interrupt를 즉시 전파해야 한다`() {
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAll { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    Thread.currentThread().interrupt()
+                    scope.join()
+                }
+            }
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `withAll joinUntil은 외부 owner interrupt를 즉시 전파해야 한다`() {
+        val ownerThread = Thread.currentThread()
+        val interrupter = Executors.newSingleThreadScheduledExecutor()
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAll { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    interrupter.schedule({ ownerThread.interrupt() }, 100, TimeUnit.MILLISECONDS)
+                    scope.joinUntil(Instant.now().plusSeconds(5))
+                }
+            }
+        } finally {
+            interrupter.shutdownNow()
+            Thread.interrupted()
+        }
+    }
+
+    @Test
     fun `subtask 성공 상태와 값을 확인해야 한다`() {
         var capturedSubtask: io.bluetape4k.concurrent.virtualthread.api.StructuredSubtask<Int>? = null
         provider.withAll { scope ->
@@ -125,6 +160,26 @@ class Jdk21StructuredTaskScopeProviderExtTest {
                 scope.fork<String> { throw RuntimeException("fail2") }
                 scope.join().result { IllegalStateException("all failed") }
             }
+        }
+    }
+
+    @Test
+    fun `withAny result는 owner interrupt를 mapper로 변환하지 않아야 한다`() {
+        var mapperCalled = false
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAny<Int> { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    Thread.currentThread().interrupt()
+                    scope.join().result {
+                        mapperCalled = true
+                        IllegalStateException(it)
+                    }
+                }
+            }
+            mapperCalled.shouldBeFalse()
+        } finally {
+            Thread.interrupted()
         }
     }
 

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -129,7 +129,8 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
      * ## 동작/계약
      * - `Joiner.awaitAllSuccessfulOrThrow()`를 사용하여 subtask 실패 시 나머지를 즉시 취소합니다.
      * - join 후 [StructuredTaskScopeAll.throwIfFailed]로 첫 번째 실패 예외를 전파합니다.
-     * - [join]은 subtask 실패 예외를 내부에 저장하여 [throwIfFailed] 호출 시 재발생시킵니다.
+     * - [join]은 subtask의 `FailedException` 원인만 저장하여 [throwIfFailed] 호출 시 재발생시킵니다.
+     * - owner thread의 [InterruptedException]은 저장하지 않고 [join]에서 즉시 전파합니다.
      *
      * ```kotlin
      * val result = Jdk25StructuredTaskScopeProvider().withAll { scope ->
@@ -160,7 +161,8 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
      *
      * ## 동작/계약
      * - `StructuredTaskScope.open<T, T>(Joiner.anySuccessfulResultOrThrow(), ...)`를 사용합니다.
-     * - [StructuredTaskScopeAny.result]에서 join 실패를 `mapper` 예외로 변환합니다.
+     * - [StructuredTaskScopeAny.result]에서 subtask 실패를 `mapper` 예외로 변환합니다.
+     * - owner thread의 [InterruptedException]은 `mapper`에 전달하지 않고 즉시 전파합니다.
      *
      * ```kotlin
      * val result = Jdk25StructuredTaskScopeProvider().withAny<String> { scope ->
@@ -231,10 +233,12 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         override fun join(): StructuredTaskScopeAll {
             try {
                 delegate.join()
-            } catch (e: Throwable) {
+            } catch (e: InterruptedException) {
+                throw e
+            } catch (e: StructuredTaskScope.FailedException) {
                 // awaitAllSuccessfulOrThrow()는 subtask 실패를 FailedException으로 래핑해서 throw.
                 // 원본 예외(cause)를 사용자에게 노출하기 위해 언래핑
-                joinException = if (e is StructuredTaskScope.FailedException) e.cause ?: e else e
+                joinException = e.cause ?: e
             }
             return this
         }
@@ -244,8 +248,10 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
                 interruptJoinUntil(deadline, "jdk25-scope-timeout") { delegate.join() }
             } catch (e: TimeoutException) {
                 throw e
-            } catch (e: Throwable) {
-                joinException = if (e is StructuredTaskScope.FailedException) e.cause ?: e else e
+            } catch (e: InterruptedException) {
+                throw e
+            } catch (e: StructuredTaskScope.FailedException) {
+                joinException = e.cause ?: e
             }
             return this
         }
@@ -283,29 +289,32 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
         }
 
         override fun join(): StructuredTaskScopeAny<T> {
-            joinedResult = runCatching { delegate.join() }
+            joinedResult = joinResult()
             return this
         }
 
         override fun joinUntil(deadline: Instant): StructuredTaskScopeAny<T> {
             interruptJoinUntil(deadline, "jdk25-any-scope-timeout") {
-                try {
-                    joinedResult = Result.success(delegate.join())
-                } catch (e: InterruptedException) {
-                    throw e
-                } catch (e: Exception) {
-                    joinedResult = Result.failure(e)
-                }
+                joinedResult = joinResult()
             }
             return this
         }
 
         override fun result(mapper: (Throwable) -> RuntimeException): T {
-            val result = joinedResult ?: runCatching { delegate.join() }
+            val result = joinedResult ?: joinResult()
             return result.getOrElse { throwable ->
                 throw mapper(throwable.cause ?: throwable)
             }
         }
+
+        private fun joinResult(): Result<T> =
+            try {
+                Result.success(delegate.join())
+            } catch (e: InterruptedException) {
+                throw e
+            } catch (e: StructuredTaskScope.FailedException) {
+                Result.failure(e)
+            }
 
         override fun close() {
             delegate.close()

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderExtTest.kt
@@ -93,6 +93,84 @@ class Jdk25StructuredTaskScopeProviderExtTest {
     }
 
     @Test
+    fun `withAll join은 기존 owner interrupt를 즉시 전파해야 한다`() {
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAll { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    Thread.currentThread().interrupt()
+                    scope.join()
+                }
+            }
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `withAll join은 외부 owner interrupt를 즉시 전파해야 한다`() {
+        val ownerThread = Thread.currentThread()
+        val interrupter = Executors.newSingleThreadScheduledExecutor()
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAll { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    interrupter.schedule({ ownerThread.interrupt() }, 100, TimeUnit.MILLISECONDS)
+                    scope.join()
+                }
+            }
+        } finally {
+            interrupter.shutdownNow()
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `withAll joinUntil은 기존 owner interrupt를 즉시 전파해야 한다`() {
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAll { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    Thread.currentThread().interrupt()
+                    scope.joinUntil(Instant.now().plusSeconds(5))
+                }
+            }
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `withAll joinUntil은 외부 owner interrupt를 즉시 전파해야 한다`() {
+        val ownerThread = Thread.currentThread()
+        val interrupter = Executors.newSingleThreadScheduledExecutor()
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAll { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    interrupter.schedule({ ownerThread.interrupt() }, 100, TimeUnit.MILLISECONDS)
+                    scope.joinUntil(Instant.now().plusSeconds(5))
+                }
+            }
+        } finally {
+            interrupter.shutdownNow()
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `withAll joinUntil은 subtask 실패 원인을 유지해야 한다`() {
+        val failure = assertFailsWith<IllegalStateException> {
+            provider.withAll { scope ->
+                scope.fork<Int> { throw IllegalStateException("subtask failed") }
+                scope.joinUntil(Instant.now().plusSeconds(5)).throwIfFailed()
+            }
+        }
+
+        failure.message shouldBeEqualTo "subtask failed"
+    }
+
+    @Test
     fun `interruptJoinUntil timeout interrupt는 TimeoutException 으로 변환하고 interrupt 상태를 clear 해야 한다`() {
         try {
             assertFailsWith<TimeoutException> {
@@ -214,6 +292,89 @@ class Jdk25StructuredTaskScopeProviderExtTest {
                 scope.join().result { IllegalStateException("all failed: $it") }
             }
         }
+    }
+
+    @Test
+    fun `withAny result는 기존 owner interrupt를 mapper로 변환하지 않아야 한다`() {
+        var mapperCalled = false
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAny<Int> { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    Thread.currentThread().interrupt()
+                    scope.join().result {
+                        mapperCalled = true
+                        IllegalStateException(it)
+                    }
+                }
+            }
+            mapperCalled.shouldBeFalse()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `withAny result 직접 호출도 owner interrupt를 mapper로 변환하지 않아야 한다`() {
+        var mapperCalled = false
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAny<Int> { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    Thread.currentThread().interrupt()
+                    scope.result {
+                        mapperCalled = true
+                        IllegalStateException(it)
+                    }
+                }
+            }
+            mapperCalled.shouldBeFalse()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `withAny result는 외부 owner interrupt를 mapper로 변환하지 않아야 한다`() {
+        val ownerThread = Thread.currentThread()
+        val interrupter = Executors.newSingleThreadScheduledExecutor()
+        var mapperCalled = false
+        try {
+            assertFailsWith<InterruptedException> {
+                provider.withAny<Int> { scope ->
+                    scope.fork { Thread.sleep(5_000); 1 }
+                    interrupter.schedule({ ownerThread.interrupt() }, 100, TimeUnit.MILLISECONDS)
+                    scope.join().result {
+                        mapperCalled = true
+                        IllegalStateException(it)
+                    }
+                }
+            }
+            mapperCalled.shouldBeFalse()
+        } finally {
+            interrupter.shutdownNow()
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `withAny subtask 실패만 mapper 입력으로 전달해야 한다`() {
+        var mappedFailure: Throwable? = null
+
+        val failure = assertFailsWith<IllegalStateException> {
+            provider.withAny<Int> { scope ->
+                scope.fork<Int> { throw IllegalArgumentException("subtask failed") }
+                scope.join().result {
+                    mappedFailure = it
+                    IllegalStateException("mapped", it)
+                }
+            }
+        }
+
+        val actualMappedFailure = mappedFailure.shouldNotBeNull()
+        actualMappedFailure.shouldBeInstanceOf<IllegalArgumentException>()
+        actualMappedFailure.message shouldBeEqualTo "subtask failed"
+        failure.cause shouldBeEqualTo actualMappedFailure
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1616

JDK25 structured task scope adapter가 owner `InterruptedException`을 subtask failure로 저장하거나 mapper 입력으로 바꾸지 않고 즉시 원형 그대로 전파하게 합니다.

## Background

milestone `2.1.0`의 #1616에서 JDK25 `join()`/`result()`의 broad catch가 owner interrupt와 `FailedException`을 같은 지연 실패 경로로 합치는 계약 불일치를 확인했습니다.

## What This Solves

- `withAll`/`withAny`/`joinUntil` public 경계의 owner interrupt 즉시 전파
- JDK21 observable contract와 JDK25 adapter의 interrupt parity 회복

## Work Done

- `InterruptedException`은 즉시 rethrow하고 `StructuredTaskScope.FailedException`만 failure slot/result에 저장하도록 분리했습니다.
- pre-interrupt, external interrupt, subtask failure, timeout 경로 회귀 테스트와 lesson을 추가했습니다.
- JDK21 public `withAll`/`withAny` owner interrupt parity도 별도 회귀 테스트로 고정했습니다.

## Validation

- `Jdk25StructuredTaskScopeProviderExtTest`: PASS (27건)
- `:bluetape4k-virtualthread-jdk25:test`: PASS (43건)
- `:bluetape4k-virtualthread-jdk21:test`: PASS (29건)
- `:bluetape4k-virtualthread-jdk25:detekt`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: independent native `code-reviewer` exact-head review

## Metadata

- Issue: #1616, milestone `2.1.0`, assignee `debop`
- PR: #1627, head `e25c38719e99f0f360dbffce1dc52589b39b9f00`, milestone `2.1.0`, assignee `debop`
- CI: https://github.com/bluetape4k/bluetape4k-projects/pull/1627/checks

## DoD Status

Required checks: 8/8; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - 사전 검증 | RED/GREEN, JDK25/JDK21 parity, lesson, exact diff 검토 수렴 | PASS | head `e25c38719e99f0f360dbffce1dc52589b39b9f00`; P0/P1/P2/P3=0 | 없음 |
| CG-12A - Guidance refresh | 현재 guidance, Type C/Kotlin skill, PR template, #1616 metadata 재확인 | PASS | live issue OPEN, milestone `2.1.0`, assignee/labels 일치 | 없음 |
| CG-13 - PR 전달 | exact head publish와 한국어 PR metadata 확인 | PASS | #1627 `e25c38719e99f0f360dbffce1dc52589b39b9f00` | 없음 |
| CG-14 - CI 및 독립 검토 | exact-head CI와 review/thread read-back | PASS | head `e25c38719e99f0f360dbffce1dc52589b39b9f00`; [CI run 33811819305](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33811819305) 12 SUCCESS/12 SKIPPED; independent review P0/P1/P2/P3=0; unresolved thread 0 | 없음 |
| CG-14 - human review | single-developer lane | N/A | 저장소 관리자 `debop` 단독 범위 | 없음 |
| CG-15 - merge-ready 보고 | exact PR/head와 CI/review 증거 보고 | PASS | PR #1627 head `e25c38719e99f0f360dbffce1dc52589b39b9f00` merge-ready 보고 완료 | 없음 |
| CG-16 - fresh merge 승인 | CG-15 이후 exact head 승인 확인 | PASS | 사용자의 후속 `승인`을 PR #1627 exact head에 귀속 | 없음 |
| CG-17 - 병합 및 live 확인 | `--rebase --match-head-commit` 병합 | PASS | `2026-09-04T04:00:33Z`; merge commit `611aa2fabaffe610df8ee242e64b3cb51372686f`; Issue #1616 CLOSED | 없음 |
| CG-18 - 동기화 및 보존 | `develop` fast-forward, 통합 테스트, 비승인 cleanup 보존 | PASS | local/`origin/develop` `611aa2fabaffe610df8ee242e64b3cb51372686f`; Core/Coroutines/VirtualThread BUILD SUCCESSFUL; Redisson 320 tests PASS | worktree/local branch 보존 |

Final status: DONE

Unchecked required items: none
