### PR TITLE
[bug][core] Progression stream 경계 overflow를 방지한다

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/ProgressionSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/ProgressionSupport.kt
@@ -1,8 +1,13 @@
 package io.bluetape4k.collections
 
 import io.bluetape4k.support.requirePositiveNumber
+import java.util.Spliterator
+import java.util.Spliterators
+import java.util.function.IntConsumer
+import java.util.function.LongConsumer
 import java.util.stream.IntStream
 import java.util.stream.LongStream
+import java.util.stream.StreamSupport
 
 private fun calculatePartitionCount(size: Int, chunkSize: Int): Int =
     size / chunkSize + if (size % chunkSize > 0) 1 else 0
@@ -37,8 +42,22 @@ fun charProgressionOf(start: Char, endInclusive: Char, step: Int = 1): CharProgr
 fun intProgressionOf(start: Int, endInclusive: Int, step: Int = 1): IntProgression =
     IntProgression.fromClosedRange(start, endInclusive, step)
 
+private fun IntProgression.toStreamSpliterator(): Spliterator.OfInt {
+    val progressionIterator = iterator()
+    return object : Spliterators.AbstractIntSpliterator(Long.MAX_VALUE, Spliterator.ORDERED) {
+        override fun tryAdvance(action: IntConsumer): Boolean {
+            if (!progressionIterator.hasNext()) return false
+            action.accept(progressionIterator.nextInt())
+            return true
+        }
+    }
+}
+
 /**
  * [IntProgression]을 [IntStream]으로 변환합니다.
+ *
+ * 경계에서 다음 값이 표현 범위를 벗어나면 overflow 값을 방출하지 않고 progression의
+ * 마지막 요소에서 정상 종료합니다.
  *
  * ```
  * val ints = intProgressionOf(1, 4, 1)
@@ -46,12 +65,12 @@ fun intProgressionOf(start: Int, endInclusive: Int, step: Int = 1): IntProgressi
  * stream.count() shouldBeEqualTo 3
  * ```
  */
-fun IntProgression.asStream(): IntStream = when {
-    step == 1  -> IntStream.rangeClosed(first, last)
-    step == -1 -> IntStream.iterate(first, { it >= last }, { it - 1 })
-    step > 0   -> IntStream.iterate(first, { it <= last }, { it + step })
-    else       -> IntStream.iterate(first, { it >= last }, { it + step })
-}
+fun IntProgression.asStream(): IntStream =
+    if (step == 1) {
+        IntStream.rangeClosed(first, last)
+    } else {
+        StreamSupport.intStream(toStreamSpliterator(), false)
+    }
 
 /**
  * [IntProgression]의 요소를 chunked 하여 [Sequence]로 반환합니다.
@@ -131,9 +150,23 @@ fun IntProgression.partitioning(partitionCount: Int = 1): Sequence<IntProgressio
 fun longProgressionOf(start: Long, endInclusive: Long, step: Long = 1L): LongProgression =
     LongProgression.fromClosedRange(start, endInclusive, step)
 
+private fun LongProgression.toStreamSpliterator(): Spliterator.OfLong {
+    val progressionIterator = iterator()
+    return object : Spliterators.AbstractLongSpliterator(Long.MAX_VALUE, Spliterator.ORDERED) {
+        override fun tryAdvance(action: LongConsumer): Boolean {
+            if (!progressionIterator.hasNext()) return false
+            action.accept(progressionIterator.nextLong())
+            return true
+        }
+    }
+}
+
 
 /**
  * asStream 기능을 제공합니다.
+ *
+ * 경계에서 다음 값이 표현 범위를 벗어나면 overflow 값을 방출하지 않고 progression의
+ * 마지막 요소에서 정상 종료합니다.
  *
  * ## 동작/계약
  * - null 입력 허용 여부는 시그니처의 nullable 표기를 따릅니다.
@@ -145,12 +178,12 @@ fun longProgressionOf(start: Long, endInclusive: Long, step: Long = 1L): LongPro
  * // result == [1, 2, 3]
  * ```
  */
-fun LongProgression.asStream(): LongStream = when {
-    step == 1L  -> LongStream.rangeClosed(first, last)
-    step == -1L -> LongStream.iterate(first, { it >= last }, { it - 1L })
-    step > 0L   -> LongStream.iterate(first, { it <= last }, { it + step })
-    else        -> LongStream.iterate(first, { it >= last }, { it + step })
-}
+fun LongProgression.asStream(): LongStream =
+    if (step == 1L) {
+        LongStream.rangeClosed(first, last)
+    } else {
+        StreamSupport.longStream(toStreamSpliterator(), false)
+    }
 
 /**
  * [LongProgression]의 요소를 chunked 하여 [Sequence]로 반환합니다.

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/ProgressionSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/ProgressionSupportTest.kt
@@ -32,6 +32,37 @@ class ProgressionSupportTest {
         }
 
         @Test
+        fun `as stream stops at positive Int boundary`() {
+            intProgressionOf(Int.MAX_VALUE - 1, Int.MAX_VALUE, 2)
+                .asStream()
+                .limit(2)
+                .toArray() shouldBeEqualTo intArrayOf(Int.MAX_VALUE - 1)
+        }
+
+        @Test
+        fun `as stream stops at Int MIN_VALUE with step minus one`() {
+            intProgressionOf(Int.MIN_VALUE, Int.MIN_VALUE, -1)
+                .asStream()
+                .limit(2)
+                .toArray() shouldBeEqualTo intArrayOf(Int.MIN_VALUE)
+        }
+
+        @Test
+        fun `as stream stops at negative Int boundary`() {
+            intProgressionOf(Int.MIN_VALUE + 2, Int.MIN_VALUE, -2)
+                .asStream()
+                .limit(3)
+                .toArray() shouldBeEqualTo intArrayOf(Int.MIN_VALUE + 2, Int.MIN_VALUE)
+        }
+
+        @Test
+        fun `as stream preserves normal negative Int progression`() {
+            intProgressionOf(3, 1, -1)
+                .asStream()
+                .toArray() shouldBeEqualTo intArrayOf(3, 2, 1)
+        }
+
+        @Test
         fun `chunked progression`() {
             val ints = intProgressionOf(1, 10, 1)
             ints.size() shouldBeEqualTo 10
@@ -103,6 +134,37 @@ class ProgressionSupportTest {
         fun `as stream`() {
             val longs = longProgressionOf(1, 10, 1)
             longs.asStream().count() shouldBeEqualTo 10
+        }
+
+        @Test
+        fun `as stream stops at positive Long boundary`() {
+            longProgressionOf(Long.MAX_VALUE - 1L, Long.MAX_VALUE, 2L)
+                .asStream()
+                .limit(2)
+                .toArray() shouldBeEqualTo longArrayOf(Long.MAX_VALUE - 1L)
+        }
+
+        @Test
+        fun `as stream stops at Long MIN_VALUE with step minus one`() {
+            longProgressionOf(Long.MIN_VALUE, Long.MIN_VALUE, -1L)
+                .asStream()
+                .limit(2)
+                .toArray() shouldBeEqualTo longArrayOf(Long.MIN_VALUE)
+        }
+
+        @Test
+        fun `as stream stops at negative Long boundary`() {
+            longProgressionOf(Long.MIN_VALUE + 2L, Long.MIN_VALUE, -2L)
+                .asStream()
+                .limit(3)
+                .toArray() shouldBeEqualTo longArrayOf(Long.MIN_VALUE + 2L, Long.MIN_VALUE)
+        }
+
+        @Test
+        fun `as stream preserves normal negative Long progression`() {
+            longProgressionOf(3L, 1L, -1L)
+                .asStream()
+                .toArray() shouldBeEqualTo longArrayOf(3L, 2L, 1L)
         }
 
         @Test

--- a/docs/lessons/2026-09-04-issue-1620-progression-stream-overflow.md
+++ b/docs/lessons/2026-09-04-issue-1620-progression-stream-overflow.md
@@ -1,0 +1,28 @@
+# Progression stream overflow 회귀 방지
+
+## 증상
+
+`IntProgression`/`LongProgression`을 Java primitive stream으로 바꿀 때 마지막
+원소 직후의 overflow 값이 stream에 섞이거나 종료하지 않을 수 있다.
+
+## 원인
+
+`IntStream.iterate`와 `LongStream.iterate`의 update lambda가 `current + step`을
+직접 계산하면 Kotlin progression이 이미 계산한 `last` 계약과 Java predicate가
+분리된다.
+
+## 적용 규칙
+
+Kotlin progression의 종료 규칙을 재사용해야 하는 adapter는 progression iterator를
+lazy primitive `Spliterator`로 감싼다. primitive update lambda에서 경계 산술을
+반복하지 않으며, `step == 1`처럼 검증된 범위 최적화만 별도 유지한다.
+
+## 검증
+
+`Int.MIN_VALUE`/`Int.MAX_VALUE`, `Long.MIN_VALUE`/`Long.MAX_VALUE`에서
+`step == -1`, `step < -1`, `step > 1`을 bounded stream 테스트로 확인하고,
+`:bluetape4k-core:check`까지 통과시킨다.
+
+## 연결 이슈
+
+- [#1620](https://github.com/bluetape4k/bluetape4k-projects/issues/1620)

--- a/docs/superpowers/plans/2026-09-04-issue-1620-progression-stream-overflow-plan.md
+++ b/docs/superpowers/plans/2026-09-04-issue-1620-progression-stream-overflow-plan.md
@@ -1,0 +1,295 @@
+# Progression stream overflow 경계 수정 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `IntProgression.asStream()`과 `LongProgression.asStream()`이 정수 경계에서
+overflow된 값을 방출하지 않고 Kotlin progression의 마지막 요소에서 정상 종료하도록
+수정한다.
+
+**Architecture:** `step == 1`의 `rangeClosed` 최적화는 유지하고, 나머지 경로는
+Kotlin progression iterator를 감싼 lazy primitive `Spliterator`를
+`StreamSupport.intStream`/`longStream`으로 노출한다. Java update lambda에서 직접
+`current + step`을 계산하지 않아 종료 판단을 Kotlin iterator에 위임한다.
+
+**Tech Stack:** Kotlin 2.4, Java 25, JUnit 5, `bluetape4k-assertions`, Gradle 9.7,
+`bluetape4k-core`.
+
+---
+
+## 파일별 책임
+
+- `bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/ProgressionSupportTest.kt`
+  - Int/Long의 양·음수 경계와 정상 역방향 stream 회귀를 먼저 추가한다.
+  - `.limit(2)`/`.limit(3)`으로 RED 단계의 wrap-around 방출을 bounded assertion으로
+    고정한다.
+- `bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/ProgressionSupport.kt`
+  - primitive `Spliterator` adapter와 `StreamSupport` 변환을 추가한다.
+  - 두 public KDoc에 경계 종료 계약을 명시한다.
+- `docs/lessons/2026-09-04-issue-1620-progression-stream-overflow.md`
+  - overflow를 유발하는 stream 최적화 변경을 재발 방지할 수 있도록 원인·규칙·검증을
+    기록한다.
+- `docs/superpowers/specs/2026-09-04-issue-1620-progression-stream-overflow-design.md`
+  - 이미 승인·커밋된 설계 기준 문서이며 이번 계획의 변경 대상은 아니다.
+
+## 구현 전 공통 게이트
+
+- [ ] 현재 Type C receipt가 `running`이고 대상 경로를 포함하는지 확인한다.
+
+  ```bash
+  python3 /Users/debop/.codex/skills/bluetape-workflow/scripts/bluetape-flow.py \
+    --state-root /Users/debop/work/bluetape4k/bluetape4k-projects/.bluetape \
+    mutation-check \
+    --session-id 01a06738-a43f-7752-89f5-ad5879fb3576 \
+    --target docs/superpowers/plans/2026-09-04-issue-1620-progression-stream-overflow-plan.md \
+    --target docs/superpowers/specs/2026-09-04-issue-1620-progression-stream-overflow-design.md \
+    --target bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/ProgressionSupport.kt \
+    --target bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/ProgressionSupportTest.kt \
+    --target docs/lessons/2026-09-04-issue-1620-progression-stream-overflow.md
+  ```
+
+- [ ] 아래 모든 Kotlin test 변경은 `$bluetape-kotlin-patterns`의 JUnit 5와
+  `bluetape4k-assertions` 규칙을 따른다. Testcontainers와 coroutine lifecycle은
+  노출되지 않으므로 별도 harness는 추가하지 않는다.
+
+## Task 1: 경계 회귀 테스트를 먼저 추가한다 (RED 준비)
+
+- [ ] `ProgressionSupportTest.IntProgression`에 다음 네 테스트를 추가한다.
+
+  ```kotlin
+  @Test
+  fun `as stream stops at positive Int boundary`() {
+      intProgressionOf(Int.MAX_VALUE - 1, Int.MAX_VALUE, 2)
+          .asStream()
+          .limit(2)
+          .toArray() shouldBeEqualTo intArrayOf(Int.MAX_VALUE - 1)
+  }
+
+  @Test
+  fun `as stream stops at Int MIN_VALUE with step minus one`() {
+      intProgressionOf(Int.MIN_VALUE, Int.MIN_VALUE, -1)
+          .asStream()
+          .limit(2)
+          .toArray() shouldBeEqualTo intArrayOf(Int.MIN_VALUE)
+  }
+
+  @Test
+  fun `as stream stops at negative Int boundary`() {
+      intProgressionOf(Int.MIN_VALUE + 2, Int.MIN_VALUE, -2)
+          .asStream()
+          .limit(3)
+          .toArray() shouldBeEqualTo intArrayOf(Int.MIN_VALUE + 2, Int.MIN_VALUE)
+  }
+
+  @Test
+  fun `as stream preserves normal negative Int progression`() {
+      intProgressionOf(3, 1, -1)
+          .asStream()
+          .toArray() shouldBeEqualTo intArrayOf(3, 2, 1)
+  }
+  ```
+
+- [ ] `ProgressionSupportTest.LongProgression`에 다음 네 테스트를 추가한다.
+
+  ```kotlin
+  @Test
+  fun `as stream stops at positive Long boundary`() {
+      longProgressionOf(Long.MAX_VALUE - 1L, Long.MAX_VALUE, 2L)
+          .asStream()
+          .limit(2)
+          .toArray() shouldBeEqualTo longArrayOf(Long.MAX_VALUE - 1L)
+  }
+
+  @Test
+  fun `as stream stops at Long MIN_VALUE with step minus one`() {
+      longProgressionOf(Long.MIN_VALUE, Long.MIN_VALUE, -1L)
+          .asStream()
+          .limit(2)
+          .toArray() shouldBeEqualTo longArrayOf(Long.MIN_VALUE)
+  }
+
+  @Test
+  fun `as stream stops at negative Long boundary`() {
+      longProgressionOf(Long.MIN_VALUE + 2L, Long.MIN_VALUE, -2L)
+          .asStream()
+          .limit(3)
+          .toArray() shouldBeEqualTo longArrayOf(Long.MIN_VALUE + 2L, Long.MIN_VALUE)
+  }
+
+  @Test
+  fun `as stream preserves normal negative Long progression`() {
+      longProgressionOf(3L, 1L, -1L)
+          .asStream()
+          .toArray() shouldBeEqualTo longArrayOf(3L, 2L, 1L)
+  }
+  ```
+
+- [ ] 구현 코드를 건드리지 않은 상태에서 다음 명령을 실행한다.
+
+  ```bash
+  ./gradlew :bluetape4k-core:test \
+    --tests 'io.bluetape4k.collections.ProgressionSupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  기대 결과는 기존 15개와 새 8개를 합친 23개 테스트에서 경계 테스트 assertion이
+  실패하는 RED이다. 실패 원인은 현재 `IntStream.iterate`/`LongStream.iterate`가
+  wrap-around 값을 방출하기 때문이어야 하며, compilation error나 hang이면 테스트를
+  먼저 바로잡고 RED를 다시 확인한다.
+
+## Task 2: lazy primitive Spliterator로 최소 구현한다 (GREEN)
+
+- [ ] `ProgressionSupport.kt` import에 다음 다섯 항목을 추가한다.
+
+  ```kotlin
+  import java.util.Spliterator
+  import java.util.Spliterators
+  import java.util.function.IntConsumer
+  import java.util.function.LongConsumer
+  import java.util.stream.StreamSupport
+  ```
+
+- [ ] `intProgressionOf`와 `IntProgression.asStream` 사이에 다음 private adapter를
+  추가한다.
+
+  ```kotlin
+  private fun IntProgression.toStreamSpliterator(): Spliterator.OfInt {
+      val progressionIterator = iterator()
+      return object : Spliterators.AbstractIntSpliterator(Long.MAX_VALUE, Spliterator.ORDERED) {
+          override fun tryAdvance(action: IntConsumer): Boolean {
+              if (!progressionIterator.hasNext()) return false
+              action.accept(progressionIterator.nextInt())
+              return true
+          }
+      }
+  }
+  ```
+
+- [ ] `IntProgression.asStream`를 다음 구현으로 교체한다. `step == 1`은
+  `rangeClosed`로 유지하고 그 외에는 iterator-backed stream만 사용한다.
+
+  ```kotlin
+  fun IntProgression.asStream(): IntStream =
+      if (step == 1) {
+          IntStream.rangeClosed(first, last)
+      } else {
+          StreamSupport.intStream(toStreamSpliterator(), false)
+      }
+  ```
+
+- [ ] `longProgressionOf`와 `LongProgression.asStream` 사이에 다음 private adapter를
+  추가한다.
+
+  ```kotlin
+  private fun LongProgression.toStreamSpliterator(): Spliterator.OfLong {
+      val progressionIterator = iterator()
+      return object : Spliterators.AbstractLongSpliterator(Long.MAX_VALUE, Spliterator.ORDERED) {
+          override fun tryAdvance(action: LongConsumer): Boolean {
+              if (!progressionIterator.hasNext()) return false
+              action.accept(progressionIterator.nextLong())
+              return true
+          }
+      }
+  }
+  ```
+
+- [ ] `LongProgression.asStream`를 다음 구현으로 교체한다.
+
+  ```kotlin
+  fun LongProgression.asStream(): LongStream =
+      if (step == 1L) {
+          LongStream.rangeClosed(first, last)
+      } else {
+          StreamSupport.longStream(toStreamSpliterator(), false)
+      }
+  ```
+
+- [ ] 두 `asStream` public KDoc에 다음 계약 문장을 각각 추가한다.
+
+  ```text
+  경계에서 다음 값이 표현 범위를 벗어나면 overflow 값을 방출하지 않고 progression의
+  마지막 요소에서 정상 종료합니다.
+  ```
+
+- [ ] 같은 targeted test 명령을 다시 실행해 23/23 GREEN을 확인한다. 실패하면 테스트
+  기대값을 바꾸지 말고 adapter의 iterator 위임·primitive callback·stream 생성만
+  수정한다.
+
+## Task 3: 회귀·모듈 검증을 확장한다
+
+- [ ] targeted GREEN 로그에서 기존 `step == 1` 테스트와 새 `step == -1`,
+  `step > 1`, `step < -1` 테스트가 모두 실행됐는지 확인한다.
+- [ ] 영향 모듈 전체 검사를 실행한다.
+
+  ```bash
+  ./gradlew :bluetape4k-core:check \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+- [ ] 다음 정적 검사를 실행한다.
+
+  ```bash
+  git diff --check
+  ```
+
+- [ ] 변경된 public JVM descriptor, dependency catalog, workflow, Ignite2 runtime,
+  `partitioning`, `Period` 구현에 diff가 없는지 확인한다. Testcontainers는 대상
+  모듈에서 사용하지 않으므로 실행하지 않고 N/A 근거를 기록한다.
+
+## Task 4: 재사용 가능한 lesson을 기록한다
+
+- [ ] 다음 내용으로 `docs/lessons/2026-09-04-issue-1620-progression-stream-overflow.md`를
+  작성한다.
+
+  ```markdown
+  # Progression stream overflow 회귀 방지
+
+  ## 증상
+
+  `IntProgression`/`LongProgression`을 Java primitive stream으로 바꿀 때 마지막
+  원소 직후의 overflow 값이 stream에 섞이거나 종료하지 않을 수 있다.
+
+  ## 원인
+
+  `IntStream.iterate`와 `LongStream.iterate`의 update lambda가 `current + step`을
+  직접 계산하면 Kotlin progression이 이미 계산한 `last` 계약과 Java predicate가
+  분리된다.
+
+  ## 적용 규칙
+
+  Kotlin progression의 종료 규칙을 재사용해야 하는 adapter는 progression iterator를
+  lazy primitive `Spliterator`로 감싼다. primitive update lambda에서 경계 산술을
+  반복하지 않으며, `step == 1`처럼 검증된 범위 최적화만 별도 유지한다.
+
+  ## 검증
+
+  `Int.MIN_VALUE`/`Int.MAX_VALUE`, `Long.MIN_VALUE`/`Long.MAX_VALUE`에서
+  `step == -1`, `step < -1`, `step > 1`을 bounded stream 테스트로 확인하고,
+  `:bluetape4k-core:check`까지 통과시킨다.
+
+  ## 연결 이슈
+
+  - [#1620](https://github.com/bluetape4k/bluetape4k-projects/issues/1620)
+  ```
+
+- [ ] lesson의 한국어 용어, 링크, 명령 토큰을 audit하고 설계 문서와 원인·해결책이
+  일치하는지 확인한다.
+
+## Task 5: 완료 증거와 커밋을 정리한다
+
+- [ ] 다음 파일만 의도된 변경인지 확인한다: `ProgressionSupport.kt`,
+  `ProgressionSupportTest.kt`, `docs/lessons/...`, 그리고 이미 커밋된 설계·계획 문서.
+- [ ] targeted test, `:bluetape4k-core:check`, `git diff --check`, 한국어 용어 audit의
+  명령·결과를 Type C receipt component evidence에 기록한다.
+- [ ] 구현 변경을 Lore 형식의 한국어 commit으로 기록한다. PR 생성·merge·branch
+  삭제는 이 계획의 범위가 아니며, exact-head를 다시 읽은 별도 승인 게이트로 남긴다.
+- [ ] 완료 전 `bluetape-kotlin-patterns/references/checklist.md`를 재검토하고
+  unchecked risk를 `PENDING` 또는 `N/A`로 명시한다.
+
+## 수용 기준
+
+- [ ] 경계에서 wrap-around 값이 방출되지 않고 progression이 정상 종료한다.
+- [ ] Int/Long의 `step > 1`, `step < -1`, `step == -1` 회귀가 모두 통과한다.
+- [ ] 정상 `step == 1` 최적화와 정상 역방향 결과가 유지된다.
+- [ ] targeted test 23/23 및 `:bluetape4k-core:check`가 fresh 실행으로 통과한다.
+- [ ] `git diff --check`와 문서 용어 audit가 통과한다.
+- [ ] PR/merge 및 Ignite2 관련 외부 issue 상태 변경은 수행하지 않는다.

--- a/docs/superpowers/specs/2026-09-04-issue-1620-progression-stream-overflow-design.md
+++ b/docs/superpowers/specs/2026-09-04-issue-1620-progression-stream-overflow-design.md
@@ -1,0 +1,111 @@
+# Issue #1620: Progression stream 경계 overflow 수정 설계
+
+## 상태와 범위
+
+- 대상 저장소: `bluetape4k-projects`
+- 대상 모듈: `bluetape4k-core`
+- 대상 버전: `2.1.0`
+- 작업 유형: Type C bugfix
+- 기준 ref: `develop` / `0be7daa7a6d98937126486ff4b84a76e416696d6`
+- 연결 이슈: [#1620](https://github.com/bluetape4k/bluetape4k-projects/issues/1620)
+
+이번 변경은 `IntProgression.asStream()`과 `LongProgression.asStream()`이
+정수 경계를 넘을 때 progression에 없는 값을 방출하거나 무한히 진행하는
+문제만 다룬다. `partitioning`(#1622), `Period` 연산(#1621), Ignite2 지원
+정책은 범위에 포함하지 않는다.
+
+## 문제와 계약
+
+현재 구현은 `IntStream.iterate`/`LongStream.iterate`의 update 함수에서
+`current + step`을 직접 계산한다. Kotlin progression이 계산한 `last`가
+마지막으로 도달 가능한 값이어도 update 함수는 마지막 원소를 방출한 뒤
+primitive overflow를 수행한다. 다음 predicate는 wrap-around된 값을 정상
+범위로 오인한다.
+
+재현 결과는 다음과 같다.
+
+```kotlin
+intProgressionOf(Int.MAX_VALUE - 1, Int.MAX_VALUE, 2)
+    .asStream().limit(2).toArray()
+// 현재: [2147483646, -2147483648]
+// 기대: [2147483646]
+
+longProgressionOf(Long.MIN_VALUE, Long.MIN_VALUE, -1)
+    .asStream().limit(2).toArray()
+// 현재: [-9223372036854775808, 9223372036854775807]
+// 기대: [-9223372036854775808]
+```
+
+`asStream()`의 계약은 Kotlin `IntProgression`/`LongProgression`의 순서와
+요소를 그대로 유지하는 것이다. 경계에서 다음 값이 표현 범위를 벗어나면
+overflow된 값을 방출하지 않고 정상적으로 종료해야 한다. 기존 public
+함수명, 반환 타입, 순차 stream 기본 동작, 정상 범위의 결과는 유지한다.
+
+## 대안 비교
+
+| 대안 | 장점 | 단점 | 결정 |
+|---|---|---|---|
+| `Stream.Builder`로 되돌림 | diff가 작고 Kotlin iterator의 종료를 그대로 사용 | 전체 요소를 eager materialization하고 이전 성능 개선을 되돌림 | 채택하지 않음 |
+| Kotlin progression iterator를 lazy primitive `Spliterator`로 감쌈 | overflow 계산을 Java update lambda에서 제거하고 지연 평가·primitive stream을 유지 | private adapter 코드가 소량 추가됨 | **채택** |
+| widened arithmetic 또는 `Math.addExact`/sentinel 조합 | 일부 경계 계산을 직접 제어할 수 있음 | `Int`와 `Long` 종료 규칙이 달라지고 예외·sentinel 상태가 복잡함 | 채택하지 않음 |
+
+## 권장 설계
+
+1. `step == 1`인 `IntProgression`/`LongProgression`은 기존
+   `rangeClosed` 최적화를 유지한다.
+2. 그 외의 경우에는 각 Kotlin progression의 `iterator()`를 사용하는
+   private `AbstractIntSpliterator`/`AbstractLongSpliterator`를 생성한다.
+3. `tryAdvance`는 iterator의 `hasNext()`를 확인한 뒤 `nextInt()` 또는
+   `nextLong()`을 한 번 방출한다. 종료와 마지막 원소 판정은 Kotlin
+   progression iterator에 위임하며, Java 쪽에서 값을 더하지 않는다.
+4. `StreamSupport.intStream`/`longStream`으로 순차 primitive stream을
+   반환한다. spliterator는 `ORDERED`만 선언하고 크기를 추정하지 않아,
+   기존 `iterate` 경로의 lazy·unsized 특성을 보존한다.
+5. overflow 예외를 만들거나 삼키지 않는다. Kotlin iterator가 계산한
+   progression의 `last`에서 정상 종료하므로 `Math.addExact`와 sentinel이
+   필요하지 않다.
+
+이 방식은 현재 저장소에 이미 존재하는 Kotlin progression의 종료 계약을
+재사용하고, 새 dependency나 public API를 추가하지 않는다. primitive
+전용 adapter를 선택하는 이유는 기존 `Sequence.asStream().mapToInt` 방식의
+boxing 비용을 피하기 위해서다.
+
+## 테스트 설계
+
+`ProgressionSupportTest`에 다음 회귀를 추가한다.
+
+- Int: 양의 `step > 1`에서 `Int.MAX_VALUE`, 음의 `step == -1`과
+  `step < -1`에서 `Int.MIN_VALUE` 경계
+- Long: 양의 `step > 1`에서 `Long.MAX_VALUE`, 음의 `step == -1`과
+  `step < -1`에서 `Long.MIN_VALUE` 경계
+- 기존 정상 범위의 `step == 1` 결과와 추가하는 정상 `step == -1` 결과
+
+RED 단계에서는 `.limit(2)` 또는 `.limit(3)`을 사용해 현재 wrap-around된
+원소가 빠르게 드러나도록 한다. 무제한 `toArray()`/`count()`를 RED 테스트에
+사용하지 않아 회귀 테스트 자체가 hang되지 않게 한다. GREEN 단계에서는
+같은 테스트로 경계 원소가 정확히 한 번만 방출되는지 확인하고, 기존
+15개 테스트와 모듈 검사를 순서대로 실행한다.
+
+## 문서와 호환성
+
+- 두 public KDoc에 경계 overflow 시 정상 종료한다는 문장을 추가한다.
+- README/API surface에는 현재 `Progression` 예제가 없으므로 별도 README
+  변경은 하지 않는다.
+- public JVM descriptor와 함수 signature는 변경하지 않는다.
+- Testcontainers, workflow, catalog, Ignite2 runtime, `partitioning` 및
+  `Period` 구현은 수정하지 않는다.
+
+## 수용 기준과 DoD
+
+- [ ] Int/Long 양·음수 경계에서 wrap-around 값이 방출되지 않는다.
+- [ ] `step > 1`, `step < -1`, `step == -1` 회귀가 모두 통과한다.
+- [ ] 정상 범위와 `step == 1` 최적화 결과가 유지된다.
+- [ ] 변경된 Kotlin source/test가 `bluetape-kotlin-patterns` 계약을 따른다.
+- [ ] targeted test, `:bluetape4k-core:check`, `git diff --check`가 통과한다.
+- [ ] P0/P1 finding이 없고, PR/merge는 별도 exact-head gate로 남는다.
+
+## 결정되지 않은 항목
+
+없음. Issue #1619의 Ignite2 복구 제안은 사용자가 확정한 `2.1.0` 전면
+폐기 정책과 충돌하므로 이 설계에서 다루지 않으며, 해당 live issue의
+상태 변경도 수행하지 않는다.


### PR DESCRIPTION
## 요약

- `IntProgression.asStream()`과 `LongProgression.asStream()`이 정수 경계에서 overflow 값을 방출하지 않도록 수정합니다.
- Kotlin progression iterator를 lazy primitive `Spliterator`의 종료 기준으로 사용합니다.
- 관련 회귀 테스트와 재발 방지 lesson을 추가합니다.

## 변경 사항

- `step == 1`의 `rangeClosed` 최적화는 유지합니다.
- 그 외 step은 `StreamSupport.intStream`/`longStream`과 iterator-backed `Spliterator`를 사용합니다.
- public 함수 signature와 JVM descriptor는 변경하지 않았습니다.
- `2.1.0`의 Ignite2 폐기 정책과 충돌하는 변경은 포함하지 않았습니다.

## 검증

- RED: 기존 구현에서 17 passing / 6 failing으로 경계 wrap-around를 재현했습니다.
- GREEN: `ProgressionSupportTest` 23/23 통과
- `./gradlew :bluetape4k-core:check --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache`
- 결과: `BUILD SUCCESSFUL` (28 actionable tasks, 6 executed)
- `git diff --check` 및 변경 문서 Korean audit 통과

Fixes #1620

## DoD Status

- [x] Int/Long 양·음수 경계에서 wrap-around 값 미방출
- [x] `step > 1`, `step < -1`, `step == -1` 회귀 테스트
- [x] 정상 `step == 1` 및 역방향 결과 유지
- [x] targeted test와 `:bluetape4k-core:check` 통과
- [x] KDoc, 설계·계획 문서, lesson 정합성 확인
- [ ] merge 및 release: 별도 exact-head 승인 게이트
