### PR TITLE
[security][grpc] SETTINGS ACK 이전 stream 제한과 TLS 회귀 테스트 활성화

### DIFF
--- a/docs/lessons/2026-09-05-issue-1635-grpc-settings-ack-security.md
+++ b/docs/lessons/2026-09-05-issue-1635-grpc-settings-ack-security.md
@@ -1,0 +1,68 @@
+# #1635: TLS handshake와 HTTP/2 SETTINGS ACK 경계를 구분한다
+
+## 배경과 원인
+
+[이슈 #1635](https://github.com/bluetape4k/bluetape4k-projects/issues/1635)는
+gRPC Java `1.84.0`의 stream 제한 보안 수정을 검증한다.
+중앙 catalog `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`가 지정한
+`grpc-netty`·`grpc-okhttp`는 `1.84.0`, Netty는 `4.2.17.Final`이다.
+
+[upstream 수정 56205f91c](https://github.com/grpc/grpc-java/commit/56205f91c2f8d2e40ba35bcd586c4bb571707f20)는
+`DefaultHttp2Connection` 생성 직후 remote endpoint에 `maxActiveStreams`를 적용한다.
+취약 경계는 TLS handshake가 아니라 **클라이언트의 SETTINGS ACK가 도착하기 전**이다.
+TLS 상호운용 테스트 통과만으로 이 경계를 검증했다고 판단하면 안 된다.
+
+## 결정
+
+- TLS는 기존 Netty 서버·OkHttp 클라이언트의 실제 loopback 통신으로 검증한다.
+- 제한은 실제 `NettyServerHandler`와 `EmbeddedChannel`로 검증한다.
+  정상 클라이언트의 자동 SETTINGS ACK를 피하려고 HTTP/2 프레임을 직접 직렬화한다.
+  제한 1과 stream 2개만 사용하며 부하 공격이나 외부 서비스 접근은 하지 않는다.
+- 초과 stream의 `RST_STREAM(REFUSED_STREAM)`, 정상 stream 유지, 취소 후 슬롯 재사용,
+  강제 종료 후 active stream 0개와 입력 buffer 해제를 각각 확인한다.
+- 미완성 메시지를 보내 deframer가 보유한 데이터도 강제 종료 시 해제되는지 확인한다.
+  transport listener와 metric recorder만 MockK로 대체한다. HTTP/2 decoder·handler는 실제 구현이다.
+- package-private 접근은 `io.grpc.netty` 테스트 패키지로 한정한다.
+  공개 API·생산 코드·의존성·CI 정책은 변경하지 않는다.
+
+## RED/GREEN에서 수정한 가정
+
+1. TLS enum의 `name`은 JSSE 프로토콜 이름이 아니다.
+   `TLS_1_3`을 전달한 기존 테스트는 활성화 직후
+   `SSLHandshakeException: No appropriate protocol`로 실패했다.
+   `javaName()`의 `TLSv1.3`으로 교정하자 같은 `emptyUnary`가 통과했다.
+2. 비활성 테스트의 기대값도 현재 fixture와 대조해야 한다.
+   `largeUnary`는 zero-filled body를 기대했지만 `TestServiceImpl`은 임의 데이터로
+   지정한 크기의 응답을 만든다. 테스트를 활성화하자 이 불일치가 드러났다.
+   payload 존재와 요청한 응답 크기를 검증하도록 수정했다. 생산 동작은 바꾸지 않았다.
+3. 해제된 pooled ByteBuf 객체의 나중 `refCnt()`는 최초 소유권의 증거가 아니다.
+   객체가 다른 출력 buffer로 재사용되어 1로 보일 수 있다.
+   직렬화 결과를 unpooled 입력으로 복사하고 원래 writer buffer는 즉시 해제하여
+   관찰 대상을 분리했다. Netty의 unreleasable preface 상수도 복사해서 전달한다.
+4. 보안 테스트는 설정값 확인에 그치지 않아야 한다.
+   임시로 시작 제한을 `Int.MAX_VALUE`로 되돌리고 설정값 assertion을 제외하자
+   실제 active stream이 2개가 되어 실패했다. 이후 임시 변이는 전부 제거했다.
+   이는 이전 artifact를 실행한 결과가 아니라 과거 상태를 모사한 mutation 검증이다.
+5. 구현 리뷰에서 writer 원본의 해제는 서버 복사본의 해제를 증명하지 못한다는 지적이 나왔다.
+   DATA 전달분만 반환하고 그중 서버가 보유한 정확한 buffer를 골라,
+   강제 종료 전 양수였던 참조 수가 같은 객체에서 0으로 바뀌는지 검증한다.
+   앞으로 소유권 테스트는 전달 경계마다 검증 대상 객체를 명시한다.
+6. TLS 회귀가 무한 대기로 바뀌지 않도록 클래스에 30초 제한을 두고,
+   Future와 streaming 완료 대기에도 각각 10초 제한을 적용한다.
+
+## 검증
+
+- 기존 보안 기준 테스트: 5개 통과.
+- 대상 TLS 4개·stream 경계 3개: `cleanTest --no-build-cache`로 3회, 매회 7개 통과.
+- gRPC 전체: 75개 통과, 실패·오류·비활성 0개.
+- 독립 구현 리뷰의 P2 buffer 검증 지적을 수정하고 재검토했다.
+  최종 판정은 P0=0, P1=0, P2=0이며 수정 후 전체 75개를 다시 통과했다.
+- Detekt 성공 종료. 기존 지적 28건은 별도이며 전체 정적 분석 무결함으로 표현하지 않는다.
+- 조사 에이전트는 응답 지연으로 중단 후 부분 결과를 회수했다. 주 세션의 upstream 직접 확인과
+  실제 테스트 실행이 구현 근거이며, 조사 결과를 독립 코드 리뷰로 계산하지 않는다.
+
+## 다음 변경 시 확인할 사항
+
+gRPC 버전 변경 시 package-private factory와 오류 프레임 계약을 재확인한다.
+통신 성공, HTTP/2 stream 거부, buffer 소유권, 실제 서버 종료를 서로 다른 증거로 다룬다.
+이 테스트는 작은 결정적 입력의 회귀 검증이지 운영 부하 한계나 모든 메모리 누수의 증명은 아니다.

--- a/docs/lessons/2026-09-05-issue-1635-grpc-settings-ack-security.md
+++ b/docs/lessons/2026-09-05-issue-1635-grpc-settings-ack-security.md
@@ -49,6 +49,15 @@ TLS 상호운용 테스트 통과만으로 이 경계를 검증했다고 판단�
    앞으로 소유권 테스트는 전달 경계마다 검증 대상 객체를 명시한다.
 6. TLS 회귀가 무한 대기로 바뀌지 않도록 클래스에 30초 제한을 두고,
    Future와 streaming 완료 대기에도 각각 10초 제한을 적용한다.
+7. 로컬 macOS ARM 통과만으로 Linux TLS fixture를 검증할 수 없다.
+   첫 CI에서 HTTP/2 보안 테스트 3개는 통과했지만 TLS 테스트 4개는 세 번 모두
+   `SSLHandshakeException: Unknown authType: GENERIC`으로 실패했다.
+   `TestUtils.installConscryptIfAvailable()`는 ARM에서는 설치를 건너뛰지만 Linux x86_64에서는
+   Conscrypt를 전역 등록한다. 이후 OkHttp `Platform`은 Conscrypt를 선택하고,
+   `newSslSocketFactoryForCa`는 JDK 기본 trust manager와 선택된 TLS provider를 조합한다.
+   CI stack의 `ConscryptEngineSocket`과 `X509TrustManagerImpl` 혼용이 이 경계와 일치했다.
+   이 저장소는 Java 25를 사용하므로 테스트의 Conscrypt 전역 설치를 제거하고
+   JDK TLS provider·trust manager 경로를 일관되게 사용한다.
 
 ## 검증
 
@@ -57,12 +66,16 @@ TLS 상호운용 테스트 통과만으로 이 경계를 검증했다고 판단�
 - gRPC 전체: 75개 통과, 실패·오류·비활성 0개.
 - 독립 구현 리뷰의 P2 buffer 검증 지적을 수정하고 재검토했다.
   최종 판정은 P0=0, P1=0, P2=0이며 수정 후 전체 75개를 다시 통과했다.
+- PR #1653의 첫 CI는 gRPC 75개 중 TLS 4개가 실패했다.
+  `Coverage Report`와 `CI Status` 실패는 `Test / IO` 실패를 전파한 결과였다.
+  provider 수정 후 로컬 TLS 4개를 통과했으며 Linux 결과는 후속 CI에서 확인한다.
 - Detekt 성공 종료. 기존 지적 28건은 별도이며 전체 정적 분석 무결함으로 표현하지 않는다.
-- 조사 에이전트는 응답 지연으로 중단 후 부분 결과를 회수했다. 주 세션의 upstream 직접 확인과
-  실제 테스트 실행이 구현 근거이며, 조사 결과를 독립 코드 리뷰로 계산하지 않는다.
+- 조사 에이전트는 응답 지연으로 중단한 뒤 공식 `TestUtils`·OkHttp `Platform` 소스 근거를 회수했다.
+  주 세션이 같은 소스를 다시 확인했으며, 조사 결과를 독립 코드 리뷰로 계산하지 않는다.
 
 ## 다음 변경 시 확인할 사항
 
 gRPC 버전 변경 시 package-private factory와 오류 프레임 계약을 재확인한다.
+TLS fixture가 provider를 전역 등록하면 지원 OS·아키텍처와 trust manager provider 조합을 CI에서 확인한다.
 통신 성공, HTTP/2 stream 거부, buffer 소유권, 실제 서버 종료를 서로 다른 증거로 다룬다.
 이 테스트는 작은 결정적 입력의 회귀 검증이지 운영 부하 한계나 모든 메모리 누수의 증명은 아니다.

--- a/docs/lessons/2026-09-05-issue-1635-grpc-settings-ack-security.md
+++ b/docs/lessons/2026-09-05-issue-1635-grpc-settings-ack-security.md
@@ -68,7 +68,9 @@ TLS 상호운용 테스트 통과만으로 이 경계를 검증했다고 판단�
   최종 판정은 P0=0, P1=0, P2=0이며 수정 후 전체 75개를 다시 통과했다.
 - PR #1653의 첫 CI는 gRPC 75개 중 TLS 4개가 실패했다.
   `Coverage Report`와 `CI Status` 실패는 `Test / IO` 실패를 전파한 결과였다.
-  provider 수정 후 로컬 TLS 4개를 통과했으며 Linux 결과는 후속 CI에서 확인한다.
+  provider 수정 후 로컬 TLS 4개를 통과했고, 후속 CI run `33970108329`도
+  재시도 없이 첫 실행에서 gRPC 75개를 모두 통과했다.
+  `Test / IO`, `Coverage Report`, `CI Status`가 모두 성공했다.
 - Detekt 성공 종료. 기존 지적 28건은 별도이며 전체 정적 분석 무결함으로 표현하지 않는다.
 - 조사 에이전트는 응답 지연으로 중단한 뒤 공식 `TestUtils`·OkHttp `Platform` 소스 근거를 회수했다.
   주 세션이 같은 소스를 다시 확인했으며, 조사 결과를 독립 코드 리뷰로 계산하지 않는다.

--- a/io/grpc/src/test/kotlin/io/bluetape4k/grpc/testing/integration/AbstractInteropTest.kt
+++ b/io/grpc/src/test/kotlin/io/bluetape4k/grpc/testing/integration/AbstractInteropTest.kt
@@ -223,13 +223,11 @@ abstract class AbstractInteropTest {
                 payload = Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(REQUEST_SIZE))).build()
             }.build()
 
-        val goldenResponse = Messages.SimpleResponse.newBuilder()
-            .apply {
-                payload = Messages.Payload.newBuilder().setBody(ByteString.copyFrom(ByteArray(RESPONSE_SIZE))).build()
-            }.build()
-
         runSuspendIO {
-            stub.unaryCall(request) shouldBeEqualTo goldenResponse
+            // TestServiceImpl은 0으로 채운 body가 아닌 임의 데이터로 요청한 크기의 응답을 만든다.
+            val response = stub.unaryCall(request)
+            response.hasPayload().shouldBeTrue()
+            response.payload.body.size() shouldBeEqualTo RESPONSE_SIZE
         }
     }
 

--- a/io/grpc/src/test/kotlin/io/bluetape4k/grpc/testing/integration/Http2OkHttpTest.kt
+++ b/io/grpc/src/test/kotlin/io/bluetape4k/grpc/testing/integration/Http2OkHttpTest.kt
@@ -15,14 +15,16 @@ import io.netty.handler.ssl.SslContextBuilder
 import io.netty.handler.ssl.SslProvider
 import io.netty.handler.ssl.SupportedCipherSuiteFilter
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import java.io.IOException
 import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 
-@Disabled("보안관련 설정 후에 테스트해야 합니다")
+@Timeout(30)
 class Http2OkHttpTest: AbstractInteropTest() {
 
     companion object: KLogging() {
@@ -63,7 +65,7 @@ class Http2OkHttpTest: AbstractInteropTest() {
         val builder = OkHttpChannelBuilder.forAddress("localhost", port)
             .maxInboundMessageSize(MAX_MESSAGE_SIZE)
             .tlsConnectionSpec(
-                arrayOf(TlsVersion.TLS_1_3.name, TlsVersion.TLS_1_2.name),
+                arrayOf(TlsVersion.TLS_1_3.javaName(), TlsVersion.TLS_1_2.javaName()),
                 SSLContext.getDefault().defaultSSLParameters.cipherSuites
             )
             .overrideAuthority(Util.authorityFromHostAndPort(TestUtils.TEST_SERVER_HOST, port))
@@ -101,10 +103,10 @@ class Http2OkHttpTest: AbstractInteropTest() {
 
         val request = requestBuilder.build()
         requestStream.onNext(request)
-        recorder.firstValue().get()
+        recorder.firstValue().get(10, TimeUnit.SECONDS)
         requestStream.onError(Exception("failed"))
 
-        recorder.awaitCompletion()
+        recorder.awaitCompletion(10, TimeUnit.SECONDS).shouldBeTrue()
 
         blockingStub!!.emptyCall(EMPTY) shouldBeEqualTo EMPTY
     }

--- a/io/grpc/src/test/kotlin/io/bluetape4k/grpc/testing/integration/Http2OkHttpTest.kt
+++ b/io/grpc/src/test/kotlin/io/bluetape4k/grpc/testing/integration/Http2OkHttpTest.kt
@@ -16,7 +16,6 @@ import io.netty.handler.ssl.SslProvider
 import io.netty.handler.ssl.SupportedCipherSuiteFilter
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.io.IOException
@@ -81,11 +80,6 @@ class Http2OkHttpTest: AbstractInteropTest() {
             throw RuntimeException(e)
         }
         return builder
-    }
-
-    @BeforeAll
-    fun loadConscrypt() {
-        TestUtils.installConscryptIfAvailable()
     }
 
     @Test

--- a/io/grpc/src/test/kotlin/io/grpc/netty/NettyServerStreamLimitTest.kt
+++ b/io/grpc/src/test/kotlin/io/grpc/netty/NettyServerStreamLimitTest.kt
@@ -1,0 +1,202 @@
+package io.grpc.netty
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.grpc.Attributes
+import io.grpc.MetricRecorder
+import io.grpc.Status
+import io.grpc.internal.ServerStream
+import io.grpc.internal.ServerStreamListener
+import io.grpc.internal.ServerTransportListener
+import io.grpc.internal.TransportTracer
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.http2.DefaultHttp2FrameWriter
+import io.netty.handler.codec.http2.DefaultHttp2Headers
+import io.netty.handler.codec.http2.Http2CodecUtil
+import io.netty.handler.codec.http2.Http2Settings
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * 실제 gRPC handler의 SETTINGS ACK 이전 제한과 buffer 소유권을 검증한다.
+ * package-private 접근은 테스트에만 한정하며 gRPC 버전 변경 시 factory 계약을 재확인한다.
+ */
+class NettyServerStreamLimitTest {
+    private val transportListener = mockk<ServerTransportListener>(relaxed = true)
+    private val streamListener = mockk<ServerStreamListener>(relaxed = true)
+    private val metricRecorder = mockk<MetricRecorder>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(transportListener, streamListener, metricRecorder)
+        every { transportListener.transportReady(any()) } answers { firstArg() }
+        every { transportListener.streamCreated(any(), any(), any()) } answers {
+            firstArg<ServerStream>().setListener(streamListener)
+        }
+    }
+
+    @Test
+    fun `SETTINGS ACK 전에도 초과 stream을 거부하고 정상 stream을 유지한다`() {
+        Fixture().use { fixture ->
+            fixture.handler.connection().remote().maxActiveStreams() shouldBeEqualTo 1
+            fixture.headers(3)
+            fixture.handler.connection().numActiveStreams() shouldBeEqualTo 1
+            fixture.headers(5)
+            fixture.handler.connection().numActiveStreams() shouldBeEqualTo 1
+            fixture.resetFrames() shouldBeEqualTo listOf(5 to 7L)
+            verify(exactly = 1) { transportListener.streamCreated(any(), any(), any()) }
+            fixture.server.isActive.shouldBeTrue()
+            fixture.forceClose()
+            fixture.handler.connection().numActiveStreams() shouldBeEqualTo 0
+            fixture.server.isActive.shouldBeFalse()
+            fixture.assertReleased()
+        }
+    }
+
+    @Test
+    fun `stream을 취소하면 ACK 전에도 다음 요청이 제한 슬롯을 재사용한다`() {
+        Fixture().use { fixture ->
+            fixture.headers(3)
+            fixture.writer.writeRstStream(fixture.client.pipeline().firstContext(), 3, 8,
+                fixture.client.newPromise())
+            fixture.transfer()
+            fixture.handler.connection().numActiveStreams() shouldBeEqualTo 0
+            fixture.headers(5)
+            fixture.handler.connection().numActiveStreams() shouldBeEqualTo 1
+            verify(exactly = 2) { transportListener.streamCreated(any(), any(), any()) }
+            fixture.forceClose()
+            fixture.assertReleased()
+        }
+    }
+
+    @Test
+    fun `미완성 메시지를 받은 stream도 강제 종료하면 buffer를 해제한다`() {
+        Fixture().use { fixture ->
+            fixture.headers(3)
+            // 길이 10인 메시지의 첫 byte만 보내 deframer가 미완성 데이터를 보유하게 한다.
+            val partial = Unpooled.buffer().writeByte(0).writeInt(10).writeByte(1)
+            fixture.writer.writeData(fixture.client.pipeline().firstContext(), 3, partial, 0, false,
+                fixture.client.newPromise())
+            val dataInputs = fixture.transfer()
+            fixture.handler.connection().numActiveStreams() shouldBeEqualTo 1
+            // 이번 DATA 전달분 중 서버가 실제 보유한 복사본을 종료 전후 동일 객체로 검사한다.
+            val retainedData = dataInputs.single { it.refCnt() > 0 }
+            fixture.forceClose()
+            fixture.handler.connection().numActiveStreams() shouldBeEqualTo 0
+            fixture.server.isActive.shouldBeFalse()
+            retainedData.refCnt() shouldBeEqualTo 0
+            fixture.assertReleased()
+            verify(exactly = 1) { streamListener.closed(any()) }
+        }
+    }
+
+    private inner class Fixture: AutoCloseable {
+        val server = EmbeddedChannel()
+        val client = EmbeddedChannel(ChannelInboundHandlerAdapter())
+        val writer = DefaultHttp2FrameWriter()
+        private val inbound = mutableListOf<ByteBuf>()
+        val handler: NettyServerHandler = NettyServerHandler.newHandler(
+            transportListener, server.newPromise(), emptyList(), TransportTracer(),
+            1, false, 65535, 8192, 8192, 1024,
+            Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+            false, Long.MAX_VALUE, 0, Long.MAX_VALUE, Attributes.EMPTY, metricRecorder
+        )
+
+        init {
+            server.pipeline().addLast(handler)
+            handler.handleProtocolNegotiationCompleted(Attributes.EMPTY, null)
+            // Netty 기본 preface는 unreleasable 상수이므로 소유권 검증용 복사본을 전달한다.
+            receive(Unpooled.copiedBuffer(Http2CodecUtil.connectionPrefaceBuf()))
+            writer.writeSettings(client.pipeline().firstContext(), Http2Settings(), client.newPromise())
+            transfer()
+            // 서버 SETTINGS는 읽거나 ACK하지 않는다. 일반 클라이언트의 자동 ACK를 사용하지 않는다.
+        }
+
+        fun headers(streamId: Int) {
+            val headers = DefaultHttp2Headers().method("POST").scheme("http")
+                .path("/test.Service/stream").authority("localhost")
+                .add("content-type", "application/grpc").add("te", "trailers")
+            writer.writeHeaders(client.pipeline().firstContext(), streamId, headers, 0, false,
+                client.newPromise())
+            transfer()
+        }
+
+        fun transfer(): List<ByteBuf> {
+            val transferred = mutableListOf<ByteBuf>()
+            client.flushOutbound()
+            while (true) {
+                val encoded = client.readOutbound<ByteBuf>() ?: break
+                // Pooled buffer는 해제 뒤 같은 객체가 재사용된다. refCnt 관찰에는 독립 복사본을 쓴다.
+                val owned = Unpooled.copiedBuffer(encoded)
+                encoded.release()
+                transferred.add(owned)
+                receive(owned)
+            }
+            server.runPendingTasks()
+            server.checkException()
+            return transferred
+        }
+
+        private fun receive(buffer: ByteBuf) {
+            inbound.add(buffer)
+            server.writeInbound(buffer)
+        }
+
+        fun forceClose() {
+            server.writeAndFlush(ForcefulCloseCommand(Status.CANCELLED))
+            server.runPendingTasks()
+            server.checkException()
+        }
+
+        fun resetFrames(): List<Pair<Int, Long>> {
+            val bytes = Unpooled.buffer()
+            try {
+                while (true) {
+                    val frame = server.readOutbound<ByteBuf>() ?: break
+                    try {
+                        bytes.writeBytes(frame)
+                    } finally {
+                        frame.release()
+                    }
+                }
+                val resets = mutableListOf<Pair<Int, Long>>()
+                while (bytes.isReadable) {
+                    val length = bytes.readUnsignedMedium()
+                    val type = bytes.readUnsignedByte().toInt()
+                    bytes.skipBytes(1)
+                    val streamId = bytes.readInt() and Int.MAX_VALUE
+                    if (type == 3) {
+                        length shouldBeEqualTo 4
+                        resets.add(streamId to bytes.readUnsignedInt())
+                    } else {
+                        bytes.skipBytes(length)
+                    }
+                }
+                return resets
+            } finally {
+                bytes.release()
+            }
+        }
+
+        fun assertReleased() {
+            inbound.filter { it.refCnt() != 0 }.map { it.javaClass.simpleName } shouldBeEqualTo emptyList()
+        }
+
+        override fun close() {
+            try {
+                server.finishAndReleaseAll()
+            } finally {
+                writer.close()
+                client.finishAndReleaseAll()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 요약

Closes #1635

gRPC Java의 HTTP/2 SETTINGS ACK 이전 stream 제한과 종료 시 buffer 해제를 회귀 테스트로 고정합니다. 비활성 상태였던 Netty 서버·OkHttp 클라이언트의 TLS 테스트도 복구합니다.

## 원인과 변경

- upstream `56205f91c`는 SETTINGS ACK 수신 전에도 remote endpoint에 stream 상한을 적용합니다. TLS handshake와는 별도 경계입니다.
- 실제 `NettyServerHandler`·`EmbeddedChannel`에 작은 입력을 보내 초과 stream의 `REFUSED_STREAM`, 정상 stream 유지, 취소 후 슬롯 재사용, 미완성 메시지의 강제 종료와 buffer 해제를 확인합니다.
- 기존 TLS 설정은 enum 이름 `TLS_1_3`을 전달해 실패했습니다. `javaName()`으로 JSSE 이름 `TLSv1.3`을 전달하고 클래스의 `@Disabled`를 제거했습니다.
- `largeUnary`의 zero-filled 기대값은 임의 body를 반환하는 실제 fixture와 달랐습니다. payload 존재와 요청한 응답 크기를 검증하도록 수정했습니다.
- 공개 API·생산 코드·catalog 버전·의존성·CI 정책은 변경하지 않습니다. `io/grpc/**`는 기존 IO CI의 gRPC 테스트 경로에 포함됩니다.

## 검증

- TLS RED: `emptyUnary` 활성화 후 `SSLHandshakeException: No appropriate protocol`; 설정 교정 후 GREEN.
- 보안 mutation RED: 제한을 일시적으로 `Int.MAX_VALUE`로 되돌리자 실제 active stream이 2개가 되어 실패. 설정값 assertion 없이도 실패를 확인했고 변이는 제거했습니다. 구버전 artifact 실행 증거와는 구분합니다.
- 대상 7개: `cleanTest --no-build-cache`로 별도 실행 3회, 매회 통과.
- gRPC 전체: 75개 통과, 실패·오류·비활성 0개.
- 첫 CI Ubuntu / Java 25: gRPC 75개 중 TLS 4개가 3회 모두 `SSLHandshakeException: Unknown authType: GENERIC`으로 실패했습니다. HTTP/2 보안 테스트 3개는 통과했습니다. Linux에서 Conscrypt를 전역 등록한 뒤 OkHttp TLS provider와 JDK trust manager가 혼용된 것이 원인이었습니다.
- CI 수정: Java 25에 불필요한 `installConscryptIfAvailable()` 호출을 제거해 provider 경로를 일관되게 유지합니다. 수정 후 TLS 4개와 gRPC 전체 75개가 로컬에서 통과했습니다. 최종 HEAD의 Linux CI도 재시도 없이 Attempt 1에서 gRPC 75개를 모두 통과했습니다.
- Detekt 성공 종료. 기존 지적 28건은 남아 있으며 새 보안 테스트 지적은 0건입니다.
- Kotlin 컴파일과 `git diff --check` 및 lesson 한국어 용어 검사 통과. IDE 도구는 사용할 수 없어 컴파일·테스트·Detekt로 검증합니다.

## 검토와 한계

- 독립 코드 리뷰: DATA buffer 소유권 검증 P2 1건을 수정하고 재검토 완료. CI provider 수정도 별도로 재검토했으며 최종 P0=0, P1=0, P2=0, P3=0, APPROVE.
- DATA 전달분의 서버 소유 복사본을 특정하여 종료 전 참조 수 양수, 강제 종료 후 동일 객체의 참조 수 0을 검증합니다. TLS 대기에도 제한 시간을 적용했습니다. 최종 수정 후 전체 75개를 다시 통과했습니다.
- HTTP/2 decoder·handler는 실제 구현이고 listener·metric recorder만 MockK로 대체합니다. 실제 TLS 통신은 기존 integration fixture가 별도로 검증합니다.
- package-private factory에 의존하는 테스트이므로 gRPC 버전 변경 시 계약을 재검증해야 합니다.
- 작은 결정적 입력에 대한 검증이며 운영 부하 한계나 모든 메모리 누수를 증명하지 않습니다.
- lesson: `docs/lessons/2026-09-05-issue-1635-grpc-settings-ack-security.md`.

## 메타데이터

- 이슈 #1635, milestone `2.1.0`, assignee `debop`
- `fix/issue-1635-grpc-security-regression` → `develop`
- PR #1653, HEAD `55d909e3ecab861a385b46293333c5e8013b569a`
- 최종 CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33970548754
- 코드 수정 CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33970108329
- 이전 실패 CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/33968789602

## DoD Status

Required checks: 12/16; N/A: 1; Blocked: 0

| 점검 | 상태 | 근거 / 다음 조치 |
|---|---|---|
| C-01 원인·이슈 | PASS | upstream 수정·현재 fixture·#1635 대조 |
| C-02 범위·이슈 확인 | PASS | #1635의 milestone·label·assignee 일치, 승인된 테스트 범위 |
| C-03 RED | PASS | TLS 실패 및 실제 stream 제한 mutation 실패 |
| C-04 최소 수정 | PASS | 생산 코드·공개 API·의존성 변경 없이 Conscrypt 전역 설치 제거 |
| C-05 GREEN·영향 검증 | PASS | 대상 7개 × 3회, provider 수정 후 TLS 4개·모듈 75개 통과 |
| C-06 lesson | PASS | 원인·관찰 오류·재발 방지 기록, 용어 검사·GNO 색인 |
| C-07 PR·CI·리뷰 | PASS | 최종 HEAD CI 전체 성공, 독립 리뷰 P0/P1/P2/P3=0, thread 0 |
| C-08 병합 준비 보고 | PASS | HEAD `55d909e3ecab861a385b46293333c5e8013b569a`, MERGEABLE/CLEAN |
| C-09 병합 후 종료 | PENDING | 별도 승인·병합·싱크 이후 |
| CG-12A 기준 재확인 | PASS | user/workspace/repo 지침 및 issue 메타데이터 재확인 |
| CG-10 독립 검토·커밋 | PASS | 후속 독립 리뷰 P0/P1/P2/P3=0, 코드 `41d9abf43`, lesson `55d909e3e` |
| CG-13 PR | PASS | #1653 live head `55d909e3ecab861a385b46293333c5e8013b569a`·base·메타데이터 일치 |
| CG-14 정확한 HEAD의 CI·리뷰 | PASS | run 33970548754 전체 성공; gRPC 75/75, Attempt 1; reviews/thread 재확인 |
| CG-16 별도 병합 승인 | PENDING | CI·리뷰 확인 후 사용자 승인 필요 |
| CG-17 병합 | PENDING | CG-16 이후 |
| CG-18 싱크·정리 | PENDING | 병합 후 로컬 싱크·작업 공간 정리 |
| 추가 사람 리뷰 | N/A | debop 단독 작업; 독립 기술 검토·CI·thread 확인은 유지 |

Final status: PENDING — PR #1653 HEAD `55d909e3ecab861a385b46293333c5e8013b569a` 병합 준비 완료, CG-16 별도 승인 대기.

Unchecked required items: C-09, CG-16, CG-17, CG-18.
