### PR TITLE
[feature][http] 응답 byte 상한 초과를 거부하는 공통 API를 제공한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,14 @@
 
 ### 추가
 
+- `InputStream`, Apache HC5 `HttpEntity`, JDK `HttpResponse<InputStream>`에 전체 본문을
+  strict byte 상한 안에서 읽는 additive API를 추가했다. 상한 초과는 부분 결과 없이
+  `ByteLimitExceededException`으로 실패하며 기존 truncation API는 그대로 유지한다.
+  raw stream은 호출자가 닫고 HTTP adapter는 획득한 body stream만 닫으므로 상위
+  response/client 수명은 호출자가 관리한다. `2.1.0` publish 뒤 중앙 catalog 또는 허용된
+  repo-local override로 선택하고 소비자별 smoke와 독립 PR을 진행한다
+  ([#1643](https://github.com/bluetape4k/bluetape4k-projects/issues/1643)).
+
 - NATS JetStream `ConsumerContext` pull consumer와 `JetStream` push
   subscription을 수집마다 생성·정리하는 cold `Flow<Message>` API를 추가했다.
   유한한 Flow 용량과 NATS pending limit을 검증하고, 취소 시 adapter 소유

--- a/docs/lessons/2026-09-06-issue-1643-bounded-http-body.md
+++ b/docs/lessons/2026-09-06-issue-1643-bounded-http-body.md
@@ -1,0 +1,49 @@
+# bounded HTTP body는 크기와 소유권을 함께 설계해야 한다
+
+## 맥락
+
+HTTP 본문을 `ByteArray`나 `String`으로 만드는 편의 함수는 호출자가 허용할 크기를 넘는
+본문을 끝까지 메모리에 적재할 수 있다. 단순히 읽기 길이만 제한하면 partial body가 정상
+결과처럼 보이거나, adapter가 획득한 stream을 누가 닫아야 하는지 불명확해진다.
+
+## 결정과 발견
+
+- strict 상한은 최대 `maxBytes`까지 성공하고, 한 byte라도 초과하면 partial 결과 없이
+  `ByteLimitExceededException`을 던진다.
+- 판정용 1 byte는 stream에서 소비되며 복원하지 않는다. raw primitive는 caller stream을
+  닫지 않고, HC5·JDK adapter는 자신이 획득한 stream을 닫는다.
+- 작은 body에 큰 `maxBytes`가 들어와도 상한 크기 배열을 미리 만들지 않는다. segment를
+  점진 할당하고 `maxBytes + 1` 정수 산술을 사용하지 않는다.
+- bulk read가 0을 반환하면 단일 byte read로 진행을 보장한다.
+- 원래 overflow/read/accessor 실패는 primary로 유지한다. cleanup 중 후속 실패는 동일
+  instance가 아닐 때만 suppressed로 추가한다.
+- blocking helper에서 발생한 `java.util.concurrent.CancellationException`을 coroutine
+  cancellation처럼 특별 승격하면 승인된 primary 계약을 깨뜨린다. suspend API가 필요하면
+  별도 cancellation 계약을 설계한다.
+
+## 결과
+
+`io/io`에 재사용 가능한 bounded read primitive를 두고, `io/http`의 HC5와 JDK adapter가
+같은 strict byte 상한과 cleanup 규칙을 공유한다. 기존 truncation API는 호환성을 위해
+유지하며, caller가 strict 거부와 prefix 수용을 명시적으로 선택한다.
+
+## 검증
+
+- primitive 테스트 9개 통과
+- HC5·JDK adapter 테스트 33개 강제 재실행 통과
+- `io` module check 1,274개 통과
+- 공개 JVM signature를 `javap`로 확인
+- 초기 failure-composition P1은 2개 RED 테스트로 재현한 뒤 GREEN으로 고정
+- 로컬 `http` 전체 check는 테스트 이미지 `bluetape4k/mock-web-server:2.1.0` 404만 남아
+  PR의 정확한 head CI에서 재검증
+
+## 향후 지침
+
+1. bounded read API는 크기 판정, partial 결과 정책, stream 위치, close 소유권을 하나의
+   계약으로 설계한다.
+2. metadata의 알려진 길이는 조기 거부에만 쓰고, 실제 stream에도 같은 상한을 적용한다.
+3. primary/suppressed 우선순위는 일반적인 예외 관례를 기계적으로 적용하지 말고 승인된
+   동기·비동기 경계와 테스트 계약을 기준으로 판단한다.
+4. decoded 또는 decompressed payload는 wire/stream byte 상한과 별도로 제한한다.
+5. 소비자 전환은 library publish, catalog 또는 허용된 repo-local override, smoke test,
+   소비자별 PR 순서로 분리하고 rollback은 strict API 호출을 되돌리는 방식으로 준비한다.

--- a/docs/review/2026-09-06-bounded-http-body-implementation-review.md
+++ b/docs/review/2026-09-06-bounded-http-body-implementation-review.md
@@ -1,0 +1,85 @@
+# Issue #1643 bounded HTTP body 구현 검토
+
+## 검토 범위와 기준
+
+- 저장소: `bluetape4k/bluetape4k-projects`
+- 기준: `origin/develop@31ee966cf339f7b895284329c8fbd53638ab837c`
+- 검토 대상 구현 commit: `d50377db38` (review·lesson artifact commit 제외)
+- 모듈 slice: `io/io` primitive, `io/http` HC5·JDK adapter
+- 설계: `docs/superpowers/specs/2026-09-06-bounded-http-body-design.md`
+- 계획: `docs/superpowers/plans/2026-09-06-bounded-http-body-plan.md`
+- 관점: 성능, 안정성, 보안, Operator/Ops, 개발자/API, 사용자/caller
+
+## 검증 증거
+
+| 증거 | 결과 |
+| --- | --- |
+| `BoundedInputStreamSupportTest` 강제 실행 | 9개 통과 |
+| HC5·JDK adapter 테스트 강제 동시 실행 | 33개 통과, `BUILD SUCCESSFUL in 30s` |
+| `:bluetape4k-io:check` | 1,274개 통과 |
+| `:bluetape4k-http:check` | 491개 중 392개 통과, 3개 건너뜀, 96개 실패 |
+| HTTP check 실패 분류 | 94개 `ContainerFetchException`과 이를 감싼 2개 `MultiException`; 모두 `bluetape4k/mock-web-server:2.1.0` 404 |
+| 공개 JVM API | `ByteLimitExceededException`, `InputStream.readAllBytes(maxBytes)`, HC5·JDK bytes/string 함수와 default bridge를 `javap`로 확인 |
+| source hygiene | `git diff --check` 통과, 금지 선할당·`maxBytes + 1` 산술·무제한 `ByteArrayOutputStream` 없음 |
+| 문서 정합성 | README locale API signature·숫자 일치, 변경 줄 한국어 용어 감사 finding 0 |
+
+로컬 HTTP 전체 check는 외부 테스트 이미지 404 때문에 완료되지 않았다. 변경 대상 HC5·JDK
+테스트는 같은 실행 환경에서 모두 통과했으며, PR의 정확한 head CI를 최종 판정 근거로 사용한다.
+
+## 여섯 관점 통합 결과
+
+| 관점 | P0 | P1 | P2 | P3 | 판정 근거 |
+| --- | ---: | ---: | ---: | ---: | --- |
+| 성능 | 0 | 0 | 0 | 0 | segment 점진 할당, 합산 용량 검사, 1-byte read-ahead로 큰 선할당과 정수 overflow를 피한다. 성능 수치 주장은 하지 않는다. |
+| 안정성 | 0 | 0 | 0 | 0 | zero-read 진행, EOF와 strict overflow, stream ownership, blocking supervisor 종료 경계를 테스트했다. |
+| 보안 | 0 | 0 | 0 | 0 | 명시적 byte 상한과 payload 비노출 예외를 제공하며 decoded/decompressed body에는 별도 상한이 필요함을 문서화했다. |
+| Operator/Ops | 0 | 0 | 0 | 0 | payload 없는 low-cardinality 분류, timeout·abort·heap 예산 책임, publish·rollback 순서를 문서화했다. |
+| 개발자/API | 0 | 0 | 0 | 0 | strict API와 기존 truncation API를 분리하고, raw stream과 adapter의 close 책임 및 stable `maxBytes`를 명시했다. |
+| 사용자/caller | 0 | 0 | 0 | 0 | null HC5 entity 정규화, JDK `BodyHandlers.ofInputStream()`, central catalog 또는 소비자별 override 전환 예제를 제공했다. |
+
+## 검토 중 발견한 P1과 처분
+
+초기 구현은 cleanup에서 발생한 `Error` 또는 `CancellationException`을 기존 overflow/read
+실패보다 우선했다. 이는 승인 설계의 Kotlin `use`식 primary/suppressed 계약과 달랐다.
+
+- RED: HC5 회귀 테스트 18개 중 2개 실패로 계약 위반을 재현했다.
+- 수정: 기존 primary를 유지하고 identity가 다른 후속 실패만 suppressed로 추가했다.
+- GREEN: HC5 18개와 공용 helper를 쓰는 JDK를 포함한 33개를 강제 재실행해 모두 통과했다.
+- 재검토: blocking `InputStream` API는 coroutine cancellation 경계가 아니므로 후속
+  `java.util.concurrent.CancellationException`을 특별 승격하지 않는다. 향후 suspend adapter는
+  별도 cancellation 계약을 설계해야 한다.
+
+## 요구와 구현 대응
+
+| 요구 | 구현·문서 증거 | 검증 |
+| --- | --- | --- |
+| 최대 `maxBytes`까지만 성공 | bounded segment read와 overflow 예외 | 경계·초과·`Int.MAX_VALUE` 테스트 |
+| partial body를 성공으로 반환하지 않음 | 초과 판정용 1 byte read-ahead | strict 실패와 기존 truncation API 비교 |
+| caller stream을 닫지 않음 | primitive는 읽기만 수행 | tracking stream 상태 검증 |
+| adapter-owned stream은 항상 정리 | 공용 `readOwnedBodyBytes`의 `finally` close | accessor/read/close 조합과 identity 검증 |
+| 알려진 oversize는 body를 읽지 않음 | metadata 판정 후 accessor·close cleanup | HC5 content length와 JDK header matrix |
+| 공개 사용법과 운영 경계 | `io/io`, `io/http` README와 CHANGELOG | locale 정합성과 공개 예제 컴파일 테스트 |
+
+## 범위와 잔여 위험
+
+- dependency, module registration, catalog, workflow, CI 구성은 변경하지 않았다.
+- helper는 blocking이며 event-loop에서 호출하면 안 된다. transport timeout과 외부 supervisor
+  abort는 caller 책임이다.
+- 제한은 helper에 전달된 stream byte에 적용된다. 압축 해제 후 본문에는 별도 제한이 필요하다.
+- 로컬 HTTP 전체 check의 이미지 404는 PR CI에서 다시 판정한다. CI가 같은 실패를 보이면
+  이미지 공급 상태와 workflow 환경을 별도로 조사하며 성공으로 간주하지 않는다.
+
+## 최종 판정
+
+- P0: 0
+- P1: 0
+- 미처분 P2/P3: 0
+- 구현 검토 게이트: `PASS`
+
+### DoD
+
+- [x] 두 모듈 slice를 여섯 관점으로 검토
+- [x] 초기 P1을 RED→GREEN 회귀 테스트로 해결
+- [x] 공개 API, 문서, ownership, failure composition 증거 확인
+- [x] 로컬 외부 이미지 실패를 성공과 분리해 기록
+- [ ] PR 정확한 head CI와 post-PR 검토

--- a/docs/review/2026-09-06-bounded-http-body-plan-review.md
+++ b/docs/review/2026-09-06-bounded-http-body-plan-review.md
@@ -1,0 +1,85 @@
+# Issue #1643 구현 계획 독립 검토 기록
+
+## 검토 범위
+
+- 대상 계획: `docs/superpowers/plans/2026-09-06-bounded-http-body-plan.md`
+- 승인 설계: `docs/superpowers/specs/2026-09-06-bounded-http-body-design.md`
+- 기준 ref: `origin/develop@6a198fa8461637d02da34fee2d2c4df28a6b7b6e`
+- 대상 단계: Type A Full Feature Step 3-R
+- 관점: 성능, 안정성, 보안, Operator/Ops, 개발자/API, 사용자/caller
+- 방식: 관점별 독립 읽기 전용 검토, 주 세션 통합, P1 관점 재검토
+- 구현 상태: production source, test, README, CHANGELOG는 아직 변경하지 않았다.
+
+## 첫 wave 결과와 처분
+
+| 우선순위 | 관점 | finding | 처분 |
+|---|---|---|---|
+| P1 | 개발자/API | primitive 예시의 존재하지 않는 `segments.flatten(total)` 때문에 계획을 그대로 실행할 수 없음 | `flattenToByteArray(totalSize)`의 exact-size allocation과 `copyInto` 구현을 추가했다. |
+| P1 | Operator/Ops | 알려진 JDK Testcontainers image 404를 기준 SHA에서 기록하지 않아 module check 실패의 baseline/회귀 판정 분기가 없음 | Task 0에 두 번으로 제한한 baseline 재현·log/XML 보존을, Task 8에 base/head 비교와 CI exact-head PENDING 분기를 추가했다. |
+| P1 | 개발자/API·Operator/Ops | blocking read-ahead test가 latch/assertion/timeout 실패에서도 stream과 executor를 종료한다는 `finally` 순서를 보장하지 않음 | supervisor close, bounded future 회수/cancel, `shutdownNow`, bounded termination 순서를 추가했다. |
+| P2 | 사용자/caller | README/KDoc의 “컴파일 가능한 예제”를 실제 compilation으로 확인하는 fixture가 없음 | IO/HC5/JDK RED test에 `README 공개 예제` compile fixture를 각각 추가하고 Task 7에서 locale·KDoc와 대조한다. |
+| P2 | 사용자/caller | #939/#451 댓글 등록·read-back 명령과 기대 상태가 없음 | `gh issue comment`, `gh issue view --json state,comments,url`, exact head/publish 전 상태의 기대 결과를 Task 10에 추가했다. |
+| P2 | 개발자/API | `maxBytes < Int.MAX_VALUE` 경계 표현이 0과 겹칠 수 있음 | Task 1은 양수 사례를 상한 4로 고정하고 0과 음수를 별도 test로 유지한다. |
+| P2 | Operator/Ops | 실제 transport timeout·supervisor close 및 heap startup validation의 소비자 후속 책임이 댓글 증거에 직접 연결되지 않음 | #939/#451 댓글 필수 내용과 read-back 기대 결과에 두 소비자 smoke 검증 의무를 추가했다. |
+
+## 주 세션 추가 교정
+
+첫 wave의 flatten 수정안을 그대로 적용하면 bulk read가 반복해서 0을 반환할 때 1-byte
+segment가 본문 크기만큼 생성될 수 있었다. 이는 byte capacity의 점근 상한은 지키지만
+설계의 `2 * actualBytes + O(segmentSize)` peak 의도와 맞지 않는다. current segment를
+끝까지 채우고 0 반환의 single byte도 같은 segment에 기록하도록 계획 예시를 다시
+교정했다. 저장 segment와 current segment capacity 합은 `maxBytes` 이하이고 segment object
+수는 `ceil(maxBytes / DEFAULT_BUFFER_SIZE)` 이하다.
+
+## 두 번째 wave 결과
+
+| 우선순위 | 관점 | finding | 처분 |
+|---|---|---|---|
+| P2 | 성능 | 구조적 memory bound와 달리 throughput/latency/GC 개선을 입증할 benchmark가 없음 | 성능 개선은 비주장으로 명시했다. 검증 대상은 선할당 금지와 구조적 memory bound뿐이며 향후 성능 주장은 별도 benchmark 이슈를 요구한다. |
+| P2 | 성능 | 동시성 heap budget이 library와 소비자 책임으로 충분히 분리되지 않음 | library에 mutable shared state가 없어 synchronization test는 N/A로 두고 workload별 동시 read·startup validation을 #939/#451 smoke 필수 항목으로 고정했다. |
+| P2 | 성능 | blocking test가 `StructuredTaskScopeTester` 대신 ad hoc executor를 쓰는 이유가 없음 | task-scope semantics가 아니라 caller-owned stream close와 executor teardown 순서를 검사하므로 bounded latch/future harness가 필요한 이유를 기록했다. |
+| P3 | 성능 | partial copy와 `ArrayList` reference overhead가 peak 설명에서 생략됨 | transient current/partial segment와 reference storage까지 peak 식에 포함했다. |
+| P2 | 보안 | known oversize의 accessor/close 자체가 block하는 경로를 검증하지 않음 | HC5/JDK 모두 latch/abort fake와 bounded cleanup으로 accessor-block·close-block을 검증하도록 추가했다. |
+| P3 | 보안 | `Long.MAX_VALUE`, whitespace, plus, comma-joined `Content-Length` 경계가 없음 | JDK parameterized header matrix에 네 사례와 known/unknown 기대 결과를 추가했다. |
+| P1 | 안정성 | worker의 원본 실패가 `ExecutionException`으로 감싸진 뒤 teardown이 중단되어 executor를 누수할 수 있고, close-block fake에서 close가 abort보다 먼저 실행될 수 있음 | non-blocking supervisor abort를 첫 단계로 옮기고, cleanup 단계를 독립 처리하며, `ExecutionException.cause` identity 검증 뒤에도 `shutdownNow`와 bounded termination이 항상 실행되도록 고정했다. |
+| P1 | 안정성 | shared cleanup helper의 accessor·known oversize·read·close 전이와 primary/suppressed 우선순위가 bullet만으로 열려 있음 | `primary`와 `ownedStream`을 사용하는 구현 가능한 `try/catch/finally` 의사코드와 각 전이의 예외·close 계약을 계획에 추가했다. |
+
+성능·보안 관점은 최신 계획에서 P0=0, P1=0이었다. 첫 안정성 lane은 liveness
+기한을 넘겨 취소했고, 같은 범위를 축소한 replacement lane에서 위 P1 두 건을 찾았다.
+개발자/API와 Operator/Ops의 첫 P1 수정안 재검토는 각각 P0=0, P1=0으로 통과했지만,
+안정성 수정이 두 영역의 계획을 다시 바꾸었으므로 최신 문서에 대해 영향 관점 재검토를
+한 번 더 수행한다.
+
+## 최종 Step 3-R 판정
+
+| 관점 | 최초 P0 | 최초 P1 | 최종 P0 | 최종 P1 | 판정 |
+|---|---:|---:|---:|---:|---|
+| 성능 | 0 | 0 | 0 | 0 | PASS |
+| 안정성 | 0 | 2 | 0 | 0 | PASS |
+| 보안 | 0 | 0 | 0 | 0 | PASS |
+| Operator/Ops | 0 | 2 | 0 | 0 | PASS |
+| 개발자/API | 0 | 1 | 0 | 0 | PASS |
+| 사용자/caller | 0 | 0 | 0 | 0 | PASS |
+
+안정성, Operator/Ops, 개발자/API 관점은 최종 수정본을 다시 읽어 P0=0, P1=0을
+확인했다. 성능·보안·사용자/caller의 P2/P3 finding은 계획에 반영하거나 명시적인 N/A
+검증 경계로 처분했으며 처리되지 않은 finding은 없다. 원래 안정성 lane의 liveness 취소는
+replacement lane과 최종 재검토로 보완했다.
+
+최종 판정: `PASS` — 구현 계획은 승인된 설계, TDD 순서, API/ABI, 자원 수명주기,
+failure precedence, 운영 실패 분기, 문서·소비자 후속 증거를 실행 가능한 수준으로 고정했다.
+구현·module test·CI·publish는 이 검토의 성공으로 완료된 것이 아니며 계획 승인 후의 별도
+게이트로 남는다.
+
+### DoD
+
+- [x] 승인 설계의 모든 수용 기준이 Task 0~10 추적표에 연결됐다.
+- [x] TDD RED→GREEN과 dependent task 순서가 명시됐다.
+- [x] exact file, command, expected result, failure branch가 명시됐다.
+- [x] KDoc, 영문·국문 module README, CHANGELOG가 범위에 포함됐다.
+- [x] allocation, blocking, cleanup, 재사용, 호환성, rollback 경계가 명시됐다.
+- [x] 6개 관점 최종 P0/P1 0건 확인
+- [x] P1 영향 관점 재검토
+- [x] 계획·검토 문서 writer/terminology/diff 검증
+
+현재 판정: `PASS` — Step 3-R은 닫혔다. 구현은 별도 계획 승인을 받기 전까지 시작하지 않는다.

--- a/docs/review/2026-09-06-bounded-http-body-review.md
+++ b/docs/review/2026-09-06-bounded-http-body-review.md
@@ -1,0 +1,60 @@
+# Issue #1643 설계 검토 기록
+
+## 검토 범위와 결과
+
+- 대상: `docs/superpowers/specs/2026-09-06-bounded-http-body-design.md`
+- 기준: `origin/develop@6a198fa8461637d02da34fee2d2c4df28a6b7b6e`
+- 관점: 성능, 안정성, 보안, Operator/Ops, 개발자/API, 사용자/caller
+- 방식: 관점별 독립 읽기 전용 검토 후 주 세션 통합, P1 관점 재검토
+- 최종 결과: P0 0건, P1 0건, 미처분 P2/P3 0건
+- 테스트·빌드: 설계 검토 단계에서는 실행하지 않음
+
+## Finding과 처분
+
+| 초기 우선순위 | 관점 | 근거와 위험 | 통합 처분 | 재검토 |
+|---|---|---|---|---|
+| P1 | 성능·안정성 | 큰 `maxBytes` 선할당과 `Int.MAX_VALUE` 산술은 작은 body에도 OOM·overflow를 만들 수 있음 | segment 점진 할당, capacity 합 상한, `maxBytes + 1` 산술 금지, 작은 body+`Int.MAX_VALUE` 검증 추가 | PASS |
+| P1 | 안정성 | adapter가 음수 상한보다 metadata 조기 거부를 먼저 수행할 수 있음 | 모든 진입점에서 body/metadata 접근 전 음수 검증으로 순서 고정 | PASS |
+| P1 | 성능·안정성 | bulk read가 계속 0이면 busy loop 또는 무한 재시도 가능 | 0 반환 시 단일 `read()`로 즉시 전환해 진행 또는 EOF를 보장 | PASS |
+| P1 | 안정성·운영 | 상한 직후 read와 close가 무기한 block될 수 있으나 완료 경계가 없음 | helper의 blocking/non-cancellable 계약, client timeout, 외부 supervisor close, event-loop 금지 책임 추가 | PASS |
+| P1 | 운영 | known oversize에서 body accessor·close와 transport cleanup의 소유권이 모호함 | accessor 반환 시 소유권 이전, overflow primary, accessor/close suppressed, 상위 cleanup 상태표 추가 | PASS |
+| P1 | 개발자/API | 판정용 1 byte 소비 뒤 primitive stream 위치가 모호함 | 판정 byte는 복원하지 않고 `maxBytes + 1` 위치에 열린 채 남는다고 명시 | PASS |
+| P1 | 사용자/caller | null HC5 entity와 empty body를 구분할 수 없는 새 계약의 migration 위험 | null→empty 정규화를 명시하고 null 보존용 `entity?.let` 예제·선택표 추가 | PASS |
+| P1 | 사용자/caller | raw primitive와 adapter의 close 책임 차이를 보여 주는 예제가 없음 | raw `InputStream.use`, HC5 response `use`, JDK body-close 예제 추가 | PASS |
+| P2 | 보안·운영 | caller가 과도한 상한을 설정하면 동시 allocation으로 heap 고갈 가능 | 기본 상한을 제공하지 않고 caller가 유한 상한을 반드시 전달하게 함. 동시성×peak 메모리 예산과 startup 검증 책임 명시 | 해결 |
+| P2 | 보안 | 제한이 wire byte인지 decoded byte인지와 decompression bomb 경계가 불명확 | 실제 전달 stream byte를 제한한다고 정의하고 후속 압축 해제에는 별도 상한 요구 | 해결 |
+| P2 | 안정성·보안 | malformed·negative·overflow·중복 `Content-Length` 처리 미정 | metadata를 unknown으로 취급하고 실제 body primitive로 판정 | 해결 |
+| P2 | 개발자/API | 예외 message 안정 계약과 constructor 불변조건이 모호함 | `maxBytes`만 안정 계약으로 유지하고 non-negative 불변조건, payload 비노출 명시 | 해결 |
+| P2 | 개발자/API | `maxBytes + 1` 테스트가 `Int.MAX_VALUE`에서 overflow | `1 <= maxBytes < Int.MAX_VALUE` 경계와 `Int.MAX_VALUE` 작은 body 사례 분리 | 해결 |
+| P2 | 개발자/API | tracking stream만으로 배열 allocation을 검증할 수 없음 | read 수·결과 크기는 runtime test, segment capacity는 구현 불변식·코드 검토로 분리 | 해결 |
+| P2 | 사용자/caller | 기존 truncation API와 strict 거부 API 선택 기준 부족 | 선택표와 Workshop #939·Clinic #451 전환 형태 추가 | 해결 |
+| P2 | 운영 | payload 없이 실패를 진단할 관측 지침 부족 | library side effect는 두지 않고 caller의 low-cardinality 집계·alert 지침 추가 | 해결 |
+| P2 | 운영 | publish·소비자 전환·rollback 순서 부재 | library publish→소비자 smoke→독립 PR→수동 strict loop rollback 순서 추가 | 해결 |
+
+## 통합 판단
+
+- 공개 API는 사용자 승인안 그대로 유지했다. 전역 최대 상한을 새로 강제하는 대신 호출자가
+  명시적 유한 상한을 제공하고 구현이 작은 body에 큰 배열을 선할당하지 않도록 했다.
+- known oversize는 content byte를 읽지 않지만 accessor와 close의 비차단성은 보장하지
+  않는다. transport별 timeout·강제 abort는 범용 adapter 밖의 caller 책임이다.
+- low-level library에 log·metric side effect를 추가하지 않는다. payload 비노출과
+  low-cardinality 분류는 application 관측 계약으로 남긴다.
+- 압축 해제 정책은 transport와 caller마다 다르므로 helper가 받은 stream byte만 제한한다.
+  후속 decode/decompression에는 별도 상한이 필요하다.
+- N/A 관점은 없다. 여섯 관점 모두 API·수명주기·호환성 또는 전달 과정에 직접 영향을
+  주므로 독립 검토했다.
+
+## 후속 검증 의무
+
+- 구현 계획에서 모든 수용 기준을 atomic test/implementation task로 매핑한다.
+- TDD에서 경계, read-ahead, zero-read, accessor/read/close failure, timeout supervisor close,
+  nullable entity와 header matrix를 검증한다.
+- 실제 KDoc/README 예제와 ABI/API, 두 모듈 check, CI를 완료하기 전에는 구현 완료로 보지
+  않는다.
+- 실제 HC5/JDK transport별 timeout·abort 동작과 decoded body 상한은 소비자 #939/#451
+  전환에서도 다시 검증한다.
+
+## Gate verdict
+
+`PASS` — 최신 통합 설계에 P0/P1 finding이 없고 모든 P2/P3가 해결되거나 명시적인 후속
+검증 의무로 처분됐다. 구현 계획 작성은 사용자 설계 문서 검토 이후에만 시작한다.

--- a/docs/superpowers/plans/2026-09-06-bounded-http-body-plan.md
+++ b/docs/superpowers/plans/2026-09-06-bounded-http-body-plan.md
@@ -1,0 +1,939 @@
+# HTTP 본문 byte 상한 초과 거부 API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `InputStream`, HC5 `HttpEntity`, JDK `HttpResponse<InputStream>`에 동일한 strict byte 상한을 적용해 상한 이하의 전체 본문만 반환하고 초과 입력은 부분 payload 없이 명시적으로 거부한다.
+
+**Architecture:** `bluetape4k-io`에 segment 기반 bounded read primitive와 전용 `IOException`을 추가한다. `bluetape4k-http`에는 adapter가 획득한 body stream의 소유권과 primary/suppressed failure 결합만 담당하는 작은 `internal` helper를 두고 HC5/JDK adapter가 같은 primitive에 위임한다. 길이 metadata는 조기 거부 힌트로만 사용하며 최종 허용 여부는 실제 stream byte 수로 판정한다.
+
+**Tech Stack:** Kotlin 2.4, Java 25, Apache HttpCore 5.4, JDK `java.net.http`, JUnit 5, MockK, `bluetape4k-assertions`, Gradle 9.7, `bluetape4k-io`, `bluetape4k-http`.
+
+---
+
+## 승인된 기준과 변경 경계
+
+- 기준 설계: `docs/superpowers/specs/2026-09-06-bounded-http-body-design.md`
+- 설계 검토: `docs/review/2026-09-06-bounded-http-body-review.md`
+- 기준 ref: `origin/develop@6a198fa8461637d02da34fee2d2c4df28a6b7b6e`
+- 연결 이슈: `bluetape4k-projects#1643`
+- 후속 소비자: `bluetape4k-workshop#939`, `clinic-appointment#451`
+- 포함: additive public API, 자원 수명주기, container 없는 회귀 테스트, KDoc, 양 언어 module README, `CHANGELOG.md`, API/ABI 증거, PR/CI, 소비자 이슈 근거 댓글
+- 제외: status/auth/retry/redirect/decode 정책, client/response 전체 close, transport별 timeout 강제 설정, streaming parser, file spill, 압축 해제 후 상한 구현, 소비자 저장소 코드·PR, publish/merge/tag/branch 삭제
+
+이번 변경은 throughput, latency, GC 또는 기존 unbounded read 대비 성능 향상을 주장하지
+않는다. 검증하는 성능 관련 계약은 작은 body에 큰 상한을 주어도 상한 크기 배열을
+선할당하지 않고, 저장 byte capacity와 최종 copy가 승인 설계의 `O(maxBytes)` 구조적
+memory bound를 지킨다는 점뿐이다. workload별 동시 read 수와 heap startup validation은
+library가 알 수 없는 소비자 설정이므로 #939/#451 smoke에서 검증한다.
+
+## 파일별 책임
+
+### 새 파일
+
+- `io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt`
+  - `ByteLimitExceededException`과 유일한 byte 판정 primitive인 `InputStream.readAllBytes(maxBytes)`를 제공한다.
+- `io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt`
+  - 경계, read-ahead, zero-progress, 메모리 불변식, 예외·소유권 계약을 고정한다.
+- `io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt`
+  - 두 adapter가 공유하는 body 획득·정확히 한 번 close·primary/suppressed failure 규칙을 `internal`로 구현한다.
+- `io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupport.kt`
+  - nullable HC5 entity와 `contentLength` 조기 거부를 공통 primitive에 연결한다.
+- `io/http/src/main/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupport.kt`
+  - JDK `Content-Length` 단일 값 해석과 body stream 수명주기를 공통 primitive에 연결한다.
+- `io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt`
+  - HC5 metadata·null/empty·accessor/read/close 조합과 기존 truncation 동작을 검증한다.
+- `io/http/src/test/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupportTest.kt`
+  - 네트워크와 container 없는 fake response로 JDK header matrix, 수명주기, bounded completion을 검증한다.
+
+### 수정 파일
+
+- `io/io/README.md`, `io/io/README.ko.md`
+  - raw `InputStream` 소유권, strict read와 caller `use` 예제를 같은 의미로 설명한다.
+- `io/http/README.md`, `io/http/README.ko.md`
+  - HC5/JDK 예제, strict/truncation 선택, blocking/timeout/decompression/관측 책임을 설명한다.
+- `CHANGELOG.md`
+  - `Unreleased`의 `추가`에 #1643 공개 API와 호환성 경계를 기록한다.
+
+### 의도적으로 수정하지 않는 파일
+
+- `io/io/src/main/kotlin/io/bluetape4k/io/InputStreamSupport.kt`
+- `io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/HttpEntitySupport.kt`
+- `io/http/src/main/kotlin/io/bluetape4k/http/jdk/JdkHttpClientSupport.kt`
+- Gradle build/catalog, module registration, workflow, benchmark, 기존 truncation 구현
+
+기존 top-level file facade를 그대로 유지하고 새 file facade에 additive API만 추가한다. `BufferFailurePolicy`는 serializer의 `Error`/cancellation/overflow 변환 정책이므로 HTTP body cleanup에 재사용하지 않는다. 두 HTTP adapter에 cleanup 코드를 복제하지 않고 `OwnedBodySupport.kt` 하나로 결합한다.
+
+## 수용 기준 추적표
+
+| 설계 DoD | 구현·검증 task |
+|---|---|
+| 공개 signature·KDoc 일치 | Task 2, 4, 6, 7, 8 |
+| `max-1`/`max`/`max+1`, 0, 음수 | Task 1, 2 |
+| `Int.MAX_VALUE`와 작은 body, 산술·선할당 안전 | Task 1, 2, 8 |
+| HC5 known/unknown/mismatch, null/empty | Task 3, 4 |
+| JDK malformed/negative/overflow/중복 header | Task 5, 6 |
+| 최대 1 byte read-ahead와 이후 stream 위치 | Task 1, 2 |
+| segment capacity 합과 `O(maxBytes)` | Task 1, 2, 8 |
+| 성공/초과/read/close/accessor failure 결합 | Task 3~6 |
+| blocking read와 supervisor close | Task 5, 6 |
+| UTF-8를 문자 수가 아닌 byte 수로 제한 | Task 3~6 |
+| 두 adapter가 같은 primitive 재사용 | Task 4, 6, 8 |
+| 기존 truncation ABI·동작 유지 | Task 3, 8 |
+| KDoc/README 선택·소유권·timeout·압축 책임 | Task 7 |
+| targeted/module/check/API/diff 검증 | Task 8 |
+| 6개 관점 독립 검토와 P0/P1 0건 | 계획 Step 3-R 및 Task 9 |
+| #939/#451에 공통 API 가용성 근거 | Task 10 |
+| publish→smoke→독립 전환→rollback·관측 순서 | Task 7, 10 |
+| PR/이슈/CI 증거 연결 | Task 9, 10 |
+
+## Task 0: 실행 기준과 RED 순서를 잠근다
+
+**Files:**
+
+- Read: `docs/superpowers/specs/2026-09-06-bounded-http-body-design.md`
+- Read: `docs/review/2026-09-06-bounded-http-body-review.md`
+- Read: `io/io/build.gradle.kts`
+- Read: `io/http/build.gradle.kts`
+
+- [ ] receipt가 `running`이고 모든 예정 mutation path를 허용하는지 구현 직전에 확인한다.
+
+  ```bash
+  python3 /Users/debop/.codex/skills/bluetape-workflow/scripts/bluetape-flow.py \
+    --state-root .bluetape mutation-check \
+    --session-id 01a06f89-f346-7093-82aa-2f8b0b34c3f7 \
+    --target io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt \
+    --target io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt \
+    --target io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt \
+    --target io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupport.kt \
+    --target io/http/src/main/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupport.kt \
+    --target io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt \
+    --target io/http/src/test/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupportTest.kt \
+    --target io/io/README.md --target io/io/README.ko.md \
+    --target io/http/README.md --target io/http/README.ko.md \
+    --target CHANGELOG.md
+  ```
+
+  기대 결과: `ok: true`, `run_state: running`, 모든 target이 현재 worktree 아래에 있다.
+
+- [ ] 작업 전 기준 상태를 확인한다.
+
+  ```bash
+  git status --short --branch
+  git rev-parse HEAD
+  git rev-parse origin/develop
+  ```
+
+  기대 결과: 계획·검토 commit 이후 clean worktree이며 구현 branch는 `feat/issue-1643-bounded-http-body`다. `origin/develop` drift가 있으면 변경 범위를 재검토하고 무조건 rebase하지 않는다.
+
+- [ ] 현재 targeted baseline을 순서대로 실행한다.
+
+  ```bash
+  ./gradlew :bluetape4k-io:test \
+    --tests 'io.bluetape4k.io.InputStreamSupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+
+  ./gradlew :bluetape4k-http:test \
+    --tests 'io.bluetape4k.http.hc5.entity.HttpEntitySupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  기대 결과: 기존 58개 `InputStreamSupportTest`, 11개 `HttpEntitySupportTest`가 실패 없이 통과한다. 숫자가 drift하면 최신 XML을 기준으로 실제 실행 수를 기록하되 실패를 무시하지 않는다.
+
+- [ ] 알려진 JDK HTTP container baseline을 현재 기준 SHA에서 별도 기록한다.
+
+  ```bash
+  mkdir -p /tmp/issue-1643-baseline-jdk-http
+  repo-test-summary -- ./gradlew :bluetape4k-http:test \
+    --tests 'io.bluetape4k.http.jdk.JdkHttpClientSupportTest' \
+    --tests 'io.bluetape4k.http.jdk.JdkHttpClientCoroutinesTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache \
+    --stacktrace > /tmp/issue-1643-baseline-jdk-http/attempt-1.log 2>&1
+  ```
+
+  첫 실행이 `bluetape4k/mock-web-server:2.1.0` pull의 `ContainerFetchException`으로
+  실패하면 output 경로만 `attempt-2.log`로 바꿔 같은 명령을 정확히 한 번만 재시도하고
+  두 실행의 Gradle log와 JUnit XML,
+  기준 SHA를 `/tmp/issue-1643-baseline-jdk-http/`에 보존한다. 두 번 모두 같은 외부 image
+  404이면 `baseline external failure`로 분류한다. 다른 test/class/stack이면 동일 baseline로
+  간주하지 않고 원인을 먼저 진단한다. 성공하면 baseline failure가 해소된 것으로 기록한다.
+
+- [ ] 새 테스트는 Testcontainers, MockWebServer Docker image, 실제 네트워크를 사용하지 않는 단위 테스트로 제한한다. blocking 사례는 latch와 bounded `Future.get`만 사용하고 `Thread.sleep`이나 무한 대기를 사용하지 않는다.
+
+## Task 1: 공통 primitive 계약 테스트를 먼저 추가한다 (RED)
+
+**Files:**
+
+- Create: `io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt`
+
+- [ ] `TrackingInputStream` test double을 파일 내부에 만든다. 다음 상태를 직접 관찰할 수 있어야 한다.
+
+  ```kotlin
+  private class TrackingInputStream(
+      private val source: ByteArray,
+      private val bulkZeroCount: Int = 0,
+      private val readFailure: Throwable? = null,
+      private val closeFailure: Throwable? = null,
+  ) : InputStream() {
+      var consumedBytes: Int = 0
+          private set
+      var bulkReadCalls: Int = 0
+          private set
+      var singleReadCalls: Int = 0
+          private set
+      var closeCalls: Int = 0
+          private set
+      // bulk read 0 반환 횟수와 원본 예외 인스턴스를 결정적으로 제어한다.
+  }
+  ```
+
+- [ ] 상한 `4`에 대해 body 길이 `3`, `4`, `5`, `8`을 parameterized test로 검증한다.
+  - 3/4 byte는 정확한 결과를 반환한다.
+  - 5/8 byte는 `ByteLimitExceededException(maxBytes=4)`이다.
+  - 초과 시 `consumedBytes == 5`이고 추가 byte는 읽지 않는다.
+  - 성공·초과 모두 `closeCalls == 0`이다.
+
+- [ ] `maxBytes == 0`에서 empty stream은 빈 배열, 1 byte stream은 read 1회 후 전용 예외임을 검증한다. `maxBytes == -1`은 read 호출 전 `IllegalArgumentException`이며 stream은 열린 채다.
+
+- [ ] `Int.MAX_VALUE`와 작은 3 byte body가 정상 완료되고 read count가 body 크기와 EOF 확인 범위에 머무는지 검증한다. 테스트는 heap allocation을 직접 관찰했다고 주장하지 않고 큰 배열 선할당 시 테스트 JVM이 실패한다는 smoke guard로 사용한다.
+
+- [ ] `README 공개 예제` 이름의 test에서 `inputStream.use { it.readAllBytes(maxBytes = 64 * 1024) }` 호출을 실제 import와 함께 컴파일·실행해 raw stream 소유권 예제를 고정한다.
+
+- [ ] bulk `read(byteArray, offset, length)`가 연속으로 0을 반환하는 stream을 사용해 각 0 직후 single-byte `read()`로 진행하고 무한 bulk retry가 없음을 검증한다.
+
+- [ ] 원본 `IOException` 인스턴스가 cause/message/stack을 바꾸지 않고 그대로 전달되며 close되지 않는지 `shouldBeSameInstanceAs`로 검증한다.
+
+- [ ] `ByteLimitExceededException`은 `maxBytes` 외 payload/부분 배열/마지막 byte 필드를 노출하지 않고 message에도 payload가 없으며, 음수 생성자 인자는 `IllegalArgumentException`임을 검증한다. 정확한 message 문구는 assertion하지 않는다.
+
+- [ ] 새 테스트만 실행해 API 부재로 인한 RED를 확인한다.
+
+  ```bash
+  ./gradlew :bluetape4k-io:test \
+    --tests 'io.bluetape4k.io.BoundedInputStreamSupportTest' \
+    --rerun-tasks --no-daemon --max-workers=1 \
+    --no-build-cache --no-configuration-cache
+  ```
+
+  기대 결과: `ByteLimitExceededException`과 `readAllBytes(maxBytes)`가 없어서 test compilation이 실패한다. 기존 코드나 assertion 실수로 인한 실패라면 테스트를 바로잡고 같은 RED를 다시 확인한다.
+
+## Task 2: segment 기반 primitive를 최소 구현한다 (GREEN)
+
+**Files:**
+
+- Create: `io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt`
+- Test: `io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt`
+
+- [ ] 전용 예외를 additive public API로 구현한다.
+
+  ```kotlin
+  class ByteLimitExceededException(
+      val maxBytes: Int,
+  ) : IOException("Input stream exceeded the configured byte limit: maxBytes=$maxBytes") {
+      init {
+          maxBytes.requireZeroOrPositiveNumber("maxBytes")
+      }
+  }
+  ```
+
+  KDoc는 `maxBytes`만 안정된 공개 정보이며 payload와 정확한 message는 호환성 계약이 아님을 설명한다.
+
+- [ ] `InputStream.readAllBytes(maxBytes)`의 첫 동작으로 `maxBytes.requireZeroOrPositiveNumber("maxBytes")`를 호출한다. `maxBytes + 1` 산술은 어느 경로에서도 사용하지 않는다.
+
+- [ ] accumulator는 최대 `DEFAULT_BUFFER_SIZE` segment를 하나씩 채우고, EOF의 마지막
+  partial segment만 실제 길이로 잘라 저장한다. bulk read가 0이어도 같은 current segment에
+  single byte를 기록해 1-byte 배열이 반복 생성되지 않게 한다.
+
+  ```kotlin
+  fun InputStream.readAllBytes(maxBytes: Int): ByteArray {
+      maxBytes.requireZeroOrPositiveNumber("maxBytes")
+      val segments = ArrayList<ByteArray>()
+      var total = 0
+
+      while (total < maxBytes) {
+          val segment = ByteArray(minOf(DEFAULT_BUFFER_SIZE, maxBytes - total))
+          var segmentSize = 0
+          while (segmentSize < segment.size) {
+              val count = read(segment, segmentSize, segment.size - segmentSize)
+              when {
+                  count < 0 -> {
+                      if (segmentSize > 0) segments += segment.copyOf(segmentSize)
+                      return segments.flattenToByteArray(total)
+                  }
+                  count > 0 -> {
+                      segmentSize += count
+                      total += count
+                  }
+                  else -> {
+                      val value = read()
+                      if (value < 0) {
+                          if (segmentSize > 0) segments += segment.copyOf(segmentSize)
+                          return segments.flattenToByteArray(total)
+                      }
+                      segment[segmentSize++] = value.toByte()
+                      total++
+                  }
+              }
+          }
+          segments += segment
+      }
+      if (read() >= 0) throw ByteLimitExceededException(maxBytes)
+      return segments.flattenToByteArray(total)
+  }
+
+  private fun List<ByteArray>.flattenToByteArray(totalSize: Int): ByteArray =
+      ByteArray(totalSize).also { result ->
+          var offset = 0
+          forEach { segment ->
+              segment.copyInto(result, destinationOffset = offset)
+              offset += segment.size
+          }
+      }
+  ```
+
+  실제 구현은 다음 불변식을 지킨다.
+  - 저장한 각 full/partial segment capacity는 그 segment에서 실제 읽은 byte 수와 같다.
+  - 저장 segment와 current segment capacity 합은 항상 `maxBytes` 이하이고, segment object
+    수는 최대 `ceil(maxBytes / DEFAULT_BUFFER_SIZE)`다.
+  - current segment는 `O(DEFAULT_BUFFER_SIZE)`이며 `ByteArray(maxBytes)`나 자동 배수 확장
+    buffer가 없다.
+  - EOF partial copy 중에는 원본 current segment와 exact partial segment가 잠시 함께
+    존재하고 final flatten 때 `ArrayList` reference storage와 결과 배열이 함께 존재한다.
+    이 transient storage를 포함해 `2 * actualBytes + O(DEFAULT_BUFFER_SIZE) + O(segment
+    references)` 범위다.
+  - 마지막 결과 배열만 exact `total`로 만들고 순서대로 한 번 복사한다.
+  - bulk read가 0이면 즉시 single-byte read로 EOF 또는 1 byte 진행을 보장한다.
+  - 원본 read exception을 catch/translate하지 않는다.
+  - primitive는 어떤 경로에서도 `close()`를 호출하지 않는다.
+
+- [ ] public KDoc에 상한·부분 결과 없음·최대 1 byte read-ahead·stream 미종료·blocking·메모리 peak·`Int.MAX_VALUE`의 가용 메모리 한계를 한국어로 기록한다.
+
+- [ ] Task 1 targeted test를 다시 실행해 GREEN을 확인한다.
+
+- [ ] 기존 `InputStreamSupportTest`도 다시 실행해 무인자 JDK member와 기존 extension 동작에 회귀가 없음을 확인한다.
+
+- [ ] primitive 단위 변경을 Lore 형식으로 commit한다.
+
+  ```bash
+  git add io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt \
+    io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt
+  git commit -m '부분 본문 수용 없이 byte 상한을 판정한다' \
+    -m 'Constraint: caller-owned InputStream은 성공과 실패 모두에서 닫지 않는다.' \
+    -m 'Rejected: ByteArrayOutputStream 선할당 및 maxBytes + 1 산술 | 큰 상한의 메모리와 정수 overflow 위험' \
+    -m 'Confidence: high' -m 'Scope-risk: moderate' \
+    -m 'Directive: 초과 판정 read-ahead는 한 byte를 넘기지 않는다.' \
+    -m 'Tested: BoundedInputStreamSupportTest와 InputStreamSupportTest' \
+    -m 'Not-tested: HTTP adapter와 module-wide check는 후속 task에서 검증'
+  ```
+
+## Task 3: HC5 adapter 계약 테스트를 먼저 추가한다 (RED)
+
+**Files:**
+
+- Create: `io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt`
+
+- [ ] MockK `HttpEntity`와 Task 1과 같은 관찰 가능한 stream을 조합해 metadata accessor, content accessor, read, close 횟수와 실패 인스턴스를 추적한다. `contentLength`는 known `Long` 또는 `-1L` unknown으로 설정한다.
+
+- [ ] 다음 표를 parameterized test와 개별 failure test로 고정한다.
+
+  | 사례 | 기대 결과 | content read | close |
+  |---|---|---:|---:|
+  | null entity, max 0/4 | empty bytes/string | 0 | 0 |
+  | empty entity | empty | EOF 확인 | 1 |
+  | known `3/4`, 실제 `3/4`, max 4 | 전체 결과 | 실제 길이+EOF | 1 |
+  | known 8, max 4 | overflow | 0 | 1 |
+  | known 3, 실제 5, max 4 | overflow | 5 | 1 |
+  | unknown, 실제 5, max 4 | overflow | 5 | 1 |
+
+- [ ] 음수 상한은 nullable/non-null entity 모두 metadata/content accessor 전에 실패하며 close하지 않음을 `verify(exactly = 0)`으로 검증한다.
+
+- [ ] known oversize에서 먼저 생성한 overflow가 primary이고 content accessor failure가 suppressed인지 검증한다. accessor가 stream을 반환했다면 read 0회, close 1회다.
+
+- [ ] known oversize의 accessor-block과 close-block을 deterministic fake로 검증한다.
+  - accessor fake는 진입 latch에서 기다리며 supervisor `abort()`가 release한 뒤
+    `SocketTimeoutException`을 던진다. 결과는 overflow primary와 accessor timeout
+    suppressed다.
+  - close-block stream은 close 진입 latch에서 기다리며 supervisor `abort()`가 release한
+    뒤 종료한다. content read 0회, adapter close 1회, bounded future 회수를 확인한다.
+  - 두 test 모두 Task 5와 같은 `try/finally`, bounded await/cancel, executor shutdown
+    순서를 사용한다.
+
+- [ ] 성공+close failure는 close failure 자체를 던지고, read/overflow failure+close failure는 원래 primary에 close failure를 한 번 suppressed한다. 같은 예외 인스턴스를 cleanup이 다시 던지는 방어 사례도 primary를 잃지 않아야 한다.
+
+- [ ] UTF-8 `가나`의 6 byte를 max 5로 읽을 때 문자열 길이와 무관하게 overflow이며, max 6에서는 원문을 반환한다.
+
+- [ ] `README 공개 예제` 이름의 test에서 closeable HC5 response scope 안에서 nullable `response.entity.readBodyBytes(maxBytes = 64 * 1024)` 호출을 컴파일·실행한다. response 자체와 entity content의 close 주체를 각각 검증한다.
+
+- [ ] 기존 `toByteArrayOrNull(maxResultLength=4)`와 `toStringOrNull(maxResultLength=4)`가 5 byte 입력의 앞 4 byte를 반환하는 truncation 회귀를 기존 `HttpEntitySupportTest`와 새 test에서 확인한다.
+
+- [ ] 새 HC5 test만 실행해 `readBodyBytes`/`readBodyString` 부재 RED를 확인한다.
+
+  ```bash
+  ./gradlew :bluetape4k-http:test \
+    --tests 'io.bluetape4k.http.hc5.entity.BoundedHttpEntitySupportTest' \
+    --rerun-tasks --no-daemon --max-workers=1 \
+    --no-build-cache --no-configuration-cache
+  ```
+
+## Task 4: 공통 owned-body helper와 HC5 adapter를 구현한다 (GREEN)
+
+**Files:**
+
+- Create: `io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt`
+- Create: `io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupport.kt`
+- Test: `io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt`
+
+- [ ] `OwnedBodySupport.kt`에 다음 책임만 가진 `internal` helper를 구현한다.
+  - known oversize이면 `ByteLimitExceededException`을 먼저 만든다.
+  - body accessor가 실패하면 known oversize primary에 suppressed하고, 일반 경로에서는 원본 accessor failure를 전달한다.
+  - accessor가 null이면 일반 경로는 empty, known oversize는 overflow다.
+  - stream을 얻은 뒤에는 성공·read/overflow failure 모두 close를 정확히 한 번 시도한다.
+  - primary가 있으면 서로 다른 close failure를 한 번 suppressed하고 primary를 다시 던진다.
+  - read 성공 뒤 close만 실패하면 close failure를 던져 결과를 반환하지 않는다.
+  - `BufferFailurePolicy`나 logging/metric을 호출하지 않는다.
+
+- [ ] helper의 ownership과 예외 우선순위는 아래 상태 머신으로 고정한다. 구현에서
+  `primary`와 `ownedStream` 전이를 다른 순서로 재구성하지 않는다.
+
+  ```kotlin
+  internal inline fun readOwnedBodyBytes(
+      maxBytes: Int,
+      knownOversize: Boolean,
+      acquireBody: () -> InputStream?,
+  ): ByteArray {
+      var primary: Throwable? =
+          if (knownOversize) ByteLimitExceededException(maxBytes) else null
+      var ownedStream: InputStream? = null
+
+      try {
+          try {
+              ownedStream = acquireBody()
+          } catch (accessorFailure: Throwable) {
+              val current = primary
+              if (current == null) {
+                  primary = accessorFailure
+                  throw accessorFailure
+              }
+              if (current !== accessorFailure) current.addSuppressed(accessorFailure)
+          }
+
+          primary?.let { throw it }
+          val stream = ownedStream ?: return byteArrayOf()
+
+          return try {
+              stream.readAllBytes(maxBytes)
+          } catch (readFailure: Throwable) {
+              primary = readFailure
+              throw readFailure
+          }
+      } finally {
+          val stream = ownedStream
+          if (stream != null) {
+              try {
+                  stream.close()
+              } catch (closeFailure: Throwable) {
+                  val current = primary
+                  if (current == null) throw closeFailure
+                  if (current !== closeFailure) current.addSuppressed(closeFailure)
+              }
+          }
+      }
+  }
+  ```
+
+  전이는 다음과 같다.
+  - accessor 이전에는 known oversize만 `primary`다. accessor가 stream을 반환하기 전에는
+    adapter가 닫을 자원이 없다.
+  - accessor-only failure는 원본을 그대로 던진다. known oversize+accessor failure는
+    overflow를 primary로 유지하고 accessor failure만 suppressed한다.
+  - null body는 일반 경로에서 empty다. known oversize에서는 accessor가 null이어도 처음
+    만든 overflow를 던진다.
+  - stream을 획득한 뒤에는 read를 시작하기 전 known oversize를 던지는 경로를 포함해
+    `finally`에서 close를 정확히 한 번 시도한다.
+  - read/overflow가 primary이면 서로 다른 close failure만 한 번 suppressed한다. 같은
+    throwable이면 self-suppression을 건너뛰고 현재 primary가 그대로 전파된다.
+  - read 성공 뒤 close-only failure는 `finally`가 원래 반환을 폐기하고 close failure를
+    그대로 던진다.
+
+- [ ] nullable HC5 extension은 반드시 아래 순서로 구현한다.
+
+  ```kotlin
+  fun HttpEntity?.readBodyBytes(maxBytes: Int): ByteArray {
+      maxBytes.requireZeroOrPositiveNumber("maxBytes")
+      if (this == null) return byteArrayOf()
+      return readOwnedBodyBytes(
+          maxBytes = maxBytes,
+          knownOversize = contentLength >= 0L && contentLength > maxBytes.toLong(),
+          acquireBody = { content },
+      )
+  }
+
+  fun HttpEntity?.readBodyString(
+      maxBytes: Int,
+      charset: Charset = Charsets.UTF_8,
+  ): String = readBodyBytes(maxBytes).toString(charset)
+  ```
+
+  길이 비교는 `Long`에서 수행한다.
+
+- [ ] public KDoc에 null→empty 정규화, null 보존용 `entity?.let`, content stream만 닫는 소유권, known length는 힌트뿐임, blocking/timeout 책임, strict/truncation 선택을 기록한다.
+
+- [ ] Task 3 targeted test와 기존 `HttpEntitySupportTest`를 모두 GREEN으로 만든다.
+
+- [ ] HC5 단위 변경을 Lore 형식으로 commit한다.
+
+  ```bash
+  git add io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt \
+    io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupport.kt \
+    io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt
+  git commit -m 'HC5 본문 소유권과 strict 상한을 함께 보존한다' \
+    -m 'Constraint: null entity는 empty로 정규화하고 기존 truncation API는 유지한다.' \
+    -m 'Rejected: EntityUtils 제한 API 재사용 | 초과를 실패하지 않고 결과를 자를 수 있음' \
+    -m 'Confidence: high' -m 'Scope-risk: moderate' \
+    -m 'Directive: metadata는 조기 거부에만 사용하고 실제 body도 항상 제한한다.' \
+    -m 'Tested: BoundedHttpEntitySupportTest와 HttpEntitySupportTest' \
+    -m 'Not-tested: JDK adapter와 module-wide check는 후속 task에서 검증'
+  ```
+
+## Task 5: JDK adapter와 bounded completion 테스트를 먼저 추가한다 (RED)
+
+**Files:**
+
+- Create: `io/http/src/test/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupportTest.kt`
+
+- [ ] 실제 네트워크 없이 `HttpResponse<InputStream>`을 구현하는 `FakeHttpResponse`를 파일 내부에 만든다. `HttpHeaders.of`, status, URI, version, body accessor와 accessor failure를 명시적으로 제어한다.
+
+  ```kotlin
+  private class FakeHttpResponse(
+      private val stream: InputStream,
+      headerValues: Map<String, List<String>> = emptyMap(),
+      private val code: Int = 200,
+      private val bodyFailure: Throwable? = null,
+  ) : HttpResponse<InputStream> {
+      private val responseHeaders = HttpHeaders.of(headerValues) { _, _ -> true }
+      // JDK HttpResponse의 모든 method를 고정 값으로 구현한다.
+  }
+  ```
+
+- [ ] `Content-Length` header matrix를 검증한다.
+  - 없음 → actual read
+  - 단일 `4` → actual read
+  - 단일 `5`, max 4 → read 0회, close 1회, overflow
+  - 단일 `Long.MAX_VALUE` → known oversize로 read 0회, close 1회
+  - 단일 `+4` → parseable non-negative 값으로 actual read
+  - 단일 ` 4 `, `4, 4` → malformed unknown으로 actual read
+  - 단일 `3`, 실제 5 → actual overflow
+  - `abc`, `-1`, `9223372036854775808`, 두 값 `4`/`4` → unknown으로 actual read
+  - status 200/404/500 → status와 무관하게 같은 body 결과
+
+- [ ] 음수 max가 `headers()`와 `body()`보다 먼저 실패하는지 accessor count로 검증한다.
+
+- [ ] HC5와 같은 success/overflow/read/accessor/close failure matrix 및 primary/suppressed identity를 검증한다.
+
+- [ ] known oversize의 body accessor-block과 close-block을 Task 3과 같은 latch/abort fake로
+  검증한다. overflow를 primary로 유지하고 accessor timeout은 suppressed하며, close가
+  release될 때까지 worker가 block된 뒤 bounded cleanup으로 회수되는지 확인한다.
+  close-block fake의 `abort()`는 close latch를 해제하는 non-blocking supervisor operation으로
+  정의하고 cleanup에서는 반드시 `abort()`를 먼저 호출한 뒤 stream close/future 회수를
+  시도한다.
+
+- [ ] UTF-8 multi-byte byte 기준과 문자열 변환 후 반환을 검증한다.
+
+- [ ] `README 공개 예제` 이름의 test에서 `BodyHandlers.ofInputStream()`이 생산하는 것과 같은 `HttpResponse<InputStream>` 타입으로 `response.readBodyBytes(maxBytes = 64 * 1024)` 호출을 컴파일·실행한다.
+
+- [ ] blocking read-ahead stream을 만든다. 정확히 max byte를 제공한 뒤 다음 `read()`에서 latch로 block하고, 별도 virtual-thread executor에서 adapter를 호출한다.
+  - `enteredReadAhead.await(5, SECONDS)`로 block 진입을 확인한다.
+  - 단순 `Future.cancel(true)`만으로 완료됐다고 주장하지 않는다.
+  - 외부 supervisor가 stream을 close하면 read가 원본 `IOException`으로 종료된다.
+  - 외부 supervisor close 1회와 adapter cleanup close 1회, 총 2회만 관찰되어 adapter 자체의 double-close가 없음을 확인한다.
+  - 전체 검증을 `try/finally`로 감싼다. `finally`에서는 assertion/latch timeout 여부와
+    무관하게 다음 순서를 끝까지 실행한다.
+    1. non-blocking `supervisor.abort()`로 read/accessor/close latch를 먼저 해제한다.
+    2. 외부 소유 stream close를 시도하되, 이전 cleanup failure가 있어도 다음 단계로 간다.
+    3. `future.get(5, SECONDS)`를 호출한다. 예상 worker failure는 `ExecutionException.cause`가
+       원본 `IOException`과 같은 인스턴스인지 검증한다. timeout이면 `future.cancel(true)`를
+       호출하고 timeout을 cleanup failure에 기록한다.
+    4. 별도 `finally`에서 항상 `executor.shutdownNow()`와
+       `executor.awaitTermination(5, SECONDS)`를 실행한다.
+  - 각 cleanup 단계는 독립 `try/catch`로 감싸 첫 cleanup failure를 보존하고 이후 서로 다른
+    failure를 suppressed한다. 검증 본문의 primary assertion failure가 있으면 cleanup failure를
+    그 assertion에 suppressed하고, 본문이 성공했으면 cleanup failure를 마지막에 던진다.
+    `ExecutionException` wrapper 자체를 곧바로 던져 executor shutdown을 건너뛰지 않는다.
+  - `ExecutorService.close()`가 blocked task를 무기한 기다리는 형태는 사용하지 않는다.
+    cleanup 단계별 timeout/실패를 assertion message에 남기고 test 자체가 worker를 영구
+    점유하지 않게 한다.
+  - 저장소의 `StructuredTaskScopeTester`는 structured concurrency task-scope 완료와
+    cancellation을 검증하는 helper다. 이번 test는 caller가 직접 소유한 blocking
+    `InputStream.close()`/transport abort와 `ExecutorService` teardown 순서를 검증해야 하므로
+    그 helper로 ownership handle을 숨기지 않고 bounded latch/future harness를 사용한다.
+
+- [ ] 새 JDK test만 실행해 public adapter 부재 RED를 확인한다.
+
+  ```bash
+  ./gradlew :bluetape4k-http:test \
+    --tests 'io.bluetape4k.http.jdk.BoundedHttpResponseSupportTest' \
+    --rerun-tasks --no-daemon --max-workers=1 \
+    --no-build-cache --no-configuration-cache
+  ```
+
+## Task 6: JDK adapter를 공통 primitive에 연결한다 (GREEN)
+
+**Files:**
+
+- Create: `io/http/src/main/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupport.kt`
+- Reuse: `io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt`
+- Test: `io/http/src/test/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupportTest.kt`
+
+- [ ] header parser는 exactly-one value만 known으로 인정한다.
+
+  ```kotlin
+  private fun HttpResponse<*>.contentLengthOrNull(): Long? =
+      headers()
+          .allValues("Content-Length")
+          .singleOrNull()
+          ?.toLongOrNull()
+          ?.takeIf { it >= 0L }
+  ```
+
+  comma가 포함된 단일 문자열도 `toLongOrNull()` 실패로 unknown이다. framing 유효성이나 smuggling 방어는 JDK client/proxy 책임이며 helper가 header를 정규화하지 않는다.
+
+- [ ] public adapter는 max를 headers/body보다 먼저 검증하고 `Long` 길이 비교 후 shared helper에 body accessor를 넘긴다.
+
+  ```kotlin
+  fun HttpResponse<InputStream>.readBodyBytes(maxBytes: Int): ByteArray {
+      maxBytes.requireZeroOrPositiveNumber("maxBytes")
+      val knownLength = contentLengthOrNull()
+      return readOwnedBodyBytes(
+          maxBytes = maxBytes,
+          knownOversize = knownLength != null && knownLength > maxBytes.toLong(),
+          acquireBody = { body() },
+      )
+  }
+  ```
+
+- [ ] 문자열 함수는 byte 함수가 성공한 뒤에만 `toString(charset)`을 호출한다. status/auth/decode/client lifecycle을 추가하지 않는다.
+
+- [ ] public KDoc에 body stream만 닫음, response/client/executor 미종료, status 미해석, malformed/multiple header unknown 처리, blocking/non-cancellable, timeout·외부 close 책임을 기록한다.
+
+- [ ] Task 5 JDK targeted test, Task 3 HC5 targeted test를 순서대로 실행해 shared helper 회귀가 없는지 확인한다.
+
+- [ ] JDK adapter 단위 변경을 Lore 형식으로 commit한다.
+
+  ```bash
+  git add io/http/src/main/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupport.kt \
+    io/http/src/test/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupportTest.kt
+  git commit -m 'JDK 응답도 같은 byte 상한과 cleanup 계약을 사용한다' \
+    -m 'Constraint: Content-Length는 단일 정상 값일 때만 조기 거부 힌트다.' \
+    -m 'Rejected: BodyHandlers.limiting 사용 | HC5와 예외 및 소유권 계약이 갈라짐' \
+    -m 'Confidence: high' -m 'Scope-risk: moderate' \
+    -m 'Directive: status와 transport timeout 정책은 caller에 남긴다.' \
+    -m 'Tested: BoundedHttpResponseSupportTest와 BoundedHttpEntitySupportTest' \
+    -m 'Not-tested: README와 module-wide check는 후속 task에서 검증'
+  ```
+
+## Task 7: KDoc·README·변경 기록에 호출자 계약을 맞춘다
+
+**Files:**
+
+- Modify: `io/io/README.md`
+- Modify: `io/io/README.ko.md`
+- Modify: `io/http/README.md`
+- Modify: `io/http/README.ko.md`
+- Modify: `CHANGELOG.md`
+- Verify KDoc: Task 2, 4, 6의 production source
+
+- [ ] `bluetape4k-io` 두 README의 InputStream section에 동일한 실행 예제를 추가한다.
+
+  ```kotlin
+  import io.bluetape4k.io.ByteLimitExceededException
+  import io.bluetape4k.io.readAllBytes
+
+  val bytes = inputStream.use {
+      it.readAllBytes(maxBytes = 64 * 1024)
+  }
+  ```
+
+  raw primitive는 stream을 닫지 않으며 caller가 `use`를 소유한다. `ByteLimitExceededException.maxBytes`만 분기에 사용하고 message/payload는 log하지 않는다.
+
+- [ ] `bluetape4k-http` 두 README에 HC5와 JDK 예제를 컴파일 가능한 import와 함께 추가한다.
+
+  ```kotlin
+  httpClient.execute(request).use { response ->
+      val body = response.entity.readBodyBytes(maxBytes = 64 * 1024)
+  }
+
+  val response = jdkClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+  val body = response.readBodyBytes(maxBytes = 64 * 1024)
+  ```
+
+  HC5 response 자체는 caller가 닫고, JDK adapter는 body stream만 닫음을 구분한다.
+
+- [ ] Task 1/3/5의 `README 공개 예제` compile fixture와 README/KDoc의 import·호출 형태가
+  같은지 확인한다.
+  - 네 README의 import, `maxBytes = 64 * 1024`, 소유권 의미가 fixture와 같은지
+    SPW-02 사실성 검사에서 대조한다.
+
+- [ ] strict/truncation 선택표를 양 언어 README에 같은 의미로 추가한다.
+  - preview/diagnostic prefix → 기존 `toByteArrayOrNull`/`toStringOrNull`
+  - JSON/schema full body → 새 `readBody*`
+  - null HC5 보존 → `entity?.let`
+  - 일반 stream → caller `use`
+
+- [ ] blocking completion 지침을 기록한다.
+  - client connect/response/read timeout을 구성한다.
+  - event-loop에서 직접 호출하지 않고 blocking I/O 경계에서 실행한다.
+  - coroutine 취소만 믿지 말고 supervisor가 stream/상위 response를 close할 수 있게 한다.
+  - helper의 정확히 상한 뒤 마지막 read와 close도 block할 수 있으며 transport별 abort는 범위 밖이다.
+
+- [ ] 보안·운영 지침을 기록한다.
+  - 제한은 adapter가 받은 stream byte에 적용된다.
+  - 후속 decompression에는 decoded byte 상한이 별도 필요하다.
+  - `동시 read 수 * (2 * maxBytes + segment overhead)`를 heap budget에 반영한다.
+  - library는 log/metric side effect를 만들지 않는다.
+  - app은 payload 없이 endpoint/operation/max와 overflow/read/close 분류만 low-cardinality로 집계한다.
+
+- [ ] publish/소비자 순서를 README의 migration note 또는 CHANGELOG 항목에 명확히 기록한다.
+  - library `2.1.0` publish
+  - 소비자가 중앙 catalog 또는 허용된 repo-local override로 버전 선택
+  - compile/targeted smoke
+  - #939/#451 별도 PR
+  - 회귀 시 이전 dependency+수동 strict loop로 rollback하며 truncation API를 대체재로 쓰지 않음
+
+- [ ] `CHANGELOG.md`의 `[Unreleased] / 추가`에 #1643 링크와 additive API, strict 초과 실패, 기존 truncation 유지, caller 소유권 요약을 한 항목으로 추가한다.
+
+- [ ] `bluetape-writer`의 SPW-01~05와 한국어 KO-01~07을 영문/국문 문서 각각 적용한다. locale 간 signature, 숫자, 링크, 소유권 의미가 같은지 diff로 확인하고 한국어 audit script를 실행한다.
+
+- [ ] 문서 변경을 Lore 형식으로 commit한다.
+
+  ```bash
+  git add io/io/README.md io/io/README.ko.md \
+    io/http/README.md io/http/README.ko.md CHANGELOG.md
+  git commit -m 'strict 본문 읽기의 호출자 책임을 공개 문서에 고정한다' \
+    -m 'Constraint: 영문과 국문 module README는 같은 API와 수명주기 계약을 설명한다.' \
+    -m 'Rejected: 기존 truncation API를 rollback 경로로 안내 | 초과 거부 의미가 다름' \
+    -m 'Confidence: high' -m 'Scope-risk: narrow' \
+    -m 'Directive: payload를 관측 데이터나 예외 메시지에 포함하지 않는다.' \
+    -m 'Tested: locale 의미 대조, Korean terminology audit, git diff --check' \
+    -m 'Not-tested: full module check와 CI는 후속 task에서 검증'
+  ```
+
+## Task 8: 모듈·정적·공개 API 검증을 완료한다
+
+**Files:**
+
+- Verify: Task 1~7의 모든 source/test/docs
+- Verify unchanged: 기존 facade source, Gradle/catalog/workflow/module registration
+
+- [ ] 새 계약 테스트를 한 JVM에서 함께 실행한다.
+
+  ```bash
+  ./gradlew :bluetape4k-io:test \
+    --tests 'io.bluetape4k.io.BoundedInputStreamSupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+
+  ./gradlew :bluetape4k-http:test \
+    --tests 'io.bluetape4k.http.hc5.entity.BoundedHttpEntitySupportTest' \
+    --tests 'io.bluetape4k.http.jdk.BoundedHttpResponseSupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  기대 결과: 모든 새 경계·failure·blocking test가 실패/오류/skip 0으로 통과한다.
+
+- [ ] 영향 모듈 check를 의존 순서대로 실행한다.
+
+  ```bash
+  ./gradlew :bluetape4k-io:check \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+
+  ./gradlew :bluetape4k-http:check \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  기대 결과: 두 명령 모두 `BUILD SUCCESSFUL`. 기존 HTTP test가 Task 0과 동일한
+  `ContainerFetchException`/image 404로 실패하면 같은 명령을 한 번만 재시도하고 기준 SHA와
+  변경 head의 failing class, exception chain, JUnit XML을 비교한다. 동일한
+  `baseline external failure`이고 신규 container-free test와 `bluetape4k-io:check`가
+  통과해도 local `bluetape4k-http:check`는 PASS가 아니다. 정확한 gap을 PR에 기록하고
+  CI exact-head 결과를 기다리며 상태를 `PENDING`으로 유지한다. CI에서도 실패하면 수정
+  또는 외부 장애 해소 전까지 완료하지 않는다. 다른 실패면 신규 회귀로 취급해 즉시
+  진단·수정한다.
+
+- [ ] jar를 빌드하고 additive public JVM surface를 read-back한다.
+
+  ```bash
+  ./gradlew :bluetape4k-io:jar :bluetape4k-http:jar \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+
+  javap -public -classpath io/io/build/libs/bluetape4k-io-2.1.0.jar \
+    io.bluetape4k.io.ByteLimitExceededException
+  javap -public -classpath io/io/build/libs/bluetape4k-io-2.1.0.jar \
+    io.bluetape4k.io.BoundedInputStreamSupportKt
+  javap -public -classpath io/http/build/libs/bluetape4k-http-2.1.0.jar \
+    io.bluetape4k.http.hc5.entity.BoundedHttpEntitySupportKt
+  javap -public -classpath io/http/build/libs/bluetape4k-http-2.1.0.jar \
+    io.bluetape4k.http.jdk.BoundedHttpResponseSupportKt
+  ```
+
+  기대 signature:
+  - exception constructor/getter의 `int maxBytes`
+  - IO facade의 `byte[] readAllBytes(InputStream, int)`
+  - HC5 facade의 bytes/string extension과 charset default bridge
+  - JDK facade의 bytes/string extension과 charset default bridge
+
+  repository-wide generic `apiCheck` task는 현재 근거가 없으므로 존재한다고 가정하지 않는다. jar 이름이 실제 version suffix와 다르면 `build/libs`를 먼저 조회해 정확한 artifact를 사용하고 결과를 기록한다.
+
+- [ ] 기존 facade와 build graph 불변을 확인한다.
+
+  ```bash
+  git diff --exit-code origin/develop -- \
+    io/io/src/main/kotlin/io/bluetape4k/io/InputStreamSupport.kt \
+    io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/HttpEntitySupport.kt \
+    io/http/src/main/kotlin/io/bluetape4k/http/jdk/JdkHttpClientSupport.kt \
+    io/io/build.gradle.kts io/http/build.gradle.kts settings.gradle.kts \
+    gradle/libs.versions.toml .github/workflows
+  ```
+
+  기대 결과: exit 0. 따라서 기존 file facade descriptor와 dependency/module/workflow 등록은 unchanged이며 새 facade만 additive다.
+
+- [ ] 메모리·재사용 정적 불변을 확인한다.
+
+  ```bash
+  rg -n 'ByteArray\(maxBytes\)|maxBytes\s*\+\s*1|ByteArrayOutputStream' \
+    io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt
+
+  rg -n 'readAllBytes\(maxBytes\)' \
+    io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt \
+    io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupport.kt \
+    io/http/src/main/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupport.kt
+  ```
+
+  첫 명령은 output 없음/exit 1이 기대 결과다. 두 번째는 shared helper에서 유일한 primitive 호출을 보여야 하며 두 adapter에 별도 byte loop가 없어야 한다.
+
+- [ ] 새 source가 top-level mutable state를 두지 않고 호출별 local accumulator와 stream만
+  사용함을 diff review로 확인한다. library 자체에는 동시 read counter나 shared heap budget
+  state가 없으므로 concurrency synchronization test는 N/A다. 실제 동시성·heap 예산과
+  startup validation은 Task 10의 #939/#451 후속 smoke 항목으로 남긴다.
+
+- [ ] benchmark/GC 검증은 N/A로 기록한다. 이 PR은 throughput/latency/GC 개선을 주장하지
+  않으며 allocation 안전성은 segment capacity 산술, `Int.MAX_VALUE` 작은 body smoke,
+  zero-progress test, 구현 review로 제한한다. 향후 성능 주장을 추가할 때만 같은 JVM
+  warmup과 0/4 KiB/64 KiB/1 MiB body, exact/overflow, 제한된 concurrency를 포함한
+  baseline/candidate benchmark를 별도 이슈로 요구한다.
+
+- [ ] 최종 정적·문서 검사를 실행한다.
+
+  ```bash
+  git diff --check origin/develop...HEAD
+  node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+    io/io/README.ko.md io/http/README.ko.md CHANGELOG.md \
+    io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt \
+    io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupport.kt \
+    io/http/src/main/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupport.kt
+  ```
+
+  기대 결과: whitespace error 0, terminology findings 0. detekt가 기존 finding을 ignore하도록 설정돼 있다면 exit 0만으로 clean이라 주장하지 않고 변경 파일 finding을 별도로 확인한다.
+
+## Task 9: 구현 6개 관점 검토와 PR 전 검증을 통과한다
+
+**Files:**
+
+- Create: `docs/review/2026-09-06-bounded-http-body-implementation-review.md`
+- Review: `origin/develop...HEAD` 전체 구현 diff
+
+- [ ] 성능, 안정성, 보안, Operator/Ops, 개발자/API, 사용자/caller 관점의 독립 reviewer가 같은 head를 read-only 검토한다. 각 finding은 severity, file:line, 재현/위험, 최소 수정안을 포함한다.
+
+- [ ] P0/P1은 모두 수정하고 영향받은 targeted/module check를 재실행한다. P2/P3은 해결하거나 근거 있는 명시적 처분을 review artifact에 남긴다.
+
+- [ ] reviewer가 특히 다음을 확인한다.
+  - segment capacity 합, peak allocation, `Int.MAX_VALUE` 산술
+  - 0-byte bulk read progress와 최대 1-byte read-ahead
+  - validation-before-accessor, known/unknown header 경계
+  - accessor/read/overflow/close failure identity와 suppression
+  - blocking read/close, executor/latch cleanup, test timeout
+  - payload/message/log/metric 비노출
+  - strict/truncation·null/empty·primitive/adapter 소유권 선택
+  - duplicate loop/helper, 새 dependency나 build graph drift 없음
+
+- [ ] 최종 head에서 P0/P1 reviewer만 재실행해 0건을 확인하고 Task 8 검증을 다시 실행한다.
+
+- [ ] issue #1643 수용 기준과 실제 로그를 연결한 한국어 PR 본문을 작성한다. unchecked 항목은 publish/소비자 전환/merge처럼 실제로 남은 것만 표시한다.
+
+- [ ] branch를 push하고 `develop <- feat/issue-1643-bounded-http-body` PR을 생성한다. PR 생성 직후 live body, head SHA, base/head, issue link, labels/milestone/assignee, review artifact를 다시 확인한다.
+
+- [ ] CI를 감시해 required checks가 모두 성공할 때까지 실패를 진단·수정·push한다. 변경된 head마다 review/targeted/module 증거를 갱신한다. merge와 auto-merge는 하지 않는다.
+
+## Task 10: 소비자 후속 근거와 최종 DoD를 연결한다
+
+**Files:**
+
+- Update external issue comment: `bluetape4k-workshop#939`
+- Update external issue comment: `clinic-appointment#451`
+- Update: PR body / `bluetape4k-projects#1643` evidence as needed
+
+- [ ] PR과 CI가 확인된 뒤 #939와 #451에 같은 provider 근거를 한국어로 남긴다.
+  - library PR URL과 exact head SHA
+  - 새 public signature와 strict/truncation 차이
+  - 아직 publish 전이면 “소비 가능 버전 아님”을 명시
+  - `2.1.0` publish 후 중앙 catalog 또는 허용된 repo-local override로 선택 가능
+  - 각 소비자 smoke와 독립 PR이 여전히 pending임
+  - 기존 수동 strict loop를 공통 API 전환 완료 전 제거하지 않음
+  - 실제 transport timeout/supervisor close와 동시 read heap budget/startup validation은
+    각 소비자 smoke에서 검증해야 함
+
+- [ ] `apply_patch`로 `/tmp/issue-1643-workshop-comment.md`와
+  `/tmp/issue-1643-clinic-comment.md`를 만들고 위 내용을 채운 뒤 댓글을 등록한다.
+
+  ```bash
+  gh issue comment 939 --repo bluetape4k/bluetape4k-workshop \
+    --body-file /tmp/issue-1643-workshop-comment.md
+  gh issue comment 451 --repo bluetape4k/clinic-appointment \
+    --body-file /tmp/issue-1643-clinic-comment.md
+  ```
+
+  기대 결과: 두 명령이 각각 comment URL을 반환한다.
+
+- [ ] live issue 상태와 마지막 댓글을 read-back한다.
+
+  ```bash
+  gh issue view 939 --repo bluetape4k/bluetape4k-workshop \
+    --json state,comments,url
+  gh issue view 451 --repo bluetape4k/clinic-appointment \
+    --json state,comments,url
+  ```
+
+  기대 결과: 두 이슈 모두 `OPEN`; 마지막 본문에 provider PR URL, exact head SHA,
+  “publish 전 소비 불가”, smoke/독립 PR pending, 수동 strict loop rollback,
+  timeout/supervisor close와 heap budget 후속 검증이 모두 있고 payload는 없다.
+
+- [ ] 두 소비자 이슈를 닫지 않는다. library PR 생성이나 CI 통과를 publish 완료로 표현하지 않는다.
+
+- [ ] 최종 PR body와 #1643에 다음 증거를 연결한다.
+  - RED와 GREEN targeted logs
+  - 두 module `check`
+  - `javap` public surface와 unchanged facade/build graph
+  - Korean docs audit와 `git diff --check`
+  - 구현 review P0/P1 0건
+  - 소비자 issue comment URL
+  - CI exact head 상태
+
+- [ ] 최종 상태를 `PENDING`으로 보고한다. PR 생성·CI·소비자 근거까지 완료되어도 merge, publish, 소비자 코드 전환은 별도 승인/후속 작업이므로 unchecked로 남긴다.
+
+## 실패·rollback·중지 조건
+
+- primitive RED가 API 부재가 아닌 flaky/hang이면 production code를 작성하지 않고 deterministic test double부터 수정한다.
+- adapter GREEN이 primitive를 우회하는 별도 loop를 요구하면 구현을 중지하고 승인된 architecture와 충돌을 보고한다.
+- `bluetape4k-http:check`의 Docker baseline failure는 신규 test와 분리해 진단하되 module failure를 성공으로 바꾸어 말하지 않는다.
+- API signature가 승인 설계와 다르거나 기존 facade/build graph가 바뀌면 해당 commit만 수정·되돌리고 새 additive facade 경계를 회복한다.
+- runtime/heap benchmark는 요구하지 않는다. allocation 주장은 구조적 불변식, 작은 body+`Int.MAX_VALUE` smoke, read count, code review 범위로 제한한다.
+- diagram은 module/API 관계와 수명주기가 설계의 표·상태 전이로 충분해 N/A다. 새 module/dependency/catalog/workflow/Kover/nightly 등록도 모두 N/A다.
+- PR 생성 뒤 required CI가 성공하고 소비자 issue 근거가 남으면 이 실행 범위의 stop condition을 충족한다. merge/publish/tag/소비자 PR/branch 삭제는 수행하지 않는다.
+
+## 최종 완료 체크리스트
+
+- [ ] 승인된 공개 API 6개 요소(전용 예외 1개와 함수 5개)의 signature가 정확하다.
+- [ ] primitive와 두 adapter의 모든 경계·실패·수명주기 test가 통과한다.
+- [ ] 기존 truncation과 facade/build graph가 유지된다.
+- [ ] KDoc, 4개 module README, CHANGELOG가 locale·의미 검사를 통과한다.
+- [ ] 두 module check, public surface read-back, 정적 검사가 통과한다.
+- [ ] 구현 6개 관점 검토에서 P0/P1이 0건이다.
+- [ ] PR과 exact-head CI 증거가 #1643 수용 기준에 연결된다.
+- [ ] #939/#451에 publish·소비자 전환이 아직 별도 단계라는 근거가 남는다.
+- [ ] merge/publish/tag/소비자 코드 변경/branch 삭제는 미수행으로 명시된다.

--- a/docs/superpowers/specs/2026-09-06-bounded-http-body-design.md
+++ b/docs/superpowers/specs/2026-09-06-bounded-http-body-design.md
@@ -1,0 +1,466 @@
+# Issue #1643: HTTP 본문 byte 상한 초과 거부 API 설계
+
+## 상태와 범위
+
+- 대상 저장소: `bluetape4k-projects`
+- 대상 모듈: `bluetape4k-io`, `bluetape4k-http`
+- 대상 버전: `2.1.0`
+- 작업 유형: Type A 공개 API 추가
+- 기준 ref: `origin/develop` / `6a198fa8461637d02da34fee2d2c4df28a6b7b6e`
+- 연결 이슈: [#1643](https://github.com/bluetape4k/bluetape4k-projects/issues/1643)
+- 소비자 추적: [bluetape4k-workshop#939](https://github.com/bluetape4k/bluetape4k-workshop/issues/939), [clinic-appointment#451](https://github.com/bluetape4k/clinic-appointment/issues/451)
+- 상태: 공개 API와 자원 소유권 설계 승인, 6개 관점 검토 통합
+
+이번 변경은 HTTP 응답 본문이 허용 byte 수를 넘으면 일부 결과를 반환하지 않고
+명시적으로 실패하는 공통 기능을 추가한다. 기존 `HttpEntity.toByteArrayOrNull()`과
+`toStringOrNull()`의 반환 길이 제한 및 잘림 동작은 변경하지 않는다.
+
+## 1. 문제와 목표
+
+현재 두 소비자가 같은 보안·안정성 경계를 서로 다르게 구현한다.
+
+- Workshop의 HC5 호출자는 `Content-Length`를 먼저 검사한 뒤 `maxBytes + 1`을 읽어
+  초과를 판정한다.
+- Clinic의 JDK `HttpClient` 호출자는 `InputStream`을 직접 반복해서 읽고 64 KiB 상한을
+  검사한다.
+- `bluetape4k-http`의 기존 `EntityUtils` adapter는 제한을 넘은 입력을 거부하는 대신
+  최대 반환 길이에서 결과를 자를 수 있으므로, JSON 같은 구조화 본문에서 정상 EOF와
+  초과 입력을 구분할 수 없다.
+
+목표는 다음과 같다.
+
+1. `InputStream`에 대해 정확한 byte 상한을 적용하는 단일 primitive를 제공한다.
+2. HC5 `HttpEntity`와 JDK `HttpResponse<InputStream>` adapter가 같은 primitive를
+   재사용한다.
+3. `maxBytes` 이하일 때만 전체 결과를 반환하고, 초과 시 부분 payload 없는 전용
+   예외를 발생시킨다.
+4. adapter가 소유한 본문 스트림을 성공·초과·읽기 실패 모두에서 닫고, 원래 실패와
+   close 실패를 함께 보존한다.
+5. 실제 읽기량을 항상 검사해 없거나 부정확한 `Content-Length`를 신뢰 경계로 사용하지
+   않는다.
+6. 기존 잘림 API의 ABI와 동작을 보존하고 두 API 계열의 선택 기준을 KDoc과 README에
+   기록한다.
+
+## 2. 범위와 비범위
+
+### 2.1 포함 범위
+
+- `bluetape4k-io`의 bounded `InputStream` 읽기 primitive와 전용 예외
+- `bluetape4k-http`의 HC5 nullable entity adapter
+- `bluetape4k-http`의 JDK `HttpResponse<InputStream>` adapter
+- byte 읽기 완료 후 명시적 `Charset`으로 변환하는 문자열 편의 함수
+- 상한 경계, 길이 헤더, read-ahead, 메모리, close, 예외 결합 계약 테스트
+- 공개 KDoc, 모듈 README, ABI/API 검증
+
+### 2.2 제외 범위
+
+- 허용 HTTP 상태 코드, 인증·인가, retry, redirect 정책
+- JSON 또는 다른 payload 형식의 decode와 schema 검증
+- 요청·연결·응답 timeout 설정
+- `HttpClient`, `CloseableHttpClient`, 전체 response 객체 종료
+- streaming parser, 파일 spill, 압축 해제 후 크기 제한 정책
+- 문자 수 제한 또는 malformed charset 입력 거부 정책
+- 기존 `toByteArrayOrNull(maxResultLength)`와 `toStringOrNull(maxResultLength)`의 의미 변경
+- 소비자 저장소의 실제 전환과 PR. 공통 API 배포 후 각 연결 이슈에서 수행한다.
+
+## 3. 현재 근거와 제약
+
+- `bluetape4k-http`는 `bluetape4k-io`를 `api` dependency로 이미 사용하므로 새 module이나
+  dependency가 필요하지 않다.
+- 로컬 httpcore5 `5.4.3` 검증에서 기존 `EntityUtils` 기반 함수는 상한을 넘은 입력을
+  예외로 거부하지 않고 결과를 잘랐다. 이 계약을 새 기능으로 바꾸면 기존 호출자의
+  동작과 호환성을 깨뜨린다.
+- JDK `BodyHandlers.ofInputStream()`은 본문을 스트림으로 넘기며 호출자가 읽기 또는
+  close를 완료해야 한다. JDK 25의 `BodyHandlers.limiting()`도 사용할 수 있지만 HC5와
+  같은 primitive·예외·소유권 계약을 제공하지 않는다.
+- `Content-Length`는 없거나 실제 body와 다를 수 있으므로 최적화와 조기 거부에만 쓰고,
+  최종 허용 여부는 읽은 byte 수로 판정한다.
+- `maxBytes`는 결과의 문자 수가 아니라 adapter에 전달된 body stream이 내놓은 byte
+  수다. transport가 투명한 압축 해제를 적용했다면 해제된 byte에, 적용하지 않았다면
+  압축된 byte에 상한이 걸린다. 문자열 변환은 byte 제한을 통과한 뒤에만 수행한다.
+
+참고 자료:
+
+- [JDK 25 `HttpResponse.BodyHandlers`](https://docs.oracle.com/en/java/javase/25/docs/api/java.net.http/java/net/http/HttpResponse.BodyHandlers.html)
+- [Apache HttpCore `EntityUtils` 공식 소스](https://hc.apache.org/httpcomponents-core-5.3.x/current/httpcore5/xref/org/apache/hc/core5/http/io/entity/EntityUtils.html)
+
+## 4. 대안 비교와 결정
+
+| 대안 | 장점 | 단점 | 결정 |
+|---|---|---|---|
+| 각 HTTP adapter에서 독립 구현 | 모듈별 코드는 바로 작성 가능 | 경계·예외·read-ahead 동작이 다시 갈라지고 소비자가 HTTP 라이브러리에 종속됨 | 채택하지 않음 |
+| 기존 `EntityUtils` adapter 의미 변경 | 공개 함수 수가 늘지 않음 | truncation ABI와 기존 호출자 동작을 깨뜨리고 JDK 경로를 해결하지 못함 | 채택하지 않음 |
+| JDK 25 `BodyHandlers.limiting()` 사용 | JDK client 경로의 코드가 짧음 | HC5와 primitive·예외가 분리되고 공통 모듈의 지원 범위를 JDK 25 API에 결합함 | 채택하지 않음 |
+| `InputStream` primitive와 얇은 HC5/JDK adapter 추가 | byte 판정과 예외를 한 곳에서 재사용하고 transport별 소유권만 분리 가능 | additive public API와 명시적 테스트가 필요함 | **채택** |
+
+사용자는 2026-09-06에 마지막 대안을 승인했다.
+
+## 5. 공개 API 계약
+
+### 5.1 `bluetape4k-io`
+
+`io.bluetape4k.io` package에 다음 API를 추가한다.
+
+```kotlin
+class ByteLimitExceededException(
+    val maxBytes: Int,
+) : IOException
+
+fun InputStream.readAllBytes(maxBytes: Int): ByteArray
+```
+
+계약은 다음과 같다.
+
+- `maxBytes`는 0 이상이어야 한다. 음수이면 읽기 전에 `IllegalArgumentException`을
+  발생시킨다. 모든 HTTP adapter도 body와 metadata에 접근하기 전에 같은 검증을 먼저
+  수행한다.
+- EOF까지 읽은 실제 byte 수가 `maxBytes` 이하이면 정확한 길이의 `ByteArray`를 반환한다.
+- 실제 byte 수가 `maxBytes`보다 크면 `ByteLimitExceededException`을 발생시키며, 이미
+  읽은 부분 payload를 반환하거나 예외 메시지에 포함하지 않는다.
+- 초과 여부를 판정하기 위해 상한 이후 최대 1 byte만 추가로 읽는다. 초과가 확인된 뒤
+  남은 stream은 소비하지 않는다.
+- 함수는 caller가 소유한 `InputStream`을 닫지 않는다. 성공, 초과, 읽기 실패 모두 같다.
+- 초과 판정에 사용한 1 byte는 이미 소비되며 원래 stream으로 되돌리지 않는다. 예외가
+  발생한 뒤 stream은 최대 `maxBytes + 1` byte를 소비한 위치에 열린 채로 남는다.
+- 원본 stream의 읽기 예외는 감싸지 않고 그대로 전달한다.
+- `maxBytes == 0`이면 첫 읽기가 EOF일 때 빈 배열을 반환하고, 1 byte라도 있으면 전용
+  예외를 발생시킨다.
+- accumulator는 `maxBytes` 크기를 선할당하거나 자동 배수 확장
+  `ByteArrayOutputStream`을 사용하지 않는다. 작은 segment에서 시작해 실제로 읽은 만큼만
+  점진적으로 늘리고, 모든 segment capacity의 합은 `maxBytes`를 넘지 않는다. 초과 확인
+  byte는 단일 정수로만 보관한다. 성공 시 정확한 길이의 결과 배열을 만들기 위한 복사
+  때문에 순간 최대 payload 메모리는 `2 * actualBytes + O(segmentSize)` 이내이며 항상
+  `O(maxBytes)`다. 입력 크기에 비례해 상한 없이 증가하지 않는다.
+
+`Int.MAX_VALUE`를 포함한 모든 non-negative `Int`는 계약상 허용한다. 그러나 이 함수는
+호출자가 지정한 상한만큼의 메모리 가용성을 보장하지 않으며, 실제 body가 JVM의 배열 또는
+heap 한계에 가까우면 다른 `ByteArray` 생성 API와 마찬가지로 `OutOfMemoryError`가 발생할
+수 있다. adapter에는 안전하지 않은 기본 상한을 두지 않고 caller가 요청 종류와 최대
+동시성에 맞는 유한한 `maxBytes`를 반드시 전달하게 한다. 내부 남은 용량 계산은
+`maxBytes + 1`을 만들지 않고 subtraction 또는 `Long` 계수로 수행해 정수 overflow를
+방지한다. `Int.MAX_VALUE`와 작은 body 조합은 큰 배열을 선할당하지 않아야 한다.
+
+`ByteLimitExceededException`은 허용 상한인 `maxBytes`만 안정된 공개 정보로 제공한다.
+생성자는 `maxBytes >= 0` 불변조건을 검사한다. 실제 body 내용, 부분 결과, 마지막 byte는
+보관하거나 메시지로 노출하지 않는다. `message`는 사람이 읽을 수 있는 설명이지만 정확한
+문구는 호환성 계약이 아니며 caller는 type과 `maxBytes`만 사용한다.
+
+### 5.2 HC5 adapter
+
+`io.bluetape4k.http.hc5.entity` package에 다음 API를 추가한다.
+
+```kotlin
+fun HttpEntity?.readBodyBytes(maxBytes: Int): ByteArray
+
+fun HttpEntity?.readBodyString(
+    maxBytes: Int,
+    charset: Charset = Charsets.UTF_8,
+): String
+```
+
+계약은 다음과 같다.
+
+- null entity와 콘텐츠가 없는 entity는 빈 `ByteArray` 또는 빈 문자열을 반환한다. 이는
+  새 strict adapter가 “읽을 body 없음”을 성공한 0-byte body로 정규화하는 의도된 계약이다.
+  body 부재와 빈 body를 구분해야 하는 caller는
+  `entity?.let { it.readBodyBytes(maxBytes) }`를 사용해 null을 보존한다.
+- 음수 `maxBytes`는 entity metadata나 content에 접근하기 전에 거부한다. 이 경우
+  adapter가 body 소유권을 얻지 않았으므로 닫지 않는다.
+- `contentLength >= 0`이고 `contentLength > maxBytes`이면 body를 읽지 않고 전용 예외로
+  조기 거부한다. overflow 예외를 primary로 만든 뒤 content stream 획득과 close를
+  시도하며, 획득 또는 close 실패는 overflow 예외의 `suppressed`로 보존한다. content
+  accessor가 null을 반환하거나 실패해 stream을 얻지 못하면 adapter가 더 닫을 자원은
+  없다.
+- 길이가 unknown이거나 `maxBytes` 이하로 선언됐어도 공통 primitive로 실제 byte 수를
+  검사한다. 헤더보다 실제 body가 길면 전용 예외로 실패한다.
+- adapter는 entity content stream을 소유하며 성공·초과·읽기 실패에서 항상 닫는다.
+- 읽기 또는 초과 예외가 primary failure이고 close도 실패하면 close 예외를
+  `suppressed`로 보존한다. 읽기는 성공했지만 close만 실패하면 close 예외를 전달한다.
+- 문자열 함수는 bounded byte 읽기가 성공한 뒤 지정된 `Charset`으로 변환한다. 기본값은
+  UTF-8이며 문자 수를 별도로 제한하지 않는다.
+- 함수 전체는 blocking이며 coroutine cancellation을 직접 지원하지 않는다. caller는
+  transport의 connect/response/read timeout을 설정하고, 취소 시 해당 response 또는
+  stream을 닫을 수 있는 수명주기를 구성해야 한다. `Dispatchers.IO` 사용은 호출 스레드
+  격리일 뿐 underlying I/O 중단을 보장하지 않는다.
+- known oversize의 “읽지 않음”은 content byte에 대한 보장이다. content accessor와
+  close는 lazy transport 동작에 따라 blocking될 수 있으며 adapter는 비차단 조기 거부를
+  보장하지 않는다.
+
+### 5.3 JDK `HttpResponse<InputStream>` adapter
+
+`io.bluetape4k.http.jdk` package에 다음 API를 추가한다.
+
+```kotlin
+fun HttpResponse<InputStream>.readBodyBytes(maxBytes: Int): ByteArray
+
+fun HttpResponse<InputStream>.readBodyString(
+    maxBytes: Int,
+    charset: Charset = Charsets.UTF_8,
+): String
+```
+
+계약은 다음과 같다.
+
+- 음수 `maxBytes`는 response header나 body에 접근하기 전에 거부한다. 이 경우 adapter가
+  body 소유권을 얻지 않았으므로 닫지 않는다.
+- `Content-Length` header가 정확히 하나이고 overflow 없이 non-negative `Long`으로
+  해석되며 `maxBytes`보다 크면 body를 읽지 않고 전용 예외로 조기 거부한다. header가
+  없거나, 여러 개이거나, malformed·negative·`Long` overflow이면 metadata를 unknown으로
+  취급하고 실제 body를 읽어 판정한다. HTTP framing 자체의 유효성·smuggling 방어는 JDK
+  client와 앞단 proxy의 책임이다.
+- header가 없거나 실제 길이와 달라도 공통 primitive로 실제 byte 수를 검사한다.
+- adapter는 `response.body()`가 반환한 `InputStream`을 소유하며 성공·초과·읽기 실패에서
+  항상 닫는다.
+- primary failure와 close failure의 결합 규칙은 HC5 adapter와 같다.
+- adapter는 응답 status를 해석하지 않는다. 2xx 외 body도 caller가 호출하면 같은 규칙으로
+  읽는다.
+- adapter는 `HttpClient`, caller의 executor, request 또는 response 객체 자체를 닫지 않는다.
+- 문자열 함수는 byte 제한 성공 후 지정된 `Charset`으로 변환한다.
+- 함수 전체는 blocking/non-cancellable이며 caller timeout과 취소 책임은 HC5 adapter와
+  같다. body accessor가 stream을 반환하기 전에 실패하면 그 예외가 primary이며 adapter가
+  닫을 stream은 없다. known oversize에서는 overflow 예외를 primary로 만든 뒤 body
+  accessor와 close 실패를 `suppressed`로 보존한다.
+
+## 6. 내부 구현 경계
+
+1. `InputStream.readAllBytes(maxBytes)`가 유일한 byte-limit 판정 primitive다.
+2. primitive는 상한 안에서만 segment를 점진 할당한다. 누적 byte가 `maxBytes`에 도달하면
+   `read()`를 정확히 한 번 호출해 EOF와 초과를 구분하며 `maxBytes + 1` 산술을 사용하지
+   않는다. 양의 길이 bulk read가 0을 반환하면 즉시 단일 `read()`로 전환한다. 단일
+   `read()`는 EOF, 예외, 또는 한 byte 중 하나를 반환하므로 0-byte retry loop를 만들지
+   않는다.
+3. HC5/JDK adapter는 길이 metadata를 조기 거부에만 사용하고, 허용 후보는 반드시
+   primitive에 전달한다.
+4. adapter의 close는 Kotlin `use`와 동일한 primary/suppressed 규칙을 따른다. 조기 거부는
+   overflow 예외를 먼저 만든 뒤 body accessor와 close를 시도해 cleanup 실패가 거부
+   원인을 가리지 않게 한다. body accessor 실패 전에는 stream 소유권을 얻지 못하므로
+   transport 전체 abort를 보장하지 않는다. caller는 response/client별 상위 cleanup
+   경계를 별도로 소유한다.
+5. 문자열 함수는 byte 함수에만 위임한다. 별도의 reader 기반 제한 로직을 만들지 않는다.
+6. 기존 `toByteArrayOrNull`, `toStringOrNull`, `consume`, `consumeQuietly`는 수정하지 않는다.
+7. 이 helper는 그 자체로 decompression bomb 방어 경계가 아니다. caller는 transport의
+   투명 압축 해제 여부를 확인하고, helper 뒤에서 압축을 해제한다면 해제 결과에도 별도
+   byte 상한을 적용한다. 압축 정책을 알 수 없는 untrusted 응답은 decode 전에 거부한다.
+8. 정확히 상한만큼 읽은 뒤 EOF 또는 다음 byte를 확인하는 마지막 `read()`도 blocking될
+   수 있다. helper 내부 deadline은 없으며 caller가 transport timeout과 외부 수명주기로
+   제한한다.
+
+### 6.1 Adapter 자원 상태 전이
+
+| 단계 | 동작 | primary failure | cleanup |
+|---|---|---|---|
+| 상한 검증 실패 | metadata/body accessor 미호출 | `IllegalArgumentException` | adapter가 얻은 자원 없음 |
+| known oversize | `ByteLimitExceededException`을 먼저 생성하고 body accessor 호출, content byte는 읽지 않음 | overflow 예외 | 획득한 stream close, accessor/close 실패는 suppressed |
+| 허용 또는 unknown 길이 | body accessor 뒤 공통 primitive 호출 | accessor/read/overflow 중 먼저 발생한 실패 | 획득한 stream close, close 실패는 suppressed |
+| 읽기 성공 | 정확한 결과 생성 | close가 실패하면 close 예외 | stream close 후에만 결과 반환 |
+| accessor가 stream 반환 전 실패 | body 읽기 미시작 | accessor 예외. known oversize이면 overflow가 primary | adapter가 닫을 stream 없음, caller의 상위 response cleanup 필요 |
+
+소유권은 body accessor가 stream을 반환한 시점에 adapter로 이전된다. adapter는 반환받은
+stream의 close를 정확히 한 번 시도한다. HC5 response나 JDK `HttpClient` 전체 수명주기는
+이전되지 않는다.
+
+### 6.2 Bounded completion 운영 계약
+
+이 API는 동기·blocking helper이므로 자체적으로 완료 시간을 제한할 수 없다. bounded
+completion이 필요한 application은 다음 조건을 모두 충족해야 한다.
+
+1. HTTP client가 제공하는 connect/response/socket/read timeout을 적용한다.
+2. helper 호출을 event-loop가 아닌 blocking I/O 실행 경계에 둔다.
+3. 외부 deadline이 만료되면 supervisor가 body stream 또는 상위 response를 닫아 진행 중
+   read를 중단할 수 있게 수명주기를 소유한다. coroutine job 취소만으로는 충분하지 않다.
+4. close 자체가 멈출 수 있는 transport라면 client pool의 eviction/abort 기능과 운영
+   timeout을 사용한다. 이 범용 adapter는 transport별 강제 abort API를 호출하지 않는다.
+
+단위 테스트는 close될 때까지 block하는 fake stream을 별도 task에서 읽고 supervisor
+close로 종료되는지 검증한다. 실제 client timeout 설정 예시는 README에 제공하되, 특정
+client 버전의 timeout이 body EOF까지 포함한다고 근거 없이 보장하지 않는다.
+
+## 7. 실패 모드와 예상 동작
+
+| 실패 모드 | 예상 동작 | 자원 상태 |
+|---|---|---|
+| 입력이 `maxBytes - 1` 또는 `maxBytes` | 전체 byte 반환 | primitive는 열어 둠, adapter는 닫음 |
+| 입력이 `maxBytes + 1` 이상 | 1 byte read-ahead 후 `ByteLimitExceededException` | primitive는 판정 byte까지 소비한 위치에 열어 둠, adapter는 닫음 |
+| known `Content-Length > maxBytes` | body를 읽지 않고 조기 거부 | adapter가 body stream을 닫음 |
+| known `Content-Length <= maxBytes`, 실제 body 초과 | 실제 읽기에서 전용 예외 | adapter가 body stream을 닫음 |
+| unknown `Content-Length`, 실제 body 초과 | 실제 읽기에서 전용 예외 | adapter가 body stream을 닫음 |
+| null HC5 entity 또는 빈 body | 빈 결과 | 열 자원 없음 또는 열린 body를 닫음 |
+| stream read 실패 | 원래 read 예외 전달 | adapter는 close 시도 |
+| 초과/read 실패 뒤 close도 실패 | 원래 예외에 close 예외를 suppressed로 추가 | close 시도 완료 |
+| 읽기 성공 뒤 close만 실패 | close 예외 전달, 성공 결과 미반환 | close 시도 완료 |
+| UTF-8 다중 byte 문자의 byte 상한 초과 | 문자 수와 무관하게 전용 예외 | adapter는 닫음 |
+| 음수 `maxBytes` | body/metadata 접근 전 `IllegalArgumentException` | primitive는 열어 둠, adapter는 body 소유권을 얻지 않음 |
+| malformed·중복·overflow `Content-Length` | metadata를 unknown으로 취급하고 실제 byte 검사 | adapter는 body를 닫음 |
+| body accessor 실패 | accessor 예외 전달. known oversize이면 overflow 예외에 suppressed | 획득한 stream이 없으므로 상위 cleanup 필요 |
+| 상한 byte 뒤 peer가 멈춤 | 마지막 판정 read가 transport timeout까지 blocking | caller가 timeout·취소·상위 cleanup 소유 |
+| helper 뒤 압축 해제 결과가 팽창 | 이 helper만으로 차단되지 않음 | caller가 decoded byte 상한 적용 |
+
+## 8. 테스트 전략
+
+### 8.1 공통 primitive
+
+`InputStreamSupportTest` 또는 전용 `BoundedInputStreamSupportTest`에서 다음을 검증한다.
+
+- `1 <= maxBytes < Int.MAX_VALUE`에서 `maxBytes - 1`, `maxBytes`, `maxBytes + 1`을,
+  별도 사례에서 `maxBytes == 0`을 검증
+- 생성형 stream이 초과 시 정확히 `maxBytes + 1`까지만 제공했는지 추적
+- `Int.MAX_VALUE` 상한과 작은 body에서 큰 배열을 선할당하지 않고 정수 overflow 없이
+  완료하는지 확인
+- 작은 body/큰 상한과 상한에 가까운 body에서 segment capacity 합이 상한을 넘지 않는지
+  구현 불변식과 코드 검토로 확인한다. tracking stream은 read 수와 결과 크기만 검증하며
+  JVM 배열 allocation을 관찰할 수 있다고 주장하지 않는다.
+- 성공·초과·read 실패에서 primitive가 stream을 닫지 않음
+- 초과 후 stream이 판정 byte까지 소비된 위치에 있고 나머지는 읽지 않았는지 확인
+- read 실패 인스턴스와 stack/cause를 그대로 보존
+- 전용 예외가 부분 payload를 필드나 메시지로 노출하지 않음
+- `read(byteArray)`가 반복적으로 0을 반환해도 단일 `read()` 전환으로 진행하며 bulk retry
+  loop를 만들지 않음
+
+### 8.2 HC5 adapter
+
+`HttpEntitySupportTest`에서 다음을 검증한다.
+
+- known/unknown `Content-Length`의 경계값
+- header보다 실제 body가 짧거나 긴 mismatch
+- null entity, empty entity
+- 음수 상한이 metadata/content 접근 전에 실패함
+- 조기 거부 시 read 0회와 close 1회
+- 조기 거부 시 body accessor/close 실패가 overflow 예외에 suppressed로 보존됨
+- 성공·초과·read 실패 시 close 1회
+- read/overflow failure가 primary이고 close failure가 suppressed인지 확인
+- UTF-8 다중 byte 입력을 byte 기준으로 거부
+- 기존 truncation 함수가 이전처럼 잘린 결과를 반환하는 회귀
+
+### 8.3 JDK adapter
+
+네트워크나 container 없이 동작하는 fake `HttpResponse<InputStream>`을 사용한
+`JdkHttpResponseSupportTest`를 추가한다.
+
+- header 없음, 정상 길이, 실제 길이 mismatch
+- malformed·negative·overflow·중복 `Content-Length`를 unknown으로 처리
+- 경계값과 조기 거부 read/close 추적
+- 성공·초과·read 실패·close 실패 결합
+- status code와 무관하게 같은 body 규칙 적용
+- adapter가 body stream 외의 client/executor 수명주기를 건드리지 않음
+- UTF-8 다중 byte 입력의 byte 기준 판정
+- 정확히 상한까지 전달한 뒤 멈춘 stream이 caller가 설정한 transport timeout으로 종료됨
+- close될 때까지 block하는 fake stream이 외부 supervisor close로 종료되고 adapter가
+  double-close하지 않음
+
+### 8.4 공개 문서 예제
+
+KDoc와 README는 소유권 차이가 드러나는 다음 형태를 컴파일 가능한 import와 함께 제공한다.
+
+```kotlin
+// raw InputStream은 caller가 소유한다.
+val bytes = inputStream.use { it.readAllBytes(maxBytes = 64 * 1024) }
+
+// HC5 adapter는 entity content만 닫는다. response 자체는 caller가 닫는다.
+httpClient.execute(request).use { response ->
+    val body = response.entity.readBodyBytes(maxBytes = 64 * 1024)
+}
+
+// JDK adapter는 BodyHandlers.ofInputStream()이 만든 body stream을 닫는다.
+val response = jdkClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+val body = response.readBodyBytes(maxBytes = 64 * 1024)
+```
+
+호출자는 필요하면 `ByteLimitExceededException`을 별도로 catch하고, 예외 `message`가 아닌
+type과 `maxBytes`로 분기한다. coroutine/event-loop 예제는 직접 호출을 금지하고 blocking
+I/O dispatcher, client timeout, 외부 close 수명주기를 함께 보여 준다.
+
+### 8.5 검증 순서
+
+1. 새 계약 테스트를 먼저 작성해 RED를 확인한다.
+2. `bluetape4k-io` primitive를 구현하고 해당 테스트를 GREEN으로 만든다.
+3. HC5/JDK adapter 테스트를 RED로 확인한 뒤 공통 primitive 위임으로 GREEN을 만든다.
+4. module-scoped test와 check를 실행한다.
+5. public ABI/API dump와 문서 검사, `git diff --check`를 실행한다.
+6. Docker image가 필요한 기존 JDK 통합 테스트 실패는 변경 코드와 분리해 기록하되,
+   신규 adapter 검증은 container 없는 단위 테스트로 완결한다.
+
+## 9. 호환성과 소비자 전환
+
+- 모든 API는 additive다. 기존 public JVM descriptor와 기본 동작을 변경하지 않는다.
+- `toByteArrayOrNull(maxResultLength)`와 `toStringOrNull(maxResultLength)`는 반환 길이를
+  제한하거나 자를 수 있는 기존 용도로 유지한다. 입력 초과를 오류로 다뤄야 하는
+  caller만 새 `readBody*` API를 사용한다.
+- `InputStream.readAllBytes()`라는 JDK member와 새 `readAllBytes(maxBytes)` extension은
+  인자 수가 달라 source 호출이 명확하다. 기존 무인자 호출은 영향을 받지 않는다.
+- 새 예외는 `IOException` 하위 타입이므로 기존 I/O 실패 처리와 결합할 수 있다. 초과를
+  구분해야 하는 caller만 구체 타입을 먼저 처리한다.
+- Workshop과 Clinic 전환은 공통 라이브러리 버전이 제공된 뒤 각 이슈에서 수행한다.
+  두 소비자는 수동 loop를 제거하되 status/auth/retry/decode 정책은 그대로 소유한다.
+- JDK 25 전용 handler를 사용하지 않으므로 모듈의 기존 target과 binary 계약을 별도로
+  높이지 않는다.
+- `maxBytes`는 신뢰되지 않은 원격 입력에서 직접 정하지 않는다. application이 요청 종류,
+  동시성, heap 예산에 맞춘 유한한 상한을 설정하고 외부 사용자가 이를 늘릴 수 없게 한다.
+- application의 최악 payload 예산은 최소한
+  `동시 bounded read 수 * (2 * maxBytes + segment overhead)`를 기준으로 잡고, 허용 heap
+  예산을 넘는 설정은 startup validation에서 거부한다. library는 배포 환경의 동시성과
+  heap을 알 수 없으므로 임의의 전역 최대값을 강제하지 않는다.
+- 제한 계층은 adapter에 실제 전달된 stream이다. transparent content decoding과 후속
+  decompression을 사용하는 application은 decoded 결과 상한을 별도로 검증한다.
+
+호출자 선택 기준은 다음과 같다.
+
+| 요구 | 사용할 API | 결과 |
+|---|---|---|
+| 미리보기·진단처럼 의도적으로 앞부분만 필요 | 기존 `toByteArrayOrNull(maxResultLength)` 또는 `toStringOrNull(...)` | 상한에서 잘릴 수 있음 |
+| JSON/schema처럼 전체 body가 상한 안에 있어야 유효 | 새 `readBodyBytes` 또는 `readBodyString` | 초과 시 전체 실패 |
+| null HC5 entity와 빈 body 구분 필요 | `entity?.let { it.readBodyBytes(maxBytes) }` | null 보존 |
+| caller-owned 일반 stream | `input.use { it.readAllBytes(maxBytes) }` | caller가 close |
+
+Workshop #939는 수동 `readNBytes(maxBytes + 1)`을 HC5 strict adapter로 바꾸되 status와
+JSON decode는 기존 계층에 남긴다. Clinic #451은 수동 JDK stream loop를 JDK strict
+adapter로 바꾸되 status/auth/schema decode 정책은 기존 계층에 남긴다.
+
+### 9.1 배포와 rollback 순서
+
+1. 공통 라이브러리 `2.1.0` API와 ABI 검증을 완료하고 publish한다.
+2. 각 예제 저장소가 중앙 catalog 또는 허용된 repository-local dependency override로 새
+   버전을 선택하고 compile·targeted smoke test를 수행한다.
+3. Workshop #939와 Clinic #451을 각각 독립 PR로 전환한다.
+4. 소비자 회귀가 발생하면 dependency와 수동 strict loop를 이전 버전으로 되돌린다.
+   기존 truncation API는 strict 거부 semantics가 다르므로 rollback 대체재로 사용하지
+   않는다.
+5. 두 소비자 전환이 완료될 때까지 기존 수동 구현 이슈를 닫지 않는다.
+
+library helper는 log, metric, tracing side effect를 만들지 않는다. application은 payload를
+기록하지 않고 endpoint/operation과 설정된 상한 같은 low-cardinality 정보만 사용해
+`ByteLimitExceededException`, read failure, suppressed close failure를 구분 집계한다. 정상
+트래픽 대비 초과율 또는 연속 close 실패가 운영 임계치를 넘으면 upstream 계약 위반,
+공격, 잘못된 상한 설정을 조사한다.
+
+## 10. 수용 기준과 DoD
+
+- [ ] 공개 API signature와 KDoc가 이 문서의 byte·소유권 계약과 일치한다.
+- [ ] `1 <= maxBytes < Int.MAX_VALUE`에서 `maxBytes - 1`, `maxBytes`, `maxBytes + 1`을,
+  별도 사례에서 0과 음수 경계를 검증한다.
+- [ ] `Int.MAX_VALUE` 상한과 작은 body가 선할당·정수 overflow 없이 처리된다.
+- [ ] known/unknown/mismatch `Content-Length`, empty body, null HC5 entity가 검증된다.
+- [ ] malformed·negative·overflow·중복 `Content-Length`가 unknown metadata로 처리된다.
+- [ ] 초과 판정의 최대 read-ahead가 1 byte임이 검증된다.
+- [ ] accumulator가 `maxBytes`를 넘지 않고 전체 메모리가 `O(maxBytes)`임이 검증된다.
+- [ ] 성공·초과·read 실패·close 실패의 자원 및 예외 결합 규칙이 검증된다.
+- [ ] body accessor 실패, blocking read timeout, 압축 계층의 호출자 책임이 문서와 테스트에
+  반영된다.
+- [ ] read-ahead 후 primitive stream 위치와 null/empty 정규화의 migration 계약이
+  검증된다.
+- [ ] UTF-8 다중 byte 입력이 문자 수가 아닌 byte 수로 제한된다.
+- [ ] HC5와 JDK adapter가 같은 `InputStream.readAllBytes(maxBytes)`를 재사용한다.
+- [ ] 기존 truncation API의 ABI와 동작이 유지된다.
+- [ ] KDoc와 `bluetape4k-io`/`bluetape4k-http` README가 사용 선택 기준을 설명한다.
+- [ ] public KDoc/README 예제가 소유권, blocking 실행 경계, 예외 처리와 strict/truncation
+  선택을 컴파일 가능한 형태로 설명한다.
+- [ ] targeted test, module test/check, ABI/API 검사, `git diff --check`가 통과한다.
+- [ ] 독립 검토의 P0/P1 finding이 없고 P2/P3은 해결하거나 명시적으로 처분한다.
+- [ ] Workshop #939와 Clinic #451에 공통 API 가용성과 후속 전환 근거를 남긴다.
+- [ ] library publish, 소비자 smoke, 독립 전환, rollback 순서와 payload 없는 관측 지침이
+  확인된다.
+- [ ] PR 본문과 이슈가 수용 기준·검증 증거를 연결하며 CI가 통과한다.
+
+## 11. 결정되지 않은 항목
+
+없음. status 정책, JSON decode, streaming parser, 소비자 전환은 의도적으로 별도 책임과
+후속 이슈에 남긴다.

--- a/docs/testlogs/2026-09.md
+++ b/docs/testlogs/2026-09.md
@@ -7,3 +7,7 @@
 | 2026-09-04 | #1618 | `LettuceWriteBehindRetryTest` entry별 retry 및 포화 재삽입 회귀 | RED → GREEN — 핵심 2 failed, 보강 후 4 passing | `(retry=2, retry=0)` batch 분리와 queue/channel 포화 시 dead-letter key·recovery value 보존을 검증 |
 | 2026-09-04 | #1618 | Lettuce map 집중 회귀 5개 class | PASS — 42 passing | blocking/suspend exhaustion, map 동작, cancellation, 혼합 retry-count 및 포화 재삽입 경로 포함 |
 | 2026-09-04 | #1618 | `:bluetape4k-lettuce:cleanTest :bluetape4k-lettuce:check --no-build-cache --no-configuration-cache` | PASS — 928 passing | 기본 924건과 별도 topology/performance 4건, compile, Detekt, Kover 포함 `BUILD SUCCESSFUL` |
+| 2026-09-06 | #1643 | HC5 failure-composition 회귀 | RED → GREEN — 18개 중 2 failed, 수정 후 18 passing | cleanup의 `Error`·`CancellationException`이 원래 overflow/read 실패를 가리던 계약 위반을 재현하고 primary/suppressed 순서를 복원 |
+| 2026-09-06 | #1643 | post-rebase bounded body 대상 테스트 | PASS — primitive 9 passing, HC5·JDK 33 passing | `origin/develop@31ee966cf3` rebase 후 `--rerun-tasks`, 단일 worker, build/configuration cache 없이 실행 |
+| 2026-09-06 | #1643 | `:bluetape4k-io:check` | PASS — 1,274 passing | Kover 포함 `BUILD SUCCESSFUL in 18s` |
+| 2026-09-06 | #1643 | `:bluetape4k-http:check` | PENDING — 392 passing, 3 pending, 96 failing | 94개 `ContainerFetchException`과 이를 감싼 2개 `MultiException`; 모두 `bluetape4k/mock-web-server:2.1.0` pull 404, bounded test failure 0, PR CI에서 재검증 |

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -8,6 +8,58 @@
 
 Apache HttpComponents 5, OkHttp3, Vert.x HttpClient, Ktor Client 등을 일관된 방식으로 사용할 수 있으며, Kotlin Coroutines와 Virtual Threads를 기본 지원합니다.
 
+## 엄격한 상한을 적용한 전체 응답 본문
+
+전체 본문이 필요하고 상한 초과 시 prefix를 반환하지 않고 실패해야 한다면 bounded adapter를
+사용합니다.
+
+```kotlin
+import io.bluetape4k.http.hc5.entity.readBodyBytes
+
+httpClient.execute(request).use { response ->
+    val body = response.entity.readBodyBytes(maxBytes = 64 * 1024)
+}
+```
+
+```kotlin
+import io.bluetape4k.http.jdk.readBodyBytes
+import java.io.InputStream
+import java.net.http.HttpResponse
+
+val response: HttpResponse<InputStream> =
+    jdkClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+val body = response.readBodyBytes(maxBytes = 64 * 1024)
+```
+
+HC5 adapter는 획득한 entity stream을 닫지만, 상위 response는 호출자가 닫아야 합니다.
+null HC5 entity는 빈 본문이 되며, null을 보존하려면
+`response.entity?.let { it.readBodyBytes(maxBytes = 64 * 1024) }`를 사용합니다. JDK adapter는
+`HttpResponse.body()`만 닫고 client나 executor는 닫지 않습니다. 두 adapter 모두 status code를
+해석하지 않습니다.
+
+| 요구 사항 | API |
+|---|---|
+| 전체 JSON/schema 본문, 초과 시 거부 | `readBodyBytes` / `readBodyString` |
+| 진단 또는 preview prefix | 기존 HC5 `toByteArrayOrNull` / `toStringOrNull` |
+| null HC5 entity 보존 | `entity?.let { ... }` |
+| 호출자 소유 일반 stream | `inputStream.use { it.readAllBytes(maxBytes) }` |
+
+이 호출과 1-byte EOF 확인, `close()`는 blocking이며 coroutine 취소만으로 cancellable해지지
+않습니다. connect, response, read timeout을 설정하고 event loop가 아니라 blocking I/O 경계에서
+호출하세요. 작업이 멈추면 supervisor가 stream이나 상위 response를 닫아 중단할 수 있어야 합니다.
+transport별 abort 동작은 이 helper의 범위가 아닙니다.
+
+상한은 adapter가 노출한 byte에 적용됩니다. 압축 해제 뒤에는 decoded byte 상한을 별도로
+적용하세요. 일시적인 heap 사용량은 대략
+`동시 read 수 * (2 * maxBytes + segment overhead)`로 잡습니다. library는 log나 metric을
+기록하지 않습니다. application은 payload와 예외 message를 제외하고 endpoint/operation,
+max, overflow/read/close 분류만 low-cardinality로 집계할 수 있습니다.
+
+도입 순서는 library `2.1.0` publish, 중앙 catalog 또는 허용된 repo-local override로 버전 선택,
+compile 및 targeted smoke, 소비자별 독립 PR입니다. 전환이 끝날 때까지 기존 수동 strict read
+loop를 유지하세요. 회귀 시 이전 dependency와 수동 loop로 rollback하며, truncation preview
+API를 strict read의 대체재로 사용하지 않습니다.
+
 ## 아키텍처
 
 ### 전체 아키텍처: 다중 백엔드 HTTP 클라이언트

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -8,6 +8,60 @@ English | [한국어](./README.ko.md)
 
 It provides a consistent interface for Apache HttpComponents 5, OkHttp3, Vert.x HttpClient, and Ktor Client, with built-in support for Kotlin Coroutines and Virtual Threads.
 
+## Strictly bounded complete response bodies
+
+Use the bounded adapters when a complete body is required and an oversized body
+must fail instead of returning a prefix.
+
+```kotlin
+import io.bluetape4k.http.hc5.entity.readBodyBytes
+
+httpClient.execute(request).use { response ->
+    val body = response.entity.readBodyBytes(maxBytes = 64 * 1024)
+}
+```
+
+```kotlin
+import io.bluetape4k.http.jdk.readBodyBytes
+import java.io.InputStream
+import java.net.http.HttpResponse
+
+val response: HttpResponse<InputStream> =
+    jdkClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+val body = response.readBodyBytes(maxBytes = 64 * 1024)
+```
+
+The HC5 adapter closes the acquired entity stream, while the caller still closes
+the enclosing response. A null HC5 entity becomes an empty body; preserve null
+with `response.entity?.let { it.readBodyBytes(maxBytes = 64 * 1024) }`. The JDK
+adapter closes only `HttpResponse.body()` and does not close the client or its
+executor. Neither adapter interprets the status code.
+
+| Need | API |
+|---|---|
+| Complete JSON/schema body; reject overflow | `readBodyBytes` / `readBodyString` |
+| Diagnostic or preview prefix | existing HC5 `toByteArrayOrNull` / `toStringOrNull` |
+| Preserve a null HC5 entity | `entity?.let { ... }` |
+| General caller-owned stream | `inputStream.use { it.readAllBytes(maxBytes) }` |
+
+These calls, the one-byte EOF check, and `close()` are blocking and are not made
+cancellable by coroutine cancellation. Configure connect, response, and read
+timeouts, call them at a blocking-I/O boundary rather than on an event loop, and
+let a supervisor close the stream or enclosing response to abort stalled work.
+Transport-specific abort behavior is outside this helper.
+
+The limit applies to bytes exposed by the adapter. Apply a separate decoded-byte
+limit after decompression. Budget temporary heap as approximately
+`concurrent reads * (2 * maxBytes + segment overhead)`. The library emits no logs
+or metrics; applications may record low-cardinality endpoint/operation, max, and
+overflow/read/close categories, but must not record payloads or exception messages.
+
+Adoption sequence: publish library `2.1.0`, select it through the central catalog
+or an allowed repository-local override, run compile and targeted smoke tests, and
+then migrate each consumer in its own PR. Until that finishes, retain the manual
+strict read loop. Roll back to the previous dependency plus that loop; the
+truncating preview APIs are not a strict-read fallback.
+
 ## Architecture
 
 ### Overall Architecture: Multi-Backend HTTP Client

--- a/io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt
@@ -3,7 +3,6 @@ package io.bluetape4k.http
 import io.bluetape4k.io.ByteLimitExceededException
 import io.bluetape4k.io.readAllBytes
 import java.io.InputStream
-import java.util.concurrent.CancellationException
 
 internal fun readOwnedBodyBytes(
     maxBytes: Int,
@@ -23,9 +22,7 @@ internal fun readOwnedBodyBytes(
                 primary = accessorFailure
                 throw accessorFailure
             }
-            val selected = selectPrimary(current, accessorFailure)
-            primary = selected
-            if (selected !== current) throw selected
+            current.addSuppressedIfDistinct(accessorFailure)
         }
 
         primary?.let { throw it }
@@ -45,25 +42,14 @@ internal fun readOwnedBodyBytes(
             } catch (closeFailure: Throwable) {
                 val current = primary
                 if (current == null) throw closeFailure
-                val selected = selectPrimary(current, closeFailure)
-                primary = selected
-                if (selected !== current) throw selected
+                current.addSuppressedIfDistinct(closeFailure)
             }
         }
     }
 }
 
-private fun selectPrimary(current: Throwable, next: Throwable): Throwable {
-    if (current === next) return current
-
-    val primary = when {
-        current is Error -> current
-        next is Error -> next
-        current is CancellationException -> current
-        next is CancellationException -> next
-        else -> current
+private fun Throwable.addSuppressedIfDistinct(secondary: Throwable) {
+    if (this !== secondary && suppressed.none { it === secondary }) {
+        addSuppressed(secondary)
     }
-    val secondary = if (primary === current) next else current
-    if (primary.suppressed.none { it === secondary }) primary.addSuppressed(secondary)
-    return primary
 }

--- a/io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/OwnedBodySupport.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.http
+
+import io.bluetape4k.io.ByteLimitExceededException
+import io.bluetape4k.io.readAllBytes
+import java.io.InputStream
+import java.util.concurrent.CancellationException
+
+internal fun readOwnedBodyBytes(
+    maxBytes: Int,
+    knownOversize: Boolean,
+    acquireBody: () -> InputStream?,
+): ByteArray {
+    var primary: Throwable? =
+        if (knownOversize) ByteLimitExceededException(maxBytes) else null
+    var ownedStream: InputStream? = null
+
+    try {
+        try {
+            ownedStream = acquireBody()
+        } catch (accessorFailure: Throwable) {
+            val current = primary
+            if (current == null) {
+                primary = accessorFailure
+                throw accessorFailure
+            }
+            val selected = selectPrimary(current, accessorFailure)
+            primary = selected
+            if (selected !== current) throw selected
+        }
+
+        primary?.let { throw it }
+        val stream = ownedStream ?: return byteArrayOf()
+
+        return try {
+            stream.readAllBytes(maxBytes)
+        } catch (readFailure: Throwable) {
+            primary = readFailure
+            throw readFailure
+        }
+    } finally {
+        val stream = ownedStream
+        if (stream != null) {
+            try {
+                stream.close()
+            } catch (closeFailure: Throwable) {
+                val current = primary
+                if (current == null) throw closeFailure
+                val selected = selectPrimary(current, closeFailure)
+                primary = selected
+                if (selected !== current) throw selected
+            }
+        }
+    }
+}
+
+private fun selectPrimary(current: Throwable, next: Throwable): Throwable {
+    if (current === next) return current
+
+    val primary = when {
+        current is Error -> current
+        next is Error -> next
+        current is CancellationException -> current
+        next is CancellationException -> next
+        else -> current
+    }
+    val secondary = if (primary === current) next else current
+    if (primary.suppressed.none { it === secondary }) primary.addSuppressed(secondary)
+    return primary
+}

--- a/io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupport.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.http.hc5.entity
+
+import io.bluetape4k.http.readOwnedBodyBytes
+import io.bluetape4k.io.ByteLimitExceededException
+import io.bluetape4k.support.requireZeroOrPositiveNumber
+import org.apache.hc.core5.http.HttpEntity
+import java.io.IOException
+import java.nio.charset.Charset
+
+/**
+ * HC5 entity 본문을 [maxBytes] 이하일 때만 전체 [ByteArray]로 반환합니다.
+ *
+ * null entity는 빈 배열로 정규화합니다. null을 보존해야 하면 `entity?.let { ... }`을 사용합니다.
+ * `Content-Length`는 조기 거부용 힌트일 뿐이며 실제 stream에도 같은 상한을 적용합니다.
+ * 획득한 content stream은 성공과 실패 모두에서 정확히 한 번 닫지만 상위 response는 닫지 않습니다.
+ * 이 호출은 blocking될 수 있으므로 client timeout과 상위 response 중단은 호출자가 구성해야 합니다.
+ * prefix preview가 필요하면 기존 `toByteArrayOrNull`을 사용하고, 완전한 본문만 허용할 때 이 함수를 사용합니다.
+ *
+ * @throws IllegalArgumentException [maxBytes]가 음수인 경우
+ * @throws ByteLimitExceededException 본문이 [maxBytes]를 초과한 경우
+ * @throws IOException content 획득, 읽기 또는 닫기에 실패한 경우
+ */
+fun HttpEntity?.readBodyBytes(maxBytes: Int): ByteArray {
+    maxBytes.requireZeroOrPositiveNumber("maxBytes")
+    if (this == null) return byteArrayOf()
+
+    val declaredLength = contentLength
+    return readOwnedBodyBytes(
+        maxBytes = maxBytes,
+        knownOversize = declaredLength >= 0L && declaredLength > maxBytes.toLong(),
+        acquireBody = { content },
+    )
+}
+
+/**
+ * HC5 entity 본문을 byte 상한 안에서 읽고 [charset]으로 변환합니다.
+ *
+ * 상한은 변환된 문자 수가 아니라 원본 stream byte 수에 적용됩니다. stream과 상위 response의
+ * 소유권, blocking 및 strict/truncation 선택은 [readBodyBytes]와 같습니다.
+ *
+ * @throws IllegalArgumentException [maxBytes]가 음수인 경우
+ * @throws ByteLimitExceededException 본문이 [maxBytes]를 초과한 경우
+ * @throws IOException content 획득, 읽기 또는 닫기에 실패한 경우
+ */
+fun HttpEntity?.readBodyString(
+    maxBytes: Int,
+    charset: Charset = Charsets.UTF_8,
+): String = readBodyBytes(maxBytes).toString(charset)

--- a/io/http/src/main/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupport.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupport.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.http.jdk
+
+import io.bluetape4k.http.readOwnedBodyBytes
+import io.bluetape4k.io.ByteLimitExceededException
+import io.bluetape4k.support.requireZeroOrPositiveNumber
+import java.io.IOException
+import java.io.InputStream
+import java.net.http.HttpHeaders
+import java.net.http.HttpResponse
+import java.nio.charset.Charset
+
+/**
+ * JDK HTTP 응답의 body stream을 [maxBytes] 이하일 때만 전체 [ByteArray]로 반환합니다.
+ *
+ * 단일 non-negative `Content-Length`만 조기 거부 힌트로 사용하며 실제 stream에도 같은
+ * 상한을 적용합니다. status code는 해석하지 않습니다. 획득한 body stream은 성공과 실패
+ * 모두에서 정확히 한 번 닫지만 response의 다른 자원 수명은 호출자가 관리합니다.
+ *
+ * 이 호출과 마지막 EOF 확인은 blocking될 수 있습니다. client timeout을 구성하고 coroutine
+ * 취소만 의존하지 말고 supervisor가 stream이나 상위 transport를 중단할 수 있게 해야 합니다.
+ *
+ * @throws IllegalArgumentException [maxBytes]가 음수인 경우
+ * @throws ByteLimitExceededException 본문이 [maxBytes]를 초과한 경우
+ * @throws IOException body 획득, 읽기 또는 닫기에 실패한 경우
+ */
+fun HttpResponse<InputStream>.readBodyBytes(maxBytes: Int): ByteArray {
+    maxBytes.requireZeroOrPositiveNumber("maxBytes")
+    val declaredLength = headers().strictContentLengthOrNull()
+
+    return readOwnedBodyBytes(
+        maxBytes = maxBytes,
+        knownOversize = declaredLength != null && declaredLength > maxBytes.toLong(),
+        acquireBody = { body() },
+    )
+}
+
+/**
+ * JDK HTTP 응답 body를 byte 상한 안에서 읽고 [charset]으로 변환합니다.
+ *
+ * 상한은 문자 수가 아니라 body stream의 byte 수에 적용됩니다. blocking, timeout, stream
+ * ownership 및 status 처리 책임은 [readBodyBytes]와 같습니다.
+ *
+ * @throws IllegalArgumentException [maxBytes]가 음수인 경우
+ * @throws ByteLimitExceededException 본문이 [maxBytes]를 초과한 경우
+ * @throws IOException body 획득, 읽기 또는 닫기에 실패한 경우
+ */
+fun HttpResponse<InputStream>.readBodyString(
+    maxBytes: Int,
+    charset: Charset = Charsets.UTF_8,
+): String = readBodyBytes(maxBytes).toString(charset)
+
+private fun HttpHeaders.strictContentLengthOrNull(): Long? {
+    val value = allValues("Content-Length").singleOrNull() ?: return null
+    if (value.isEmpty() || value != value.trim()) return null
+    return value.toLongOrNull()?.takeIf { it >= 0L }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt
@@ -1,0 +1,348 @@
+package io.bluetape4k.http.hc5.entity
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.io.ByteLimitExceededException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.apache.hc.core5.http.ContentType
+import org.apache.hc.core5.http.HttpEntity
+import org.apache.hc.core5.http.io.entity.StringEntity
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.io.InputStream
+import java.net.SocketTimeoutException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit.SECONDS
+
+class BoundedHttpEntitySupportTest {
+
+    @Test
+    fun `null entity는 empty로 정규화한다`() {
+        val entity: HttpEntity? = null
+
+        entity.readBodyBytes(maxBytes = 0).isEmpty().shouldBeTrue()
+        entity.readBodyString(maxBytes = 4) shouldBeEqualTo ""
+    }
+
+    @Test
+    fun `known length와 실제 본문을 모두 strict 상한으로 검증하고 stream을 닫는다`() {
+        listOf(3, 4).forEach { size ->
+            val stream = TrackingInputStream(ByteArray(size) { it.toByte() })
+            val entity = entity(contentLength = size.toLong(), stream = stream)
+
+            entity.readBodyBytes(maxBytes = 4) shouldBeEqualTo ByteArray(size) { it.toByte() }
+            stream.closeCalls shouldBeEqualTo 1
+        }
+
+        listOf(5, 8).forEach { size ->
+            val stream = TrackingInputStream(ByteArray(size) { it.toByte() })
+            val entity = entity(contentLength = -1L, stream = stream)
+
+            val failure = assertFailsWith<ByteLimitExceededException> {
+                entity.readBodyBytes(maxBytes = 4)
+            }
+            failure.maxBytes shouldBeEqualTo 4
+            stream.consumedBytes shouldBeEqualTo 5
+            stream.closeCalls shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `known length는 힌트일 뿐이며 non-null empty와 더 짧은 실제 본문을 반환한다`() {
+        listOf(byteArrayOf(), byteArrayOf(1, 2)).forEach { expected ->
+            val stream = TrackingInputStream(expected)
+
+            entity(contentLength = 4L, stream = stream).readBodyBytes(maxBytes = 4) shouldBeEqualTo expected
+            stream.closeCalls shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `known length가 상한 이하여도 실제 본문이 크면 overflow다`() {
+        val stream = TrackingInputStream(ByteArray(5))
+
+        val failure = assertFailsWith<ByteLimitExceededException> {
+            entity(contentLength = 3L, stream = stream).readBodyBytes(maxBytes = 4)
+        }
+
+        failure.maxBytes shouldBeEqualTo 4
+        stream.consumedBytes shouldBeEqualTo 5
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `known oversize는 content를 읽지 않고 획득한 stream을 닫는다`() {
+        val stream = TrackingInputStream(ByteArray(8))
+        val entity = entity(contentLength = 8L, stream = stream)
+
+        val failure = assertFailsWith<ByteLimitExceededException> {
+            entity.readBodyBytes(maxBytes = 4)
+        }
+
+        failure.maxBytes shouldBeEqualTo 4
+        stream.consumedBytes shouldBeEqualTo 0
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `음수 상한은 metadata와 content accessor 전에 거부한다`() {
+        val entity = mockk<HttpEntity>()
+        val nullable: HttpEntity? = null
+
+        assertFailsWith<IllegalArgumentException> { entity.readBodyBytes(maxBytes = -1) }
+        assertFailsWith<IllegalArgumentException> { nullable.readBodyBytes(maxBytes = -1) }
+
+        verify(exactly = 0) { entity.contentLength }
+        verify(exactly = 0) { entity.content }
+    }
+
+    @Test
+    fun `known oversize는 accessor 실패를 suppressed로 보존한다`() {
+        val accessorFailure = IOException("content accessor failed")
+        val entity = mockk<HttpEntity>()
+        every { entity.contentLength } returns 8L
+        every { entity.content } throws accessorFailure
+
+        val failure = assertFailsWith<ByteLimitExceededException> {
+            entity.readBodyBytes(maxBytes = 4)
+        }
+
+        failure.suppressed.single() shouldBeSameInstanceAs accessorFailure
+    }
+
+    @Test
+    fun `known oversize accessor cancellation은 제어 흐름을 primary로 보존한다`() {
+        val cancellation = CancellationException("cancelled")
+        val entity = mockk<HttpEntity>()
+        every { entity.contentLength } returns 8L
+        every { entity.content } throws cancellation
+
+        val actual = assertFailsWith<CancellationException> {
+            entity.readBodyBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs cancellation
+        (actual.suppressed.single() as ByteLimitExceededException).maxBytes shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `read와 close 실패의 primary와 suppressed identity를 보존한다`() {
+        val readFailure = IOException("read failed")
+        val closeFailure = IOException("close failed")
+        val stream = TrackingInputStream(byteArrayOf(1), readFailure = readFailure, closeFailure = closeFailure)
+
+        val actual = assertFailsWith<IOException> {
+            entity(contentLength = -1L, stream = stream).readBodyBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs readFailure
+        actual.suppressed.single() shouldBeSameInstanceAs closeFailure
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `overflow와 close 실패는 overflow를 primary로 보존한다`() {
+        val closeFailure = IOException("close failed")
+        val stream = TrackingInputStream(ByteArray(5), closeFailure = closeFailure)
+
+        val actual = assertFailsWith<ByteLimitExceededException> {
+            entity(contentLength = -1L, stream = stream).readBodyBytes(maxBytes = 4)
+        }
+
+        actual.maxBytes shouldBeEqualTo 4
+        actual.suppressed.single() shouldBeSameInstanceAs closeFailure
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `close fatal error는 일반 read 실패보다 우선한다`() {
+        val readFailure = IOException("read failed")
+        val fatal = LinkageError("fatal close")
+        val stream = TrackingInputStream(byteArrayOf(1), readFailure = readFailure, closeFailure = fatal)
+
+        val actual = assertFailsWith<LinkageError> {
+            entity(contentLength = -1L, stream = stream).readBodyBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs fatal
+        actual.suppressed.single() shouldBeSameInstanceAs readFailure
+    }
+
+    @Test
+    fun `성공 뒤 close 실패는 결과 대신 원본 close 실패를 던진다`() {
+        val closeFailure = IOException("close failed")
+        val stream = TrackingInputStream(byteArrayOf(1), closeFailure = closeFailure)
+
+        val actual = assertFailsWith<IOException> {
+            entity(contentLength = 1L, stream = stream).readBodyBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs closeFailure
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `read와 close가 같은 실패를 던져도 self suppression하지 않는다`() {
+        val shared = IOException("shared failure")
+        val stream = TrackingInputStream(byteArrayOf(1), readFailure = shared, closeFailure = shared)
+
+        val actual = assertFailsWith<IOException> {
+            entity(contentLength = -1L, stream = stream).readBodyBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs shared
+        actual.suppressed.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `문자열 상한은 character가 아니라 UTF-8 byte에 적용한다`() {
+        assertFailsWith<ByteLimitExceededException> {
+            entity(contentLength = -1L, stream = TrackingInputStream("가나".toByteArray()))
+                .readBodyString(maxBytes = 5)
+        }
+
+        entity(contentLength = -1L, stream = TrackingInputStream("가나".toByteArray()))
+            .readBodyString(maxBytes = 6) shouldBeEqualTo "가나"
+    }
+
+    @Test
+    fun `known oversize accessor block은 supervisor abort 후 bounded하게 종료한다`() {
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val timeout = SocketTimeoutException("accessor timeout")
+        val entity = mockk<HttpEntity>()
+        every { entity.contentLength } returns 8L
+        every { entity.content } answers {
+            entered.countDown()
+            release.await()
+            throw timeout
+        }
+
+        withVirtualExecutor { executor ->
+            val future = executor.submit<ByteArray> { entity.readBodyBytes(maxBytes = 4) }
+            try {
+                entered.await(5, SECONDS).shouldBeTrue()
+                release.countDown()
+                val wrapper = assertFailsWith<ExecutionException> { future.get(5, SECONDS) }
+                val failure = wrapper.cause as ByteLimitExceededException
+                failure.suppressed.single() shouldBeSameInstanceAs timeout
+            } finally {
+                release.countDown()
+                future.cancel(true)
+            }
+        }
+    }
+
+    @Test
+    fun `known oversize close block은 supervisor abort 후 bounded하게 종료한다`() {
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val stream = object: TrackingInputStream(ByteArray(8)) {
+            override fun close() {
+                closeCalls++
+                entered.countDown()
+                release.await()
+            }
+        }
+
+        withVirtualExecutor { executor ->
+            val future = executor.submit<ByteArray> {
+                entity(contentLength = 8L, stream = stream).readBodyBytes(maxBytes = 4)
+            }
+            try {
+                entered.await(5, SECONDS).shouldBeTrue()
+                stream.consumedBytes shouldBeEqualTo 0
+                release.countDown()
+                val wrapper = assertFailsWith<ExecutionException> { future.get(5, SECONDS) }
+                (wrapper.cause as ByteLimitExceededException).maxBytes shouldBeEqualTo 4
+                stream.closeCalls shouldBeEqualTo 1
+            } finally {
+                release.countDown()
+                future.cancel(true)
+            }
+        }
+    }
+
+    @Test
+    fun `기존 API는 strict failure가 아니라 prefix truncation을 유지한다`() {
+        StringEntity("12345", ContentType.TEXT_PLAIN).toByteArrayOrNull(maxResultLength = 4)!!
+            .toString(Charsets.UTF_8) shouldBeEqualTo "1234"
+        StringEntity("12345", ContentType.TEXT_PLAIN)
+            .toStringOrNull(maxResultLength = 4) shouldBeEqualTo "1234"
+    }
+
+    @Test
+    fun `README 공개 예제는 response와 entity content 수명을 구분한다`() {
+        val stream = TrackingInputStream("body".toByteArray())
+        val responseEntity = entity(contentLength = 4L, stream = stream)
+        val response = BasicClassicHttpResponse(200).apply {
+            entity = responseEntity
+        }
+
+        response.use {
+            it.entity.readBodyBytes(maxBytes = 64 * 1024) shouldBeEqualTo "body".toByteArray()
+        }
+
+        stream.closeCalls shouldBeEqualTo 1
+        verify(exactly = 1) { responseEntity.close() }
+    }
+
+    private fun entity(contentLength: Long, stream: InputStream): HttpEntity =
+        mockk<HttpEntity>(relaxed = true).also { entity ->
+            every { entity.contentLength } returns contentLength
+            every { entity.content } returns stream
+        }
+
+    private inline fun <T> withVirtualExecutor(block: (java.util.concurrent.ExecutorService) -> T): T {
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        try {
+            return block(executor)
+        } finally {
+            executor.shutdownNow()
+            executor.awaitTermination(5, SECONDS).shouldBeTrue()
+        }
+    }
+
+    private open class TrackingInputStream(
+        private val source: ByteArray,
+        private val readFailure: Throwable? = null,
+        private val closeFailure: Throwable? = null,
+    ): InputStream() {
+        private var position = 0
+
+        var consumedBytes: Int = 0
+            private set
+        var closeCalls: Int = 0
+            protected set
+
+        override fun read(): Int {
+            readFailure?.let { throw it }
+            if (position >= source.size) return -1
+            consumedBytes++
+            return source[position++].toInt() and 0xff
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            readFailure?.let { throw it }
+            if (position >= source.size) return -1
+            val count = minOf(length, source.size - position)
+            source.copyInto(buffer, offset, position, position + count)
+            position += count
+            consumedBytes += count
+            return count
+        }
+
+        override fun close() {
+            closeCalls++
+            closeFailure?.let { throw it }
+        }
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/hc5/entity/BoundedHttpEntitySupportTest.kt
@@ -119,18 +119,18 @@ class BoundedHttpEntitySupportTest {
     }
 
     @Test
-    fun `known oversize accessor cancellation은 제어 흐름을 primary로 보존한다`() {
+    fun `known oversize accessor cancellation은 overflow primary에 suppressed로 보존한다`() {
         val cancellation = CancellationException("cancelled")
         val entity = mockk<HttpEntity>()
         every { entity.contentLength } returns 8L
         every { entity.content } throws cancellation
 
-        val actual = assertFailsWith<CancellationException> {
+        val actual = assertFailsWith<ByteLimitExceededException> {
             entity.readBodyBytes(maxBytes = 4)
         }
 
-        actual shouldBeSameInstanceAs cancellation
-        (actual.suppressed.single() as ByteLimitExceededException).maxBytes shouldBeEqualTo 4
+        actual.maxBytes shouldBeEqualTo 4
+        actual.suppressed.single() shouldBeSameInstanceAs cancellation
     }
 
     @Test
@@ -163,17 +163,17 @@ class BoundedHttpEntitySupportTest {
     }
 
     @Test
-    fun `close fatal error는 일반 read 실패보다 우선한다`() {
+    fun `close fatal error도 원래 read 실패에 suppressed로 보존한다`() {
         val readFailure = IOException("read failed")
         val fatal = LinkageError("fatal close")
         val stream = TrackingInputStream(byteArrayOf(1), readFailure = readFailure, closeFailure = fatal)
 
-        val actual = assertFailsWith<LinkageError> {
+        val actual = assertFailsWith<IOException> {
             entity(contentLength = -1L, stream = stream).readBodyBytes(maxBytes = 4)
         }
 
-        actual shouldBeSameInstanceAs fatal
-        actual.suppressed.single() shouldBeSameInstanceAs readFailure
+        actual shouldBeSameInstanceAs readFailure
+        actual.suppressed.single() shouldBeSameInstanceAs fatal
     }
 
     @Test

--- a/io/http/src/test/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupportTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/jdk/BoundedHttpResponseSupportTest.kt
@@ -1,0 +1,397 @@
+package io.bluetape4k.http.jdk
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.io.ByteLimitExceededException
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.io.InputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Optional
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit.SECONDS
+import javax.net.ssl.SSLSession
+
+class BoundedHttpResponseSupportTest {
+
+    @Test
+    fun `Content-Length 단일 non-negative 값만 known length로 사용한다`() {
+        val knownStream = TrackingInputStream(ByteArray(4) { it.toByte() })
+        val knownResponse = FakeHttpResponse(
+            stream = knownStream,
+            headerValues = mapOf("Content-Length" to listOf("4")),
+        )
+
+        knownResponse.readBodyBytes(maxBytes = 4) shouldBeEqualTo ByteArray(4) { it.toByte() }
+        knownStream.consumedBytes shouldBeEqualTo 4
+        knownStream.closeCalls shouldBeEqualTo 1
+
+        val unknownHeaders = listOf(
+            emptyMap(),
+            mapOf("Content-Length" to listOf("4, 4")),
+            mapOf("Content-Length" to listOf("abc")),
+            mapOf("Content-Length" to listOf("-1")),
+            mapOf("Content-Length" to listOf("9223372036854775808")),
+            mapOf("Content-Length" to listOf("4", "4")),
+        )
+
+        unknownHeaders.forEach { headers ->
+            val stream = TrackingInputStream(ByteArray(5) { it.toByte() })
+            val response = FakeHttpResponse(stream = stream, headerValues = headers)
+
+            assertFailsWith<ByteLimitExceededException> {
+                response.readBodyBytes(maxBytes = 4)
+            }
+            stream.consumedBytes shouldBeEqualTo 5
+            stream.closeCalls shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `known oversize header는 body를 읽지 않고 닫는다`() {
+        listOf("5", "+5", " 5 ", Long.MAX_VALUE.toString()).forEach { value ->
+            val stream = TrackingInputStream(ByteArray(8))
+            val response = FakeHttpResponse(
+                stream = stream,
+                headerValues = mapOf("Content-Length" to listOf(value)),
+            )
+
+            val failure = assertFailsWith<ByteLimitExceededException> {
+                response.readBodyBytes(maxBytes = 4)
+            }
+
+            failure.maxBytes shouldBeEqualTo 4
+            stream.consumedBytes shouldBeEqualTo 0
+            stream.closeCalls shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `declared length가 작아도 실제 body가 크면 overflow다`() {
+        val stream = TrackingInputStream(ByteArray(5))
+        val response = FakeHttpResponse(
+            stream = stream,
+            headerValues = mapOf("Content-Length" to listOf("3")),
+        )
+
+        assertFailsWith<ByteLimitExceededException> { response.readBodyBytes(maxBytes = 4) }
+        stream.consumedBytes shouldBeEqualTo 5
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `status code와 무관하게 body 계약을 적용한다`() {
+        listOf(200, 404, 500).forEach { status ->
+            val stream = TrackingInputStream("body".toByteArray())
+            val response = FakeHttpResponse(stream = stream, code = status)
+
+            response.readBodyString(maxBytes = 4) shouldBeEqualTo "body"
+            stream.closeCalls shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `음수 상한은 headers와 body accessor 전에 거부한다`() {
+        val response = FakeHttpResponse(stream = TrackingInputStream(byteArrayOf(1)))
+
+        assertFailsWith<IllegalArgumentException> { response.readBodyBytes(maxBytes = -1) }
+
+        response.headersCalls shouldBeEqualTo 0
+        response.bodyCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `known oversize는 body accessor 실패를 suppressed로 보존한다`() {
+        val accessorFailure = IOException("body accessor failed")
+        val response = FakeHttpResponse(
+            stream = TrackingInputStream(ByteArray(8)),
+            headerValues = mapOf("Content-Length" to listOf("8")),
+            bodySupplier = { throw accessorFailure },
+        )
+
+        val failure = assertFailsWith<ByteLimitExceededException> {
+            response.readBodyBytes(maxBytes = 4)
+        }
+
+        failure.suppressed.single() shouldBeSameInstanceAs accessorFailure
+    }
+
+    @Test
+    fun `일반 읽기 경로의 body accessor 실패 identity를 보존한다`() {
+        val accessorFailure = IOException("body accessor failed")
+        val stream = TrackingInputStream(ByteArray(4))
+        val response = FakeHttpResponse(
+            stream = stream,
+            bodySupplier = { throw accessorFailure },
+        )
+
+        val actual = assertFailsWith<IOException> {
+            response.readBodyBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs accessorFailure
+        stream.consumedBytes shouldBeEqualTo 0
+        stream.closeCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `read와 close 실패의 identity를 보존한다`() {
+        val readFailure = IOException("read failed")
+        val closeFailure = IOException("close failed")
+        val stream = TrackingInputStream(byteArrayOf(1), readFailure = readFailure, closeFailure = closeFailure)
+
+        val actual = assertFailsWith<IOException> {
+            FakeHttpResponse(stream).readBodyBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs readFailure
+        actual.suppressed.single() shouldBeSameInstanceAs closeFailure
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `성공 뒤 close 실패는 결과 대신 원본 close 실패를 던진다`() {
+        val closeFailure = IOException("close failed")
+        val stream = TrackingInputStream(byteArrayOf(1), closeFailure = closeFailure)
+
+        val actual = assertFailsWith<IOException> {
+            FakeHttpResponse(stream).readBodyBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs closeFailure
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `overflow와 close 실패는 overflow를 primary로 보존한다`() {
+        val closeFailure = IOException("close failed")
+        val stream = TrackingInputStream(ByteArray(5), closeFailure = closeFailure)
+
+        val actual = assertFailsWith<ByteLimitExceededException> {
+            FakeHttpResponse(stream).readBodyBytes(maxBytes = 4)
+        }
+
+        actual.maxBytes shouldBeEqualTo 4
+        actual.suppressed.single() shouldBeSameInstanceAs closeFailure
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `UTF-8 문자열도 byte 상한으로 판정한다`() {
+        assertFailsWith<ByteLimitExceededException> {
+            FakeHttpResponse(TrackingInputStream("가나".toByteArray())).readBodyString(maxBytes = 5)
+        }
+
+        FakeHttpResponse(TrackingInputStream("가나".toByteArray()))
+            .readBodyString(maxBytes = 6) shouldBeEqualTo "가나"
+    }
+
+    @Test
+    fun `known oversize body accessor block은 abort 후 bounded하게 종료한다`() {
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val timeout = IOException("body timeout")
+        val response = FakeHttpResponse(
+            stream = TrackingInputStream(ByteArray(8)),
+            headerValues = mapOf("Content-Length" to listOf("8")),
+            bodySupplier = {
+                entered.countDown()
+                release.await()
+                throw timeout
+            },
+        )
+
+        withVirtualExecutor { executor ->
+            val future = executor.submit<ByteArray> { response.readBodyBytes(maxBytes = 4) }
+            try {
+                entered.await(5, SECONDS).shouldBeTrue()
+                release.countDown()
+                val wrapper = assertFailsWith<ExecutionException> { future.get(5, SECONDS) }
+                val failure = wrapper.cause as ByteLimitExceededException
+                failure.suppressed.single() shouldBeSameInstanceAs timeout
+            } finally {
+                release.countDown()
+                future.cancel(true)
+            }
+        }
+    }
+
+    @Test
+    fun `known oversize close block은 abort 후 bounded하게 종료한다`() {
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val stream = object: TrackingInputStream(ByteArray(8)) {
+            override fun close() {
+                closeCalls++
+                entered.countDown()
+                release.await()
+            }
+        }
+        val response = FakeHttpResponse(
+            stream = stream,
+            headerValues = mapOf("Content-Length" to listOf("8")),
+        )
+
+        withVirtualExecutor { executor ->
+            val future = executor.submit<ByteArray> { response.readBodyBytes(maxBytes = 4) }
+            try {
+                entered.await(5, SECONDS).shouldBeTrue()
+                stream.consumedBytes shouldBeEqualTo 0
+                release.countDown()
+                val wrapper = assertFailsWith<ExecutionException> { future.get(5, SECONDS) }
+                (wrapper.cause as ByteLimitExceededException).maxBytes shouldBeEqualTo 4
+                stream.closeCalls shouldBeEqualTo 1
+            } finally {
+                release.countDown()
+                future.cancel(true)
+            }
+        }
+    }
+
+    @Test
+    fun `정확히 상한 뒤 blocking read-ahead는 외부 close로 회수한다`() {
+        val enteredReadAhead = CountDownLatch(1)
+        val released = CountDownLatch(1)
+        val readFailure = IOException("supervisor closed stream")
+        val stream = BlockingReadAheadInputStream(
+            source = ByteArray(4),
+            enteredReadAhead = enteredReadAhead,
+            released = released,
+            readFailure = readFailure,
+        )
+        val response = FakeHttpResponse(stream)
+
+        withVirtualExecutor { executor ->
+            val future = executor.submit<ByteArray> { response.readBodyBytes(maxBytes = 4) }
+            try {
+                enteredReadAhead.await(5, SECONDS).shouldBeTrue()
+                stream.close()
+                val wrapper = assertFailsWith<ExecutionException> { future.get(5, SECONDS) }
+                wrapper.cause shouldBeSameInstanceAs readFailure
+                stream.closeCalls shouldBeEqualTo 2
+            } finally {
+                stream.abort()
+                future.cancel(true)
+            }
+        }
+    }
+
+    @Test
+    fun `README 공개 예제는 BodyHandlers ofInputStream 응답 타입에서 컴파일된다`() {
+        val response: HttpResponse<InputStream> = FakeHttpResponse(TrackingInputStream("body".toByteArray()))
+
+        response.readBodyBytes(maxBytes = 64 * 1024) shouldBeEqualTo "body".toByteArray()
+    }
+
+    private inline fun <T> withVirtualExecutor(block: (java.util.concurrent.ExecutorService) -> T): T {
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        try {
+            return block(executor)
+        } finally {
+            executor.shutdownNow()
+            executor.awaitTermination(5, SECONDS).shouldBeTrue()
+        }
+    }
+
+    private class FakeHttpResponse(
+        private val stream: InputStream,
+        headerValues: Map<String, List<String>> = emptyMap(),
+        private val code: Int = 200,
+        private val bodySupplier: () -> InputStream = { stream },
+    ): HttpResponse<InputStream> {
+        private val responseHeaders = HttpHeaders.of(headerValues) { _, _ -> true }
+        private val responseRequest = HttpRequest.newBuilder(URI.create("https://example.com")).build()
+
+        var headersCalls: Int = 0
+            private set
+        var bodyCalls: Int = 0
+            private set
+
+        override fun statusCode(): Int = code
+
+        override fun request(): HttpRequest = responseRequest
+
+        override fun previousResponse(): Optional<HttpResponse<InputStream>> = Optional.empty()
+
+        override fun headers(): HttpHeaders {
+            headersCalls++
+            return responseHeaders
+        }
+
+        override fun body(): InputStream {
+            bodyCalls++
+            return bodySupplier()
+        }
+
+        override fun sslSession(): Optional<SSLSession> = Optional.empty()
+
+        override fun uri(): URI = responseRequest.uri()
+
+        override fun version(): HttpClient.Version = HttpClient.Version.HTTP_2
+    }
+
+    private open class TrackingInputStream(
+        private val source: ByteArray,
+        private val readFailure: Throwable? = null,
+        private val closeFailure: Throwable? = null,
+    ): InputStream() {
+        private var position = 0
+
+        var consumedBytes: Int = 0
+            protected set
+        var closeCalls: Int = 0
+            protected set
+
+        override fun read(): Int {
+            readFailure?.let { throw it }
+            if (position >= source.size) return -1
+            consumedBytes++
+            return source[position++].toInt() and 0xff
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            readFailure?.let { throw it }
+            if (position >= source.size) return -1
+            val count = minOf(length, source.size - position)
+            source.copyInto(buffer, offset, position, position + count)
+            position += count
+            consumedBytes += count
+            return count
+        }
+
+        override fun close() {
+            closeCalls++
+            closeFailure?.let { throw it }
+        }
+    }
+
+    private class BlockingReadAheadInputStream(
+        source: ByteArray,
+        private val enteredReadAhead: CountDownLatch,
+        private val released: CountDownLatch,
+        private val readFailure: IOException,
+    ): TrackingInputStream(source) {
+        override fun read(): Int {
+            enteredReadAhead.countDown()
+            released.await()
+            throw readFailure
+        }
+
+        override fun close() {
+            closeCalls++
+            released.countDown()
+        }
+
+        fun abort() {
+            released.countDown()
+        }
+    }
+}

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -197,6 +197,27 @@ val restored = compressor.decompressOrNull(compressed) // 손상/null/empty 시 
 
 ## 사용 예제
 
+### 엄격한 상한을 적용한 `InputStream` 읽기
+
+전체 본문이 필요하고 상한 초과 시 부분 결과 없이 실패해야 한다면
+`readAllBytes(maxBytes)`를 사용합니다.
+
+```kotlin
+import io.bluetape4k.io.ByteLimitExceededException
+import io.bluetape4k.io.readAllBytes
+
+val bytes = inputStream.use {
+    it.readAllBytes(maxBytes = 64 * 1024)
+}
+```
+
+이 primitive는 stream을 닫지 않으므로 호출자가 소유권을 가지며, 예제는 `use`로 닫습니다.
+분기에는 `ByteLimitExceededException.maxBytes`만 사용하고 예외 message나 본문 payload를
+log에 남기지 마세요. 마지막 EOF 확인도 block될 수 있으므로 transport timeout을 설정하고,
+작업을 중단해야 할 때 supervisor가 stream을 닫을 수 있게 구성하세요. 일시적인 heap 사용량은
+대략 `동시 read 수 * (2 * maxBytes + segment overhead)`로 잡습니다. 이 상한은 전달된
+stream의 byte에만 적용되므로 이후 압축 해제에는 decoded byte 상한이 별도로 필요합니다.
+
 ### 압축
 
 ```kotlin

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -196,6 +196,29 @@ This allows callers to distinguish "corrupt input" (returns `null`) from "empty 
 
 ## Usage Examples
 
+### Strictly bounded `InputStream` reads
+
+Use `readAllBytes(maxBytes)` when a complete body is required and exceeding the
+limit must fail without returning a partial result:
+
+```kotlin
+import io.bluetape4k.io.ByteLimitExceededException
+import io.bluetape4k.io.readAllBytes
+
+val bytes = inputStream.use {
+    it.readAllBytes(maxBytes = 64 * 1024)
+}
+```
+
+The primitive does not close the stream; the caller owns it, so the example uses
+`use`. Only `ByteLimitExceededException.maxBytes` is stable for branching. Do not
+log the exception message or body payload. The final EOF check can block, so set
+transport timeouts and let a supervisor close the stream when an operation must be
+aborted. Budget temporary heap as approximately
+`concurrent reads * (2 * maxBytes + segment overhead)`. A later decompression step
+needs a separate decoded-byte limit because this limit applies only to bytes read
+from the supplied stream.
+
 ### Compression
 
 ```kotlin

--- a/io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.io
+
+import io.bluetape4k.support.requireZeroOrPositiveNumber
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * 입력 스트림이 설정한 byte 상한을 초과했음을 나타냅니다.
+ *
+ * [maxBytes]만 안정된 공개 정보입니다. 예외에는 본문이나 부분 결과를 저장하지 않으며,
+ * message의 정확한 문구는 호환성 계약이 아닙니다.
+ */
+class ByteLimitExceededException(
+    val maxBytes: Int,
+): IOException("Input stream exceeded the configured byte limit: maxBytes=$maxBytes") {
+    init {
+        maxBytes.requireZeroOrPositiveNumber("maxBytes")
+    }
+}
+
+/**
+ * 이 스트림을 끝까지 읽되 결과가 [maxBytes]를 넘으면 [ByteLimitExceededException]을 던집니다.
+ *
+ * 초과 시 부분 결과를 반환하지 않으며 판정을 위해 최대 한 byte만 더 읽습니다. 이 함수는
+ * 호출자가 소유한 스트림을 닫지 않습니다. 읽기와 마지막 EOF 확인은 blocking될 수 있으므로
+ * timeout과 중단은 호출자가 구성해야 합니다.
+ *
+ * 결과를 만들 때 실제 본문 크기의 약 두 배와 고정 크기 segment가 일시적으로 필요합니다.
+ * [maxBytes]가 [Int.MAX_VALUE]여도 큰 배열을 먼저 할당하지 않지만, 실제로 큰 본문을 읽을 때는
+ * 그만큼의 가용 메모리가 필요합니다.
+ *
+ * @param maxBytes 허용할 최대 byte 수
+ * @return 상한 이하인 전체 본문
+ * @throws IllegalArgumentException [maxBytes]가 음수인 경우
+ * @throws ByteLimitExceededException 본문이 [maxBytes]를 초과한 경우
+ * @throws IOException 스트림 읽기에 실패한 경우
+ */
+fun InputStream.readAllBytes(maxBytes: Int): ByteArray {
+    maxBytes.requireZeroOrPositiveNumber("maxBytes")
+
+    val segments = ArrayList<ByteArray>()
+    var total = 0
+
+    while (total < maxBytes) {
+        val segment = ByteArray(minOf(DEFAULT_BUFFER_SIZE, maxBytes - total))
+        var segmentSize = 0
+
+        while (segmentSize < segment.size) {
+            val count = read(segment, segmentSize, segment.size - segmentSize)
+            when {
+                count < 0 -> {
+                    if (segmentSize > 0) segments += segment.copyOf(segmentSize)
+                    return segments.flattenToByteArray(total)
+                }
+
+                count > 0 -> {
+                    segmentSize += count
+                    total += count
+                }
+
+                else -> {
+                    val value = read()
+                    if (value < 0) {
+                        if (segmentSize > 0) segments += segment.copyOf(segmentSize)
+                        return segments.flattenToByteArray(total)
+                    }
+                    segment[segmentSize++] = value.toByte()
+                    total++
+                }
+            }
+        }
+        segments += segment
+    }
+
+    if (read() >= 0) throw ByteLimitExceededException(maxBytes)
+    return segments.flattenToByteArray(total)
+}
+
+private fun List<ByteArray>.flattenToByteArray(totalSize: Int): ByteArray =
+    ByteArray(totalSize).also { result ->
+        var offset = 0
+        forEach { segment ->
+            segment.copyInto(result, destinationOffset = offset)
+            offset += segment.size
+        }
+    }

--- a/io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt
@@ -1,0 +1,176 @@
+package io.bluetape4k.io
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.io.InputStream
+
+class BoundedInputStreamSupportTest {
+
+    @Test
+    fun `상한 이하에서는 전체 본문을 반환하고 stream을 닫지 않는다`() {
+        listOf(3, 4).forEach { size ->
+            val expected = ByteArray(size) { it.toByte() }
+            val stream = TrackingInputStream(expected)
+
+            stream.readAllBytes(maxBytes = 4) shouldBeEqualTo expected
+            stream.consumedBytes shouldBeEqualTo size
+            stream.closeCalls shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `상한을 넘으면 한 byte만 미리 읽고 부분 결과 없이 실패한다`() {
+        listOf(5, 8).forEach { size ->
+            val stream = TrackingInputStream(ByteArray(size) { it.toByte() })
+
+            val failure = assertFailsWith<ByteLimitExceededException> {
+                stream.readAllBytes(maxBytes = 4)
+            }
+
+            failure.maxBytes shouldBeEqualTo 4
+            stream.consumedBytes shouldBeEqualTo 5
+            stream.bulkReadCalls shouldBeEqualTo 1
+            stream.singleReadCalls shouldBeEqualTo 1
+            stream.closeCalls shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `상한이 0이면 empty만 허용한다`() {
+        val empty = TrackingInputStream(byteArrayOf())
+        empty.readAllBytes(maxBytes = 0).isEmpty().shouldBeTrue()
+        empty.consumedBytes shouldBeEqualTo 0
+        empty.closeCalls shouldBeEqualTo 0
+
+        val nonEmpty = TrackingInputStream(byteArrayOf(1))
+        val failure = assertFailsWith<ByteLimitExceededException> {
+            nonEmpty.readAllBytes(maxBytes = 0)
+        }
+        failure.maxBytes shouldBeEqualTo 0
+        nonEmpty.consumedBytes shouldBeEqualTo 1
+        nonEmpty.singleReadCalls shouldBeEqualTo 1
+        nonEmpty.closeCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `음수 상한은 읽기 전에 거부한다`() {
+        val stream = TrackingInputStream(byteArrayOf(1))
+
+        assertFailsWith<IllegalArgumentException> {
+            stream.readAllBytes(maxBytes = -1)
+        }
+
+        stream.bulkReadCalls shouldBeEqualTo 0
+        stream.singleReadCalls shouldBeEqualTo 0
+        stream.closeCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `Int MAX VALUE 상한은 작은 본문을 큰 배열 선할당 없이 읽는다`() {
+        val expected = byteArrayOf(1, 2, 3)
+        val stream = TrackingInputStream(expected)
+
+        stream.readAllBytes(maxBytes = Int.MAX_VALUE) shouldBeEqualTo expected
+        stream.consumedBytes shouldBeEqualTo expected.size
+        stream.bulkReadCalls shouldBeEqualTo 2
+        stream.closeCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `bulk read가 0이면 single read로 진행한다`() {
+        val expected = byteArrayOf(1, 2, 3, 4)
+        val stream = TrackingInputStream(expected, bulkZeroCount = 3)
+
+        stream.readAllBytes(maxBytes = 4) shouldBeEqualTo expected
+        stream.bulkReadCalls shouldBeEqualTo 4
+        stream.singleReadCalls shouldBeEqualTo 4
+        stream.closeCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `read 실패는 원본 인스턴스를 보존하고 stream을 닫지 않는다`() {
+        val expected = IOException("read failed")
+        val stream = TrackingInputStream(byteArrayOf(1), readFailure = expected)
+
+        val actual = assertFailsWith<IOException> {
+            stream.readAllBytes(maxBytes = 4)
+        }
+
+        actual shouldBeSameInstanceAs expected
+        stream.closeCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `전용 예외는 상한 외에 본문 정보를 노출하지 않는다`() {
+        val failure = ByteLimitExceededException(4)
+
+        failure.maxBytes shouldBeEqualTo 4
+        failure.message.orEmpty().contains("secret-body").shouldBeFalse()
+        ByteLimitExceededException::class.java.methods
+            .filter { it.declaringClass == ByteLimitExceededException::class.java }
+            .map { it.name }
+            .toSet() shouldBeEqualTo setOf("getMaxBytes")
+        assertFailsWith<IllegalArgumentException> { ByteLimitExceededException(-1) }
+    }
+
+    @Test
+    fun `README 공개 예제는 caller가 raw stream 수명을 소유한다`() {
+        val stream = TrackingInputStream("body".toByteArray())
+
+        stream.use { inputStream ->
+            inputStream.readAllBytes(maxBytes = 64 * 1024) shouldBeEqualTo "body".toByteArray()
+        }
+
+        stream.closeCalls shouldBeEqualTo 1
+    }
+
+    private class TrackingInputStream(
+        private val source: ByteArray,
+        bulkZeroCount: Int = 0,
+        private val readFailure: Throwable? = null,
+    ): InputStream() {
+        private var position = 0
+        private var remainingBulkZeroCount = bulkZeroCount
+
+        var consumedBytes: Int = 0
+            private set
+        var bulkReadCalls: Int = 0
+            private set
+        var singleReadCalls: Int = 0
+            private set
+        var closeCalls: Int = 0
+            private set
+
+        override fun read(): Int {
+            singleReadCalls++
+            readFailure?.let { throw it }
+            if (position >= source.size) return -1
+            consumedBytes++
+            return source[position++].toInt() and 0xff
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            bulkReadCalls++
+            readFailure?.let { throw it }
+            if (remainingBulkZeroCount > 0) {
+                remainingBulkZeroCount--
+                return 0
+            }
+            if (position >= source.size) return -1
+            val count = minOf(length, source.size - position)
+            source.copyInto(buffer, offset, position, position + count)
+            position += count
+            consumedBytes += count
+            return count
+        }
+
+        override fun close() {
+            closeCalls++
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1643

기존 truncation API의 호환성을 유지하면서, HTTP 응답 본문이 호출자가 지정한 byte 상한을
넘으면 partial 결과 없이 명시적으로 실패하는 공통 API를 제공합니다.

## Background

HC5의 기존 `toByteArrayOrNull(maxResultLength)` 계열은 초과 입력을 잘라 반환하므로,
Workshop #939와 Clinic #451은 서로 다른 수동 strict loop를 유지하고 있었습니다.
`io/io`의 bounded primitive와 `io/http`의 HC5·JDK adapter가 같은 크기·소유권·cleanup
계약을 사용하도록 통합했습니다.

## What This Solves

- `maxBytes`를 넘는 body를 부분 성공으로 오인하지 않고 payload 없는 전용 예외로 거부합니다.
- raw `InputStream`, HC5 entity, JDK response의 stream 소유권과 read/accessor/close 실패 우선순위를 고정합니다.
- known/unknown·부정확한 `Content-Length`, UTF-8 다중 byte, zero-progress read와 blocking cleanup 경계를 검증합니다.

## Work Done

- `io/io`: `ByteLimitExceededException`과 `InputStream.readAllBytes(maxBytes)`를 추가하고 segment 점진 할당, 최대 1-byte read-ahead, `Int.MAX_VALUE` 안전성을 구현했습니다.
- `io/http`: HC5 nullable entity와 JDK `HttpResponse<InputStream>`용 bytes/string adapter를 공용 ownership helper에 연결했습니다.
- failure composition: 원래 overflow/read/accessor 실패를 primary로 유지하고 identity가 다른 후속 cleanup 실패만 suppressed로 보존합니다.
- 문서: 영문·국문 module README, KDoc, CHANGELOG, 구현 리뷰, lesson, `docs/testlogs/2026-09.md`를 갱신했습니다.

## Validation

- `:bluetape4k-io:test --tests BoundedInputStreamSupportTest --rerun-tasks`: PASS — 9 passing
- `:bluetape4k-http:test --tests BoundedHttpEntitySupportTest --tests BoundedHttpResponseSupportTest --rerun-tasks`: PASS — 33 passing
- `:bluetape4k-io:check`: PASS — 1,274 passing, Kover 포함
- `:bluetape4k-http:check`: 로컬 환경에서는 392 passing, 3 pending, 96 failing. 94개 `ContainerFetchException`과 이를 감싼 2개 `MultiException`은 모두 `bluetape4k/mock-web-server:2.1.0` pull 404이며 bounded test failure는 0입니다. exact-head CI의 `Test / IO HTTP`는 PASS했습니다.
- `javap -public`: PASS — 전용 예외, IO 함수, HC5·JDK bytes/string 함수와 default bridge 확인
- `git diff --check origin/develop...HEAD`: PASS
- 한국어 용어 감사: 변경 줄과 신규 리뷰·lesson·testlog finding 0. 전체 파일의 기존 용어 finding 5건은 `origin/develop`에 이미 존재함을 `git blame`으로 확인했습니다.

## Review Notes

- P0/P1: 0
- P2/P3: 미처분 finding 없음
- 초기 P1: cleanup의 `Error`·`CancellationException`을 기존 primary보다 우선하던 구현을 RED 2건으로 재현한 뒤 수정했고, HC5·JDK 33건으로 재검증했습니다.
- Review evidence: `docs/review/2026-09-06-bounded-http-body-implementation-review.md`
- Lesson: `docs/lessons/2026-09-06-issue-1643-bounded-http-body.md`

## Metadata

- Issue: #1643, milestone `2.1.0`, assignee `debop`, labels `enhancement`, `test`
- PR: #1661, head `87cb04c48a8e47587692767933cb0af5c42417d0`, base `develop`, milestone `2.1.0`, assignee `debop`
- CI: [run 34023949279](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34023949279) PASS — Build, IO, IO HTTP, Coverage, 정책·보안 검사 모두 성공
- 소비자 근거: [bluetape4k-workshop#939 댓글](https://github.com/bluetape4k/bluetape4k-workshop/issues/939#issuecomment-5558301061), [clinic-appointment#451 댓글](https://github.com/bluetape4k/clinic-appointment/issues/451#issuecomment-5558301066). 아직 publish 전이므로 소비 가능한 release가 아닙니다.

## 변경 유형

- [x] `feat` — 새 기능
- [ ] `fix` — 버그 수정
- [ ] `refactor` — 리팩토링
- [ ] `perf` — 성능 개선
- [x] `test` — 테스트 추가/수정
- [x] `docs` — 문서 변경
- [ ] `chore` — 빌드/설정/의존성

## 저장소 체크리스트

- [x] 변경된 모듈의 `README.md` + `README.ko.md` 업데이트
- [x] 공개 API와 비자명한 내부 계약에 한국어 KDoc 추가
- [x] `docs/testlogs/2026-09.md`에 결과 기록
- [x] 독립 여섯 관점 review와 exact-head 재검토 완료 — P0/P1 0
- [x] issue 자동 종료용 `Closes #1643` 명시
- [x] `.worktrees/feat-issue-1643-bounded-http-body`에서 작업
- [x] 기존 facade, module registration, catalog, CI/Nightly, Kover 설정 불변 확인
- [x] `docs/superpowers/index`는 `origin/develop`에 존재하지 않아 N/A
- [x] diagram은 기존 문서 표와 상태 계약으로 충분하고 새 시각 관계가 없어 N/A

## DoD Status

Required checks: 27/31; N/A: 2; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| A-01~A-05 | 요구·근거·설계·계획·위험을 승인 순서로 고정 | PASS | spec, plan, 2-R/3-R review; 최신 base `31ee966cf3` | 없음 |
| A-06 | TDD로 primitive와 두 adapter 구현 | PASS | RED→GREEN commits와 9+33 targeted tests | 없음 |
| A-07 | spec/plan·모듈·공개 API·hazard 검증 | PASS | IO check 1,274; HTTP 외부 이미지 gap 분류; exact-head CI IO HTTP PASS; `javap`; 정적 검사 | 없음 |
| A-08 | 여섯 관점 pre-PR review 수렴 | PASS | exact head `87cb04c48a8`, P0/P1 0 | 없음 |
| A-09 | durable lesson commit | PASS | `docs/lessons/2026-09-06-issue-1643-bounded-http-body.md` | 없음 |
| A-10 | PR 생성·live CI·review | PASS | PR #1661, CI run 34023949279, exact-head 독립 재검토 P0/P1 0, review thread 0 | 없음 |
| A-11 | 소비자 근거·merge-ready 보고 | PASS | workshop#939·clinic#451 댓글 read-back, exact-head merge-ready 근거 준비 | 없음 |
| A-12 | fresh 승인 후 merge closeout | PENDING | merge 권한 미사용 | CG-16~CG-18 |
| CG-01~CG-11 | 공통 preflight·구현·검토·PR 권한 | PASS | 승인된 repo/base/head와 committed exact diff | 없음 |
| CG-12 | exact head publish | PASS | local/remote `87cb04c48a8e47587692767933cb0af5c42417d0` 일치 | 없음 |
| CG-12A | guidance refresh | PASS | user/workspace/repo AGENTS, Type A leaf, common gates, 중앙·repo PR template, live #1643 재확인 | drift 없음 |
| CG-13 | PR 생성·metadata/body read-back | PASS | PR #1661, exact head/base, milestone·assignee·labels, `closingIssuesReferences` #1643, 마지막 `## DoD Status` 확인 | 없음 |
| CG-14 | exact-head CI·review/thread | PASS | CI 전부 성공, 독립 개발자·운영·성능 검토 P0/P1 0, review thread 0, `MERGEABLE/CLEAN` | 없음 |
| CG-15 | merge-ready 보고 | PASS | exact head, CI, review, consumer 근거와 미완료 merge gate를 사용자에게 보고 | 없음 |
| CG-16 | fresh merge 승인 | PENDING | 기존 승인은 merge 승인 아님 | CG-15 이후 새 승인 대기 |
| CG-17 | merge 실행·검증 | PENDING | merge 미수행 | CG-16 이후에만 수행 |
| CG-18 | local sync·cleanup | PENDING | worktree/branch 보존 | merge 검증 후 별도 수행 |

Final status: PENDING — PR #1661은 merge-ready이며 fresh merge 승인 대기

Unchecked required items: A-12, CG-16, CG-17, CG-18
