### PR TITLE
[P1] Lettuce write-behind 재시도에서 최신 값 순서를 보존한다

### DIFF
--- a/docs/lessons/2026-09-06-issue-1657-write-behind-retry-order.md
+++ b/docs/lessons/2026-09-06-issue-1657-write-behind-retry-order.md
@@ -1,0 +1,31 @@
+# Issue #1657: deque 앞쪽에 batch를 복원할 때는 역순으로 삽입한다
+
+## 맥락
+
+`LettuceLoadedMap`은 write-behind batch를 queue 앞에서 꺼내고, 동일 키가 여러 번
+등장하면 마지막 값을 `MapWriter`에 전달한다. 쓰기가 실패했을 때 꺼낸 entry를 원래
+순서대로 `offerFirst`하면 deque에는 역순으로 복원된다. `(key, A), (key, B)`가
+`(key, B), (key, A)`로 바뀌므로 다음 batch는 오래된 `A`를 선택한다.
+
+## 결정
+
+- deque 앞쪽에 실패한 batch를 복원할 때는 entry를 역순으로 순회한다.
+- queue 여유가 부족하면 같은 키의 최신 retry entry를 먼저 보존한다.
+- entry별 retry count와 기존 dead-letter 경계는 바꾸지 않는다.
+- 동일 키의 마지막 값 선택은 재시도 전후와 재시도 중 새 값이 도착한 경우에도 유지한다.
+
+## 검증
+
+- 기존 구현에서 `A -> B -> 실패 -> 재시도`가 `B -> A`로 바뀌는 RED를 확인했다.
+- 실패 중 `C`가 도착하는 경로에서 재시도 batch가 `B`, 후속 batch가 `C`를 선택함을
+  검증했다.
+- retry count 소진과 queue 포화 dead-letter 테스트를 함께 실행해 기존 경계를 확인했다.
+- `:bluetape4k-lettuce:test` 926개와 `:bluetape4k-lettuce:detekt`가 통과했다.
+
+## 향후 지침
+
+FIFO batch를 deque의 앞쪽에 복원할 때는 `addFirst`나 `offerFirst` 호출 순서만 보지
+말고, 복원 뒤 전체 queue 순서와 동일 키 병합 결과를 함께 검증한다. append-only
+channel은 앞쪽 삽입을 지원하지 않으므로 같은 정책을 그대로 적용하지 않는다. channel
+기반 구현은 accepted entry 보존, 용량 상한, close와 retry의 경합을 먼저 정의한 뒤
+별도 회귀 테스트로 고정한다. 이 후속 작업은 Issue #1664에서 추적한다.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceLoadedMap.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit
  * - **Read-through**: 캐시 미스 시 [MapLoader]를 통해 DB에서 값을 로드하고 Redis에 캐싱한다.
  * - **Write-through**: [MapWriter]를 통해 DB에 즉시 쓰고 Redis도 갱신한다.
  * - **Write-behind**: [MapWriter]를 통해 DB에 비동기로 쓰고 Redis는 즉시 갱신한다.
+ *   같은 batch의 동일 키는 마지막 값을 사용하며, 실패한 batch도 원래 순서로 재시도한다.
  * - **NONE**: Redis만 사용하고 DB 쓰기를 하지 않는다.
  *
  * ```kotlin
@@ -314,7 +315,7 @@ class LettuceLoadedMap<K: Any, V: Any>(
                 val attempts = entries.map { it.third + 1 }
                 log.error(e) { "Write-behind flush 실패 (attempts=$attempts): ${batch.keys}" }
                 val failed = mutableListOf<Triple<K, V, Int>>()
-                entries.forEach { (k, v, retryCount) ->
+                entries.asReversed().forEach { (k, v, retryCount) ->
                     val nextRetryCount = retryCount + 1
                     if (nextRetryCount < MAX_DEAD_LETTER_RETRY) {
                         // 개선: offerFirst 반환값 확인 — 큐가 가득 찬 경우 재시도 항목이 유실될 수 있음.
@@ -336,7 +337,8 @@ class LettuceLoadedMap<K: Any, V: Any>(
                         //       HSET 실패 시 LPUSH를 건너뛰어 복구 불가 상태(모니터링 오탐)를 방지합니다.
                         val deadLetterKey = "${config.keyPrefix}:dead-letter"
                         val deadLetterValuesKey = "${config.keyPrefix}:dead-letter:values"
-                        val failedBatch = failed.associate { it.first to it.second }
+                        // entries를 역순으로 재삽입하면서 수집했으므로 dead-letter 병합은 원래 순서로 복원한다.
+                        val failedBatch = failed.asReversed().associate { it.first to it.second }
                         val valueMap = failedBatch.entries.associate { (k, v) -> keySerializer(k) to v }
                         // HSET 먼저: 실패 시 LPUSH 건너뜀 (복구 데이터 우선)
                         commands.hset(deadLetterValuesKey, valueMap)

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceWriteBehindRetryTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceWriteBehindRetryTest.kt
@@ -15,11 +15,118 @@ import kotlinx.coroutines.channels.Channel
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.jvm.isAccessible
 
 internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
+
+    @Test
+    fun `blocking write-behind는 실패 후에도 동일 키의 최신 값을 유지한다`() {
+        val writes = mutableListOf<Map<String, String>>()
+        val attempts = AtomicInteger()
+        val writer = object: MapWriter<String, String> {
+            override fun write(map: Map<String, String>) {
+                writes += map
+                if (attempts.getAndIncrement() == 0) {
+                    error("simulated write failure")
+                }
+            }
+
+            override fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = "latest-write-wins:${randomName()}",
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 2,
+        )
+
+        LettuceLoadedMap(client = client, writer = writer, config = config).use { map ->
+            map.writeBehindQueue().apply {
+                add(Triple("same-key", "old-value", 0))
+                add(Triple("same-key", "latest-value", 0))
+            }
+
+            map.flushWriteBehindQueue()
+            map.flushWriteBehindQueue()
+
+            writes shouldBeEqualTo listOf(
+                mapOf("same-key" to "latest-value"),
+                mapOf("same-key" to "latest-value"),
+            )
+        }
+    }
+
+    @Test
+    fun `blocking write-behind는 재시도 중 도착한 최신 값을 순서대로 처리한다`() {
+        val writes = mutableListOf<Map<String, String>>()
+        val attempts = AtomicInteger()
+        lateinit var loadedMap: LettuceLoadedMap<String, String>
+        val writer = object: MapWriter<String, String> {
+            override fun write(map: Map<String, String>) {
+                writes += map
+                if (attempts.getAndIncrement() == 0) {
+                    loadedMap.writeBehindQueue().add(Triple("same-key", "newest-value", 0))
+                    error("simulated write failure")
+                }
+            }
+
+            override fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = "concurrent-latest-write-wins:${randomName()}",
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 2,
+        )
+
+        loadedMap = LettuceLoadedMap(client = client, writer = writer, config = config)
+        loadedMap.use { map ->
+            map.writeBehindQueue().apply {
+                add(Triple("same-key", "old-value", 0))
+                add(Triple("same-key", "latest-retried-value", 0))
+            }
+
+            map.flushWriteBehindQueue()
+            map.flushWriteBehindQueue()
+            map.flushWriteBehindQueue()
+
+            writes shouldBeEqualTo listOf(
+                mapOf("same-key" to "latest-retried-value"),
+                mapOf("same-key" to "latest-retried-value"),
+                mapOf("same-key" to "newest-value"),
+            )
+        }
+    }
+
+    @Test
+    fun `blocking write-behind는 retry 소진 시 동일 키의 최신 값을 dead-letter에 보존한다`() {
+        val prefix = "latest-dead-letter:${randomName()}"
+        val writer = object: MapWriter<String, String> {
+            override fun write(map: Map<String, String>) = error("simulated write failure")
+
+            override fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 2,
+        )
+
+        LettuceLoadedMap(client = client, writer = writer, config = config).use { map ->
+            map.writeBehindQueue().apply {
+                add(Triple("same-key", "old-value", 2))
+                add(Triple("same-key", "latest-value", 2))
+            }
+
+            map.flushWriteBehindQueue()
+
+            map.writeBehindQueue().toList() shouldBeEqualTo emptyList()
+            client.connect(LettuceBinaryCodec<String>(BinarySerializers.LZ4Fory)).use { connection ->
+                connection.sync().hget("$prefix:dead-letter:values", "same-key") shouldBeEqualTo "latest-value"
+            }
+        }
+    }
 
     @Test
     fun `blocking write-behind는 entry별 retry count를 보존한다`() {


### PR DESCRIPTION
## 요약

Closes #1657

실패한 blocking write-behind batch를 원래 FIFO 순서로 복원해 동일 키의 최신 값이 재시도와 dead-letter에서도 유지되도록 합니다.

## 배경

`LettuceLoadedMap.flushWriteBehindQueue()`는 `(key, A), (key, B)`를 처리하다 실패하면 정방향 `offerFirst`로 queue에 다시 넣었습니다. 복원 결과가 `B, A`가 되어 다음 batch가 오래된 `A`를 선택하는 문제였습니다.

## 해결 내용

- 실패 전후에도 동일 키의 latest-write-wins 순서를 유지합니다.
- retry 소진이나 queue 포화로 dead-letter에 보낼 때도 동일 키의 최신 값을 보존합니다.
- retry 도중 신규 값 `C`가 도착하면 재시도 값 `B` 뒤에 `C`가 처리되도록 합니다.

## 변경 사항

- 실패 batch를 역순으로 `offerFirst`해 deque의 원래 순서를 복원했습니다.
- 역순으로 수집된 실패 entry를 dead-letter 병합 전에 다시 원래 순서로 복원했습니다.
- 동일 키 재시도, 동시 신규 값, retry 소진, queue 포화 회귀 테스트를 추가했습니다.
- 재사용 가능한 deque 복원 원칙을 lesson으로 기록했습니다.
- suspended 구현의 append-only `Channel` 위험은 별도 설계가 필요해 #1664로 분리했습니다.

## 검증

- RED `A -> B -> 실패 -> 재시도`: 기존 구현은 두 번째 write가 `old-value`여서 실패
- RED duplicate-key dead-letter: 중간 수정은 `old-value`를 저장해 실패
- targeted: 7/7 통과
- Lettuce 전체: 927 tests 및 detekt 통과
- exact head `5690f4f2b4f18de51a40f9fb72b19620dbb799d2`: GitHub Actions 24개 terminal, 12 success, 12 path skip, failure 0
- `git diff --check` 및 한국어 용어 감사 통과

## 검토

- inline exact-diff review: P0/P1 = 0/0
- P2: suspended `Channel` 의미는 후속 #1664로 분리
- 독립 `code-reviewer` 두 lane은 deadline 내 usable verdict를 반환하지 못해 provenance `PENDING`
- live GitHub review thread: 0, unresolved 0
- API/ABI: public signature와 dependency 변경 없음
- 성능: blocking failure path는 기존과 같은 O(batch size), queue capacity 변경 없음

## DoD Status

- [x] 결함과 FIFO 근본 원인 재현
- [x] blocking deque 범위와 suspended 후속 범위 분리
- [x] 동일 키 재시도·dead-letter RED/GREEN
- [x] targeted·전체 Lettuce·detekt 검증
- [x] exact-head GitHub Actions 통과
- [x] live review/thread read-back 및 mergeability `CLEAN`
- [x] lesson과 후속 #1664 기록
- [ ] 독립 review provenance 확보
- [ ] merge — 사용자가 다섯 PR을 함께 수행
