### PR TITLE
fix: RuleProxy가 검증한 method descriptor를 직접 호출한다

### DIFF
--- a/docs/lessons/2026-09-04-issue-1617-rule-proxy-descriptor.md
+++ b/docs/lessons/2026-09-04-issue-1617-rule-proxy-descriptor.md
@@ -1,0 +1,40 @@
+# Issue #1617: reflection으로 찾은 Method descriptor를 이름으로 축약하지 않는다
+
+## 맥락
+
+`RuleDefinitionValidator`와 `RuleProxy`는 `@Condition`, `@Action`, `@Priority`가 붙은
+정확한 `Method`를 찾고도 실행 직전에 메서드 이름으로 다시 조회했다. 같은 이름의
+overload가 먼저 반환되면 검증한 parameter/return descriptor와 실제 invoke 대상이 달라져
+`RuleException`, `argument type mismatch`, `wrong number of arguments`가 발생했다.
+
+## 결정
+
+- annotation discovery에서 얻은 `Method`를 condition parameter 주입과 invoke에 함께 쓴다.
+- action 정렬 객체가 보관한 `Method`를 그대로 invoke한다.
+- priority annotation을 가진 `Method`를 이름 재조회 없이 invoke한다.
+- 이름이 같은 overload가 annotation method보다 먼저 노출되는 fixture로 세 경로를 각각
+  검증한다.
+- generic interface 구현에서 compiler가 생성한 bridge method가 함께 노출되는 경로도
+  별도 회귀 테스트로 고정한다.
+
+## 결과
+
+reflection 순서와 무관하게 annotation이 붙은 descriptor가 condition, action, priority의
+실제 호출 대상이 된다. public API와 JVM descriptor는 변경하지 않았고 private name-based
+lookup만 제거했다.
+
+## 검증
+
+- 수정 전 `RuleProxyTest`: 12 tests 중 새 회귀 4건 실패.
+- 수정 후 `RuleProxyTest`: 12 passing.
+- `:bluetape4k-rule-engine:test`: 356 passing, 5 pending.
+- compile/detekt task: `BUILD SUCCESSFUL`; 새 fixture의 Detekt finding 0.
+- `git diff --check`: 통과.
+
+## 향후 지침
+
+reflection 기반 validator, dispatcher, serializer가 annotation이나 signature로 멤버를
+선택하면 선택 결과의 `Method`, `Constructor`, `Field` identity를 실행 단계까지 보존한다.
+이름은 로그와 표시 용도로만 사용하고 overload, bridge, 상속 멤버를 다시 고르는 key로
+사용하지 않는다. 회귀 테스트는 같은 이름이면서 parameter descriptor가 다른 멤버를 먼저
+노출해 name-only lookup이 반드시 실패하도록 구성한다.

--- a/docs/testlogs/2026-09.md
+++ b/docs/testlogs/2026-09.md
@@ -1,0 +1,6 @@
+# 테스트 실행 기록
+
+| 날짜 | 이슈 | 검증 범위 | 결과 | 비고 |
+|---|---|---|---|---|
+| 2026-09-04 | #1617 | `RuleProxyTest` overload/bridge 회귀 | RED → GREEN — 4 failed, 수정 후 12 passing | condition/action/priority overload와 `ACC_BRIDGE|ACC_SYNTHETIC` generic bridge가 name-only 재조회에서 실패함을 확인 |
+| 2026-09-04 | #1617 | `:bluetape4k-rule-engine:cleanTest :bluetape4k-rule-engine:check --no-build-cache` | PASS — 356 passing, 5 pending | compile, Detekt, Kover 검증 포함 `BUILD SUCCESSFUL`; 변경 fixture 신규 Detekt finding 없음 |

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/RuleProxy.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/RuleProxy.kt
@@ -93,10 +93,9 @@ class RuleProxy(private val target: Any): InvocationHandler {
         log.debug { "Evaluate method ... method=${conditionMethod?.name}, facts=$facts" }
 
         return try {
-            val actualParameters = getActualParameters(conditionMethod!!, facts)
-            conditionMethod?.run {
-                getTargetMethod(this.name).invoke(target, *actualParameters.toTypedArray())
-            }
+            val method = checkNotNull(conditionMethod) { "Condition method is required." }
+            val actualParameters = getActualParameters(method, facts)
+            method.invoke(target, *actualParameters.toTypedArray())
         } catch (e: NoSuchFactException) {
             log.warn(e) {
                 "Rule '${targetClass.name}' has been evaluated to false " +
@@ -118,7 +117,7 @@ class RuleProxy(private val target: Any): InvocationHandler {
             actionMethodBeans.forEach { action ->
                 val actualParameters = getActualParameters(action.method, facts)
                 log.trace { "Invoke method '${action.method.name}' with parameter '$actualParameters'" }
-                getTargetMethod(action.method.name).invoke(target, *actualParameters.toTypedArray())
+                action.method.invoke(target, *actualParameters.toTypedArray())
             }
         }
         return null
@@ -175,10 +174,6 @@ class RuleProxy(private val target: Any): InvocationHandler {
         return if (priorityComparison != 0) priorityComparison else ruleName.compareTo(other.name)
     }
 
-    private fun getTargetMethod(methodName: String): Method {
-        return methods.find { it.name == methodName }!!
-    }
-
     private val ruleName: String by lazy {
         val annotation = ruleAnnotation
         if (annotation.name == DEFAULT_RULE_NAME) targetClass.simpleName
@@ -201,7 +196,7 @@ class RuleProxy(private val target: Any): InvocationHandler {
         methods
             .find { it.isAnnotationPresent(PriorityAnnotation::class.java) }
             ?.let { method ->
-                priority = getTargetMethod(method.name).invoke(target) as Int
+                priority = method.invoke(target) as Int
             }
 
         priority

--- a/utils/rule-engine/src/test/kotlin/io/bluetape4k/rule/core/RuleProxyTest.kt
+++ b/utils/rule-engine/src/test/kotlin/io/bluetape4k/rule/core/RuleProxyTest.kt
@@ -76,6 +76,39 @@ class RuleProxyTest {
         fun execute(facts: Facts) {}
     }
 
+    open class AnnotatedMethods(private val annotatedPriority: Int = 7) {
+        @PriorityAnnotation
+        fun priority(): Int = annotatedPriority
+
+        @ConditionAnnotation
+        fun matches(@FactAnnotation("score") score: Int): Boolean = score > 50
+
+        @ActionAnnotation
+        fun record(@FactAnnotation("events") events: MutableList<String>) {
+            events += "annotated"
+        }
+    }
+
+    @RuleAnnotation(name = "overloaded")
+    class OverloadedRule: AnnotatedMethods() {
+        fun priority(ignored: Int): Int = ignored
+
+        fun matches(facts: Facts): Boolean = facts.containsKey("wrong-overload")
+
+        fun record(facts: Facts) {
+            facts["wrong-overload"] = true
+        }
+    }
+
+    interface GenericCondition<T> {
+        fun matches(value: T): Boolean
+    }
+
+    @RuleAnnotation(name = "bridge")
+    class BridgeConditionRule: AnnotatedMethods(), GenericCondition<String> {
+        override fun matches(value: String): Boolean = value.isNotEmpty()
+    }
+
     @Test
     fun `어노테이션 기반 Rule을 asRule로 변환`() {
         val rule = AgeCheckRule().asRule()
@@ -148,5 +181,40 @@ class RuleProxyTest {
         val rule2 = AgeCheckRule().asRule()
         (rule1 == rule2).shouldBeTrue()
         (rule1.hashCode() == rule2.hashCode()).shouldBeTrue()
+    }
+
+    @Test
+    fun `Priority는 이름이 같은 overload가 있어도 annotated descriptor를 호출한다`() {
+        val rule = OverloadedRule().asRule()
+
+        rule.priority shouldBeEqualTo 7
+    }
+
+    @Test
+    fun `Condition은 이름이 같은 overload가 있어도 annotated descriptor를 호출한다`() {
+        val rule = OverloadedRule().asRule()
+
+        rule.evaluate(Facts.of("score" to 80)).shouldBeTrue()
+    }
+
+    @Test
+    fun `Action은 이름이 같은 overload가 있어도 annotated descriptor를 호출한다`() {
+        val rule = OverloadedRule().asRule()
+        val events = mutableListOf<String>()
+        val facts = Facts.of("events" to events)
+
+        rule.execute(facts)
+
+        events shouldBeEqualTo listOf("annotated")
+    }
+
+    @Test
+    fun `Condition은 compiler bridge가 있어도 annotated descriptor를 호출한다`() {
+        val bridge = BridgeConditionRule::class.java.methods.single { it.name == "matches" && it.isBridge }
+        bridge.parameterTypes.single() shouldBeEqualTo Any::class.java
+
+        val rule = BridgeConditionRule().asRule()
+
+        rule.evaluate(Facts.of("score" to 80)).shouldBeTrue()
     }
 }


### PR DESCRIPTION
## 변경 요약

`RuleProxy`가 annotation discovery에서 검증한 정확한 `Method`를 condition, action, priority 실행까지 보존합니다. 메서드 이름으로 다시 조회하던 private fallback을 제거해 overload와 Kotlin compiler bridge가 공존해도 다른 descriptor를 호출하지 않게 합니다.

Closes #1617

## 원인과 해결

- 기존 구현은 `@Condition`, `@Action`, `@Priority`가 붙은 `Method`를 찾은 뒤 `methods.find { it.name == methodName }`으로 다시 선택했습니다.
- `Class.getMethods()` 순서는 descriptor 선택 계약이 아니므로 같은 이름의 overload 또는 compiler bridge가 먼저 반환되면 parameter/return contract가 달라졌습니다.
- 이미 검증된 `Method` 인스턴스를 parameter 주입과 `invoke`에 직접 사용하도록 최소 수정했습니다.
- public API와 JVM descriptor는 변경하지 않았습니다.

## 변경 유형

- [x] `fix` — 버그 수정
- [x] `test` — 테스트 추가/수정
- [x] `docs` — lesson 및 테스트 실행 기록

## 테스트

- [x] 수정 전 `RuleProxyTest`: 12 tests 중 신규 회귀 4건 실패
- [x] 수정 후 `RuleProxyTest`: 12 passing
- [x] `:bluetape4k-rule-engine:cleanTest :bluetape4k-rule-engine:check --no-build-cache`: 356 passing, 5 pending, `BUILD SUCCESSFUL`
- [x] compile, Detekt, Kover 검증 통과; 변경 fixture 신규 Detekt finding 없음
- [x] `docs/testlogs/2026-09.md`에 결과 기록

## Code Review

- [x] 독립 native `code-reviewer` 재검토 완료 — P0/P1/P2 0
- [x] 실제 `matches(Object)`가 `ACC_BRIDGE|ACC_SYNTHETIC`인 fixture 확인
- [x] exact-head GitHub CI 및 live review/thread read-back

## 체크리스트

- [x] lesson 작성: `docs/lessons/2026-09-04-issue-1617-rule-proxy-descriptor.md`
- [x] README 변경 N/A — public API와 사용법 변경 없음
- [x] KDoc 변경 N/A — 공개 API 추가 없음
- [x] 격리 worktree `fix/rule-proxy-overload-descriptor`에서 작업
- [x] Docker, Spring Boot, cache ABI, virtualthread 조건 N/A — `utils/rule-engine` 한정 변경

## 남은 위험

- reflection 구현의 외부 consumer runtime은 별도로 실행하지 않았습니다.
- overload와 실제 compiler bridge, 전체 모듈 test/check로 변경 경계를 검증했습니다.

## DoD Status

Required checks: 8/8; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - 사전 검증 | RED/GREEN, 모듈 check, lesson, 독립 검토 수렴 | PASS | local head `bc708639edd88e56a526958501ce856470b162d1`; 356 passing, 5 pending; P0/P1/P2=0 | 없음 |
| CG-12A - Guidance refresh | 현재 guidance, Type C/Kotlin skill, PR template, #1617 metadata 재확인 | PASS | issue OPEN, milestone `2.1.0`, assignee `debop`, labels `bug`/`test`; no drift | 없음 |
| CG-13 - PR 전달 | exact head publish와 한국어 PR metadata 확인 | PASS | PR #1628 head `bc708639edd88e56a526958501ce856470b162d1`; base `develop`; milestone/assignee/labels 일치 | 없음 |
| CG-14 - CI 및 독립 검토 | exact-head CI와 review/thread read-back | PASS | [CI run 33838800352](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33838800352) 11 SUCCESS/13 conditional SKIPPED; aggregate `CI Status` SUCCESS; local module check 356 passing; independent review P0/P1/P2=0; unresolved thread 0 | 없음 |
| CG-14 - human review | single-developer lane | N/A | 저장소 관리자 `debop` 단독 범위 | 없음 |
| CG-15 - merge-ready 보고 | exact PR/head와 CI/review 증거 보고 | PASS | PR #1628 head `bc708639edd88e56a526958501ce856470b162d1` merge-ready 보고 완료 | 없음 |
| CG-16 - fresh merge 승인 | CG-15 이후 exact head 승인 확인 | PASS | 사용자의 후속 `승인`을 PR #1628 head `bc708639edd88e56a526958501ce856470b162d1`에 귀속 | 없음 |
| CG-17 - 병합 및 live 확인 | 승인된 exact head rebase merge 및 live 확인 | PASS | `2026-09-04T05:12:40Z`; merge commit `255017749cc5f601e9a1eb1396e9a8c209458f43`; Issue #1617 CLOSED | 없음 |
| CG-18 - 동기화 및 정리 | local sync, 통합 검증, GNO 인덱싱, worktree/branch 정리 | PASS | local/`origin/develop` `255017749cc5f601e9a1eb1396e9a8c209458f43`; 356 passing, 5 pending; GNO lesson 검색 성공; canonical worktree 1개·local branch `develop`/`main` | 없음 |

Final status: DONE

Unchecked required items: none
