### PR TITLE
[P2][bug][core/collections] 극단값 progression partition overflow 수정

### DIFF
--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/ProgressionSupport.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/collections/ProgressionSupport.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.collections
 
 import io.bluetape4k.support.requirePositiveNumber
+import java.math.BigInteger
 import java.util.Spliterator
 import java.util.Spliterators
 import java.util.function.IntConsumer
@@ -9,8 +10,48 @@ import java.util.stream.IntStream
 import java.util.stream.LongStream
 import java.util.stream.StreamSupport
 
-private fun calculatePartitionCount(size: Int, chunkSize: Int): Int =
-    size / chunkSize + if (size % chunkSize > 0) 1 else 0
+private val BIG_INTEGER_ONE = BigInteger.ONE
+private val BIG_INTEGER_INT_MAX = BigInteger.valueOf(Int.MAX_VALUE.toLong())
+
+private fun progressionElementCount(first: Long, last: Long, step: Long): BigInteger {
+    if ((step > 0 && first > last) || (step < 0 && first < last)) {
+        return BigInteger.ZERO
+    }
+
+    val distance = if (step > 0) {
+        BigInteger.valueOf(last).subtract(BigInteger.valueOf(first))
+    } else {
+        BigInteger.valueOf(first).subtract(BigInteger.valueOf(last))
+    }
+    return distance.divide(BigInteger.valueOf(step).abs()).add(BIG_INTEGER_ONE)
+}
+
+private fun calculatePartitionCount(size: BigInteger, chunkSize: Int): Int {
+    if (size.signum() == 0) return 0
+
+    val chunk = BigInteger.valueOf(chunkSize.toLong())
+    val partitionCount = size.add(chunk).subtract(BIG_INTEGER_ONE).divide(chunk)
+    require(partitionCount <= BIG_INTEGER_INT_MAX) {
+        "partition count exceeds Int.MAX_VALUE: $partitionCount"
+    }
+    return partitionCount.intValueExact()
+}
+
+private fun IntProgression.elementCount(): BigInteger =
+    progressionElementCount(first.toLong(), last.toLong(), step.toLong())
+
+private fun LongProgression.elementCount(): BigInteger =
+    progressionElementCount(first, last, step)
+
+private fun IntProgression.valueAt(index: BigInteger): Int =
+    BigInteger.valueOf(first.toLong())
+        .add(BigInteger.valueOf(step.toLong()).multiply(index))
+        .intValueExact()
+
+private fun LongProgression.valueAt(index: BigInteger): Long =
+    BigInteger.valueOf(first)
+        .add(BigInteger.valueOf(step).multiply(index))
+        .longValueExact()
 
 /**
  * 시작 문자([start]) ~ 종료 문자([endInclusive]) 에 해당하는 [CharProgression]을 빌드합니다.
@@ -84,9 +125,15 @@ fun IntProgression.asStream(): IntStream =
  *
  * @param chunk chunk size
  * @return chunk된 [IntProgression]의 [Sequence]
+ *
+ * progression 요소 수가 커서 계산된 partition 수가 Int 범위를 넘으면
+ * [IllegalArgumentException]을 던집니다.
  */
-fun IntProgression.chunked(chunk: Int): Sequence<IntProgression> =
-    partitioning(partitionCount = calculatePartitionCount(count(), chunk.also { it.requirePositiveNumber("chunk") }))
+fun IntProgression.chunked(chunk: Int): Sequence<IntProgression> {
+    chunk.requirePositiveNumber("chunk")
+    val partitionCount = calculatePartitionCount(elementCount(), chunk)
+    return if (partitionCount == 0) emptySequence() else partitioning(partitionCount)
+}
 
 /**
  * [IntProgression]을 partitioning 하여 [Sequence]로 반환합니다.
@@ -105,6 +152,10 @@ fun IntProgression.chunked(chunk: Int): Sequence<IntProgression> =
  *
  * @param partitionCount partition count
  * @return partitioned [IntProgression]의 [Sequence]
+ *
+ * 전체 요소 수와 각 경계는 확장 정밀도로 계산하므로 Int 표현 범위 전체를
+ * 포함하는 progression도 요소를 잃지 않습니다. `chunked`에서 계산된 partition
+ * 수가 Int 범위를 넘으면 [IllegalArgumentException]을 던집니다.
  */
 fun IntProgression.partitioning(partitionCount: Int = 1): Sequence<IntProgression> = sequence {
     partitionCount.requirePositiveNumber("partitionCount")
@@ -115,23 +166,28 @@ fun IntProgression.partitioning(partitionCount: Int = 1): Sequence<IntProgressio
         return@sequence
     }
 
-    val step = self.step
-    val count = if (step > 0) (self.last - self.first) / step + 1 else (self.first - self.last) / (-step) + 1
-    val reminder = count % partitionCount
-    val partitionSize = count / partitionCount + (if (reminder > 0) 1 else 0)
+    val count = self.elementCount()
+    if (count.signum() == 0) {
+        return@sequence
+    }
 
-    var start = self.first
-    repeat(partitionCount) {
-        if ((step > 0 && start > self.last) || (step < 0 && start < self.last)) {
+    val step = self.step
+    val partitionSize = count.add(BigInteger.valueOf(partitionCount.toLong()))
+        .subtract(BIG_INTEGER_ONE)
+        .divide(BigInteger.valueOf(partitionCount.toLong()))
+    repeat(partitionCount) { partitionIndex ->
+        val startIndex = partitionSize.multiply(BigInteger.valueOf(partitionIndex.toLong()))
+        if (startIndex >= count) {
             return@sequence
         }
-        val endInclusive = (start + (partitionSize - 1) * step).let { rawEnd ->
-            if (step > 0) rawEnd.coerceAtMost(self.last) else rawEnd.coerceAtLeast(self.last)
-        }
 
-        val partition = IntProgression.fromClosedRange(start, endInclusive, step)
+        val endIndex = startIndex.add(partitionSize).min(count).subtract(BIG_INTEGER_ONE)
+        val partition = IntProgression.fromClosedRange(
+            self.valueAt(startIndex),
+            self.valueAt(endIndex),
+            step,
+        )
         yield(partition)
-        start = endInclusive + step
     }
 }
 
@@ -196,10 +252,16 @@ fun LongProgression.asStream(): LongStream =
  * ```
  *
  * @param chunk chunk size
- * @return chunk된 [IntProgression]의 [Sequence]
+ * @return chunk된 [LongProgression]의 [Sequence]
+ *
+ * progression 요소 수가 커서 계산된 partition 수가 Int 범위를 넘으면
+ * [IllegalArgumentException]을 던집니다.
  */
-fun LongProgression.chunked(chunk: Int): Sequence<LongProgression> =
-    partitioning(partitionCount = calculatePartitionCount(count(), chunk.also { it.requirePositiveNumber("chunk") }))
+fun LongProgression.chunked(chunk: Int): Sequence<LongProgression> {
+    chunk.requirePositiveNumber("chunk")
+    val partitionCount = calculatePartitionCount(elementCount(), chunk)
+    return if (partitionCount == 0) emptySequence() else partitioning(partitionCount)
+}
 
 /**
  * [LongProgression]을 [partitionCount] 갯수로 분할합니다.
@@ -218,6 +280,10 @@ fun LongProgression.chunked(chunk: Int): Sequence<LongProgression> =
  *
  * @param partitionCount 분할 갯수 (기본: 1)
  * @return 분할된 [LongProgression]의 [Sequence]
+ *
+ * 전체 요소 수와 각 경계는 확장 정밀도로 계산하므로 Long 표현 범위 전체를
+ * 포함하는 progression도 요소를 잃지 않습니다. `chunked`에서 계산된 partition
+ * 수가 Int 범위를 넘으면 [IllegalArgumentException]을 던집니다.
  */
 fun LongProgression.partitioning(partitionCount: Int = 1): Sequence<LongProgression> = sequence {
     partitionCount.requirePositiveNumber("partitionCount")
@@ -228,22 +294,27 @@ fun LongProgression.partitioning(partitionCount: Int = 1): Sequence<LongProgress
         return@sequence
     }
 
-    val step = self.step
-    val count = (if (step > 0) (self.last - self.first) / step + 1 else (self.first - self.last) / (-step) + 1).toInt()
-    val reminder = count % partitionCount
-    val partitionSize = count / partitionCount + (if (reminder > 0) 1 else 0)
+    val count = self.elementCount()
+    if (count.signum() == 0) {
+        return@sequence
+    }
 
-    var start = self.first
-    repeat(partitionCount) {
-        if ((step > 0 && start > self.last) || (step < 0 && start < self.last)) {
+    val step = self.step
+    val partitionSize = count.add(BigInteger.valueOf(partitionCount.toLong()))
+        .subtract(BIG_INTEGER_ONE)
+        .divide(BigInteger.valueOf(partitionCount.toLong()))
+    repeat(partitionCount) { partitionIndex ->
+        val startIndex = partitionSize.multiply(BigInteger.valueOf(partitionIndex.toLong()))
+        if (startIndex >= count) {
             return@sequence
         }
-        val endInclusive = (start + (partitionSize - 1).toLong() * step).let { rawEnd ->
-            if (step > 0) rawEnd.coerceAtMost(self.last) else rawEnd.coerceAtLeast(self.last)
-        }
 
-        val partition = LongProgression.fromClosedRange(start, endInclusive, step)
+        val endIndex = startIndex.add(partitionSize).min(count).subtract(BIG_INTEGER_ONE)
+        val partition = LongProgression.fromClosedRange(
+            self.valueAt(startIndex),
+            self.valueAt(endIndex),
+            step,
+        )
         yield(partition)
-        start = endInclusive + step
     }
 }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/ProgressionSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/ProgressionSupportTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.collections
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.logging.KLogging
@@ -120,6 +121,47 @@ class ProgressionSupportTest {
             partitioned[1] shouldBeEqualTo intProgressionOf(2, 2, 1)
             partitioned[2] shouldBeEqualTo intProgressionOf(3, 3, 1)
         }
+
+        @Test
+        fun `partitioning preserves the full Int range`() {
+            val ints = intProgressionOf(Int.MIN_VALUE, Int.MAX_VALUE)
+            val partitioned = ints.partitioning(2).toList()
+
+            partitioned shouldHaveSize 2
+            partitioned[0] shouldBeEqualTo intProgressionOf(Int.MIN_VALUE, -1)
+            partitioned[1] shouldBeEqualTo intProgressionOf(0, Int.MAX_VALUE)
+            ints.partitioning(1).toList() shouldBeEqualTo listOf(ints)
+        }
+
+        @Test
+        fun `partitioning preserves extreme Int ranges with a non-unit step`() {
+            val ascending = intProgressionOf(Int.MIN_VALUE, Int.MAX_VALUE, 2)
+            val ascendingParts = ascending.partitioning(2).toList()
+            ascendingParts[0] shouldBeEqualTo intProgressionOf(Int.MIN_VALUE, -2, 2)
+            ascendingParts[1] shouldBeEqualTo intProgressionOf(0, Int.MAX_VALUE - 1, 2)
+
+            val descending = intProgressionOf(Int.MAX_VALUE, Int.MIN_VALUE, -2)
+            val descendingParts = descending.partitioning(2).toList()
+            descendingParts[0] shouldBeEqualTo intProgressionOf(Int.MAX_VALUE, 1, -2)
+            descendingParts[1] shouldBeEqualTo intProgressionOf(-1, Int.MIN_VALUE + 1, -2)
+        }
+
+        @Test
+        fun `partitioning preserves an extreme descending Int range`() {
+            val ints = intProgressionOf(Int.MAX_VALUE, Int.MIN_VALUE, -1)
+            val partitioned = ints.partitioning(2).toList()
+
+            partitioned shouldHaveSize 2
+            partitioned[0] shouldBeEqualTo intProgressionOf(Int.MAX_VALUE, 0, -1)
+            partitioned[1] shouldBeEqualTo intProgressionOf(-1, Int.MIN_VALUE, -1)
+        }
+
+        @Test
+        fun `chunked rejects an Int partition count that cannot be represented`() {
+            assertFailsWith<IllegalArgumentException> {
+                intProgressionOf(Int.MIN_VALUE, Int.MAX_VALUE).chunked(1).toList()
+            }
+        }
     }
 
     @Nested
@@ -224,6 +266,47 @@ class ProgressionSupportTest {
             partitioned[0] shouldBeEqualTo longProgressionOf(1, 1, 1)
             partitioned[1] shouldBeEqualTo longProgressionOf(2, 2, 1)
             partitioned[2] shouldBeEqualTo longProgressionOf(3, 3, 1)
+        }
+
+        @Test
+        fun `partitioning preserves the full Long range`() {
+            val longs = longProgressionOf(Long.MIN_VALUE, Long.MAX_VALUE)
+            val partitioned = longs.partitioning(2).toList()
+
+            partitioned shouldHaveSize 2
+            partitioned[0] shouldBeEqualTo longProgressionOf(Long.MIN_VALUE, -1L)
+            partitioned[1] shouldBeEqualTo longProgressionOf(0L, Long.MAX_VALUE)
+            longs.partitioning(1).toList() shouldBeEqualTo listOf(longs)
+        }
+
+        @Test
+        fun `partitioning preserves extreme Long ranges with a non-unit step`() {
+            val ascending = longProgressionOf(Long.MIN_VALUE, Long.MAX_VALUE, 2L)
+            val ascendingParts = ascending.partitioning(2).toList()
+            ascendingParts[0] shouldBeEqualTo longProgressionOf(Long.MIN_VALUE, -2L, 2L)
+            ascendingParts[1] shouldBeEqualTo longProgressionOf(0L, Long.MAX_VALUE - 1L, 2L)
+
+            val descending = longProgressionOf(Long.MAX_VALUE, Long.MIN_VALUE, -2L)
+            val descendingParts = descending.partitioning(2).toList()
+            descendingParts[0] shouldBeEqualTo longProgressionOf(Long.MAX_VALUE, 1L, -2L)
+            descendingParts[1] shouldBeEqualTo longProgressionOf(-1L, Long.MIN_VALUE + 1L, -2L)
+        }
+
+        @Test
+        fun `partitioning preserves an extreme descending Long range`() {
+            val longs = longProgressionOf(Long.MAX_VALUE, Long.MIN_VALUE, -1L)
+            val partitioned = longs.partitioning(2).toList()
+
+            partitioned shouldHaveSize 2
+            partitioned[0] shouldBeEqualTo longProgressionOf(Long.MAX_VALUE, 0L, -1L)
+            partitioned[1] shouldBeEqualTo longProgressionOf(-1L, Long.MIN_VALUE, -1L)
+        }
+
+        @Test
+        fun `chunked rejects a Long partition count that cannot be represented`() {
+            assertFailsWith<IllegalArgumentException> {
+                longProgressionOf(Long.MIN_VALUE, Long.MAX_VALUE).chunked(1).toList()
+            }
         }
     }
 }

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/ProgressionSupportTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/collections/ProgressionSupportTest.kt
@@ -75,6 +75,24 @@ class ProgressionSupportTest {
         }
 
         @Test
+        fun `chunked preserves descending non-unit steps`() {
+            intProgressionOf(10, 1, -2).chunked(2).toList() shouldBeEqualTo listOf(
+                intProgressionOf(10, 8, -2),
+                intProgressionOf(6, 4, -2),
+                intProgressionOf(2, 2, -2),
+            )
+        }
+
+        @Test
+        fun `empty progression keeps chunked and partitioning contracts`() {
+            val empty = intProgressionOf(3, 1)
+
+            empty.chunked(2).toList() shouldBeEqualTo emptyList()
+            empty.partitioning(1).toList() shouldBeEqualTo listOf(empty)
+            empty.partitioning(2).toList() shouldBeEqualTo emptyList()
+        }
+
+        @Test
         fun `partitioning evenly`() {
             val ints = intProgressionOf(1, 10, 1)
             val partitioned = ints.partitioning(2).toList()
@@ -218,6 +236,24 @@ class ProgressionSupportTest {
             chunked.forEach {
                 log.debug { "group=$it" }
             }
+        }
+
+        @Test
+        fun `chunked preserves descending non-unit steps`() {
+            longProgressionOf(10, 1, -2).chunked(2).toList() shouldBeEqualTo listOf(
+                longProgressionOf(10, 8, -2),
+                longProgressionOf(6, 4, -2),
+                longProgressionOf(2, 2, -2),
+            )
+        }
+
+        @Test
+        fun `empty progression keeps chunked and partitioning contracts`() {
+            val empty = longProgressionOf(3, 1)
+
+            empty.chunked(2).toList() shouldBeEqualTo emptyList()
+            empty.partitioning(1).toList() shouldBeEqualTo listOf(empty)
+            empty.partitioning(2).toList() shouldBeEqualTo emptyList()
         }
 
         @Test

--- a/docs/lessons/2026-09-04-issue-1622-progression-partition-overflow.md
+++ b/docs/lessons/2026-09-04-issue-1622-progression-partition-overflow.md
@@ -33,21 +33,21 @@ val longParts = longs.partitioning(2).toList()
 - 요소 수는 JDK의 `java.math.BigInteger`로 `abs(last - first) / abs(step) + 1`을 계산한다. 방향이 맞지 않는 빈 progression은 0으로 처리한다.
 - partition 경계는 이전 `endInclusive`에 `step`을 더하지 않고, 원본의 요소 인덱스에 대해 `first + step * index`를 확장 정밀도로 계산한 뒤 `Int` 또는 `Long`으로 정확히 변환한다.
 - `partitioning(partitionCount)`은 `partitionCount`가 양수인 한 전체 `Int`/`Long` 표현 범위에서도 경계를 보존한다. `partitionCount == 1`은 원본을 그대로 반환한다.
-- `chunked(chunk)`는 안전하게 계산한 요소 수에서 partition 수를 구한다. 결과 partition 수가 `Int.MAX_VALUE`를 넘으면 표현할 수 없으므로 명시적으로 `IllegalArgumentException`을 던진다. 빈 progression은 빈 `Sequence`를 반환한다.
+- `chunked(chunk)`는 안전하게 계산한 요소 수에서 partition 수를 구한다. 결과 partition 수가 `Int.MAX_VALUE`를 넘으면 표현할 수 없으므로 명시적으로 `IllegalArgumentException`을 던진다. 빈 progression은 빈 `Sequence`를 반환한다. 빈 progression의 `partitioning(1)`은 원본을 보존하고 `partitioning(2)` 이상은 빈 `Sequence`를 반환한다.
 - 새 외부 의존성은 추가하지 않았다. `BigInteger`는 JDK 표준 라이브러리다.
 
 ## TDD 및 검증
 
-초기 RED에서는 기존 구현으로 `ProgressionSupportTest` 29개를 실행했고, 극단적인 Int/Long 오름차순·내림차순 partition과 `chunked` 표현 한계 검증 6개가 실패했다. `chunked` 경계에서는 기대한 `IllegalArgumentException` 대신 `ArithmeticException`이 노출되었다.
+초기 RED에서는 기존 기준 테스트 23개에 극단적인 Int/Long 오름차순·내림차순 partition과 `chunked` 표현 한계 검증 6개를 추가해 중간 상태의 `ProgressionSupportTest` 29개를 실행했고, 추가한 6개가 실패했다. `chunked` 경계에서는 기대한 `IllegalArgumentException` 대신 `ArithmeticException`이 노출되었다. 구현 단계에서 extreme non-unit/descending 경계 2개를 추가해 31개로 만든 뒤 GREEN을 확인했다. 이후 리뷰에서 확인된 계약 공백을 해소하기 위해 Int/Long의 빈 progression `chunked`·`partitioning(1/2)`와 정상 descending/non-unit `chunked` 테스트 4개를 추가했다.
 
 구현 후 다음 검증을 완료했다.
 
-- `ProgressionSupportTest`: 31/31 통과
-- `:bluetape4k-core:check`: 1,670개 테스트 통과, `BUILD SUCCESSFUL`
+- `ProgressionSupportTest`: 35/35 통과
+- `:bluetape4k-core:check`: 1,670개 테스트 통과, `BUILD SUCCESSFUL` (리뷰 후 추가 계약 테스트는 targeted suite에서 별도 확인)
 - `git diff --check`: 통과
 - `code_quality_checker.py`: findings 0
 
-테스트는 양의·음의 step, `partitionCount` 1/2 및 요소 수보다 많은 partition, 전체 Int/Long 범위, `chunked`의 표현 한계를 포함한다. 전체 범위의 모든 요소를 메모리에 올리는 대신 partition 경계와 progression 계약을 검증했다.
+테스트는 양의·음의 step, descending/non-unit `chunked`, 빈 progression의 `chunked`·`partitioning(1/2)`, `partitionCount` 1/2 및 요소 수보다 많은 partition, 전체 Int/Long 범위, `chunked`의 표현 한계를 포함한다. 전체 범위의 모든 요소를 메모리에 올리는 대신 partition 경계와 progression 계약을 검증했다.
 
 ## 재발 방지 규칙
 

--- a/docs/lessons/2026-09-04-issue-1622-progression-partition-overflow.md
+++ b/docs/lessons/2026-09-04-issue-1622-progression-partition-overflow.md
@@ -1,0 +1,57 @@
+# Progression partition overflow 교훈
+
+이 문서는 [Issue #1622](https://github.com/bluetape4k/bluetape4k-projects/issues/1622)의 회귀 원인과 재발 방지 규칙을 기록한다.
+
+## 문제
+
+`IntProgression.partitioning`은 `self.last - self.first`를 `Int`로 계산한 뒤 partition 크기를 구했다. `Int.MIN_VALUE..Int.MAX_VALUE`처럼 전체 표현 범위를 포함하는 progression에서는 차이가 `Int` 범위를 넘어 음수로 wrap되어 빈 partition 또는 잘못된 경계를 만들었다.
+
+`LongProgression.partitioning`도 같은 차이를 `Long`으로 계산한 뒤 `.toInt()`로 축소했다. `Long.MIN_VALUE..Long.MAX_VALUE`의 요소 수는 `Long.MAX_VALUE`를 넘으므로 결과가 음수·0으로 변환되었다. `chunked`는 이 잘못된 `count()` 결과를 재사용해 잘못된 partition 수를 계산하거나 `ArithmeticException`을 노출했다.
+
+대표적인 재현 입력은 다음과 같다.
+
+```kotlin
+val ints = intProgressionOf(Int.MIN_VALUE, Int.MAX_VALUE)
+val intParts = ints.partitioning(2).toList()
+
+val longs = longProgressionOf(Long.MIN_VALUE, Long.MAX_VALUE)
+val longParts = longs.partitioning(2).toList()
+```
+
+두 경우 모두 원본의 모든 요소를 보존하는 두 개의 유효한 progression이 필요하다. 전체 요소를 실제로 순회하지 않고도 각 partition의 `first`, `last`, `step` 경계로 보존 여부를 검증할 수 있다.
+
+## 원인
+
+범위의 양 끝을 먼저 같은 정수 타입으로 빼는 방식은 다음 두 단계에서 실패했다.
+
+1. `Int`에서는 `last - first` 자체가 overflow한다.
+2. `Long`에서는 차이가 `Long`으로 표현되더라도 요소 수가 `Long.MAX_VALUE`보다 클 수 있는데 `.toInt()`가 이를 검증하지 않고 축소한다.
+3. `endInclusive + step`으로 다음 시작점을 만들면 마지막 경계에서 다시 overflow할 수 있다.
+
+## 결정
+
+- 요소 수는 JDK의 `java.math.BigInteger`로 `abs(last - first) / abs(step) + 1`을 계산한다. 방향이 맞지 않는 빈 progression은 0으로 처리한다.
+- partition 경계는 이전 `endInclusive`에 `step`을 더하지 않고, 원본의 요소 인덱스에 대해 `first + step * index`를 확장 정밀도로 계산한 뒤 `Int` 또는 `Long`으로 정확히 변환한다.
+- `partitioning(partitionCount)`은 `partitionCount`가 양수인 한 전체 `Int`/`Long` 표현 범위에서도 경계를 보존한다. `partitionCount == 1`은 원본을 그대로 반환한다.
+- `chunked(chunk)`는 안전하게 계산한 요소 수에서 partition 수를 구한다. 결과 partition 수가 `Int.MAX_VALUE`를 넘으면 표현할 수 없으므로 명시적으로 `IllegalArgumentException`을 던진다. 빈 progression은 빈 `Sequence`를 반환한다.
+- 새 외부 의존성은 추가하지 않았다. `BigInteger`는 JDK 표준 라이브러리다.
+
+## TDD 및 검증
+
+초기 RED에서는 기존 구현으로 `ProgressionSupportTest` 29개를 실행했고, 극단적인 Int/Long 오름차순·내림차순 partition과 `chunked` 표현 한계 검증 6개가 실패했다. `chunked` 경계에서는 기대한 `IllegalArgumentException` 대신 `ArithmeticException`이 노출되었다.
+
+구현 후 다음 검증을 완료했다.
+
+- `ProgressionSupportTest`: 31/31 통과
+- `:bluetape4k-core:check`: 1,670개 테스트 통과, `BUILD SUCCESSFUL`
+- `git diff --check`: 통과
+- `code_quality_checker.py`: findings 0
+
+테스트는 양의·음의 step, `partitionCount` 1/2 및 요소 수보다 많은 partition, 전체 Int/Long 범위, `chunked`의 표현 한계를 포함한다. 전체 범위의 모든 요소를 메모리에 올리는 대신 partition 경계와 progression 계약을 검증했다.
+
+## 재발 방지 규칙
+
+1. 범위 차이와 요소 수를 계산하기 전에 대상 타입의 표현 범위를 확인하고, 필요하면 즉시 더 넓은 표현으로 승격한다.
+2. 더 넓은 타입의 값을 `toInt()`로 줄일 때는 먼저 상한을 검증하고, 표현 불가능하면 호출자에게 명시적인 예외를 반환한다.
+3. progression의 다음 경계를 값 누적으로 계산하지 말고 원본 인덱스에서 독립적으로 계산해 마지막 `step` overflow를 차단한다.
+4. 양의·음의 step과 표현 범위의 양 끝을 같은 회귀 테스트 묶음으로 유지한다.


### PR DESCRIPTION
## 요약

Closes #1622

`IntProgression.partitioning`과 `LongProgression.partitioning`이 타입 경계 전체를 포함하는 progression에서도 요소를 잃지 않도록 overflow-safe 산술을 적용합니다.

## 원인

기존 구현은 `self.last - self.first`를 `Int` 또는 `Long`으로 먼저 계산했습니다. `LongProgression`은 계산한 요소 수를 `.toInt()`로 축소했습니다. 이 방식은 `Int.MIN_VALUE..Int.MAX_VALUE`와 `Long.MIN_VALUE..Long.MAX_VALUE`에서 wrap-around 또는 표현 범위 축소를 일으켜 partition 경계를 누락시켰습니다.

## 변경 내용

- 요소 수와 partition 크기를 `BigInteger`로 계산합니다.
- partition 경계를 누적 `endInclusive + step`이 아니라 원본 progression 인덱스에서 독립적으로 계산합니다.
- `partitionCount == 1`, 양·음의 step, 요소 수보다 많은 partition에서도 기존 순서와 progression 계약을 유지합니다.
- 빈 progression의 `chunked`와 `partitioning(1/2)` 계약, descending/non-unit `chunked` 경계를 직접 회귀 테스트로 고정합니다.
- `chunked`가 계산한 partition 수가 `Int.MAX_VALUE`를 넘으면 모호한 overflow 대신 명시적인 `IllegalArgumentException`을 반환합니다.
- 전체 범위 progression을 메모리에 materialize하지 않는 경계 회귀 테스트와 한국어 lesson/KDoc를 추가했습니다.
- public API signature와 JVM descriptor를 변경하지 않았으며, 새 외부 의존성은 추가하지 않았습니다. Ignite2 관련 surface는 변경하지 않았습니다.

## 검증

- RED: 기준 `ProgressionSupportTest` 23개에 회귀 테스트 6개를 추가한 중간 상태 29개에서 6개가 실패했습니다. 이후 extreme non-unit/descending 경계 2개를 추가한 31개 GREEN을 거쳤고, 리뷰 후 빈 progression 계약 및 정상 descending/non-unit `chunked` 테스트 4개를 보강해 현재 35/35 passing입니다.
- GREEN: `./gradlew :bluetape4k-core:test --tests 'io.bluetape4k.collections.ProgressionSupportTest' --no-configuration-cache` → 35/35 passing.
- Module: 새 exact-head hosted CI의 `Test / Core`가 1,674 passing과 `BUILD SUCCESSFUL`로 종료했고, `Build`도 compile·publication metadata 검증을 통과했습니다.
- Static/docs: 변경 source/test `code_quality_checker.py` findings 0, core Detekt 재실행 exit 0, `git diff --check` 통과, 한국어 terminology audit findings 0.
- CI exact head: [run 33877749771](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33877749771)에서 applicable checks 12/12가 성공했습니다. path-filter가 변경 모듈을 `core`로만 판정해 비관련 12개 matrix는 `N/A (skipping)`이며 실패·pending은 0건입니다. Coverage Report는 전체 89.31%, core 87.12%입니다.
- GNO: merge 후 canonical checkout에서 `gno update`가 docs collection에 lesson을 반영했고, `gno embed --collection bluetape4k-wiki`는 추가 chunk 없이 최신 상태였습니다. `gno search '1622' -c bluetape4k-docs`에서 lesson URI를 확인했습니다.
- Review: 독립 검토에서 P0/P1은 0이었고, 테스트 수 기록 및 빈/descending `chunked` 계약 공백을 이번 commit에서 해소했습니다. GitHub 제출 review·issue comment·inline thread는 현재 0건이며, single-developer 저장소의 human-review subgate는 N/A입니다.

## 범위 및 후속

- Issue #1622의 `bluetape4k-core` collections bugfix만 포함합니다.
- `docs/testlogs/2026-09.md`는 승인된 변경 scope를 source/test/lesson으로 유지하기 위해 수정하지 않았습니다. 검증 수치는 이 PR과 lesson에 고정했습니다.
- exact-head CI와 live review/thread를 확인한 뒤 fresh merge approval을 받아 병합했습니다.

## DoD Status

| 항목 | 상태 | 증거 |
|---|---|---|
| overflow-safe count/경계 계산 | PASS | `ProgressionSupport.kt`, commit `efcb967` |
| Int/Long 극단값 partition 회귀 테스트 | PASS | `ProgressionSupportTest` 35/35 |
| 빈/descending `chunked` 계약 및 KDoc/lesson | PASS | 직접 회귀 테스트, 명시적 `IllegalArgumentException`, lesson 및 terminology audit |
| core module 검증 | PASS | 새 exact-head `Test / Core`, 1,674 passing, `BUILD SUCCESSFUL`; Build publication metadata failures=0 |
| exact-head CI/live review | PASS | PR #1633 @ `efcb967db4491b90909fd72a4cac9600d711697d`, [CI run 33877749771](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33877749771) success; applicable 12/12, path-filtered N/A 12, pending/failure 0; live reviews/comments/threads 0 |
| merge/sync/cleanup | PASS | squash merge `74b678c865fff4dbec045f4a9a1cbabec57cdd6d`; canonical `develop` 동기화 및 #1622 worktree/local branch 정리 완료, #1620 worktree 보존 |
