### PR TITLE
길이 제한 Reader API로 무제한 line 할당을 차단한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,14 @@
   repo-local override로 선택하고 소비자별 smoke와 독립 PR을 진행한다
   ([#1643](https://github.com/bluetape4k/bluetape4k-projects/issues/1643)).
 
+- `bluetape4k-io`에 UTF-16 code unit 상한을 읽는 동안 적용하는
+  `BoundedLineReader`를 추가했다. LF·CRLF·CR과 마지막 개행 없는 line을 지원하며,
+  상한을 넘은 line은 전체 할당 없이 `LineLimitExceededException`으로 거부한다.
+  wrapper가 제공받은 `Reader`를 닫지 않는 ownership 계약을 유지하고, Graph NDJSON
+  consumer 적용은 별도 작업으로 남긴다
+  ([#1642](https://github.com/bluetape4k/bluetape4k-projects/issues/1642),
+  [Graph #615](https://github.com/bluetape4k/bluetape4k-graph/issues/615)).
+
 - `bluetape4k-io`에 callback과 stream close가 성공한 뒤에만 sibling temporary file을
   atomic move하는 `Path.writeAtomically`를 추가했다. 지원하지 않는 atomic replacement는
   일반 move fallback을 사용하지 않으며, 기존 target 교체와 metadata는 filesystem

--- a/docs/lessons/2026-09-06-bounded-line-reader.md
+++ b/docs/lessons/2026-09-06-bounded-line-reader.md
@@ -1,0 +1,62 @@
+# 길이 제한 Reader는 문자 단위와 소유권을 함께 고정해야 한다
+
+## 맥락
+
+`Reader.readLine()`은 line 전체를 먼저 문자열로 만들기 때문에, JSON/NDJSON parsing
+전에 신뢰할 수 없는 긴 line이 들어오면 입력 크기만큼 메모리를 사용할 수 있다. 이번
+변경은 `bluetape4k-io`에 domain parser와 분리된 provider API를 추가해 읽는 중에 line
+길이를 판정하도록 했다. Graph의 Jackson2·Jackson3 consumer 전환은 provider artifact가
+준비된 뒤의 별도 작업으로 남겼다.
+
+## 결정과 발견
+
+- `BoundedLineReader` 상태 보유 wrapper와 `Reader.boundedLineReader(...)` factory를
+  제공한다. 반복 `readLine()` 호출 사이의 CR lookahead와 buffer 잔여 상태를 한 객체가
+  보존하므로 호출마다 새 extension을 만드는 방식보다 계약이 분명하다.
+- `maxLineChars`는 Kotlin/JVM `Char`와 같은 UTF-16 code unit 단위다. supplementary
+  character 하나는 두 unit으로 세며, LF·CRLF·CR terminator는 상한에 포함하지 않는다.
+- 상한까지는 반환하고 다음 일반 code unit을 읽기 전에
+  `LineLimitExceededException`을 던진다. 현재 줄에 남은 허용량에 `+1`을 더한
+  bounded read만 수행해 overflow를 판정하며, 예외에는 입력 payload를 저장하지 않는다.
+- 내부 buffer는 고정 크기이고, CR 뒤의 LF 확인이 필요할 때만 code unit 하나를
+  read-ahead한다. bulk `Reader.read`가 0을 반환하는 구현은 단일 `read()`로 진행한다.
+- wrapper는 `Closeable`을 구현하지 않고 원본 `Reader`를 닫지 않는다. timeout, blocking,
+  dispatcher, close 및 JSON/NDJSON parsing은 caller가 계속 소유한다.
+
+## 결과
+
+`bluetape4k-io`에 빈 입력·빈 line·개행 없는 마지막 line, LF/CRLF/CR, 정확한 상한과
+초과, surrogate counting, generated Reader read-count, IOException identity와 close
+ownership를 고정한 테스트 10개를 추가했다. English/Korean README와 `CHANGELOG.md`에는
+같은 factory 사용 예제와 책임 경계를 기록했다.
+
+초기 RED에서는 production symbol이 없어 `compileTestKotlin`이 실패했고, API 구현 후
+동일 targeted class가 10개 모두 통과했다. 첫 detekt report에서 새 production/test
+파일의 `ReturnCount`를 확인한 뒤 상태 머신의 결과 변수와 테스트 reader의 `when`으로
+정리했으며, 재실행 시 변경 파일 finding은 0건이었다. 모듈 전체 테스트는 1,308개가
+통과했다.
+
+## 재사용 체크리스트
+
+1. 상한의 단위를 byte, code point, UTF-16 code unit 중 하나로 명시하고 supplementary
+   character 경계를 테스트한다.
+2. terminator를 상한에 포함할지, CR 뒤 lookahead를 어디까지 허용할지 고정한다.
+3. `max + 1` 계산은 `Int` overflow 없이 수행하고, generated Reader로 실제 소비량을
+   검증한다.
+4. wrapper와 underlying Reader의 close ownership 및 원본 IOException identity를
+   테스트한다.
+5. provider helper에는 JSON/domain parsing을 넣지 않고 consumer migration을 별도 PR로
+   유지한다.
+
+## 잔여 범위
+
+이번 작업은 provider API와 로컬 검증까지만 포함한다. Graph #615 consumer 적용, 공개
+artifact resolution, PR CI, release 및 동시 사용/thread-safety 계약은 후속 검증 대상이다.
+
+## 검증
+
+- `:bluetape4k-io:test --tests 'io.bluetape4k.io.BoundedLineReaderSupportTest'`: 10 passing
+- `:bluetape4k-io:cleanTest :bluetape4k-io:test`: 1,308 passing
+- `:bluetape4k-io:build`: `BUILD SUCCESSFUL`
+- `:bluetape4k-io:detekt`: exit 0, 변경 파일 finding 0건; 기존 파일 finding은 baseline으로 남음
+- Korean terminology audit와 `git diff --check`: 통과

--- a/docs/superpowers/plans/2026-09-06-bounded-line-reader-plan.md
+++ b/docs/superpowers/plans/2026-09-06-bounded-line-reader-plan.md
@@ -1,0 +1,470 @@
+# Bounded Line Reader Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `bluetape4k-io`에 UTF-16 code unit 상한을 읽는 동안 적용하는 caller-owned `BoundedLineReader` API를 추가해 길이 초과 줄을 전체 할당 전에 거부한다.
+
+**Architecture:** `BoundedLineReaderSupport.kt`에 예외, 상태 보유 wrapper, `Reader.boundedLineReader` factory를 둔다. wrapper는 고정 char buffer와 pending code unit으로 LF/CRLF/CR을 해석하며, 현재 줄 허용량에 맞춰 underlying `Reader.read` 길이를 줄인다. 기존 `Reader.readLine()`과 JSON/NDJSON domain은 변경하지 않는다.
+
+**Tech Stack:** Kotlin 2.4, Java 25, Gradle 9.7, JUnit 5, `bluetape4k-assertions`, `bluetape4k-core` required helpers, `bluetape4k-io` README locales.
+
+---
+
+## 승인된 기준과 변경 경계
+
+- 설계: `docs/superpowers/specs/2026-09-06-bounded-line-reader-design.md`
+- 이슈: `bluetape4k/bluetape4k-projects#1642`
+- 후속 consumer: `bluetape4k/bluetape4k-graph#615`
+- 기준 HEAD: `9811932427aac4c6cfba7b16ae3def215e93a2fe`
+- 브랜치: `feat/issue-1642-bounded-line-reader`
+- 포함: `io/io` production API, unit tests, Korean KDoc, bilingual module README, root `CHANGELOG.md`, lesson, local verification
+- 제외: Graph source/PR, dependency/catalog/module registration, publish, push, PR creation, merge
+
+## 파일별 책임
+
+### 새 파일
+
+- `io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt`
+  - `LineLimitExceededException`, `BoundedLineReader`, `Reader.boundedLineReader`를
+    제공한다. public KDoc은 UTF-16 단위, error, ownership, examples를 설명한다.
+- `io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt`
+  - 입력/terminator/limit/read-ahead/exception/ownership 계약을 실제 Reader로
+    검증한다.
+
+### 수정 파일
+
+- `io/io/README.md`
+  - bounded line API의 영어 계약과 `use` 예제를 추가한다.
+- `io/io/README.ko.md`
+  - 같은 구조와 의미의 한국어 설명·예제를 추가한다.
+- `CHANGELOG.md`
+  - `Unreleased/추가`에 provider API와 Graph #615 후속 경계를 기록한다.
+- `docs/superpowers/specs/2026-09-06-bounded-line-reader-design.md`
+  - 승인된 설계 기준.
+- `docs/superpowers/plans/2026-09-06-bounded-line-reader-plan.md`
+  - 이 실행 계획.
+- `docs/lessons/2026-09-06-bounded-line-reader.md`
+  - 구현 중 드러난 설계/검증 교훈과 재발 방지 guard를 기록한다.
+
+## 수용 기준 추적표
+
+| 설계 기준 | 계획 task |
+|---|---|
+| API와 exception signature | Task 2 |
+| 음수 상한·잘못된 buffer 검증 | Task 1, 2 |
+| LF/CRLF/CR 및 pending 보존 | Task 1, 2 |
+| empty input/line/final EOF | Task 1, 2 |
+| max-1/max/max+1 | Task 1, 2 |
+| UTF-16 surrogate counting | Task 1, 2 |
+| max+1 이내 overflow와 generated Reader | Task 1, 2 |
+| fixed buffer/read-count bound | Task 1, 2 |
+| IOException identity와 caller-owned Reader | Task 1, 2 |
+| Korean KDoc와 README locale parity | Task 3 |
+| targeted/module/build/detekt/diff check | Task 4 |
+| exact self-review P0/P1 | Task 5 |
+| lesson 및 Korean Lore commit | Task 6 |
+
+## Task 0: 재확인과 기준 테스트
+
+**Files:**
+
+- Read: `AGENTS.md`, `/Users/debop/.codex/AGENTS.md`,
+  `/Users/debop/work/bluetape4k/.github/docs/workspace/AGENTS.md`
+- Read: `docs/superpowers/specs/2026-09-06-bounded-line-reader-design.md`
+- Read: `io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt`
+- Read: `io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt`
+
+- [ ] **Step 1: 기준 branch와 diff를 읽는다**
+
+  ```bash
+  git status --short --branch
+  git rev-parse HEAD
+  git rev-parse origin/develop
+  git diff --stat origin/develop...HEAD
+  ```
+
+  Expected: `feat/issue-1642-bounded-line-reader`, clean worktree, HEAD equals
+  the approved base or only the spec/plan commit, and no unrelated files.
+
+- [ ] **Step 2: 기존 bounded IO regression을 확인한다**
+
+  ```bash
+  ./gradlew :bluetape4k-io:test \
+    --tests 'io.bluetape4k.io.BoundedInputStreamSupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  Expected: existing bounded stream tests complete with zero failures. Any
+  failure is diagnosed before new production code is written.
+
+## Task 1: RED — behavior tests first
+
+**Files:**
+
+- Create: `io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt`
+
+- [ ] **Step 1: public behavior tests를 작성한다**
+
+  Add JUnit 5 tests using `io.bluetape4k.assertions.assertFailsWith` and
+  `shouldBeEqualTo`. The tests must cover the following concrete cases:
+
+  ```kotlin
+  @Test
+  fun `LF CRLF CR empty line and final line without newline are preserved`() {
+      val bounded = StringReader("lf\n\r\ncr\rfinal")
+          .boundedLineReader(maxLineChars = 8, bufferSize = 2)
+
+      bounded.readLine() shouldBeEqualTo "lf"
+      bounded.readLine() shouldBeEqualTo ""
+      bounded.readLine() shouldBeEqualTo "cr"
+      bounded.readLine() shouldBeEqualTo "final"
+      bounded.readLine() shouldBeEqualTo null
+  }
+
+  @Test
+  fun `limit boundary accepts exact length and rejects the next code unit`() {
+      StringReader("abcd").boundedLineReader(4).readLine() shouldBeEqualTo "abcd"
+
+      assertFailsWith<LineLimitExceededException> {
+          StringReader("abcde").boundedLineReader(4).readLine()
+      }.maxLineChars shouldBeEqualTo 4
+  }
+
+  @Test
+  fun `supplementary character counts as two code units`() {
+      StringReader("😀").boundedLineReader(2).readLine() shouldBeEqualTo "😀"
+      assertFailsWith<LineLimitExceededException> {
+          StringReader("😀").boundedLineReader(1).readLine()
+      }.maxLineChars shouldBeEqualTo 1
+  }
+  ```
+
+  Every over-limit assertion must prove the exception and stable property.
+
+- [ ] **Step 2: RED test를 실행한다**
+
+  ```bash
+  ./gradlew :bluetape4k-io:test \
+    --tests 'io.bluetape4k.io.BoundedLineReaderSupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  Expected: compilation/test failure because `BoundedLineReader`, factory, and
+  exception do not yet exist. Record the actual missing-symbol failure in the
+  execution notes; do not interpret a test discovery failure as RED evidence.
+
+- [ ] **Step 3: boundary and lifecycle RED cases를 추가한다**
+
+  Add tests for empty input (`null`), empty lines (`""`), `maxLineChars == 0`,
+  invalid negative/zero parameters before any underlying read, bulk `read == 0`
+  fallback, original IOException identity, and wrapper non-close behavior.
+
+- [ ] **Step 4: generated Reader read-count RED case를 추가한다**
+
+  Use a generated Reader that emits `'x'` indefinitely and increments a count
+  on every code unit returned. With `maxLineChars = 4` and `bufferSize = 3`,
+  assert `LineLimitExceededException` and `readCount <= 5`. Do not allocate an
+  unbounded string or use an OOM test.
+
+## Task 2: GREEN — minimal implementation
+
+**Files:**
+
+- Create: `io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt`
+- Test: `io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt`
+
+- [ ] **Step 1: validation and exception을 구현한다**
+
+  ```kotlin
+  @file:JvmName("BoundedLineReaderSupport")
+
+  package io.bluetape4k.io
+
+  import io.bluetape4k.support.requirePositiveNumber
+  import io.bluetape4k.support.requireZeroOrPositiveNumber
+  import java.io.IOException
+  import java.io.Reader
+
+  class LineLimitExceededException(
+      val maxLineChars: Int,
+  ) : IOException("Reader line exceeded the configured character limit: maxLineChars=$maxLineChars") {
+      init {
+          maxLineChars.requireZeroOrPositiveNumber("maxLineChars")
+      }
+  }
+
+  class BoundedLineReader(
+      private val reader: Reader,
+      maxLineChars: Int,
+      bufferSize: Int = DEFAULT_BUFFER_SIZE,
+  ) {
+      private val maxLineChars = maxLineChars.requireZeroOrPositiveNumber("maxLineChars")
+      private val bufferSize = bufferSize.requirePositiveNumber("bufferSize")
+      private val buffer = CharArray(this.bufferSize)
+      private var bufferIndex = 0
+      private var bufferLimit = 0
+      private var pendingChar = NO_PENDING_CHAR
+
+      fun readLine(): String? {
+          val line = StringBuilder(minOf(maxLineChars, bufferSize))
+          var lineLength = 0
+
+          while (true) {
+              val value = nextChar(lineLength)
+              when {
+                  value < 0 -> return if (lineLength == 0) null else line.toString()
+                  value == LF -> return line.toString()
+                  value == CR -> {
+                      val following = readAfterCarriageReturn()
+                      if (following >= 0 && following != LF) pendingChar = following
+                      return line.toString()
+                  }
+                  lineLength == maxLineChars -> throw LineLimitExceededException(maxLineChars)
+                  else -> {
+                      line.append(value.toChar())
+                      lineLength++
+                  }
+              }
+          }
+      }
+
+      private fun nextChar(lineLength: Int): Int {
+          if (pendingChar != NO_PENDING_CHAR) {
+              return pendingChar.also { pendingChar = NO_PENDING_CHAR }
+          }
+          if (bufferIndex < bufferLimit) return buffer[bufferIndex++].code
+
+          val requested = minOf(
+              bufferSize.toLong(),
+              maxLineChars.toLong() - lineLength.toLong() + 1L,
+          ).toInt()
+          val count = reader.read(buffer, 0, requested)
+          if (count > 0) {
+              bufferIndex = 1
+              bufferLimit = count
+              return buffer[0].code
+          }
+          if (count < 0) return EOF
+          return reader.read()
+      }
+
+      private fun readAfterCarriageReturn(): Int {
+          if (bufferIndex < bufferLimit) return buffer[bufferIndex++].code
+          return reader.read()
+      }
+
+      private companion object {
+          const val EOF = -1
+          const val LF = '\n'.code
+          const val CR = '\r'.code
+          const val NO_PENDING_CHAR = -2
+      }
+  }
+
+  fun Reader.boundedLineReader(
+      maxLineChars: Int,
+      bufferSize: Int = DEFAULT_BUFFER_SIZE,
+  ): BoundedLineReader = BoundedLineReader(this, maxLineChars, bufferSize)
+  ```
+
+  The implementation must not expose the Reader as a mutable property and must
+  not implement `Closeable`.
+
+- [ ] **Step 2: fixed-buffer state machine을 구현한다**
+
+  Use the complete state machine from Step 1. Keep private `bufferIndex`,
+  `bufferLimit`, and `pendingChar` state. Bulk reads request
+  `minOf(bufferSize.toLong(), maxLineChars.toLong() - lineLength.toLong() + 1L)`
+  converted safely to `Int`. If a non-empty bulk read returns zero, fall back to
+  one `Reader.read()` call. Reuse buffered chars before reading the underlying
+  Reader.
+
+- [ ] **Step 3: line terminator와 overflow를 구현한다**
+
+  Process LF and CR before appending a code unit. For CR, consume a following LF
+  from the existing buffer or perform exactly one single-character read; retain
+  a non-LF character in `pendingChar`. Before appending any ordinary character,
+  compare `lineLength == maxLineChars` and throw `LineLimitExceededException`
+  before appending the over-limit code unit.
+
+- [ ] **Step 4: factory와 KDoc을 추가한다**
+
+  Add `Reader.boundedLineReader(maxLineChars, bufferSize)` and Korean KDoc for
+  the exception, wrapper, `readLine`, and factory. The KDoc must state UTF-16
+  code-unit counting, terminators, read-ahead, ownership, blocking, and a
+  `reader.use` example.
+
+- [ ] **Step 5: GREEN targeted test를 실행한다**
+
+  ```bash
+  ./gradlew :bluetape4k-io:test \
+    --tests 'io.bluetape4k.io.BoundedLineReaderSupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  Expected: all new tests pass with zero failures and no skipped tests. If a
+  test fails, inspect the raw failure, fix production code, and rerun the full
+  targeted class.
+
+## Task 3: Public documentation and change record
+
+**Files:**
+
+- Modify: `io/io/README.md`
+- Modify: `io/io/README.ko.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: English README example을 추가한다**
+
+  Add a “Bounded line reads” subsection near the existing bounded byte example.
+  Show `reader.use`, `boundedLineReader(maxLineChars = 64 * 1024)`, repeated
+  `readLine()`, and state that the limit counts UTF-16 code units, excludes
+  terminators, rejects before full-line allocation, and leaves JSON parsing and
+  reader close to the caller.
+
+- [ ] **Step 2: 한국어 README를 source-equivalent로 추가한다**
+
+  Add the same example and contract in Korean. Keep API names, commands, URLs,
+  numbers, and code tokens exact. Preserve the existing English/한국어 switch.
+
+- [ ] **Step 3: CHANGELOG를 기록한다**
+
+  Add a Korean `Unreleased/추가` entry linking #1642. Say that the provider API
+  is available and Graph #615 is a later consumer migration; do not claim the
+  consumer migration is complete.
+
+- [ ] **Step 4: documentation read-back을 수행한다**
+
+  Read both README sections and the changed KDoc against the design. Run the
+  Korean term audit on `README.ko.md` after all technical tokens are frozen:
+
+  ```bash
+  node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+    io/io/README.ko.md
+  ```
+
+  Expected: no unexplained terminology findings and equivalent contracts in
+  both locales.
+
+## Task 4: Targeted and proportional verification
+
+**Files:**
+
+- Inspect: all changed files and `git diff origin/develop...HEAD`
+
+- [ ] **Step 1: targeted class and module check을 실행한다**
+
+  ```bash
+  ./gradlew :bluetape4k-io:test \
+    --tests 'io.bluetape4k.io.BoundedLineReaderSupportTest' \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ./gradlew :bluetape4k-io:build \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ./gradlew :bluetape4k-io:detekt \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  Expected: targeted tests, module build, and Detekt exit 0. Read Detekt output
+  for new findings rather than relying only on exit code.
+
+- [ ] **Step 2: complete module test를 실행한다**
+
+  ```bash
+  ./gradlew :bluetape4k-io:cleanTest :bluetape4k-io:test \
+    --no-daemon --max-workers=1 --no-build-cache --no-configuration-cache
+  ```
+
+  Expected: the full `bluetape4k-io` test suite passes; record the actual JUnit
+  count from the fresh XML/report.
+
+- [ ] **Step 3: diff and API surface를 검토한다**
+
+  ```bash
+  git diff --check
+  git diff --stat
+  git diff -- io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt \
+    io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt
+  ```
+
+  Check no new `!!`, no swallowed IOException, no Reader close, no unbounded
+  pre-read, no JSON logic, and no unrelated module/workflow/catalog changes.
+
+## Task 5: Exact self-review and P0/P1 convergence
+
+**Files:**
+
+- Inspect: all branch diff, design, plan, tests, KDoc, both README locales, changelog
+
+- [ ] **Step 1: review required contracts**
+
+  Review validation/exception identity, CR lookahead, max+1 read bound,
+  surrogate counting, generated Reader termination, caller ownership, public
+  API naming, Java/Kotlin compatibility, Korean documentation, and Graph scope.
+
+- [ ] **Step 2: record findings and repair blockers**
+
+  Record each finding with file/line and P0/P1/P2/P3. Fix all P0/P1 findings and
+  rerun the affected Task 4 commands. P2/P3 items are fixed when local and
+  cheap; otherwise document the rationale in the lesson.
+
+- [ ] **Step 3: final checklist을 확인한다**
+
+  Apply Kotlin final checklist `KT-FIN-01` through `KT-FIN-11`, testing checklist
+  `KT-TEST-01` through `KT-TEST-05`, and writer `SPW-01` through `SPW-05` for the
+  integrated docs. Expected: P0=0, P1=0, diagnostics clear, and no unchecked
+  applicable item.
+
+## Task 6: Lesson and Korean Lore commit
+
+**Files:**
+
+- Create/update: `docs/lessons/2026-09-06-bounded-line-reader.md`
+- Commit: all approved changed files only
+
+- [ ] **Step 1: lesson을 작성한다**
+
+  Record context, the wrapper-vs-extension decision, UTF-16/read-ahead surprise,
+  RED/GREEN evidence, test/build/detekt/diff results, review findings, and the
+  future guard for provider/consumer separation. If no unexpected finding exists,
+  state concrete evidence-backed `N/A` rather than filler.
+
+- [ ] **Step 2: lesson writer gate와 diff check를 완료한다**
+
+  Apply `SPW-01` through `SPW-05` and `KO-01` through `KO-07`, then run:
+
+  ```bash
+  git diff --check
+  git status --short
+  ```
+
+  Expected: all changed files are intentional and documentation is Korean with
+  source-equivalent README locales.
+
+- [ ] **Step 3: Lore commit을 생성한다**
+
+  ```bash
+  git add CHANGELOG.md io/io/README.md io/io/README.ko.md \
+    io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt \
+    io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt \
+    docs/superpowers/specs/2026-09-06-bounded-line-reader-design.md \
+    docs/superpowers/plans/2026-09-06-bounded-line-reader-plan.md \
+    docs/lessons/2026-09-06-bounded-line-reader.md
+  git commit -m "feat: 길이 제한 Reader API를 제공한다" -m "줄 단위 입력을 읽는 동안 UTF-16 code unit 상한을 적용해 전체 초과 줄 할당을 막는다.
+
+Constraint: Graph consumer migration은 provider API 발행 이후의 별도 저장소 범위다.
+Rejected: Reader extension 단독 구현과 Sequence API는 상태·lifecycle 계약이 불명확해 제외했다.
+Confidence: high
+Scope-risk: narrow
+Directive: consumer는 boundedLineReader를 opt-in으로 적용하고 원본 Reader close를 계속 소유한다.
+Tested: targeted io test, clean module test, build, detekt, git diff --check
+Not-tested: Graph consumer와 published artifact resolution은 후속 PR 범위다."
+  ```
+
+  Expected: Korean Lore commit succeeds and `git show --stat --oneline HEAD`
+  contains only the approved issue scope.
+
+## Stop condition
+
+Stop at local commit with fresh test/build/detekt/diff evidence and report the
+commit SHA, RED/GREEN observations, API decision, risks, and gaps to the parent
+agent. Do not push, create a PR, edit Graph, merge, publish, or delete branches.

--- a/docs/superpowers/plans/2026-09-06-bounded-line-reader-plan.md
+++ b/docs/superpowers/plans/2026-09-06-bounded-line-reader-plan.md
@@ -74,7 +74,7 @@
 - Read: `io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt`
 - Read: `io/io/src/test/kotlin/io/bluetape4k/io/BoundedInputStreamSupportTest.kt`
 
-- [ ] **Step 1: 기준 branch와 diff를 읽는다**
+- [x] **Step 1: 기준 branch와 diff를 읽는다**
 
   ```bash
   git status --short --branch
@@ -86,7 +86,7 @@
   Expected: `feat/issue-1642-bounded-line-reader`, clean worktree, HEAD equals
   the approved base or only the spec/plan commit, and no unrelated files.
 
-- [ ] **Step 2: 기존 bounded IO regression을 확인한다**
+- [x] **Step 2: 기존 bounded IO regression을 확인한다**
 
   ```bash
   ./gradlew :bluetape4k-io:test \
@@ -103,7 +103,7 @@
 
 - Create: `io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt`
 
-- [ ] **Step 1: public behavior tests를 작성한다**
+- [x] **Step 1: public behavior tests를 작성한다**
 
   Add JUnit 5 tests using `io.bluetape4k.assertions.assertFailsWith` and
   `shouldBeEqualTo`. The tests must cover the following concrete cases:
@@ -141,7 +141,7 @@
 
   Every over-limit assertion must prove the exception and stable property.
 
-- [ ] **Step 2: RED test를 실행한다**
+- [x] **Step 2: RED test를 실행한다**
 
   ```bash
   ./gradlew :bluetape4k-io:test \
@@ -153,13 +153,13 @@
   exception do not yet exist. Record the actual missing-symbol failure in the
   execution notes; do not interpret a test discovery failure as RED evidence.
 
-- [ ] **Step 3: boundary and lifecycle RED cases를 추가한다**
+- [x] **Step 3: boundary and lifecycle RED cases를 추가한다**
 
   Add tests for empty input (`null`), empty lines (`""`), `maxLineChars == 0`,
   invalid negative/zero parameters before any underlying read, bulk `read == 0`
   fallback, original IOException identity, and wrapper non-close behavior.
 
-- [ ] **Step 4: generated Reader read-count RED case를 추가한다**
+- [x] **Step 4: generated Reader read-count RED case를 추가한다**
 
   Use a generated Reader that emits `'x'` indefinitely and increments a count
   on every code unit returned. With `maxLineChars = 4` and `bufferSize = 3`,
@@ -173,7 +173,7 @@
 - Create: `io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt`
 - Test: `io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt`
 
-- [ ] **Step 1: validation and exception을 구현한다**
+- [x] **Step 1: validation and exception을 구현한다**
 
   ```kotlin
   @file:JvmName("BoundedLineReaderSupport")
@@ -270,7 +270,7 @@
   The implementation must not expose the Reader as a mutable property and must
   not implement `Closeable`.
 
-- [ ] **Step 2: fixed-buffer state machine을 구현한다**
+- [x] **Step 2: fixed-buffer state machine을 구현한다**
 
   Use the complete state machine from Step 1. Keep private `bufferIndex`,
   `bufferLimit`, and `pendingChar` state. Bulk reads request
@@ -279,7 +279,7 @@
   one `Reader.read()` call. Reuse buffered chars before reading the underlying
   Reader.
 
-- [ ] **Step 3: line terminator와 overflow를 구현한다**
+- [x] **Step 3: line terminator와 overflow를 구현한다**
 
   Process LF and CR before appending a code unit. For CR, consume a following LF
   from the existing buffer or perform exactly one single-character read; retain
@@ -287,14 +287,14 @@
   compare `lineLength == maxLineChars` and throw `LineLimitExceededException`
   before appending the over-limit code unit.
 
-- [ ] **Step 4: factory와 KDoc을 추가한다**
+- [x] **Step 4: factory와 KDoc을 추가한다**
 
   Add `Reader.boundedLineReader(maxLineChars, bufferSize)` and Korean KDoc for
   the exception, wrapper, `readLine`, and factory. The KDoc must state UTF-16
   code-unit counting, terminators, read-ahead, ownership, blocking, and a
   `reader.use` example.
 
-- [ ] **Step 5: GREEN targeted test를 실행한다**
+- [x] **Step 5: GREEN targeted test를 실행한다**
 
   ```bash
   ./gradlew :bluetape4k-io:test \
@@ -314,7 +314,7 @@
 - Modify: `io/io/README.ko.md`
 - Modify: `CHANGELOG.md`
 
-- [ ] **Step 1: English README example을 추가한다**
+- [x] **Step 1: English README example을 추가한다**
 
   Add a “Bounded line reads” subsection near the existing bounded byte example.
   Show `reader.use`, `boundedLineReader(maxLineChars = 64 * 1024)`, repeated
@@ -322,18 +322,18 @@
   terminators, rejects before full-line allocation, and leaves JSON parsing and
   reader close to the caller.
 
-- [ ] **Step 2: 한국어 README를 source-equivalent로 추가한다**
+- [x] **Step 2: 한국어 README를 source-equivalent로 추가한다**
 
   Add the same example and contract in Korean. Keep API names, commands, URLs,
   numbers, and code tokens exact. Preserve the existing English/한국어 switch.
 
-- [ ] **Step 3: CHANGELOG를 기록한다**
+- [x] **Step 3: CHANGELOG를 기록한다**
 
   Add a Korean `Unreleased/추가` entry linking #1642. Say that the provider API
   is available and Graph #615 is a later consumer migration; do not claim the
   consumer migration is complete.
 
-- [ ] **Step 4: documentation read-back을 수행한다**
+- [x] **Step 4: documentation read-back을 수행한다**
 
   Read both README sections and the changed KDoc against the design. Run the
   Korean term audit on `README.ko.md` after all technical tokens are frozen:
@@ -352,7 +352,7 @@
 
 - Inspect: all changed files and `git diff origin/develop...HEAD`
 
-- [ ] **Step 1: targeted class and module check을 실행한다**
+- [x] **Step 1: targeted class and module check을 실행한다**
 
   ```bash
   ./gradlew :bluetape4k-io:test \
@@ -367,7 +367,7 @@
   Expected: targeted tests, module build, and Detekt exit 0. Read Detekt output
   for new findings rather than relying only on exit code.
 
-- [ ] **Step 2: complete module test를 실행한다**
+- [x] **Step 2: complete module test를 실행한다**
 
   ```bash
   ./gradlew :bluetape4k-io:cleanTest :bluetape4k-io:test \
@@ -377,7 +377,7 @@
   Expected: the full `bluetape4k-io` test suite passes; record the actual JUnit
   count from the fresh XML/report.
 
-- [ ] **Step 3: diff and API surface를 검토한다**
+- [x] **Step 3: diff and API surface를 검토한다**
 
   ```bash
   git diff --check
@@ -421,14 +421,14 @@
 - Create/update: `docs/lessons/2026-09-06-bounded-line-reader.md`
 - Commit: all approved changed files only
 
-- [ ] **Step 1: lesson을 작성한다**
+- [x] **Step 1: lesson을 작성한다**
 
   Record context, the wrapper-vs-extension decision, UTF-16/read-ahead surprise,
   RED/GREEN evidence, test/build/detekt/diff results, review findings, and the
   future guard for provider/consumer separation. If no unexpected finding exists,
   state concrete evidence-backed `N/A` rather than filler.
 
-- [ ] **Step 2: lesson writer gate와 diff check를 완료한다**
+- [x] **Step 2: lesson writer gate와 diff check를 완료한다**
 
   Apply `SPW-01` through `SPW-05` and `KO-01` through `KO-07`, then run:
 

--- a/docs/superpowers/specs/2026-09-06-bounded-line-reader-design.md
+++ b/docs/superpowers/specs/2026-09-06-bounded-line-reader-design.md
@@ -266,13 +266,13 @@ terminator 판정 read-ahead를 포함해도 buffer 외부에서 무제한으로
 
 ## 10. DoD와 검토 결과
 
-- [ ] `bluetape4k-workflow` 공통 gates와 Type A 단계가 PASS한다.
-- [ ] 공개 API/KDoc/README locale parity가 source와 일치한다.
-- [ ] targeted test, `:bluetape4k-io:build`, `:bluetape4k-io:detekt`,
+- [x] `bluetape4k-workflow` 공통 gates와 Type A 단계가 PASS한다.
+- [x] 공개 API/KDoc/README locale parity가 source와 일치한다.
+- [x] targeted test, `:bluetape4k-io:build`, `:bluetape4k-io:detekt`,
   `git diff --check`가 fresh evidence로 통과한다.
 - [ ] exact diff self-review에서 P0=0/P1=0이다.
 - [ ] Korean Lore commit에 이 spec, plan, 구현, test, README, lesson만 포함된다.
-- [ ] Graph #615 consumer 변경과 push/PR/merge는 이 worktree 밖 범위다.
+- [x] Graph #615 consumer 변경과 push/PR/merge는 이 worktree 밖 범위다.
 
 검토 시점의 spec writer gate: `SPW-01`~`SPW-05` PASS.
 한국어 naturalness gate: `KO-01`~`KO-07` PASS.

--- a/docs/superpowers/specs/2026-09-06-bounded-line-reader-design.md
+++ b/docs/superpowers/specs/2026-09-06-bounded-line-reader-design.md
@@ -1,0 +1,278 @@
+# Issue #1642 길이 제한 Reader API 설계
+
+## 1. 상태와 범위
+
+- 대상 저장소: `bluetape4k-projects`
+- 대상 모듈: `bluetape4k-io`
+- 대상 버전: `2.1.0-SNAPSHOT`
+- 작업 유형: Type A 공개 API 추가
+- 기준 ref: `origin/develop@9811932427aac4c6cfba7b16ae3def215e93a2fe`
+- 연결 이슈: [#1642](https://github.com/bluetape4k/bluetape4k-projects/issues/1642)
+- 후속 소비자: [bluetape4k-graph#615](https://github.com/bluetape4k/bluetape4k-graph/issues/615)
+- 이번 PR: 공통 provider API와 단위 테스트·문서만 제공한다. Graph consumer 코드는
+  수정하지 않는다.
+
+Graph의 Jackson2·Jackson3 NDJSON 입력기는 `Reader.readLine()`으로 한 줄을 먼저
+문자열로 만든다. 신뢰할 수 없는 입력이 길어지면 JSON parsing 전에 한 줄 전체를
+할당하므로, 호출자가 선택한 UTF-16 문자 수 상한을 읽는 동안 적용하는 재사용 가능한
+Reader 경계가 필요하다.
+
+이번 API는 JSON, NDJSON, 행 번호, codec, source lifecycle을 알지 못한다. 소비자는
+자신이 소유한 `Reader`를 wrapper에 제공하고, 반환된 줄을 domain parser에 전달하며,
+wrapper가 닫히지 않으므로 원본 `Reader`의 close를 직접 책임진다.
+
+## 2. 목표와 성공 조건
+
+다음 계약을 만족하는 공개 API를 추가한다.
+
+1. `Reader`를 감싼 `BoundedLineReader`가 반복해서 한 줄씩 반환한다.
+2. `maxLineChars`는 UTF-8 byte나 Unicode code point가 아니라 UTF-16 code unit 수로
+   계산한다. 따라서 supplementary character 하나는 두 code unit으로 센다.
+3. `maxLineChars` 이하의 줄은 `String`으로 반환한다. `maxLineChars`를 넘는
+   첫 code unit을 읽는 즉시 `LineLimitExceededException`을 발생시킨다.
+4. line terminator는 LF(`\n`), CRLF(`\r\n`), CR(`\r`)을 모두 지원한다. terminator는
+   길이 상한에 포함하지 않는다.
+5. 빈 입력은 첫 호출에서 `null`, 빈 줄은 `""`, 마지막 개행이 없는 마지막 줄은
+   문자열을 반환하고 다음 호출에서 `null`을 반환한다.
+6. 내부 char buffer는 고정 크기이고, 한 번의 underlying `Reader.read` 요청은 현재
+   줄의 허용량과 buffer 크기 중 작은 값으로 제한한다. 줄 초과 판정은 최대
+   `maxLineChars + 1` code unit을 읽은 시점에 끝나며, CR terminator 판별을 위한
+   추가 read-ahead도 한 code unit으로 제한한다.
+7. wrapper는 원본 `Reader`를 닫지 않고, 원본 읽기 예외를 감싸지 않고 그대로 전파한다.
+8. public KDoc, 양 언어 module README 예제, API 색인과 테스트가 이 계약을 설명하고
+   고정한다.
+
+성공 조건은 API가 긴 입력을 전체 할당하지 않고 거부하며, 여러 줄의 경계와 UTF-16
+   단위가 정확하고, underlying Reader의 close 책임과 예외 identity가 보존되는 것을
+   테스트로 증명하는 것이다.
+
+## 3. 현재 근거
+
+### 3.1 저장소와 기존 helper
+
+- `io/io/src/main/kotlin/io/bluetape4k/io/BoundedInputStreamSupport.kt`는
+  `ByteLimitExceededException`과 `InputStream.readAllBytes(maxBytes)`를 제공한다.
+  입력 stream을 닫지 않고, 고정 segment와 최대 1 byte의 overflow 판정 read를 사용한다.
+  새 Reader API는 이 caller-owned와 bounded read-ahead 원칙을 차용하되, 문자 단위와
+  줄 terminator가 필요한 별도 상태 machine으로 둔다.
+- `io/io/src/main/kotlin/io/bluetape4k/io/InputStreamSupport.kt`의
+  `DEFAULT_BUFFER_SIZE`와 `requirePositiveNumber`는 기존 buffer/검증 규칙이다.
+- `io/io/README.md`와 `io/io/README.ko.md`는 같은 구조의 사용 예제를 가진다.
+- Okio의 `BufferedSuspendedSource.readUtf8LineStrict(limit)`는 UTF-8 byte 단위이고
+  CR 단독 및 개행 없는 EOF 계약이 달라 이번 Reader helper를 대체하지 못한다.
+
+### 3.2 소비자와 경계
+
+- Graph의 `Jackson2RecordParser`와 `Jackson3RecordParser`는 각각 표준
+  `reader.readLine()`을 사용한다. 공통 IO 모듈이 제공할 수 있는 것은 줄 반환과
+  상한뿐이며, parser의 JSON 오류·행 번호·입력 source 소유권은 후속 consumer PR이
+  유지한다.
+- [Projects #1642](https://github.com/bluetape4k/bluetape4k-projects/issues/1642)는
+  기존 unbounded API를 호환성 없이 교체하지 않는 opt-in API를 요구한다.
+- [Graph #615](https://github.com/bluetape4k/bluetape4k-graph/issues/615)는 provider
+  merge와 artifact 가용성 이후 Jackson2·Jackson3 양쪽에 같은 helper를 적용한다.
+
+## 4. 대안 비교와 결정
+
+### 4.1 `Reader.readLine(maxLineChars)` extension
+
+호출이 짧고 기존 `readLine()`과 비슷하지만, 호출마다 새로운 상태를 만들면 CR 뒤의
+다음 code unit을 안전하게 보관할 수 없다. mutable state를 `Reader`에 저장할 수도
+없으므로 반복 호출 API로는 lifecycle과 read-ahead 계약이 불명확하다.
+
+결정: 채택하지 않는다.
+
+### 4.2 `Sequence<String>` 또는 callback 소비 API
+
+한 번의 생성으로 상태를 유지할 수 있지만, lazy sequence의 iterator 종료·예외·원본
+Reader close 시점을 함께 정의해야 한다. Graph 소비자는 기존 `while` loop와 행별
+parser 오류 흐름을 유지해야 하므로 새로운 iterator lifecycle이 불필요하게 커진다.
+
+결정: 채택하지 않는다.
+
+### 4.3 `BoundedLineReader` 상태 보유 wrapper
+
+Reader와 상한을 한 번만 검증하고 반복 `readLine()` 호출을 제공한다. 고정 buffer,
+CR lookahead, caller-owned close를 한 객체 안에서 명시할 수 있으며, JSON domain을
+추가하지 않는다. `bufferSize`를 선택 인자로 노출하면 소비자는 read-ahead를 작은
+값으로 조정할 수 있고 테스트는 실제 읽기량을 측정할 수 있다.
+
+결정: **채택**. public class와 factory extension을 additive API로 제공한다.
+
+## 5. 선택한 공개 API
+
+```kotlin
+package io.bluetape4k.io
+
+class LineLimitExceededException(
+    val maxLineChars: Int,
+) : IOException
+
+class BoundedLineReader(
+    reader: Reader,
+    maxLineChars: Int,
+    bufferSize: Int = DEFAULT_BUFFER_SIZE,
+) {
+    fun readLine(): String?
+}
+
+fun Reader.boundedLineReader(
+    maxLineChars: Int,
+    bufferSize: Int = DEFAULT_BUFFER_SIZE,
+): BoundedLineReader
+```
+
+### 5.1 입력 검증
+
+- `maxLineChars`는 0 이상이어야 한다. 음수이면 underlying Reader에 접근하기 전에
+  `IllegalArgumentException`을 발생시킨다.
+- `bufferSize`는 양수여야 한다. 0 이하이면 underlying Reader에 접근하기 전에
+  `IllegalArgumentException`을 발생시킨다.
+- 검증에는 `requireZeroOrPositiveNumber("maxLineChars")`와
+  `requirePositiveNumber("bufferSize")`를 사용하고, 검증된 값을 내부 field에
+  저장한다.
+- `maxLineChars == 0`은 빈 줄만 허용한다. 첫 code unit이 LF/CR이면 빈 문자열을
+  반환하고, 일반 code unit이면 즉시 전용 예외를 발생시킨다.
+
+### 5.2 줄 반환과 EOF
+
+- `readLine()`은 입력을 다음 LF, CRLF, CR 또는 EOF까지 읽는다.
+- 입력이 시작부터 EOF이면 `null`을 반환한다.
+- terminator 직전 code unit이 없으면 빈 문자열을 반환한다.
+- EOF 전에 한 개 이상의 code unit을 읽었으면 terminator가 없어도 문자열을 반환한다.
+- 마지막 줄을 반환한 뒤 다음 호출은 `null`이다.
+- wrapper의 `readLine()`은 원본 Reader를 닫지 않는다. caller는 다음처럼 원본을
+  직접 닫는다.
+
+```kotlin
+reader.use {
+    val lines = it.boundedLineReader(maxLineChars = 64 * 1024)
+    while (true) {
+        val line = lines.readLine() ?: break
+        consume(line)
+    }
+}
+```
+
+### 5.3 UTF-16 상한
+
+Kotlin/JVM `Char` 하나를 하나의 code unit으로 센다. 문자열의 surrogate pair를
+분리해 code point로 합치거나 정규화하지 않는다.
+
+- `"abcd"`는 4 code unit이다.
+- `"😀"`는 2 code unit이다.
+- `maxLineChars == 2`에서 `"😀"`은 성공한다.
+- `maxLineChars == 1`에서 `"😀"`은 low surrogate를 읽는 순간 실패한다.
+
+상한을 넘은 줄의 부분 `String`은 반환하지 않으며 예외 message나 property에 payload를
+저장하지 않는다. `LineLimitExceededException.maxLineChars`만 분기 가능한 안정된
+정보이며 message의 정확한 문구는 호환성 계약이 아니다.
+
+### 5.4 read-ahead와 resource ownership
+
+내부 buffer는 생성 시 `bufferSize` 길이로 한 번 할당한다. 현재 줄 길이를 `length`라
+할 때 bulk read 요청 길이는 다음 값이다.
+
+```kotlin
+minOf(bufferSize.toLong(), maxLineChars.toLong() - length + 1L).toInt()
+```
+
+`+1`은 최대 허용 길이 다음 code unit을 읽어 overflow를 판정하기 위한 값이며, `Long`
+산술로 `Int.MAX_VALUE` overflow를 피한다. newline 또는 EOF가 먼저 나오면 그 지점에서
+반환한다. CR을 읽은 뒤 다음 code unit이 buffer에 없으면 underlying `Reader.read()`를
+한 번만 호출해 LF 여부를 판정하고, LF가 아니면 다음 `readLine()`을 위해 pending
+code unit으로 보관한다. 따라서 줄 초과 시 입력 소비는 `maxLineChars + 1` 이내이고,
+terminator 판정 read-ahead를 포함해도 buffer 외부에서 무제한으로 읽지 않는다.
+
+`BoundedLineReader`는 `Closeable`을 구현하지 않는다. wrapper가 원본 Reader를 소유하지
+않는다는 사실을 API surface에서 드러내고, 성공·EOF·전용 예외·원본 IOException
+경로에서 close를 시도하지 않는다.
+
+## 6. 내부 동작
+
+상태는 `buffer`, `bufferIndex`, `bufferLimit`, `pendingChar` 네 부분으로 제한한다.
+
+1. `readLine()` 시작 시 `StringBuilder`를 `minOf(maxLineChars, bufferSize)` capacity로
+   만든다. 상한이 `Int.MAX_VALUE`여도 상한 크기를 선할당하지 않는다.
+2. pending code unit이 있으면 먼저 소비한다. 없으면 buffer에 남은 code unit을
+   사용하고, 비어 있으면 현재 줄에 남은 허용량을 고려한 bulk read를 수행한다.
+3. bulk read가 0을 반환하면 `Reader.read()`로 한 code unit을 요청한다. `Reader.read()`
+   의 0은 NUL code unit이므로 유효한 입력으로 처리한다.
+4. LF이면 줄을 반환한다. CR이면 pending/buffer/단일 read-ahead로 LF를 소비하고 줄을
+   반환하거나 다음 code unit을 pending에 둔다.
+5. terminator가 아닌 code unit을 읽기 전에 `lineLength == maxLineChars`이면
+   `LineLimitExceededException`을 발생시킨다. 아니면 builder에 append한다.
+6. EOF에서 builder가 비어 있으면 `null`, 그렇지 않으면 builder 문자열을 반환한다.
+
+이 알고리즘은 입력에 비례해 내부 buffer와 현재 허용 상한까지만 사용한다. 단일 줄의
+허용 결과 문자열 자체는 상한까지 커질 수 있으며, caller가 동시에 처리하는 줄 수의
+메모리 예산은 caller가 책임진다.
+
+## 7. 실패 모드와 책임 경계
+
+| 상황 | 계약 | 검증 |
+|---|---|---|
+| `maxLineChars < 0` | 읽기 전에 `IllegalArgumentException` | tracking Reader 호출 수 0 |
+| `bufferSize <= 0` | 읽기 전에 `IllegalArgumentException` | tracking Reader 호출 수 0 |
+| 줄이 상한 초과 | 첫 초과 code unit에서 `LineLimitExceededException` | `maxLineChars`와 소비 code unit 수 검증 |
+| CR 다음이 LF가 아님 | 다음 code unit을 잃지 않고 다음 호출에서 반환 | `"a\rb"`와 작은 buffer 테스트 |
+| underlying read 실패 | 같은 IOException instance를 그대로 전달 | custom Reader identity 검증 |
+| caller가 Reader를 닫아야 함 | wrapper는 close를 호출하지 않음 | close counter 검증 |
+| supplementary character | surrogate pair를 두 code unit으로 계산 | 상한 1/2 경계 테스트 |
+| 무한/generated Reader | 전체 입력을 읽지 않고 상한+1 이내에서 종료 | read-count bound 테스트 |
+
+다음 항목은 이번 API가 보장하지 않는다.
+
+- Unicode grapheme, code point 또는 normalized text 단위 제한
+- JSON/NDJSON parsing, schema, 행 번호, codec 오류 변환
+- Reader의 blocking timeout, coroutine cancellation, executor/dispatcher 선택
+- underlying Reader의 thread safety 또는 여러 wrapper 간 동기화
+- overflow 후 Reader를 EOF까지 drain하거나 부분 문자열을 복구하는 동작
+
+## 8. 호환성과 downstream migration
+
+- 기존 `Reader.readLine()`과 `InputStream` helper는 변경하지 않는다. 새 API는 opt-in
+  top-level class/factory이므로 source와 binary compatibility를 유지한다.
+- 새 예외는 `IOException`으로 분류한다. caller는 type과 `maxLineChars`만 사용하고
+  message에 payload가 없다는 계약을 따른다.
+- Graph #615는 Projects API가 `2.1.0-SNAPSHOT`으로 제공된 후 Jackson2·Jackson3
+  parser에 동일한 `boundedLineReader(maxLineChars)`를 생성해 loop를 교체한다.
+  parser의 JSON domain과 source close는 Graph가 계속 소유한다.
+- 외부 API publish, Graph catalog 동기화, consumer migration, merge와 release는 이번
+  PR에 포함하지 않는다.
+
+## 9. 테스트와 문서 수용 기준
+
+### 테스트
+
+- LF, CRLF, CR을 각각 읽고 여러 줄 사이의 다음 code unit을 보존한다.
+- empty input, empty line, final line without newline을 구분한다.
+- `maxLineChars - 1`, `maxLineChars`, `maxLineChars + 1` 경계를 검증한다.
+- `maxLineChars == 0`, 음수 상한, 잘못된 buffer size를 검증한다.
+- supplementary character의 surrogate pair를 두 code unit으로 계산한다.
+- generated infinite Reader에서 overflow가 `maxLineChars + 1` code unit 안에 발생하고
+  read-count가 무제한으로 증가하지 않음을 검증한다.
+- custom Reader의 bulk read 0 fallback, IOException identity, close 미호출을 검증한다.
+- 작은 `bufferSize`에서 CRLF/CR lookahead와 read-ahead 경계를 검증한다.
+
+### 문서
+
+- 새 public class, exception, factory, `readLine()`에 한국어 KDoc과 ownership/단위/
+  overflow 예제를 추가한다.
+- `io/io/README.md`와 `io/io/README.ko.md`에 source-equivalent bounded line example,
+  UTF-16 단위, close 책임, JSON domain 제외를 추가한다.
+- `CHANGELOG.md`의 `Unreleased/추가`에 #1642 provider API를 기록한다. 후속 Graph
+  migration이 완료되지 않았으므로 consumer 완료로 표현하지 않는다.
+
+## 10. DoD와 검토 결과
+
+- [ ] `bluetape4k-workflow` 공통 gates와 Type A 단계가 PASS한다.
+- [ ] 공개 API/KDoc/README locale parity가 source와 일치한다.
+- [ ] targeted test, `:bluetape4k-io:build`, `:bluetape4k-io:detekt`,
+  `git diff --check`가 fresh evidence로 통과한다.
+- [ ] exact diff self-review에서 P0=0/P1=0이다.
+- [ ] Korean Lore commit에 이 spec, plan, 구현, test, README, lesson만 포함된다.
+- [ ] Graph #615 consumer 변경과 push/PR/merge는 이 worktree 밖 범위다.
+
+검토 시점의 spec writer gate: `SPW-01`~`SPW-05` PASS.
+한국어 naturalness gate: `KO-01`~`KO-07` PASS.

--- a/docs/testlogs/2026-09.md
+++ b/docs/testlogs/2026-09.md
@@ -15,3 +15,5 @@
 | 2026-09-06 | #1645 | current develop 통합 뒤 `:bluetape4k-io:test`와 Detekt | PASS — 1,298 passing, 신규 Detekt finding 0 | `origin/develop@8e5ff93d71` rebase 뒤 `--rerun-tasks --no-build-cache --no-configuration-cache`; Kotlin/Java compile과 ABI 확인 포함 |
 | 2026-09-06 | #1639 | Fory 1.6.0 fixture, current Kotlin metadata 및 Redis serializer 회귀 | PASS — targeted 4+3 passing | fixture SHA-256 `4e672fb8d1b5cad5cd66537461ce714f4027b794a8be32e54d8337f6cddac819`; failures/errors/skipped 0 |
 | 2026-09-06 | #1639 | IO, Spring Boot Redis, Hibernate Lettuce 전체 build와 Detekt | PASS — 1,302 + 102 + 38 passing | 세 모듈 failures/errors/skipped 0, 변경 후 targeted test와 Detekt 재실행 성공 |
+| 2026-09-06 | #1642 | `BoundedLineReaderSupportTest` 길이·개행·read-ahead·ownership 회귀 | RED → GREEN — 10 passing | production symbol 부재 compile RED 뒤 구현; failures/errors/skipped 0 |
+| 2026-09-06 | #1642 | `:bluetape4k-io:build`와 Detekt | PASS — 1,308 passing | 신규 production/test Detekt finding 0, Korean terminology audit와 `git diff --check` 통과 |

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -218,6 +218,30 @@ log에 남기지 마세요. 마지막 EOF 확인도 block될 수 있으므로 tr
 대략 `동시 read 수 * (2 * maxBytes + segment overhead)`로 잡습니다. 이 상한은 전달된
 stream의 byte에만 적용되므로 이후 압축 해제에는 decoded byte 상한이 별도로 필요합니다.
 
+### 길이 제한 line 읽기
+
+line 단위 입력을 읽을 때 전체 line을 먼저 무제한으로 할당하지 않고 읽는 중에
+거부하려면 `boundedLineReader(maxLineChars)`를 사용합니다.
+
+```kotlin
+import io.bluetape4k.io.boundedLineReader
+
+reader.use {
+    val lines = it.boundedLineReader(maxLineChars = 64 * 1024)
+    while (true) {
+        val line = lines.readLine() ?: break
+        consume(line)
+    }
+}
+```
+
+`maxLineChars`는 UTF-16 code unit 수로 계산하므로 supplementary character 하나는
+두 unit으로 셉니다. LF, CRLF, CR은 line을 끝내며 상한에 포함하지 않습니다. 상한을
+초과한 line은 범위를 벗어난 첫 code unit을 읽는 즉시 `LineLimitExceededException`을
+발생시키고 부분 line을 반환하지 않습니다. wrapper는 고정 read buffer를 사용하고
+제공받은 `Reader`를 닫지 않으므로 Reader 수명, timeout, blocking 동작과 JSON/NDJSON
+parsing은 호출자가 책임집니다.
+
 ### 압축
 
 ```kotlin

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -238,7 +238,10 @@ reader.use {
 `maxLineChars`는 UTF-16 code unit 수로 계산하므로 supplementary character 하나는
 두 unit으로 셉니다. LF, CRLF, CR은 line을 끝내며 상한에 포함하지 않습니다. 상한을
 초과한 line은 범위를 벗어난 첫 code unit을 읽는 즉시 `LineLimitExceededException`을
-발생시키고 부분 line을 반환하지 않습니다. wrapper는 고정 read buffer를 사용하고
+발생시키고 부분 line을 반환하지 않습니다. overflow 뒤 현재 줄 drain과 동일 wrapper의
+재사용은 보장하지 않으므로 해당 source 처리를 중단하고 Reader를 닫으세요.
+`maxLineChars`가 음수이거나 `bufferSize`가 0 이하이면 생성 시
+`IllegalArgumentException`이 발생합니다. wrapper는 고정 read buffer를 사용하고
 제공받은 `Reader`를 닫지 않으므로 Reader 수명, timeout, blocking 동작과 JSON/NDJSON
 parsing은 호출자가 책임집니다. `maxLineChars`와 `bufferSize`는 read-ahead 경계이지
 프로세스 전체 heap 예산이 아니므로, 외부 설정값은 배포 메모리 예산에 맞는 안전한

--- a/io/io/README.ko.md
+++ b/io/io/README.ko.md
@@ -240,7 +240,9 @@ reader.use {
 초과한 line은 범위를 벗어난 첫 code unit을 읽는 즉시 `LineLimitExceededException`을
 발생시키고 부분 line을 반환하지 않습니다. wrapper는 고정 read buffer를 사용하고
 제공받은 `Reader`를 닫지 않으므로 Reader 수명, timeout, blocking 동작과 JSON/NDJSON
-parsing은 호출자가 책임집니다.
+parsing은 호출자가 책임집니다. `maxLineChars`와 `bufferSize`는 read-ahead 경계이지
+프로세스 전체 heap 예산이 아니므로, 외부 설정값은 배포 메모리 예산에 맞는 안전한
+범위로 제한해야 합니다.
 
 ### 압축
 

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -242,6 +242,8 @@ An over-limit line throws `LineLimitExceededException` as soon as its first
 out-of-range code unit is read; no partial line is returned. The wrapper uses a
 fixed read buffer and does not close the supplied `Reader`, so the caller owns
 the reader lifecycle, timeouts, blocking behavior, and any JSON/NDJSON parsing.
+These limits bound read-ahead, not total process heap, so externally configured
+values must be capped against the deployment's memory budget.
 
 ### Compression
 

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -239,7 +239,10 @@ reader.use {
 `maxLineChars` counts UTF-16 code units, so a supplementary character counts as
 two units. LF, CRLF, and CR terminate a line and are not included in the limit.
 An over-limit line throws `LineLimitExceededException` as soon as its first
-out-of-range code unit is read; no partial line is returned. The wrapper uses a
+out-of-range code unit is read; no partial line is returned. Draining the current
+line and reusing the same wrapper after overflow are not supported; abort that
+source and close its reader. A negative `maxLineChars` or non-positive
+`bufferSize` throws `IllegalArgumentException` during construction. The wrapper uses a
 fixed read buffer and does not close the supplied `Reader`, so the caller owns
 the reader lifecycle, timeouts, blocking behavior, and any JSON/NDJSON parsing.
 These limits bound read-ahead, not total process heap, so externally configured

--- a/io/io/README.md
+++ b/io/io/README.md
@@ -219,6 +219,30 @@ aborted. Budget temporary heap as approximately
 needs a separate decoded-byte limit because this limit applies only to bytes read
 from the supplied stream.
 
+### Bounded line reads
+
+Use `boundedLineReader(maxLineChars)` when a line-oriented input must be rejected
+while it is being read instead of allocating an unbounded complete line first:
+
+```kotlin
+import io.bluetape4k.io.boundedLineReader
+
+reader.use {
+    val lines = it.boundedLineReader(maxLineChars = 64 * 1024)
+    while (true) {
+        val line = lines.readLine() ?: break
+        consume(line)
+    }
+}
+```
+
+`maxLineChars` counts UTF-16 code units, so a supplementary character counts as
+two units. LF, CRLF, and CR terminate a line and are not included in the limit.
+An over-limit line throws `LineLimitExceededException` as soon as its first
+out-of-range code unit is read; no partial line is returned. The wrapper uses a
+fixed read buffer and does not close the supplied `Reader`, so the caller owns
+the reader lifecycle, timeouts, blocking behavior, and any JSON/NDJSON parsing.
+
 ### Compression
 
 ```kotlin

--- a/io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt
@@ -52,6 +52,7 @@ class LineLimitExceededException(
  * @param reader 줄을 제공할 Reader
  * @param maxLineChars 허용할 최대 UTF-16 code unit 수
  * @param bufferSize 내부 char buffer 크기
+ * @throws IllegalArgumentException [maxLineChars]가 음수이거나 [bufferSize]가 0 이하인 경우
  */
 class BoundedLineReader(
     private val reader: Reader,
@@ -71,7 +72,9 @@ class BoundedLineReader(
      * 입력이 시작부터 EOF이면 `null`을 반환합니다. 빈 줄은 빈 문자열로 반환하고,
      * 마지막 줄에 종결자가 없어도 읽은 code unit을 반환한 뒤 다음 호출에서 `null`을
      * 반환합니다. 초과한 줄은 부분 문자열 없이 [LineLimitExceededException]으로
-     * 실패합니다. 이 함수는 원본 Reader를 닫지 않습니다.
+     * 실패합니다. overflow 뒤 현재 줄 drain이나 wrapper 재사용은 보장하지 않으므로
+     * 호출자는 해당 source 처리를 중단하고 원본 Reader를 닫아야 합니다. 이 함수는
+     * 원본 Reader를 직접 닫지 않습니다.
      *
      * @return 다음 줄 또는 입력이 끝난 경우 `null`
      * @throws LineLimitExceededException 줄이 [maxLineChars]를 초과한 경우
@@ -161,6 +164,7 @@ class BoundedLineReader(
  * @param maxLineChars 허용할 최대 UTF-16 code unit 수
  * @param bufferSize 내부 char buffer 크기
  * @return 길이 제한을 적용한 line reader
+ * @throws IllegalArgumentException [maxLineChars]가 음수이거나 [bufferSize]가 0 이하인 경우
  */
 fun Reader.boundedLineReader(
     maxLineChars: Int,

--- a/io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt
@@ -1,0 +1,166 @@
+@file:JvmName("BoundedLineReaderSupport")
+
+package io.bluetape4k.io
+
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.support.requireZeroOrPositiveNumber
+import java.io.IOException
+import java.io.Reader
+
+/**
+ * Reader가 반환한 한 줄이 허용한 UTF-16 code unit 상한을 초과했음을 나타냅니다.
+ *
+ * 예외에는 부분 줄을 저장하지 않습니다. 분기할 때는 [maxLineChars]만 사용하고
+ * message의 정확한 문구나 입력 내용을 계약으로 사용하지 마세요.
+ *
+ * @property maxLineChars 초과가 발생한 줄에 적용한 UTF-16 code unit 상한
+ */
+class LineLimitExceededException(
+    val maxLineChars: Int,
+) : IOException("Reader line exceeded the configured character limit: maxLineChars=$maxLineChars") {
+    init {
+        maxLineChars.requireZeroOrPositiveNumber("maxLineChars")
+    }
+}
+
+/**
+ * Reader에서 한 줄을 읽을 때 UTF-16 code unit 상한을 적용합니다.
+ *
+ * 한 줄의 길이가 [maxLineChars]를 넘으면 초과한 첫 code unit을 읽는 즉시
+ * [LineLimitExceededException]을 발생시킵니다. LF, CRLF, CR을 줄 종결자로 인식하며
+ * 종결자는 상한에 포함하지 않습니다. 상한 단위는 UTF-8 byte나 Unicode code point가
+ * 아니므로 supplementary character 하나는 두 code unit으로 계산합니다.
+ *
+ * 내부 buffer는 [bufferSize]로 고정하고, 현재 줄의 허용량을 넘는 bulk read를 요청하지
+ * 않습니다. CR 뒤의 LF를 확인할 때만 다음 code unit 하나를 미리 읽을 수 있습니다.
+ * 이 wrapper는 원본 [Reader]를 닫지 않으므로 성공·EOF·실패 후의 close는 호출자가
+ * 소유합니다. 읽기는 blocking일 수 있으므로 timeout과 coroutine dispatcher도 호출자가
+ * 구성해야 합니다.
+ *
+ * ```kotlin
+ * reader.use {
+ *     val lines = it.boundedLineReader(maxLineChars = 64 * 1024)
+ *     while (true) {
+ *         val line = lines.readLine() ?: break
+ *         consume(line)
+ *     }
+ * }
+ * ```
+ *
+ * @param reader 줄을 제공할 Reader
+ * @param maxLineChars 허용할 최대 UTF-16 code unit 수
+ * @param bufferSize 내부 char buffer 크기
+ */
+class BoundedLineReader(
+    private val reader: Reader,
+    maxLineChars: Int,
+    bufferSize: Int = DEFAULT_BUFFER_SIZE,
+) {
+    private val maxLineChars = maxLineChars.requireZeroOrPositiveNumber("maxLineChars")
+    private val bufferSize = bufferSize.requirePositiveNumber("bufferSize")
+    private val buffer = CharArray(this.bufferSize)
+    private var bufferIndex = 0
+    private var bufferLimit = 0
+    private var pendingChar = NO_PENDING_CHAR
+
+    /**
+     * 다음 줄을 반환합니다.
+     *
+     * 입력이 시작부터 EOF이면 `null`을 반환합니다. 빈 줄은 빈 문자열로 반환하고,
+     * 마지막 줄에 종결자가 없어도 읽은 code unit을 반환한 뒤 다음 호출에서 `null`을
+     * 반환합니다. 초과한 줄은 부분 문자열 없이 [LineLimitExceededException]으로
+     * 실패합니다. 이 함수는 원본 Reader를 닫지 않습니다.
+     *
+     * @return 다음 줄 또는 입력이 끝난 경우 `null`
+     * @throws LineLimitExceededException 줄이 [maxLineChars]를 초과한 경우
+     * @throws IOException 원본 Reader가 읽기에 실패한 경우
+     */
+    @Throws(IOException::class)
+    fun readLine(): String? {
+        val line = StringBuilder(minOf(maxLineChars, bufferSize))
+        var lineLength = 0
+        var completed = false
+        var result: String? = null
+
+        while (!completed) {
+            val value = nextChar(lineLength)
+            when {
+                value < 0 -> {
+                    result = if (lineLength == 0) null else line.toString()
+                    completed = true
+                }
+                value == LF -> {
+                    result = line.toString()
+                    completed = true
+                }
+                value == CR -> {
+                    val following = readAfterCarriageReturn()
+                    if (following >= 0 && following != LF) {
+                        pendingChar = following
+                    }
+                    result = line.toString()
+                    completed = true
+                }
+                lineLength == maxLineChars -> throw LineLimitExceededException(maxLineChars)
+                else -> {
+                    line.append(value.toChar())
+                    lineLength++
+                }
+            }
+        }
+        return result
+    }
+
+    private fun nextChar(lineLength: Int): Int {
+        val result = when {
+            pendingChar != NO_PENDING_CHAR -> pendingChar.also { pendingChar = NO_PENDING_CHAR }
+            bufferIndex < bufferLimit -> buffer[bufferIndex++].code
+            else -> {
+                val requested = minOf(
+                    bufferSize.toLong(),
+                    maxLineChars.toLong() - lineLength.toLong() + 1L,
+                ).toInt()
+                val count = reader.read(buffer, 0, requested)
+                when {
+                    count > 0 -> {
+                        bufferIndex = 1
+                        bufferLimit = count
+                        buffer[0].code
+                    }
+                    count < 0 -> EOF
+                    else -> reader.read()
+                }
+            }
+        }
+        return result
+    }
+
+    private fun readAfterCarriageReturn(): Int {
+        if (bufferIndex < bufferLimit) {
+            return buffer[bufferIndex++].code
+        }
+        return reader.read()
+    }
+
+    private companion object {
+        const val EOF = -1
+        const val LF = '\n'.code
+        const val CR = '\r'.code
+        const val NO_PENDING_CHAR = -2
+    }
+}
+
+/**
+ * Reader를 UTF-16 code unit 길이 제한을 적용하는 [BoundedLineReader]로 감쌉니다.
+ *
+ * 반환된 wrapper는 [this]를 닫지 않습니다. wrapper를 다 사용한 뒤 원본 Reader의
+ * close를 호출하거나 `use`로 감싸세요.
+ *
+ * @param maxLineChars 허용할 최대 UTF-16 code unit 수
+ * @param bufferSize 내부 char buffer 크기
+ * @return 길이 제한을 적용한 line reader
+ */
+fun Reader.boundedLineReader(
+    maxLineChars: Int,
+    bufferSize: Int = DEFAULT_BUFFER_SIZE,
+): BoundedLineReader = BoundedLineReader(this, maxLineChars, bufferSize)

--- a/io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt
+++ b/io/io/src/main/kotlin/io/bluetape4k/io/BoundedLineReaderSupport.kt
@@ -33,6 +33,8 @@ class LineLimitExceededException(
  *
  * 내부 buffer는 [bufferSize]로 고정하고, 현재 줄의 허용량을 넘는 bulk read를 요청하지
  * 않습니다. CR 뒤의 LF를 확인할 때만 다음 code unit 하나를 미리 읽을 수 있습니다.
+ * 이 read-ahead 경계가 프로세스 전체 heap 사용량을 제한하지는 않으므로, 외부 설정으로
+ * 두 상한을 받을 때는 호출자가 배포 환경의 메모리 예산 안에서 허용 범위를 제한해야 합니다.
  * 이 wrapper는 원본 [Reader]를 닫지 않으므로 성공·EOF·실패 후의 close는 호출자가
  * 소유합니다. 읽기는 blocking일 수 있으므로 timeout과 coroutine dispatcher도 호출자가
  * 구성해야 합니다.

--- a/io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt
+++ b/io/io/src/test/kotlin/io/bluetape4k/io/BoundedLineReaderSupportTest.kt
@@ -1,0 +1,206 @@
+package io.bluetape4k.io
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.io.Reader
+import java.io.StringReader
+
+class BoundedLineReaderSupportTest {
+
+    @Test
+    fun `LF CRLF CR empty line and final line without newline are preserved`() {
+        val bounded = StringReader("lf\n\r\ncr\rfinal")
+            .boundedLineReader(maxLineChars = 8, bufferSize = 2)
+
+        bounded.readLine() shouldBeEqualTo "lf"
+        bounded.readLine() shouldBeEqualTo ""
+        bounded.readLine() shouldBeEqualTo "cr"
+        bounded.readLine() shouldBeEqualTo "final"
+        bounded.readLine() shouldBeEqualTo null
+    }
+
+    @Test
+    fun `empty input and empty lines are distinguished from EOF`() {
+        StringReader("").boundedLineReader(maxLineChars = 0).readLine() shouldBeEqualTo null
+
+        val bounded = StringReader("\n\r\n\r")
+            .boundedLineReader(maxLineChars = 0, bufferSize = 1)
+
+        bounded.readLine() shouldBeEqualTo ""
+        bounded.readLine() shouldBeEqualTo ""
+        bounded.readLine() shouldBeEqualTo ""
+        bounded.readLine() shouldBeEqualTo null
+    }
+
+    @Test
+    fun `limit boundary accepts exact length and rejects the next code unit`() {
+        StringReader("ab\n").boundedLineReader(3).readLine() shouldBeEqualTo "ab"
+        StringReader("abc\n").boundedLineReader(3).readLine() shouldBeEqualTo "abc"
+
+        val failure = assertFailsWith<LineLimitExceededException> {
+            StringReader("abcd\n").boundedLineReader(3).readLine()
+        }
+
+        failure.maxLineChars shouldBeEqualTo 3
+        failure.message.orEmpty().contains("abcd").shouldBeEqualTo(false)
+    }
+
+    @Test
+    fun `zero limit accepts only a terminated empty line`() {
+        StringReader("\n").boundedLineReader(0).readLine() shouldBeEqualTo ""
+
+        val failure = assertFailsWith<LineLimitExceededException> {
+            StringReader("x").boundedLineReader(0).readLine()
+        }
+
+        failure.maxLineChars shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `supplementary character counts as two UTF-16 code units`() {
+        StringReader("😀\n").boundedLineReader(2).readLine() shouldBeEqualTo "😀"
+
+        val failure = assertFailsWith<LineLimitExceededException> {
+            StringReader("😀\n").boundedLineReader(1).readLine()
+        }
+
+        failure.maxLineChars shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `CR lookahead preserves the first code unit of the next line`() {
+        val reader = TrackingReader("first\rsecond")
+        val bounded = reader.boundedLineReader(maxLineChars = 16, bufferSize = 2)
+
+        bounded.readLine() shouldBeEqualTo "first"
+        bounded.readLine() shouldBeEqualTo "second"
+        bounded.readLine() shouldBeEqualTo null
+    }
+
+    @Test
+    fun `generated reader fails after max plus one code units`() {
+        val reader = GeneratedReader()
+        val failure = assertFailsWith<LineLimitExceededException> {
+            reader.boundedLineReader(maxLineChars = 4, bufferSize = 3).readLine()
+        }
+
+        failure.maxLineChars shouldBeEqualTo 4
+        reader.charsRead shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `bulk read zero falls back to one code unit read`() {
+        val reader = TrackingReader("x\n", bulkZeroCount = 1)
+        val bounded = reader.boundedLineReader(maxLineChars = 4, bufferSize = 2)
+
+        bounded.readLine() shouldBeEqualTo "x"
+        reader.bulkReadCalls shouldBeEqualTo 2
+        reader.singleReadCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `invalid limits are rejected before touching the reader`() {
+        val reader = TrackingReader("x")
+
+        assertFailsWith<IllegalArgumentException> {
+            reader.boundedLineReader(maxLineChars = -1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            reader.boundedLineReader(maxLineChars = 1, bufferSize = 0)
+        }
+
+        reader.bulkReadCalls shouldBeEqualTo 0
+        reader.singleReadCalls shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `underlying reader failure keeps its identity and wrapper never closes it`() {
+        val expected = IOException("read failed")
+        val reader = TrackingReader("x", readFailure = expected)
+
+        val actual = assertFailsWith<IOException> {
+            reader.boundedLineReader(maxLineChars = 4).readLine()
+        }
+
+        actual shouldBeSameInstanceAs expected
+        reader.closeCalls shouldBeEqualTo 0
+
+        reader.close()
+        reader.closeCalls shouldBeEqualTo 1
+    }
+
+    private class TrackingReader(
+        source: String,
+        bulkZeroCount: Int = 0,
+        private val readFailure: IOException? = null,
+    ) : Reader() {
+        private val source = source.toCharArray()
+        private var position = 0
+        private var remainingBulkZeroCount = bulkZeroCount
+
+        var charsRead: Int = 0
+            private set
+        var bulkReadCalls: Int = 0
+            private set
+        var singleReadCalls: Int = 0
+            private set
+        var closeCalls: Int = 0
+            private set
+
+        override fun read(cbuf: CharArray, off: Int, len: Int): Int {
+            bulkReadCalls++
+            readFailure?.let { throw it }
+            if (len == 0) return 0
+            val result = when {
+                remainingBulkZeroCount > 0 -> {
+                    remainingBulkZeroCount--
+                    0
+                }
+                position >= source.size -> -1
+                else -> {
+                    val count = minOf(len, source.size - position)
+                    source.copyInto(cbuf, off, position, position + count)
+                    position += count
+                    charsRead += count
+                    count
+                }
+            }
+            return result
+        }
+
+        override fun read(): Int {
+            singleReadCalls++
+            readFailure?.let { throw it }
+            if (position >= source.size) return -1
+
+            charsRead++
+            return source[position++].code
+        }
+
+        override fun close() {
+            closeCalls++
+        }
+    }
+
+    private class GeneratedReader : Reader() {
+        var charsRead: Int = 0
+            private set
+
+        override fun read(cbuf: CharArray, off: Int, len: Int): Int {
+            require(len > 0)
+            cbuf.fill('x', off, off + len)
+            charsRead += len
+            return len
+        }
+
+        override fun read(): Int {
+            charsRead++
+            return 'x'.code
+        }
+
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
## 변경 요약

- `BoundedLineReader`와 `Reader.boundedLineReader(...)`를 추가해 line 전체 할당 전에 UTF-16 code unit 상한을 적용합니다.
- LF/CRLF/CR, exact-limit/overflow, surrogate pair, zero-read fallback, IOException identity와 Reader ownership을 테스트합니다.
- overflow 후 drain/reuse 비보장, caller-owned close/timeout/dispatcher, read-ahead와 heap budget의 차이를 KDoc/README에 명시합니다.

Closes #1642
후속 consumer 적용: bluetape4k/bluetape4k-graph#615

## 변경 유형

- [x] `feat` — 새 기능
- [ ] `fix` — 버그 수정
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `perf` — 성능 개선
- [x] `test` — 테스트 추가/수정
- [x] `docs` — 문서만 변경
- [ ] `chore` — 빌드/설정/의존성

## 테스트

- [x] targeted test — 10 passing
- [x] `:bluetape4k-io:cleanTest :bluetape4k-io:test` — 1,308 passing
- [x] `:bluetape4k-io:build` — `BUILD SUCCESSFUL`
- [x] `:bluetape4k-io:detekt` — exit 0, 변경 파일 finding 0
- [x] 한국어 용어 audit findings=0, `git diff --check` 통과
- [x] `docs/testlogs/2026-09.md`에 결과 기록

## Code Review

- [x] Performance/Stability/Security/Operator/Developer/User exact-diff review — P0=0, P1=0
- [x] User P2 3건 보완 후 API/Ops/User 재리뷰 통과
- [x] Performance P3: 전용 JMH/GC benchmark 부재 — 비차단 gap으로 기록
- [x] rebase head `96bf5991a9af`의 PR exact-head CI와 review/thread read-back 완료

## Issue 연결 및 자동 종료

- [x] `Closes #1642`로 병합 완료 시 자동 종료 계약을 명시했습니다.
- [x] Graph #615 consumer 적용은 별도 후속 이슈로 유지합니다.
- [x] merge SHA `81eee97e5a9d`와 #1642 종료 상태를 live read-back했습니다.

## 체크리스트

- [x] `io/io/README.md`와 `README.ko.md`를 함께 갱신했습니다.
- [x] 새 public API에 한국어 KDoc을 추가했습니다.
- [x] `worktree`에서 작업 후 PR을 생성합니다.
- [x] Spring Boot, Nightly, Docker image, `virtualthread` 변경 없음 — N/A.
- [x] `docs/superpowers/index/YYYY-MM.md` 없음 — N/A.

## DoD Status

- DONE: provider API, TDD/전체 모듈 검증, KDoc/README/CHANGELOG/lesson, 독립 리뷰 P0/P1=0.
- DONE: #1639 testlog를 보존한 최신 `develop` rebase, targeted 10 passing, `git diff --check` 통과.
- DONE: rebase head `96bf5991a9af`의 hosted CI `12 success / 12 skipped / 0 failed`, reviews 0, threads 0, `MERGEABLE/CLEAN` read-back.
- DONE: exact-head squash merge와 merge 후 live read-back을 완료했습니다.
- DONE: #1642는 이 PR의 provider API 완료 범위로 종료하고 Graph #615 consumer 적용은 별도 추적합니다.
- NOT DONE: release와 cleanup은 현재 단계 범위가 아닙니다.
