### PR TITLE
[P1][infra-lettuce] write-behind retry 상태를 entry별로 보존한다

### DIFF
--- a/docs/lessons/2026-09-04-issue-1618-lettuce-entry-retry.md
+++ b/docs/lessons/2026-09-04-issue-1618-lettuce-entry-retry.md
@@ -1,0 +1,43 @@
+# Issue #1618: 배치 재시도 상태는 entry별로 전이한다
+
+## 맥락
+
+`LettuceLoadedMap`과 `LettuceSuspendedLoadedMap`의 write-behind queue는 각 entry에
+retry count를 보관한다. 그러나 writer batch가 실패하면 첫 entry의 retry count만 증가시켜
+나머지 entry에도 적용했다. 이미 두 번 실패한 entry와 처음 실패한 entry가 한 batch에
+섞이면 첫 entry 순서에 따라 재시도 상한이 늦어지거나 fresh entry가 조기 dead-letter됐다.
+
+## 결정
+
+- writer batch 실패 후 각 entry의 기존 retry count에서 `nextRetryCount`를 독립 계산한다.
+- `nextRetryCount < MAX_DEAD_LETTER_RETRY`인 entry만 queue 또는 channel에 다시 넣는다.
+- 재시도 상한에 도달했거나 queue/channel 포화로 다시 넣을 수 없는 entry만 dead-letter에
+  기록한다.
+- dead-letter의 복구 값 `HSET` 후 모니터링 키 `LPUSH` 순서와 suspend cancellation 전파는
+  유지한다.
+- `(retry=2, retry=0)` 혼합 batch를 직접 구성해 동기·suspend 구현이 같은 상태 전이를
+  수행하는지 회귀 테스트로 고정한다.
+
+## 결과
+
+retry 2 entry는 다음 실패인 attempt 3에서 dead-letter되고, 같은 batch의 fresh entry는
+retry 1 상태로 남는다. batch 내 순서가 다른 entry의 수명에 영향을 주지 않으며 기존
+retry exhaustion과 write-behind map 동작도 유지된다. public API와 JVM descriptor 변경은
+없다.
+
+## 검증
+
+- 수정 전 `LettuceWriteBehindRetryTest`: 2 tests 중 2 failures.
+- 수정 후 `LettuceWriteBehindRetryTest`: 4 passing. 혼합 retry-count 2건과 queue/channel
+  포화 시 dead-letter key·recovery value 보존 2건을 포함한다.
+- Lettuce map 집중 회귀: 42 passing.
+- `:bluetape4k-lettuce:check`: 기본 924 passing과 별도 topology/performance 4 passing,
+  총 928 passing.
+- compile, Detekt, Kover 및 `git diff --check`: 통과.
+
+## 향후 지침
+
+batch element가 retry, offset, sequence, deadline처럼 독립 상태를 보유하면 batch 대표값을
+전체 상태 전이에 재사용하지 않는다. 실패한 I/O는 한 번이어도 후속 retry/dead-letter
+결정은 element별 이전 상태에서 계산한다. 회귀 테스트는 서로 다른 상태의 element를 한
+batch에 넣고 각 결과를 동시에 검증해야 한다.

--- a/docs/testlogs/2026-09.md
+++ b/docs/testlogs/2026-09.md
@@ -4,3 +4,6 @@
 |---|---|---|---|---|
 | 2026-09-04 | #1617 | `RuleProxyTest` overload/bridge 회귀 | RED → GREEN — 4 failed, 수정 후 12 passing | condition/action/priority overload와 `ACC_BRIDGE|ACC_SYNTHETIC` generic bridge가 name-only 재조회에서 실패함을 확인 |
 | 2026-09-04 | #1617 | `:bluetape4k-rule-engine:cleanTest :bluetape4k-rule-engine:check --no-build-cache` | PASS — 356 passing, 5 pending | compile, Detekt, Kover 검증 포함 `BUILD SUCCESSFUL`; 변경 fixture 신규 Detekt finding 없음 |
+| 2026-09-04 | #1618 | `LettuceWriteBehindRetryTest` entry별 retry 및 포화 재삽입 회귀 | RED → GREEN — 핵심 2 failed, 보강 후 4 passing | `(retry=2, retry=0)` batch 분리와 queue/channel 포화 시 dead-letter key·recovery value 보존을 검증 |
+| 2026-09-04 | #1618 | Lettuce map 집중 회귀 5개 class | PASS — 42 passing | blocking/suspend exhaustion, map 동작, cancellation, 혼합 retry-count 및 포화 재삽입 경로 포함 |
+| 2026-09-04 | #1618 | `:bluetape4k-lettuce:cleanTest :bluetape4k-lettuce:check --no-build-cache --no-configuration-cache` | PASS — 928 passing | 기본 924건과 별도 topology/performance 4건, compile, Detekt, Kover 포함 `BUILD SUCCESSFUL` |

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMap.kt
@@ -311,33 +311,24 @@ class LettuceLoadedMap<K: Any, V: Any>(
         val batch = entries.associate { it.first to it.second }
         runCatching { writer?.write(batch) }
             .onFailure { e ->
-                val retryCount = entries.first().third + 1
-                log.error(e) { "Write-behind flush 실패 (attempt $retryCount): ${batch.keys}" }
-                if (retryCount < MAX_DEAD_LETTER_RETRY) {
-                    // 개선: offerFirst 반환값 확인 — 큐가 가득 찬 경우 재시도 항목이 유실될 수 있음.
-                    //       유실 항목은 dead-letter로 즉시 처리합니다.
-                    val failed = mutableListOf<Triple<K, V, Int>>()
-                    entries.forEach { (k, v, _) ->
-                        val offered = queue.offerFirst(Triple(k, v, retryCount))
+                val attempts = entries.map { it.third + 1 }
+                log.error(e) { "Write-behind flush 실패 (attempts=$attempts): ${batch.keys}" }
+                val failed = mutableListOf<Triple<K, V, Int>>()
+                entries.forEach { (k, v, retryCount) ->
+                    val nextRetryCount = retryCount + 1
+                    if (nextRetryCount < MAX_DEAD_LETTER_RETRY) {
+                        // 개선: offerFirst 반환값 확인 — 큐가 가득 찬 경우 재시도 항목이 유실될 수 있음.
+                        //       유실 항목은 dead-letter로 즉시 처리합니다.
+                        val offered = queue.offerFirst(Triple(k, v, nextRetryCount))
                         if (!offered) {
-                            log.warn { "재시도 큐 포화 — dead-letter 전송: key=$k (attempt=$retryCount)" }
-                            failed.add(Triple(k, v, retryCount))
+                            log.warn { "재시도 큐 포화 — dead-letter 전송: key=$k (attempt=$nextRetryCount)" }
+                            failed.add(Triple(k, v, nextRetryCount))
                         }
+                    } else {
+                        failed.add(Triple(k, v, nextRetryCount))
                     }
-                    if (failed.isNotEmpty()) {
-                        // 큐 포화로 재시도 불가한 항목은 dead-letter에 기록
-                        runCatching {
-                            val deadLetterKey = "${config.keyPrefix}:dead-letter"
-                            val deadLetterValuesKey = "${config.keyPrefix}:dead-letter:values"
-                            val failedBatch = failed.associate { it.first to it.second }
-                            val valueMap = failedBatch.entries.associate { (k, v) -> keySerializer(k) to v }
-                            // HSET 먼저 (복구 데이터 우선), 실패 시 LPUSH 건너뜀
-                            commands.hset(deadLetterValuesKey, valueMap)
-                            val serializedKeys = failedBatch.keys.map { keySerializer(it) }
-                            strCommands.lpush(deadLetterKey, *serializedKeys.toTypedArray())
-                        }.onFailure { ex -> log.error(ex) { "Dead letter 기록 실패 (큐 포화 fallback)" } }
-                    }
-                } else {
+                }
+                if (failed.isNotEmpty()) {
                     runCatching {
                         // 개선: 기존엔 키만 LPUSH 했기 때문에 실패한 엔트리 복구가 불가능했습니다.
                         //       이제 HSET(복구용 값)을 먼저 저장 후 LPUSH(모니터링용 키 목록)를 저장합니다.
@@ -345,10 +336,11 @@ class LettuceLoadedMap<K: Any, V: Any>(
                         //       HSET 실패 시 LPUSH를 건너뛰어 복구 불가 상태(모니터링 오탐)를 방지합니다.
                         val deadLetterKey = "${config.keyPrefix}:dead-letter"
                         val deadLetterValuesKey = "${config.keyPrefix}:dead-letter:values"
-                        val valueMap = batch.entries.associate { (k, v) -> keySerializer(k) to v }
+                        val failedBatch = failed.associate { it.first to it.second }
+                        val valueMap = failedBatch.entries.associate { (k, v) -> keySerializer(k) to v }
                         // HSET 먼저: 실패 시 LPUSH 건너뜀 (복구 데이터 우선)
                         commands.hset(deadLetterValuesKey, valueMap)
-                        val serializedKeys = batch.keys.map { keySerializer(it) }
+                        val serializedKeys = failedBatch.keys.map { keySerializer(it) }
                         strCommands.lpush(deadLetterKey, *serializedKeys.toTypedArray())
                     }.onFailure { ex -> log.error(ex) { "Dead letter 기록 실패" } }
                 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
@@ -352,22 +352,23 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            val retryCount = entries.first().third + 1
-            log.error(e) { "Write-behind flush 실패 (attempt $retryCount): ${batch.keys}" }
-            if (retryCount < MAX_DEAD_LETTER_RETRY) {
-                val dropped = mutableMapOf<K, V>()
-                entries.forEach { (k, v, _) ->
-                    val result = writeBehindChannel?.trySend(Triple(k, v, retryCount))
+            val attempts = entries.map { it.third + 1 }
+            log.error(e) { "Write-behind flush 실패 (attempts=$attempts): ${batch.keys}" }
+            val deadLetters = mutableMapOf<K, V>()
+            entries.forEach { (k, v, retryCount) ->
+                val nextRetryCount = retryCount + 1
+                if (nextRetryCount < MAX_DEAD_LETTER_RETRY) {
+                    val result = writeBehindChannel?.trySend(Triple(k, v, nextRetryCount))
                     if (result == null || result.isFailure) {
-                        log.warn { "Requeue failed for key=$k (attempt $retryCount): channel full or closed" }
-                        dropped[k] = v
+                        log.warn { "Requeue failed for key=$k (attempt $nextRetryCount): channel full or closed" }
+                        deadLetters[k] = v
                     }
+                } else {
+                    deadLetters[k] = v
                 }
-                if (dropped.isNotEmpty()) {
-                    writeToDeadLetter(dropped)
-                }
-            } else {
-                writeToDeadLetter(batch)
+            }
+            if (deadLetters.isNotEmpty()) {
+                writeToDeadLetter(deadLetters)
             }
         }
     }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceWriteBehindRetryTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceWriteBehindRetryTest.kt
@@ -1,0 +1,191 @@
+package io.bluetape4k.redis.lettuce.map
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.io.serializer.BinarySerializers
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.redis.lettuce.AbstractLettuceTest
+import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec
+import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.LinkedBlockingDeque
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.jvm.isAccessible
+
+internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
+
+    @Test
+    fun `blocking write-behind는 entry별 retry count를 보존한다`() {
+        val prefix = "entry-retry-loaded:${randomName()}"
+        val writer = object: MapWriter<String, String> {
+            override fun write(map: Map<String, String>) = error("simulated write failure")
+
+            override fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 2,
+        )
+
+        LettuceLoadedMap(client = client, writer = writer, config = config).use { map ->
+            map.writeBehindQueue().apply {
+                add(Triple("retried-key", "retried-value", 2))
+                add(Triple("fresh-key", "fresh-value", 0))
+            }
+
+            map.flushWriteBehindQueue()
+
+            map.writeBehindQueue().toList() shouldBeEqualTo
+                listOf(Triple("fresh-key", "fresh-value", 1))
+            client.connect(StringCodec.UTF8).use { connection ->
+                connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo listOf("retried-key")
+            }
+        }
+    }
+
+    @Test
+    fun `suspend write-behind는 entry별 retry count를 보존한다`() = runSuspendIO {
+        val prefix = "entry-retry-suspended:${randomName()}"
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) = error("simulated write failure")
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val cancelledScope = CoroutineScope(SupervisorJob() + Dispatchers.IO).also { it.cancel() }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 2,
+        )
+
+        LettuceSuspendedLoadedMap(
+            client = client,
+            writer = writer,
+            config = config,
+            scope = cancelledScope,
+        ).use { map ->
+            map.flushBatch(
+                listOf(
+                    Triple("retried-key", "retried-value", 2),
+                    Triple("fresh-key", "fresh-value", 0),
+                )
+            )
+
+            map.writeBehindChannel().tryReceive().getOrNull() shouldBeEqualTo
+                Triple("fresh-key", "fresh-value", 1)
+            map.writeBehindChannel().tryReceive().getOrNull().shouldBeNull()
+            client.connect(StringCodec.UTF8).use { connection ->
+                connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo listOf("retried-key")
+            }
+        }
+    }
+
+    @Test
+    fun `blocking write-behind는 retry queue 포화 시 entry를 dead-letter에 보존한다`() {
+        val prefix = "entry-retry-loaded-full:${randomName()}"
+        lateinit var loadedMap: LettuceLoadedMap<String, String>
+        val writer = object: MapWriter<String, String> {
+            override fun write(map: Map<String, String>) {
+                loadedMap.writeBehindQueue().add(Triple("queue-blocker", "blocker-value", 0))
+                error("simulated write failure")
+            }
+
+            override fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 1,
+            writeBehindQueueCapacity = 1,
+        )
+
+        loadedMap = LettuceLoadedMap(client = client, writer = writer, config = config)
+        loadedMap.use { map ->
+            map.writeBehindQueue().add(Triple("failed-key", "failed-value", 0))
+
+            map.flushWriteBehindQueue()
+
+            map.writeBehindQueue().toList() shouldBeEqualTo
+                listOf(Triple("queue-blocker", "blocker-value", 0))
+            map.writeBehindQueue().clear()
+            client.connect(StringCodec.UTF8).use { connection ->
+                connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo listOf("failed-key")
+            }
+            client.connect(LettuceBinaryCodec<String>(BinarySerializers.LZ4Fory)).use { connection ->
+                connection.sync().hget("$prefix:dead-letter:values", "failed-key") shouldBeEqualTo "failed-value"
+            }
+        }
+    }
+
+    @Test
+    fun `suspend write-behind는 retry channel 포화 시 entry를 dead-letter에 보존한다`() = runSuspendIO {
+        val prefix = "entry-retry-suspended-full:${randomName()}"
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) = error("simulated write failure")
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val cancelledScope = CoroutineScope(SupervisorJob() + Dispatchers.IO).also { it.cancel() }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 1,
+            writeBehindQueueCapacity = 1,
+        )
+
+        LettuceSuspendedLoadedMap(
+            client = client,
+            writer = writer,
+            config = config,
+            scope = cancelledScope,
+        ).use { map ->
+            map.writeBehindChannel().trySend(Triple("channel-blocker", "blocker-value", 0)).isSuccess shouldBeEqualTo true
+
+            map.flushBatch(listOf(Triple("failed-key", "failed-value", 0)))
+
+            map.writeBehindChannel().tryReceive().getOrNull() shouldBeEqualTo
+                Triple("channel-blocker", "blocker-value", 0)
+            map.writeBehindChannel().tryReceive().getOrNull().shouldBeNull()
+            client.connect(StringCodec.UTF8).use { connection ->
+                connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo listOf("failed-key")
+            }
+            client.connect(LettuceBinaryCodec<String>(BinarySerializers.LZ4Fory)).use { connection ->
+                connection.sync().hget("$prefix:dead-letter:values", "failed-key") shouldBeEqualTo "failed-value"
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun LettuceLoadedMap<String, String>.writeBehindQueue(): LinkedBlockingDeque<Triple<String, String, Int>> =
+        javaClass.getDeclaredField("writeBehindQueue")
+            .apply { isAccessible = true }
+            .get(this) as LinkedBlockingDeque<Triple<String, String, Int>>
+
+    private fun LettuceLoadedMap<String, String>.flushWriteBehindQueue() {
+        javaClass.getDeclaredMethod("flushWriteBehindQueue")
+            .apply { isAccessible = true }
+            .invoke(this)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun LettuceSuspendedLoadedMap<String, String>.writeBehindChannel(): Channel<Triple<String, String, Int>> =
+        javaClass.getDeclaredField("writeBehindChannel")
+            .apply { isAccessible = true }
+            .get(this) as Channel<Triple<String, String, Int>>
+
+    private suspend fun LettuceSuspendedLoadedMap<String, String>.flushBatch(
+        entries: List<Triple<String, String, Int>>,
+    ) {
+        val method = this::class.declaredMemberFunctions.single { it.name == "flushBatch" }
+        method.isAccessible = true
+        method.callSuspend(this, entries)
+    }
+}


### PR DESCRIPTION
## 요약

- blocking·suspend write-behind batch 실패 시 각 entry의 기존 retry count에서 다음 상태를 계산합니다.
- 재시도 상한에 도달한 entry만 dead-letter로 보내고, 같은 batch의 fresh entry는 retry queue/channel에 유지합니다.
- queue/channel 포화 시 재삽입에 실패한 entry를 dead-letter로 보내는 기존 #486 보장을 유지합니다.

Closes #1618

## 근본 원인

두 구현이 `entries.first().third + 1`을 batch 전체의 retry count로 사용했습니다. 서로 다른 retry 상태의 entry가 같은 batch에 섞이면 첫 entry 순서에 따라 exhausted entry의 상한 도달이 늦어지거나 fresh entry가 조기 dead-letter됐습니다.

## 변경 사항

- `LettuceLoadedMap`과 `LettuceSuspendedLoadedMap`에서 `nextRetryCount`를 entry별로 계산합니다.
- 상한 도달 또는 재삽입 실패 entry만 모아 기존 dead-letter 구조에 기록합니다.
- `(retry=2, retry=0)` 혼합 batch와 queue/channel 포화 재삽입 실패를 동기·suspend 양쪽에서 검증하는 회귀 테스트를 추가했습니다.
- 재사용 가능한 교훈과 2026-09 테스트 실행 기록을 남겼습니다.

## 검증

- RED: `LettuceWriteBehindRetryTest` 2 failed
- GREEN: `LettuceWriteBehindRetryTest` 4 passing
- Lettuce map 집중 회귀: 42 passing
- `:bluetape4k-lettuce:cleanTest :bluetape4k-lettuce:check`: 기본 924 passing + 별도 topology/performance 4 passing, 총 928 passing
- compile, Detekt, Kover: `BUILD SUCCESSFUL`
- `git diff --check`: PASS

## 리뷰

- 독립 코드 리뷰: P0/P1/P2/P3 = 0/0/0/0, verdict `CLEAR`
- public API/ABI 변경: 없음

## DoD Status

- [x] Issue #1618 근본 원인과 혼합 batch 재현을 확인했습니다.
- [x] blocking·suspend 구현이 entry별 retry count를 보존합니다.
- [x] retry 2 entry는 attempt 3에서 dead-letter됩니다.
- [x] 같은 batch의 fresh entry는 retry 1로 유지됩니다.
- [x] 기존 exhaustion과 queue/channel 재삽입 실패 처리 계약을 유지합니다.
- [x] targeted 및 전체 Lettuce 검증이 통과했습니다.
- [x] 독립 리뷰에서 P0/P1 차단 finding이 없습니다.
- [x] PR exact-head required CI가 terminal success입니다.

Required checks: 8; Done: 8; Pending: 0; Blocked: 0

Final status: DONE

Unchecked required items: none
