### PR TITLE
MDC 복사·복원 API와 공용 TaskDecorator를 추가한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,14 @@
 
 ### 추가
 
+- `bluetape4k-logging`에 전체 MDC snapshot을 복사·교체·복원하는
+  `captureMdcContext`와 `withMdcContext`를 추가하고,
+  `bluetape4k-spring-boot-core`에 재사용 worker용 `MdcTaskDecorator`를 제공한다.
+  빈 caller context도 worker의 stale 값을 숨기며 정상·예외·중첩 실행 뒤 worker의
+  이전 전체 map을 복원한다. executor와 bean lifecycle은 애플리케이션이 소유하고,
+  Workshop 소비자 이전은 후속 #941에서 진행한다
+  ([#1644](https://github.com/bluetape4k/bluetape4k-projects/issues/1644)).
+
 - `InputStream`, Apache HC5 `HttpEntity`, JDK `HttpResponse<InputStream>`에 전체 본문을
   strict byte 상한 안에서 읽는 additive API를 추가했다. 상한 초과는 부분 결과 없이
   `ByteLimitExceededException`으로 실패하며 기존 truncation API는 그대로 유지한다.

--- a/bluetape4k/logging/README.ko.md
+++ b/bluetape4k/logging/README.ko.md
@@ -27,7 +27,7 @@ Kotlin에서 SLF4J 로깅을 더 쉽고 효율적으로 사용하기 위한 라�
 - **Lambda 기반 Lazy Logging**: 로그 레벨이 활성화되지 않으면 메시지를 생성하지 않아 성능 향상
 - **클래스 기반 로깅**: `KLogging`을 사용한 간편한 클래스 로거 정의
 - **함수 레벨 로깅**: Package 함수에서도 쉽게 사용 가능
-- **MDC 지원**: Slf4j MDC를 Kotlin 스타일로 간편하게 사용
+- **MDC 지원**: Slf4j MDC를 Kotlin 스타일로 간편하게 사용하며, 재사용 worker를 위한 불변 MDC 복사본 제공
 - **Coroutines 지원**: Coroutines 환경에서 MDC 컨텍스트 전파
 - **KLoggingChannel**: Coroutines Channel 기반 비동기 로깅 (고성능)
 - **에러 강조**: warn/error 로그에 자동으로 🔥 이모지 추가
@@ -175,6 +175,34 @@ withLoggingContext("userId" to userId) {
     log.info { "User action logged" }
 }
 ```
+
+#### 재사용 worker에서 MDC 복사본 사용하기
+
+작업을 제출할 때 `captureMdcContext`를 호출하고 worker 경계에서
+`withMdcContext`를 사용합니다. MDC 복사본은 캡처 시점에 고정되며, 빈
+MDC 복사본은 task 실행 중 worker MDC를 비웁니다. 정상 종료와 예외 종료 모두
+worker가 실행 전에 가지고 있던 전체 map을 복원합니다.
+
+```kotlin
+import io.bluetape4k.logging.captureMdcContext
+import io.bluetape4k.logging.withMdcContext
+import org.slf4j.MDC
+
+MDC.put("requestId", requestId)
+val submittedContext = captureMdcContext()
+MDC.put("requestId", "a-later-value") // submittedContext에는 반영되지 않음
+
+executor.execute {
+    withMdcContext(submittedContext) {
+        log.info { "제출 시점의 request context가 활성화됨" }
+    }
+}
+```
+
+`withMdcContext`는 scope 동안 MDC 전체를 대체하고 `finally`에서 worker의
+이전 전체 map을 복원하므로 task가 추가한 key가 다음 task로 새지 않습니다.
+이는 기존 key별 병합과 빈 map no-op semantics를 유지하는
+`withLoggingContext`와 의도적으로 다른 동작입니다.
 
 ### 5. Coroutines에서 MDC 사용하기
 

--- a/bluetape4k/logging/README.ko.md
+++ b/bluetape4k/logging/README.ko.md
@@ -182,6 +182,8 @@ withLoggingContext("userId" to userId) {
 `withMdcContext`를 사용합니다. MDC 복사본은 캡처 시점에 고정되며, 빈
 MDC 복사본은 task 실행 중 worker MDC를 비웁니다. 정상 종료와 예외 종료 모두
 worker가 실행 전에 가지고 있던 전체 map을 복원합니다.
+MDC 값은 이 API가 검증하거나 가리지 않으므로 정제된 비밀이 아닌 식별자만 사용하고,
+raw token, header, payload는 MDC에 넣지 마세요.
 
 ```kotlin
 import io.bluetape4k.logging.captureMdcContext

--- a/bluetape4k/logging/README.ko.md
+++ b/bluetape4k/logging/README.ko.md
@@ -184,6 +184,8 @@ MDC 복사본은 task 실행 중 worker MDC를 비웁니다. 정상 종료와 �
 worker가 실행 전에 가지고 있던 전체 map을 복원합니다.
 MDC 값은 이 API가 검증하거나 가리지 않으므로 정제된 비밀이 아닌 식별자만 사용하고,
 raw token, header, payload는 MDC에 넣지 마세요.
+복사 비용은 MDC 항목 수에 비례하고 queued task는 실행될 때까지 복사본을 보유하므로,
+MDC를 작은 low-cardinality 식별자 집합으로 유지하세요.
 
 ```kotlin
 import io.bluetape4k.logging.captureMdcContext

--- a/bluetape4k/logging/README.md
+++ b/bluetape4k/logging/README.md
@@ -182,6 +182,8 @@ Use `captureMdcContext` when a task is submitted and `withMdcContext` at the
 worker boundary. The snapshot is copied at capture time, an empty snapshot
 clears the worker MDC while the task runs, and the worker's complete previous
 map is restored after normal or exceptional completion.
+The API copies values without validation or redaction. Put only sanitized,
+non-secret identifiers in MDC; never put raw tokens, headers, or payloads there.
 
 ```kotlin
 import io.bluetape4k.logging.captureMdcContext

--- a/bluetape4k/logging/README.md
+++ b/bluetape4k/logging/README.md
@@ -184,6 +184,8 @@ clears the worker MDC while the task runs, and the worker's complete previous
 map is restored after normal or exceptional completion.
 The API copies values without validation or redaction. Put only sanitized,
 non-secret identifiers in MDC; never put raw tokens, headers, or payloads there.
+Copying is proportional to the number of MDC entries, and queued tasks retain
+their copy until execution. Keep MDC to a small, low-cardinality identifier set.
 
 ```kotlin
 import io.bluetape4k.logging.captureMdcContext

--- a/bluetape4k/logging/README.md
+++ b/bluetape4k/logging/README.md
@@ -27,7 +27,7 @@ A library that makes SLF4J logging in Kotlin easier and more efficient.
 - **Lambda-based Lazy Logging**: Messages are not constructed unless the log level is enabled — improves performance
 - **Class-level Logging**: Simple static logger definition using `KLogging`
 - **Function-level Logging**: Works in top-level and package-level functions too
-- **MDC Support**: SLF4J MDC in idiomatic Kotlin style
+- **MDC Support**: SLF4J MDC in idiomatic Kotlin style, including immutable snapshots for reusable worker tasks
 - **Coroutines Support**: MDC context propagation in coroutine environments
 - **KLoggingChannel**: High-performance async logging backed by a Coroutines channel
 - **Error Highlighting**: Automatically prepends 🔥 emoji to warn/error log messages
@@ -175,6 +175,34 @@ withLoggingContext("userId" to userId) {
     log.info { "User action logged" }
 }
 ```
+
+#### MDC Snapshots for Reusable Worker Tasks
+
+Use `captureMdcContext` when a task is submitted and `withMdcContext` at the
+worker boundary. The snapshot is copied at capture time, an empty snapshot
+clears the worker MDC while the task runs, and the worker's complete previous
+map is restored after normal or exceptional completion.
+
+```kotlin
+import io.bluetape4k.logging.captureMdcContext
+import io.bluetape4k.logging.withMdcContext
+import org.slf4j.MDC
+
+MDC.put("requestId", requestId)
+val submittedContext = captureMdcContext()
+MDC.put("requestId", "a-later-value") // does not change submittedContext
+
+executor.execute {
+    withMdcContext(submittedContext) {
+        log.info { "The submitted request context is active" }
+    }
+}
+```
+
+`withMdcContext` replaces the complete MDC for its scope and restores the
+worker's previous map in `finally`; task-local keys therefore do not leak into
+the next task. This is intentionally different from `withLoggingContext`,
+which keeps its existing key-by-key merge and empty-map no-op semantics.
 
 ### 5. MDC in Coroutines
 

--- a/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt
+++ b/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.logging
 
 import org.slf4j.MDC
+import java.util.Collections
+import java.util.LinkedHashMap
 
 /**
  * 단일 키-값을 MDC에 적용한 범위 안에서 블록을 실행합니다.
@@ -106,5 +108,32 @@ inline fun <T> withLoggingContext(
         cleanupCallbacks.forEach { callback ->
             runCatching { callback() }
         }
+    }
+}
+
+private fun immutableMdcCopy(context: Map<String, String>): Map<String, String> =
+    Collections.unmodifiableMap(LinkedHashMap(context))
+
+/** 현재 thread의 MDC 전체를 caller와 분리된 읽기 전용 MDC map으로 복사합니다. */
+fun captureMdcContext(): Map<String, String> =
+    MDC.getCopyOfContextMap()?.let(::immutableMdcCopy) ?: emptyMap()
+
+private fun replaceMdcContext(context: Map<String, String>) {
+    if (context.isEmpty()) {
+        MDC.clear()
+    } else {
+        MDC.setContextMap(context)
+    }
+}
+
+/** 전체 MDC를 scope 동안 대체하고 정상·예외 모두 scope 진입 전 context를 복원합니다. */
+fun <T> withMdcContext(context: Map<String, String>, block: () -> T): T {
+    val previous = captureMdcContext()
+    val applied = immutableMdcCopy(context)
+    return try {
+        replaceMdcContext(applied)
+        block()
+    } finally {
+        replaceMdcContext(previous)
     }
 }

--- a/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt
+++ b/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt
@@ -114,7 +114,12 @@ inline fun <T> withLoggingContext(
 private fun immutableMdcCopy(context: Map<String, String>): Map<String, String> =
     Collections.unmodifiableMap(LinkedHashMap(context))
 
-/** 현재 thread의 MDC 전체를 caller와 분리된 읽기 전용 MDC map으로 복사합니다. */
+/**
+ * 현재 thread의 MDC 전체를 caller와 분리된 읽기 전용 MDC map으로 복사합니다.
+ *
+ * MDC에는 정제된 비밀이 아닌 식별자만 넣으세요. 이 함수는 raw token, header, payload를
+ * 검증하거나 가리지 않고 그대로 복사합니다.
+ */
 fun captureMdcContext(): Map<String, String> =
     MDC.getCopyOfContextMap()?.let(::immutableMdcCopy) ?: emptyMap()
 

--- a/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt
+++ b/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt
@@ -118,7 +118,8 @@ private fun immutableMdcCopy(context: Map<String, String>): Map<String, String> 
  * 현재 thread의 MDC 전체를 caller와 분리된 읽기 전용 MDC map으로 복사합니다.
  *
  * MDC에는 정제된 비밀이 아닌 식별자만 넣으세요. 이 함수는 raw token, header, payload를
- * 검증하거나 가리지 않고 그대로 복사합니다.
+ * 검증하거나 가리지 않고 그대로 복사합니다. 비용은 MDC 항목 수에 비례하므로
+ * context는 작은 low-cardinality 식별자 집합으로 유지하세요.
  */
 fun captureMdcContext(): Map<String, String> =
     MDC.getCopyOfContextMap()?.let(::immutableMdcCopy) ?: emptyMap()

--- a/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt
+++ b/bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt
@@ -132,7 +132,16 @@ private fun replaceMdcContext(context: Map<String, String>) {
     }
 }
 
-/** 전체 MDC를 scope 동안 대체하고 정상·예외 모두 scope 진입 전 context를 복원합니다. */
+/**
+ * 전체 MDC를 [context]로 대체한 범위에서 [block]을 실행합니다.
+ *
+ * 전달 map은 적용 전에 다시 복사합니다. 빈 map은 범위 안의 MDC를 clear하며, 정상 반환과
+ * 예외 모두 범위 진입 전 전체 MDC를 복원합니다. 빈 map을 no-op으로 처리하고 key별로
+ * 병합하는 [withLoggingContext]와는 다른 전체 대체 계약입니다.
+ *
+ * @param context 범위 안에서 사용할 전체 MDC map
+ * @param block MDC가 대체된 상태에서 실행할 코드
+ */
 fun <T> withMdcContext(context: Map<String, String>, block: () -> T): T {
     val previous = captureMdcContext()
     val applied = immutableMdcCopy(context)

--- a/bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/MdcContextSnapshotTest.kt
+++ b/bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/MdcContextSnapshotTest.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.logging
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+
+class MdcContextSnapshotTest {
+    @BeforeEach
+    fun setUp() {
+        MDC.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+    }
+
+    @Test
+    fun `capture snapshot은 caller 변경과 분리된다`() {
+        MDC.setContextMap(mapOf("request" to "before", "tenant" to "blue"))
+
+        val snapshot = captureMdcContext()
+        MDC.setContextMap(mapOf("request" to "after", "late" to "value"))
+
+        assertFailsWith<UnsupportedOperationException> {
+            @Suppress("UNCHECKED_CAST")
+            (snapshot as MutableMap<String, String>)["request"] = "mutated"
+        }
+
+        withMdcContext(snapshot) {
+            MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("request" to "before", "tenant" to "blue")
+        }
+
+        snapshot shouldBeEqualTo mapOf("request" to "before", "tenant" to "blue")
+        MDC.get("request") shouldBeEqualTo "after"
+    }
+
+    @Test
+    fun `전달 map은 적용 전에 복사되어 block 안의 원본 변경과 분리된다`() {
+        val context = linkedMapOf("request" to "before")
+
+        withMdcContext(context) {
+            context["request"] = "after"
+            context["late"] = "value"
+
+            MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("request" to "before")
+        }
+
+        context shouldBeEqualTo mapOf("request" to "after", "late" to "value")
+    }
+
+    @Test
+    fun `빈 snapshot은 전체 context를 숨기고 원래 map을 복원한다`() {
+        MDC.setContextMap(mapOf("seed" to "worker", "stale" to "value"))
+
+        withMdcContext(emptyMap()) {
+            MDC.getCopyOfContextMap().orEmpty() shouldBeEqualTo emptyMap<String, String>()
+        }
+
+        MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("seed" to "worker", "stale" to "value")
+    }
+
+    @Test
+    fun `예외와 nested scope에서도 전체 context를 복원한다`() {
+        MDC.setContextMap(mapOf("scope" to "outer", "seed" to "worker"))
+
+        val failure = assertFailsWith<IllegalStateException> {
+            withMdcContext(mapOf("scope" to "inner", "inner" to "yes")) {
+                withMdcContext(mapOf("scope" to "nested")) {
+                    MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("scope" to "nested")
+                }
+                MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("scope" to "inner", "inner" to "yes")
+                error("expected")
+            }
+        }
+
+        failure.message shouldBeEqualTo "expected"
+        MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("scope" to "outer", "seed" to "worker")
+    }
+}

--- a/docs/lessons/2026-09-06-mdc-task-decorator.md
+++ b/docs/lessons/2026-09-06-mdc-task-decorator.md
@@ -1,0 +1,104 @@
+# 재사용 worker의 MDC 전파는 복사와 복원을 한 계약으로 다뤄야 한다
+
+## 문제와 결정
+
+Issue #1644는 세 Workshop 모듈에 중복된 `LoggingTaskDecorator`를 Projects의
+공용 provider로 승격하는 작업이다. 기존 구현은 `decorate` 시점에 caller map을
+읽고 worker에서 적용했지만, worker가 원래 보유한 MDC를 저장하거나 task 종료 후
+복원하지 않았다. 따라서 재사용 executor에서 stale key와 task-local key가 다음
+작업으로 남을 수 있다.
+
+다음 계약을 채택했다.
+
+| 경계 | 결정 |
+|---|---|
+| logging API | `captureMdcContext()`가 caller 전체를 새 immutable `Map<String, String>`으로 복사 |
+| 실행 scope | `withMdcContext`가 worker의 진입 map을 저장하고 caller map으로 전체 대체 |
+| 빈 caller | `MDC.clear()`로 worker 값을 task 실행 중 숨김 |
+| 종료 | 정상 반환·예외·nested 모두 `finally`에서 진입 map 복원 |
+| Spring adapter | `MdcTaskDecorator`는 wrapping만 담당하고 executor/bean/close lifecycle은 소유하지 않음 |
+| 호환성 | 기존 `withLoggingContext`의 key별 merge, 빈 map no-op semantics는 변경하지 않음 |
+
+새 public MDC 복사본 class 대신 map API를 선택했다. logging이 Spring과 독립적으로
+남고, 새 ABI·직렬화 계약 없이 기존 MDC 자료형을 재사용할 수 있기 때문이다.
+`withMdcContext`는 전달 map도 적용 전에 다시 복사해 캡처한 MDC map과 직접 전달된
+mutable map 모두 late mutation에서 격리한다. core에는 이 primitive를 호출하기 위한
+project dependency `implementation(project(":bluetape4k-logging"))`만 추가했다.
+
+## TDD 실행 증거
+
+### RED
+
+구현 전 다음 명령을 실행했다.
+
+```bash
+./gradlew :bluetape4k-logging:test \
+  --tests 'io.bluetape4k.logging.MdcContextSnapshotTest' --no-daemon
+```
+
+`compileTestKotlin`이 종료코드 1로 실패했고, 새 테스트의
+`captureMdcContext`와 `withMdcContext`가 unresolved reference로 보고됐다.
+이는 기존 logging baseline 실패가 아니라 아직 추가하지 않은 provider API를
+검출한 RED다.
+
+Spring 테스트도 구현 전 다음 명령에서 종료코드 1을 반환했다.
+
+```bash
+./gradlew :bluetape4k-spring-boot-core:test \
+  --tests 'io.bluetape4k.spring.task.MdcTaskDecoratorTest' --no-daemon
+```
+
+`MdcTaskDecorator` 부재가 `compileTestKotlin`에서 보고되어 adapter RED를
+확인했다.
+
+### GREEN
+
+최소 구현 후 다음 두 targeted test가 모두 종료코드 0으로 완료됐다.
+
+```bash
+./gradlew :bluetape4k-logging:test \
+  --tests 'io.bluetape4k.logging.MdcContextSnapshotTest' --no-daemon
+# 4 passing
+
+./gradlew :bluetape4k-spring-boot-core:test \
+  --tests 'io.bluetape4k.spring.task.MdcTaskDecoratorTest' --no-daemon
+# 5 passing
+```
+
+logging 테스트는 immutable capture, 전달 map 복사, 빈 context clear와 복원,
+예외·nested 복원을 검증한다. Spring 테스트는 하나의
+`Executors.newSingleThreadExecutor()`를 재사용해 서로 다른 caller context,
+빈 caller, 예외, nested decorator, decorate 이후 caller 변경을 검증한다.
+
+## 재발 방지 기준
+
+| 잘못된 가정 | 드러난 교훈 | 다음 작업에서 먼저 확인할 것 |
+|---|---|---|
+| `MDC.setContextMap`만 하면 task context 전파가 끝난다 | 재사용 worker의 진입 map을 저장·복원하지 않으면 task 간 오염이 남는다 | apply 전 worker MDC 복사본, 정상·예외 `finally` 복원 |
+| 빈 caller map은 기존 worker map을 그대로 둬도 된다 | caller가 context를 갖지 않는 경우도 worker stale 값이 노출되면 안 된다 | 빈 MDC 복사본을 명시적으로 `MDC.clear()` |
+| `Map` 타입이면 caller mutation이 자동으로 격리된다 | Kotlin read-only interface만으로는 backing map의 변경 가능성을 표현하지 못한다 | capture와 apply 양쪽에서 실제 map copy 및 immutable wrapper |
+| 기존 `withLoggingContext`를 재사용하면 된다 | 기존 함수는 key별 merge와 empty-map no-op라는 다른 public 계약이다 | 새 full-replace primitive를 추가하고 기존 테스트를 보존 |
+| decorator가 executor를 편의상 생성·종료해도 된다 | lifecycle ownership이 섞이면 Spring 설정과 shutdown 책임이 충돌한다 | adapter는 Runnable wrapping만 하고 lifecycle은 caller 소유 |
+
+## 검증 한계와 남은 작업
+
+- Workshop consumer migration, issue #941, PR CI, release/publish, merge는
+  provider-only 범위 밖이며 이 작업에서 검증하지 않는다.
+- targeted test는 logging 4개와 Spring core 5개가 통과했고 실패·오류·제외는
+  모두 0이었다. 전체 module build에서는 logging 55개와 Spring core 255개가
+  통과했으며 두 module의 detekt도 종료코드 0으로 완료됐다.
+- dependency diff는 `spring-boot/core`에
+  `implementation(project(":bluetape4k-logging"))` 한 줄만 추가한다. production
+  source의 concurrency quick scan에서는 이번 변경에서 새 무제한 대기·blocking·
+  `runCatching` 사용이 발견되지 않았다.
+- 한국어 문서 5개 용어 감사 findings 0과 `git diff --check` 통과를 확인했다.
+- Spring core test compile 시 기존
+  `SpringContextPropagationConformanceTest.kt`의 exhaustive `when` redundant
+  warning이 보였지만 이번 변경의 source가 아니며 별도 수정하지 않는다.
+
+## 문서 DoD
+
+문제 근거, API 선택, lifecycle 경계, 실제 RED/GREEN, 재발 방지와 검증 한계를
+한국어로 기록했다. targeted/module 명령·count·findings를 read-back했고,
+독립 여섯 관점 리뷰와 exact-head PR CI는 다음 gate로 남긴다(SPW-01–04,
+KO-01–06).

--- a/docs/superpowers/plans/2026-09-06-mdc-task-decorator-plan.md
+++ b/docs/superpowers/plans/2026-09-06-mdc-task-decorator-plan.md
@@ -1,0 +1,297 @@
+# #1644 MDC snapshot과 TaskDecorator 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** 재사용 worker에서 MDC를 안전하게 전달·복원하는 logging primitive와 Spring `TaskDecorator`를 `bluetape4k-projects`에 추가한다.
+
+**Architecture:** Spring과 독립적인 `bluetape4k/logging`의 immutable map snapshot 및 full replace/restore primitive를 먼저 만들고, `spring-boot/core`의 얇은 `MdcTaskDecorator`가 이를 호출한다. executor와 bean lifecycle은 소비자가 소유한다.
+
+**Tech Stack:** Kotlin, SLF4J MDC, Spring Framework `TaskDecorator`, JUnit 5, `bluetape4k-assertions`, Gradle version catalog.
+
+## 기준과 실행 경계
+
+- 이슈: [#1644](https://github.com/bluetape4k/bluetape4k-projects/issues/1644), milestone `2.1.0`, base `develop`.
+- 기준 head: `9811932427aac4c6cfba7b16ae3def215e93a2fe`.
+- 브랜치: `feat/issue-1644-mdc-task-decorator`.
+- 승인된 작업 위치: `/Users/debop/work/bluetape4k/bluetape4k-projects/.worktrees/feat-issue-1644-mdc-task-decorator`.
+- 이 child lane은 provider만 수정한다. Workshop, `bluetape4k-exposed-workshop`, consumer migration, release, push, PR, merge는 수정·실행하지 않는다.
+- `bluetape4k/logging` 변경은 Kotlin 패턴과 logging 테스트 지침을, `spring-boot/core` 변경은 Spring/Kotlin 패턴을 따른다.
+- 새 외부 dependency나 version catalog 변경은 금지한다. core에 필요한 project dependency는 logging 하나다.
+- 모든 public KDoc과 README/lesson/spec/plan/commit prose는 한국어로 작성하고 API 이름, 경로, 명령은 그대로 둔다.
+
+## 파일별 책임
+
+| 파일 | 책임 |
+|---|---|
+| `bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt` | immutable snapshot capture 및 full replace/restore primitive 추가; 기존 `withLoggingContext` 유지 |
+| `bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/MdcContextSnapshotTest.kt` | capture, empty, exception, nested, late mutation의 RED/GREEN 회귀 테스트 |
+| `spring-boot/core/build.gradle.kts` | logging project `implementation` 한 줄만 추가 |
+| `spring-boot/core/src/main/kotlin/io/bluetape4k/spring/task/MdcTaskDecorator.kt` | Spring `TaskDecorator` adapter; executor/bean/lifecycle 소유 없음 |
+| `spring-boot/core/src/test/kotlin/io/bluetape4k/spring/task/MdcTaskDecoratorTest.kt` | single reusable worker에서 consumer-facing contract 검증 |
+| `bluetape4k/logging/README.md`·`README.ko.md` | logging public API usage와 full replace 계약 |
+| `spring-boot/core/README.md`·`README.ko.md` | Spring executor 연결 예와 lifecycle ownership |
+| `docs/superpowers/specs/2026-09-06-mdc-task-decorator-design.md` | 승인 설계 source of truth |
+| `docs/superpowers/plans/2026-09-06-mdc-task-decorator-plan.md` | 실행 순서와 검증 명령 |
+| `docs/lessons/2026-09-06-mdc-task-decorator.md` | 실제 실패·결정·재발 방지 lesson |
+
+## 작업 1 — 승인 문서 확정 및 격리 확인
+
+복잡도: 낮음. 선행: root가 승인한 #1644 provider 범위. 산출물: 이 spec/plan 커밋.
+
+- [ ] live `gh issue view 1644 --repo bluetape4k/bluetape4k-projects`와 기준 head를 대조한다.
+- [ ] 설계 문서에 문제 근거, non-goal, immutable snapshot 계약, lifecycle 경계, 실패 모드, 테스트 matrix, acceptance criteria를 기록한다.
+- [ ] 본 계획과 설계를 read-back하고 `git diff --check`를 실행한다.
+- [ ] spec/plan만 Korean Lore commit으로 먼저 커밋한다. 이 커밋은 source/test 구현을 포함하지 않는다.
+
+문서 커밋은 다음 결정 기록을 사용한다.
+
+```text
+MDC 전파 계약을 공용 provider 설계로 고정해 consumer 중복을 줄인다
+
+Spring adapter는 logging primitive만 호출하고 executor lifecycle을 소유하지 않는다.
+Constraint: provider는 Workshop과 독립적으로 배포 가능한 public API여야 한다.
+Rejected: adapter별 MDC 직접 조작 | 복구 누락과 구현 중복을 다시 만든다.
+Confidence: high
+Scope-risk: moderate
+Directive: consumer는 decorator를 executor 구성에만 연결하고 executor 수명은 계속 소유한다.
+Tested: 문서 구조와 git diff --check
+Not-tested: 구현 전 source/test 행위
+```
+
+## 작업 2 — logging 테스트를 먼저 추가해 RED 고정
+
+복잡도: 중간. 선행: 작업 1. 파일: `MdcContextSnapshotTest.kt`.
+
+- [ ] 기존 `MdcSupportTest`의 helper와 assertion convention을 확인하고, `MDC.clear()`를 각 테스트 전후에 보장한다.
+- [ ] 다음 테스트를 production API보다 먼저 추가한다. 함수와 decorator가 아직 없으므로 test compile RED가 나와야 한다.
+
+```kotlin
+package io.bluetape4k.logging
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNullOrEmpty
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+
+class MdcContextSnapshotTest {
+    @BeforeEach
+    fun setUp() {
+        MDC.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+    }
+
+    @Test
+    fun `capture snapshot은 caller 변경과 분리된다`() {
+        MDC.put("request", "before")
+        val snapshot = captureMdcContext()
+        MDC.put("request", "after")
+
+        withMdcContext(snapshot) {
+            MDC.get("request") shouldBeEqualTo "before"
+        }
+    }
+
+    @Test
+    fun `빈 snapshot은 전체 context를 숨기고 원래 map을 복원한다`() {
+        MDC.setContextMap(mapOf("seed" to "worker", "stale" to "value"))
+
+        withMdcContext(emptyMap()) {
+            MDC.getCopyOfContextMap().orEmpty() shouldBeNullOrEmpty()
+        }
+
+        MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("seed" to "worker", "stale" to "value")
+    }
+
+    @Test
+    fun `예외와 nested scope에서도 전체 context를 복원한다`() {
+        MDC.setContextMap(mapOf("scope" to "outer"))
+        val failure = assertFailsWith<IllegalStateException> {
+            withMdcContext(mapOf("scope" to "inner", "inner" to "yes")) {
+                withMdcContext(mapOf("scope" to "nested")) {
+                    MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("scope" to "nested")
+                }
+                MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("scope" to "inner", "inner" to "yes")
+                error("expected")
+            }
+        }
+
+        failure.message shouldBeEqualTo "expected"
+        MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("scope" to "outer")
+    }
+}
+```
+
+- [ ] RED 출력에서 missing `captureMdcContext`/`withMdcContext`를 확인하고, 이를 구현 누락의 증거로 lesson에 기록한다. 기존 `withLoggingContext` 테스트가 먼저 깨지면 새 테스트가 아니라 baseline 문제이므로 원인을 진단한다.
+
+## 작업 3 — immutable MDC primitive 구현
+
+복잡도: 중간. 선행: 작업 2 RED. 파일: `MdcSupport.kt`.
+
+- [ ] 기존 import와 `withLoggingContext` 본문을 보존한다.
+- [ ] 다음 구현을 파일 하단에 추가한다.
+
+```kotlin
+private fun immutableMdcCopy(context: Map<String, String>): Map<String, String> =
+    java.util.Collections.unmodifiableMap(java.util.LinkedHashMap(context))
+
+/** 현재 thread의 MDC 전체를 caller와 분리된 읽기 전용 snapshot으로 복사합니다. */
+public fun captureMdcContext(): Map<String, String> =
+    MDC.getCopyOfContextMap()?.let(::immutableMdcCopy) ?: emptyMap()
+
+private fun replaceMdcContext(context: Map<String, String>) {
+    if (context.isEmpty()) {
+        MDC.clear()
+    } else {
+        MDC.setContextMap(context)
+    }
+}
+
+/** 전체 MDC를 scope 동안 대체하고 정상·예외 모두 scope 진입 전 context를 복원합니다. */
+public fun <T> withMdcContext(context: Map<String, String>, block: () -> T): T {
+    val previous = captureMdcContext()
+    val applied = immutableMdcCopy(context)
+    return try {
+        replaceMdcContext(applied)
+        block()
+    } finally {
+        replaceMdcContext(previous)
+    }
+}
+```
+
+- [ ] `captureMdcContext`가 null/empty MDC에서 immutable empty map을 반환하고, `withMdcContext`가 전달 map을 다시 copy하는지 확인한다.
+- [ ] `withLoggingContext`의 map filtering, null pair no-op, key별 restoration을 변경하지 않는다.
+- [ ] logging 단위 테스트를 다시 실행해 GREEN으로 전환한다.
+
+## 작업 4 — Spring adapter와 dependency 추가
+
+복잡도: 낮음. 선행: 작업 3 GREEN. 파일: core build와 새 Kotlin source.
+
+- [ ] `spring-boot/core/build.gradle.kts`의 기존 project dependency 위치에 아래 한 줄만 추가한다.
+
+```kotlin
+implementation(project(":bluetape4k-logging"))
+```
+
+- [ ] `MdcTaskDecorator.kt`를 다음 내용으로 추가한다.
+
+```kotlin
+package io.bluetape4k.spring.task
+
+import io.bluetape4k.logging.captureMdcContext
+import io.bluetape4k.logging.withMdcContext
+import org.springframework.core.task.TaskDecorator
+
+/**
+ * decorate 시점의 caller MDC를 task 실행 동안 적용하고 worker의 이전 context를 복원합니다.
+ *
+ * executor 생성·종료와 Spring bean 등록은 이 decorator의 책임이 아닙니다.
+ */
+public class MdcTaskDecorator : TaskDecorator {
+    override fun decorate(task: Runnable): Runnable {
+        val callerContext = captureMdcContext()
+        return Runnable {
+            withMdcContext(callerContext) {
+                task.run()
+            }
+        }
+    }
+}
+```
+
+- [ ] package와 class가 기존 Spring public package naming, visibility, KDoc 규칙에 맞는지 확인한다.
+- [ ] adapter production code에는 executor 생성/close, `@Bean`, `@Configuration`, global MDC mutation이 없다.
+
+## 작업 5 — single-worker Spring 테스트를 추가해 GREEN 고정
+
+복잡도: 중간. 선행: 작업 4. 파일: `MdcTaskDecoratorTest.kt`.
+
+- [ ] 테스트가 `Executors.newSingleThreadExecutor()` 하나를 `@BeforeEach`에서 만들고 `@AfterEach`에서 shutdown/await 및 caller MDC clear를 수행하게 한다.
+- [ ] worker seed와 map 관찰은 같은 executor에 제한 시간 있는 `Future.get(5, TimeUnit.SECONDS)`로 수행한다. 무제한 `get`/`join`은 사용하지 않는다.
+- [ ] 다음 사례를 모두 구현한다.
+
+```kotlin
+@Test
+fun `서로 다른 caller context와 task local key는 worker 사이에 새지 않는다`() { /* single worker에 두 decorated task 제출 */ }
+
+@Test
+fun `빈 caller context는 worker context를 숨기고 종료 후 복원한다`() { /* seed map, empty caller, post-run seed */ }
+
+@Test
+fun `예외 task도 worker context를 복원한다`() { /* cause 보존, post-run seed */ }
+
+@Test
+fun `nested decorator는 outer와 seed context를 순서대로 복원한다`() { /* inner 종료 후 outer, outer 종료 후 seed */ }
+
+@Test
+fun `decorate 이후 caller 변경은 task snapshot에 반영되지 않는다`() { /* decorate 후 caller 변경 */ }
+```
+
+위 각 주석은 테스트 이름·helper로 표현해야 하며, 실제 테스트에는 assertion을 남긴다. 테스트는 production executor lifecycle을 대신 관리하지 않는다.
+
+- [ ] Spring core targeted test를 실행하고 다섯 사례가 GREEN인지 확인한다.
+- [ ] 기존 core 테스트도 실행해 dependency 추가가 기존 Spring 지원 코드에 영향을 주지 않는지 확인한다.
+
+## 작업 6 — README와 lesson 갱신
+
+복잡도: 낮음. 선행: 작업 5 GREEN.
+
+- [ ] logging 두 README에 다음 흐름을 한국어로 설명한다: `MDC.put` → `captureMdcContext` → caller 변경 가능 → `withMdcContext` 전체 적용/복원. 빈 context가 clear된다는 점과 기존 `withLoggingContext`가 별도 semantics라는 점을 명시한다.
+- [ ] core 두 README에 `MdcTaskDecorator`를 executor 설정의 `taskDecorator`로 연결하는 예를 추가하고, executor 생성·shutdown은 애플리케이션 소유라는 주의를 명시한다.
+- [ ] `docs/lessons/2026-09-06-mdc-task-decorator.md`에 실제 RED/GREEN 명령·결과, API 선택, 실패 모드, 재발 방지와 남은 검증 gap을 기록한다. 실행하지 않은 CI/consumer migration을 통과로 쓰지 않는다.
+- [ ] README 예제가 실제 public API import/package와 일치하는지 read-back한다.
+
+## 작업 7 — 검증과 self-review
+
+복잡도: 중간. 선행: 작업 6.
+
+- [ ] `git diff --check`를 실행한다.
+- [ ] `./gradlew :bluetape4k-logging:test --tests 'io.bluetape4k.logging.MdcContextSnapshotTest'`를 실행한다.
+- [ ] `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.task.MdcTaskDecoratorTest'`를 실행한다.
+- [ ] 두 모듈 compile/build를 실행한다. core build는 logging dependency resolution을 포함해야 한다.
+- [ ] 변경된 Kotlin source의 detekt task를 실행하고, task 미존재·환경 skip은 성공으로 둔갑시키지 않는다.
+- [ ] dependency diff를 확인해 core의 새 project dependency가 logging 하나인지 확인한다.
+- [ ] `git diff develop...HEAD` 및 staged diff를 self-review한다. P0/P1 findings=0이어야 하며, public API/ABI, thread-local restore, exception path, nested path, lifecycle ownership, docs parity를 별도로 확인한다.
+- [ ] 테스트 XML에서 실패·오류·제외 count를 읽고, 제외 테스트를 통과로 집계하지 않는다.
+
+## 작업 8 — 최종 provider commit과 handoff
+
+복잡도: 낮음. 선행: 작업 7의 검증 성공. 산출물: Korean Lore commit SHA.
+
+- [ ] 의도된 파일만 stage한다. Workshop worktree, `.bluetape` owner state, unrelated changes는 포함하지 않는다.
+- [ ] 다음 형식의 한국어 Lore commit을 만든다.
+
+```text
+재사용 worker의 MDC 누수를 공용 snapshot 계약으로 차단한다
+
+caller snapshot과 worker 이전 context를 분리해 정상·예외·중첩 실행 후 상태를 복원한다.
+Constraint: adapter는 executor와 bean lifecycle을 소유하지 않아야 한다.
+Rejected: 기존 withLoggingContext 변경 | key별 병합 semantics를 사용하는 호출부를 깨뜨린다.
+Confidence: high
+Scope-risk: moderate
+Directive: consumer는 MdcTaskDecorator를 executor 구성에만 연결한다.
+Tested: logging/core targeted tests, build, detekt, git diff --check
+Not-tested: Workshop migration, PR CI, release/publish, merge
+```
+
+- [ ] commit SHA, 변경 파일, RED/GREEN evidence, dependency/API decision, risks/gaps를 parent `/root`에 보낸다.
+- [ ] push/PR/merge는 수행하지 않는다.
+
+## 완료 기준
+
+- [ ] spec/plan/lesson이 정확한 경로에 있다.
+- [ ] immutable snapshot, full replacement, worker restore가 정상·예외·nested에서 검증된다.
+- [ ] late caller mutation과 empty caller context가 검증된다.
+- [ ] `withLoggingContext` 기존 semantics가 유지된다.
+- [ ] core dependency diff가 필요한 project dependency 하나로 제한된다.
+- [ ] README parity와 한국어 KDoc이 완료된다.
+- [ ] targeted tests/build/detekt/diff check 및 P0/P1 self-review evidence가 있다.
+- [ ] provider-only Korean Lore commit을 만들었고 push/PR/merge와 Workshop 변경은 없다.
+

--- a/docs/superpowers/plans/2026-09-06-mdc-task-decorator-plan.md
+++ b/docs/superpowers/plans/2026-09-06-mdc-task-decorator-plan.md
@@ -1,10 +1,10 @@
-# #1644 MDC snapshot과 TaskDecorator 구현 계획
+# #1644 MDC 복사본과 TaskDecorator 구현 계획
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
 
 **Goal:** 재사용 worker에서 MDC를 안전하게 전달·복원하는 logging primitive와 Spring `TaskDecorator`를 `bluetape4k-projects`에 추가한다.
 
-**Architecture:** Spring과 독립적인 `bluetape4k/logging`의 immutable map snapshot 및 full replace/restore primitive를 먼저 만들고, `spring-boot/core`의 얇은 `MdcTaskDecorator`가 이를 호출한다. executor와 bean lifecycle은 소비자가 소유한다.
+**Architecture:** Spring과 독립적인 `bluetape4k/logging`의 불변 MDC map 복사본 및 full replace/restore primitive를 먼저 만들고, `spring-boot/core`의 얇은 `MdcTaskDecorator`가 이를 호출한다. executor와 bean lifecycle은 소비자가 소유한다.
 
 **Tech Stack:** Kotlin, SLF4J MDC, Spring Framework `TaskDecorator`, JUnit 5, `bluetape4k-assertions`, Gradle version catalog.
 
@@ -23,7 +23,7 @@
 
 | 파일 | 책임 |
 |---|---|
-| `bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt` | immutable snapshot capture 및 full replace/restore primitive 추가; 기존 `withLoggingContext` 유지 |
+| `bluetape4k/logging/src/main/kotlin/io/bluetape4k/logging/MdcSupport.kt` | 불변 MDC map capture 및 full replace/restore primitive 추가; 기존 `withLoggingContext` 유지 |
 | `bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/MdcContextSnapshotTest.kt` | capture, empty, exception, nested, late mutation의 RED/GREEN 회귀 테스트 |
 | `spring-boot/core/build.gradle.kts` | logging project `implementation` 한 줄만 추가 |
 | `spring-boot/core/src/main/kotlin/io/bluetape4k/spring/task/MdcTaskDecorator.kt` | Spring `TaskDecorator` adapter; executor/bean/lifecycle 소유 없음 |
@@ -38,10 +38,10 @@
 
 복잡도: 낮음. 선행: root가 승인한 #1644 provider 범위. 산출물: 이 spec/plan 커밋.
 
-- [ ] live `gh issue view 1644 --repo bluetape4k/bluetape4k-projects`와 기준 head를 대조한다.
-- [ ] 설계 문서에 문제 근거, non-goal, immutable snapshot 계약, lifecycle 경계, 실패 모드, 테스트 matrix, acceptance criteria를 기록한다.
-- [ ] 본 계획과 설계를 read-back하고 `git diff --check`를 실행한다.
-- [ ] spec/plan만 Korean Lore commit으로 먼저 커밋한다. 이 커밋은 source/test 구현을 포함하지 않는다.
+- [x] live `gh issue view 1644 --repo bluetape4k/bluetape4k-projects`와 기준 head를 대조한다.
+- [x] 설계 문서에 문제 근거, non-goal, 불변 MDC 복사본 계약, lifecycle 경계, 실패 모드, 테스트 matrix, acceptance criteria를 기록한다.
+- [x] 본 계획과 설계를 read-back하고 `git diff --check`를 실행한다.
+- [x] spec/plan만 Korean Lore commit으로 먼저 커밋한다. 이 커밋은 source/test 구현을 포함하지 않는다.
 
 문서 커밋은 다음 결정 기록을 사용한다.
 
@@ -62,8 +62,8 @@ Not-tested: 구현 전 source/test 행위
 
 복잡도: 중간. 선행: 작업 1. 파일: `MdcContextSnapshotTest.kt`.
 
-- [ ] 기존 `MdcSupportTest`의 helper와 assertion convention을 확인하고, `MDC.clear()`를 각 테스트 전후에 보장한다.
-- [ ] 다음 테스트를 production API보다 먼저 추가한다. 함수와 decorator가 아직 없으므로 test compile RED가 나와야 한다.
+- [x] 기존 `MdcSupportTest`의 helper와 assertion convention을 확인하고, `MDC.clear()`를 각 테스트 전후에 보장한다.
+- [x] 다음 테스트를 production API보다 먼저 추가한다. 함수와 decorator가 아직 없으므로 test compile RED가 나와야 한다.
 
 ```kotlin
 package io.bluetape4k.logging
@@ -128,14 +128,14 @@ class MdcContextSnapshotTest {
 }
 ```
 
-- [ ] RED 출력에서 missing `captureMdcContext`/`withMdcContext`를 확인하고, 이를 구현 누락의 증거로 lesson에 기록한다. 기존 `withLoggingContext` 테스트가 먼저 깨지면 새 테스트가 아니라 baseline 문제이므로 원인을 진단한다.
+- [x] RED 출력에서 missing `captureMdcContext`/`withMdcContext`를 확인하고, 이를 구현 누락의 증거로 lesson에 기록한다. 기존 `withLoggingContext` 테스트가 먼저 깨지면 새 테스트가 아니라 baseline 문제이므로 원인을 진단한다.
 
 ## 작업 3 — immutable MDC primitive 구현
 
 복잡도: 중간. 선행: 작업 2 RED. 파일: `MdcSupport.kt`.
 
-- [ ] 기존 import와 `withLoggingContext` 본문을 보존한다.
-- [ ] 다음 구현을 파일 하단에 추가한다.
+- [x] 기존 import와 `withLoggingContext` 본문을 보존한다.
+- [x] 다음 구현을 파일 하단에 추가한다.
 
 ```kotlin
 private fun immutableMdcCopy(context: Map<String, String>): Map<String, String> =
@@ -166,21 +166,21 @@ public fun <T> withMdcContext(context: Map<String, String>, block: () -> T): T {
 }
 ```
 
-- [ ] `captureMdcContext`가 null/empty MDC에서 immutable empty map을 반환하고, `withMdcContext`가 전달 map을 다시 copy하는지 확인한다.
-- [ ] `withLoggingContext`의 map filtering, null pair no-op, key별 restoration을 변경하지 않는다.
-- [ ] logging 단위 테스트를 다시 실행해 GREEN으로 전환한다.
+- [x] `captureMdcContext`가 null/empty MDC에서 immutable empty map을 반환하고, `withMdcContext`가 전달 map을 다시 copy하는지 확인한다.
+- [x] `withLoggingContext`의 map filtering, null pair no-op, key별 restoration을 변경하지 않는다.
+- [x] logging 단위 테스트를 다시 실행해 GREEN으로 전환한다.
 
 ## 작업 4 — Spring adapter와 dependency 추가
 
 복잡도: 낮음. 선행: 작업 3 GREEN. 파일: core build와 새 Kotlin source.
 
-- [ ] `spring-boot/core/build.gradle.kts`의 기존 project dependency 위치에 아래 한 줄만 추가한다.
+- [x] `spring-boot/core/build.gradle.kts`의 기존 project dependency 위치에 아래 한 줄만 추가한다.
 
 ```kotlin
 implementation(project(":bluetape4k-logging"))
 ```
 
-- [ ] `MdcTaskDecorator.kt`를 다음 내용으로 추가한다.
+- [x] `MdcTaskDecorator.kt`를 다음 내용으로 추가한다.
 
 ```kotlin
 package io.bluetape4k.spring.task
@@ -206,16 +206,16 @@ public class MdcTaskDecorator : TaskDecorator {
 }
 ```
 
-- [ ] package와 class가 기존 Spring public package naming, visibility, KDoc 규칙에 맞는지 확인한다.
-- [ ] adapter production code에는 executor 생성/close, `@Bean`, `@Configuration`, global MDC mutation이 없다.
+- [x] package와 class가 기존 Spring public package naming, visibility, KDoc 규칙에 맞는지 확인한다.
+- [x] adapter production code에는 executor 생성/close, `@Bean`, `@Configuration`, global MDC mutation이 없다.
 
 ## 작업 5 — single-worker Spring 테스트를 추가해 GREEN 고정
 
 복잡도: 중간. 선행: 작업 4. 파일: `MdcTaskDecoratorTest.kt`.
 
-- [ ] 테스트가 `Executors.newSingleThreadExecutor()` 하나를 `@BeforeEach`에서 만들고 `@AfterEach`에서 shutdown/await 및 caller MDC clear를 수행하게 한다.
-- [ ] worker seed와 map 관찰은 같은 executor에 제한 시간 있는 `Future.get(5, TimeUnit.SECONDS)`로 수행한다. 무제한 `get`/`join`은 사용하지 않는다.
-- [ ] 다음 사례를 모두 구현한다.
+- [x] 테스트가 `Executors.newSingleThreadExecutor()` 하나를 `@BeforeEach`에서 만들고 `@AfterEach`에서 shutdown/await 및 caller MDC clear를 수행하게 한다.
+- [x] worker seed와 map 관찰은 같은 executor에 제한 시간 있는 `Future.get(5, TimeUnit.SECONDS)`로 수행한다. 무제한 `get`/`join`은 사용하지 않는다.
+- [x] 다음 사례를 모두 구현한다.
 
 ```kotlin
 @Test
@@ -236,30 +236,30 @@ fun `decorate 이후 caller 변경은 task snapshot에 반영되지 않는다`()
 
 위 각 주석은 테스트 이름·helper로 표현해야 하며, 실제 테스트에는 assertion을 남긴다. 테스트는 production executor lifecycle을 대신 관리하지 않는다.
 
-- [ ] Spring core targeted test를 실행하고 다섯 사례가 GREEN인지 확인한다.
-- [ ] 기존 core 테스트도 실행해 dependency 추가가 기존 Spring 지원 코드에 영향을 주지 않는지 확인한다.
+- [x] Spring core targeted test를 실행하고 다섯 사례가 GREEN인지 확인한다.
+- [x] 기존 core 테스트도 실행해 dependency 추가가 기존 Spring 지원 코드에 영향을 주지 않는지 확인한다.
 
 ## 작업 6 — README와 lesson 갱신
 
 복잡도: 낮음. 선행: 작업 5 GREEN.
 
-- [ ] logging 두 README에 다음 흐름을 한국어로 설명한다: `MDC.put` → `captureMdcContext` → caller 변경 가능 → `withMdcContext` 전체 적용/복원. 빈 context가 clear된다는 점과 기존 `withLoggingContext`가 별도 semantics라는 점을 명시한다.
-- [ ] core 두 README에 `MdcTaskDecorator`를 executor 설정의 `taskDecorator`로 연결하는 예를 추가하고, executor 생성·shutdown은 애플리케이션 소유라는 주의를 명시한다.
-- [ ] `docs/lessons/2026-09-06-mdc-task-decorator.md`에 실제 RED/GREEN 명령·결과, API 선택, 실패 모드, 재발 방지와 남은 검증 gap을 기록한다. 실행하지 않은 CI/consumer migration을 통과로 쓰지 않는다.
-- [ ] README 예제가 실제 public API import/package와 일치하는지 read-back한다.
+- [x] logging 두 README에 다음 흐름을 한국어로 설명한다: `MDC.put` → `captureMdcContext` → caller 변경 가능 → `withMdcContext` 전체 적용/복원. 빈 context가 clear된다는 점과 기존 `withLoggingContext`가 별도 semantics라는 점을 명시한다.
+- [x] core 두 README에 `MdcTaskDecorator`를 executor 설정의 `taskDecorator`로 연결하는 예를 추가하고, executor 생성·shutdown은 애플리케이션 소유라는 주의를 명시한다.
+- [x] `docs/lessons/2026-09-06-mdc-task-decorator.md`에 실제 RED/GREEN 명령·결과, API 선택, 실패 모드, 재발 방지와 남은 검증 gap을 기록한다. 실행하지 않은 CI/consumer migration을 통과로 쓰지 않는다.
+- [x] README 예제가 실제 public API import/package와 일치하는지 read-back한다.
 
 ## 작업 7 — 검증과 self-review
 
 복잡도: 중간. 선행: 작업 6.
 
-- [ ] `git diff --check`를 실행한다.
-- [ ] `./gradlew :bluetape4k-logging:test --tests 'io.bluetape4k.logging.MdcContextSnapshotTest'`를 실행한다.
-- [ ] `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.task.MdcTaskDecoratorTest'`를 실행한다.
-- [ ] 두 모듈 compile/build를 실행한다. core build는 logging dependency resolution을 포함해야 한다.
-- [ ] 변경된 Kotlin source의 detekt task를 실행하고, task 미존재·환경 skip은 성공으로 둔갑시키지 않는다.
-- [ ] dependency diff를 확인해 core의 새 project dependency가 logging 하나인지 확인한다.
+- [x] `git diff --check`를 실행한다.
+- [x] `./gradlew :bluetape4k-logging:test --tests 'io.bluetape4k.logging.MdcContextSnapshotTest'`를 실행한다.
+- [x] `./gradlew :bluetape4k-spring-boot-core:test --tests 'io.bluetape4k.spring.task.MdcTaskDecoratorTest'`를 실행한다.
+- [x] 두 모듈 compile/build를 실행한다. core build는 logging dependency resolution을 포함해야 한다.
+- [x] 변경된 Kotlin source의 detekt task를 실행하고, task 미존재·환경 skip은 성공으로 둔갑시키지 않는다.
+- [x] dependency diff를 확인해 core의 새 project dependency가 logging 하나인지 확인한다.
 - [ ] `git diff develop...HEAD` 및 staged diff를 self-review한다. P0/P1 findings=0이어야 하며, public API/ABI, thread-local restore, exception path, nested path, lifecycle ownership, docs parity를 별도로 확인한다.
-- [ ] 테스트 XML에서 실패·오류·제외 count를 읽고, 제외 테스트를 통과로 집계하지 않는다.
+- [x] 테스트 XML에서 실패·오류·제외 count를 읽고, 제외 테스트를 통과로 집계하지 않는다.
 
 ## 작업 8 — 최종 provider commit과 handoff
 
@@ -269,7 +269,7 @@ fun `decorate 이후 caller 변경은 task snapshot에 반영되지 않는다`()
 - [ ] 다음 형식의 한국어 Lore commit을 만든다.
 
 ```text
-재사용 worker의 MDC 누수를 공용 snapshot 계약으로 차단한다
+재사용 worker의 MDC 누수를 공용 복사·복원 계약으로 차단한다
 
 caller snapshot과 worker 이전 context를 분리해 정상·예외·중첩 실행 후 상태를 복원한다.
 Constraint: adapter는 executor와 bean lifecycle을 소유하지 않아야 한다.
@@ -286,12 +286,11 @@ Not-tested: Workshop migration, PR CI, release/publish, merge
 
 ## 완료 기준
 
-- [ ] spec/plan/lesson이 정확한 경로에 있다.
-- [ ] immutable snapshot, full replacement, worker restore가 정상·예외·nested에서 검증된다.
-- [ ] late caller mutation과 empty caller context가 검증된다.
-- [ ] `withLoggingContext` 기존 semantics가 유지된다.
-- [ ] core dependency diff가 필요한 project dependency 하나로 제한된다.
-- [ ] README parity와 한국어 KDoc이 완료된다.
+- [x] spec/plan/lesson이 정확한 경로에 있다.
+- [x] 불변 MDC 복사본, full replacement, worker restore가 정상·예외·nested에서 검증된다.
+- [x] late caller mutation과 empty caller context가 검증된다.
+- [x] `withLoggingContext` 기존 semantics가 유지된다.
+- [x] core dependency diff가 필요한 project dependency 하나로 제한된다.
+- [x] README parity와 한국어 KDoc이 완료된다.
 - [ ] targeted tests/build/detekt/diff check 및 P0/P1 self-review evidence가 있다.
 - [ ] provider-only Korean Lore commit을 만들었고 push/PR/merge와 Workshop 변경은 없다.
-

--- a/docs/superpowers/specs/2026-09-06-mdc-task-decorator-design.md
+++ b/docs/superpowers/specs/2026-09-06-mdc-task-decorator-design.md
@@ -1,4 +1,4 @@
-# #1644 MDC snapshot과 공용 TaskDecorator 설계
+# #1644 MDC 복사본과 공용 TaskDecorator 설계
 
 ## 목적과 승인 범위
 
@@ -20,9 +20,9 @@
 
 ### 목표
 
-- caller의 현재 MDC 전체를 `decorate` 호출 시점에 복사하는 immutable snapshot API를 `bluetape4k/logging`에 추가한다.
-- worker task 실행 시 worker가 가진 이전 MDC 전체를 캡처하고 caller snapshot으로 완전히 대체한다.
-- caller snapshot이 비어 있으면 worker MDC를 반드시 clear하여 caller context가 없는 task가 worker context를 관찰하지 않게 한다.
+- caller의 현재 MDC 전체를 `decorate` 호출 시점에 복사하는 불변 MDC map API를 `bluetape4k/logging`에 추가한다.
+- worker task 실행 시 worker가 가진 이전 MDC 전체를 캡처하고 caller MDC 복사본으로 완전히 대체한다.
+- caller MDC 복사본이 비어 있으면 worker MDC를 반드시 clear하여 caller context가 없는 task가 worker context를 관찰하지 않게 한다.
 - 정상 반환, 예외, 중첩 실행의 모든 경로에서 worker의 이전 전체 MDC를 복원한다. task가 추가한 key도 복원 후 사라져야 한다.
 - `spring-boot/core`에 executor의 생성·shutdown·close와 bean 자동 등록을 소유하지 않는 재사용 가능한 `MdcTaskDecorator`를 제공한다.
 - single worker를 재사용하는 테스트로 서로 다른 context, 빈 context, 예외, 중첩, decorate 이후 caller 변경을 검증한다.
@@ -47,8 +47,8 @@ fun <T> withMdcContext(context: Map<String, String>, block: () -> T): T
 ```
 
 - `captureMdcContext()`는 현재 thread의 MDC 전체를 새 `LinkedHashMap`으로 복사하고 실제 변경 불가능한 `Map`으로 감싼다. MDC가 없거나 비어 있으면 빈 map을 반환한다.
-- `withMdcContext`는 전달 map도 다시 복사하여 caller가 이후 원본 mutable map을 바꾸거나 snapshot을 우회 변경해도 실행 중 context가 바뀌지 않게 한다.
-- block 시작 전에 현재 worker MDC 전체를 capture하고, 전달 snapshot이 비어 있으면 `MDC.clear()`, 아니면 `MDC.setContextMap`으로 전체를 대체한다.
+- `withMdcContext`는 전달 map도 다시 복사하여 caller가 이후 원본 mutable map을 바꾸거나 MDC 복사본을 우회 변경해도 실행 중 context가 바뀌지 않게 한다.
+- block 시작 전에 현재 worker MDC 전체를 capture하고, 전달 MDC 복사본이 비어 있으면 `MDC.clear()`, 아니면 `MDC.setContextMap`으로 전체를 대체한다.
 - block이 정상 반환하거나 예외를 던져도 `finally`에서 capture한 worker MDC 전체를 같은 방식으로 복구한다.
 - `withLoggingContext`는 기존 key별 병합·복원 구현을 그대로 유지한다. 전체 대체가 필요한 adapter만 새 primitive를 사용한다.
 
@@ -56,9 +56,9 @@ fun <T> withMdcContext(context: Map<String, String>, block: () -> T): T
 
 | 시점 | 상태 | 계약 |
 |---|---|---|
-| `decorate(task)` 호출 | caller MDC | caller 전체를 immutable snapshot으로 복사 |
+| `decorate(task)` 호출 | caller MDC | caller 전체를 불변 MDC map으로 복사 |
 | worker `run()` 진입 | worker MDC | worker의 이전 전체 map을 capture |
-| task 실행 | worker MDC | 빈 snapshot이면 clear, 아니면 caller snapshot으로 전체 대체 |
+| task 실행 | worker MDC | 빈 MDC 복사본이면 clear, 아니면 caller MDC 복사본으로 전체 대체 |
 | task 종료 | worker MDC | 정상·예외 모두 이전 worker map으로 전체 복원 |
 | nested decorator 종료 | outer task MDC | inner 진입 전 outer map으로 복원하고, outer 종료 후 원래 worker map으로 복원 |
 
@@ -85,17 +85,17 @@ adapter는 task wrapping만 책임진다. `TaskExecutor`, `ExecutorService`, Spr
 
 | 선택지 | 판정 | 이유 |
 |---|---|---|
-| `Map<String, String>` snapshot + `withMdcContext` | 채택 | logging이 Spring과 독립적이고 호출부가 작으며 기존 map 기반 MDC와 직접 맞는다. 읽기 전용 Kotlin 타입과 실제 unmodifiable copy로 late mutation을 차단한다. |
+| `Map<String, String>` MDC 복사본 + `withMdcContext` | 채택 | logging이 Spring과 독립적이고 호출부가 작으며 기존 map 기반 MDC와 직접 맞는다. 읽기 전용 Kotlin 타입과 실제 unmodifiable copy로 late mutation을 차단한다. |
 | public `MdcContextSnapshot` data class | 기각 | 새 public ABI·직렬화 계약을 만들고, 단순 map보다 소비자·binary compatibility 부담이 커진다. 이 값은 도메인 객체가 아니라 일회성 실행 경계다. |
 | Spring adapter에서 MDC를 직접 조작 | 기각 | Workshop의 중복 구현과 복구 누락을 다시 만들며, non-Spring executor 소비자가 같은 복구 계약을 재사용할 수 없다. |
-| caller map을 그대로 `setContextMap`에 전달 | 기각 | caller의 late mutation과 backend의 map 보관 방식에 의해 snapshot 계약이 깨진다. |
+| caller map을 그대로 `setContextMap`에 전달 | 기각 | caller의 late mutation과 backend의 map 보관 방식에 의해 불변 복사 계약이 깨진다. |
 | 기존 `withLoggingContext`를 전체 대체 semantics로 변경 | 기각 | 현재 key별 병합·빈 map no-op semantics를 사용하는 호출부를 깨뜨린다. 새 primitive를 별도로 둔다. |
 
 ## 실패 모드와 대응
 
 | 실패 모드 | 탐지 방법 | 대응 |
 |---|---|---|
-| caller가 decorate 후 MDC를 변경했는데 worker가 변경된 값을 봄 | decorate 후 caller key를 변경하고 worker가 원래 snapshot을 읽는 테스트 | decorate 시 새 map을 복사하고 immutable wrapper 사용 |
+| caller가 decorate 후 MDC를 변경했는데 worker가 변경된 값을 봄 | decorate 후 caller key를 변경하고 worker가 원래 MDC 복사본을 읽는 테스트 | decorate 시 새 map을 복사하고 immutable wrapper 사용 |
 | 빈 caller context가 worker의 stale key를 봄 | worker에 seed map을 넣은 뒤 빈 caller task에서 map을 확인 | 적용 단계에서 `MDC.clear()` 수행 |
 | task가 추가한 key가 다음 task로 샘 | 동일 single worker에서 task 종료 후 seed map과 비교 | `finally`에서 이전 전체 map을 다시 설정 |
 | 예외 task가 worker context를 오염시킴 | task가 예외를 던진 뒤 같은 worker map을 검사 | 예외를 삼키지 않고 `finally` 복원 |
@@ -109,8 +109,8 @@ adapter는 task wrapping만 책임진다. `TaskExecutor`, `ExecutorService`, Spr
 
 `bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/MdcContextSnapshotTest.kt`에 다음을 둔다.
 
-- snapshot이 capture 시점의 값만 가지며 late caller mutation과 분리된다.
-- 빈 snapshot이 현재 전체 MDC를 숨기고, block 종료 후 기존 map(추가 key 포함)을 복구한다.
+- MDC 복사본이 capture 시점의 값만 가지며 late caller mutation과 분리된다.
+- 빈 MDC 복사본이 현재 전체 MDC를 숨기고, block 종료 후 기존 map(추가 key 포함)을 복구한다.
 - block 예외 후에도 기존 map을 복구한다.
 - nested context가 inner 종료 후 outer, outer 종료 후 원래 map을 복구한다.
 - 기존 `MdcSupportTest`의 `withLoggingContext` 사례는 수정하지 않고 회귀 기준으로 유지한다.
@@ -125,14 +125,14 @@ adapter는 task wrapping만 책임진다. `TaskExecutor`, `ExecutorService`, Spr
 | 빈 caller context | worker seed context가 task 실행 중 보이지 않고 task 후 seed map 복구 |
 | 예외 | `Future.get`의 원인 예외를 보존하면서 worker seed map 복구 |
 | 중첩 decorator | inner 종료 후 outer map, outer 종료 후 seed map 복구 |
-| decorate 후 변경 | caller 변경이 이미 wrapping된 task의 snapshot에 영향을 주지 않음 |
+| decorate 후 변경 | caller 변경이 이미 wrapping된 task의 MDC 복사본에 영향을 주지 않음 |
 
 모든 사례는 동일 worker에서 제한 시간 있는 `Future.get`을 사용하고, 테스트 `finally`에서 executor와 caller MDC를 정리한다. 테스트가 executor lifecycle을 소유하는 것은 production API가 소유하지 않음을 검증하기 위한 것이다.
 
 ## 문서와 호환성
 
 - public API의 한국어 KDoc을 추가한다.
-- `bluetape4k/logging/README.md`·`README.ko.md`에 snapshot과 reusable worker 사용 예를 같은 계약으로 추가한다.
+- `bluetape4k/logging/README.md`·`README.ko.md`에 MDC 복사본과 reusable worker 사용 예를 같은 계약으로 추가한다.
 - `spring-boot/core/README.md`·`README.ko.md`에 `MdcTaskDecorator` 연결 예와 executor lifecycle이 caller 소유라는 주의를 추가한다.
 - `spring-boot/core/build.gradle.kts`에는 `implementation(project(":bluetape4k-logging"))`만 추가한다. 외부 의존성, catalog, version은 변경하지 않는다.
 - package 자동 등록이나 Spring auto-configuration은 만들지 않으므로 settings/module registration 변경이 없다.
@@ -142,8 +142,8 @@ adapter는 task wrapping만 책임진다. `TaskExecutor`, `ExecutorService`, Spr
 | ID | 완료 조건 | 증거 |
 |---|---|---|
 | AC-01 | 승인된 spec/plan/lesson이 정확한 경로에 있고 한국어 문서 검사를 통과 | 파일 read-back, `git diff --check` |
-| AC-02 | logging snapshot이 capture/apply/restore 전체 계약을 제공 | logging 단위 테스트의 RED/GREEN 결과 |
-| AC-03 | `MdcTaskDecorator`가 caller snapshot을 decorate 시점에 잡고 worker 이전 map을 복원 | Spring single-worker 테스트 GREEN |
+| AC-02 | logging MDC 복사본이 capture/apply/restore 전체 계약을 제공 | logging 단위 테스트의 RED/GREEN 결과 |
+| AC-03 | `MdcTaskDecorator`가 caller MDC map을 decorate 시점에 잡고 worker 이전 map을 복원 | Spring single-worker 테스트 GREEN |
 | AC-04 | `withLoggingContext` semantics와 기존 테스트가 유지 | 기존 logging 테스트 및 diff self-review |
 | AC-05 | core에는 필요한 project dependency 하나만 추가 | build diff와 dependency graph |
 | AC-06 | public KDoc과 두 언어 README가 API 계약과 일치 | 문서 read-back·용어 audit |
@@ -156,4 +156,3 @@ adapter는 task wrapping만 책임진다. `TaskExecutor`, `ExecutorService`, Spr
 수락 기준을 기록했다. 승인된 provider-only 범위를 넘는 Workshop 변경·PR·merge는
 보류한다. 구현 후 lesson에 실제 RED/GREEN과 검증 한계를 갱신하고, 최종 diff에서
 P0/P1 findings=0을 확인한다.
-

--- a/docs/superpowers/specs/2026-09-06-mdc-task-decorator-design.md
+++ b/docs/superpowers/specs/2026-09-06-mdc-task-decorator-design.md
@@ -1,0 +1,159 @@
+# #1644 MDC snapshot과 공용 TaskDecorator 설계
+
+## 목적과 승인 범위
+
+- 이슈: [#1644](https://github.com/bluetape4k/bluetape4k-projects/issues/1644), milestone `2.1.0`, 담당자 `debop`.
+- 기준 커밋: `9811932427aac4c6cfba7b16ae3def215e93a2fe` (`develop`).
+- 작업 브랜치: `feat/issue-1644-mdc-task-decorator`, PR base: `develop`.
+- 사용자가 승인한 #1639, #1641, #1642, #1644 provider-first 작업 중 Projects provider 범위만 다룬다. Workshop 소비자 이관, push, PR 생성, merge는 이 작업에 포함하지 않는다.
+- 문제의 성격은 Projects의 재현된 운영 장애가 아니라, 세 Workshop 모듈에 중복된 MDC 전달 코드에서 공통 계약을 승격하는 P2 개선이다.
+
+## 현재 근거
+
+1. live issue #1644는 `bluetape4k-projects`에 public Spring `TaskDecorator`를 제공하고, Spring과 무관한 logging primitive를 필요한 경우 별도로 제공하도록 요구한다.
+2. 이슈가 가리키는 세 Workshop의 `LoggingTaskDecorator`는 `decorate` 시점에 `MDC.getCopyOfContextMap()`을 읽어 worker에서 `MDC.setContextMap`만 수행한다. worker가 원래 가지고 있던 context를 저장하거나 `finally`에서 복구하지 않으므로 재사용 executor에서 task 간 누수가 가능하다.
+3. Projects의 `bluetape4k/logging` `MdcSupport.kt`에 있는 `withLoggingContext`는 key 단위로 context를 병합하고 기존 key별 의미(빈 map은 no-op, null value 무시, block 종료 후 key별 복원)를 이미 제공한다. 이 동작은 호환성을 위해 변경하지 않는다.
+4. `bluetape4k/logging`은 Spring에 의존하지 않으며 `spring-boot/core`는 현재 logging 프로젝트를 runtime dependency로 사용하지 않는다. 따라서 adapter가 primitive를 호출하기 위한 project dependency 하나만 core에 추가한다.
+5. 세 소비자의 실제 migration과 artifact/catalog 호환성은 Workshop 이슈 #941의 후속 범위다. 이 설계는 provider API와 그 독립 검증까지만 확정한다.
+
+## 목표와 비목표
+
+### 목표
+
+- caller의 현재 MDC 전체를 `decorate` 호출 시점에 복사하는 immutable snapshot API를 `bluetape4k/logging`에 추가한다.
+- worker task 실행 시 worker가 가진 이전 MDC 전체를 캡처하고 caller snapshot으로 완전히 대체한다.
+- caller snapshot이 비어 있으면 worker MDC를 반드시 clear하여 caller context가 없는 task가 worker context를 관찰하지 않게 한다.
+- 정상 반환, 예외, 중첩 실행의 모든 경로에서 worker의 이전 전체 MDC를 복원한다. task가 추가한 key도 복원 후 사라져야 한다.
+- `spring-boot/core`에 executor의 생성·shutdown·close와 bean 자동 등록을 소유하지 않는 재사용 가능한 `MdcTaskDecorator`를 제공한다.
+- single worker를 재사용하는 테스트로 서로 다른 context, 빈 context, 예외, 중첩, decorate 이후 caller 변경을 검증한다.
+
+### 비목표
+
+- 기존 `withLoggingContext`의 semantics 또는 public signature 변경.
+- executor 생성, thread pool 크기·정책, shutdown/close, Spring bean 자동 등록 또는 auto-configuration.
+- coroutine `MDCContext` 경로, Reactor context, logging backend 교체.
+- Workshop 코드 수정, 소비자 migration, release/publish, PR/merge.
+
+## 선택한 API와 동작 계약
+
+### Logging primitive
+
+`bluetape4k/logging`에 다음 두 함수를 추가한다.
+
+```kotlin
+fun captureMdcContext(): Map<String, String>
+
+fun <T> withMdcContext(context: Map<String, String>, block: () -> T): T
+```
+
+- `captureMdcContext()`는 현재 thread의 MDC 전체를 새 `LinkedHashMap`으로 복사하고 실제 변경 불가능한 `Map`으로 감싼다. MDC가 없거나 비어 있으면 빈 map을 반환한다.
+- `withMdcContext`는 전달 map도 다시 복사하여 caller가 이후 원본 mutable map을 바꾸거나 snapshot을 우회 변경해도 실행 중 context가 바뀌지 않게 한다.
+- block 시작 전에 현재 worker MDC 전체를 capture하고, 전달 snapshot이 비어 있으면 `MDC.clear()`, 아니면 `MDC.setContextMap`으로 전체를 대체한다.
+- block이 정상 반환하거나 예외를 던져도 `finally`에서 capture한 worker MDC 전체를 같은 방식으로 복구한다.
+- `withLoggingContext`는 기존 key별 병합·복원 구현을 그대로 유지한다. 전체 대체가 필요한 adapter만 새 primitive를 사용한다.
+
+실행 순서는 다음과 같다.
+
+| 시점 | 상태 | 계약 |
+|---|---|---|
+| `decorate(task)` 호출 | caller MDC | caller 전체를 immutable snapshot으로 복사 |
+| worker `run()` 진입 | worker MDC | worker의 이전 전체 map을 capture |
+| task 실행 | worker MDC | 빈 snapshot이면 clear, 아니면 caller snapshot으로 전체 대체 |
+| task 종료 | worker MDC | 정상·예외 모두 이전 worker map으로 전체 복원 |
+| nested decorator 종료 | outer task MDC | inner 진입 전 outer map으로 복원하고, outer 종료 후 원래 worker map으로 복원 |
+
+### Spring adapter
+
+새 public 타입은 `io.bluetape4k.spring.task.MdcTaskDecorator`로 둔다.
+
+```kotlin
+public class MdcTaskDecorator : TaskDecorator {
+    override fun decorate(task: Runnable): Runnable {
+        val callerContext = captureMdcContext()
+        return Runnable {
+            withMdcContext(callerContext) {
+                task.run()
+            }
+        }
+    }
+}
+```
+
+adapter는 task wrapping만 책임진다. `TaskExecutor`, `ExecutorService`, Spring `@Bean`, lifecycle callback을 만들거나 닫지 않는다. 사용자는 자신의 executor 설정에서 `taskDecorator`로 연결한다.
+
+### API 선택과 대안
+
+| 선택지 | 판정 | 이유 |
+|---|---|---|
+| `Map<String, String>` snapshot + `withMdcContext` | 채택 | logging이 Spring과 독립적이고 호출부가 작으며 기존 map 기반 MDC와 직접 맞는다. 읽기 전용 Kotlin 타입과 실제 unmodifiable copy로 late mutation을 차단한다. |
+| public `MdcContextSnapshot` data class | 기각 | 새 public ABI·직렬화 계약을 만들고, 단순 map보다 소비자·binary compatibility 부담이 커진다. 이 값은 도메인 객체가 아니라 일회성 실행 경계다. |
+| Spring adapter에서 MDC를 직접 조작 | 기각 | Workshop의 중복 구현과 복구 누락을 다시 만들며, non-Spring executor 소비자가 같은 복구 계약을 재사용할 수 없다. |
+| caller map을 그대로 `setContextMap`에 전달 | 기각 | caller의 late mutation과 backend의 map 보관 방식에 의해 snapshot 계약이 깨진다. |
+| 기존 `withLoggingContext`를 전체 대체 semantics로 변경 | 기각 | 현재 key별 병합·빈 map no-op semantics를 사용하는 호출부를 깨뜨린다. 새 primitive를 별도로 둔다. |
+
+## 실패 모드와 대응
+
+| 실패 모드 | 탐지 방법 | 대응 |
+|---|---|---|
+| caller가 decorate 후 MDC를 변경했는데 worker가 변경된 값을 봄 | decorate 후 caller key를 변경하고 worker가 원래 snapshot을 읽는 테스트 | decorate 시 새 map을 복사하고 immutable wrapper 사용 |
+| 빈 caller context가 worker의 stale key를 봄 | worker에 seed map을 넣은 뒤 빈 caller task에서 map을 확인 | 적용 단계에서 `MDC.clear()` 수행 |
+| task가 추가한 key가 다음 task로 샘 | 동일 single worker에서 task 종료 후 seed map과 비교 | `finally`에서 이전 전체 map을 다시 설정 |
+| 예외 task가 worker context를 오염시킴 | task가 예외를 던진 뒤 같은 worker map을 검사 | 예외를 삼키지 않고 `finally` 복원 |
+| nested decorator가 outer 또는 원래 worker map을 잃음 | outer→inner 순서와 inner 종료 후 두 단계 map 검사 | 각 `withMdcContext` 호출이 자기 진입 map을 독립적으로 저장·복원 |
+| mutable caller map이 실행 중 변경됨 | direct `withMdcContext` 호출에서도 원본을 변경하는 테스트 | 적용 전에 전달 map을 다시 copy |
+| adapter가 executor lifecycle을 닫음 | decorator 사용 후 executor가 계속 task를 받을 수 있는지와 소유 주체를 코드 검사 | adapter에는 lifecycle API와 bean 등록을 넣지 않음 |
+
+## 검증 설계
+
+### Logging 테스트
+
+`bluetape4k/logging/src/test/kotlin/io/bluetape4k/logging/MdcContextSnapshotTest.kt`에 다음을 둔다.
+
+- snapshot이 capture 시점의 값만 가지며 late caller mutation과 분리된다.
+- 빈 snapshot이 현재 전체 MDC를 숨기고, block 종료 후 기존 map(추가 key 포함)을 복구한다.
+- block 예외 후에도 기존 map을 복구한다.
+- nested context가 inner 종료 후 outer, outer 종료 후 원래 map을 복구한다.
+- 기존 `MdcSupportTest`의 `withLoggingContext` 사례는 수정하지 않고 회귀 기준으로 유지한다.
+
+### Spring 테스트
+
+`spring-boot/core/src/test/kotlin/io/bluetape4k/spring/task/MdcTaskDecoratorTest.kt`는 하나의 `Executors.newSingleThreadExecutor()`를 테스트가 소유하고 재사용한다. production decorator는 executor를 만들거나 닫지 않는다.
+
+| 사례 | 검증 |
+|---|---|
+| 서로 다른 caller context | 두 task가 각각 자신의 map만 보고 첫 task의 task-local key가 두 번째로 새지 않음 |
+| 빈 caller context | worker seed context가 task 실행 중 보이지 않고 task 후 seed map 복구 |
+| 예외 | `Future.get`의 원인 예외를 보존하면서 worker seed map 복구 |
+| 중첩 decorator | inner 종료 후 outer map, outer 종료 후 seed map 복구 |
+| decorate 후 변경 | caller 변경이 이미 wrapping된 task의 snapshot에 영향을 주지 않음 |
+
+모든 사례는 동일 worker에서 제한 시간 있는 `Future.get`을 사용하고, 테스트 `finally`에서 executor와 caller MDC를 정리한다. 테스트가 executor lifecycle을 소유하는 것은 production API가 소유하지 않음을 검증하기 위한 것이다.
+
+## 문서와 호환성
+
+- public API의 한국어 KDoc을 추가한다.
+- `bluetape4k/logging/README.md`·`README.ko.md`에 snapshot과 reusable worker 사용 예를 같은 계약으로 추가한다.
+- `spring-boot/core/README.md`·`README.ko.md`에 `MdcTaskDecorator` 연결 예와 executor lifecycle이 caller 소유라는 주의를 추가한다.
+- `spring-boot/core/build.gradle.kts`에는 `implementation(project(":bluetape4k-logging"))`만 추가한다. 외부 의존성, catalog, version은 변경하지 않는다.
+- package 자동 등록이나 Spring auto-configuration은 만들지 않으므로 settings/module registration 변경이 없다.
+
+## 수락 기준
+
+| ID | 완료 조건 | 증거 |
+|---|---|---|
+| AC-01 | 승인된 spec/plan/lesson이 정확한 경로에 있고 한국어 문서 검사를 통과 | 파일 read-back, `git diff --check` |
+| AC-02 | logging snapshot이 capture/apply/restore 전체 계약을 제공 | logging 단위 테스트의 RED/GREEN 결과 |
+| AC-03 | `MdcTaskDecorator`가 caller snapshot을 decorate 시점에 잡고 worker 이전 map을 복원 | Spring single-worker 테스트 GREEN |
+| AC-04 | `withLoggingContext` semantics와 기존 테스트가 유지 | 기존 logging 테스트 및 diff self-review |
+| AC-05 | core에는 필요한 project dependency 하나만 추가 | build diff와 dependency graph |
+| AC-06 | public KDoc과 두 언어 README가 API 계약과 일치 | 문서 read-back·용어 audit |
+| AC-07 | targeted test, build, detekt, diff check가 성공하고 P0/P1 self-review가 0 | 명령·종료코드·최종 diff |
+| AC-08 | Korean Lore commit이 provider-only 파일만 포함 | `git show --stat`, commit trailers |
+
+## 명세 DoD
+
+문제 근거, 목표/비목표, API 계약, 대안, 실패 모드, 테스트 matrix, 의존성 결정,
+수락 기준을 기록했다. 승인된 provider-only 범위를 넘는 Workshop 변경·PR·merge는
+보류한다. 구현 후 lesson에 실제 RED/GREEN과 검증 한계를 갱신하고, 최종 diff에서
+P0/P1 findings=0을 확인한다.
+

--- a/docs/testlogs/2026-09.md
+++ b/docs/testlogs/2026-09.md
@@ -17,3 +17,5 @@
 | 2026-09-06 | #1639 | IO, Spring Boot Redis, Hibernate Lettuce 전체 build와 Detekt | PASS — 1,302 + 102 + 38 passing | 세 모듈 failures/errors/skipped 0, 변경 후 targeted test와 Detekt 재실행 성공 |
 | 2026-09-06 | #1642 | `BoundedLineReaderSupportTest` 길이·개행·read-ahead·ownership 회귀 | RED → GREEN — 10 passing | production symbol 부재 compile RED 뒤 구현; failures/errors/skipped 0 |
 | 2026-09-06 | #1642 | `:bluetape4k-io:build`와 Detekt | PASS — 1,308 passing | 신규 production/test Detekt finding 0, Korean terminology audit와 `git diff --check` 통과 |
+| 2026-09-06 | #1644 | logging MDC 복사·복원 및 Spring `MdcTaskDecorator` 회귀 | RED → GREEN — 4+5 passing | 새 provider와 adapter 부재 compile RED 뒤 구현; failures/errors/skipped 0 |
+| 2026-09-06 | #1644 | logging 및 Spring core 전체 build와 Detekt | PASS — 55 + 255 passing | 신규 concurrency finding 0, Korean terminology audit와 `git diff --check` 통과 |

--- a/spring-boot/core/README.ko.md
+++ b/spring-boot/core/README.ko.md
@@ -34,6 +34,12 @@ Spring Boot 4.x 기반 공통 기능 통합 모듈입니다.
 - `SpringObservationKeyValues`를 통한 Micrometer low-cardinality/high-cardinality key value 그룹화
 - Prometheus와 OpenTelemetry export는 애플리케이션 소유의 Spring Boot Actuator 설정으로 유지
 
+### MDC TaskDecorator
+
+- 재사용 Spring worker에 caller의 불변 MDC 복사본을 전달하는 `MdcTaskDecorator`
+- caller context가 비어 있으면 task 실행 중 worker MDC를 비우고, 성공·실패 후 worker의 이전 전체 map 복원
+- executor 생성·종료와 Spring bean lifecycle은 애플리케이션이 소유
+
 ### 테스트 유틸리티
 
 - Spring Boot Test 기반 통합 테스트 지원
@@ -128,6 +134,35 @@ val created = webClient.httpPost("/users", newUser)
     .bodyToMono(User::class.java)
     .awaitSingle()
 ```
+
+### MDC TaskDecorator
+
+애플리케이션이 소유한 executor에 `MdcTaskDecorator`를 연결합니다. `decorate`
+호출 시점에 caller MDC를 캡처하고, task 실행 중 worker MDC를 대체한 뒤
+`finally`에서 worker의 이전 map을 복원합니다.
+
+```kotlin
+import io.bluetape4k.spring.task.MdcTaskDecorator
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+@Configuration(proxyBeanMethods = false)
+class TaskExecutionConfiguration {
+    @Bean
+    fun applicationTaskExecutor(): ThreadPoolTaskExecutor =
+        ThreadPoolTaskExecutor().apply {
+            corePoolSize = 4
+            maxPoolSize = 8
+            setTaskDecorator(MdcTaskDecorator())
+            initialize()
+        }
+}
+```
+
+decorator는 executor를 생성하거나 닫지 않으며 자동 bean을 등록하지 않습니다.
+caller MDC가 비어 있으면 task 실행 중 stale worker 값을 숨기고, task가
+추가한 key는 이전 context를 복원할 때 제거됩니다.
 
 ### WebFlux 컨트롤러 (Coroutines)
 
@@ -240,6 +275,7 @@ class UserControllerTest(@Autowired val client: WebTestClient) {
 | 범주                          | 의존 방식     | 설명                      |
 |-------------------------------|---------------|---------------------------|
 | `spring-boot-starter-webflux` | `compileOnly` | WebFlux + Coroutines 필수 |
+| `bluetape4k-logging`           | `implementation` | MDC TaskDecorator 지원       |
 | `bluetape4k-coroutines`       | `compileOnly` | Coroutines 지원           |
 | `micrometer-observation`      | `compileOnly` | Observation 헬퍼 지원     |
 | `spring-boot-starter-web`     | `compileOnly` | 선택적 서블릿 지원        |

--- a/spring-boot/core/README.md
+++ b/spring-boot/core/README.md
@@ -34,6 +34,12 @@ A unified module providing common features for Spring Boot 4.x applications.
 - Low-cardinality and high-cardinality Micrometer key value grouping through `SpringObservationKeyValues`
 - Prometheus and OpenTelemetry export remain application-owned Spring Boot Actuator configuration
 
+### MDC Task Decorator
+
+- `MdcTaskDecorator` propagates an immutable caller MDC snapshot across reusable Spring workers
+- Empty caller context clears worker MDC for the task; the worker's previous complete map is restored after success or failure
+- Executor creation, shutdown, and Spring bean lifecycle remain application-owned
+
 ### Test Utilities
 
 - Integration test support based on Spring Boot Test
@@ -128,6 +134,35 @@ val created = webClient.httpPost("/users", newUser)
     .bodyToMono(User::class.java)
     .awaitSingle()
 ```
+
+### MDC TaskDecorator
+
+Connect `MdcTaskDecorator` to an executor owned by the application. It captures
+the caller MDC when `decorate` is called, replaces the worker MDC while the task
+runs, and restores the worker's previous map in `finally`.
+
+```kotlin
+import io.bluetape4k.spring.task.MdcTaskDecorator
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+@Configuration(proxyBeanMethods = false)
+class TaskExecutionConfiguration {
+    @Bean
+    fun applicationTaskExecutor(): ThreadPoolTaskExecutor =
+        ThreadPoolTaskExecutor().apply {
+            corePoolSize = 4
+            maxPoolSize = 8
+            setTaskDecorator(MdcTaskDecorator())
+            initialize()
+        }
+}
+```
+
+The decorator does not create or close the executor and does not register an
+automatic bean. An empty caller MDC hides stale worker values for the task, and
+task-local keys are removed when the worker's previous context is restored.
 
 ### WebFlux Controller (Coroutines)
 
@@ -240,6 +275,7 @@ class UserControllerTest(@Autowired val client: WebTestClient) {
 | Category                      | Scope         | Description                       |
 |-------------------------------|---------------|-----------------------------------|
 | `spring-boot-starter-webflux` | `compileOnly` | Required for WebFlux + Coroutines |
+| `bluetape4k-logging`           | `implementation` | MDC TaskDecorator support       |
 | `bluetape4k-coroutines`       | `compileOnly` | Coroutines support                |
 | `micrometer-observation`      | `compileOnly` | Observation helper support        |
 | `spring-boot-starter-web`     | `compileOnly` | Optional servlet support          |

--- a/spring-boot/core/build.gradle.kts
+++ b/spring-boot/core/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-actuator")
 
     // Spring core
+    implementation(project(":bluetape4k-logging"))
     compileOnly(project(":bluetape4k-io"))
     compileOnly(project(":bluetape4k-jackson3"))
     compileOnly("org.springframework:spring-context-support")

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/task/MdcTaskDecorator.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/task/MdcTaskDecorator.kt
@@ -1,0 +1,21 @@
+package io.bluetape4k.spring.task
+
+import io.bluetape4k.logging.captureMdcContext
+import io.bluetape4k.logging.withMdcContext
+import org.springframework.core.task.TaskDecorator
+
+/**
+ * decorate 시점의 caller MDC를 task 실행 동안 적용하고 worker의 이전 context를 복원합니다.
+ *
+ * executor 생성·종료와 Spring bean 등록은 이 decorator의 책임이 아닙니다.
+ */
+class MdcTaskDecorator : TaskDecorator {
+    override fun decorate(task: Runnable): Runnable {
+        val callerContext = captureMdcContext()
+        return Runnable {
+            withMdcContext(callerContext) {
+                task.run()
+            }
+        }
+    }
+}

--- a/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/task/MdcTaskDecorator.kt
+++ b/spring-boot/core/src/main/kotlin/io/bluetape4k/spring/task/MdcTaskDecorator.kt
@@ -7,6 +7,9 @@ import org.springframework.core.task.TaskDecorator
 /**
  * decorate 시점의 caller MDC를 task 실행 동안 적용하고 worker의 이전 context를 복원합니다.
  *
+ * decorate한 task는 실행될 때까지 복사한 MDC map을 보유합니다. queue가 큰 executor에서는
+ * MDC를 작은 low-cardinality 식별자 집합으로 유지하세요.
+ *
  * executor 생성·종료와 Spring bean 등록은 이 decorator의 책임이 아닙니다.
  */
 class MdcTaskDecorator : TaskDecorator {

--- a/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/task/MdcTaskDecoratorTest.kt
+++ b/spring-boot/core/src/test/kotlin/io/bluetape4k/spring/task/MdcTaskDecoratorTest.kt
@@ -1,0 +1,145 @@
+package io.bluetape4k.spring.task
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeNullOrEmpty
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.slf4j.MDC
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SAME_THREAD)
+class MdcTaskDecoratorTest {
+
+    private lateinit var executor: ExecutorService
+    private val decorator = MdcTaskDecorator()
+
+    @BeforeEach
+    fun setUp() {
+        MDC.clear()
+        executor = Executors.newSingleThreadExecutor()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+        executor.shutdownNow()
+        executor.awaitTermination(5, TimeUnit.SECONDS).shouldBeTrue()
+    }
+
+    @Test
+    fun `서로 다른 caller context와 task local key는 재사용 worker 사이에 새지 않는다`() {
+        seedWorkerContext(mapOf("worker" to "seed"))
+
+        MDC.setContextMap(mapOf("request" to "one"))
+        val first = decorator.decorate(Runnable {
+            MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("request" to "one")
+            MDC.put("taskOnly", "first")
+        })
+        runOnWorker(first)
+        workerContext() shouldBeEqualTo mapOf("worker" to "seed")
+
+        MDC.setContextMap(mapOf("request" to "two", "tenant" to "blue"))
+        val second = decorator.decorate(Runnable {
+            MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("request" to "two", "tenant" to "blue")
+            MDC.get("taskOnly").shouldBeNullOrEmpty()
+        })
+        runOnWorker(second)
+        workerContext() shouldBeEqualTo mapOf("worker" to "seed")
+    }
+
+    @Test
+    fun `빈 caller context는 worker context를 숨기고 종료 후 복원한다`() {
+        seedWorkerContext(mapOf("worker" to "seed", "stale" to "value"))
+        MDC.clear()
+
+        val decorated = decorator.decorate(Runnable {
+            MDC.getCopyOfContextMap().orEmpty() shouldBeEqualTo emptyMap<String, String>()
+            MDC.put("taskOnly", "empty-caller")
+        })
+        runOnWorker(decorated)
+
+        workerContext() shouldBeEqualTo mapOf("worker" to "seed", "stale" to "value")
+    }
+
+    @Test
+    fun `예외 task도 worker context를 복원한다`() {
+        seedWorkerContext(mapOf("worker" to "seed", "stale" to "value"))
+        MDC.setContextMap(mapOf("request" to "failure"))
+
+        val decorated = decorator.decorate(Runnable {
+            MDC.get("request") shouldBeEqualTo "failure"
+            MDC.put("taskOnly", "failure")
+            error("boom")
+        })
+        val failure = assertFailsWith<ExecutionException> {
+            executor.submit(decorated).get(5, TimeUnit.SECONDS)
+        }
+
+        failure.cause shouldBeInstanceOf IllegalStateException::class
+        failure.cause?.message shouldBeEqualTo "boom"
+        workerContext() shouldBeEqualTo mapOf("worker" to "seed", "stale" to "value")
+    }
+
+    @Test
+    fun `nested decorator는 outer와 seed context를 순서대로 복원한다`() {
+        seedWorkerContext(mapOf("worker" to "seed"))
+        MDC.setContextMap(mapOf("request" to "outer"))
+
+        val decorated = decorator.decorate(Runnable {
+            MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("request" to "outer")
+            MDC.put("outerOnly", "value")
+
+            val nested = decorator.decorate(Runnable {
+                MDC.getCopyOfContextMap() shouldBeEqualTo mapOf(
+                    "request" to "outer",
+                    "outerOnly" to "value",
+                )
+                MDC.put("innerOnly", "value")
+            })
+            nested.run()
+
+            MDC.getCopyOfContextMap() shouldBeEqualTo mapOf(
+                "request" to "outer",
+                "outerOnly" to "value",
+            )
+        })
+        runOnWorker(decorated)
+
+        workerContext() shouldBeEqualTo mapOf("worker" to "seed")
+    }
+
+    @Test
+    fun `decorate 이후 caller 변경은 task snapshot에 반영되지 않는다`() {
+        seedWorkerContext(mapOf("worker" to "seed"))
+        MDC.setContextMap(mapOf("request" to "before"))
+        val decorated = decorator.decorate(Runnable {
+            MDC.getCopyOfContextMap() shouldBeEqualTo mapOf("request" to "before")
+        })
+
+        MDC.setContextMap(mapOf("request" to "after", "late" to "value"))
+        runOnWorker(decorated)
+
+        workerContext() shouldBeEqualTo mapOf("worker" to "seed")
+    }
+
+    private fun seedWorkerContext(context: Map<String, String>) {
+        runOnWorker(Runnable { MDC.setContextMap(context) })
+    }
+
+    private fun workerContext(): Map<String, String> =
+        executor.submit(Callable { MDC.getCopyOfContextMap().orEmpty() })
+            .get(5, TimeUnit.SECONDS)
+
+    private fun runOnWorker(task: Runnable) {
+        executor.submit(task).get(5, TimeUnit.SECONDS)
+    }
+}


### PR DESCRIPTION
## 변경 요약

- immutable MDC capture와 full-replace/restore scope API를 logging 모듈에 추가합니다.
- `MdcTaskDecorator`를 Spring core 공용 adapter로 제공해 재사용 worker의 stale MDC 누수를 차단합니다.
- empty map clear, 정상·예외·nested 복원, late mutation 격리, caller-owned executor lifecycle을 테스트하고 문서화합니다.

Closes #1644
후속 consumer 적용: bluetape4k/bluetape4k-workshop#941

## 변경 유형

- [x] `feat` — 새 기능
- [ ] `fix` — 버그 수정
- [ ] `refactor` — 리팩토링 (기능 변경 없음)
- [ ] `perf` — 성능 개선
- [x] `test` — 테스트 추가/수정
- [x] `docs` — 문서만 변경
- [ ] `chore` — 빌드/설정/의존성

## 테스트

- [x] rebase head logging targeted — 4 passing
- [x] rebase head Spring Boot core targeted — 5 passing
- [x] logging 전체 — 55 passing
- [x] Spring core 전체 — 255 passing
- [x] 두 모듈 build/detekt — `BUILD SUCCESSFUL`, 변경 파일 finding 0
- [x] 한국어 용어 audit 10건 검토 — MDC `snapshot` 도메인/API 표현, 기존 base, 영문 README, Kotlin 식별자로 판정해 미해결 0
- [x] `git diff --check`와 conflict marker 검사 통과
- [x] `docs/testlogs/2026-09.md`에 결과 기록

## Code Review

- [x] 기존 exact-diff Performance/Stability/Security/Operator/Developer/User review — P0=0, P1=0
- [x] User P2 KDoc 보완 후 API/Ops/User 재리뷰 통과
- [x] rebase head inline fallback review — P0=0, P1=0; 독립 reviewer는 사용량 제한으로 실행 불가
- [x] Performance P2: MDC map 복사·queue 보유 비용은 문서화된 수용 tradeoff
- [x] Performance P3: 전용 JMH/GC benchmark 부재 — 비차단 gap으로 기록
- [x] rebase head `cdd703cb32c3`의 PR exact-head CI와 review/thread read-back 완료

## Issue 연결 및 자동 종료

- [x] `Closes #1644`로 병합 시 자동 종료되도록 명시했습니다.
- [x] Workshop #941 consumer 적용은 별도 후속 이슈로 유지합니다.
- [x] merge SHA `1a4738b6248c`와 #1644 자동 종료 상태를 live read-back했습니다.

## 체크리스트

- [x] logging/core의 `README.md`와 `README.ko.md`를 함께 갱신했습니다.
- [x] 새 public API에 한국어 KDoc을 추가했습니다.
- [x] Spring Boot 4/Framework 7 호환 코드 경계를 유지했습니다.
- [x] Nightly의 logging/core 독립 test와 non-demo kover task 등록을 확인했습니다.
- [x] 최신 `develop` rebase에서 #1639·#1642·#1644 testlog를 모두 보존했습니다.
- [x] `worktree`에서 작업 후 PR을 생성했습니다.
- [x] `docs/superpowers/index/YYYY-MM.md` 없음 — N/A.
- [x] Docker image 및 `virtualthread` 변경 없음 — N/A.

## DoD Status

- DONE: provider API/adapter, TDD/전체 모듈 검증, KDoc/README/CHANGELOG/lesson, 기존 독립 리뷰 P0/P1=0.
- DONE: `origin/develop@81eee97e5a9d` rebase, targeted 4+5 passing, feature blob 12/12 동일, `git diff --check` 통과.
- DONE: rebase head inline fallback review P0/P1=0; 독립 rebase reviewer는 사용량 제한으로 실행 불가.
- DONE: rebase head `cdd703cb32c3`의 hosted CI `15 success / 11 skipped / 0 failed`, reviews 0, threads 0, `MERGEABLE/CLEAN` read-back.
- DONE: exact-head squash merge와 merge 후 live read-back을 완료했습니다.
- DONE: #1644는 이 PR의 provider API 완료 범위로 종료하며 Workshop #941 consumer 적용은 별도 추적합니다.
- NOT DONE: release와 cleanup은 현재 단계 범위가 아닙니다.
