### PR TITLE
[bug][http] Future 요청 취소 예제의 간헐적 실패를 결정적 테스트로 해결

### DIFF
--- a/docs/lessons/2026-09-05-issue-1651-http-request-future-cancellation.md
+++ b/docs/lessons/2026-09-05-issue-1651-http-request-future-cancellation.md
@@ -1,0 +1,59 @@
+# #1651: HTTP Future 취소는 실행 순서별로 검증한다
+
+## 잘못된 가정과 관찰
+
+`ClientWithRequestFuture`는 GET 제출 직후 `cancel(true)`를 호출하고 10ms 뒤
+`get()`이 직접 `CancellationException`을 던진다고 가정했다.
+[CI 33932767933](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33932767933)의
+첫 시도에서는 `ExecutionException(CancellationException)`으로 실패했고 재시도는 통과했다.
+로컬의 기존 예제도 1회 통과했으므로 단일 성공은 경합 부재의 증거가 아니다.
+
+실제 소비 버전인 HC5 `5.6.4`의 JAR 바이트코드를 확인했다.
+`HttpRequestFutureTask.cancel()`은 callable 취소 표시, 요청 취소,
+`FutureTask.cancel()` 순서로 실행한다. callable이 취소 표시를 읽고 먼저 예외로
+완료되면 마지막 `cancel()`은 `false`를 반환하고, `get()`은 취소 원인을
+`ExecutionException`으로 감싼다. 빠른 GET이 먼저 정상 완료하는 경우도 있으므로
+`cancel()` 호출 자체를 취소 성공으로 해석해서는 안 된다.
+
+## 결정과 검증 구조
+
+- 정상 GET·제한 시간·콜백 예제는 기존 컨테이너 기반 테스트에 유지한다.
+- 취소 예제는 `ClientWithRequestFutureCancellationTest`로 분리한다.
+  네트워크 응답 속도나 고정 sleep 대신 제출된 Runnable의 실행 순서를 제어한다.
+- 실제 `futureRequestExecutionServiceOf`와 HC5 Future/callable을 사용한다.
+  MockK는 executor의 제출과 HTTP I/O 경계만 대체한다. Future 결과나 취소 상태는
+  모킹하지 않는다. 전용 동시성 테스터는 스트레스 검증에 적합하지만, 여기서는
+  라이브러리 내부 두 단계 사이의 정확한 실행 순서를 지정해야 한다.
+- 취소 콜백에서 제출된 Runnable을 실행해 callable 선행 완료를 강제한다.
+  실행 전 취소, 감싸진 취소, 정상 완료, 일반 I/O 실패를 별도로 검증한다.
+- 일반 예외를 모두 취소로 간주하는 catch나 공용 예외 정규화 계층은 추가하지 않는다.
+  공개 API, 의존성 버전, CI 재시도 정책은 변경하지 않는다.
+
+## 재현과 검증
+
+- RED: 기존 직접 취소 예외 가정을 적용한 결정적 테스트가
+  `Expected CancellationException but got ExecutionException`으로 실패했다.
+  전체 4개 중 3개 통과, 1개 실패, 오류·제외 0개였다.
+- GREEN: 경합 경로에서 `ExecutionException`의 직접 원인이
+  `CancellationException`인지 검증한다. 기존 네트워크 예제를 포함해 5개 통과했다.
+- `cleanTest --no-build-cache`를 포함한 대상 검증을 별도 JVM에서 5회 실행해
+  매회 5개가 통과했다. HTTP 전체는 460개 중 457개 통과, 기존 비활성 3개,
+  실패·오류 0개였다. Detekt 기존 지적은 변경 파일 밖에 남아 있다.
+- 처음 반복 명령은 `cleanTest`만 사용해 테스트 결과가 `FROM-CACHE`로 복원됐다.
+  이를 반복 실행 증거에서 제외하고 `--no-build-cache`로 다시 검증했다.
+  앞으로 실행 횟수를 보고할 때 테스트 태스크의 실제 실행 여부를 먼저 확인한다.
+- 첫 회귀 테스트 작성 때 assertion 이름을 추정해 컴파일 오류가 발생했다.
+  실제 `shouldBeSameInstanceAs` 선언을 확인해 수정했다. 컴파일 실패를 RED로
+  계산하지 않았으며, 다음 변경부터 assertion 선언을 먼저 조회한다.
+
+## 재발 방지
+
+1. 취소 요청, Future의 취소 상태, 요청 실행 실패를 구분한다.
+2. 경합 테스트는 먼저 필요한 사건 순서를 고정하고, 고정 sleep으로 순서를 추정하지 않는다.
+3. 포장된 예외는 정확한 원인 타입을 확인하고 정상 완료·다른 실패 대조군을 둔다.
+4. 재시도 성공을 초기 실패의 해결 근거로 삼지 않는다. 실제 JUnit과 첫 시도 로그를 대조한다.
+5. 예제의 실행 제어를 바꾸더라도 실제 라이브러리 상태 전이는 검증 대상에 남긴다.
+
+관련 기록: [#1651](https://github.com/bluetape4k/bluetape4k-projects/issues/1651),
+[#1646](https://github.com/bluetape4k/bluetape4k-projects/pull/1646),
+[기존 동시성 예제 분류](2026-05-18-infra-io-concurrency-migration.md).

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientWithRequestFuture.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientWithRequestFuture.kt
@@ -8,13 +8,11 @@ import io.bluetape4k.http.hc5.protocol.httpClientContextOf
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
-import io.bluetape4k.assertions.fail
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.core5.concurrent.FutureCallback
 import org.apache.hc.core5.http.HttpStatus
 import org.apache.hc.core5.http.io.HttpClientResponseHandler
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CancellationException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -46,18 +44,8 @@ class ClientWithRequestFuture: AbstractHc5Test() {
             val wasItOk1 = futureTask1.get()
             log.debug { "It was ok? $wasItOk1" }
 
-            // 요청 취소
-            try {
-                val request2 = HttpGet("$httpbinBaseUrl/get")
-                val futureTask2 = requestExecService.execute(request2, httpClientContextOf(), handler)
-                futureTask2.cancel(true)
-                Thread.sleep(10)
-                val wasItOk2 = futureTask2.get()
-                log.debug { "It was ok? $wasItOk2" }
-                fail("여기까지 실행되면 안됩니다. 작업이 취소되어야 합니다.")
-            } catch (e: CancellationException) {
-                log.debug { "취소 후 예외가 발생하는 것이 정상 동작입니다." }
-            }
+            // 취소 예제는 ClientWithRequestFutureCancellationTest에서 실행 순서를 제어해 검증합니다.
+            // 빠른 GET 요청은 cancel() 전에 완료될 수 있으므로 취소 성공을 가정하지 않습니다.
 
             // 타임아웃이 있는 요청
             val request3 = HttpGet("$httpbinBaseUrl/get")

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientWithRequestFutureCancellationTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/examples/ClientWithRequestFutureCancellationTest.kt
@@ -1,0 +1,124 @@
+package io.bluetape4k.http.hc5.examples
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.http.hc5.http.futureRequestExecutionServiceOf
+import io.bluetape4k.http.hc5.protocol.httpClientContextOf
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.apache.hc.client5.http.classic.methods.HttpGet
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.core5.concurrent.FutureCallback
+import org.apache.hc.core5.http.ClassicHttpRequest
+import org.apache.hc.core5.http.io.HttpClientResponseHandler
+import org.apache.hc.core5.http.protocol.HttpContext
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * 실제 HC5 Future의 실행 순서를 제어해 취소 결과를 검증합니다.
+ * executor는 작업 제출만 가로채며 Future와 callable의 상태 전이는 실제 구현을 사용합니다.
+ */
+class ClientWithRequestFutureCancellationTest {
+
+    private val httpclient = mockk<CloseableHttpClient>(relaxed = true)
+    private val executor = mockk<ExecutorService>(relaxed = true)
+    private val callback = mockk<FutureCallback<Boolean>>(relaxed = true)
+    private val task = slot<Runnable>()
+    private val handler = HttpClientResponseHandler { true }
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(httpclient, executor, callback)
+        task.clear()
+        // 스트레스 드라이버가 아니라 HC5에 전달하는 executor의 실행 순서를 제어합니다.
+        every { executor.execute(capture(task)) } just Runs
+    }
+
+    @Test
+    fun `실행 전에 취소하면 직접 취소 예외가 발생한다`() {
+        futureRequestExecutionServiceOf(httpclient, executor).use { service ->
+            val future = service.execute(HttpGet("http://localhost/unused"), httpClientContextOf(), handler)
+
+            future.cancel(true).shouldBeTrue()
+            task.captured.run()
+
+            future.isCancelled.shouldBeTrue()
+            assertFailsWith<CancellationException> { future.get(1, TimeUnit.SECONDS) }
+            verify(exactly = 0) {
+                httpclient.execute(any<ClassicHttpRequest>(), any<HttpContext>(), handler)
+            }
+        }
+        verify(exactly = 1) {
+            executor.shutdownNow()
+            httpclient.close()
+        }
+    }
+
+    @Test
+    fun `취소 표시 후 callable이 먼저 완료되어도 취소 결과를 확인한다`() {
+        // callable.cancel()의 표시 직후, FutureTask.cancel()보다 먼저 실행합니다.
+        every { callback.cancelled() } answers { task.captured.run() }
+        futureRequestExecutionServiceOf(httpclient, executor).use { service ->
+            val future = service.execute(HttpGet("http://localhost/unused"), httpClientContextOf(), handler, callback)
+
+            future.cancel(true).shouldBeFalse()
+
+            future.isDone.shouldBeTrue()
+            future.isCancelled.shouldBeFalse()
+            // callable이 예외로 먼저 완료되면 get()이 취소 원인을 ExecutionException으로 감쌉니다.
+            val error = assertFailsWith<ExecutionException> { future.get(1, TimeUnit.SECONDS) }
+            error.cause.shouldBeInstanceOf<CancellationException>()
+            verify(exactly = 1) { callback.cancelled() }
+            verify(exactly = 0) {
+                httpclient.execute(any<ClassicHttpRequest>(), any<HttpContext>(), handler)
+            }
+        }
+        verify(exactly = 1) {
+            executor.shutdownNow()
+            httpclient.close()
+        }
+    }
+
+    @Test
+    fun `이미 성공한 요청은 취소 성공으로 오인하지 않는다`() {
+        every { httpclient.execute(any<ClassicHttpRequest>(), any<HttpContext>(), handler) } returns true
+        futureRequestExecutionServiceOf(httpclient, executor).use { service ->
+            val future = service.execute(HttpGet("http://localhost/unused"), httpClientContextOf(), handler)
+            task.captured.run()
+
+            future.cancel(true).shouldBeFalse()
+
+            future.isCancelled.shouldBeFalse()
+            future.get(1, TimeUnit.SECONDS).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `취소와 무관한 실패는 원인을 그대로 전달한다`() {
+        val failure = IOException("요청 실패")
+        every { httpclient.execute<Boolean>(any<ClassicHttpRequest>(), any<HttpContext>(), handler) } throws failure
+        futureRequestExecutionServiceOf(httpclient, executor).use { service ->
+            val future = service.execute(HttpGet("http://localhost/unused"), httpClientContextOf(), handler)
+            task.captured.run()
+
+            future.cancel(true).shouldBeFalse()
+
+            val error = assertFailsWith<ExecutionException> { future.get(1, TimeUnit.SECONDS) }
+            error.cause.shouldBeSameInstanceAs(failure)
+        }
+    }
+}


### PR DESCRIPTION
## 요약

Closes #1651

HTTP Future 취소 예제가 네트워크 응답 속도와 취소 순서에 따라 간헐적으로 실패하던 문제를 해결합니다. 취소 검증을 실제 HC5 상태 전이를 사용하는 결정적 테스트로 분리합니다.

## 배경과 원인

[CI 33932767933](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33932767933)의 첫 시도에서 `ClientWithRequestFuture.kt:55`가 `ExecutionException(CancellationException)`으로 실패했고 재시도에서는 통과했습니다.

HC5 `5.6.4`는 callable 취소 표시 후 `FutureTask.cancel()`을 호출합니다. 그 사이 callable이 취소 예외로 완료되면 `get()`이 예외를 감쌉니다. 기존 예제는 직접 `CancellationException`만 처리했고, 빠른 GET이 취소 전에 정상 완료할 가능성도 배제하지 못했습니다.

## 변경

- 기존 GET·타임아웃·콜백 예제는 유지하고 `cancel()+sleep(10)` 블록을 별도 테스트로 이동했습니다.
- 실제 `futureRequestExecutionServiceOf`와 HC5 Future/callable을 사용합니다. executor 제출과 HTTP I/O 경계만 MockK로 제어합니다.
- 실행 전 취소, 취소 중 callable 선행 완료, 이미 성공한 요청, 일반 `IOException` 실패를 검증합니다.
- 취소 콜백 1회, 취소 경로 HTTP 실행 0회, 서비스 종료 시 executor/client 정리를 확인합니다.
- 공개 API, 의존성 버전, CI 재시도 정책 변경은 없습니다.

## 검증

- RED: 기존 직접 취소 예외 가정을 결정적 실행 순서에 적용해 4개 중 1개 실패. `Expected CancellationException but got ExecutionException`을 확인했습니다. 컴파일 오류는 RED 증거에서 제외했습니다.
- GREEN: 대상 5개 통과.
- `:bluetape4k-http:cleanTest :bluetape4k-http:test --tests '*ClientWithRequestFuture*' --max-workers=1 --no-configuration-cache --no-build-cache`: 별도 JVM에서 5회, 매회 5개 통과. `FROM-CACHE` 결과는 반복 증거에서 제외했습니다.
- `:bluetape4k-http:cleanTest :bluetape4k-http:test :bluetape4k-http:detekt --max-workers=1 --no-configuration-cache --no-build-cache`: JUnit 101 suites, 460개 중 457개 통과, 실패·오류 0개, 기존 비활성 3개.
- 기존 비활성: `ClientProxyAuthentication`, `AsyncClientCustomSSL`, `SslExample` 각 1개. 통과로 계산하지 않았습니다.
- Detekt는 성공 종료했지만 변경되지 않은 37개 파일의 기존 지적 74건이 남습니다. 변경 파일 지적은 0건입니다. MockK/ByteBuddy의 JDK Unsafe 경고도 별도 잔여 사항입니다.
- IDE 도구가 없어 Kotlin 컴파일·테스트·Detekt로 대체 검증했습니다. `git diff --check`와 한국어 용어 검사 통과.

## 검토와 lesson

- 독립 `code-reviewer`의 최종 검토: P0=0, P1=0, P2=0. 취소 콜백 호출 횟수 확인 권고를 반영했습니다.
- 이 테스트는 HC5 `5.6.4`의 내부 취소 순서를 의도적으로 고정합니다. 버전 변경 시 두 취소 경로를 재검토해야 합니다. 실제 네트워크 전송 중단의 전체 계약을 증명하는 테스트는 아닙니다.
- `docs/lessons/2026-09-05-issue-1651-http-request-future-cancellation.md`: 원인, RED/GREEN, 캐시 복원과 실행 증거 구분을 기록했습니다. 작업 전용 GNO `issue1651`에 색인·검색 확인; 병합 후 기본 `bluetape4k-docs` 색인 및 작업 컬렉션 정리 예정입니다.

## 메타데이터

- 이슈 #1651, milestone `2.1.0`, assignee `debop`
- HEAD `a494d153be82f46709708872fadc265500398861`
- `fix/http-request-future-cancellation` → `develop`

## DoD Status

Required checks: 12/12; N/A: 1; Blocked: 0

| 점검 | 상태 | 근거 / 다음 조치 |
|---|---|---|
| C-01 원인·이슈 | PASS | CI 첫 시도, HC5 바이트코드, #1651 등록·메타데이터 확인 |
| C-03 RED | PASS | 실제 HC5 경합 경로 4개 중 1개 의도한 실패 |
| C-04 최소 수정 | PASS | 예제 분리, 공개 API·의존성 불변 |
| C-05 GREEN·영향 검증 | PASS | 대상 5개 × 캐시 없는 5회, HTTP 457개 통과·기존 비활성 3개 |
| C-06 lesson | PASS | 한국어 lesson, 용어 검사, GNO issue1651 색인·검색 |
| CG-10 독립 검토·커밋 | PASS | P0/P1/P2=0, HEAD a494d153be82f46709708872fadc265500398861 |
| CG-12A 기준 재확인 | PASS | user/workspace/repo AGENTS hash 불변, Type C/common gates/PR template/issue 메타데이터 재확인 |
| CG-13 PR | PASS | 승인된 repository/base/head, 이슈 연결 및 메타데이터 일치 |
| CG-14 정확한 HEAD의 CI·리뷰 | PASS | CI 33965678972: 정확한 HEAD에서 적용 검사 12개 성공, 변경 범위 밖 12개 제외. HTTP 첫 시도 통과, 리뷰·thread 0개, MERGEABLE |
| CG-16 별도 병합 승인 | PASS | 정확한 HEAD의 병합 준비 보고 후 사용자 승인, HEAD·CI·리뷰·thread 재확인 |
| CG-17 병합 | PASS | match-head-commit으로 rebase 병합, 6162611f6b2e54cfdf586becc52e91a261a6ec85, 이슈 #1651 CLOSED |
| CG-18 싱크·정리 | PASS | develop=origin/develop=6162611f6, 검증 HEAD와 전체 tree 동일, 깨끗한 상태. 복구 bundle·검증 자료 보존 후 해당 로컬 worktree·브랜치 제거. GNO 기본 docs 검색 확인 및 issue1651 제거. 정리 전후 원격 refs 불변 |
| 추가 사람 리뷰 | N/A | debop 단독 작업, 별도 사람 리뷰 요청 없음; 독립 검토 및 live thread 확인은 유지 |

CI 최종 증거: [33965678972](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33965678972), HEAD `a494d153be82f46709708872fadc265500398861`. IO HTTP 로그의 `Command completed after 1 attempt(s).`와 JUnit artifact를 확인했습니다. HTTP 449개 통과·기존 비활성 3개, Retrofit2 304개 통과·비활성 4개, Vert.x 227개 통과, Feign 241개 통과·비활성 2개이며 실패·오류는 모두 0개입니다. 대상 취소 테스트 4개와 기존 예제 1개가 실제 실행되어 통과했습니다. 로컬 HTTP 결과와의 8개 차이는 기존 `excludeBenchmarks=true`에 의한 `HttpClientBenchmarkTest` 제외입니다. 제외된 작업·테스트는 통과로 계산하지 않았습니다.

마무리 증거: 복구 자료는 `/Users/debop/work/bluetape4k/.cleanup-archives/projects-issue-1651-20260905`에 보관했습니다. 기존 작업 컬렉션 색인 계획은 완료했으며 lesson은 `gno://bluetape4k-docs/bluetape4k-projects/docs/lessons/2026-09-05-issue-1651-http-request-future-cancellation.md`에서 검색됩니다. Rebase로 커밋 해시는 바뀌었지만 검증한 HEAD와 병합 결과의 전체 tree가 동일합니다. 배포·태그·workflow dispatch는 실행하지 않았습니다.

Final status: DONE — CG-16·17·18 완료.

Unchecked required items: 없음.
