### PR TITLE
fix(ci): Ignite 2 제거 후 Full Nightly image gate 집계를 복구

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1385,10 +1385,7 @@ jobs:
             --input-dir shard-artifacts \
             --output-dir build/reports/testcontainers-image-gate \
             --manifest scripts/testcontainers_image_gate_manifest.json \
-            --expected-shards 4 \
-            --platform-id amd64 \
-            --expected-tag 2.18.0 \
-            --expected-architecture amd64
+            --expected-shards 4
           aggregate_exit=$?
           set -e
           test "$SHARD_RESULT" = success

--- a/scripts/aggregate_testcontainers_image_gate.py
+++ b/scripts/aggregate_testcontainers_image_gate.py
@@ -54,6 +54,14 @@ def aggregate_summaries(
     expected_by_id = {str(entry["id"]): entry for entry in manifest_entries}
     if len(expected_by_id) != len(manifest_entries):
         raise AggregationError("manifest contains duplicate family ids")
+    strict_family_ids = [
+        str(entry["id"]) for entry in manifest_entries if entry.get("platforms")
+    ]
+    if strict_family_ids:
+        raise AggregationError(
+            "strict platform families require explicit aggregate verification: "
+            + ", ".join(strict_family_ids)
+        )
 
     summaries = list(shard_summaries)
     if len(summaries) != expected_shard_count:

--- a/scripts/aggregate_testcontainers_image_gate.py
+++ b/scripts/aggregate_testcontainers_image_gate.py
@@ -283,9 +283,6 @@ def aggregate_reports(
     *,
     manifest_path: Path = MANIFEST,
     expected_shard_count: int,
-    platform_id: str,
-    expected_tag: str,
-    expected_architecture: str,
 ) -> dict[str, Any]:
     """Load shard artifacts, create canonical artifacts, and verify the release gate."""
 
@@ -364,9 +361,9 @@ def aggregate_reports(
     verification_errors = verify_release_summary(
         summary,
         expected_coverage=f"{expected_release_count}/{expected_release_count}",
-        platform_id=platform_id,
-        expected_tag=expected_tag,
-        expected_architecture=expected_architecture,
+        platform_id=None,
+        expected_tag=None,
+        expected_architecture=None,
         report_dir=output_dir,
     )
     if verification_errors:
@@ -417,9 +414,6 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--manifest", type=Path, default=MANIFEST)
     parser.add_argument("--expected-shards", type=int, required=True)
-    parser.add_argument("--platform-id", default="amd64")
-    parser.add_argument("--expected-tag", default="2.18.0")
-    parser.add_argument("--expected-architecture", default="amd64")
     return parser.parse_args(argv)
 
 
@@ -431,9 +425,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.output_dir,
             manifest_path=args.manifest,
             expected_shard_count=args.expected_shards,
-            platform_id=args.platform_id,
-            expected_tag=args.expected_tag,
-            expected_architecture=args.expected_architecture,
         )
     except (AggregationError, OSError, ValueError) as error:
         _write_blocked_summary(args.output_dir, [str(error)], args.manifest)

--- a/scripts/run_testcontainers_image_gate.py
+++ b/scripts/run_testcontainers_image_gate.py
@@ -343,12 +343,12 @@ def verify_release_summary(
     summary: dict[str, Any],
     *,
     expected_coverage: str,
-    platform_id: str,
-    expected_tag: str,
-    expected_architecture: str,
+    platform_id: str | None,
+    expected_tag: str | None,
+    expected_architecture: str | None,
     report_dir: Path | None = None,
 ) -> list[str]:
-    """Return fail-closed Release verifier findings for one native platform gate."""
+    """Return fail-closed Release verifier findings, with an optional strict platform gate."""
 
     errors: list[str] = []
     if summary.get("schema_version") != 2:
@@ -380,6 +380,8 @@ def verify_release_summary(
             or junit.get("errors", 1) != 0
         ):
             errors.append(f"successful JUnit evidence is required: {result.get('id')}")
+    if platform_id is None:
+        return errors
     platform_results = [item for item in summary.get("platforms", []) if item.get("platform_id") == platform_id]
     if len(platform_results) != 1:
         errors.append(f"exactly one {platform_id} platform result is required")

--- a/scripts/test_aggregate_testcontainers_image_gate.py
+++ b/scripts/test_aggregate_testcontainers_image_gate.py
@@ -119,6 +119,32 @@ class TestAggregateTestcontainersImageGate(unittest.TestCase):
         with self.assertRaisesRegex(AggregationError, "counter mismatch"):
             aggregate_summaries([summary], entries, expected_shard_count=1)
 
+    def test_aggregate_rejects_strict_platform_family_without_explicit_verifier(self) -> None:
+        entries = [
+            {
+                "id": "strict-family",
+                "releaseRequired": True,
+                "platforms": [
+                    {
+                        "id": "amd64",
+                        "os": "linux",
+                        "architecture": "amd64",
+                        "tag": "1.0",
+                        "runner": "ubuntu-24.04",
+                    }
+                ],
+            }
+        ]
+        with self.assertRaisesRegex(
+            AggregationError,
+            "strict platform families require explicit aggregate verification",
+        ):
+            aggregate_summaries(
+                [_summary(0, [_result("strict-family")], count=1)],
+                entries,
+                expected_shard_count=1,
+            )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/test_ignite2_removal.py
+++ b/scripts/test_ignite2_removal.py
@@ -19,13 +19,6 @@ class Ignite2RemovalTest(unittest.TestCase):
         for relative in (".github/workflows/nightly-tests.yml", ".github/workflows/release.yml"):
             workflow = (ROOT / relative).read_text(encoding="utf-8")
             self.assertNotIn("ignite2", workflow.lower(), relative)
-        nightly = (ROOT / ".github/workflows/nightly-tests.yml").read_text(encoding="utf-8")
-        for obsolete_argument in (
-            "--platform-id amd64",
-            "--expected-tag 2.18.0",
-            "--expected-architecture amd64",
-        ):
-            self.assertNotIn(obsolete_argument, nightly)
 
     def test_build_contract_has_no_ignite2_runtime_dependency_or_jvm_options(self) -> None:
         root_build = (ROOT / "build.gradle.kts").read_text(encoding="utf-8")

--- a/scripts/test_ignite2_removal.py
+++ b/scripts/test_ignite2_removal.py
@@ -19,6 +19,13 @@ class Ignite2RemovalTest(unittest.TestCase):
         for relative in (".github/workflows/nightly-tests.yml", ".github/workflows/release.yml"):
             workflow = (ROOT / relative).read_text(encoding="utf-8")
             self.assertNotIn("ignite2", workflow.lower(), relative)
+        nightly = (ROOT / ".github/workflows/nightly-tests.yml").read_text(encoding="utf-8")
+        for obsolete_argument in (
+            "--platform-id amd64",
+            "--expected-tag 2.18.0",
+            "--expected-architecture amd64",
+        ):
+            self.assertNotIn(obsolete_argument, nightly)
 
     def test_build_contract_has_no_ignite2_runtime_dependency_or_jvm_options(self) -> None:
         root_build = (ROOT / "build.gradle.kts").read_text(encoding="utf-8")

--- a/scripts/test_run_testcontainers_image_gate.py
+++ b/scripts/test_run_testcontainers_image_gate.py
@@ -821,6 +821,40 @@ class TestRunTestcontainersImageGate(unittest.TestCase):
             verify_release_summary(summary, expected_coverage="1/1", platform_id="arm64", expected_tag="1.0-arm64", expected_architecture="arm64"),
         )
 
+    def test_release_verifier_accepts_generic_summary_without_platform_contract(self) -> None:
+        summary = {
+            "schema_version": 2,
+            "coverage": "1/1",
+            "release_gate": True,
+            "status": "success",
+            "selected": 1,
+            "blocked": 0,
+            "product_failure": 0,
+            "infrastructure_failure": 0,
+            "release_required_selected": 1,
+            "release_required_success": 1,
+            "results": [
+                {
+                    "id": "generic-family",
+                    "release_required": True,
+                    "status": "success",
+                    "junit": {"tests": 1, "skipped": 0, "failures": 0, "errors": 0},
+                }
+            ],
+            "platforms": [],
+        }
+
+        self.assertEqual(
+            [],
+            verify_release_summary(
+                summary,
+                expected_coverage="1/1",
+                platform_id=None,
+                expected_tag=None,
+                expected_architecture=None,
+            ),
+        )
+
     def test_budget_formula_and_52_family_artifact_guard(self) -> None:
         self.assertEqual(
             318,

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -274,6 +274,12 @@ class TestTestcontainersImageGate(unittest.TestCase):
         self.assertIn("needs: [test-testcontainers, test-testcontainers-image-gate, plan]", workflow)
         self.assertIn("needs.test-testcontainers-image-gate.result == 'skipped'", workflow)
         self.assertIn("name: nightly-testcontainers-image-gate-${{ github.run_id }}-amd64", workflow)
+        for obsolete_argument in (
+            "--platform-id amd64",
+            "--expected-tag 2.18.0",
+            "--expected-architecture amd64",
+        ):
+            self.assertNotIn(obsolete_argument, workflow)
 
     def test_release_publish_reuses_full_nightly_gate_summary(self) -> None:
         workflow = (self.root / ".github/workflows/release.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## 변경 요약

Ignite 2 제거 후에도 Full Nightly aggregate가 단일 amd64 strict platform 결과를 요구해 실패하던 회귀를 수정합니다.

현재 51개 image family에는 strict platform 계약이 없습니다. aggregate는 전체 coverage, release gate, JUnit, family artifact를 계속 fail-closed로 검증하고, pull·architecture·workload를 포함한 strict platform 검증은 해당 계약이 명시된 family 실행에서만 적용합니다.

Full Nightly run [#34033352868](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34033352868)의 네 shard artifact를 변경 코드로 재집계하면 이전의 `exactly one amd64 platform result is required` 대신 전체 `51/51`, release-required `47/47`, `release_gate=true`로 완료됩니다.

## 변경 유형

- [x] `fix` — 버그 수정
- [x] `test` — 테스트 추가/수정
- [x] `chore` — GitHub Actions 설정 수정

## 검증

- TDD RED: generic summary가 `exactly one None platform result is required`로 실패하고 Nightly workflow에 obsolete aggregate 인자가 남아 있음을 확인
- TDD GREEN: 신규 회귀 테스트와 기존 strict platform 검증 테스트 통과
- Python 정책 테스트: 157개 통과
- 실제 실패 artifact 재집계: selected `51/51`, release `47/47`, family artifact 51개, `blocked=0`
- `actionlint .github/workflows/nightly-tests.yml`: 통과
- `python3 -m py_compile ...`: 통과
- `git diff --check`: 통과

## 범위

- generic aggregate에서 platform 계약을 선택 사항으로 분리
- aggregate CLI와 Nightly workflow의 제거된 Ignite 2 전용 `amd64/2.18.0` 인자 삭제
- generic aggregate와 Ignite 2 제거 workflow 계약의 회귀 테스트 추가
- strict platform family 재도입 시 전용 aggregate verifier 없이 fail-closed로 차단
- Kotlin/Gradle production module 변경 없음

Closes #1666

## DoD Status

- [x] 원인과 실패 run evidence를 issue #1666에 기록
- [x] generic summary가 strict platform 결과 없이 검증됨
- [x] strict platform verifier의 기존 증거 검증 유지
- [x] 실패 run artifact 51/51, 47/47 재집계 성공
- [x] Python 정책 테스트 157개, actionlint, py_compile, diff check 통과
- [x] 수정 exact-head GitHub Actions CI 통과 — run #34037044924, 26/26 success
- [x] code review 완료 — code-reviewer APPROVE, architect CLEAR
- [ ] 병합 후 exact-head Full Nightly 성공
