### PR TITLE
Ktor 애플리케이션 리소스 lifecycle을 공통화한다

### DIFF
--- a/docs/lessons/2026-09-06-issue-1656-ktor-attributes-side-effects.md
+++ b/docs/lessons/2026-09-06-issue-1656-ktor-attributes-side-effects.md
@@ -1,0 +1,79 @@
+# #1656: Ktor Attributes 경쟁과 lifecycle side effect를 분리한다
+
+## 배경
+
+Ktor plugin과 애플리케이션 시작 코드가 만든 client, executor, scheduler 같은 리소스는
+`Application` lifecycle에 맞춰 닫혀야 한다. 개별 plugin마다 `ApplicationStopped`를 직접
+구독하면 중복 종료, 종료 순서 불일치, failure handling 누락이 반복된다.
+
+공통 registry를 `Application.attributes.computeIfAbsent`로 설치하는 발상만으로는 충분하지
+않다. supplier는 경쟁 중 둘 이상 평가될 수 있으므로, supplier 안에서 event를 구독하면
+선택되지 않은 값도 subscription이라는 side effect를 남길 수 있다.
+
+## 결정
+
+- attribute supplier는 side effect 없는 private holder만 생성한다.
+- attribute에서 선택된 holder의 `install()`만 `ApplicationStopped`를 한 번 구독한다.
+- holder의 상태와 subscription handle은 같은 lock으로 직렬화한다.
+- registry는 등록 역순 종료, 조기 token 종료, 늦은 등록의 즉시 종료를 하나의 claim 규칙으로
+  처리한다.
+- close action은 caller thread에서 동기적으로 실행한다. coroutine scope, dispatcher,
+  timeout, retry, backend drain 정책은 registry가 소유하지 않는다.
+- report와 logger에는 opaque registration ID, phase, fatal 여부만 남긴다. resource 문자열,
+  예외 message, cause, class 이름은 노출하지 않는다.
+
+## 실패와 예상 밖의 점
+
+첫 구현은 테스트 편의를 위해 holder와 registrar seam을 `internal`로 두었다. Kotlin의
+`internal`은 JVM bytecode에서 package-private가 아니므로 Java 소비자에게 public
+implementation class로 보였다. production seam을 public ABI로 만드는 대신 테스트에서
+private holder를 reflection으로 호출하고, `javap`과 외부 package 테스트로 노출면을 고정했다.
+
+또한 Ktor application job의 disposal timeout과 `ApplicationStopped` handler의 실행 제한이
+같다고 가정하면 안 된다. 실제 short-timeout fixture에서 application child가 timeout 뒤에도
+정리 중인 상태를 만들고, bounded adapter가 drain을 끝낸 뒤 resource를 닫도록 검증했다.
+
+## 결과
+
+`installApplicationResourceLifecycle()`은 동시 호출에서도 같은 registry를 반환하며 event
+subscription을 한 번만 만든다. registry와 token의 종료가 경합해도 항목별 close는 최대 한
+번 실행된다. `OPEN`, `DRAINING`, `CLOSED` 중 어느 시점에 report를 읽어도
+`attempted == inFlight + closed + failures.size`가 유지된다.
+
+implementation holder는 JVM package-private이고 함수형 registrar를 위한 별도 class도
+생성되지 않는다. public registration token에는 Kotlin compiler의 synthetic bridge만 남으며,
+Java source가 호출할 수 있는 non-synthetic public constructor는 없다.
+
+## 검증 근거
+
+| 주장 | 근거 | 결과 |
+|---|---|---|
+| attribute supplier가 side effect를 만들지 않음 | private holder 생성과 winner `install()` 분리 | 동시 installer와 callback-before-handle 테스트 통과 |
+| 종료가 정확히 한 번 실행됨 | token/registry barrier 경합과 중복 stop callback | 각 resource와 subscription dispose 1회 |
+| disposal timeout 뒤 drain 경계 | `shutdownTimeout = 1L`인 `testApplication` fixture | child 활성 상태를 관찰한 뒤 drain 완료 후 resource close |
+| 실패 정보 비노출 | registry/Ktor logger appender, fatal marker, secret resource fixture | message, cause, class, `toString()` sentinel 미검출 |
+| public ABI 제한 | `javap -public`, class modifier, 외부 package 소비 테스트 | holder `ACC_PUBLIC` 없음, non-synthetic public token constructor 없음 |
+| publication 계약 유지 | POM/module metadata validator와 설정 diff | validator failures=0, 직접 dependency 12개, 설정 diff 0 |
+| 모듈 동작 | `:bluetape4k-ktor-core:check`, Kover, detekt | 39 tests, skipped/failures/errors 0 |
+
+구현 기준 commit은 `f41fea0f5`다. Ktor의 `AttributesJvm` 구현과 event subscription 반환
+handle을 실제 소비 JAR source에서 확인했으며, 라이브러리 내부 구현을 public API 계약으로
+승격하지 않았다.
+
+## Review Miss
+
+초기 검토 계획은 registry의 역순·멱등성에 집중해 JVM visibility와 Ktor disposal timeout 뒤
+실행 순서를 별도 fixture로 요구하지 않았다. 독립 구현 검토가 이 두 항목과 logger backend
+자체의 실패 경로를 P1으로 찾아냈다. 이후 ABI 검사, short-timeout fixture, fatal/ordinary
+failure 및 throwing appender matrix를 추가했다.
+
+## 다음 변경 시 지킬 점
+
+1. `Attributes.computeIfAbsent` supplier에는 subscription, thread 시작, resource allocation 같은
+   side effect를 넣지 않는다.
+2. Kotlin `internal`을 Java/Kotlin 소비자 모두에게 비공개인 JVM 경계로 표현하지 않는다.
+3. lifecycle timeout, event dispatch, resource drain을 하나의 제한 시간으로 가정하지 않는다.
+4. 동시성 report는 완료 결과뿐 아니라 `DRAINING`과 늦은 close의 `inFlight` 상태에서도 invariant를
+   검증한다.
+5. 실패 격리는 resource action뿐 아니라 logger와 subscription disposal이 던지는 경우까지
+   포함한다.

--- a/docs/lessons/2026-09-06-issue-1656-ktor-attributes-side-effects.md
+++ b/docs/lessons/2026-09-06-issue-1656-ktor-attributes-side-effects.md
@@ -41,8 +41,8 @@ subscription을 한 번만 만든다. registry와 token의 종료가 경합해�
 `attempted == inFlight + closed + failures.size`가 유지된다.
 
 implementation holder는 JVM package-private이고 함수형 registrar를 위한 별도 class도
-생성되지 않는다. public registration token에는 Kotlin compiler의 synthetic bridge만 남으며,
-Java source가 호출할 수 있는 non-synthetic public constructor는 없다.
+생성되지 않는다. registration token은 public interface이고 실제 구현은 private이므로
+소비자에게 생성자나 factory 구현을 노출하지 않는다.
 
 ## 검증 근거
 
@@ -52,11 +52,11 @@ Java source가 호출할 수 있는 non-synthetic public constructor는 없다.
 | 종료가 정확히 한 번 실행됨 | token/registry barrier 경합과 중복 stop callback | 각 resource와 subscription dispose 1회 |
 | disposal timeout 뒤 drain 경계 | `shutdownTimeout = 1L`인 `testApplication` fixture | child 활성 상태를 관찰한 뒤 drain 완료 후 resource close |
 | 실패 정보 비노출 | registry/Ktor logger appender, fatal marker, secret resource fixture | message, cause, class, `toString()` sentinel 미검출 |
-| public ABI 제한 | `javap -public`, class modifier, 외부 package 소비 테스트 | holder `ACC_PUBLIC` 없음, non-synthetic public token constructor 없음 |
+| public ABI 제한 | `javap -public`, class modifier, 외부 package 소비 테스트 | holder `ACC_PUBLIC` 없음, token은 생성자 없는 interface |
 | publication 계약 유지 | POM/module metadata validator와 설정 diff | validator failures=0, 직접 dependency 12개, 설정 diff 0 |
 | 모듈 동작 | `:bluetape4k-ktor-core:check`, Kover, detekt | 39 tests, skipped/failures/errors 0 |
 
-구현 기준 commit은 `f41fea0f5`다. Ktor의 `AttributesJvm` 구현과 event subscription 반환
+구현 기준 commit은 `419798fff`다. Ktor의 `AttributesJvm` 구현과 event subscription 반환
 handle을 실제 소비 JAR source에서 확인했으며, 라이브러리 내부 구현을 public API 계약으로
 승격하지 않았다.
 

--- a/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
@@ -76,9 +76,67 @@ backend ownership은 caller adapter에 남긴다.
   - 부분 실패 계속 진행 및 EARLY/SHUTDOWN/LATE report 누적
   - latch로 고정한 `DRAINING/inFlight` 읽기 결과와 counter invariant
   - fatal `Error` 뒤 나머지 cleanup과 sanitized marker
+  - `register { job.cancel() }` 뒤 독립 `Job.isCancelled == true`
   - 경합 반복에서 double close와 미종료 항목 없음
   - close action이 caller thread에서 실행됨
 - [ ] production 파일이 없는 상태에서 compile 실패가 새 API 부재 때문인지 확인한다.
+
+  핵심 test 코드는 다음 oracle을 그대로 사용한다.
+
+  ```kotlin
+  @Test
+  fun `report invariant remains valid while shutdown action is in flight`() {
+      val started = CountDownLatch(1)
+      val release = CountDownLatch(1)
+      val registry = ApplicationResourceRegistry()
+      registry.register {
+          started.countDown()
+          release.await(5, TimeUnit.SECONDS).shouldBeTrue()
+      }
+      val executor = Executors.newSingleThreadExecutor()
+      try {
+          val closeFuture = executor.submit { registry.close() }
+          started.await(5, TimeUnit.SECONDS).shouldBeTrue()
+          val report = registry.closeReport
+          report.state shouldBeEqualTo ApplicationResourceRegistryState.DRAINING
+          report.attempted shouldBeEqualTo
+              report.inFlight + report.closed + report.failures.size
+          release.countDown()
+          closeFuture.get(5, TimeUnit.SECONDS)
+      } finally {
+          release.countDown()
+          executor.shutdownNow()
+      }
+  }
+
+  @Test
+  fun `job cancellation can be adapted through a synchronous close action`() {
+      val job = Job()
+      val registry = ApplicationResourceRegistry()
+      registry.register { job.cancel() }
+      registry.close()
+      job.isCancelled.shouldBeTrue()
+  }
+  ```
+
+- [ ] failed implementation lane의 untracked production 파일은 `.codex/issue-1656-red-hold/`로
+  가역적으로 옮긴 뒤 RED를 재실행하고 반드시 원위치한다. test 파일은 그대로 두며 README와
+  committed spec/plan은 건드리지 않는다.
+
+  ```bash
+  mkdir -p .codex/issue-1656-red-hold
+  BT4K_HELD_SOURCE=.codex/issue-1656-red-hold/ApplicationResourceLifecycle.kt
+  BT4K_LIVE_SOURCE=ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt
+  mv "$BT4K_LIVE_SOURCE" "$BT4K_HELD_SOURCE"
+  trap 'test ! -f "$BT4K_HELD_SOURCE" || mv "$BT4K_HELD_SOURCE" "$BT4K_LIVE_SOURCE"' EXIT INT TERM
+  ./gradlew :bluetape4k-ktor-core:test \
+    --tests 'io.bluetape4k.ktor.core.ApplicationResourceRegistryTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
+  BT4K_RED_EXIT=$?
+  mv "$BT4K_HELD_SOURCE" "$BT4K_LIVE_SOURCE"
+  trap - EXIT INT TERM
+  test "$BT4K_RED_EXIT" -ne 0
+  ```
 
   ```bash
   ./gradlew :bluetape4k-ktor-core:test \
@@ -100,8 +158,6 @@ backend ownership은 caller adapter에 남긴다.
   marker로 모든 claim 처리 뒤 다시 던진다.
 - [ ] `Entry : AutoCloseable`과 `closeSafe`를 사용하되 failure 분류와 report 완료 전이는
   error handler 밖의 단일 lock transition에서 수행한다.
-- [ ] `Job()` fixture에 `register { job.cancel() }`을 등록해 `isCancelled`가 되는 독립 test를
-  포함한다.
 - [ ] 경합 test는 barrier/latch, 최대 8 worker, 5초 timeout, `shutdownNow()` cleanup을 사용한다.
 - [ ] Task 1 명령을 그대로 다시 실행해 GREEN을 만든다. 기대값이나 계약을 구현 편의로 약화하지
   않는다.
@@ -122,20 +178,84 @@ backend ownership은 caller adapter에 남긴다.
   resource 정보를 log로 흘리지 않게 한다.
 - [ ] 경합 시 attribute supplier가 여러 번 평가될 수 있어도 loser holder는 subscription을 만들지
   않고 winner holder만 하나의 callback을 설치함을 concurrency fixture로 검증한다.
+- [ ] production installer를 수정하기 전에 Ktor lifecycle/fake registrar test selector를 실행해
+  현재 구현의 duplicate-subscription/sticky-failure assertion이 실패하는 RED를 확인한다.
+
+  ```bash
+  ./gradlew :bluetape4k-ktor-core:test \
+    --tests 'io.bluetape4k.ktor.core.ApplicationResourceLifecycleTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
+  ```
+
+  기대 RED: fake registrar의 `subscribeCount`가 1보다 크거나, 두 번째 install이 registrar를 다시
+  호출하거나, 원본 failure가 cause/message/suppressed에 남는 assertion이 실패한다. 기존
+  `testApplication` failure나 timeout은 RED로 인정하지 않는다.
 - [ ] 외부 package compile fixture를 추가하고 targeted Ktor integration tests를 GREEN으로 만든다.
 
   ```kotlin
-  private class ApplicationResourceLifecycleHolder {
+  internal fun interface ApplicationResourceSubscriptionRegistrar {
+      fun subscribe(onStopped: () -> Unit): DisposableHandle
+  }
+
+  internal class ApplicationResourceLifecycleHolder(
+      private val registrar: ApplicationResourceSubscriptionRegistrar,
+  ) {
       private val lock = ReentrantLock()
       private var state: InstallState = InstallState.NEW
       val registry = ApplicationResourceRegistry()
 
-      fun install(application: Application): ApplicationResourceRegistry = lock.withLock {
-          // Only the attribute winner reaches side-effectful subscribe; READY returns registry,
-          // FAILED throws a sanitized installation error, and a created handle is disposed on failure.
+      fun install(): ApplicationResourceRegistry = lock.withLock {
+          when (state) {
+              InstallState.READY -> registry
+              InstallState.FAILED -> throw sanitizedInstallationFailure()
+              InstallState.NEW -> try {
+                  subscription = registrar.subscribe(::onStopped)
+                  state = InstallState.READY
+                  registry
+              } catch (_: Throwable) {
+                  state = InstallState.FAILED
+                  registry.close()
+                  throw sanitizedInstallationFailure()
+              }
+          }
       }
   }
   ```
+
+  public installer의 `computeIfAbsent` block은 위 holder와 Ktor registrar 객체만 만들고
+  `subscribe`를 호출하지 않는다. block이 반환한 winner holder에만 `install()`을 호출한다.
+
+  fake registrar test seam의 exact oracle은 다음과 같다.
+
+  ```kotlin
+  @Test
+  fun `winner holder subscribes once and disposes once`() {
+      val registrar = RecordingRegistrar()
+      val holder = ApplicationResourceLifecycleHolder(registrar)
+      repeat(8) { holder.install() shouldBeSameInstanceAs holder.registry }
+      registrar.subscribeCount.get() shouldBeEqualTo 1
+      registrar.raiseStopped()
+      registrar.disposeCount.get() shouldBeEqualTo 1
+  }
+
+  @Test
+  fun `failed holder never retries and exposes only sanitized failure`() {
+      val registrar = FailingRegistrar(IllegalStateException("credential-secret"))
+      val holder = ApplicationResourceLifecycleHolder(registrar)
+      repeat(2) {
+          val failure = assertFailsWith<IllegalStateException> { holder.install() }
+          failure.message shouldBeEqualTo "Application resource lifecycle installation failed."
+          failure.cause shouldBeNull()
+          failure.suppressed.toList() shouldBeEmpty()
+      }
+      registrar.subscribeCount.get() shouldBeEqualTo 1
+  }
+  ```
+
+  `RecordingRegistrar`는 raw `subscribeCount`, callback, 반환 handle의 `disposeCount`를 각각
+  보유한다. `FailingRegistrar`는 handle을 반환하지 않고 subscribe에서 throw하므로 orphan
+  handle 수는 0이다. handle 반환 뒤 holder에는 fallible 설치 단계가 없으며, dispose failure는
+  callback test에서 별도로 주입해 report 보존과 sanitized logging을 확인한다.
 
   ```bash
   ./gradlew :bluetape4k-ktor-core:test \
@@ -204,11 +324,48 @@ backend ownership은 caller adapter에 남긴다.
 - [ ] CHANGELOG는 unreleased change convention이 없고 이 저장소가 PR 단위 CHANGELOG를 쓰지 않아
   N/A, diagram은 state transition이 spec 표로 충분해 N/A, AGENTS/workflow/catalog/module
   registration은 변경하지 않아 N/A임을 review evidence에 기록한다.
-- [ ] lesson 파일을 작성·검증해 README/KDoc과 함께 세 번째 Lore commit을 만든다.
-- [ ] Graph adoption은 `bluetape4k/bluetape4k-graph`에서 authority/중복 issue·PR/현재 metadata를
-  live 확인한 뒤 한국어 issue 생성, assignee/milestone/labels 적용, body read-back을 각각 수행한다.
-- [ ] Leader adoption은 `bluetape4k/bluetape4k-leader`에서 같은 순서로 별도 수행한다.
-- [ ] AWS adoption은 `bluetape4k/bluetape4k-aws`에서 같은 순서로 별도 수행한다.
+- [ ] lesson은 context, decision, failure/surprise, outcome, verification evidence, review miss,
+  future guard를 각각 별도 heading으로 작성한다.
+- [ ] lesson `SPW-01`: 대상은 향후 Ktor lifecycle 구현자, 목적은 attribute supplier의
+  side-effect 금지, source ledger는 Ktor 3.5.2 `AttributesJvm.kt`와 이 spec/plan으로 고정한다.
+- [ ] lesson `SPW-02`: 위 7개 필수 heading과 evidence-backed 결과를 모두 채운다.
+- [ ] lesson `SPW-03`: 한국어 naturalness checklist와 용어 감사를 통과한다.
+- [ ] lesson `SPW-04`: `computeIfAbsent` source line, holder protocol, concurrency/failure test와
+  commit SHA를 source-to-claim 표로 대조한다.
+- [ ] lesson `SPW-05`: rendered Markdown의 heading/table/code fence를 read-back하고 5/5 PASS를
+  workflow evidence에 기록한다.
+
+  ```bash
+  node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs --json \
+    docs/lessons/2026-09-06-issue-1656-ktor-attributes-side-effects.md
+  git diff --check
+  ```
+
+- [ ] lesson 파일을 README/KDoc과 함께 세 번째 Lore commit으로 만든다.
+
+### Graph adoption issue
+
+- [ ] 사용자 승인 spec이 `bluetape4k/bluetape4k-graph` issue 생성 authority를 포함하는지 기록한다.
+- [ ] live duplicate issue/PR과 assignee/milestone/labels를 조회한다.
+- [ ] 중복이 없을 때 한국어 issue를 생성한다.
+- [ ] 별도 명령으로 assignee/milestone/labels를 적용한다.
+- [ ] issue body와 metadata를 live read-back한다.
+
+### Leader adoption issue
+
+- [ ] 사용자 승인 spec이 `bluetape4k/bluetape4k-leader` issue 생성 authority를 포함하는지 기록한다.
+- [ ] live duplicate issue/PR과 assignee/milestone/labels를 조회한다.
+- [ ] 중복이 없을 때 한국어 issue를 생성한다.
+- [ ] 별도 명령으로 assignee/milestone/labels를 적용한다.
+- [ ] issue body와 metadata를 live read-back한다.
+
+### AWS adoption issue
+
+- [ ] 사용자 승인 spec이 `bluetape4k/bluetape4k-aws` issue 생성 authority를 포함하는지 기록한다.
+- [ ] live duplicate issue/PR과 assignee/milestone/labels를 조회한다.
+- [ ] 중복이 없을 때 한국어 issue를 생성한다.
+- [ ] 별도 명령으로 assignee/milestone/labels를 적용한다.
+- [ ] issue body와 metadata를 live read-back한다.
 - [ ] 세 adoption 이슈 URL을 #1656 PR 본문에 연결한다. 생성 authority나 target metadata가
   불명확하면 issue 생성만 `PENDING`으로 두고 projects 구현/PR과 섞어 추정하지 않는다.
 
@@ -221,7 +378,7 @@ backend ownership은 caller adapter에 남긴다.
   ./gradlew :bluetape4k-ktor-core:test --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
   ./gradlew :bluetape4k-ktor-core:check --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
   ./gradlew :bluetape4k-ktor-core:detekt --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
-  if rg -n 'CoroutineScope|Dispatchers|asyncRunWithTimeout|closeTimeout|CompletableFuture|ForkJoinPool|Executors|Executor|kotlin\.concurrent\.thread|runBlocking|Timer\(|Thread\(' \
+  if rg -n 'CoroutineScope|GlobalScope|Dispatchers|newSingleThreadContext|newFixedThreadPoolContext|asyncRunWithTimeout|closeTimeout|CompletableFuture|ForkJoinPool|Executors|Executor|kotlin\.concurrent\.thread|runBlocking|Timer\(|Thread\(|Thread\.ofVirtual|Thread\.startVirtualThread' \
     ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt; then
     exit 1
   else

--- a/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
@@ -211,10 +211,10 @@ backend ownership은 caller adapter에 남긴다.
 
   internal class ApplicationResourceLifecycleHolder(
       private val registrar: ApplicationResourceSubscriptionRegistrar,
+      private val lock: ReentrantLock = ReentrantLock(),
   ) {
       private enum class InstallState { NEW, READY, FAILED, STOPPED }
 
-      private val lock = ReentrantLock()
       private var state: InstallState = InstallState.NEW
       private var subscription: DisposableHandle? = null
       internal val registry = ApplicationResourceRegistry()
@@ -316,6 +316,25 @@ backend ownership은 caller adapter에 남긴다.
           failure.suppressed.toList() shouldBeEmpty()
       }
       registrar.subscribeCount.get() shouldBeEqualTo 1
+  }
+
+  private class ObservedReentrantLock : ReentrantLock() {
+      val callbackContended = CountDownLatch(1)
+      private val observeContention = AtomicBoolean()
+
+      fun observeNextContention() {
+          check(observeContention.compareAndSet(false, true))
+      }
+
+      override fun lock() {
+          if (!observeContention.compareAndSet(true, false)) {
+              super.lock()
+              return
+          }
+          if (super.tryLock()) return
+          callbackContended.countDown()
+          super.lock()
+      }
   }
   ```
 

--- a/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
@@ -182,6 +182,7 @@ backend ownership은 caller adapter에 남긴다.
 
   internal class ApplicationResourceLifecycleHolder(
       private val registrar: ApplicationResourceSubscriptionRegistrar,
+      private val lock: ReentrantLock = ReentrantLock(),
   ) {
       val registry = ApplicationResourceRegistry()
 
@@ -284,13 +285,15 @@ backend ownership은 caller adapter에 남긴다.
   @Test
   fun `callback before handle publication disposes the published handle once`() {
       val registrar = BlockingRecordingRegistrar()
-      val holder = ApplicationResourceLifecycleHolder(registrar)
+      val observedLock = ObservedReentrantLock()
+      val holder = ApplicationResourceLifecycleHolder(registrar, observedLock)
       val executor = Executors.newFixedThreadPool(2)
       try {
           val install = executor.submit<ApplicationResourceRegistry> { holder.install() }
           registrar.handlerRegistered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+          observedLock.observeNextContention()
           val stop = executor.submit { registrar.raiseStopped() }
-          registrar.callbackStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+          observedLock.callbackContended.await(5, TimeUnit.SECONDS).shouldBeTrue()
           registrar.allowHandleReturn.countDown()
           install.get(5, TimeUnit.SECONDS) shouldBeSameInstanceAs holder.registry
           stop.get(5, TimeUnit.SECONDS)
@@ -317,11 +320,13 @@ backend ownership은 caller adapter에 남긴다.
   ```
 
   `RecordingRegistrar`는 raw `subscribeCount`, callback, 반환 handle의 `disposeCount`를 각각
-  보유한다. `BlockingRecordingRegistrar`는 handler 저장 뒤 handle 반환 직전 latch에서 멈추고,
-  `raiseStopped()`가 handler 호출 직전에 `callbackStarted`를 count down한다. test는 callback 시작을
-  await한 뒤 handle 반환을 허용해 callback/handle-publication race를 결정적으로 만든다. holder는
-  subscribe와 handle 저장을 같은 lock에서 수행하고 callback도 같은 lock에서 handle을 claim하므로
-  dispose owner는 하나다.
+  보유한다. `BlockingRecordingRegistrar`는 handler 저장 뒤 handle 반환 직전 latch에서 멈춘다.
+  `ObservedReentrantLock`은 handler가 공개된 뒤 armed 상태에서 callback thread의 `tryLock()`이
+  실패한 경우에만 `callbackContended`를 count down하고 실제 `lock()` 대기로 전환한다. test는 이
+  contention 증거를 await한 뒤 handle 반환을 허용해 callback-before-publication race를 결정적으로
+  만든다. holder는 subscribe와 handle 저장을 같은 lock에서 수행하고 callback도 같은 lock에서
+  handle을 claim하므로 dispose owner는 하나다. production은 기본 `ReentrantLock()`을 사용하고 이
+  internal constructor seam은 external public API/ABI에 노출하지 않는다.
   `FailingRegistrar`는 handle을 반환하지 않고 subscribe에서 throw하므로 orphan handle 수는 0이다.
   handle 반환 뒤 holder에는 fallible 설치 단계가 없으며, dispose failure는 callback test에서
   별도로 주입해 report 보존과 sanitized logging을 확인한다.

--- a/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
@@ -227,7 +227,7 @@ backend ownership은 caller adapter에 남긴다.
                       val handle = registrar.subscribe(::onStopped)
                       subscription = handle
                       state = InstallState.READY
-                      null
+                      return registry
                   } catch (_: Throwable) {
                       state = InstallState.FAILED
                       sanitizedInstallationFailure()
@@ -290,6 +290,7 @@ backend ownership은 caller adapter에 남긴다.
           val install = executor.submit<ApplicationResourceRegistry> { holder.install() }
           registrar.handlerRegistered.await(5, TimeUnit.SECONDS).shouldBeTrue()
           val stop = executor.submit { registrar.raiseStopped() }
+          registrar.callbackStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
           registrar.allowHandleReturn.countDown()
           install.get(5, TimeUnit.SECONDS) shouldBeSameInstanceAs holder.registry
           stop.get(5, TimeUnit.SECONDS)
@@ -316,9 +317,11 @@ backend ownership은 caller adapter에 남긴다.
   ```
 
   `RecordingRegistrar`는 raw `subscribeCount`, callback, 반환 handle의 `disposeCount`를 각각
-  보유한다. `BlockingRecordingRegistrar`는 handler 저장 뒤 handle 반환 직전 latch에서 멈춰
-  callback/handle-publication race를 결정적으로 만든다. holder는 subscribe와 handle 저장을 같은
-  lock에서 수행하고 callback도 같은 lock에서 handle을 claim하므로 dispose owner는 하나다.
+  보유한다. `BlockingRecordingRegistrar`는 handler 저장 뒤 handle 반환 직전 latch에서 멈추고,
+  `raiseStopped()`가 handler 호출 직전에 `callbackStarted`를 count down한다. test는 callback 시작을
+  await한 뒤 handle 반환을 허용해 callback/handle-publication race를 결정적으로 만든다. holder는
+  subscribe와 handle 저장을 같은 lock에서 수행하고 callback도 같은 lock에서 handle을 claim하므로
+  dispose owner는 하나다.
   `FailingRegistrar`는 handle을 반환하지 않고 subscribe에서 throw하므로 orphan handle 수는 0이다.
   handle 반환 뒤 holder에는 fallible 설치 단계가 없으며, dispose failure는 callback test에서
   별도로 주입해 report 보존과 sanitized logging을 확인한다.

--- a/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
@@ -1,0 +1,249 @@
+# Ktor 애플리케이션 리소스 lifecycle 공통화 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ktor application이 소유한 동기식 리소스를 application 종료와 연결하고, 역순·최대
+한 번·late registration·재진입·실패 격리 계약을 공통 API와 테스트로 제공한다.
+
+**Architecture:** `ktor/core`에 순수 동기식 `ApplicationResourceRegistry`와 명시적
+`ApplicationStopped` installer를 추가한다. registry는 한 lock에서 claim과 immutable report
+읽기 결과만 직렬화하고 실제 close는 lock 밖에서 실행한다. suspend, timeout, dispatcher,
+backend ownership은 caller adapter에 남긴다.
+
+**Tech Stack:** Kotlin 2.4, Java 25, Ktor 3.5.2, JUnit 5, `bluetape4k-assertions`,
+`kotlinx-coroutines-test`, Gradle 9.7.
+
+---
+
+## 파일별 책임
+
+- `ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt`
+  - public enum/report/registration/registry와 Ktor installer를 한 파일에 구현한다.
+- `ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/ApplicationResourceRegistryTest.kt`
+  - 순수 registry의 상태 전이, ordering, concurrency, reentrancy, failure contract를 검증한다.
+- `ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycleTest.kt`
+  - Ktor event 연결, installer idempotency, stop/cancellation/failure 동작을 검증한다.
+- `ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/consumer/ApplicationResourceLifecyclePublicApiTest.kt`
+  - 외부 package 관점 public API compile fixture를 제공한다.
+- `ktor/core/src/test/resources/abi/application-resource-lifecycle-javap.txt`
+  - 검토된 public JVM signature 기준을 고정한다.
+- `ktor/core/README.md`, `ktor/core/README.ko.md`
+  - 설치, ownership, bounded close, timeout/강제 종료 제약을 같은 의미로 기록한다.
+- `docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md`
+  - 승인된 계약과 review 반영 근거를 보존한다.
+- `docs/lessons/2026-09-06-issue-1656-ktor-attributes-side-effects.md`
+  - `Attributes.computeIfAbsent`의 multiple-evaluation 위험과 side-effect-free holder 규칙을
+    재사용 가능한 lesson으로 기록한다.
+
+## 구현 전 공통 게이트
+
+- [ ] workflow receipt가 `running`이고 모든 변경 대상에 대한 mutation authority가 있는지 확인한다.
+- [ ] 이슈 #1656이 여전히 OPEN이고 중복 PR이 없으며 milestone/labels/assignee가 유지되는지 live
+  GitHub state로 다시 확인한다.
+- [ ] 승인된 설계 문서의 최종 report invariant와 단일 production 파일 source audit를 확인한다.
+- [ ] 승인된 spec과 이 계획만 먼저 stage해 Lore commit을 만든다. 이미 보존된 partial
+  production/test edits는 이 commit에 포함하지 않는다.
+
+  ```bash
+  git add docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md \
+    docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
+  git diff --cached --check
+  git commit
+  ```
+
+  기대 결과: 첫 commit에는 승인된 spec/plan 두 파일만 포함되고 working tree에는 보존된
+  implementation/README 변경만 남는다.
+
+## Pre-mortem과 stop condition
+
+| 실패 모드 | 조기 신호 | 예방·검증 | stop condition |
+|---|---|---|---|
+| attribute loser가 subscription 생성 | 동시 installer 뒤 callback 횟수 > 1 | supplier는 side-effect-free holder만 생성, winner holder lock 초기화 | 정확히 하나를 증명하지 못하면 구현 중단 |
+| report 불변식이 close 중 깨짐 | `ApplicationResourceCloseReport` 생성 예외 | failure/inFlight/closed 완료 전이를 한 lock에서 수행, latch 관찰 | 모든 중간 읽기 invariant가 아니면 중단 |
+| secret이 log/marker로 유출 | sentinel이 appender/event/report에 나타남 | cause를 logger에 전달하지 않고 negative assertion | 한 surface라도 sentinel이면 중단 |
+| shutdown callback이 무기한 실행 | short-timeout fixture 종료 지연 | bounded action을 caller 계약으로 고정, registry는 timeout 미소유 | unbounded test/hang이면 adapter 계약 재검토 |
+| ABI 검증이 installer를 누락 | golden에 `ApplicationResourceLifecycleKt` 없음 | golden 생성과 human diff review를 분리 | top-level signature 미포함이면 PR 금지 |
+
+## Task 1: Registry 계약을 테스트로 잠근다 (RED)
+
+- [ ] `ApplicationResourceRegistryTest`에 다음 실패하는 테스트를 먼저 추가한다.
+  - 초기 report `OPEN/0/0/0/emptyList()`
+  - registration token과 registry close의 idempotency 및 exact-once
+  - 등록 역순 종료와 early-closed 항목 제외
+  - identity 중복 등록 거부와 정보 비노출 message
+  - DRAINING/CLOSED late registration 즉시 종료
+  - close 중 registry/token/register 재진입과 deadlock 부재
+  - 부분 실패 계속 진행 및 EARLY/SHUTDOWN/LATE report 누적
+  - latch로 고정한 `DRAINING/inFlight` 읽기 결과와 counter invariant
+  - fatal `Error` 뒤 나머지 cleanup과 sanitized marker
+  - 경합 반복에서 double close와 미종료 항목 없음
+  - close action이 caller thread에서 실행됨
+- [ ] production 파일이 없는 상태에서 compile 실패가 새 API 부재 때문인지 확인한다.
+
+  ```bash
+  ./gradlew :bluetape4k-ktor-core:test \
+    --tests 'io.bluetape4k.ktor.core.ApplicationResourceRegistryTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
+  ```
+
+  기대 RED: `Unresolved reference 'ApplicationResourceRegistry'` 등 새 API 부재 compile 오류다.
+  assertion mismatch, timeout, 기존 test failure면 RED로 인정하지 않고 fixture를 먼저 수정한다.
+
+## Task 2: 최소 동기식 Registry를 구현한다 (GREEN)
+
+- [ ] 승인된 public enum/data class/registration/registry API를 production 한 파일에 추가한다.
+- [ ] `ReentrantLock`, identity ownership set, ordered entry list, monotonic opaque ID로 claim을
+  선형화하고 실제 close는 lock 밖에서 실행한다.
+- [ ] `attempted == inFlight + closed + failures.size`가 모든 immutable report 읽기 결과에서
+  유지되도록 counters와 failure list를 같은 lock 안에서 갱신한다.
+- [ ] non-fatal/fatal failure 모두 다음 cleanup을 계속하고, fatal은 원본 message/cause 없는
+  marker로 모든 claim 처리 뒤 다시 던진다.
+- [ ] `Entry : AutoCloseable`과 `closeSafe`를 사용하되 failure 분류와 report 완료 전이는
+  error handler 밖의 단일 lock transition에서 수행한다.
+- [ ] `Job()` fixture에 `register { job.cancel() }`을 등록해 `isCancelled`가 되는 독립 test를
+  포함한다.
+- [ ] 경합 test는 barrier/latch, 최대 8 worker, 5초 timeout, `shutdownNow()` cleanup을 사용한다.
+- [ ] Task 1 명령을 그대로 다시 실행해 GREEN을 만든다. 기대값이나 계약을 구현 편의로 약화하지
+  않는다.
+- [ ] registry GREEN 시점의 diff를 검토하고 implementation commit은 Ktor integration test까지
+  함께 완료한 뒤 만든다.
+
+## Task 3: Ktor lifecycle 연결을 테스트하고 구현한다
+
+- [ ] `ApplicationResourceLifecycleTest`에 installer 반복/동시 호출, `ApplicationStopped` 종료,
+  정상 cancellation/join 이후 close, partial/fatal failure 격리, single subscription을 검증한다.
+- [ ] short-timeout embedded engine fixture로 disposal timeout 뒤 `ApplicationStopped`가 발생하며
+  adapter가 background job을 먼저 bounded drain해야 하는 제약을 검증한다.
+- [ ] `Attributes.computeIfAbsent` supplier에는 side effect 없는 holder만 만들고, attribute
+  winner holder의 lock/state에서 direct monitoring subscription을 exactly-once 초기화한다.
+  설치 실패 시 생성한 handle을 dispose하고 holder를 failed 상태로 고정해 orphan
+  registry/subscription이나 닫힌 registry의 정상 반환을 막는다.
+- [ ] event callback은 registry close 후 `finally`에서 subscription을 dispose하고, marker가
+  resource 정보를 log로 흘리지 않게 한다.
+- [ ] 경합 시 attribute supplier가 여러 번 평가될 수 있어도 loser holder는 subscription을 만들지
+  않고 winner holder만 하나의 callback을 설치함을 concurrency fixture로 검증한다.
+- [ ] 외부 package compile fixture를 추가하고 targeted Ktor integration tests를 GREEN으로 만든다.
+
+  ```kotlin
+  private class ApplicationResourceLifecycleHolder {
+      private val lock = ReentrantLock()
+      private var state: InstallState = InstallState.NEW
+      val registry = ApplicationResourceRegistry()
+
+      fun install(application: Application): ApplicationResourceRegistry = lock.withLock {
+          // Only the attribute winner reaches side-effectful subscribe; READY returns registry,
+          // FAILED throws a sanitized installation error, and a created handle is disposed on failure.
+      }
+  }
+  ```
+
+  ```bash
+  ./gradlew :bluetape4k-ktor-core:test \
+    --tests 'io.bluetape4k.ktor.core.ApplicationResourceLifecycleTest' \
+    --tests 'io.bluetape4k.ktor.core.consumer.ApplicationResourceLifecyclePublicApiTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
+  ```
+
+  기대 GREEN: 동시 installer가 같은 registry를 반환하고 `ApplicationStopped` callback과 close는
+  정확히 한 번 실행된다. short-timeout fixture도 test timeout 안에 끝난다.
+
+- [ ] secret sentinel fixture는 exception message, exception class, resource `toString()`을 서로
+  다른 값으로 두고 registry report, registry logger appender, Ktor environment logger,
+  marker message/cause/suppressed를 각각 negative assertion한다. throw하는 test appender를
+  붙인 경우에도 다음 close와 final report가 완료됨을 확인하고 `finally`에서 appender를 제거한다.
+- [ ] registry/Ktor tests GREEN 뒤 production/test/ABI fixture만 stage해 두 번째 Lore commit을
+  만든다.
+
+## Task 4: 공개 문서와 ABI/publication 계약을 고정한다
+
+- [ ] 모든 public API에 한국어 KDoc으로 ownership, caller-thread, bounded synchronous close,
+  graceful-only, ordering/timeout 제약을 기록한다.
+- [ ] 영문/국문 README에 같은 설치 예와 운영 제약을 반영하고 용어 감사를 통과시킨다.
+- [ ] `javap -public` 결과를 build report에 먼저 생성하고 reviewer가 public class들과
+  `ApplicationResourceLifecycleKt.installApplicationResourceLifecycle(Application)`을 확인한 뒤
+  별도 단계에서 golden fixture를 갱신한다. 생성 출력을 검토 없이 복사하지 않는다.
+- [ ] generated POM/module metadata validators, `checkPomFileForBluetape4kPublication`, 외부 package
+  compile fixture, origin/develop 대비 dependency 설정 무변경을 확인한다.
+
+  ```bash
+  ./gradlew :bluetape4k-ktor-core:jar \
+    :bluetape4k-ktor-core:compileTestKotlin \
+    :bluetape4k-ktor-core:generatePomFileForBluetape4kPublication \
+    :bluetape4k-ktor-core:generateMetadataFileForBluetape4kPublication \
+    :bluetape4k-ktor-core:checkPomFileForBluetape4kPublication
+  mkdir -p ktor/core/build/reports/api
+  javap -public -classpath ktor/core/build/classes/kotlin/main \
+    io.bluetape4k.ktor.core.ApplicationResourceClosePhase \
+    io.bluetape4k.ktor.core.ApplicationResourceRegistryState \
+    io.bluetape4k.ktor.core.ApplicationResourceCloseFailure \
+    io.bluetape4k.ktor.core.ApplicationResourceRegistry \
+    io.bluetape4k.ktor.core.ApplicationResourceRegistration \
+    io.bluetape4k.ktor.core.ApplicationResourceCloseReport \
+    io.bluetape4k.ktor.core.ApplicationResourceLifecycleKt \
+    > ktor/core/build/reports/api/application-resource-lifecycle-javap.txt
+  diff -u ktor/core/src/test/resources/abi/application-resource-lifecycle-javap.txt \
+    ktor/core/build/reports/api/application-resource-lifecycle-javap.txt
+  ruby scripts/publication/validate_poms.rb \
+    ktor/core/build/publications/Bluetape4k/pom-default.xml
+  ruby scripts/publication/validate_module_metadata.rb \
+    ktor/core/build/publications/Bluetape4k/module.json
+  git diff --exit-code origin/develop -- \
+    ktor/core/build.gradle.kts gradle/libs.versions.toml settings.gradle.kts
+  ```
+
+  기대 결과: reviewed golden exact diff 0, 두 validator 성공, publication/dependency 설정 diff 0.
+- [ ] 문서 traceability를 확인한다.
+
+  | 계약 | KDoc | README.md | README.ko.md |
+  |---|---|---|---|
+  | explicit install/single owner | installer/registry | Application-owned resources | 애플리케이션 소유 리소스 |
+  | reverse/late/idempotent | registry/token | contract paragraph | 계약 문단 |
+  | bounded caller-thread close | registry/report | operations paragraph | 운영 제약 문단 |
+  | disposal timeout/graceful-only | installer | final paragraph | 마지막 문단 |
+
+- [ ] CHANGELOG는 unreleased change convention이 없고 이 저장소가 PR 단위 CHANGELOG를 쓰지 않아
+  N/A, diagram은 state transition이 spec 표로 충분해 N/A, AGENTS/workflow/catalog/module
+  registration은 변경하지 않아 N/A임을 review evidence에 기록한다.
+- [ ] lesson 파일을 작성·검증해 README/KDoc과 함께 세 번째 Lore commit을 만든다.
+- [ ] Graph adoption은 `bluetape4k/bluetape4k-graph`에서 authority/중복 issue·PR/현재 metadata를
+  live 확인한 뒤 한국어 issue 생성, assignee/milestone/labels 적용, body read-back을 각각 수행한다.
+- [ ] Leader adoption은 `bluetape4k/bluetape4k-leader`에서 같은 순서로 별도 수행한다.
+- [ ] AWS adoption은 `bluetape4k/bluetape4k-aws`에서 같은 순서로 별도 수행한다.
+- [ ] 세 adoption 이슈 URL을 #1656 PR 본문에 연결한다. 생성 authority나 target metadata가
+  불명확하면 issue 생성만 `PENDING`으로 두고 projects 구현/PR과 섞어 추정하지 않는다.
+
+## Task 5: 회귀·리뷰·PR gate를 닫는다
+
+- [ ] targeted test, `:bluetape4k-ktor-core:test`, `check`, `detekt`, source audit,
+  `git diff --check`, 한국어 용어 감사를 fresh 실행한다.
+
+  ```bash
+  ./gradlew :bluetape4k-ktor-core:test --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
+  ./gradlew :bluetape4k-ktor-core:check --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
+  ./gradlew :bluetape4k-ktor-core:detekt --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
+  if rg -n 'CoroutineScope|Dispatchers|asyncRunWithTimeout|closeTimeout|CompletableFuture|ForkJoinPool|Executors|Executor|kotlin\.concurrent\.thread|runBlocking|Timer\(|Thread\(' \
+    ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt; then
+    exit 1
+  else
+    BT4K_RG_EXIT=$?
+    test "$BT4K_RG_EXIT" -eq 1
+  fi
+  git diff --check
+  ```
+
+  기대 결과: 세 Gradle 명령 성공, source audit no-match exit 1을 성공으로 변환, whitespace 오류 0건.
+- [ ] six-perspective code review를 exact diff에 수행하고 각 관점 `P0=0, P1=0`으로 수렴시킨다.
+- [ ] 각 단계의 기존 세 Lore commit을 read-back하고 잔여 변경이 있으면 의도별로 별도 commit한다.
+  한꺼번에 생성 출력을 stage하지 않는다. 이후 origin head에 push한다.
+- [ ] 한국어 PR 본문에 계약, 검증, follow-up, 위험, `## DoD Status`를 기록해 develop 대상 PR을
+  생성한다. assignee/labels/milestone을 #1656과 맞춘다.
+- [ ] PR exact-head checks, reviews/threads, mergeability, body metadata를 read-back한다. merge와
+  auto-merge는 수행하지 않는다.
+
+## 완료 조건
+
+- [ ] 설계의 public API, concurrency, failure, lifecycle 계약이 테스트와 구현에서 일치한다.
+- [ ] production close 경로에 새 thread/scope/dispatcher/timeout helper가 없다.
+- [ ] module/API/POM/문서 검증과 exact-head CI가 통과한다.
+- [ ] #1656을 닫는 PR이 생성되고 후속 adoption 이슈가 연결된다.
+- [ ] worktree/branch는 사용자의 일괄 merge 전까지 보존된다.

--- a/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
+++ b/docs/superpowers/plans/2026-09-06-issue-1656-ktor-resource-lifecycle-plan.md
@@ -58,7 +58,7 @@ backend ownership은 caller adapter에 남긴다.
 
 | 실패 모드 | 조기 신호 | 예방·검증 | stop condition |
 |---|---|---|---|
-| attribute loser가 subscription 생성 | 동시 installer 뒤 callback 횟수 > 1 | supplier는 side-effect-free holder만 생성, winner holder lock 초기화 | 정확히 하나를 증명하지 못하면 구현 중단 |
+| attribute loser가 subscription 생성 | fake registrar raw `subscribeCount > 1` | supplier는 side-effect-free holder만 생성, winner holder lock 초기화 | 정확히 하나를 증명하지 못하면 구현 중단 |
 | report 불변식이 close 중 깨짐 | `ApplicationResourceCloseReport` 생성 예외 | failure/inFlight/closed 완료 전이를 한 lock에서 수행, latch 관찰 | 모든 중간 읽기 invariant가 아니면 중단 |
 | secret이 log/marker로 유출 | sentinel이 appender/event/report에 나타남 | cause를 logger에 전달하지 않고 negative assertion | 한 surface라도 sentinel이면 중단 |
 | shutdown callback이 무기한 실행 | short-timeout fixture 종료 지연 | bounded action을 caller 계약으로 고정, registry는 timeout 미소유 | unbounded test/hang이면 adapter 계약 재검토 |
@@ -138,12 +138,6 @@ backend ownership은 caller adapter에 남긴다.
   test "$BT4K_RED_EXIT" -ne 0
   ```
 
-  ```bash
-  ./gradlew :bluetape4k-ktor-core:test \
-    --tests 'io.bluetape4k.ktor.core.ApplicationResourceRegistryTest' \
-    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
-  ```
-
   기대 RED: `Unresolved reference 'ApplicationResourceRegistry'` 등 새 API 부재 compile 오류다.
   assertion mismatch, timeout, 기존 test failure면 RED로 인정하지 않고 fixture를 먼저 수정한다.
 
@@ -172,14 +166,31 @@ backend ownership은 caller adapter에 남긴다.
   adapter가 background job을 먼저 bounded drain해야 하는 제약을 검증한다.
 - [ ] `Attributes.computeIfAbsent` supplier에는 side effect 없는 holder만 만들고, attribute
   winner holder의 lock/state에서 direct monitoring subscription을 exactly-once 초기화한다.
-  설치 실패 시 생성한 handle을 dispose하고 holder를 failed 상태로 고정해 orphan
-  registry/subscription이나 닫힌 registry의 정상 반환을 막는다.
+  subscribe failure는 holder를 failed 상태로 고정해 재시도와 닫힌 registry의 정상 반환을
+  막는다. handle 반환 뒤에는 fallible installation stage를 두지 않는다.
 - [ ] event callback은 registry close 후 `finally`에서 subscription을 dispose하고, marker가
   resource 정보를 log로 흘리지 않게 한다.
 - [ ] 경합 시 attribute supplier가 여러 번 평가될 수 있어도 loser holder는 subscription을 만들지
   않고 winner holder만 하나의 callback을 설치함을 concurrency fixture로 검증한다.
-- [ ] production installer를 수정하기 전에 Ktor lifecycle/fake registrar test selector를 실행해
-  현재 구현의 duplicate-subscription/sticky-failure assertion이 실패하는 RED를 확인한다.
+- [ ] fake registrar tests를 먼저 추가하고 selector를 실행해 seam type 부재 compile RED-A를
+  확인한다. 그다음 아래 naive compile scaffold만 추가해 RED-B를 실행한다.
+
+  ```kotlin
+  internal fun interface ApplicationResourceSubscriptionRegistrar {
+      fun subscribe(onStopped: () -> Unit): DisposableHandle
+  }
+
+  internal class ApplicationResourceLifecycleHolder(
+      private val registrar: ApplicationResourceSubscriptionRegistrar,
+  ) {
+      val registry = ApplicationResourceRegistry()
+
+      fun install(): ApplicationResourceRegistry {
+          registrar.subscribe { registry.close() }
+          return registry
+      }
+  }
+  ```
 
   ```bash
   ./gradlew :bluetape4k-ktor-core:test \
@@ -187,9 +198,9 @@ backend ownership은 caller adapter에 남긴다.
     --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache --rerun-tasks
   ```
 
-  기대 RED: fake registrar의 `subscribeCount`가 1보다 크거나, 두 번째 install이 registrar를 다시
-  호출하거나, 원본 failure가 cause/message/suppressed에 남는 assertion이 실패한다. 기존
-  `testApplication` failure나 timeout은 RED로 인정하지 않는다.
+  기대 RED-A: registrar/holder unresolved compile failure다. 기대 RED-B: 8개 worker 경합 뒤
+  `subscribeCount == 1`, sticky `FAILED`, sanitized failure, handle dispose exactly-once 중 하나
+  이상의 assertion이 실패한다. 기존 `testApplication` failure나 timeout은 RED로 인정하지 않는다.
 - [ ] 외부 package compile fixture를 추가하고 targeted Ktor integration tests를 GREEN으로 만든다.
 
   ```kotlin
@@ -200,23 +211,43 @@ backend ownership은 caller adapter에 남긴다.
   internal class ApplicationResourceLifecycleHolder(
       private val registrar: ApplicationResourceSubscriptionRegistrar,
   ) {
+      private enum class InstallState { NEW, READY, FAILED, STOPPED }
+
       private val lock = ReentrantLock()
       private var state: InstallState = InstallState.NEW
-      val registry = ApplicationResourceRegistry()
+      private var subscription: DisposableHandle? = null
+      internal val registry = ApplicationResourceRegistry()
 
-      fun install(): ApplicationResourceRegistry = lock.withLock {
-          when (state) {
-              InstallState.READY -> registry
-              InstallState.FAILED -> throw sanitizedInstallationFailure()
-              InstallState.NEW -> try {
-                  subscription = registrar.subscribe(::onStopped)
-                  state = InstallState.READY
-                  registry
-              } catch (_: Throwable) {
-                  state = InstallState.FAILED
-                  registry.close()
-                  throw sanitizedInstallationFailure()
+      internal fun install(): ApplicationResourceRegistry {
+          val failure = lock.withLock {
+              when (state) {
+                  InstallState.READY, InstallState.STOPPED -> return registry
+                  InstallState.FAILED -> sanitizedInstallationFailure()
+                  InstallState.NEW -> try {
+                      val handle = registrar.subscribe(::onStopped)
+                      subscription = handle
+                      state = InstallState.READY
+                      null
+                  } catch (_: Throwable) {
+                      state = InstallState.FAILED
+                      sanitizedInstallationFailure()
+                  }
               }
+          }
+          registry.close()
+          throw failure ?: error("Installation failure state is required.")
+      }
+
+      private fun onStopped() {
+          val handle = lock.withLock {
+              if (state != InstallState.READY) return
+              state = InstallState.STOPPED
+              subscription.also { subscription = null }
+          }
+          try {
+              registry.close()
+          } finally {
+              handle?.disposeWithoutCauseLogging()
           }
       }
   }
@@ -232,10 +263,42 @@ backend ownership은 caller adapter에 남긴다.
   fun `winner holder subscribes once and disposes once`() {
       val registrar = RecordingRegistrar()
       val holder = ApplicationResourceLifecycleHolder(registrar)
-      repeat(8) { holder.install() shouldBeSameInstanceAs holder.registry }
-      registrar.subscribeCount.get() shouldBeEqualTo 1
-      registrar.raiseStopped()
-      registrar.disposeCount.get() shouldBeEqualTo 1
+      val barrier = CyclicBarrier(8)
+      val executor = Executors.newFixedThreadPool(8)
+      try {
+          val futures = List(8) {
+              executor.submit {
+                  barrier.await(5, TimeUnit.SECONDS)
+                  holder.install()
+              }
+          }
+          futures.forEach { it.get(5, TimeUnit.SECONDS) shouldBeSameInstanceAs holder.registry }
+          registrar.subscribeCount.get() shouldBeEqualTo 1
+          registrar.raiseStopped()
+          registrar.disposeCount.get() shouldBeEqualTo 1
+      } finally {
+          executor.shutdownNow()
+      }
+  }
+
+  @Test
+  fun `callback before handle publication disposes the published handle once`() {
+      val registrar = BlockingRecordingRegistrar()
+      val holder = ApplicationResourceLifecycleHolder(registrar)
+      val executor = Executors.newFixedThreadPool(2)
+      try {
+          val install = executor.submit<ApplicationResourceRegistry> { holder.install() }
+          registrar.handlerRegistered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+          val stop = executor.submit { registrar.raiseStopped() }
+          registrar.allowHandleReturn.countDown()
+          install.get(5, TimeUnit.SECONDS) shouldBeSameInstanceAs holder.registry
+          stop.get(5, TimeUnit.SECONDS)
+          registrar.subscribeCount.get() shouldBeEqualTo 1
+          registrar.disposeCount.get() shouldBeEqualTo 1
+      } finally {
+          registrar.allowHandleReturn.countDown()
+          executor.shutdownNow()
+      }
   }
 
   @Test
@@ -253,9 +316,12 @@ backend ownership은 caller adapter에 남긴다.
   ```
 
   `RecordingRegistrar`는 raw `subscribeCount`, callback, 반환 handle의 `disposeCount`를 각각
-  보유한다. `FailingRegistrar`는 handle을 반환하지 않고 subscribe에서 throw하므로 orphan
-  handle 수는 0이다. handle 반환 뒤 holder에는 fallible 설치 단계가 없으며, dispose failure는
-  callback test에서 별도로 주입해 report 보존과 sanitized logging을 확인한다.
+  보유한다. `BlockingRecordingRegistrar`는 handler 저장 뒤 handle 반환 직전 latch에서 멈춰
+  callback/handle-publication race를 결정적으로 만든다. holder는 subscribe와 handle 저장을 같은
+  lock에서 수행하고 callback도 같은 lock에서 handle을 claim하므로 dispose owner는 하나다.
+  `FailingRegistrar`는 handle을 반환하지 않고 subscribe에서 throw하므로 orphan handle 수는 0이다.
+  handle 반환 뒤 holder에는 fallible 설치 단계가 없으며, dispose failure는 callback test에서
+  별도로 주입해 report 보존과 sanitized logging을 확인한다.
 
   ```bash
   ./gradlew :bluetape4k-ktor-core:test \

--- a/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
@@ -189,25 +189,32 @@ fun Application.installApplicationResourceLifecycle(): ApplicationResourceRegist
 1. caller는 application module 초기화에서 installer를 명시적으로 호출한다.
 2. Ktor 3.5.2의 `Attributes.computeIfAbsent` supplier는 경합 시 여러 번 평가될 수 있으므로
    supplier에서는 side effect 없는 lifecycle holder만 만든다. attribute winner holder가
-   자체 lock/state에서 event subscription을 정확히 한 번 초기화한다. 설치 도중 실패하면
-   생성한 subscription을 dispose하고 holder를 failed 상태로 고정해 orphan
-   registry/subscription이나 닫힌 registry의 정상 반환을 허용하지 않는다.
-3. subscription은 `ApplicationStopped`에서 registry를 동기적으로 닫고 `finally`에서 자기
+   자체 lock과 `NEW -> READY` 또는 `NEW -> FAILED` 상태 전이에서 event subscription을 정확히
+   한 번 초기화한다. 내부 subscription registrar seam은 Kotlin `internal`로 제한하고 public
+   installer는 Ktor monitor registrar만 주입한다. fake registrar test는 raw subscribe 횟수와
+   handle dispose 횟수를 callback/registry close 횟수와 별도로 관찰한다.
+3. subscribe가 throw하면 holder는 registry를 닫고 `FAILED`로 고정한다. 최초 호출과 이후 모든
+   호출은 원본 message/cause/suppressed가 없는 동일 type/message의 sanitized installation
+   exception을 던지며 재시도하지 않는다. Ktor registrar는 handle 반환 뒤 fallible 작업을 하지
+   않으므로 installation rollback에 아직 획득한 handle이 남는 단계가 없다. 반환된 handle의
+   dispose는 `ApplicationStopped` callback에서 정확히 한 번 시도하고 dispose 실패도 원본
+   Throwable 없이 기록하며 registry close 결과를 되돌리지 않는다.
+4. subscription은 `ApplicationStopped`에서 registry를 동기적으로 닫고 `finally`에서 자기
    자신을 dispose한다. plugin uninstall 뒤에 발생하는 event를 쓰므로 custom plugin
    instance의 `AutoCloseable` 또는 uninstall 순서에 기대지 않는다.
-4. public API는 다른 lifecycle event를 선택하는 configuration을 제공하지 않는다.
-5. `ApplicationStopping`에서 suspend cleanup이 필요한 adapter는 순수 registry와 자체
+5. public API는 다른 lifecycle event를 선택하는 configuration을 제공하지 않는다.
+6. `ApplicationStopping`에서 suspend cleanup이 필요한 adapter는 순수 registry와 자체
    `MonitoringEvent` 동기 bridge를 사용한다. installer와 custom bridge를 같은 registry에
    중복 연결하지 않는다.
-6. application coroutine `Job`을 공통 registry가 직접 await하지 않는다. 독립 `Job`의
+7. application coroutine `Job`을 공통 registry가 직접 await하지 않는다. 독립 `Job`의
    취소만 필요하면 caller가 `register { job.cancel() }`을 사용한다.
-7. application stop 이후에도 외부 코드가 보유한 registry reference로 register할 수
+8. application stop 이후에도 외부 코드가 보유한 registry reference로 register할 수
    있으나, 해당 action은 즉시 실행된다.
-8. `ApplicationStopped` 전에 Ktor disposal timeout이 발생하면 application `Job`이 아직
+9. `ApplicationStopped` 전에 Ktor disposal timeout이 발생하면 application `Job`이 아직
    끝나지 않았을 수 있다. resource를 사용하는 background job은 adapter가
    `ApplicationStopping`에서 bounded drain하거나, cancellation을 무시한 job이 resource에
    접근하지 않는다는 조건을 보장해야 한다.
-9. 서로 다른 Ktor plugin의 event handler 실행 순서는 이 registry가 보장하지 않는다.
+10. 서로 다른 Ktor plugin의 event handler 실행 순서는 이 registry가 보장하지 않는다.
    의존 리소스는 하나의 composite action으로 묶거나 한 registry에 의존 순서대로 등록한다.
 
 사용 예는 다음과 같다.
@@ -312,6 +319,12 @@ adoption checklist가 이를 금지한다.
   원본 message/cause가 log에 없음을 검증함
 - installer 반복·동시 호출이 side-effect-free attribute supplier와 winner holder 초기화 경계를
   통해 단일 registry와 단일 subscription만 생성함
+- fake registrar가 raw subscribe 1회와 callback 뒤 handle dispose 1회를 직접 보고하며,
+  registry close 횟수와 별도로 assertion됨
+- subscribe failure 뒤 raw subscribe가 1회에서 멈추고 최초/후속 호출이 같은 sanitized
+  type/message와 빈 cause/suppressed를 반환하며 registry를 정상 반환하지 않음
+- handle dispose failure가 registry report를 되돌리거나 callback을 재설치하지 않고 원본
+  failure 정보를 log/marker에 노출하지 않음
 - `io.bluetape4k.ktor.core.consumer.ApplicationResourceLifecyclePublicApiTest`가 외부 package에서
   installer, registry, registration, report public API를 compile하고 기본 사용 예를 실행함
 
@@ -363,7 +376,7 @@ ruby -r rexml/document -e '
 ' ktor/core/build/publications/Bluetape4k/pom-default.xml
 git diff --exit-code origin/develop -- \
   ktor/core/build.gradle.kts gradle/libs.versions.toml settings.gradle.kts
-if rg -n 'CoroutineScope|Dispatchers|asyncRunWithTimeout|closeTimeout|CompletableFuture|ForkJoinPool|Executors|Executor|kotlin\.concurrent\.thread|runBlocking|Timer\(|Thread\(' \
+if rg -n 'CoroutineScope|GlobalScope|Dispatchers|newSingleThreadContext|newFixedThreadPoolContext|asyncRunWithTimeout|closeTimeout|CompletableFuture|ForkJoinPool|Executors|Executor|kotlin\.concurrent\.thread|runBlocking|Timer\(|Thread\(|Thread\.ofVirtual|Thread\.startVirtualThread' \
   ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt; then
   exit 1
 else

--- a/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
@@ -1,0 +1,453 @@
+# Issue #1656: Ktor 애플리케이션 소유 리소스 lifecycle 공통화 설계
+
+## 상태와 범위
+
+- 대상 저장소: `bluetape4k-projects`
+- 대상 모듈: `bluetape4k-ktor-core`
+- 대상 버전: `2.1.0`
+- 작업 유형: Type A 공개 API 추가
+- 기준 ref: `origin/develop` / `8e5ff93d71faa372efaf1012088acc9e480bf04e`
+- 연결 이슈: [#1656](https://github.com/bluetape4k/bluetape4k-projects/issues/1656)
+- 비교 저장소: `bluetape4k-graph`, `bluetape4k-leader`, `bluetape4k-aws`
+- 상태: 2026-09-06 사용자 최종 승인, 명세 P0/P1 해소
+
+이번 변경은 Ktor application이 소유한 리소스를 application 종료와 연결하는 최소 registry를
+`ktor/core`에 추가한다. Graph, Leader, AWS의 실제 전환은 공통 API가 배포된 뒤 별도
+adoption 이슈와 PR에서 수행한다.
+
+## 1. 문제와 목표
+
+Graph, Leader, AWS의 Ktor plugin은 application 소유 리소스의 등록과 종료를 각자
+구현한다. 구현마다 idempotent close, 종료 역순, late registration, 일부 실패 격리,
+reentrant close 보장이 달라 공통 동작을 반복해서 검증해야 한다.
+
+목표는 다음과 같다.
+
+1. application마다 하나의 resource registry를 명시적으로 설치한다.
+2. 등록 token과 registry 종료를 하나의 선형화 경계로 직렬화한다.
+3. registry를 여러 번 닫아도 각 등록 항목을 최대 한 번만 닫는다.
+4. 정상 종료에서는 등록의 역순으로 리소스를 닫는다.
+5. registry 종료 뒤 들어온 late registration은 즉시 닫는다.
+6. resource close가 registry나 다른 등록 token으로 재진입해도 deadlock이 발생하지 않는다.
+7. 한 항목의 close 실패가 나머지 항목의 종료를 막지 않는다.
+8. 정상 종료에 새 thread, dispatcher, coroutine scope를 만들지 않는다.
+9. 종료 실패를 resource 정보 없이 opaque registration ID와 close phase로 진단할 수 있다.
+
+## 2. 범위와 비범위
+
+### 2.1 포함 범위
+
+- `ApplicationResourceRegistry`의 동기식 등록·종료 계약
+- `AutoCloseable`과 동기식 close action 등록
+- 개별 등록을 조기에 종료하는 idempotent registration token
+- Ktor `ApplicationStopped` event와 registry를 연결하는 명시적 installer
+- 종료 대상 목록의 최소 성공·실패 집계
+- lifecycle, 동시성, 실패 격리, coroutine cancellation 회귀 테스트
+- 공개 API 한국어 KDoc과 영문·국문 README 사용 예
+
+### 2.2 제외 범위
+
+- suspend cleanup, `Job.join`, 비동기 close 완료 대기
+- registry가 직접 제공하는 timeout, retry, backoff, dispatcher와 coroutine scope 소유권
+- backend client 생성, 소유권 판정, health/readiness와 shutdown 순서 정책
+- exception message, credential, resource 내부 식별자를 포함한 상세 report
+- Graph·Leader의 신규 production dependency와 publication POM 변경
+- Graph·Leader·AWS의 실제 plugin 전환
+- JVM 전체 shutdown hook이나 전역 registry
+
+Leader의 bounded `Job` await와 상세 shutdown report는 Leader adapter에 남긴다. AWS의
+`MonitoringEvent` 동기 callback과 backend별 ownership, timeout bridge도 AWS adapter가
+소유한다. 공통 registry는 이 정책을 흡수하지 않는다. 대신 등록 대상은 application 시작
+경로가 소유하는 trusted resource/action으로 제한하고, 각 close는 caller 또는 adapter가
+반드시 유한한 시간 안에 동기적으로 끝나도록 보장해야 한다. request나 외부 입력으로 close
+action을 동적 등록하는 사용은 지원하지 않는다.
+
+## 3. 현재 근거와 제약
+
+- `bluetape4k-ktor-core`는 이미 `bluetape4k-core`와 Ktor server core를 `api` dependency로
+  사용한다. 새 module이나 외부 dependency는 필요하지 않다.
+- 기존 `ShutdownQueue`는 JVM 전역이라 application별 격리와 late/reentrant registration
+  계약을 제공하지 못한다.
+- `AutoCloseable.closeSafe`는 close 실패를 항목별로 격리할 수 있다.
+  `closeTimeout`은 별도 비동기 실행을 만들기 때문에 공통 정상 종료 경로에서는 사용하지
+  않고 bounded wait가 필요한 domain adapter에 남긴다.
+- Ktor 공식 문서는 `ApplicationStopped`를 application resource 해제 지점으로 안내한다.
+- Ktor 3.5.2 JVM engine은 `ApplicationStopping`을 발생시킨 뒤 application job을
+  cancel/join하고 plugin을 제거하려고 시도한 다음 `ApplicationStopped`를 발생시킨다.
+  `disposeAndJoin()`이 engine `shutdownTimeout`을 넘겨도 engine은 예외를 격리하고
+  `ApplicationStopped`를 발생시키므로, 이 event는 모든 application coroutine이 실제로
+  종료됐다는 증거가 아니다.
+- `MonitoringEvent` handler는 suspend lambda가 아닌 동기식 `(Param) -> Unit`이다. 공통
+  registry의 close 경로도 동기식으로 유지한다.
+- `ApplicationStopped` handler 실행은 engine의 `disposeAndJoin()` timeout 바깥에 있다.
+  따라서 registry는 engine timeout에 기대지 않고 등록 action 자체의 bounded completion을
+  공개 선행조건으로 둔다.
+
+참고 자료:
+
+- [Ktor application monitoring](https://ktor.io/docs/server-events.html)
+- [Ktor 3.5.2 `EmbeddedServerJvm`](https://github.com/ktorio/ktor/blob/3.5.2/ktor-server/ktor-server-core/jvm/src/io/ktor/server/engine/EmbeddedServerJvm.kt#L293-L318)
+- [Ktor 3.5.2 `MonitoringEvent`](https://github.com/ktorio/ktor/blob/3.5.2/ktor-server/ktor-server-core/common/src/io/ktor/server/application/hooks/CommonHooks.kt#L50-L68)
+- [Ktor 3.5.2 `AttributesJvm.computeIfAbsent`](https://github.com/ktorio/ktor/blob/3.5.2/ktor-utils/jvm/src/io/ktor/util/AttributesJvm.kt#L38-L51)
+
+## 4. 대안 비교와 결정
+
+| 대안 | 장점 | 단점 | 결정 |
+|---|---|---|---|
+| 각 plugin의 lifecycle 유지 | dependency와 API 변화가 없음 | 중복 구현과 서로 다른 종료 보장이 계속됨 | 채택하지 않음 |
+| application attribute를 처음 사용할 때 lazy 등록 | 호출 코드가 짧음 | lifecycle 설치 시점이 숨겨지고 시작 이후 첫 접근을 안전하게 설명하기 어려움 | 채택하지 않음 |
+| suspend registry가 `Job`, timeout, report를 모두 소유 | 한 abstraction에서 상세 종료를 수행 | Leader 정책을 중복하고 새 scope/thread 및 backend별 정책을 공통 모듈에 끌어들임 | 채택하지 않음 |
+| 명시적 Ktor installer와 동기식 최소 registry | 설치·소유권이 드러나고 기존 adapter 정책을 보존하며 공통 불변식만 재사용 | suspend cleanup은 adapter가 별도로 연결해야 함 | **채택** |
+
+## 5. 공개 API 계약
+
+`io.bluetape4k.ktor.core` package에 다음 API를 추가한다. 세부 이름은 구현 중 compile
+검증에서 Ktor API 충돌이 확인되면 의미를 유지한 채 조정할 수 있으며, 명세 변경으로
+기록한다.
+
+```kotlin
+enum class ApplicationResourceClosePhase {
+    EARLY,
+    SHUTDOWN,
+    LATE_REGISTRATION,
+}
+
+enum class ApplicationResourceRegistryState {
+    OPEN,
+    DRAINING,
+    CLOSED,
+}
+
+data class ApplicationResourceCloseFailure(
+    val registrationId: Long,
+    val phase: ApplicationResourceClosePhase,
+    val fatal: Boolean,
+)
+
+data class ApplicationResourceCloseReport(
+    val state: ApplicationResourceRegistryState,
+    val attempted: Int,
+    val inFlight: Int,
+    val closed: Int,
+    val failures: List<ApplicationResourceCloseFailure>,
+)
+
+class ApplicationResourceRegistration internal constructor(...) : AutoCloseable {
+    val id: Long
+    override fun close()
+}
+
+class ApplicationResourceRegistry : AutoCloseable {
+    fun register(resource: AutoCloseable): ApplicationResourceRegistration
+    fun register(closeAction: () -> Unit): ApplicationResourceRegistration
+    val closeReport: ApplicationResourceCloseReport
+    override fun close()
+}
+
+fun Application.installApplicationResourceLifecycle(): ApplicationResourceRegistry
+```
+
+계약은 다음과 같다.
+
+- installer는 application마다 registry를 정확히 하나 설치하고 반환한다.
+- 같은 application에서 installer를 다시 호출하면 기존 registry를 반환한다.
+- `register`는 해당 항목을 조기에 닫을 수 있는 registration token을 반환한다. token의
+  양수 `id`는 registry 안에서만 단조 증가하는 opaque 값이며 resource 정보로부터 파생하지
+  않는다.
+- token과 registry는 경합하더라도 항목을 최대 한 번만 claim하고 닫는다.
+- token close는 registry에서 항목을 제거한 뒤 실제 close를 lock 밖에서 수행한다.
+- 동일 `AutoCloseable` 또는 동일 close-action 객체의 중복 등록은 registry lifetime 동안
+  identity 기준으로 거부한다. `IllegalArgumentException` message에는 resource 문자열이나
+  class 이름을 넣지 않는다. 서로 다른 lambda가 같은 내부 resource를 capture하는 경우는
+  탐지할 수 없으므로 caller가 단일 ownership을 지켜야 한다.
+- registry close는 아직 claim되지 않은 항목의 역순 종료 대상 목록을 만든 뒤 실제 close를 lock
+  밖에서 수행한다.
+- registry close가 시작된 뒤의 등록은 항목을 보관하지 않고 호출 thread에서 즉시 닫으며
+  no-op registration token을 반환한다.
+- `closeReport`는 property를 읽는 순간의 registry state와 `EARLY`, `SHUTDOWN`,
+  `LATE_REGISTRATION` close 결과를 한 lock 안에서 복사한 immutable value다. close claim 시
+  `attempted`와 `inFlight`를 함께 올리고 완료 시 `inFlight`를 내리면서 `closed` 또는
+  `failures`를 갱신하므로, close 진행 중에도 `attempted == inFlight + closed +
+  failures.size`를 만족한다. 초기값은 `OPEN/0/0/0/emptyList()`다.
+- 최초 registry close는 lock 안에서 `OPEN -> DRAINING`으로 전환하고 종료 대상 목록을
+  분리한다. 모든 shutdown 항목의 결과를 반영한 뒤 `CLOSED`로 전환한다. `DRAINING` 중
+  재진입한 registry close는 no-op이고 새 등록은 `LATE_REGISTRATION`으로 즉시 처리한다.
+  `CLOSED` 뒤에도 late close가 진행되는 동안 `inFlight > 0`일 수 있으며, 그 결과는 같은
+  누적 report의 다음 immutable copy에 보인다.
+- 일반 failure와 JVM-fatal `Error`는 모두 나머지 cleanup을 막지 않는다. fatal 여부는 report와
+  숫자 기반 log에 남기고 모든 claim 항목을 시도한 뒤 원본 message/cause가 없는 sanitized
+  fatal marker를 다시 던진다. 순수 registry를 직접 닫는 caller에는 marker가 전달된다.
+  installer 경로에서는 Ktor `safeRaiseEvent`가 marker를 engine 밖으로 전파하지 않으므로,
+  sanitized warning과 report가 실제 운영 신호다. 이로써 치명 실패를 일반 실패와 구분하면서
+  credential이나 resource 내부 정보가 Ktor log로 전파되지 않게 한다.
+- `close()`는 순수 registry를 자체 `MonitoringEvent` bridge에서 재사용할 수 있도록 공개한다.
+  installer가 반환한 registry의 close ownership은 installer에만 있으며 caller가 직접
+  `close()`하거나 다른 종료 bridge와 동시에 연결해서는 안 된다.
+
+## 6. Ktor lifecycle 계약
+
+1. caller는 application module 초기화에서 installer를 명시적으로 호출한다.
+2. Ktor 3.5.2의 `Attributes.computeIfAbsent` supplier는 경합 시 여러 번 평가될 수 있으므로
+   supplier에서는 side effect 없는 lifecycle holder만 만든다. attribute winner holder가
+   자체 lock/state에서 event subscription을 정확히 한 번 초기화한다. 설치 도중 실패하면
+   생성한 subscription을 dispose하고 holder를 failed 상태로 고정해 orphan
+   registry/subscription이나 닫힌 registry의 정상 반환을 허용하지 않는다.
+3. subscription은 `ApplicationStopped`에서 registry를 동기적으로 닫고 `finally`에서 자기
+   자신을 dispose한다. plugin uninstall 뒤에 발생하는 event를 쓰므로 custom plugin
+   instance의 `AutoCloseable` 또는 uninstall 순서에 기대지 않는다.
+4. public API는 다른 lifecycle event를 선택하는 configuration을 제공하지 않는다.
+5. `ApplicationStopping`에서 suspend cleanup이 필요한 adapter는 순수 registry와 자체
+   `MonitoringEvent` 동기 bridge를 사용한다. installer와 custom bridge를 같은 registry에
+   중복 연결하지 않는다.
+6. application coroutine `Job`을 공통 registry가 직접 await하지 않는다. 독립 `Job`의
+   취소만 필요하면 caller가 `register { job.cancel() }`을 사용한다.
+7. application stop 이후에도 외부 코드가 보유한 registry reference로 register할 수
+   있으나, 해당 action은 즉시 실행된다.
+8. `ApplicationStopped` 전에 Ktor disposal timeout이 발생하면 application `Job`이 아직
+   끝나지 않았을 수 있다. resource를 사용하는 background job은 adapter가
+   `ApplicationStopping`에서 bounded drain하거나, cancellation을 무시한 job이 resource에
+   접근하지 않는다는 조건을 보장해야 한다.
+9. 서로 다른 Ktor plugin의 event handler 실행 순서는 이 registry가 보장하지 않는다.
+   의존 리소스는 하나의 composite action으로 묶거나 한 registry에 의존 순서대로 등록한다.
+
+사용 예는 다음과 같다.
+
+```kotlin
+fun Application.module() {
+    val resources = installApplicationResourceLifecycle()
+    val client = createClient()
+
+    resources.register(client)
+}
+```
+
+## 7. 동시성과 상태 전이
+
+registry는 하나의 `ReentrantLock`, ordered entry list, state와 report counter를 사용한다. 실제
+resource close는 lock 안에서 호출하지 않는다.
+
+| 현재 상태 | 동작 | 결과 |
+|---|---|---|
+| OPEN | resource/action 등록 | list 뒤에 추가하고 token 반환 |
+| OPEN | 동일 객체 재등록 | 정보 노출 없는 `IllegalArgumentException` |
+| OPEN | token close | entry claim·제거 후 lock 밖에서 즉시 close |
+| OPEN | registry close | DRAINING으로 전환하고 역순 종료 대상 목록을 분리 |
+| DRAINING | registry close | no-op, 진행 중 report 유지 |
+| DRAINING/CLOSED | 새 객체 register | lock 밖에서 즉시 close하고 no-op token 반환 |
+| DRAINING/CLOSED | 기존 identity 재등록 | 정보 노출 없는 `IllegalArgumentException` |
+| DRAINING | shutdown 대상 완료 | 마지막 항목 완료 뒤 CLOSED로 전환 |
+| 임의 close 실행 중 | registry/token/register 재진입 | lock을 보유하지 않으므로 독립 상태 전이를 수행 |
+
+동시에 시작한 register와 close 중 lock을 먼저 획득한 연산이 선형화 지점이 된다. register가
+먼저면 종료 대상 목록에 포함되고, close가 먼저면 late registration으로 즉시 닫힌다. 두
+경우 모두 항목은 최대 한 번 닫힌다.
+
+installer를 사용한 registry는 lifecycle bridge가 단일 close owner다. custom bridge가 필요한
+adapter는 installer를 사용하지 않고 순수 registry를 정확히 하나의 event에 연결한다. 서로
+다른 thread에서 registry close를 동시에 소유하는 구성은 지원하지 않으며, API/KDoc과
+adoption checklist가 이를 금지한다.
+
+## 8. 실패, 운영, 보안 계약
+
+- 각 resource/action은 `closeSafe`를 통해 독립적으로 닫고 error handler 자체는 절대
+  exception을 던지지 않는다.
+- 실패는 `failures`에 집계하고 다음 항목의 close를 계속한다.
+- `closed`는 예외 없이 종료된 항목 수이며 close 진행 중에도
+  `attempted == inFlight + closed + failures.size`를 만족한다.
+- failure는 opaque `registrationId`, `phase`, `fatal`만 포함한다. exception instance,
+  message, stack trace, resource `toString`, resource/class/name은 담지 않는다.
+- registry log는 failure마다 `registrationId`, `phase`, `fatal`만 warning으로 남기며 원본
+  `Throwable`을 logger에 전달하지 않는다. late failure도 `LATE_REGISTRATION`으로 report와
+  log에 함께 남는다.
+- caller가 등록한 close action은 application-startup code가 소유하는 trusted 작업이어야
+  하고 유한한 시간 안에 동기적으로 끝나야 한다. Ktor engine timeout은 이 callback에
+  적용되지 않으며 registry도 강제로 중단하지 않는다. backend wait가 있으면 adapter가
+  caller-owned timeout/deadline으로 bounded completion을 먼저 제공해야 한다.
+- `closeSafe`가 `Throwable`을 격리하는 현재 계약을 재사용하되 fatal 분류를 보존한다.
+  cancellation을 신호로 사용해야 하는 suspend adapter는 이 동기 경계 밖에서 cancellation
+  우선순위를 보존한다.
+- close가 끝나지 않는 동안 registry는 완료 report를 만들 수 없다. 운영 환경은 server
+  shutdown deadline과 process termination 정책으로 hung adapter를 탐지하며, registry는
+  이를 대신하지 않는다.
+
+## 9. 테스트 전략
+
+### 9.1 Registry 단위 테스트
+
+- registry를 두 번 닫아도 각 항목이 한 번만 닫힘
+- registration token과 registry close가 경합해도 한 번만 닫힘
+- 세 항목이 등록 역순으로 닫힘
+- token으로 먼저 닫은 항목은 registry 종료 대상 목록에서 제외됨
+- 동일 resource/action 객체의 중복 등록은 identity 기준으로 거부됨
+- 종료 후 등록은 즉시 닫히고 no-op token을 반환함
+- resource close 안에서 registry close를 다시 호출해도 deadlock이 없음
+- resource close 안에서 새 resource를 등록하면 late registration으로 즉시 닫힘
+- 중간 항목이 실패해도 앞뒤 항목이 계속 닫히고 EARLY/SHUTDOWN/LATE report가 정확함
+- close 전 report는 `OPEN/0/0/0/emptyList()`이고, close action을 latch로 멈춘 동안 읽은
+  report는 `DRAINING`, `inFlight > 0`, counter invariant를 만족함
+- early close만 수행한 report와 shutdown 완료 후 `CLOSED/inFlight=0` report가 정확함
+- opaque ID와 phase로 실패를 구분하며 exception message와 resource 문자열이 report/log에
+  포함되지 않음
+- fatal `Error`가 남은 cleanup 뒤 sanitized marker로 전달되고 원본 message/cause는 노출되지 않음
+- secret sentinel이 registry report/logger, Ktor environment logger, marker의
+  message/cause/suppressed 어느 곳에도 남지 않음
+- logging backend가 실패해도 report 전이와 나머지 cleanup이 계속됨
+- `register { job.cancel() }`로 독립 coroutine `Job`이 취소됨
+- 반복 경합 테스트에서 double close와 미종료 항목이 없음
+- finite close action이 JUnit `assertTimeout` 안에서 caller thread와 같은 thread에서 끝남
+
+경합 테스트는 latch/barrier로 선형화 경계를 통제하고 무작위 sleep에 의존하지 않는다.
+
+### 9.2 Ktor 통합 테스트
+
+- installer를 반복 호출해도 동일 registry를 반환함
+- `testApplication` 종료가 `ApplicationStopped` hook을 통해 등록 resource를 닫음
+- 정상 disposal fixture에서는 application coroutine이 취소·join된 뒤 resource close
+  action이 실행됨
+- 별도 short-timeout embedded-engine fixture에서는 disposal timeout 뒤에도
+  `ApplicationStopped`가 발생함을 확인하고, adapter가 background job을 먼저 bounded
+  drain하여 resource close와 동시 접근하지 않음을 latch로 검증함
+- 일부 close 실패가 application stop 자체와 나머지 resource cleanup을 막지 않음
+- installer 경로의 fatal failure가 sanitized warning/report로 남고 engine stop은 계속되며,
+  원본 message/cause가 log에 없음을 검증함
+- installer 반복·동시 호출이 side-effect-free attribute supplier와 winner holder 초기화 경계를
+  통해 단일 registry와 단일 subscription만 생성함
+- `io.bluetape4k.ktor.core.consumer.ApplicationResourceLifecyclePublicApiTest`가 외부 package에서
+  installer, registry, registration, report public API를 compile하고 기본 사용 예를 실행함
+
+### 9.3 검증 명령
+
+```bash
+./gradlew :bluetape4k-ktor-core:test --no-build-cache --rerun-tasks
+./gradlew :bluetape4k-ktor-core:check --no-build-cache --rerun-tasks
+./gradlew :bluetape4k-ktor-core:detekt --no-build-cache --rerun-tasks
+./gradlew :bluetape4k-ktor-core:jar \
+  :bluetape4k-ktor-core:compileTestKotlin \
+  :bluetape4k-ktor-core:generatePomFileForBluetape4kPublication \
+  :bluetape4k-ktor-core:generateMetadataFileForBluetape4kPublication \
+  :bluetape4k-ktor-core:checkPomFileForBluetape4kPublication
+ruby scripts/publication/validate_poms.rb \
+  ktor/core/build/publications/Bluetape4k/pom-default.xml
+ruby scripts/publication/validate_module_metadata.rb \
+  ktor/core/build/publications/Bluetape4k/module.json
+mkdir -p ktor/core/build/reports/api
+javap -public -classpath ktor/core/build/classes/kotlin/main \
+  io.bluetape4k.ktor.core.ApplicationResourceClosePhase \
+  io.bluetape4k.ktor.core.ApplicationResourceRegistryState \
+  io.bluetape4k.ktor.core.ApplicationResourceCloseFailure \
+  io.bluetape4k.ktor.core.ApplicationResourceRegistry \
+  io.bluetape4k.ktor.core.ApplicationResourceRegistration \
+  io.bluetape4k.ktor.core.ApplicationResourceCloseReport \
+  io.bluetape4k.ktor.core.ApplicationResourceLifecycleKt \
+  > ktor/core/build/reports/api/application-resource-lifecycle-javap.txt
+diff -u \
+  ktor/core/src/test/resources/abi/application-resource-lifecycle-javap.txt \
+  ktor/core/build/reports/api/application-resource-lifecycle-javap.txt
+ruby -r rexml/document -e '
+  document = REXML::Document.new(File.read(ARGV.fetch(0)))
+  actual = REXML::XPath.match(document, "/project/dependencies/dependency").map do |node|
+    [node.elements["groupId"].text, node.elements["artifactId"].text, node.elements["scope"].text].join(":")
+  end
+  expected = %w[
+    org.jetbrains:annotations:compile org.slf4j:slf4j-api:compile
+    io.github.bluetape4k:bluetape4k-core:compile io.ktor:ktor-server-core-jvm:compile
+    io.ktor:ktor-server-content-negotiation:compile io.ktor:ktor-server-status-pages:compile
+    io.ktor:ktor-serialization-kotlinx-json:compile
+    org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:compile
+    org.jetbrains.kotlin:kotlin-stdlib:runtime org.jetbrains.kotlin:kotlin-reflect:runtime
+    org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:runtime
+    org.jetbrains.kotlinx:atomicfu-jvm:runtime
+  ]
+  abort("unexpected ktor-core POM dependency set") unless actual == expected
+  puts "ktor-core-pom-baseline: dependencies=#{actual.length}"
+' ktor/core/build/publications/Bluetape4k/pom-default.xml
+git diff --exit-code origin/develop -- \
+  ktor/core/build.gradle.kts gradle/libs.versions.toml settings.gradle.kts
+if rg -n 'CoroutineScope|Dispatchers|asyncRunWithTimeout|closeTimeout|CompletableFuture|ForkJoinPool|Executors|Executor|kotlin\.concurrent\.thread|runBlocking|Timer\(|Thread\(' \
+  ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt; then
+  exit 1
+else
+  BT4K_RG_EXIT=$?
+  test "$BT4K_RG_EXIT" -eq 1
+fi
+git diff --check
+```
+
+이 repository에는 해당 module용 binary-compatibility task가 없다. 따라서 외부 package의
+compile fixture와 review된 golden file에 대한 `javap -public` exact diff로 공개 signature를
+검증한다. generated POM/module metadata validator와 기준 ref에서 확인한 12개 dependency의
+정확한 순서·scope 비교로 publication 계약을 검증한다. dependency 파일은 `origin/develop`과
+동일해야 한다. workflow/catalog/module registration은 변경하지 않으므로 관련 diff가 생기지
+않았는지 함께 검토한다.
+
+production 구현은 `ApplicationResourceLifecycle.kt` 한 파일에 둔다. 구현 중 production 파일을
+분리해야 한다면 위 비동기 primitive source audit도 `ktor/core/src/main/kotlin` 아래 이번 변경의
+모든 production 파일을 대상으로 확장하고, no-match `rg` exit code 1만 성공으로 인정한다.
+
+## 10. 문서, 호환성, adoption
+
+- 새 public class, property, function에 실제 동작과 제한을 설명하는 한국어 KDoc을 작성한다.
+- `ktor/core/README.md`와 `README.ko.md`에 explicit installation, ownership, stop timing,
+  bounded synchronous close 선행조건, opaque failure 진단, disposal-timeout caveat를 같은
+  의미로 기록한다.
+- 이 계약은 graceful shutdown 전용이다. `SIGKILL`, JVM crash, OOM처럼
+  `ApplicationStopped`가 발생하지 않는 강제 종료에서는 cleanup을 보장하지 않는다고
+  README와 KDoc에 명시한다.
+- 기존 `installBluetape4kKtorCore()`의 signature와 기본 동작은 바꾸지 않는다.
+- 새 기능은 additive API이며 기존 Ktor application에 자동 설치되지 않는다.
+- 새 dependency와 module은 추가하지 않는다.
+- projects PR에서 Graph, Leader, AWS의 adoption 범위와 dependency/POM 검증을 각각 durable
+  follow-up 이슈로 등록한다. adoption 구현은 projects PR merge, exact artifact publication,
+  POM/module metadata 확인 뒤 시작하며 이번 이슈에 포함하지 않는다.
+- publication 전 rollback은 projects PR revert다. publication 후 adoption rollback은 각
+  adapter의 registry 연결만 제거하고 기존 lifecycle 구현으로 복귀한다.
+- adoption checklist는 trusted startup-only registration, bounded synchronous close,
+  single lifecycle bridge ownership, cross-plugin ordering 비보장을 확인해야 한다.
+
+## 11. 수용 기준과 DoD
+
+- [ ] 공개 API와 내부 상태 전이가 이 명세와 일치한다.
+- [ ] idempotent, reverse-order, late, reentrant, partial-failure 계약이 테스트로 증명된다.
+- [ ] coroutine cancellation은 action adapter 경계로 증명되고 generic bounded await는 없다.
+- [ ] 정상 close 경로에 새 thread, dispatcher, coroutine scope가 없다.
+- [ ] 모든 등록 action의 bounded completion 선행조건이 KDoc/README/adoption checklist에 있다.
+- [ ] report와 log가 opaque ID/phase/fatal만 사용하고 credential/resource 내부 정보를 노출하지 않는다.
+- [ ] Ktor disposal timeout 뒤에도 발생하는 `ApplicationStopped` 의미와 background job 제약이 검증된다.
+- [ ] 영문·국문 README와 한국어 KDoc이 실제 API 이름·동작과 일치한다.
+- [ ] targeted test, module check, detekt, diff check, API/POM 검증이 통과한다.
+- [ ] 여섯 관점 spec/plan/code review가 각각 `P0=0, P1=0`으로 수렴한다.
+- [ ] Graph·Leader·AWS adoption이 별도 이슈로 추적된다.
+- [ ] PR exact-head CI, review/thread read-back, mergeability를 확인한다.
+
+## 12. 결정되지 않은 항목
+
+없음. installer는 Ktor custom plugin uninstall에 기대지 않고 application attribute와
+`ApplicationStopped` subscription을 사용한다. 구현 중 Ktor public API 제약으로 내부 저장
+형태가 바뀌더라도 명시적 설치, application별 단일 registry, 단일 event bridge, 동기 close라는
+공개 계약은 유지한다.
+
+## 13. 1차 명세 검토 반영
+
+- Performance: P1 1건과 P2 1건에 대해 trusted bounded action 선행조건, caller-thread test,
+  비동기 primitive source audit를 반영했다.
+- Security: P2 3건에 대해 startup-only 등록, fatal 분류·sanitized marker, identity 중복
+  거부를 반영했다.
+- Operations: P1 4건과 P2 3건에 대해 disposal-timeout 의미, opaque ID/phase report, 정확한
+  publication 명령, late 집계, adoption·ordering 계약을 반영했다.
+- 2차 review의 Performance P2 1건은 유효한 regex와 `rg` exit code 1만 허용하는 fail-closed
+  source audit로 수정했다.
+- 2차 review의 Operations P1 3건은 `state/inFlight` 원자 report, 정상/timeout fixture 분리,
+  `checkPomFile`·외부 package compile fixture·`javap` golden diff·12개 POM dependency
+  baseline으로 수정했다. fatal marker는 installer 경로에서 Ktor가 격리하므로 sanitized
+  warning/report가 운영 신호임을 명시했다.
+- Stability, Developer/API, User/Caller 독립 lane은 command deadline 안에 verdict를 반환하지
+  못해 main-session fallback으로 검토했다. fallback은 close ownership 단일화, installer의
+  atomic installation, cumulative immutable-copy report, 재진입과 중복 ownership 제한,
+  README/KDoc parity를 명세에 추가했다.
+- 최종 plan review의 P1은 Ktor `Attributes.computeIfAbsent` supplier가 경합 시 여러 번 평가될
+  수 있다는 점이었다. supplier는 side-effect-free holder만 만들고 winner holder의 lock/state가
+  subscription을 exactly-once 초기화·rollback하도록 계약과 concurrency test를 수정했다.
+- 최종 Operations 재검토의 유효한 P1 1건은 §8의 진행 중 report invariant를
+  `attempted == inFlight + closed + failures.size`로 정정해 해소했다. API 예시에는 이미
+  `state/inFlight`가 포함되어 있음을 exact-line read-back으로 확인했다.
+- 구현과 heavy validation은 작성된 명세 승인 뒤 수행한다.

--- a/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
@@ -191,8 +191,12 @@ fun Application.installApplicationResourceLifecycle(): ApplicationResourceRegist
    supplier에서는 side effect 없는 lifecycle holder만 만든다. attribute winner holder가
    자체 lock과 `NEW -> READY` 또는 `NEW -> FAILED` 상태 전이에서 event subscription을 정확히
    한 번 초기화한다. 내부 subscription registrar seam은 Kotlin `internal`로 제한하고 public
-   installer는 Ktor monitor registrar만 주입한다. fake registrar test는 raw subscribe 횟수와
-   handle dispose 횟수를 callback/registry close 횟수와 별도로 관찰한다.
+   installer는 Ktor monitor registrar만 주입한다. holder는 subscribe 호출과 handle publication을
+   같은 lock 안에서 수행하고 callback도 같은 lock에서 handle ownership을 claim한다. Ktor
+   `Events.subscribe` 구현은 handler를 등록할 뿐 callback을 동기 호출하지 않으므로, 다른 thread에서 handler가 handle
+   반환 전에 실행돼도 holder lock에서 대기한 뒤 publication된 handle을 정확히 한 번 claim한다.
+   fake registrar test는 raw subscribe 횟수와 handle dispose 횟수를 callback/registry close
+   횟수와 별도로 관찰한다.
 3. subscribe가 throw하면 holder는 registry를 닫고 `FAILED`로 고정한다. 최초 호출과 이후 모든
    호출은 원본 message/cause/suppressed가 없는 동일 type/message의 sanitized installation
    exception을 던지며 재시도하지 않는다. Ktor registrar는 handle 반환 뒤 fallible 작업을 하지
@@ -321,6 +325,8 @@ adoption checklist가 이를 금지한다.
   통해 단일 registry와 단일 subscription만 생성함
 - fake registrar가 raw subscribe 1회와 callback 뒤 handle dispose 1회를 직접 보고하며,
   registry close 횟수와 별도로 assertion됨
+- fake registrar가 handler를 공개한 뒤 handle 반환 직전 latch에서 멈추고 다른 thread가 callback을
+  시작하는 경합에서도 publication 뒤 handle dispose가 정확히 한 번 수행됨
 - subscribe failure 뒤 raw subscribe가 1회에서 멈추고 최초/후속 호출이 같은 sanitized
   type/message와 빈 cause/suppressed를 반환하며 registry를 정상 반환하지 않음
 - handle dispose failure가 registry report를 되돌리거나 callback을 재설치하지 않고 원본

--- a/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
@@ -196,7 +196,9 @@ fun Application.installApplicationResourceLifecycle(): ApplicationResourceRegist
    `Events.subscribe` 구현은 handler를 등록할 뿐 callback을 동기 호출하지 않으므로, 다른 thread에서 handler가 handle
    반환 전에 실행돼도 holder lock에서 대기한 뒤 publication된 handle을 정확히 한 번 claim한다.
    fake registrar test는 raw subscribe 횟수와 handle dispose 횟수를 callback/registry close
-   횟수와 별도로 관찰한다.
+   횟수와 별도로 관찰한다. callback-before-publication 검증에는 internal test-only lock seam을
+   주입해 callback thread의 `tryLock()` 실패를 직접 관찰하며, production은 기본
+   `ReentrantLock()`을 사용한다.
 3. subscribe가 throw하면 holder는 registry를 닫고 `FAILED`로 고정한다. 최초 호출과 이후 모든
    호출은 원본 message/cause/suppressed가 없는 동일 type/message의 sanitized installation
    exception을 던지며 재시도하지 않는다. Ktor registrar는 handle 반환 뒤 fallible 작업을 하지
@@ -325,9 +327,9 @@ adoption checklist가 이를 금지한다.
   통해 단일 registry와 단일 subscription만 생성함
 - fake registrar가 raw subscribe 1회와 callback 뒤 handle dispose 1회를 직접 보고하며,
   registry close 횟수와 별도로 assertion됨
-- fake registrar가 handler를 공개한 뒤 handle 반환 직전 latch에서 멈추고, 다른 thread의
-  callback 시작 latch를 관찰한 다음 handle 반환을 허용하는 경합에서도 publication 뒤 handle
-  dispose가 정확히 한 번 수행됨
+- fake registrar가 handler를 공개한 뒤 handle 반환 직전 latch에서 멈추고, test-only lock이
+  다른 thread callback의 `tryLock()` 실패를 관찰한 다음 handle 반환을 허용하는 경합에서도
+  publication 뒤 handle dispose가 정확히 한 번 수행됨
 - subscribe failure 뒤 raw subscribe가 1회에서 멈추고 최초/후속 호출이 같은 sanitized
   type/message와 빈 cause/suppressed를 반환하며 registry를 정상 반환하지 않음
 - handle dispose failure가 registry report를 되돌리거나 callback을 재설치하지 않고 원본

--- a/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-06-issue-1656-ktor-resource-lifecycle-design.md
@@ -325,8 +325,9 @@ adoption checklist가 이를 금지한다.
   통해 단일 registry와 단일 subscription만 생성함
 - fake registrar가 raw subscribe 1회와 callback 뒤 handle dispose 1회를 직접 보고하며,
   registry close 횟수와 별도로 assertion됨
-- fake registrar가 handler를 공개한 뒤 handle 반환 직전 latch에서 멈추고 다른 thread가 callback을
-  시작하는 경합에서도 publication 뒤 handle dispose가 정확히 한 번 수행됨
+- fake registrar가 handler를 공개한 뒤 handle 반환 직전 latch에서 멈추고, 다른 thread의
+  callback 시작 latch를 관찰한 다음 handle 반환을 허용하는 경합에서도 publication 뒤 handle
+  dispose가 정확히 한 번 수행됨
 - subscribe failure 뒤 raw subscribe가 1회에서 멈추고 최초/후속 호출이 같은 sanitized
   type/message와 빈 cause/suppressed를 반환하며 registry를 정상 반환하지 않음
 - handle dispose failure가 registry report를 되돌리거나 callback을 재설치하지 않고 원본

--- a/ktor/core/README.ko.md
+++ b/ktor/core/README.ko.md
@@ -15,6 +15,8 @@ bluetape4k 애플리케이션에서 공통으로 쓰는 작은 Ktor 서버 기�
 - `ApiErrorResponse`와 `StatusPagesConfig.bluetape4kErrorResponses()`는 일관된 JSON 오류 응답을 만듭니다.
 - `/healthz`, `/readyz` 라우트는 기본적으로 `HealthResponse.up()`을 반환합니다.
 - Query/path 파라미터 도우미로 반복되는 Ktor 라우트 검증 코드를 줄일 수 있습니다.
+- `installApplicationResourceLifecycle()`은 애플리케이션이 소유한 동기식 리소스를
+  `ApplicationStopped`에서 닫습니다.
 
 ## 의존성
 
@@ -53,3 +55,38 @@ fun Application.module() {
 기본 installer는 content negotiation, JSON 오류 처리, health/readiness route를
 추가합니다. 애플리케이션이 특정 Ktor plugin을 직접 관리해야 한다면
 `Bluetape4kKtorCoreConfig`로 해당 기능만 끄면 됩니다.
+
+## 애플리케이션 소유 리소스
+
+애플리케이션 시작 시 resource lifecycle을 명시적으로 설치하고, 해당 애플리케이션이 소유한
+리소스만 등록합니다.
+
+```kotlin
+import io.bluetape4k.ktor.core.installApplicationResourceLifecycle
+
+fun Application.module() {
+    val resources = installApplicationResourceLifecycle()
+    val client = createClient()
+
+    resources.register(client)
+}
+```
+
+registry는 아직 남은 항목을 등록의 역순으로 닫고, 종료 뒤 등록된 항목은 즉시 닫습니다.
+registration token과 registry 종료는 멱등이며 서로 경합해도 각 항목을 최대 한 번만
+claim합니다. close 실패는 다른 항목과 격리하고 opaque registration ID, close phase, fatal
+여부만 report에 남깁니다. 예외 message, stack trace, class 이름, resource 문자열은 노출하지
+않습니다.
+
+close action은 호출한 thread에서 동기식으로 실행됩니다. 애플리케이션 시작 경로가 소유하고
+유한한 시간 안에 끝나는 trusted action만 등록해야 합니다. registry는 coroutine scope,
+dispatcher, thread, timeout, retry, backend별 drain 정책을 만들지 않습니다. background job이
+리소스를 계속 사용한다면 adapter가 resource 종료 전에 bounded drain을 수행하거나, job이 더
+이상 resource에 접근하지 않는다는 조건을 보장해야 합니다.
+
+Ktor application job의 disposal timeout이 발생한 뒤에도 `ApplicationStopped`가 발생할 수
+있으며, 이 event handler는 해당 timeout 바깥에서 실행됩니다. 따라서 lifecycle 설치만으로
+모든 application coroutine의 완료를 보장하지 않습니다. 이 기능은 graceful shutdown 전용이며
+`SIGKILL`, JVM crash, OOM 경로의 cleanup은 보장하지 않습니다. registry를 닫는 lifecycle
+bridge는 하나만 두고, 의존 리소스는 하나의 composite action으로 묶거나 의존 순서대로
+등록합니다.

--- a/ktor/core/README.md
+++ b/ktor/core/README.md
@@ -15,6 +15,8 @@ Small Ktor server defaults for bluetape4k applications.
 - `ApiErrorResponse` and `StatusPagesConfig.bluetape4kErrorResponses()` produce consistent JSON error payloads.
 - `/healthz` and `/readyz` routes return `HealthResponse.up()` by default.
 - Query and path parameter helpers keep repeated Ktor route validation compact.
+- `installApplicationResourceLifecycle()` closes application-owned synchronous resources on
+  `ApplicationStopped`.
 
 ## Dependency
 
@@ -53,3 +55,37 @@ fun Application.module() {
 The default installer adds content negotiation, JSON error handling, and
 health/readiness routes. When an application already owns one of those Ktor
 plugins, disable that part with `Bluetape4kKtorCoreConfig`.
+
+## Application-owned resources
+
+Install the resource lifecycle explicitly during application startup, then register only resources
+owned by that application:
+
+```kotlin
+import io.bluetape4k.ktor.core.installApplicationResourceLifecycle
+
+fun Application.module() {
+    val resources = installApplicationResourceLifecycle()
+    val client = createClient()
+
+    resources.register(client)
+}
+```
+
+The registry closes pending entries in reverse registration order and closes a late registration
+immediately. Registration tokens and registry shutdown are idempotent: each entry is claimed at most
+once even when they race. Close failures are isolated and reported with an opaque registration ID,
+close phase, and fatal flag; exception messages, stack traces, class names, and resource strings are
+not exposed.
+
+Close actions run synchronously on the caller thread. Register only trusted startup-owned actions
+that finish within a bounded time. The registry does not create a coroutine scope, dispatcher,
+thread, timeout, retry, or backend-specific drain policy. If a resource is still used by a background
+job, its adapter must perform a bounded drain before resource shutdown or otherwise guarantee that
+the job cannot access the resource.
+
+`ApplicationStopped` may still be raised after Ktor's application-job disposal times out, and its
+handlers run outside that disposal timeout. The lifecycle therefore does not prove that every
+application coroutine has completed. It is a graceful-shutdown facility only; `SIGKILL`, JVM crash,
+and OOM paths do not guarantee cleanup. Keep exactly one lifecycle bridge as the registry's close
+owner, and place dependent resources in one composite action or register them in dependency order.

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt
@@ -101,21 +101,20 @@ public data class ApplicationResourceCloseReport(
  * close action은 token을 호출한 caller thread에서 동기적으로 실행되며, 이 API는
  * timeout·dispatcher·coroutine scope를 소유하지 않습니다.
  */
-public class ApplicationResourceRegistration private constructor(
-    public val id: Long,
-    private val closeAction: () -> Unit,
-): AutoCloseable {
-
-    internal object Factory {
-        internal fun create(
-            id: Long,
-            closeAction: () -> Unit,
-        ): ApplicationResourceRegistration = ApplicationResourceRegistration(id, closeAction)
-    }
+public interface ApplicationResourceRegistration : AutoCloseable {
+    /** registry lifetime 안에서만 의미가 있는 opaque ID입니다. */
+    public val id: Long
 
     /**
      * 이 token이 소유한 항목을 조기에 닫습니다. 이미 claim된 token이면 아무 작업도 하지 않습니다.
      */
+    override fun close()
+}
+
+private class DefaultApplicationResourceRegistration(
+    override val id: Long,
+    private val closeAction: () -> Unit,
+): ApplicationResourceRegistration {
     override fun close(): Unit = closeAction()
 }
 
@@ -234,7 +233,7 @@ public class ApplicationResourceRegistry : AutoCloseable {
             if (state == ApplicationResourceRegistryState.OPEN) {
                 entries += entry
                 RegistrationPlan(
-                    registration = ApplicationResourceRegistration.Factory.create(entry.id) {
+                    registration = DefaultApplicationResourceRegistration(entry.id) {
                         closeEntry(entry)
                     },
                     lateEntry = null
@@ -242,7 +241,7 @@ public class ApplicationResourceRegistry : AutoCloseable {
             } else {
                 claimLocked(entry)
                 RegistrationPlan(
-                    registration = ApplicationResourceRegistration.Factory.create(entry.id) {},
+                    registration = DefaultApplicationResourceRegistration(entry.id) {},
                     lateEntry = entry
                 )
             }

--- a/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt
+++ b/ktor/core/src/main/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycle.kt
@@ -1,0 +1,454 @@
+package io.bluetape4k.ktor.core
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.closeSafe
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
+import io.ktor.util.AttributeKey
+import kotlinx.coroutines.DisposableHandle as CoroutinesDisposableHandle
+import java.io.Serializable as JavaSerializable
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * 등록된 애플리케이션 리소스를 닫을 때 사용한 lifecycle 단계입니다.
+ */
+public enum class ApplicationResourceClosePhase {
+    /** 애플리케이션 종료 전에 registration token으로 직접 닫은 단계입니다. */
+    EARLY,
+
+    /** `ApplicationStopped`에 연결된 registry 종료 단계입니다. */
+    SHUTDOWN,
+
+    /** registry 종료가 시작된 뒤 새로 등록되어 즉시 닫힌 단계입니다. */
+    LATE_REGISTRATION,
+}
+
+/**
+ * 애플리케이션 리소스 registry의 lifecycle 상태입니다.
+ */
+public enum class ApplicationResourceRegistryState {
+    /** 새 리소스를 등록할 수 있는 상태입니다. */
+    OPEN,
+
+    /** 기존 리소스를 닫는 중이며 새 등록은 즉시 닫히는 상태입니다. */
+    DRAINING,
+
+    /** 정상적인 registry 종료가 끝난 상태입니다. */
+    CLOSED,
+}
+
+/**
+ * 리소스 하나의 close 실패를 민감한 리소스 정보 없이 표현합니다.
+ *
+ * @property registrationId registry lifetime 안에서만 의미가 있는 opaque ID입니다.
+ * @property phase close가 시도된 lifecycle 단계입니다.
+ * @property fatal JVM `Error` 계열 실패인지 여부입니다.
+ */
+public data class ApplicationResourceCloseFailure(
+    val registrationId: Long,
+    val phase: ApplicationResourceClosePhase,
+    val fatal: Boolean,
+): JavaSerializable {
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * registry close 진행 상황을 읽은 시점의 불변 결과입니다.
+ *
+ * `attempted == inFlight + closed + failures.size` invariant는 close 중에도 유지됩니다.
+ * 등록된 close action은 caller thread에서 동기적으로 실행되므로 이 report는 완료를
+ * 기다리거나 timeout을 제공하지 않습니다.
+ *
+ * @property state 결과를 읽은 순간의 registry 상태입니다.
+ * @property attempted claim되어 close를 시도한 항목 수입니다.
+ * @property inFlight 현재 close action이 실행 중인 항목 수입니다.
+ * @property closed 예외 없이 close가 끝난 항목 수입니다.
+ * @property failures 실패한 항목의 opaque 진단 정보입니다.
+ */
+public data class ApplicationResourceCloseReport(
+    val state: ApplicationResourceRegistryState,
+    val attempted: Int,
+    val inFlight: Int,
+    val closed: Int,
+    val failures: List<ApplicationResourceCloseFailure>,
+): JavaSerializable {
+
+    init {
+        require(attempted >= 0) { "attempted must be non-negative." }
+        require(inFlight >= 0) { "inFlight must be non-negative." }
+        require(closed >= 0) { "closed must be non-negative." }
+        require(attempted == inFlight + closed + failures.size) {
+            "attempted must equal inFlight + closed + failures.size."
+        }
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * registry에 등록된 항목을 application 종료 전에 조기에 닫는 token입니다.
+ *
+ * token과 registry close가 동시에 호출되어도 한 항목은 최대 한 번만 close됩니다.
+ * close action은 token을 호출한 caller thread에서 동기적으로 실행되며, 이 API는
+ * timeout·dispatcher·coroutine scope를 소유하지 않습니다.
+ */
+public class ApplicationResourceRegistration private constructor(
+    public val id: Long,
+    private val closeAction: () -> Unit,
+): AutoCloseable {
+
+    internal object Factory {
+        internal fun create(
+            id: Long,
+            closeAction: () -> Unit,
+        ): ApplicationResourceRegistration = ApplicationResourceRegistration(id, closeAction)
+    }
+
+    /**
+     * 이 token이 소유한 항목을 조기에 닫습니다. 이미 claim된 token이면 아무 작업도 하지 않습니다.
+     */
+    override fun close(): Unit = closeAction()
+}
+
+/**
+ * Ktor application이 소유한 동기식 리소스의 등록·종료 registry입니다.
+ *
+ * registry는 애플리케이션 시작 코드가 소유하는 trusted, bounded close action만 받습니다.
+ * `close()`와 token close는 caller thread에서 동기적으로 실행되며, registry가 새 thread,
+ * dispatcher, coroutine scope 또는 timeout을 만들지 않습니다. 등록 순서의 역순으로
+ * shutdown close를 수행하고, 동일 객체의 중복 등록을 identity 기준으로 거부하며,
+ * 종료 중 새 등록은 호출 thread에서 즉시 닫습니다.
+ *
+ * registry를 직접 닫는 경우 caller가 lifecycle ownership을 하나만 연결해야 합니다.
+ * `installApplicationResourceLifecycle`이 반환한 registry는 installer가 `ApplicationStopped`
+ * 이벤트에서 닫으므로 caller가 별도로 close하지 않아야 합니다. 이 계약은 graceful shutdown
+ * 전용이며 `SIGKILL`, JVM crash, OOM 등 `ApplicationStopped`가 발생하지 않는 종료는 보장하지
+ * 않습니다.
+ */
+public class ApplicationResourceRegistry : AutoCloseable {
+
+    public companion object : KLogging()
+
+    private val lock = ReentrantLock()
+    private val entries = ArrayList<Entry>()
+    private val ownedIdentities = Collections.newSetFromMap(IdentityHashMap<Any, Boolean>())
+    private val failures = ArrayList<ApplicationResourceCloseFailure>()
+
+    private var nextRegistrationId: Long = 1L
+    private var state: ApplicationResourceRegistryState = ApplicationResourceRegistryState.OPEN
+    private var attempted: Int = 0
+    private var inFlight: Int = 0
+    private var closed: Int = 0
+
+    /**
+     * 현재 registry 상태와 close 누적 결과를 읽기 시점의 불변 값으로 반환합니다.
+     */
+    public val closeReport: ApplicationResourceCloseReport
+        get() = lock.withLock {
+            ApplicationResourceCloseReport(
+                state = state,
+                attempted = attempted,
+                inFlight = inFlight,
+                closed = closed,
+                failures = failures.toList()
+            )
+        }
+
+    /**
+     * [resource]를 등록하고 조기 close용 token을 반환합니다.
+     *
+     * 동일한 [resource] identity는 registry lifetime 동안 한 번만 등록할 수 있습니다.
+     * 종료가 시작된 뒤 등록하면 resource는 보관되지 않고 호출 thread에서 즉시 닫힙니다.
+     */
+    public fun register(resource: AutoCloseable): ApplicationResourceRegistration =
+        registerInternal(resource) { resource.close() }
+
+    /**
+     * 동기식 [closeAction]을 등록하고 조기 close용 token을 반환합니다.
+     *
+     * 동일한 close-action 객체 identity는 registry lifetime 동안 한 번만 등록할 수 있습니다.
+     * action은 application startup code가 소유하는 trusted 작업이어야 하며 유한한 시간 안에
+     * 끝나야 합니다.
+     */
+    public fun register(closeAction: () -> Unit): ApplicationResourceRegistration =
+        registerInternal(closeAction, closeAction)
+
+    /**
+     * 아직 claim되지 않은 항목을 등록 역순으로 동기적으로 닫습니다.
+     *
+     * 한 항목의 일반 예외나 JVM `Error`가 나도 나머지 항목을 계속 시도합니다. fatal 실패가
+     * 있었으면 모든 항목을 시도한 뒤 원본 message·cause가 없는 sanitized marker를 던집니다.
+     */
+    override fun close() {
+        val shutdownEntries = lock.withLock {
+            if (state != ApplicationResourceRegistryState.OPEN) {
+                return
+            }
+
+            state = ApplicationResourceRegistryState.DRAINING
+            entries
+                .asReversed()
+                .toList()
+                .onEach { entry -> claimLocked(entry) }
+                .also { entries.clear() }
+        }
+
+        var fatalFailure = false
+        try {
+            shutdownEntries.forEach { entry ->
+                fatalFailure = executeClose(entry, ApplicationResourceClosePhase.SHUTDOWN) || fatalFailure
+            }
+        } finally {
+            lock.withLock {
+                state = ApplicationResourceRegistryState.CLOSED
+            }
+        }
+
+        if (fatalFailure) {
+            throw SanitizedFatalCloseMarker()
+        }
+    }
+
+    private fun registerInternal(
+        identity: Any,
+        closeAction: () -> Unit,
+    ): ApplicationResourceRegistration {
+        val registration = lock.withLock {
+            if (!ownedIdentities.add(identity)) {
+                throw IllegalArgumentException("Application resource is already registered.")
+            }
+
+            val entry = Entry(
+                id = nextIdLocked(),
+                closeAction = closeAction,
+            )
+            if (state == ApplicationResourceRegistryState.OPEN) {
+                entries += entry
+                RegistrationPlan(
+                    registration = ApplicationResourceRegistration.Factory.create(entry.id) {
+                        closeEntry(entry)
+                    },
+                    lateEntry = null
+                )
+            } else {
+                claimLocked(entry)
+                RegistrationPlan(
+                    registration = ApplicationResourceRegistration.Factory.create(entry.id) {},
+                    lateEntry = entry
+                )
+            }
+        }
+
+        registration.lateEntry?.let { entry ->
+            val fatalFailure = executeClose(entry, ApplicationResourceClosePhase.LATE_REGISTRATION)
+            if (fatalFailure) {
+                throw SanitizedFatalCloseMarker()
+            }
+        }
+        return registration.registration
+    }
+
+    private fun closeEntry(entry: Entry) {
+        val claimed = lock.withLock {
+            if (entry.claimed) {
+                false
+            } else {
+                entries.remove(entry)
+                claimLocked(entry)
+                true
+            }
+        }
+        if (claimed) {
+            if (executeClose(entry, ApplicationResourceClosePhase.EARLY)) {
+                throw SanitizedFatalCloseMarker()
+            }
+        }
+    }
+
+    private fun claimLocked(entry: Entry) {
+        check(!entry.claimed) { "A resource entry may only be claimed once." }
+        entry.claimed = true
+        attempted += 1
+        inFlight += 1
+    }
+
+    private fun executeClose(
+        entry: Entry,
+        phase: ApplicationResourceClosePhase,
+    ): Boolean {
+        var fatalFailure = false
+        var failure: ApplicationResourceCloseFailure? = null
+        entry.closeSafe { cause ->
+            fatalFailure = cause is Error
+            failure = ApplicationResourceCloseFailure(
+                registrationId = entry.id,
+                phase = phase,
+                fatal = fatalFailure
+            )
+        }
+        finishClose(failure)
+        return fatalFailure
+    }
+
+    private fun finishClose(failure: ApplicationResourceCloseFailure?) {
+        lock.withLock {
+            check(inFlight > 0) { "A resource close must have an in-flight claim." }
+            inFlight -= 1
+            if (failure == null) {
+                closed += 1
+            } else {
+                failures += failure
+            }
+        }
+
+        if (failure != null) {
+            try {
+                log.warn {
+                    "Application resource close failed: registrationId=${failure.registrationId}, " +
+                        "phase=${failure.phase}, fatal=${failure.fatal}"
+                }
+            } catch (_: Throwable) {
+                // 로깅 backend 자체의 실패가 나머지 cleanup을 중단시키면 안 됩니다.
+            }
+        }
+    }
+
+    private fun nextIdLocked(): Long {
+        check(nextRegistrationId > 0) { "Application resource registration IDs are exhausted." }
+        return nextRegistrationId++
+    }
+
+    private class Entry(
+        val id: Long,
+        val closeAction: () -> Unit,
+        var claimed: Boolean = false,
+    ): AutoCloseable {
+        override fun close(): Unit = closeAction()
+    }
+
+    private data class RegistrationPlan(
+        val registration: ApplicationResourceRegistration,
+        val lateEntry: Entry?,
+    )
+}
+
+private class SanitizedFatalCloseMarker : Error("Application resource close failed")
+
+private val applicationResourceLifecycleKey =
+    AttributeKey<ApplicationResourceLifecycleHolder>("bluetape4k.application.resource.lifecycle")
+
+private typealias ApplicationResourceSubscriptionRegistrar =
+    (onStopped: () -> Unit) -> CoroutinesDisposableHandle
+
+/**
+ * registry와 lifecycle subscription의 소유권을 같은 lock으로 직렬화합니다.
+ *
+ * `Attributes.computeIfAbsent`가 supplier를 둘 이상 평가할 수 있으므로 이 holder
+ * 자체는 side effect 없이 만들어지고, 실제 subscription은 winner의 [install]에서
+ * 정확히 한 번만 생성됩니다.
+ */
+private class ApplicationResourceLifecycleHolder(
+    private val registrar: ApplicationResourceSubscriptionRegistrar,
+    private val lock: ReentrantLock = ReentrantLock(),
+) {
+    private enum class State {
+        NEW,
+        READY,
+        FAILED,
+        STOPPED,
+    }
+
+    private var state = State.NEW
+    private var subscription: CoroutinesDisposableHandle? = null
+
+    val registry = ApplicationResourceRegistry()
+
+    /**
+     * subscription을 정확히 한 번 설치하고 winner의 registry를 반환합니다.
+     * 설치 실패는 민감한 원인 없이 sticky `FAILED` 상태로 보존합니다.
+     */
+    fun install(): ApplicationResourceRegistry {
+        val failure = lock.withLock {
+            when (state) {
+                State.READY, State.STOPPED -> return registry
+                State.FAILED -> throw sanitizedInstallationFailure()
+                State.NEW -> try {
+                    val candidate = registrar(::onStopped)
+                    subscription = candidate
+                    state = State.READY
+                    return registry
+                } catch (_: Throwable) {
+                    state = State.FAILED
+                    sanitizedInstallationFailure()
+                }
+            }
+        }
+
+        registry.closeSafe()
+        throw failure
+    }
+
+    private fun onStopped() {
+        val handle = lock.withLock {
+            if (state != State.READY) {
+                return
+            }
+
+            state = State.STOPPED
+            subscription.also { subscription = null }
+        }
+
+        try {
+            registry.close()
+        } finally {
+            handle?.let(::disposeWithoutCauseLogging)
+        }
+    }
+
+    private fun sanitizedInstallationFailure(): IllegalStateException =
+        IllegalStateException("Application resource lifecycle installation failed.")
+
+    private fun disposeWithoutCauseLogging(handle: CoroutinesDisposableHandle) {
+        try {
+            handle.dispose()
+        } catch (_: Throwable) {
+            try {
+                ApplicationResourceRegistry.log.warn {
+                    "Application resource lifecycle subscription disposal failed."
+                }
+            } catch (_: Throwable) {
+                // 로깅 backend 자체의 실패가 lifecycle cleanup을 중단시키면 안 됩니다.
+            }
+        }
+    }
+}
+
+/**
+ * `ApplicationStopped`에 [ApplicationResourceRegistry]를 명시적으로 연결합니다.
+ *
+ * application attribute에 registry와 단일 event subscription을 원자적으로 저장하므로
+ * 같은 application에서 반복 또는 동시 호출해도 동일 registry를 반환합니다. `ApplicationStopped`
+ * callback은 registry를 동기적으로 닫고 subscription을 dispose합니다. caller는 반환된
+ * registry를 직접 close하지 말고, 등록 action이 startup 소유의 bounded 동기 작업인지 확인해야
+ * 합니다. Ktor disposal timeout은 이 callback을 중단하지 않으며, `ApplicationStopped`가
+ * 발생하지 않는 강제 종료에서는 cleanup을 보장하지 않습니다.
+ */
+public fun Application.installApplicationResourceLifecycle(): ApplicationResourceRegistry {
+    val slot = attributes.computeIfAbsent(applicationResourceLifecycleKey) {
+        ApplicationResourceLifecycleHolder(
+            { onStopped ->
+                monitor.subscribe(ApplicationStopped) { onStopped() }
+            }
+        )
+    }
+    return slot.install()
+}

--- a/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycleTest.kt
+++ b/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycleTest.kt
@@ -1,0 +1,559 @@
+package io.bluetape4k.ktor.core
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.ktor.server.application.Application
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Assertions.assertTimeout
+import org.junit.jupiter.api.Test
+import java.lang.reflect.InvocationTargetException
+import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+
+class ApplicationResourceLifecycleTest {
+
+    @Test
+    fun `installer is idempotent and closes resources at ApplicationStopped`() {
+        val closeCount = AtomicInteger()
+        lateinit var registry: ApplicationResourceRegistry
+
+        testApplication {
+            application {
+                val first = installApplicationResourceLifecycle()
+                val second = installApplicationResourceLifecycle()
+                first shouldBeSameInstanceAs second
+                registry = first
+                registry.register { closeCount.incrementAndGet() }
+            }
+        }
+
+        closeCount.get() shouldBeEqualTo 1
+        registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        registry.closeReport.closed shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `ApplicationStopped closes resources after application children are joined`() {
+        lateinit var registry: ApplicationResourceRegistry
+        var childJoinedBeforeClose = false
+
+        testApplication {
+            application {
+                val child = launch {
+                    awaitCancellation()
+                }
+                registry = installApplicationResourceLifecycle()
+                registry.register { childJoinedBeforeClose = child.isCompleted }
+            }
+        }
+
+        childJoinedBeforeClose.shouldBeTrue()
+        registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+            state = ApplicationResourceRegistryState.CLOSED,
+            attempted = 1,
+            inFlight = 0,
+            closed = 1,
+            failures = emptyList()
+        )
+    }
+
+    @Test
+    fun `ApplicationStopped after disposal timeout lets a bounded adapter drain before resource close`() {
+        val resourceInUse = AtomicBoolean()
+        val childCancellationStarted = CountDownLatch(1)
+        val allowChildFinish = CountDownLatch(1)
+        val childDrained = CountDownLatch(1)
+        val activeWhenCloseStarted = AtomicBoolean()
+        val overlapAfterDrain = AtomicBoolean(true)
+        lateinit var registry: ApplicationResourceRegistry
+
+        try {
+            assertTimeout(Duration.ofSeconds(10)) {
+                testApplication {
+                    engine {
+                        shutdownTimeout = 1L
+                    }
+                    application {
+                        launch(start = CoroutineStart.UNDISPATCHED) {
+                            resourceInUse.set(true)
+                            try {
+                                awaitCancellation()
+                            } finally {
+                                withContext(NonCancellable) {
+                                    childCancellationStarted.countDown()
+                                    allowChildFinish.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                                    resourceInUse.set(false)
+                                    childDrained.countDown()
+                                }
+                            }
+                        }
+
+                        registry = installApplicationResourceLifecycle()
+                        registry.register {
+                            activeWhenCloseStarted.set(resourceInUse.get())
+                            childCancellationStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                            allowChildFinish.countDown()
+                            childDrained.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                            overlapAfterDrain.set(resourceInUse.get())
+                        }
+                    }
+                }
+            }
+        } finally {
+            allowChildFinish.countDown()
+        }
+
+        activeWhenCloseStarted.get().shouldBeTrue()
+        overlapAfterDrain.get().shouldBeFalse()
+        registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        registry.closeReport.closed shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `installer fatal close failure does not prevent remaining cleanup`() {
+        val remainingCloseCount = AtomicInteger()
+        lateinit var registry: ApplicationResourceRegistry
+
+        testApplication {
+            application {
+                registry = installApplicationResourceLifecycle()
+                registry.register { remainingCloseCount.incrementAndGet() }
+                registry.register { throw AssertionError("credential-secret") }
+            }
+        }
+
+        remainingCloseCount.get() shouldBeEqualTo 1
+        registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        registry.closeReport.failures.single().fatal.shouldBeTrue()
+        registry.closeReport.toString() shouldBeEqualTo
+            "ApplicationResourceCloseReport(state=CLOSED, attempted=2, inFlight=0, closed=1, " +
+            "failures=[ApplicationResourceCloseFailure(registrationId=2, phase=SHUTDOWN, fatal=true)])"
+    }
+
+    @Test
+    fun `installer ordinary close failure does not prevent remaining cleanup`() {
+        val remainingCloseCount = AtomicInteger()
+        lateinit var registry: ApplicationResourceRegistry
+
+        testApplication {
+            application {
+                registry = installApplicationResourceLifecycle()
+                registry.register { remainingCloseCount.incrementAndGet() }
+                registry.register { throw IllegalStateException("credential-secret") }
+            }
+        }
+
+        remainingCloseCount.get() shouldBeEqualTo 1
+        registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        registry.closeReport.closed shouldBeEqualTo 1
+        registry.closeReport.failures.single().fatal.shouldBeFalse()
+    }
+
+    @Test
+    fun `concurrent installer calls return one registry`() {
+        lateinit var application: Application
+        val registries = mutableListOf<ApplicationResourceRegistry>()
+        val listLock = Any()
+        val start = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(8)
+
+        try {
+            testApplication {
+                application {
+                    application = this
+                    val futures = List(8) {
+                        executor.submit<ApplicationResourceRegistry> {
+                            start.await(5, TimeUnit.SECONDS)
+                            application.installApplicationResourceLifecycle()
+                        }
+                    }
+                    start.countDown()
+                    futures.forEach { future ->
+                        synchronized(listLock) {
+                            registries += future.get(5, TimeUnit.SECONDS)
+                        }
+                    }
+                }
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        registries.size shouldBeEqualTo 8
+        registries.drop(1).forEach { it shouldBeSameInstanceAs registries.first() }
+    }
+
+    @Test
+    fun `late registration through installer reference closes after application stopped`() {
+        lateinit var registry: ApplicationResourceRegistry
+        val lateCloseCount = AtomicInteger()
+
+        testApplication {
+            application {
+                registry = installApplicationResourceLifecycle()
+            }
+        }
+
+        registry.register { lateCloseCount.incrementAndGet() }
+
+        lateCloseCount.get() shouldBeEqualTo 1
+        registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        registry.closeReport.closed shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `installer fatal registration after stop exposes sanitized marker`() {
+        lateinit var registry: ApplicationResourceRegistry
+
+        testApplication {
+            application {
+                registry = installApplicationResourceLifecycle()
+            }
+        }
+
+        val marker = assertFailsWith<Error> {
+            registry.register { throw AssertionError("credential-secret") }
+        }
+
+        marker.message.orEmpty().contains("credential-secret").shouldBeFalse()
+        registry.closeReport.failures.single().phase shouldBeEqualTo
+            ApplicationResourceClosePhase.LATE_REGISTRATION
+    }
+
+    @Test
+    fun `winner holder subscribes once and disposes once`() {
+        val registrar = RecordingRegistrar()
+        val holder = PrivateLifecycleHolder(registrar::subscribe)
+        val barrier = java.util.concurrent.CyclicBarrier(8)
+        val executor = Executors.newFixedThreadPool(8)
+        try {
+            val futures = List(8) {
+                executor.submit<ApplicationResourceRegistry> {
+                    barrier.await(5, TimeUnit.SECONDS)
+                    holder.install()
+                }
+            }
+            futures.forEach { it.get(5, TimeUnit.SECONDS) shouldBeSameInstanceAs holder.registry }
+            registrar.subscribeCount.get() shouldBeEqualTo 1
+
+            registrar.raiseStopped()
+            registrar.raiseStopped()
+
+            registrar.disposeCount.get() shouldBeEqualTo 1
+            holder.registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `callback before handle publication waits for the ready holder and disposes once`() {
+        val registrar = BlockingRecordingRegistrar()
+        val observedLock = ObservedReentrantLock()
+        val holder = PrivateLifecycleHolder(registrar::subscribe, observedLock)
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val install = executor.submit<ApplicationResourceRegistry> { holder.install() }
+            registrar.handlerRegistered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            observedLock.observeNextContention()
+            val stop = executor.submit { registrar.raiseStopped() }
+
+            observedLock.callbackContended.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            registrar.allowHandleReturn.countDown()
+
+            install.get(5, TimeUnit.SECONDS) shouldBeSameInstanceAs holder.registry
+            stop.get(5, TimeUnit.SECONDS)
+            registrar.subscribeCount.get() shouldBeEqualTo 1
+            registrar.disposeCount.get() shouldBeEqualTo 1
+        } finally {
+            registrar.allowHandleReturn.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `failed holder never retries and exposes only sanitized failure`() {
+        val registrar = FailingRegistrar(IllegalStateException("credential-secret"))
+        val holder = PrivateLifecycleHolder(registrar::subscribe)
+
+        repeat(2) {
+            val failure = assertFailsWith<IllegalStateException> { holder.install() }
+            failure.message shouldBeEqualTo "Application resource lifecycle installation failed."
+            failure.cause shouldBeEqualTo null
+            failure.suppressed.toList() shouldBeEqualTo emptyList()
+        }
+        registrar.subscribeCount.get() shouldBeEqualTo 1
+        holder.registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+    }
+
+    @Test
+    fun `subscription disposal failure is swallowed without changing the close report`() {
+        val registrar = RecordingRegistrar(IllegalStateException("credential-secret"))
+        val holder = PrivateLifecycleHolder(registrar::subscribe)
+        holder.install()
+
+        registrar.raiseStopped()
+
+        registrar.disposeCount.get() shouldBeEqualTo 1
+        holder.registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+            state = ApplicationResourceRegistryState.CLOSED,
+            attempted = 0,
+            inFlight = 0,
+            closed = 0,
+            failures = emptyList()
+        )
+    }
+
+    @Test
+    fun `registry and marker diagnostics exclude exception and resource secrets`() {
+        val logger = ApplicationResourceRegistry.log as Logger
+        val appender = CapturingAppender().also { logger.attach(it) }
+        val registry = ApplicationResourceRegistry()
+        val resource = SecretResource("resource-secret") {
+            throw CredentialSecretFailure("message-secret")
+        }
+
+        try {
+            registry.register(resource)
+            val marker = assertFailsWith<Error> { registry.close() }
+
+            val surfaces = buildList {
+                add(registry.closeReport.toString())
+                add(marker.message.orEmpty())
+                add(marker.cause?.toString().orEmpty())
+                addAll(marker.suppressed.map(Throwable::toString))
+                addAll(appender.events.map { it.formattedMessage.orEmpty() })
+                addAll(appender.events.map { it.throwableProxy?.message.orEmpty() })
+            }
+            listOf("resource-secret", "message-secret", "CredentialSecretFailure").forEach { secret ->
+                surfaces.forEach { it.contains(secret).shouldBeFalse() }
+            }
+        } finally {
+            logger.detach(appender)
+        }
+    }
+
+    @Test
+    fun `Ktor environment logger excludes fatal resource secrets`() {
+        val appender = CapturingAppender()
+        var logger: Logger? = null
+        var previousLevel: Level? = null
+        lateinit var registry: ApplicationResourceRegistry
+
+        try {
+            testApplication {
+                application {
+                    logger = environment.log as Logger
+                    previousLevel = logger?.level
+                    logger?.level = Level.DEBUG
+                    logger?.attach(appender)
+                    registry = installApplicationResourceLifecycle()
+                    registry.register(SecretResource("resource-secret") {
+                        throw CredentialSecretFailure("message-secret")
+                    })
+                }
+            }
+
+            val surfaces = buildList {
+                add(registry.closeReport.toString())
+                addAll(appender.events.map { it.formattedMessage.orEmpty() })
+                addAll(appender.events.map { it.throwableProxy?.message.orEmpty() })
+            }
+            listOf("resource-secret", "message-secret", "CredentialSecretFailure").forEach { secret ->
+                surfaces.forEach { it.contains(secret).shouldBeFalse() }
+            }
+            registry.closeReport.failures.single().fatal.shouldBeTrue()
+        } finally {
+            logger?.detach(appender)
+            logger?.level = previousLevel
+        }
+    }
+
+    @Test
+    fun `throwing logging backend does not stop remaining cleanup`() {
+        val logger = ApplicationResourceRegistry.log as Logger
+        val appender = ThrowingAppender().also { logger.attach(it) }
+        val remainingCloseCount = AtomicInteger()
+        val registry = ApplicationResourceRegistry()
+        registry.register { remainingCloseCount.incrementAndGet() }
+        registry.register { throw IllegalStateException("message-secret") }
+
+        try {
+            registry.close()
+        } finally {
+            logger.detach(appender)
+        }
+
+        remainingCloseCount.get() shouldBeEqualTo 1
+        registry.closeReport.closed shouldBeEqualTo 1
+        registry.closeReport.failures.single().fatal.shouldBeFalse()
+    }
+
+    private class RecordingRegistrar(
+        private val disposeFailure: Throwable? = null,
+    ) {
+        val subscribeCount = AtomicInteger()
+        val disposeCount = AtomicInteger()
+
+        @Volatile
+        private var callback: (() -> Unit)? = null
+
+        fun subscribe(onStopped: () -> Unit): DisposableHandle {
+            subscribeCount.incrementAndGet()
+            callback = onStopped
+            return RecordingHandle(disposeCount, disposeFailure)
+        }
+
+        fun raiseStopped() {
+            callback?.invoke()
+        }
+    }
+
+    private class BlockingRecordingRegistrar {
+        val subscribeCount = AtomicInteger()
+        val disposeCount = AtomicInteger()
+        val handlerRegistered = CountDownLatch(1)
+        val allowHandleReturn = CountDownLatch(1)
+
+        @Volatile
+        private var callback: (() -> Unit)? = null
+
+        fun subscribe(onStopped: () -> Unit): DisposableHandle {
+            subscribeCount.incrementAndGet()
+            callback = onStopped
+            handlerRegistered.countDown()
+            allowHandleReturn.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            return RecordingHandle(disposeCount)
+        }
+
+        fun raiseStopped() {
+            callback?.invoke()
+        }
+    }
+
+    private class FailingRegistrar(
+        private val failure: Throwable,
+    ) {
+        val subscribeCount = AtomicInteger()
+
+        fun subscribe(onStopped: () -> Unit): DisposableHandle {
+            subscribeCount.incrementAndGet()
+            throw failure
+        }
+    }
+
+    private class RecordingHandle(
+        private val disposeCount: AtomicInteger,
+        private val disposeFailure: Throwable? = null,
+    ) : DisposableHandle {
+        override fun dispose() {
+            disposeCount.incrementAndGet()
+            disposeFailure?.let { throw it }
+        }
+    }
+
+    /**
+     * production holder를 public/internal ABI로 노출하지 않고도 lifecycle state machine을 검증합니다.
+     */
+    private class PrivateLifecycleHolder(
+        registrar: (onStopped: () -> Unit) -> DisposableHandle,
+        lock: ReentrantLock = ReentrantLock(),
+    ) {
+        private val holderClass = Class.forName(
+            "io.bluetape4k.ktor.core.ApplicationResourceLifecycleHolder"
+        )
+        private val delegate = holderClass.declaredConstructors
+            .single { it.parameterCount == 2 }
+            .also { it.isAccessible = true }
+            .newInstance(registrar, lock)
+        private val registryGetter = holderClass
+            .getDeclaredMethod("getRegistry")
+            .also { it.isAccessible = true }
+        private val installMethod = holderClass
+            .getDeclaredMethod("install")
+            .also { it.isAccessible = true }
+
+        val registry: ApplicationResourceRegistry
+            get() = registryGetter.invoke(delegate) as ApplicationResourceRegistry
+
+        fun install(): ApplicationResourceRegistry = try {
+            installMethod.invoke(delegate) as ApplicationResourceRegistry
+        } catch (failure: InvocationTargetException) {
+            throw failure.targetException
+        }
+    }
+
+    private class ObservedReentrantLock : java.util.concurrent.locks.ReentrantLock() {
+        val callbackContended = CountDownLatch(1)
+        private val observeContention = java.util.concurrent.atomic.AtomicBoolean()
+
+        fun observeNextContention() {
+            check(observeContention.compareAndSet(false, true))
+        }
+
+        override fun lock() {
+            if (!observeContention.compareAndSet(true, false)) {
+                super.lock()
+                return
+            }
+            if (super.tryLock()) return
+            callbackContended.countDown()
+            super.lock()
+        }
+    }
+
+    private class SecretResource(
+        private val name: String,
+        private val closeAction: () -> Unit,
+    ) : AutoCloseable {
+        override fun close(): Unit = closeAction()
+
+        override fun toString(): String = name
+    }
+
+    private class CredentialSecretFailure(message: String) : AssertionError(message)
+
+    private class CapturingAppender : AppenderBase<ILoggingEvent>() {
+        val events = CopyOnWriteArrayList<ILoggingEvent>()
+
+        override fun append(eventObject: ILoggingEvent) {
+            events += eventObject
+        }
+    }
+
+    private class ThrowingAppender : AppenderBase<ILoggingEvent>() {
+        override fun append(eventObject: ILoggingEvent) {
+            throw AssertionError("logger-secret")
+        }
+    }
+
+    private fun Logger.attach(appender: AppenderBase<ILoggingEvent>) {
+        appender.context = loggerContext
+        appender.start()
+        addAppender(appender)
+    }
+
+    private fun Logger.detach(appender: AppenderBase<ILoggingEvent>) {
+        detachAppender(appender)
+        appender.stop()
+    }
+}

--- a/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycleTest.kt
+++ b/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/ApplicationResourceLifecycleTest.kt
@@ -347,6 +347,7 @@ class ApplicationResourceLifecycleTest {
             listOf("resource-secret", "message-secret", "CredentialSecretFailure").forEach { secret ->
                 surfaces.forEach { it.contains(secret).shouldBeFalse() }
             }
+            appender.events.size shouldBeEqualTo 1
         } finally {
             logger.detach(appender)
         }
@@ -381,6 +382,9 @@ class ApplicationResourceLifecycleTest {
             listOf("resource-secret", "message-secret", "CredentialSecretFailure").forEach { secret ->
                 surfaces.forEach { it.contains(secret).shouldBeFalse() }
             }
+            appender.events.any { event ->
+                event.throwableProxy?.message == "Application resource close failed"
+            }.shouldBeTrue()
             registry.closeReport.failures.single().fatal.shouldBeTrue()
         } finally {
             logger?.detach(appender)
@@ -404,6 +408,7 @@ class ApplicationResourceLifecycleTest {
         }
 
         remainingCloseCount.get() shouldBeEqualTo 1
+        appender.appendCount.get() shouldBeEqualTo 1
         registry.closeReport.closed shouldBeEqualTo 1
         registry.closeReport.failures.single().fatal.shouldBeFalse()
     }
@@ -541,7 +546,10 @@ class ApplicationResourceLifecycleTest {
     }
 
     private class ThrowingAppender : AppenderBase<ILoggingEvent>() {
+        val appendCount = AtomicInteger()
+
         override fun append(eventObject: ILoggingEvent) {
+            appendCount.incrementAndGet()
             throw AssertionError("logger-secret")
         }
     }

--- a/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/ApplicationResourceRegistryTest.kt
+++ b/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/ApplicationResourceRegistryTest.kt
@@ -1,0 +1,384 @@
+package io.bluetape4k.ktor.core
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotContain
+import kotlinx.coroutines.Job
+import org.junit.jupiter.api.Assertions.assertTimeout
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class ApplicationResourceRegistryTest {
+
+    @Test
+    fun `registry starts open with an empty report`() {
+        val registry = ApplicationResourceRegistry()
+
+        registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+            state = ApplicationResourceRegistryState.OPEN,
+            attempted = 0,
+            inFlight = 0,
+            closed = 0,
+            failures = emptyList()
+        )
+    }
+
+    @Test
+    fun `registry closes resources exactly once in reverse registration order`() {
+        val closed = mutableListOf<String>()
+        val registry = ApplicationResourceRegistry()
+
+        registry.register { closed += "first" }
+        registry.register { closed += "second" }
+        registry.register { closed += "third" }
+
+        registry.close()
+        registry.close()
+
+        closed shouldBeEqualTo listOf("third", "second", "first")
+        registry.closeReport.closed shouldBeEqualTo 3
+        registry.closeReport.attempted shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `registration token closes its resource early and registry excludes it`() {
+        val closed = mutableListOf<String>()
+        val registry = ApplicationResourceRegistry()
+        val early = registry.register { closed += "early" }
+        registry.register { closed += "shutdown" }
+
+        early.close()
+        early.close()
+
+        registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+            state = ApplicationResourceRegistryState.OPEN,
+            attempted = 1,
+            inFlight = 0,
+            closed = 1,
+            failures = emptyList()
+        )
+
+        registry.close()
+
+        closed shouldBeEqualTo listOf("early", "shutdown")
+        registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+            state = ApplicationResourceRegistryState.CLOSED,
+            attempted = 2,
+            inFlight = 0,
+            closed = 2,
+            failures = emptyList()
+        )
+    }
+
+    @Test
+    fun `duplicate resource and action identities are rejected without information disclosure`() {
+        val registry = ApplicationResourceRegistry()
+        val resource = NamedResource("credential-secret")
+        val action: () -> Unit = { }
+
+        registry.register(resource)
+        val resourceFailure = assertFailsWith<IllegalArgumentException> {
+            registry.register(resource)
+        }
+        registry.register(action)
+        val actionFailure = assertFailsWith<IllegalArgumentException> {
+            registry.register(action)
+        }
+
+        resourceFailure.message shouldNotContain "credential-secret"
+        resourceFailure.message shouldNotContain "NamedResource"
+        actionFailure.message shouldNotContain "Function"
+    }
+
+    @Test
+    fun `late registration closes immediately and is recorded in the cumulative report`() {
+        val closed = mutableListOf<String>()
+        val registry = ApplicationResourceRegistry()
+        registry.close()
+
+        val late = registry.register { closed += "late" }
+        late.close()
+
+        closed shouldBeEqualTo listOf("late")
+        registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+            state = ApplicationResourceRegistryState.CLOSED,
+            attempted = 1,
+            inFlight = 0,
+            closed = 1,
+            failures = emptyList()
+        )
+    }
+
+    @Test
+    fun `early close failure is isolated and reported with the early phase`() {
+        val registry = ApplicationResourceRegistry()
+        val registration = registry.register { throw IllegalStateException("credential-secret") }
+
+        registration.close()
+
+        registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+            state = ApplicationResourceRegistryState.OPEN,
+            attempted = 1,
+            inFlight = 0,
+            closed = 0,
+            failures = listOf(
+                ApplicationResourceCloseFailure(
+                    registrationId = registration.id,
+                    phase = ApplicationResourceClosePhase.EARLY,
+                    fatal = false
+                )
+            )
+        )
+        registry.close()
+    }
+
+    @Test
+    fun `late close failure is isolated and reported with the late phase`() {
+        val registry = ApplicationResourceRegistry()
+        registry.close()
+
+        registry.register { throw IllegalStateException("credential-secret") }
+
+        val report = registry.closeReport
+        report.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        report.attempted shouldBeEqualTo 1
+        report.inFlight shouldBeEqualTo 0
+        report.closed shouldBeEqualTo 0
+        report.failures shouldBeEqualTo listOf(
+            ApplicationResourceCloseFailure(
+                registrationId = 1,
+                phase = ApplicationResourceClosePhase.LATE_REGISTRATION,
+                fatal = false
+            )
+        )
+    }
+
+    @Test
+    fun `shutdown close continues after ordinary failures and reports its phase`() {
+        val closed = mutableListOf<String>()
+        val registry = ApplicationResourceRegistry()
+        registry.register { closed += "first" }
+        val failing = registry.register { throw IllegalStateException("credential-secret") }
+        registry.register { closed += "last" }
+
+        registry.close()
+
+        closed shouldBeEqualTo listOf("last", "first")
+        val report = registry.closeReport
+        report.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        report.attempted shouldBeEqualTo 3
+        report.inFlight shouldBeEqualTo 0
+        report.closed shouldBeEqualTo 2
+        report.failures shouldBeEqualTo listOf(
+            ApplicationResourceCloseFailure(
+                registrationId = failing.id,
+                phase = ApplicationResourceClosePhase.SHUTDOWN,
+                fatal = false
+            )
+        )
+        report.toString() shouldNotContain "credential-secret"
+    }
+
+    @Test
+    fun `report invariant remains valid while shutdown action is in flight`() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val registry = ApplicationResourceRegistry()
+        registry.register {
+            started.countDown()
+            release.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val closeFuture = executor.submit { registry.close() }
+            started.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            val report = registry.closeReport
+            report.state shouldBeEqualTo ApplicationResourceRegistryState.DRAINING
+            report.attempted shouldBeEqualTo 1
+            report.inFlight shouldBeEqualTo 1
+            report.closed shouldBeEqualTo 0
+            report.failures shouldBeEqualTo emptyList()
+
+            release.countDown()
+            closeFuture.get(5, TimeUnit.SECONDS)
+        } finally {
+            release.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `reentrant close and late registration do not deadlock`() {
+        val closed = mutableListOf<String>()
+        val registry = ApplicationResourceRegistry()
+        registry.register {
+            closed += "shutdown"
+            registry.close()
+            registry.register { closed += "late" }
+        }
+
+        registry.close()
+
+        closed shouldBeEqualTo listOf("shutdown", "late")
+        registry.closeReport.closed shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `fatal failure is sanitized after remaining resources are closed`() {
+        val closed = mutableListOf<String>()
+        val registry = ApplicationResourceRegistry()
+        registry.register { closed += "first" }
+        registry.register { throw AssertionError("credential-secret") }
+        registry.register { closed += "last" }
+
+        val marker = assertFailsWith<Error> { registry.close() }
+
+        closed shouldBeEqualTo listOf("last", "first")
+        marker.message.orEmpty() shouldNotContain "credential-secret"
+        marker.cause shouldBeEqualTo null
+        registry.closeReport.failures.single().fatal.shouldBeTrue()
+    }
+
+    @Test
+    fun `job cancellation can be adapted through a synchronous close action`() {
+        val job = Job()
+        val registry = ApplicationResourceRegistry()
+        registry.register { job.cancel() }
+
+        registry.close()
+
+        job.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `close action executes on the caller thread`() {
+        val registry = ApplicationResourceRegistry()
+        val caller = Thread.currentThread()
+        var closer: Thread? = null
+        registry.register { closer = Thread.currentThread() }
+
+        assertTimeout(Duration.ofSeconds(1)) {
+            registry.close()
+        }
+
+        closer shouldBeSameInstanceAs caller
+    }
+
+    @Test
+    fun `token and registry close race still closes each entry exactly once`() {
+        repeat(8) {
+            val closeCounts = List(8) { AtomicInteger() }
+            val registry = ApplicationResourceRegistry()
+            val registrations = closeCounts.map { count ->
+                registry.register { count.incrementAndGet() }
+            }
+            val barrier = CyclicBarrier(registrations.size + 1)
+            val executor = Executors.newFixedThreadPool(registrations.size + 1)
+            try {
+                val futures = registrations.map { registration ->
+                    executor.submit {
+                        barrier.await(5, TimeUnit.SECONDS)
+                        registration.close()
+                    }
+                }
+                val closeFuture = executor.submit {
+                    barrier.await(5, TimeUnit.SECONDS)
+                    registry.close()
+                }
+                futures.forEach { it.get(5, TimeUnit.SECONDS) }
+                closeFuture.get(5, TimeUnit.SECONDS)
+            } finally {
+                executor.shutdownNow()
+            }
+
+            closeCounts.forEach { it.get() shouldBeEqualTo 1 }
+            registry.closeReport.closed shouldBeEqualTo closeCounts.size
+            registry.closeReport.inFlight shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `owned identity remains unavailable while draining and after close`() {
+        val closeStarted = CountDownLatch(1)
+        val allowClose = CountDownLatch(1)
+        val registry = ApplicationResourceRegistry()
+        val resource = AutoCloseable {
+            closeStarted.countDown()
+            allowClose.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+        registry.register(resource)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val closeFuture = executor.submit { registry.close() }
+            closeStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.DRAINING
+            assertFailsWith<IllegalArgumentException> { registry.register(resource) }
+            allowClose.countDown()
+            closeFuture.get(5, TimeUnit.SECONDS)
+            assertFailsWith<IllegalArgumentException> { registry.register(resource) }
+        } finally {
+            allowClose.countDown()
+            executor.shutdownNow()
+        }
+
+        registry.closeReport.state shouldBeEqualTo ApplicationResourceRegistryState.CLOSED
+        registry.closeReport.inFlight shouldBeEqualTo 0
+        registry.closeReport.failures.isEmpty().shouldBeTrue()
+        registry.closeReport.closed shouldBeEqualTo 1
+        registry.closeReport.attempted.shouldBeEqualTo(1)
+        registry.closeReport.failures.any { it.fatal }.shouldBeFalse()
+    }
+
+    @Test
+    fun `late registration report remains valid while its close action is in flight`() {
+        val closeStarted = CountDownLatch(1)
+        val allowClose = CountDownLatch(1)
+        val registry = ApplicationResourceRegistry()
+        registry.close()
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val registration = executor.submit {
+                registry.register {
+                    closeStarted.countDown()
+                    allowClose.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                }
+            }
+            closeStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+            registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+                state = ApplicationResourceRegistryState.CLOSED,
+                attempted = 1,
+                inFlight = 1,
+                closed = 0,
+                failures = emptyList()
+            )
+
+            allowClose.countDown()
+            registration.get(5, TimeUnit.SECONDS)
+        } finally {
+            allowClose.countDown()
+            executor.shutdownNow()
+        }
+
+        registry.closeReport.inFlight shouldBeEqualTo 0
+        registry.closeReport.closed shouldBeEqualTo 1
+    }
+
+    private class NamedResource(
+        private val name: String,
+    ) : AutoCloseable {
+        override fun close() = Unit
+
+        override fun toString(): String = name
+    }
+}

--- a/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/consumer/ApplicationResourceLifecyclePublicApiTest.kt
+++ b/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/consumer/ApplicationResourceLifecyclePublicApiTest.kt
@@ -45,13 +45,12 @@ class ApplicationResourceLifecyclePublicApiTest {
     }
 
     @Test
-    fun `implementation seams and token constructors are not public API`() {
+    fun `implementation seams and token implementations are not public API`() {
         val holder = Class.forName("io.bluetape4k.ktor.core.ApplicationResourceLifecycleHolder")
         Modifier.isPublic(holder.modifiers) shouldBeEqualTo false
 
         val registration = Class.forName("io.bluetape4k.ktor.core.ApplicationResourceRegistration")
-        registration.declaredConstructors.none { constructor ->
-            Modifier.isPublic(constructor.modifiers) && !constructor.isSynthetic
-        } shouldBeEqualTo true
+        registration.isInterface shouldBeEqualTo true
+        registration.declaredConstructors.isEmpty() shouldBeEqualTo true
     }
 }

--- a/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/consumer/ApplicationResourceLifecyclePublicApiTest.kt
+++ b/ktor/core/src/test/kotlin/io/bluetape4k/ktor/core/consumer/ApplicationResourceLifecyclePublicApiTest.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.ktor.core.consumer
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.ktor.core.ApplicationResourceClosePhase
+import io.bluetape4k.ktor.core.ApplicationResourceCloseReport
+import io.bluetape4k.ktor.core.ApplicationResourceRegistry
+import io.bluetape4k.ktor.core.ApplicationResourceRegistryState
+import io.bluetape4k.ktor.core.installApplicationResourceLifecycle
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Modifier
+
+/**
+ * 별도 package의 caller가 접근하는 public lifecycle 계약을 고정합니다.
+ */
+class ApplicationResourceLifecyclePublicApiTest {
+
+    @Test
+    fun `consumer can use registry report and registration token`() {
+        val registry = ApplicationResourceRegistry()
+        val resource = AutoCloseable { }
+        val action: () -> Unit = { }
+
+        val resourceRegistration = registry.register(resource)
+        registry.register(action)
+        resourceRegistration.close()
+        registry.close()
+
+        registry.closeReport shouldBeEqualTo ApplicationResourceCloseReport(
+            state = ApplicationResourceRegistryState.CLOSED,
+            attempted = 2,
+            inFlight = 0,
+            closed = 2,
+            failures = emptyList()
+        )
+        ApplicationResourceClosePhase.values().toList().size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `consumer can install lifecycle on a Ktor application`() = testApplication {
+        application {
+            val registry = installApplicationResourceLifecycle()
+            registry.register(AutoCloseable { })
+        }
+    }
+
+    @Test
+    fun `implementation seams and token constructors are not public API`() {
+        val holder = Class.forName("io.bluetape4k.ktor.core.ApplicationResourceLifecycleHolder")
+        Modifier.isPublic(holder.modifiers) shouldBeEqualTo false
+
+        val registration = Class.forName("io.bluetape4k.ktor.core.ApplicationResourceRegistration")
+        registration.declaredConstructors.none { constructor ->
+            Modifier.isPublic(constructor.modifiers) && !constructor.isSynthetic
+        } shouldBeEqualTo true
+    }
+}

--- a/ktor/core/src/test/resources/abi/application-resource-lifecycle-javap.txt
+++ b/ktor/core/src/test/resources/abi/application-resource-lifecycle-javap.txt
@@ -1,0 +1,73 @@
+Compiled from "ApplicationResourceLifecycle.kt"
+public final class io.bluetape4k.ktor.core.ApplicationResourceClosePhase extends java.lang.Enum<io.bluetape4k.ktor.core.ApplicationResourceClosePhase> {
+  public static final io.bluetape4k.ktor.core.ApplicationResourceClosePhase EARLY;
+  public static final io.bluetape4k.ktor.core.ApplicationResourceClosePhase SHUTDOWN;
+  public static final io.bluetape4k.ktor.core.ApplicationResourceClosePhase LATE_REGISTRATION;
+  public static io.bluetape4k.ktor.core.ApplicationResourceClosePhase[] values();
+  public static io.bluetape4k.ktor.core.ApplicationResourceClosePhase valueOf(java.lang.String);
+  public static kotlin.enums.EnumEntries<io.bluetape4k.ktor.core.ApplicationResourceClosePhase> getEntries();
+}
+Compiled from "ApplicationResourceLifecycle.kt"
+public final class io.bluetape4k.ktor.core.ApplicationResourceRegistryState extends java.lang.Enum<io.bluetape4k.ktor.core.ApplicationResourceRegistryState> {
+  public static final io.bluetape4k.ktor.core.ApplicationResourceRegistryState OPEN;
+  public static final io.bluetape4k.ktor.core.ApplicationResourceRegistryState DRAINING;
+  public static final io.bluetape4k.ktor.core.ApplicationResourceRegistryState CLOSED;
+  public static io.bluetape4k.ktor.core.ApplicationResourceRegistryState[] values();
+  public static io.bluetape4k.ktor.core.ApplicationResourceRegistryState valueOf(java.lang.String);
+  public static kotlin.enums.EnumEntries<io.bluetape4k.ktor.core.ApplicationResourceRegistryState> getEntries();
+}
+Compiled from "ApplicationResourceLifecycle.kt"
+public final class io.bluetape4k.ktor.core.ApplicationResourceCloseFailure implements java.io.Serializable {
+  public static final io.bluetape4k.ktor.core.ApplicationResourceCloseFailure$Companion Companion;
+  public io.bluetape4k.ktor.core.ApplicationResourceCloseFailure(long, io.bluetape4k.ktor.core.ApplicationResourceClosePhase, boolean);
+  public final long getRegistrationId();
+  public final io.bluetape4k.ktor.core.ApplicationResourceClosePhase getPhase();
+  public final boolean getFatal();
+  public final long component1();
+  public final io.bluetape4k.ktor.core.ApplicationResourceClosePhase component2();
+  public final boolean component3();
+  public final io.bluetape4k.ktor.core.ApplicationResourceCloseFailure copy(long, io.bluetape4k.ktor.core.ApplicationResourceClosePhase, boolean);
+  public static io.bluetape4k.ktor.core.ApplicationResourceCloseFailure copy$default(io.bluetape4k.ktor.core.ApplicationResourceCloseFailure, long, io.bluetape4k.ktor.core.ApplicationResourceClosePhase, boolean, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+}
+Compiled from "ApplicationResourceLifecycle.kt"
+public final class io.bluetape4k.ktor.core.ApplicationResourceRegistry implements java.lang.AutoCloseable {
+  public static final io.bluetape4k.ktor.core.ApplicationResourceRegistry$Companion Companion;
+  public io.bluetape4k.ktor.core.ApplicationResourceRegistry();
+  public final io.bluetape4k.ktor.core.ApplicationResourceCloseReport getCloseReport();
+  public final io.bluetape4k.ktor.core.ApplicationResourceRegistration register(java.lang.AutoCloseable);
+  public final io.bluetape4k.ktor.core.ApplicationResourceRegistration register(kotlin.jvm.functions.Function0<kotlin.Unit>);
+  public void close();
+}
+Compiled from "ApplicationResourceLifecycle.kt"
+public final class io.bluetape4k.ktor.core.ApplicationResourceRegistration implements java.lang.AutoCloseable {
+  public final long getId();
+  public void close();
+  public io.bluetape4k.ktor.core.ApplicationResourceRegistration(long, kotlin.jvm.functions.Function0, kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "ApplicationResourceLifecycle.kt"
+public final class io.bluetape4k.ktor.core.ApplicationResourceCloseReport implements java.io.Serializable {
+  public static final io.bluetape4k.ktor.core.ApplicationResourceCloseReport$Companion Companion;
+  public io.bluetape4k.ktor.core.ApplicationResourceCloseReport(io.bluetape4k.ktor.core.ApplicationResourceRegistryState, int, int, int, java.util.List<io.bluetape4k.ktor.core.ApplicationResourceCloseFailure>);
+  public final io.bluetape4k.ktor.core.ApplicationResourceRegistryState getState();
+  public final int getAttempted();
+  public final int getInFlight();
+  public final int getClosed();
+  public final java.util.List<io.bluetape4k.ktor.core.ApplicationResourceCloseFailure> getFailures();
+  public final io.bluetape4k.ktor.core.ApplicationResourceRegistryState component1();
+  public final int component2();
+  public final int component3();
+  public final int component4();
+  public final java.util.List<io.bluetape4k.ktor.core.ApplicationResourceCloseFailure> component5();
+  public final io.bluetape4k.ktor.core.ApplicationResourceCloseReport copy(io.bluetape4k.ktor.core.ApplicationResourceRegistryState, int, int, int, java.util.List<io.bluetape4k.ktor.core.ApplicationResourceCloseFailure>);
+  public static io.bluetape4k.ktor.core.ApplicationResourceCloseReport copy$default(io.bluetape4k.ktor.core.ApplicationResourceCloseReport, io.bluetape4k.ktor.core.ApplicationResourceRegistryState, int, int, int, java.util.List, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+}
+Compiled from "ApplicationResourceLifecycle.kt"
+public final class io.bluetape4k.ktor.core.ApplicationResourceLifecycleKt {
+  public static final io.bluetape4k.ktor.core.ApplicationResourceRegistry installApplicationResourceLifecycle(io.ktor.server.application.Application);
+}

--- a/ktor/core/src/test/resources/abi/application-resource-lifecycle-javap.txt
+++ b/ktor/core/src/test/resources/abi/application-resource-lifecycle-javap.txt
@@ -42,10 +42,9 @@ public final class io.bluetape4k.ktor.core.ApplicationResourceRegistry implement
   public void close();
 }
 Compiled from "ApplicationResourceLifecycle.kt"
-public final class io.bluetape4k.ktor.core.ApplicationResourceRegistration implements java.lang.AutoCloseable {
-  public final long getId();
-  public void close();
-  public io.bluetape4k.ktor.core.ApplicationResourceRegistration(long, kotlin.jvm.functions.Function0, kotlin.jvm.internal.DefaultConstructorMarker);
+public interface io.bluetape4k.ktor.core.ApplicationResourceRegistration extends java.lang.AutoCloseable {
+  public abstract long getId();
+  public abstract void close();
 }
 Compiled from "ApplicationResourceLifecycle.kt"
 public final class io.bluetape4k.ktor.core.ApplicationResourceCloseReport implements java.io.Serializable {


### PR DESCRIPTION
## 요약

Ktor 애플리케이션이 소유한 동기식 resource를 `ApplicationStopped`에서 일관되게 닫는 공통 registry를 `ktor/core`에 추가합니다.

- attribute supplier와 event subscription side effect를 분리해 동시 설치에서도 하나의 registry와 subscription만 소유합니다.
- registration token 조기 종료, 등록 역순 shutdown, late registration 즉시 종료를 하나의 exactly-once claim 규칙으로 처리합니다.
- close 실패를 다른 resource와 격리하고 opaque ID, phase, fatal 여부만 report에 남깁니다.
- close action은 caller thread에서 동기적으로 실행하며 thread, coroutine scope, timeout, retry, backend drain 정책을 만들지 않습니다.
- public token은 interface로 제한하고 holder와 실제 token 구현은 JVM public ABI에서 숨깁니다.

Closes #1656

## API와 운영 계약

```kotlin
fun Application.module() {
    val resources = installApplicationResourceLifecycle()
    val client = createClient()

    resources.register(client)
}
```

이 lifecycle은 graceful shutdown 전용입니다. `ApplicationStopped`가 발생하지 않는 `SIGKILL`, JVM crash, OOM cleanup은 보장하지 않습니다. background job이 resource를 사용한다면 caller-owned adapter가 bounded drain 또는 resource 접근 종료를 보장해야 합니다.

## 검증

- `:bluetape4k-ktor-core:cleanTest :bluetape4k-ktor-core:test --no-build-cache`: 39 passed, skipped/failures/errors 0
- `:bluetape4k-ktor-core:check`, Kover verify, detekt 통과
- POM 및 module metadata validator: failures 0
- `javap -public` golden exact match
- holder와 private token 구현: `ACC_PUBLIC` 없음, nested Factory class 없음
- dependency/catalog/settings diff 0, 한국어 용어 감사와 `git diff --check` 통과
- exact head `128d89301e757b83342fce970ed4d1fd60a90cc7`: GitHub Actions 24개 terminal, 12 success, 12 path skip, failure 0

Gradle publication task는 성공했지만 기존 configuration-cache 직렬화 문제 8건을 보고하고 cache entry를 폐기합니다. publication artifact와 validator 결과에는 실패가 없습니다.

## 검토

- 승인된 설계·구현 계획: P0/P1/P2 = 0/0/0
- 독립 architecture/contract exact-head review: P0/P1/P2 = 0/0/0, `CLEAR`
- 독립 comprehensive exact-head review: P0/P1/P2 = 0/0/2, `CLEAR`
- 비차단 P2: subscription disposal failure에서 secret 미기록을 직접 assert하지 않음, register-vs-close deterministic phase oracle 부재
- live GitHub review thread: 0, unresolved 0

## 후속 adoption

- Graph: https://github.com/bluetape4k/bluetape4k-graph/issues/618
- Leader: https://github.com/bluetape4k/bluetape4k-leader/issues/897
- AWS: https://github.com/bluetape4k/bluetape4k-aws/issues/643

## DoD Status

- [x] 공통 registry와 `ApplicationStopped` installer 구현
- [x] 동시성, 종료 순서, late/reentrant, 부분 실패, 정보 비노출 회귀 테스트
- [x] public ABI와 publication metadata 검증
- [x] 영문/국문 README와 lesson 작성
- [x] Graph·Leader·AWS adoption issue 분리
- [x] 독립 architecture 및 comprehensive review `CLEAR`
- [x] exact-head GitHub Actions 통과
- [x] live review/thread read-back 및 mergeability `CLEAN`
- [ ] merge 후 downstream adoption 시작 — 사용자가 다섯 PR을 함께 merge한 뒤 별도 진행
