### PR TITLE
Fory JSON 도입 판단을 재현 가능한 PoC로 고정한다

### DIFF
--- a/docs/evidence/issue-1641/poc/build.gradle.kts
+++ b/docs/evidence/issue-1641/poc/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    kotlin("jvm") version "2.4.10"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.apache.fory:fory-json-kotlin:1.7.1")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.22.2")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.65")
+}
+
+kotlin {
+    jvmToolchain(25)
+}
+
+application {
+    mainClass = "Issue1641EvaluationKt"
+}
+
+tasks.withType<JavaExec>().configureEach {
+    jvmArgs("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED")
+}

--- a/docs/evidence/issue-1641/poc/settings.gradle.kts
+++ b/docs/evidence/issue-1641/poc/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "issue-1641-fory-json-evaluation"

--- a/docs/evidence/issue-1641/poc/src/main/kotlin/Issue1641Evaluation.kt
+++ b/docs/evidence/issue-1641/poc/src/main/kotlin/Issue1641Evaluation.kt
@@ -14,7 +14,7 @@ value class AccountId(val value: Long)
 
 @JsonSubTypes(property = "type")
 sealed interface AccountEvent {
-    data class Created(val actor: String): AccountEvent
+    data class Created(val actor: String) : AccountEvent
 }
 
 data class Account(
@@ -90,6 +90,7 @@ private fun verifyIncrementalNdjson(fory: ForyJson) {
     if (decoder.finish()) restored += decoder.value()
 
     val expected = listOf(sample, sample.copy(id = AccountId(8), note = "끝"))
+    check(restored.size == expected.size)
     check(restored.zip(expected).all { (actual, item) -> actual.sameValueAs(item) })
     println("NDJSON PASS records=${restored.size} chunks=${(bytes.size + 2) / 3}")
 }

--- a/docs/evidence/issue-1641/poc/src/main/kotlin/Issue1641Evaluation.kt
+++ b/docs/evidence/issue-1641/poc/src/main/kotlin/Issue1641Evaluation.kt
@@ -125,6 +125,8 @@ private fun verifyIncrementalArray(fory: ForyJson) {
     }
     check(!decoder.finish())
     check(restored.map { it.id } == listOf(AccountId(7), AccountId(9)))
+    check(runCatching { decoder.decodeNext(ByteBuffer.wrap(byteArrayOf())) }.exceptionOrNull() is IllegalStateException)
+    check(runCatching { decoder.finish() }.exceptionOrNull() is IllegalStateException)
     println("ARRAY PASS records=${restored.size} chunks=${(bytes.size + 4) / 5}")
 }
 
@@ -141,7 +143,24 @@ private fun verifyFailureAndLimit(fory: ForyJson) {
     }.exceptionOrNull()
     check(failure is JsonStreamValueLimitException)
     check(runCatching { limited.decodeNext(ByteBuffer.wrap(byteArrayOf())) }.exceptionOrNull() is IllegalStateException)
-    println("FAILURE PASS malformed=terminal limit=${failure.maxValueBytes}")
+
+    val malformedArray = fory.newArrayStreamDecoder(type, 1_024)
+    malformedArray.decodeNext(ByteBuffer.wrap("[{\"id\":".toByteArray()))
+    check(runCatching { malformedArray.finish() }.isFailure)
+    check(runCatching { malformedArray.finish() }.exceptionOrNull() is IllegalStateException)
+
+    val limitedArray = fory.newArrayStreamDecoder(type, 16)
+    val arrayLimitFailure = runCatching {
+        limitedArray.decodeNext(ByteBuffer.wrap("[{\"name\":\"0123456789\"}]".toByteArray()))
+    }.exceptionOrNull()
+    check(arrayLimitFailure is JsonStreamValueLimitException)
+    check(
+        runCatching { limitedArray.decodeNext(ByteBuffer.wrap(byteArrayOf())) }.exceptionOrNull() is IllegalStateException,
+    )
+    println(
+        "FAILURE PASS ndjsonMalformed=terminal ndjsonLimit=${failure.maxValueBytes} " +
+            "arrayMalformed=terminal arrayLimit=${arrayLimitFailure.maxValueBytes} arraySuccess=terminal",
+    )
 }
 
 private fun compareRepresentations(fory: ForyJson) {
@@ -167,27 +186,22 @@ private fun compareRepresentations(fory: ForyJson) {
     check(jackson.readValue<FlatAccount>(jacksonJson).payload.contentEquals(flat.payload))
     check(JSON.parseObject(fastjson, FlatAccount::class.java).payload.contentEquals(flat.payload))
     val crossReads = linkedMapOf(
-        "Fory<-Jackson" to runCatching { fory.fromJson(jacksonJson, type).sameValueAs(flat) }.getOrDefault(false),
-        "Fory<-Fastjson2" to runCatching { fory.fromJson(fastjson, type).sameValueAs(flat) }.getOrDefault(false),
-        "Jackson<-Fory" to runCatching { jackson.readValue<FlatAccount>(foryJson).sameValueAs(flat) }.getOrDefault(false),
-        "Jackson<-Fastjson2" to runCatching { jackson.readValue<FlatAccount>(fastjson).sameValueAs(flat) }.getOrDefault(false),
-        "Fastjson2<-Fory" to runCatching {
+        "Fory<-Jackson" to observeCrossRead { fory.fromJson(jacksonJson, type).sameValueAs(flat) },
+        "Fory<-Fastjson2" to observeCrossRead { fory.fromJson(fastjson, type).sameValueAs(flat) },
+        "Jackson<-Fory" to observeCrossRead { jackson.readValue<FlatAccount>(foryJson).sameValueAs(flat) },
+        "Jackson<-Fastjson2" to observeCrossRead { jackson.readValue<FlatAccount>(fastjson).sameValueAs(flat) },
+        "Fastjson2<-Fory" to observeCrossRead {
             JSON.parseObject(foryJson, FlatAccount::class.java).sameValueAs(flat)
-        }.getOrDefault(false),
-        "Fastjson2<-Jackson" to runCatching {
+        },
+        "Fastjson2<-Jackson" to observeCrossRead {
             JSON.parseObject(jacksonJson, FlatAccount::class.java).sameValueAs(flat)
-        }.getOrDefault(false),
+        },
     )
-    check(
-        crossReads == linkedMapOf(
-            "Fory<-Jackson" to true,
-            "Fory<-Fastjson2" to false,
-            "Jackson<-Fory" to true,
-            "Jackson<-Fastjson2" to true,
-            "Fastjson2<-Fory" to false,
-            "Fastjson2<-Jackson" to false,
-        ),
-    )
+    check(crossReads.filterKeys { it in setOf("Fory<-Jackson", "Jackson<-Fory", "Jackson<-Fastjson2") }
+        .values.all { it.compatible })
+    check(crossReads["Fory<-Fastjson2"]?.failureType == "org.apache.fory.json.ForyJsonException")
+    check(crossReads["Fastjson2<-Fory"]?.failureType == "com.alibaba.fastjson2.JSONException")
+    check(crossReads["Fastjson2<-Jackson"]?.failureType == "com.alibaba.fastjson2.JSONException")
     println(
         "REPRESENTATION Fory=${foryJson.toByteArray().size} " +
             "Jackson=${jacksonJson.toByteArray().size} Fastjson2=${fastjson.toByteArray().size} " +
@@ -220,6 +234,19 @@ private data class BackendMeasurement(
     val allocatedBytesPerOperation: Long,
     val peakHeapDeltaBytes: Long,
 )
+
+private data class CrossReadObservation(
+    val compatible: Boolean,
+    val failureType: String? = null,
+)
+
+private fun observeCrossRead(read: () -> Boolean): CrossReadObservation =
+    try {
+        if (read()) CrossReadObservation(compatible = true)
+        else CrossReadObservation(compatible = false, failureType = "VALUE_MISMATCH")
+    } catch (failure: Exception) {
+        CrossReadObservation(compatible = false, failureType = failure::class.java.name)
+    }
 
 private fun measureBackend(name: String, iterations: Int, encode: () -> String): BackendMeasurement {
     val threadBean = ManagementFactory.getThreadMXBean() as? ThreadMXBean

--- a/docs/evidence/issue-1641/poc/src/main/kotlin/Issue1641Evaluation.kt
+++ b/docs/evidence/issue-1641/poc/src/main/kotlin/Issue1641Evaluation.kt
@@ -1,0 +1,175 @@
+import com.alibaba.fastjson2.JSON
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import java.nio.ByteBuffer
+import kotlin.system.measureNanoTime
+import org.apache.fory.json.ForyJson
+import org.apache.fory.json.JsonStreamValueLimitException
+import org.apache.fory.json.annotation.JsonSubTypes
+import org.apache.fory.json.kotlin.ForyJsonKotlin
+import org.apache.fory.json.kotlin.jsonTypeRef
+
+@JvmInline
+value class AccountId(val value: Long)
+
+@JsonSubTypes(property = "type")
+sealed interface AccountEvent {
+    data class Created(val actor: String): AccountEvent
+}
+
+data class Account(
+    val id: AccountId,
+    val name: String = "anonymous",
+    val note: String?,
+    val tags: List<String>,
+    val event: AccountEvent,
+    val sequence: Long,
+    val payload: ByteArray,
+)
+
+data class FlatAccount(
+    val name: String,
+    val sequence: Long,
+    val payload: ByteArray,
+)
+
+private val sample = Account(
+    id = AccountId(7),
+    note = null,
+    tags = listOf("kotlin", "json"),
+    event = AccountEvent.Created("debop"),
+    sequence = Long.MAX_VALUE,
+    payload = byteArrayOf(0, 1, 2, 127, -1),
+)
+
+fun main() {
+    val fory = ForyJsonKotlin.builder().writeLongAsString(true).build()
+    verifyKotlinModel(fory)
+    verifyIncrementalNdjson(fory)
+    verifyIncrementalArray(fory)
+    verifyFailureAndLimit(fory)
+    compareRepresentations(fory)
+    benchmark(fory)
+}
+
+private fun verifyKotlinModel(fory: ForyJson) {
+    val type = jsonTypeRef<Account>()
+    val json = fory.toJson(sample, type)
+    val restored = fory.fromJson(json, type)
+    check(restored.sameValueAs(sample))
+    check("\"${Long.MAX_VALUE}\"" in json)
+    check(fory.fromJson(json.replace("\"name\":\"anonymous\",", ""), type).name == "anonymous")
+
+    val listType = jsonTypeRef<List<Account>>()
+    val listJson = fory.toJson(listOf(sample), listType)
+    check(fory.fromJson(listJson, listType).single().sameValueAs(sample))
+    check(fory.fromJson(json, Account::class.java).sameValueAs(sample))
+    val rawList = fory.fromJson(listJson, List::class.java)
+    check(rawList.single() !is Account)
+
+    println(
+        "MODEL PASS bytes=${json.toByteArray().size} " +
+            "rawGenericElement=${rawList.single()!!::class.java.simpleName} json=$json",
+    )
+}
+
+private fun verifyIncrementalNdjson(fory: ForyJson) {
+    val type = jsonTypeRef<Account>()
+    val first = fory.toJson(sample, type)
+    val second = fory.toJson(sample.copy(id = AccountId(8), note = "끝"), type)
+    val bytes = "$first\r\n$second".toByteArray()
+    val decoder = fory.newNdjsonStreamDecoder(type, 1_024)
+    val restored = mutableListOf<Account>()
+
+    bytes.asList().chunked(3).forEach { chunk ->
+        val buffer = ByteBuffer.wrap(chunk.toByteArray())
+        while (buffer.hasRemaining()) {
+            if (decoder.decodeNext(buffer)) restored += decoder.value()
+        }
+    }
+    if (decoder.finish()) restored += decoder.value()
+
+    val expected = listOf(sample, sample.copy(id = AccountId(8), note = "끝"))
+    check(restored.zip(expected).all { (actual, item) -> actual.sameValueAs(item) })
+    println("NDJSON PASS records=${restored.size} chunks=${(bytes.size + 2) / 3}")
+}
+
+private fun verifyIncrementalArray(fory: ForyJson) {
+    val type = jsonTypeRef<Account>()
+    val json = "[${fory.toJson(sample, type)},${fory.toJson(sample.copy(id = AccountId(9)), type)}]"
+    val bytes = json.toByteArray()
+    val decoder = fory.newArrayStreamDecoder(type, 1_024)
+    val restored = mutableListOf<Account>()
+
+    bytes.asList().chunked(5).forEach { chunk ->
+        val buffer = ByteBuffer.wrap(chunk.toByteArray())
+        while (buffer.hasRemaining()) {
+            if (decoder.decodeNext(buffer)) restored += decoder.value()
+        }
+    }
+    check(!decoder.finish())
+    check(restored.map { it.id } == listOf(AccountId(7), AccountId(9)))
+    println("ARRAY PASS records=${restored.size} chunks=${(bytes.size + 4) / 5}")
+}
+
+private fun verifyFailureAndLimit(fory: ForyJson) {
+    val type = jsonTypeRef<Account>()
+    val malformed = fory.newNdjsonStreamDecoder(type, 1_024)
+    malformed.decodeNext(ByteBuffer.wrap("{\"id\":".toByteArray()))
+    check(runCatching { malformed.finish() }.isFailure)
+    check(runCatching { malformed.finish() }.exceptionOrNull() is IllegalStateException)
+
+    val limited = fory.newNdjsonStreamDecoder(type, 16)
+    val failure = runCatching {
+        limited.decodeNext(ByteBuffer.wrap("{\"name\":\"0123456789\"}\n".toByteArray()))
+    }.exceptionOrNull()
+    check(failure is JsonStreamValueLimitException)
+    check(runCatching { limited.decodeNext(ByteBuffer.wrap(byteArrayOf())) }.exceptionOrNull() is IllegalStateException)
+    println("FAILURE PASS malformed=terminal limit=${failure.maxValueBytes}")
+}
+
+private fun compareRepresentations(fory: ForyJson) {
+    val flat = FlatAccount("debop", Long.MAX_VALUE, sample.payload)
+    val type = jsonTypeRef<FlatAccount>()
+    val jackson = jacksonObjectMapper()
+    val foryJson = fory.toJson(flat, type)
+    val jacksonJson = jackson.writeValueAsString(flat)
+    val fastjson = JSON.toJSONString(flat)
+
+    check(fory.fromJson(foryJson, type).payload.contentEquals(flat.payload))
+    check(jackson.readValue<FlatAccount>(jacksonJson).payload.contentEquals(flat.payload))
+    check(JSON.parseObject(fastjson, FlatAccount::class.java).payload.contentEquals(flat.payload))
+    println(
+        "REPRESENTATION Fory=${foryJson.toByteArray().size} " +
+            "Jackson=${jacksonJson.toByteArray().size} Fastjson2=${fastjson.toByteArray().size}",
+    )
+}
+
+private fun benchmark(fory: ForyJson) {
+    val flat = FlatAccount("debop", Long.MAX_VALUE, sample.payload)
+    val type = jsonTypeRef<FlatAccount>()
+    val jackson = jacksonObjectMapper()
+    repeat(2_000) {
+        fory.toJson(flat, type)
+        jackson.writeValueAsString(flat)
+        JSON.toJSONString(flat)
+    }
+
+    val iterations = 20_000
+    val foryNanos = measureNanoTime { repeat(iterations) { fory.toJson(flat, type) } }
+    val jacksonNanos = measureNanoTime { repeat(iterations) { jackson.writeValueAsString(flat) } }
+    val fastjsonNanos = measureNanoTime { repeat(iterations) { JSON.toJSONString(flat) } }
+    println(
+        "BENCH iterations=$iterations Fory.nsOp=${foryNanos / iterations} " +
+            "Jackson.nsOp=${jacksonNanos / iterations} Fastjson2.nsOp=${fastjsonNanos / iterations}",
+    )
+}
+
+private fun Account.sameValueAs(other: Account): Boolean =
+    id == other.id &&
+        name == other.name &&
+        note == other.note &&
+        tags == other.tags &&
+        event == other.event &&
+        sequence == other.sequence &&
+        payload.contentEquals(other.payload)

--- a/docs/evidence/issue-1641/poc/src/main/kotlin/Issue1641Evaluation.kt
+++ b/docs/evidence/issue-1641/poc/src/main/kotlin/Issue1641Evaluation.kt
@@ -1,6 +1,9 @@
 import com.alibaba.fastjson2.JSON
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import java.lang.management.MemoryType
 import java.nio.ByteBuffer
 import kotlin.system.measureNanoTime
 import org.apache.fory.json.ForyJson
@@ -21,7 +24,7 @@ data class Account(
     val id: AccountId,
     val name: String = "anonymous",
     val note: String?,
-    val tags: List<String>,
+    val tags: List<String?>,
     val event: AccountEvent,
     val sequence: Long,
     val payload: ByteArray,
@@ -36,7 +39,7 @@ data class FlatAccount(
 private val sample = Account(
     id = AccountId(7),
     note = null,
-    tags = listOf("kotlin", "json"),
+    tags = listOf("kotlin", null, "json"),
     event = AccountEvent.Created("debop"),
     sequence = Long.MAX_VALUE,
     payload = byteArrayOf(0, 1, 2, 127, -1),
@@ -58,7 +61,13 @@ private fun verifyKotlinModel(fory: ForyJson) {
     val restored = fory.fromJson(json, type)
     check(restored.sameValueAs(sample))
     check("\"${Long.MAX_VALUE}\"" in json)
-    check(fory.fromJson(json.replace("\"name\":\"anonymous\",", ""), type).name == "anonymous")
+    check(restored.tags[1] == null)
+
+    val namedJson = fory.toJson(sample.copy(name = "explicit"), type)
+    val withoutName = namedJson.replace("\"name\":\"explicit\",", "")
+    check(withoutName != namedJson)
+    check("\"name\"" !in withoutName)
+    check(fory.fromJson(withoutName, type).name == "anonymous")
 
     val listType = jsonTypeRef<List<Account>>()
     val listJson = fory.toJson(listOf(sample), listType)
@@ -77,11 +86,13 @@ private fun verifyIncrementalNdjson(fory: ForyJson) {
     val type = jsonTypeRef<Account>()
     val first = fory.toJson(sample, type)
     val second = fory.toJson(sample.copy(id = AccountId(8), note = "끝"), type)
-    val bytes = "$first\r\n$second".toByteArray()
+    val third = fory.toJson(sample.copy(id = AccountId(9), note = "마지막"), type)
+    val bytes = "$first\n$second\r\n$third".toByteArray()
     val decoder = fory.newNdjsonStreamDecoder(type, 1_024)
     val restored = mutableListOf<Account>()
 
-    bytes.asList().chunked(3).forEach { chunk ->
+    check("끝".toByteArray().size == 3)
+    bytes.asList().chunked(1).forEach { chunk ->
         val buffer = ByteBuffer.wrap(chunk.toByteArray())
         while (buffer.hasRemaining()) {
             if (decoder.decodeNext(buffer)) restored += decoder.value()
@@ -89,10 +100,14 @@ private fun verifyIncrementalNdjson(fory: ForyJson) {
     }
     if (decoder.finish()) restored += decoder.value()
 
-    val expected = listOf(sample, sample.copy(id = AccountId(8), note = "끝"))
+    val expected = listOf(
+        sample,
+        sample.copy(id = AccountId(8), note = "끝"),
+        sample.copy(id = AccountId(9), note = "마지막"),
+    )
     check(restored.size == expected.size)
     check(restored.zip(expected).all { (actual, item) -> actual.sameValueAs(item) })
-    println("NDJSON PASS records=${restored.size} chunks=${(bytes.size + 2) / 3}")
+    println("NDJSON PASS records=${restored.size} chunks=${bytes.size} utf8ByteSplit=true separators=LF,CRLF")
 }
 
 private fun verifyIncrementalArray(fory: ForyJson) {
@@ -137,12 +152,46 @@ private fun compareRepresentations(fory: ForyJson) {
     val jacksonJson = jackson.writeValueAsString(flat)
     val fastjson = JSON.toJSONString(flat)
 
+    val foryTree = jackson.readTree(foryJson)
+    val jacksonTree = jackson.readTree(jacksonJson)
+    val fastjsonTree = jackson.readTree(fastjson)
+    check(foryTree.path("sequence").isTextual)
+    check(jacksonTree.path("sequence").isIntegralNumber)
+    check(fastjsonTree.path("sequence").isIntegralNumber)
+    check(foryTree.path("payload").asText() == "AAECf/8=")
+    check(jacksonTree.path("payload").asText() == "AAECf/8=")
+    check(fastjsonTree.path("payload").isArray)
+    check(fastjsonTree.path("payload").map { it.asInt() } == listOf(0, 1, 2, 127, -1))
+
     check(fory.fromJson(foryJson, type).payload.contentEquals(flat.payload))
     check(jackson.readValue<FlatAccount>(jacksonJson).payload.contentEquals(flat.payload))
     check(JSON.parseObject(fastjson, FlatAccount::class.java).payload.contentEquals(flat.payload))
+    val crossReads = linkedMapOf(
+        "Fory<-Jackson" to runCatching { fory.fromJson(jacksonJson, type).sameValueAs(flat) }.getOrDefault(false),
+        "Fory<-Fastjson2" to runCatching { fory.fromJson(fastjson, type).sameValueAs(flat) }.getOrDefault(false),
+        "Jackson<-Fory" to runCatching { jackson.readValue<FlatAccount>(foryJson).sameValueAs(flat) }.getOrDefault(false),
+        "Jackson<-Fastjson2" to runCatching { jackson.readValue<FlatAccount>(fastjson).sameValueAs(flat) }.getOrDefault(false),
+        "Fastjson2<-Fory" to runCatching {
+            JSON.parseObject(foryJson, FlatAccount::class.java).sameValueAs(flat)
+        }.getOrDefault(false),
+        "Fastjson2<-Jackson" to runCatching {
+            JSON.parseObject(jacksonJson, FlatAccount::class.java).sameValueAs(flat)
+        }.getOrDefault(false),
+    )
+    check(
+        crossReads == linkedMapOf(
+            "Fory<-Jackson" to true,
+            "Fory<-Fastjson2" to false,
+            "Jackson<-Fory" to true,
+            "Jackson<-Fastjson2" to true,
+            "Fastjson2<-Fory" to false,
+            "Fastjson2<-Jackson" to false,
+        ),
+    )
     println(
         "REPRESENTATION Fory=${foryJson.toByteArray().size} " +
-            "Jackson=${jacksonJson.toByteArray().size} Fastjson2=${fastjson.toByteArray().size}",
+            "Jackson=${jacksonJson.toByteArray().size} Fastjson2=${fastjson.toByteArray().size} " +
+            "crossRead=$crossReads Fory.json=$foryJson Jackson.json=$jacksonJson Fastjson2.json=$fastjson",
     )
 }
 
@@ -157,14 +206,60 @@ private fun benchmark(fory: ForyJson) {
     }
 
     val iterations = 20_000
-    val foryNanos = measureNanoTime { repeat(iterations) { fory.toJson(flat, type) } }
-    val jacksonNanos = measureNanoTime { repeat(iterations) { jackson.writeValueAsString(flat) } }
-    val fastjsonNanos = measureNanoTime { repeat(iterations) { JSON.toJSONString(flat) } }
-    println(
-        "BENCH iterations=$iterations Fory.nsOp=${foryNanos / iterations} " +
-            "Jackson.nsOp=${jacksonNanos / iterations} Fastjson2.nsOp=${fastjsonNanos / iterations}",
+    val results = listOf(
+        measureBackend("Fory", iterations) { fory.toJson(flat, type) },
+        measureBackend("Jackson", iterations) { jackson.writeValueAsString(flat) },
+        measureBackend("Fastjson2", iterations) { JSON.toJSONString(flat) },
+    )
+    println("BENCH iterations=$iterations ${results.joinToString(" ") { it.summary() }}")
+}
+
+private data class BackendMeasurement(
+    val name: String,
+    val nanosPerOperation: Long,
+    val allocatedBytesPerOperation: Long,
+    val peakHeapDeltaBytes: Long,
+)
+
+private fun measureBackend(name: String, iterations: Int, encode: () -> String): BackendMeasurement {
+    val threadBean = ManagementFactory.getThreadMXBean() as? ThreadMXBean
+        ?: error("Current JVM does not expose ThreadMXBean allocation counters")
+    check(threadBean.isThreadAllocatedMemorySupported)
+    if (!threadBean.isThreadAllocatedMemoryEnabled) {
+        threadBean.isThreadAllocatedMemoryEnabled = true
+    }
+    val heapPools = ManagementFactory.getMemoryPoolMXBeans()
+        .filter { it.isValid && it.type == MemoryType.HEAP }
+
+    System.gc()
+    heapPools.forEach { it.resetPeakUsage() }
+    val baselineHeap = heapPools.sumOf { it.usage.used }
+    val threadId = Thread.currentThread().threadId()
+    val allocatedBefore = threadBean.getThreadAllocatedBytes(threadId)
+    var checksum = 0
+    val nanos = measureNanoTime {
+        repeat(iterations) {
+            checksum = 31 * checksum + encode().length
+        }
+    }
+    val allocatedBytes = threadBean.getThreadAllocatedBytes(threadId) - allocatedBefore
+    val peakHeap = heapPools.sumOf { it.peakUsage.used }
+    check(checksum != 0)
+
+    return BackendMeasurement(
+        name = name,
+        nanosPerOperation = nanos / iterations,
+        allocatedBytesPerOperation = allocatedBytes / iterations,
+        peakHeapDeltaBytes = (peakHeap - baselineHeap).coerceAtLeast(0L),
     )
 }
+
+private fun BackendMeasurement.summary(): String =
+    "$name.nsOp=$nanosPerOperation $name.allocBOp=$allocatedBytesPerOperation " +
+        "$name.peakHeapDeltaB=$peakHeapDeltaBytes"
+
+private fun FlatAccount.sameValueAs(other: FlatAccount): Boolean =
+    name == other.name && sequence == other.sequence && payload.contentEquals(other.payload)
 
 private fun Account.sameValueAs(other: Account): Boolean =
     id == other.id &&

--- a/docs/lessons/2026-09-06-issue-1641-fory-json-evaluation.md
+++ b/docs/lessons/2026-09-06-issue-1641-fory-json-evaluation.md
@@ -1,0 +1,43 @@
+# #1641: codec 기능 검증과 공용 API 적합성을 분리한다
+
+## 배경
+
+Fory JSON 1.7.1은 Kotlin constructor default, nullability, value class,
+generic type과 제한된 증분 decoder를 제공한다. 기능 목록만 보면 기존
+`JsonSerializer` backend나 공용 NDJSON primitive로 바로 추가할 수 있어 보였다.
+
+## 확인된 차이
+
+- `jsonTypeRef<List<Account>>()`는 정확한 모델을 복원하지만
+  `List::class.java`는 동적 `JsonObject`를 반환했다.
+- sealed base는 명시적인 `@JsonSubTypes` schema가 필요했다.
+- 증분 decoder는 한 stream을 소유하며 실패 뒤 재사용할 수 없는 terminal
+  lifecycle을 갖는다.
+- `ByteArray` 기본 표현은 1.7.1에서 Base64로 바뀌었고 1.7.0의 numeric-array
+  입력을 호환 방식으로 읽지 않는다.
+- 짧은 직렬화 측정은 유망했지만 allocation, parser, concurrency나 실제 payload를
+  포함하지 않았다.
+
+## 결정
+
+2.1.0에서는 production dependency와 public API를 추가하지 않는다. 독립 PoC와
+평가 기록만 커밋하고 #1641을 평가 완료로 종결한다.
+
+## 재발 방지 규칙
+
+새 serializer를 공용 interface에 추가하기 전에 다음을 별도로 증명한다.
+
+1. codec 자체가 대상 언어 모델을 처리하는가.
+2. 공용 interface의 타입 토큰이 그 의미를 손실 없이 표현하는가.
+3. wire representation 변경을 versioning과 fixture로 고정했는가.
+4. streaming lifecycle과 caller ownership을 실제 consumer가 요구하는가.
+5. benchmark가 production 순위가 아니라 결정 범위에 맞는 항목을 측정했는가.
+
+기능 검증 PASS는 공용 API 적합성 PASS를 뜻하지 않는다.
+
+## 검증
+
+- `./gradlew -p docs/evidence/issue-1641/poc run --no-daemon`
+- Kotlin model, NDJSON, array, malformed/limit 항목 PASS
+- 3회 제한 측정 결과와 표현 크기는
+  `docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md`에 기록

--- a/docs/lessons/2026-09-06-issue-1641-fory-json-evaluation.md
+++ b/docs/lessons/2026-09-06-issue-1641-fory-json-evaluation.md
@@ -13,10 +13,10 @@ generic type과 제한된 증분 decoder를 제공한다. 기능 목록만 보�
 - sealed base는 명시적인 `@JsonSubTypes` schema가 필요했다.
 - 증분 decoder는 한 stream을 소유하며 실패 뒤 재사용할 수 없는 terminal
   lifecycle을 갖는다.
-- `ByteArray` 기본 표현은 1.7.1에서 Base64로 바뀌었고 1.7.0의 numeric-array
-  입력을 호환 방식으로 읽지 않는다.
-- 짧은 직렬화 측정은 유망했지만 allocation, parser, concurrency나 실제 payload를
-  포함하지 않았다.
+- Fory와 Jackson은 `ByteArray`를 Base64로 쓰지만 Fastjson2 JSON text는 signed
+  numeric array로 쓴다. cross-read도 비대칭이라 공통 wire 형식으로 볼 수 없다.
+- 짧은 직렬화 diagnostic에서 latency, current-thread allocation과 process heap pool
+  peak 증가량을 관찰했지만 parser, concurrency나 실제 payload는 포함하지 않았다.
 
 ## 결정
 
@@ -31,13 +31,21 @@ generic type과 제한된 증분 decoder를 제공한다. 기능 목록만 보�
 2. 공용 interface의 타입 토큰이 그 의미를 손실 없이 표현하는가.
 3. wire representation 변경을 versioning과 fixture로 고정했는가.
 4. streaming lifecycle과 caller ownership을 실제 consumer가 요구하는가.
-5. benchmark가 production 순위가 아니라 결정 범위에 맞는 항목을 측정했는가.
+5. latency, allocation, peak memory가 모두 관찰됐는지와 그 측정 한계를 분리했는가.
 
 기능 검증 PASS는 공용 API 적합성 PASS를 뜻하지 않는다.
+
+독립 리뷰는 최초 PoC가 nullable collection element와 실제 default-field 제거를
+증명하지 못하고, backend 표현 비교와 allocation/peak memory 관찰도 부족하다는 P2
+4건을 찾았다. 각 항목을 executable assertion과 제한된 JVM diagnostic으로 보강했다.
+특히 Fastjson2의 numeric byte array와 Fory/Jackson의 Base64가 만드는 cross-read
+비대칭을 크기 비교만으로 숨기지 않게 됐다.
 
 ## 검증
 
 - `./gradlew -p docs/evidence/issue-1641/poc run --no-daemon`
-- Kotlin model, NDJSON, array, malformed/limit 항목 PASS
-- 3회 제한 측정 결과와 표현 크기는
+- Kotlin model, nullable collection element, byte-split NDJSON, array,
+  malformed/limit 항목 PASS
+- backend 표현/cross-read와 latency/allocation/peak heap 관찰 결과는
   `docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md`에 기록
+- 독립 리뷰 최초 P0=0/P1=0/P2=4, 보완 후 재검토 대기

--- a/docs/lessons/2026-09-06-issue-1641-fory-json-evaluation.md
+++ b/docs/lessons/2026-09-06-issue-1641-fory-json-evaluation.md
@@ -41,6 +41,11 @@ generic type과 제한된 증분 decoder를 제공한다. 기능 목록만 보�
 특히 Fastjson2의 numeric byte array와 Fory/Jackson의 Base64가 만드는 cross-read
 비대칭을 크기 비교만으로 숨기지 않게 됐다.
 
+2차 리뷰는 cross-read 실패를 boolean으로 축약하면 예상 불호환과 뜻밖의 backend
+오류를 구분할 수 없고, array decoder의 terminal lifecycle도 빠졌음을 지적했다.
+실패 조합별 `ForyJsonException`/`JSONException` 유형과 array malformed/limit,
+성공·실패 뒤 재사용 금지를 assertion으로 고정했다.
+
 ## 검증
 
 - `./gradlew -p docs/evidence/issue-1641/poc run --no-daemon`
@@ -48,4 +53,4 @@ generic type과 제한된 증분 decoder를 제공한다. 기능 목록만 보�
   malformed/limit 항목 PASS
 - backend 표현/cross-read와 latency/allocation/peak heap 관찰 결과는
   `docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md`에 기록
-- 독립 리뷰 최초 P0=0/P1=0/P2=4, 보완 후 재검토 대기
+- 독립 리뷰 최초 P0=0/P1=0/P2=4, 2차 P2=2, 두 차례 보완 후 최종 재검토 대기

--- a/docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md
+++ b/docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md
@@ -56,9 +56,9 @@ JDK 25에서는 Fory가 사용하는 `java.lang.invoke` 경로를 위해 PoC의
 | generic root | PASS/제약 | `jsonTypeRef<List<Account>>()`는 복원, raw `List::class.java`는 `JsonObject` 반환 |
 | sealed hierarchy | PASS/명시 필요 | `@JsonSubTypes(property = "type")`로 폐쇄 subtype table 지정 |
 | NDJSON decoder | PASS | 1바이트 chunk로 UTF-8 code point 중간 분할, LF/CRLF, final newline 없음, 3건 복원 |
-| array decoder | PASS | 5바이트 chunk, 2건 복원 |
+| array decoder | PASS | 5바이트 chunk, 2건 복원, 성공 뒤 terminal 상태 |
 | malformed/truncated | PASS | `finish()` 실패 후 decoder가 terminal 상태 유지 |
-| `maxValueBytes` | PASS | 16바이트 제한에서 `JsonStreamValueLimitException` |
+| `maxValueBytes` | PASS | NDJSON/array 모두 16바이트 제한에서 `JsonStreamValueLimitException` |
 | `Long` | PASS | `writeLongAsString(true)`에서 `Long.MAX_VALUE`를 문자열로 출력 |
 | `ByteArray` | PASS | `AAECf/8=` Base64 문자열로 출력 |
 
@@ -89,19 +89,23 @@ reader가 writer의 JSON을 동일 `FlatAccount`로 복원하는 cross-read 결�
 | Jackson | PASS | PASS | PASS |
 | Fastjson2 | FAIL | FAIL | PASS |
 
+실패 조합은 단순 boolean으로 축약하지 않는다. Fory가 Fastjson2 numeric byte array를
+읽을 때는 `ForyJsonException`, Fastjson2가 Fory/Jackson Base64 byte string을 읽을
+때는 `JSONException`임을 PoC assertion으로 고정한다. 다른 예외 유형은 평가 실패다.
+
 ## latency·allocation·peak heap 관찰
 
 각 backend를 2,000회 warmup한 뒤 고정 `FlatAccount`를 20,000회 직렬화했다.
 JDK `ThreadMXBean`으로 현재 thread allocation을, heap memory pool의 peak를 reset한
 뒤 실행 전 사용량 대비 peak 증가량을 함께 관찰했다.
 
-| backend | latency | thread allocation | peak heap 증가 |
+| backend | 관찰 latency 범위 | thread allocation | peak heap 증가 |
 | --- | ---: | ---: | ---: |
-| Fory JSON | 279 ns/op | 112 B/op | 0 B |
-| Jackson | 701 ns/op | 584 B/op | 8,388,608 B |
-| Fastjson2 | 363 ns/op | 280 B/op | 0 B |
+| Fory JSON | 271–288 ns/op | 112 B/op | 0 B |
+| Jackson | 508–968 ns/op | 584 B/op | 8,388,608 B |
+| Fastjson2 | 348–606 ns/op | 280 B/op | 0 B |
 
-이 값은 로컬 GraalVM JDK 25의 단일 process에서 실행한 짧은 diagnostic이다.
+이 값은 로컬 GraalVM JDK 25에서 반복 실행한 짧은 diagnostic의 관찰 범위다.
 `ThreadMXBean` 값은 현재 thread allocation만 포함하고, peak heap 증가는 memory pool
 region 단위라서 0 B는 무할당이 아니라 기존 pool 범위 안에서 실행됐다는 뜻이다.
 JMH benchmark, allocation profiler, parser 비용, 실제 payload 분포를 대신하지 않으며
@@ -149,4 +153,6 @@ production 성능 순위를 주장하지 않는다.
 
 독립 exact-diff 검토에서 누락됐던 nullable collection element, 실제 default-field
 제거, UTF-8 중간 분할, backend cross-read와 allocation/peak heap 근거를 PoC에
-추가했다. 보완 후 동일 재현 명령이 전 항목과 `BUILD SUCCESSFUL`을 출력한다.
+추가했다. 2차 검토에서 cross-read 실패 예외 유형과 array decoder의 실패·성공 후
+terminal lifecycle을 더 고정했다. 보완 후 동일 재현 명령이 전 항목과
+`BUILD SUCCESSFUL`을 출력한다.

--- a/docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md
+++ b/docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md
@@ -1,0 +1,134 @@
+# Issue #1641 — Fory 1.7 Kotlin JSON 및 증분 decoder 평가
+
+## 결정
+
+**2.1.0에는 도입하지 않는다.**
+
+Fory JSON 1.7.1의 Kotlin 모델 지원과 증분 NDJSON/array decoder는 동작했고,
+짧은 직렬화 측정에서도 검토를 계속할 만한 결과가 나왔다. 그러나 현재
+`JsonSerializer`의 `Class<T>` 계약은 `jsonTypeRef<T>()`가 보존하는
+Kotlin nullability, value class, generic 인자를 표현하지 못한다. 증분 decoder도
+호출자가 `ByteBuffer` 공급, 단일 stream lifecycle, terminal failure를 직접
+관리해야 한다.
+
+따라서 이번 이슈에서는 production dependency, module, public API를 추가하지
+않는다. `JsonSerializer`에 구조적 타입 토큰을 도입하거나 실제 NDJSON
+consumer가 생기면 별도 Type A 설계로 다시 평가한다.
+
+## 범위
+
+- Apache Fory `fory-json-kotlin:1.7.1`
+- Kotlin `2.4.10`, JDK `25`
+- Kotlin data class의 default/nullability/generic/value class/sealed hierarchy
+- UTF-8 chunk를 3바이트 또는 5바이트로 분할한 NDJSON/array decoder
+- final newline이 없는 NDJSON, CRLF, malformed/truncated input, `maxValueBytes`
+- `Long` 문자열 정책과 `ByteArray` Base64 표현
+- Jackson 2.22.2 및 Fastjson2 2.0.65와 동일한 flat model의 JSON text 직렬화 비교
+
+현재 `FastjsonSerializer.serialize`는 JSONB를 사용하므로 아래 JSON text
+측정은 `JsonSerializer.serialize` backend 순위가 아니다. allocation,
+deserialization, concurrency, 장시간 warmup도 측정하지 않았다.
+
+## 재현 방법
+
+독립 PoC는 main Gradle project에 등록되지 않는다.
+
+```bash
+./gradlew -p docs/evidence/issue-1641/poc run --no-daemon
+```
+
+JDK 25에서는 Fory가 사용하는 `java.lang.invoke` 경로를 위해 PoC의
+`JavaExec`에 다음 옵션을 한정했다.
+
+```text
+--add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+```
+
+## 기능 검증 결과
+
+| 항목 | 결과 | 관찰 |
+| --- | --- | --- |
+| Kotlin data class | PASS | 생성자 기반 왕복 |
+| default parameter | PASS | JSON에서 `name`을 제거하면 `anonymous` 사용 |
+| nullability | PASS | nullable `note=null` 왕복 |
+| value class | PASS | `AccountId(Long)` 왕복 |
+| generic root | PASS/제약 | `jsonTypeRef<List<Account>>()`는 복원, raw `List::class.java`는 `JsonObject` 반환 |
+| sealed hierarchy | PASS/명시 필요 | `@JsonSubTypes(property = "type")`로 폐쇄 subtype table 지정 |
+| NDJSON decoder | PASS | 3바이트 chunk, CRLF, final newline 없음, 2건 복원 |
+| array decoder | PASS | 5바이트 chunk, 2건 복원 |
+| malformed/truncated | PASS | `finish()` 실패 후 decoder가 terminal 상태 유지 |
+| `maxValueBytes` | PASS | 16바이트 제한에서 `JsonStreamValueLimitException` |
+| `Long` | PASS | `writeLongAsString(true)`에서 `Long.MAX_VALUE`를 문자열로 출력 |
+| `ByteArray` | PASS | `AAECf/8=` Base64 문자열로 출력 |
+
+공식 문서는 Kotlin module이 binary protocol을 바꾸지 않는 별도 JSON module이며,
+`jsonTypeRef<T>()`를 재사용해야 한다고 설명한다.
+
+- <https://fory.apache.org/docs/next/json/kotlin/>
+- <https://fory.apache.org/blog/fory_1_7_1_release/>
+- Maven coordinate: `org.apache.fory:fory-json-kotlin:1.7.1`
+
+## 표현 크기와 짧은 측정
+
+동일한 `FlatAccount(name, Long.MAX_VALUE, ByteArray(5))`를 JSON text로
+직렬화했다.
+
+| backend | UTF-8 크기 |
+| --- | ---: |
+| Fory JSON | 70 bytes |
+| Jackson | 68 bytes |
+| Fastjson2 | 72 bytes |
+
+각 process에서 2,000회 warmup 뒤 20,000회 직렬화했다.
+
+| 실행 | Fory | Jackson | Fastjson2 |
+| --- | ---: | ---: | ---: |
+| 1 | 281 ns/op | 725 ns/op | 332 ns/op |
+| 2 | 199 ns/op | 596 ns/op | 298 ns/op |
+| 3 | 286 ns/op | 663 ns/op | 351 ns/op |
+| 추적 fixture 재실행 | 237 ns/op | 1,418 ns/op | 332 ns/op |
+
+이 값은 로컬 GraalVM JDK 25에서 실행한 짧은 `measureNanoTime` 결과다.
+JMH benchmark, allocation profile, parser 비용, 실제 payload 분포를 대신하지
+않으며 production 성능 순위를 주장하지 않는다. Jackson 수치의 실행 간 변동도
+이 측정이 채택 근거가 될 수 없음을 보여준다.
+
+## 도입 선택지
+
+| 선택지 | 판정 | 이유 |
+| --- | --- | --- |
+| 기존 `io/json`에 `ForyJsonSerializer` 추가 | 거부 | raw `Class<T>`가 generic/nullability/value-class 계약을 잃고 기존 interface 의미와 불일치 |
+| 새 public Fory JSON module 및 구조적 타입 API | 보류 | module/dependency/BOM/API/호환성 정책을 함께 결정해야 하는 Type A 범위 |
+| 증분 decoder를 공용 NDJSON API로 즉시 감싸기 | 보류 | stream ownership, buffer 공급, cancellation/backpressure, terminal failure 계약과 실제 consumer가 필요 |
+| 독립 PoC와 평가 기록만 유지 | 선택 | production surface를 바꾸지 않고 기능·제약·재검토 조건을 재현 가능하게 보존 |
+
+## 실패 모드와 후속 게이트
+
+1. raw `Class<T>`로 parameterized root를 읽으면 typed model 대신 동적
+   `JsonObject`가 나온다.
+2. `@JsonSubTypes`가 없는 interface/abstract sealed property는 자동 schema로
+   처리되지 않는다.
+3. malformed input이나 limit 초과 뒤 decoder를 재사용하면
+   `IllegalStateException`으로 실패한다.
+4. 1.7.1의 기본 `ByteArray` Base64는 1.7.0 numeric-array 출력과 읽기 호환되지
+   않으므로 wire policy를 암묵적으로 채택할 수 없다.
+5. 짧은 직렬화 수치만으로 dependency와 public API 비용을 정당화할 수 없다.
+
+다음 조건을 모두 충족할 때 별도 도입 이슈를 만든다.
+
+- `jsonTypeRef<T>()`와 동등한 구조적 타입 계약을 노출할 API 설계
+- JSON text와 JSONB를 구분한 backend compatibility suite
+- 실제 NDJSON consumer의 ownership, cancellation, backpressure 요구사항
+- JMH 기반 serialize/deserialize/allocation 비교
+- 중앙 catalog alias, BOM, module 등록, README locale, CI/Nightly 범위
+
+## DoD
+
+- [x] Kotlin 모델의 default/nullability/generic/value class/sealed 계약을 검증했다.
+- [x] NDJSON/array decoder의 chunk, CRLF, final record, malformed, limit,
+  terminal lifecycle을 검증했다.
+- [x] `Long`과 `ByteArray` 표현 정책을 확인했다.
+- [x] 재현 가능한 독립 PoC와 제한된 측정 결과를 남겼다.
+- [x] 현재 `JsonSerializer`와의 계약 차이를 기록했다.
+- [x] 2.1.0 production 도입을 보류하고 재검토 게이트를 명시했다.
+- [ ] public module/API 도입 — 이번 이슈 범위에서 제외한다.

--- a/docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md
+++ b/docs/superpowers/research/2026-09-06-issue-1641-fory-json-evaluation.md
@@ -20,14 +20,14 @@ consumer가 생기면 별도 Type A 설계로 다시 평가한다.
 - Apache Fory `fory-json-kotlin:1.7.1`
 - Kotlin `2.4.10`, JDK `25`
 - Kotlin data class의 default/nullability/generic/value class/sealed hierarchy
-- UTF-8 chunk를 3바이트 또는 5바이트로 분할한 NDJSON/array decoder
+- UTF-8 chunk를 1바이트 또는 5바이트로 분할한 NDJSON/array decoder
 - final newline이 없는 NDJSON, CRLF, malformed/truncated input, `maxValueBytes`
 - `Long` 문자열 정책과 `ByteArray` Base64 표현
 - Jackson 2.22.2 및 Fastjson2 2.0.65와 동일한 flat model의 JSON text 직렬화 비교
 
 현재 `FastjsonSerializer.serialize`는 JSONB를 사용하므로 아래 JSON text
-측정은 `JsonSerializer.serialize` backend 순위가 아니다. allocation,
-deserialization, concurrency, 장시간 warmup도 측정하지 않았다.
+측정은 `JsonSerializer.serialize` backend 순위가 아니다. deserialization,
+concurrency, 장시간 warmup은 측정하지 않았다.
 
 ## 재현 방법
 
@@ -51,10 +51,11 @@ JDK 25에서는 Fory가 사용하는 `java.lang.invoke` 경로를 위해 PoC의
 | Kotlin data class | PASS | 생성자 기반 왕복 |
 | default parameter | PASS | JSON에서 `name`을 제거하면 `anonymous` 사용 |
 | nullability | PASS | nullable `note=null` 왕복 |
+| nullable collection element | PASS | `List<String?>`의 가운데 `null` 왕복 |
 | value class | PASS | `AccountId(Long)` 왕복 |
 | generic root | PASS/제약 | `jsonTypeRef<List<Account>>()`는 복원, raw `List::class.java`는 `JsonObject` 반환 |
 | sealed hierarchy | PASS/명시 필요 | `@JsonSubTypes(property = "type")`로 폐쇄 subtype table 지정 |
-| NDJSON decoder | PASS | 3바이트 chunk, CRLF, final newline 없음, 2건 복원 |
+| NDJSON decoder | PASS | 1바이트 chunk로 UTF-8 code point 중간 분할, LF/CRLF, final newline 없음, 3건 복원 |
 | array decoder | PASS | 5바이트 chunk, 2건 복원 |
 | malformed/truncated | PASS | `finish()` 실패 후 decoder가 terminal 상태 유지 |
 | `maxValueBytes` | PASS | 16바이트 제한에서 `JsonStreamValueLimitException` |
@@ -68,30 +69,43 @@ JDK 25에서는 Fory가 사용하는 `java.lang.invoke` 경로를 위해 PoC의
 - <https://fory.apache.org/blog/fory_1_7_1_release/>
 - Maven coordinate: `org.apache.fory:fory-json-kotlin:1.7.1`
 
-## 표현 크기와 짧은 측정
+## 표현·상호 읽기 정책
 
 동일한 `FlatAccount(name, Long.MAX_VALUE, ByteArray(5))`를 JSON text로
 직렬화했다.
 
-| backend | UTF-8 크기 |
-| --- | ---: |
-| Fory JSON | 70 bytes |
-| Jackson | 68 bytes |
-| Fastjson2 | 72 bytes |
+| backend | `Long` | `ByteArray` | UTF-8 크기 |
+| --- | --- | --- | ---: |
+| Fory JSON | 문자열 | Base64 문자열 | 70 bytes |
+| Jackson | JSON 정수 | Base64 문자열 | 68 bytes |
+| Fastjson2 | JSON 정수 | signed numeric array | 72 bytes |
 
-각 process에서 2,000회 warmup 뒤 20,000회 직렬화했다.
+reader가 writer의 JSON을 동일 `FlatAccount`로 복원하는 cross-read 결과는 다음과
+같다. 이 비대칭 때문에 세 backend의 wire text를 상호 호환 형식으로 간주하지 않는다.
 
-| 실행 | Fory | Jackson | Fastjson2 |
+| reader \ writer | Fory JSON | Jackson | Fastjson2 |
+| --- | --- | --- | --- |
+| Fory JSON | PASS | PASS | FAIL |
+| Jackson | PASS | PASS | PASS |
+| Fastjson2 | FAIL | FAIL | PASS |
+
+## latency·allocation·peak heap 관찰
+
+각 backend를 2,000회 warmup한 뒤 고정 `FlatAccount`를 20,000회 직렬화했다.
+JDK `ThreadMXBean`으로 현재 thread allocation을, heap memory pool의 peak를 reset한
+뒤 실행 전 사용량 대비 peak 증가량을 함께 관찰했다.
+
+| backend | latency | thread allocation | peak heap 증가 |
 | --- | ---: | ---: | ---: |
-| 1 | 281 ns/op | 725 ns/op | 332 ns/op |
-| 2 | 199 ns/op | 596 ns/op | 298 ns/op |
-| 3 | 286 ns/op | 663 ns/op | 351 ns/op |
-| 추적 fixture 재실행 | 237 ns/op | 1,418 ns/op | 332 ns/op |
+| Fory JSON | 279 ns/op | 112 B/op | 0 B |
+| Jackson | 701 ns/op | 584 B/op | 8,388,608 B |
+| Fastjson2 | 363 ns/op | 280 B/op | 0 B |
 
-이 값은 로컬 GraalVM JDK 25에서 실행한 짧은 `measureNanoTime` 결과다.
-JMH benchmark, allocation profile, parser 비용, 실제 payload 분포를 대신하지
-않으며 production 성능 순위를 주장하지 않는다. Jackson 수치의 실행 간 변동도
-이 측정이 채택 근거가 될 수 없음을 보여준다.
+이 값은 로컬 GraalVM JDK 25의 단일 process에서 실행한 짧은 diagnostic이다.
+`ThreadMXBean` 값은 현재 thread allocation만 포함하고, peak heap 증가는 memory pool
+region 단위라서 0 B는 무할당이 아니라 기존 pool 범위 안에서 실행됐다는 뜻이다.
+JMH benchmark, allocation profiler, parser 비용, 실제 payload 분포를 대신하지 않으며
+production 성능 순위를 주장하지 않는다.
 
 ## 도입 선택지
 
@@ -119,16 +133,20 @@ JMH benchmark, allocation profile, parser 비용, 실제 payload 분포를 대�
 - `jsonTypeRef<T>()`와 동등한 구조적 타입 계약을 노출할 API 설계
 - JSON text와 JSONB를 구분한 backend compatibility suite
 - 실제 NDJSON consumer의 ownership, cancellation, backpressure 요구사항
-- JMH 기반 serialize/deserialize/allocation 비교
+- JMH와 profiler 기반 serialize/deserialize/allocation/peak-memory 비교
 - 중앙 catalog alias, BOM, module 등록, README locale, CI/Nightly 범위
 
 ## DoD
 
-- [x] Kotlin 모델의 default/nullability/generic/value class/sealed 계약을 검증했다.
+- [x] Kotlin 모델의 default/nullability/nullable collection element/generic/value class/sealed 계약을 검증했다.
 - [x] NDJSON/array decoder의 chunk, CRLF, final record, malformed, limit,
   terminal lifecycle을 검증했다.
-- [x] `Long`과 `ByteArray` 표현 정책을 확인했다.
-- [x] 재현 가능한 독립 PoC와 제한된 측정 결과를 남겼다.
+- [x] `Long`과 `ByteArray` 표현 및 backend cross-read 정책을 확인했다.
+- [x] 재현 가능한 독립 PoC와 latency/allocation/peak heap의 제한된 측정 결과를 남겼다.
 - [x] 현재 `JsonSerializer`와의 계약 차이를 기록했다.
 - [x] 2.1.0 production 도입을 보류하고 재검토 게이트를 명시했다.
 - [ ] public module/API 도입 — 이번 이슈 범위에서 제외한다.
+
+독립 exact-diff 검토에서 누락됐던 nullable collection element, 실제 default-field
+제거, UTF-8 중간 분할, backend cross-read와 allocation/peak heap 근거를 PoC에
+추가했다. 보완 후 동일 재현 명령이 전 항목과 `BUILD SUCCESSFUL`을 출력한다.


### PR DESCRIPTION
## 변경 요약

- Fory 1.7 Kotlin JSON API의 모델, nullable collection element, NDJSON/array 복원, terminal failure와 입력 상한을 독립 PoC로 검증합니다.
- raw `Class<T>`가 구조적 generic type을 보존하지 못하는 제약과 streaming lifecycle의 추가 설계 비용을 기록합니다.
- 2.1.0에는 Fory JSON을 통합하지 않고, 재현 가능한 평가 근거만 유지한다는 결론을 고정합니다.

Closes #1641

## 변경 유형

- [ ] `feat` — 새 기능
- [ ] `fix` — 버그 수정
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `perf` — 성능 개선
- [ ] `test` — 테스트 추가/수정
- [x] `docs` — 문서만 변경
- [ ] `chore` — 빌드/설정/의존성

## 테스트

- [x] `./gradlew -p docs/evidence/issue-1641/poc run --no-daemon` — model, 1-byte UTF-8 split NDJSON 3건, array 2건, terminal/limit failure 검증
- [x] Fory/Jackson/Fastjson2 long·ByteArray 표현과 6개 cross-read 조합을 assertion으로 고정
- [x] 20,000회 serialize latency, current-thread allocation, process peak heap diagnostic 기록
- [x] PoC는 production Gradle graph와 분리되어 있습니다.
- [x] doc-only 평가이므로 `docs/testlogs/YYYY-MM.md` 갱신은 N/A입니다.

## Code Review

- [x] 독립 exact-diff code review 완료 — P0/P1 blocker 해소
- [x] hosted CI는 `docs/**` `paths-ignore`로 N/A, review/thread 0 read-back 완료

## Issue 연결 및 자동 종료

- [x] `Closes #1641`를 명시했습니다.
- [ ] merge 후 `closingIssuesReferences`와 issue state를 live read-back합니다.

## 체크리스트

- [x] production API/dependency/module 변경 없음.
- [x] `worktree`에서 작업 후 PR을 생성합니다.
- [x] README/KDoc 변경 없음 — 독립 evidence와 판단 문서만 추가합니다.
- [x] Spring Boot, Nightly, Docker image, `virtualthread` 변경 없음 — N/A.
- [x] `docs/superpowers/index/YYYY-MM.md` 없음 — N/A.

## DoD Status

- DONE: 재현 가능한 Fory JSON PoC, 표현·cross-read·latency/allocation/peak heap 근거, 제약·비목표·2.1.0 도입 보류 결정 문서화.
- DONE: hosted CI는 docs-only path 정책상 N/A, reviews/threads 0, `MERGEABLE/CLEAN` read-back.
- NOT DONE: production 통합, merge, release, cleanup은 범위가 아닙니다.
