### PR TITLE
[test][feign] 13.14 HTTP 경계 계약 검증을 보강한다

### DIFF
--- a/docs/lessons/2026-09-06-issue-1638-feign-http-contracts.md
+++ b/docs/lessons/2026-09-06-issue-1638-feign-http-contracts.md
@@ -1,0 +1,60 @@
+# Feign HTTP 회귀 테스트는 수정된 client 경계를 먼저 구분한다
+
+## 기준과 결정
+
+- 대상: [#1638](https://github.com/bluetape4k/bluetape4k-projects/issues/1638), Feign 13.14.
+- 기준 HEAD: `6a198fa8461637d02da34fee2d2c4df28a6b7b6e`.
+- 기본 catalog ref: `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`.
+- `dependencyInsight --dependency feign-core --configuration testRuntimeClasspath`에서 실제 13.14 해석을 확인했다.
+- 새 dependency나 production 변경 없이 기존 응답 확장 함수와 HC5/Vert.x 공통 테스트를 보강했다.
+
+## upstream 수정과 적용 범위
+
+공식 [13.14 release](https://github.com/OpenFeign/feign/releases/tag/13.14)와 아래 PR diff를
+2026-09-06에 GitHub API로 읽었다. 전체 원문은 복제하지 않고 판단에 필요한 내용을 요약했다.
+
+| 공식 수정 | 적용 경계 | 이번 검증 |
+|---|---|---|
+| [#3427](https://github.com/OpenFeign/feign/pull/3427) charset fallback | core `Response.charset()` | absent/unsupported/illegal charset, UTF-8·한글·emoji 보존, 유효한 ISO-8859-1 유지 |
+| [#3444](https://github.com/OpenFeign/feign/pull/3444) CR/LF 제거 | core `HeaderTemplate`의 literal·resolved value | CR, LF, CRLF 각각의 template 결과와 실제 수신 헤더, 주입 헤더 부재 |
+| [#3463](https://github.com/OpenFeign/feign/pull/3463), [#3507](https://github.com/OpenFeign/feign/pull/3507) 빈 요청 | `DefaultClient`의 HttpURLConnection | 이 구현의 기대값을 복제하지 않고 HC5/Vert.x의 GET/POST/PUT/PATCH와 null/empty body를 직접 검증 |
+| [#3492](https://github.com/OpenFeign/feign/pull/3492) 음수 길이 | `DefaultClient`·Google client | HC5/Vert.x는 음수 응답 길이를 전송 오류로 거부한다. timeout을 성공으로 허용하지 않는다 |
+| [#3431](https://github.com/OpenFeign/feign/pull/3431) 길이 축소 변환 | `Http2Client` | HC5 자체 streaming body의 기존 범위 검사로 Int 초과 길이가 null인지 확인 |
+| [#3448](https://github.com/OpenFeign/feign/pull/3448), [#3451](https://github.com/OpenFeign/feign/pull/3451) 중복 길이 헤더 | `DefaultClient` | HC5/Vert.x에서 대소문자별 Content-Length가 자동 생성 헤더와 중복되지 않고 UTF-8 바이트 길이와 일치하는지 확인 |
+| [#3417](https://github.com/OpenFeign/feign/pull/3417), [#3432](https://github.com/OpenFeign/feign/pull/3432) multipart 헤더 | multipart encoder | 사용하지 않는 API로 이번 범위에서 제외 |
+
+Vert.x는 전체 body를 받은 뒤 Feign 응답을 만든다. HC5의 streaming 길이 메타데이터 테스트를
+그대로 옮기면 거대한 body 또는 의도적인 조기 연결 종료를 테스트하게 된다. 따라서
+`Long.MAX_VALUE`를 선언한 fixture는 HC5에만 적용하고 실제 대용량 body는 만들지 않았다.
+이 fixture의 close 중 불완전 body 오류는 `closeSafe()`로 정리하며, 전송 완료를 증명한다고 주장하지 않는다.
+
+## 실패한 가정과 다음 검증 기준
+
+1. **테스트 설계:** GET은 길이 헤더가 없을 것이라고 가정했으나 HC5 테스트가
+   `Expected ["0"] to equal to []`로 실패했다. 공식 `ApacheHttp5Client.toClassicHttpRequest()`는
+   body가 null이어도 빈 entity를 만든다. 현재 HC5와 Vert.x는 네 method 모두 길이 0을 전송한다.
+   다음에는 release 제목이 아니라 해당 adapter의 entity 생성과 전송 코드를 먼저 확인한다.
+2. **오류 모델:** Vert.x가 음수 길이를 `DecoderException`으로 감쌀 것이라고 가정했지만
+   실제 원인은 `IllegalArgumentException: Content-Length value is not a number: -5`였다.
+   HTTP decoder의 실패 전달 경로와 실제 cause를 읽은 뒤 assertion을 정한다.
+   `TimeoutException`과 `SocketTimeoutException`은 거부 결과로 인정하지 않는다.
+3. **조사 운영:** 독립 조사 담당이 응답하지 않아 중단하고 주 세션이 공식 release·PR diff를 확인했다.
+   helper의 command deadline 판정과 plain-session 90초 무응답 제한이 달랐다.
+   다음에는 native lane의 deadline을 실제 대기 제한과 맞추고, 중단 의도와 결과를 순서대로 기록한다.
+   이번 조사를 독립 검증으로 표시하지 않는다.
+
+## 검증
+
+독립 설계 리뷰는 P0/P1 없이 WATCH(P2)를 남겼다. 공통 suite에 두 adapter의 정확한 wire 정책과
+core 통합 검증이 함께 있어 향후 다른 adapter를 추가할 때 결합 비용이 생긴다는 지적이다.
+현재 HC5/Vert.x로 한정한 KDoc과 후속 adapter의 기대값 검토 지침을 추가했다.
+현재 지원 범위를 넘어선 테스트 재배치는 이번 이슈에 포함하지 않는다.
+독립 코드 리뷰는 제한 시간 내 결과를 반환하지 않아 중단했으며, 주 세션의 inline fallback review로 대체한다.
+
+- 기존 대상 테스트: 19개 통과.
+- 보강 후 대상 테스트: 56개 통과. 신규 37개이며 null/empty body와 literal/resolved template은 각 invocation 안에서 둘 다 검증한다.
+- `./gradlew :bluetape4k-feign:cleanTest :bluetape4k-feign:test :bluetape4k-feign:detekt --no-build-cache`:
+  280개, 실패·오류·skip 0. 기존 gzip/deflate·coroutine 경로 포함.
+- detekt는 기존 production 지적을 출력한다. 이번 변경의 production diff는 없으며, 이를 경고 0으로 해석하지 않는다.
+- production 수정이 없으므로 제품 수정의 RED/GREEN을 주장하지 않는다. 위 실패는 테스트 가정 교정 근거다.
+- README·public API·module 등록·catalog 변경 없음.

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/FeignResponseSupportTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/FeignResponseSupportTest.kt
@@ -8,6 +8,9 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
 
 /**
  * [FeignResponseSupport]의 Content-Type 판별 및 본문 접근 확장 함수를 검증합니다.
@@ -124,6 +127,42 @@ class FeignResponseSupportTest: AbstractFeignTest() {
         val reader = response.bodyAsReader()
         val content = reader.readText()
         content shouldBeEqualTo expected
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = [
+        "text/plain",
+        "text/plain; charset=UTF-8",
+        "text/plain; charset=\"UTF-8\"",
+        "text/plain; charset=not-a-charset",
+        "text/plain; charset=invalid charset",
+    ])
+    fun `charset이 없거나 유효하지 않으면 UTF-8 본문을 보존한다`(contentType: String?) {
+        val expected = "한글 응답 café 😀"
+        feignResponse {
+            status(200)
+            request(dummyRequest)
+            headers(contentType?.let { mapOf("Content-Type" to listOf(it)) }.orEmpty())
+            body(expected.toByteArray(Charsets.UTF_8))
+        }.use { response ->
+            response.charset() shouldBeEqualTo Charsets.UTF_8
+            response.bodyAsReader().use { it.readText() } shouldBeEqualTo expected
+        }
+    }
+
+    @Test
+    fun `유효한 응답 charset은 UTF-8로 덮어쓰지 않는다`() {
+        val expected = "café déjà vu"
+        feignResponse {
+            status(200)
+            request(dummyRequest)
+            headers(mapOf("Content-Type" to listOf("text/plain; charset=ISO-8859-1")))
+            body(expected.toByteArray(Charsets.ISO_8859_1))
+        }.use { response ->
+            response.charset() shouldBeEqualTo Charsets.ISO_8859_1
+            response.bodyAsReader().use { it.readText() } shouldBeEqualTo expected
+        }
     }
 
     @Test

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/FeignClientConformanceTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/FeignClientConformanceTest.kt
@@ -3,11 +3,16 @@ package io.bluetape4k.feign.clients
 import feign.AsyncClient
 import feign.Client
 import feign.Request
+import feign.RequestTemplate
 import feign.Response
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.feign.AbstractFeignTest
+import io.bluetape4k.feign.bodyAsReader
 import io.bluetape4k.feign.feignRequestOf
 import io.bluetape4k.support.closeSafe
 import io.bluetape4k.support.toUtf8String
@@ -17,13 +22,21 @@ import okhttp3.mockwebserver.SocketPolicy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.io.IOException
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
 /**
- * Shared conformance tests for synchronous Feign HTTP transport adapters.
+ * 현재 지원하는 HC5와 Vert.x 동기 adapter의 전송 통합 계약을 검증합니다.
+ *
+ * core의 charset 및 header-template 처리가 실제 전송 경로에서도 유지되는지 확인합니다.
+ * 빈 요청의 길이 0은 두 adapter의 현재 정책이며 모든 Feign Client의 불변 조건은 아닙니다.
+ * 다른 adapter를 추가할 때는 정확한 wire header 기대값을 먼저 검토해야 합니다.
  */
 abstract class FeignSyncClientConformanceTest: AbstractFeignTest() {
 
@@ -70,6 +83,109 @@ abstract class FeignSyncClientConformanceTest: AbstractFeignTest() {
 
     private fun request(): Request =
         feignRequestOf(server.url("/").toString())
+
+    @ParameterizedTest
+    @EnumSource(value = Request.HttpMethod::class, names = ["GET", "POST", "PUT", "PATCH"])
+    fun `빈 요청은 HTTP method와 본문 없는 계약을 보존한다`(method: Request.HttpMethod) {
+        for (body in listOf(null, byteArrayOf())) {
+            server.enqueue(MockResponse())
+            client.execute(
+                feignRequestOf(server.url("/").toString(), method, body = body),
+                defaultOptions()
+            ).use { it.status() shouldBeEqualTo 200 }
+
+            val recorded = server.takeRequest(2, TimeUnit.SECONDS).shouldNotBeNull()
+            recorded.method shouldBeEqualTo method.name
+            recorded.bodySize shouldBeEqualTo 0L
+            // HC5는 빈 entity를 만들고, Vert.x는 빈 본문의 길이를 명시합니다.
+            recorded.headers.values("Content-Length") shouldBeEqualTo listOf("0")
+            recorded.getHeader("Content-Type").shouldBeNull()
+            recorded.getHeader("Transfer-Encoding").shouldBeNull()
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["Content-Length", "content-length", "CoNtEnT-LeNgTh"])
+    fun `UTF-8 요청의 바이트 길이를 중복 헤더 없이 전송한다`(headerName: String) {
+        val expected = "한글 café 😀"
+        val bytes = expected.toByteArray(Charsets.UTF_8)
+        server.enqueue(MockResponse())
+        client.execute(
+            feignRequestOf(
+                server.url("/").toString(),
+                Request.HttpMethod.POST,
+                headers = mapOf(headerName to listOf(bytes.size.toString())),
+                body = bytes
+            ),
+            defaultOptions()
+        ).use { it.status() shouldBeEqualTo 200 }
+
+        val recorded = server.takeRequest(2, TimeUnit.SECONDS).shouldNotBeNull()
+        recorded.headers.values("Content-Length") shouldBeEqualTo listOf(bytes.size.toString())
+        recorded.bodySize shouldBeEqualTo bytes.size.toLong()
+        recorded.body.readUtf8() shouldBeEqualTo expected
+        recorded.getHeader("Transfer-Encoding").shouldBeNull()
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["\r", "\n", "\r\n"])
+    fun `header template은 개행을 제거하고 별도 헤더를 주입하지 않는다`(newline: String) {
+        val value = "safe" + newline + "X-Injected: evil"
+        for (template in listOf(
+            RequestTemplate().method(Request.HttpMethod.GET).header("X-Custom", value),
+            RequestTemplate().method(Request.HttpMethod.GET).header("X-Custom", "{value}")
+        )) {
+            val resolved = template.resolve(mapOf("value" to value))
+            resolved.headers()["X-Custom"]?.toList() shouldBeEqualTo listOf("safeX-Injected: evil")
+            server.enqueue(MockResponse())
+            client.execute(
+                feignRequestOf(server.url("/").toString(), headers = resolved.headers()),
+                defaultOptions()
+            ).use { it.status() shouldBeEqualTo 200 }
+            val recorded = server.takeRequest(2, TimeUnit.SECONDS).shouldNotBeNull()
+            recorded.getHeader("X-Custom") shouldBeEqualTo "safeX-Injected: evil"
+            recorded.getHeader("X-Injected").shouldBeNull()
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["text/plain", "text/plain; charset=not-a-charset", "text/plain; charset=invalid charset"])
+    fun `전송된 비ASCII 응답을 charset fallback으로 복원한다`(contentType: String) {
+        val expected = "한글 응답 café 😀"
+        server.enqueue(MockResponse().setHeader("Content-Type", contentType).setBody(expected))
+        client.execute(request(), defaultOptions()).use { response ->
+            response.bodyAsReader().use { it.readText() } shouldBeEqualTo expected
+        }
+    }
+
+    @Test
+    fun `음수 응답 길이는 정상 body로 반환하지 않고 전송 오류로 거부한다`() {
+        server.enqueue(
+            MockResponse().setBody("invalid")
+                .setHeader("Content-Length", "-5")
+                .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
+        )
+
+        val error = assertFailsWith<Exception> {
+            client.execute(request(), defaultOptions()).use { response ->
+                response.body().asInputStream().readBytes()
+            }
+        }
+        // 동기 HC5의 IOException과 Vert.x future의 원인 예외를 구분하며 timeout은 허용하지 않습니다.
+        val transportError = if (error is ExecutionException) error.cause else error
+        (transportError is IOException || transportError is IllegalArgumentException)
+            .shouldBeTrue()
+        generateSequence(error as Throwable) { it.cause }
+            .none { it is java.net.SocketTimeoutException || it is java.util.concurrent.TimeoutException }
+            .shouldBeTrue()
+        val messages = generateSequence(error as Throwable) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString(" ")
+            .lowercase()
+        messages shouldContain "content"
+        messages shouldContain "length"
+        messages shouldContain "-5"
+    }
 }
 
 /**

--- a/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/hc5/ApacheHc5ClientConformanceTest.kt
+++ b/io/feign/src/test/kotlin/io/bluetape4k/feign/clients/hc5/ApacheHc5ClientConformanceTest.kt
@@ -2,18 +2,66 @@ package io.bluetape4k.feign.clients.hc5
 
 import feign.AsyncClient
 import feign.Client
+import feign.Request
 import feign.hc5.ApacheHttp5Client
 import feign.hc5.AsyncApacheHttp5Client
 import io.bluetape4k.feign.clients.FeignAsyncClientConformanceTest
 import io.bluetape4k.feign.clients.FeignSyncClientConformanceTest
 import io.bluetape4k.http.hc5.async.httpAsyncClientOf
+import io.bluetape4k.http.hc5.classic.httpClientOf
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.feign.feignRequestOf
+import io.bluetape4k.support.closeSafe
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.api.AfterEach
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import java.util.concurrent.TimeUnit
 import org.apache.hc.client5.http.protocol.HttpClientContext
 import java.util.*
 
 class ApacheHc5ClientConformanceTest: FeignSyncClientConformanceTest() {
 
+    private lateinit var transport: CloseableHttpClient
+
     override fun newClient(): Client =
-        ApacheHttp5Client()
+        ApacheHttp5Client(httpClientOf().also { transport = it })
+
+    @AfterEach
+    fun closeTransport() {
+        transport.close()
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = [2147483648L, Long.MAX_VALUE])
+    fun `Int 범위를 넘는 streaming 응답 길이는 null이며 음수로 좁히지 않는다`(length: Long) {
+        MockWebServer().use { server ->
+            server.start()
+            // 대용량 본문을 만들지 않고 응답 헤더의 long-to-int 변환만 검증합니다.
+            server.enqueue(
+                MockResponse().setBody("")
+                    .setHeader("Content-Length", length)
+                    .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
+            )
+            httpClientOf().use { transport ->
+                val response = ApacheHttp5Client(transport).execute(
+                    feignRequestOf(server.url("/").toString()),
+                    Request.Options(1, TimeUnit.SECONDS, 2, TimeUnit.SECONDS, true)
+                )
+                try {
+                    response.status() shouldBeEqualTo 200
+                    response.body().length().shouldBeNull()
+                } finally {
+                    // 의도적으로 잘린 body의 close 오류는 길이 메타데이터 검증 대상이 아닙니다.
+                    response.closeSafe()
+                }
+            }
+        }
+    }
 }
 
 class ApacheHc5AsyncClientConformanceTest: FeignAsyncClientConformanceTest<HttpClientContext>() {


### PR DESCRIPTION
## 요약

Closes #1638

Feign 13.14의 HTTP 경계 수정을 실제 사용하는 HC5/Vert.x 경로에서 검증합니다.
production 및 dependency 변경 없이 회귀 계약 테스트 37개를 추가했습니다.

## 배경과 변경

- 실제 `testRuntimeClasspath`의 `feign-core:13.14`를 확인했습니다.
- absent/invalid charset의 UTF-8 fallback, 비ASCII body 보존, 유효한 ISO-8859-1을 검증합니다.
- GET/POST/PUT/PATCH 각각 null/empty body와 실제 method·길이·Content-Type·Transfer-Encoding을 확인합니다.
- Content-Length 대소문자별 자동 헤더 중복 부재와 UTF-8 바이트 길이 일치를 확인합니다.
- 음수 응답 길이는 전송 오류로 거부하고 timeout이나 다른 연결 오류를 성공으로 인정하지 않습니다.
- HC5 streaming body의 Int 초과 길이는 null임을 검증합니다.
- header template literal/substitution의 CR·LF·CRLF 제거와 실제 추가 헤더 주입 부재를 확인합니다.

## 범위와 한계

DefaultClient·Google·Http2Client의 upstream 수정과 현재 HC5/Vert.x 동작을 구분했습니다.
모든 테스트가 13.13에서 실패한다거나 거대한 body 전송을 완료했다고 주장하지 않습니다.
multipart API는 제외했습니다. README/public API/module/catalog 변경은 없습니다.

## 검증

- `./gradlew :bluetape4k-feign:dependencyInsight --dependency feign-core --configuration testRuntimeClasspath`: 13.14.
- 대상 테스트: 기존 19개 → 56개, 모두 통과.
- `./gradlew :bluetape4k-feign:cleanTest :bluetape4k-feign:test :bluetape4k-feign:detekt --no-build-cache`: **280개, 실패·오류·skip 0**, exit 0. gzip/deflate·coroutine 포함.
- detekt는 `ignoreFailures=true`이며 기존 production 지적이 남습니다. 추가 test 지적은 없습니다.
- `git diff --check`, 한국어 용어 audit 통과.

## 검토

- P0=0, P1=0.
- 독립 architecture review: WATCH(P2=1). 공통 suite의 정확한 wire 기대값은 현재 HC5/Vert.x 정책입니다.
  이를 KDoc에 명시했고 미래 adapter 추가 시 기대값 검토를 요구합니다. 지금 테스트 분리 리팩터링은 하지 않습니다.
- 독립 code-reviewer는 제한 시간 내 결과를 반환하지 않아 중단했습니다.
  workflow의 승인된 예외에 따라 주 세션 **inline fallback review**를 수행했습니다. 독립 코드 검증으로 표시하지 않습니다.
- inline 검토: charset byte-array/reader, template와 wire 주입 assertion, 길이 오류 cause/timeout 배제, bounded I/O와 close 경로, ABI 무변경, 전체 테스트 근거를 대조했습니다.
- [lesson](docs/lessons/2026-09-06-issue-1638-feign-http-contracts.md)에 upstream 링크·틀린 가정·검증 한계를 기록했습니다.
- GNO index/get 보존 확인. 새 collection의 keyword search 미검색은 남은 검색 도구 한계입니다.

## 메타데이터

- Issue #1638 / milestone `2.1.0` / assignee `debop` / labels `test`, `dependencies`.
- Head: `45e75adf6882c40def4b3ecf3658a853104ea567`, base: `develop`.
- CI: [run 34011779502](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34011779502) exact HEAD 성공. 12 SUCCESS / 12 SKIPPED(비대상 모듈), 실패 0. Build·IO HTTP·Coverage Report 포함. fresh 승인 후 rebase merge 완료(`31ee966cf339f7b895284329c8fbd53638ab837c`). 삭제 명령은 실행하지 않았습니다.

## DoD Status

Required checks: 99/99; N/A: 5; Blocked: 0

<details>
<summary>단계별 검증 내역</summary>

| Check | Action | Status | Evidence | Failure / Next Action |
|---|---|---|---|---|
| WF-00 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| WF-01 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| WF-02 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| WF-03 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| WF-04 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| WF-04A | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| WF-05 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| WF-06 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-01 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-02 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-03 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-04 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-05 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-06 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-07 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-08 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-09 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-10 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-11 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-12 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CG-12A | 해당 계약 검증 | PASS | AGENTS 계층·leaf·common·template·issue 최신 읽기, 변화 없음 | 새 실패 시 재검증 |
| CG-13 | PR·CI·검토 결과 확인 | PASS | PR #1655 metadata/head read-back, CI run 34011779502 성공, 리뷰·미해결 스레드 0, MERGEABLE | HEAD 변경 시 재검증 |
| CG-14 | PR·CI·검토 결과 확인 | PASS | PR #1655 metadata/head read-back, CI run 34011779502 성공, 리뷰·미해결 스레드 0, MERGEABLE | HEAD 변경 시 재검증 |
| CG-15 | PR·CI·검토 결과 확인 | PASS | PR #1655 metadata/head read-back, CI run 34011779502 성공, 리뷰·미해결 스레드 0, MERGEABLE | HEAD 변경 시 재검증 |
| CG-16 | 승인·병합·로컬 동기화 | PASS | 사용자 승인 후 exact HEAD 45e75adf6882 재확인; CI·리뷰·hold 통과 | 없음 |
| CG-17 | 승인·병합·로컬 동기화 | PASS | rebase merge 완료; merge SHA 31ee966cf339f7b895284329c8fbd53638ab837c; issue1638 CLOSED | 없음 |
| CG-18 | 승인·병합·로컬 동기화 | PASS | canonical develop=origin/develop=31ee966cf339; clean; 검증 HEAD와 전체 tree 동일; 삭제 승인 없는 로컬 branch/worktree 보존 | 없음 |
| CG-X01 | 범위 확인 | N/A | Projects 범위에 tag/release/dispatch/삭제 없음 | 새 실패 시 재검증 |
| B-01 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| B-02 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| B-03 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| B-04 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| B-05 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| B-06 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| B-07 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| B-08 | PR·CI·검토 결과 확인 | PASS | PR #1655 metadata/head read-back, CI run 34011779502 성공, 리뷰·미해결 스레드 0, MERGEABLE | HEAD 변경 시 재검증 |
| B-09 | PR·CI·검토 결과 확인 | PASS | PR #1655 metadata/head read-back, CI run 34011779502 성공, 리뷰·미해결 스레드 0, MERGEABLE | HEAD 변경 시 재검증 |
| B-10 | 승인·병합·로컬 동기화 | PASS | CG-16~18 완료. 명시된 병합·동기화 범위 완료; 추가 삭제 없음 | 없음 |
| CL-01 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CL-02 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CL-03 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CL-04 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CL-05 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CL-06 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CL-07 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| CL-08 | 해당 계약 검증 | PASS | 승인된 Type B 범위, 현 diff·로그·아래 검토 근거 | 새 실패 시 재검증 |
| KT-01 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-02 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-03 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-04 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-05 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-TEST-01 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-TEST-02 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-TEST-03 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-TEST-04 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-TEST-05 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-01 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-02 | 범위 확인 | N/A | production validation 변경 없음 | 새 실패 시 재검증 |
| KT-FIN-03 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-04 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-05 | 범위 확인 | N/A | Exposed 코드 변경 없음 | 새 실패 시 재검증 |
| KT-FIN-06 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-07 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-08 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-09 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-10 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| KT-FIN-11 | 해당 계약 검증 | PASS | Kotlin compile, 280 tests, detekt, diff 검사 | 새 실패 시 재검증 |
| SPW-plan-01 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-plan-02 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-plan-03 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-plan-04 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-plan-05 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-plan-01 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-plan-02 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-plan-03 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-plan-04 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-plan-05 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-plan-06 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-plan-07 | 범위 확인 | N/A | 계획은 승인된 대화 본문으로 파일 audit 대상 없음 | 새 실패 시 재검증 |
| SPW-lesson-01 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-lesson-02 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-lesson-03 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-lesson-04 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-lesson-05 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-review-01 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-review-02 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-review-03 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-review-04 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| SPW-review-05 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-lesson-01 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-lesson-02 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-lesson-03 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-lesson-04 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-lesson-05 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-lesson-06 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-lesson-07 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-review-01 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-review-02 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-review-03 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-review-04 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-review-05 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-review-06 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| KO-review-07 | 해당 계약 검증 | PASS | inline 계획·lesson·리뷰의 근거 대조 및 한국어 audit | 새 실패 시 재검증 |
| CG-14-human | 범위 확인 | N/A | debop 단독 유지보수 lane; 별도 사람 리뷰 요청 없음 | 새 실패 시 재검증 |

</details>

Final status: DONE — fresh 승인 후 병합·로컬 동기화 및 보존 확인 완료.

Unchecked required items: 없음.


