### PR TITLE
TimePeriodChain의 파괴적 mutation을 원자적으로 차단한다

### DIFF
--- a/docs/lessons/2026-09-06-issue-1658-time-period-chain-mutations.md
+++ b/docs/lessons/2026-09-06-issue-1658-time-period-chain-mutations.md
@@ -1,0 +1,75 @@
+# #1658: MutableList 위임은 불변식을 자동으로 지켜주지 않는다
+
+## 문제
+
+`TimePeriodChain`은 `TimePeriodContainer`의 `MutableList` 위임을 상속한다. 직접 구현한
+`set`은 기존 원소를 `removeAt`으로 먼저 삭제한 뒤 지원하지 않는 indexed `add`를 호출했다.
+따라서 `UnsupportedOperationException`이 발생해도 chain은 이미 손상됐다.
+
+직접 override하지 않은 `removeAt`, `clear`, iterator, list iterator, `subList`, `removeIf`,
+`replaceAll`, 정렬 API와 공개 `periods` view도 raw backing list를 변경할 수 있었다.
+`remove(element)`와 `add(index, element)` 두 메서드만 막아서는 `MutableList` 계약의 우회
+경로를 닫을 수 없다.
+
+## 결정
+
+- 기존 `MutableList` ABI와 public no-arg constructor는 유지한다.
+- chain이 지원하는 collection mutation은 [끝에 추가하는 `add`와 `addAll`]로 한정한다.
+- private storage는 mutable backing과 `Collections.unmodifiableList` view를 함께 소유한다.
+- 상위 `TimePeriodContainer`의 delegate와 공개 `periods`에는 unmodifiable view만 전달한다.
+- `TimePeriodChain.add`만 private backing에 접근해 기존 contiguity 재배치 뒤 append한다.
+- 기존 기간과 같은 값을 다시 추가하면 setup 전에 `false`를 반환해 동일 객체를 이동하거나
+  self collection을 순회 중 변경하지 않는다.
+- chain 자신이나 동일한 `periods` view를 `addAll` source로 받으면 snapshot 전에 `false`를
+  반환한다.
+- `set`, indexed add, remove와 outer Java default mutation은 상태 변경이나 callback 호출 전에
+  같은 종류의 예외를 던진다.
+
+custom collection wrapper는 iterator의 변경 감지까지 다시 구현해야 하므로 사용하지 않았다.
+JDK unmodifiable view가 delegate와 collection view mutation을 한 경계에서 거부하고, outer
+`removeIf`, `replaceAll`, sort는 `TimePeriodChain`이 직접 override해 callback 전에 거부한다.
+
+## RED/GREEN
+
+RED에서 targeted 16개 중 2개가 실패했다.
+
+- 실패한 `set` 뒤 chain 크기가 3개에서 2개로 줄었다.
+- `removeAt(0)`은 예외 없이 첫 원소를 삭제했다.
+
+GREEN에서는 다음 경로를 각각 새 chain에서 실행하고 `UnsupportedOperationException`과 원본
+순서 보존을 함께 검증했다.
+
+- `set`, `remove`, `removeAt`, `clear`, `removeAll`, `retainAll`, `removeIf`, `replaceAll`
+- iterator/list iterator의 `remove`, `set`, `add`
+- `subList`의 `clear`, `set`, `add`
+- indexed `addAll`, `reset`, 공개 `periods`의 직접·iterator mutation
+- start/end/duration 정렬
+- 기존 원소 재추가와 `addAll(chain)`, `addAll(chain.periods)`의 no-op 계약
+- Java default mutation의 predicate, operator, comparator가 호출되지 않는 계약
+- 상속한 `periods` 구현을 사용하는 subclass에도 같은 mutation guard가 적용되는 계약
+
+`TimePeriodChain`은 기존 공개 상속 계약을 유지한다. 따라서 subclass가 `periods`를 직접
+재정의하면 이 mutation과 contiguity 계약을 해당 subclass가 보존해야 한다.
+
+## 결과와 검증
+
+- targeted `TimePeriodChainTest`: 20 passed, failures/errors/skipped 0
+- javatimes 전체: 696 passed, 36 기존 pending, failures/errors 0
+- `:bluetape4k-javatimes:check`, Kover verify, detekt: 성공
+- `javap -public`: 기존 public no-arg constructor와 `MutableList` bridge 유지
+- production caller 검색: 저장소 안에서 destructive chain mutation 사용 없음
+- `git diff --check`: 통과
+
+## Review Miss
+
+초기 구현은 눈에 보이는 override만 chain 계약이라고 간주했다. Kotlin delegation이 생성한
+bridge, collection view가 반환하는 iterator와 `subList`, Java default mutation까지 같은
+backing을 공유한다는 점을 함께 검토해야 했다.
+
+## 다음 변경 시 지킬 점
+
+1. invariant가 있는 collection은 직접 선언한 mutation뿐 아니라 모든 view와 default method를
+   검토한다.
+2. 실패를 지원하지 않는 계약으로 표현할 때 상태를 먼저 바꾸지 않는다.
+3. 공개 mutable 타입을 즉시 바꿀 수 없다면 ABI는 유지하되 backing 접근 권한을 분리한다.
+4. 허용된 mutation과 거부된 mutation을 같은 delegate에 섞지 않는다.

--- a/utils/javatimes/src/main/kotlin/io/bluetape4k/javatimes/period/TimePeriodChain.kt
+++ b/utils/javatimes/src/main/kotlin/io/bluetape4k/javatimes/period/TimePeriodChain.kt
@@ -7,9 +7,18 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.trace
 import java.time.Duration
 import java.time.ZonedDateTime
+import java.util.Collections
+import java.util.Comparator
+import java.util.function.Predicate
+import java.util.function.UnaryOperator
 
 /**
- * [ITimePeriodChain] 의 기본 구현체
+ * [ITimePeriodChain]의 기본 구현체입니다.
+ *
+ * 체인의 기간은 [add]와 [addAll]로 끝에만 추가할 수 있습니다. `MutableList` 호환성을 위해
+ * 노출되는 교체·삭제·정렬 API와 [periods] view의 mutation은 상태를 바꾸기 전에
+ * [UnsupportedOperationException]을 던집니다.
+ * [periods]를 재정의하는 subclass는 같은 mutation과 contiguity 계약을 직접 보존해야 합니다.
  *
  * ```kotlin
  * val now = ZonedDateTime.now()
@@ -21,7 +30,11 @@ import java.time.ZonedDateTime
  * chain.size // 2
  * ```
  */
-open class TimePeriodChain: TimePeriodContainer(), ITimePeriodChain {
+open class TimePeriodChain private constructor(
+    private val storage: TimePeriodChainStorage,
+): TimePeriodContainer(storage.guarded), ITimePeriodChain {
+
+    constructor(): this(TimePeriodChainStorage())
 
     companion object: KLogging() {
         @JvmStatic
@@ -52,26 +65,46 @@ open class TimePeriodChain: TimePeriodContainer(), ITimePeriodChain {
         }
 
     override operator fun set(index: Int, element: ITimePeriod): ITimePeriod {
-        removeAt(index)
-        add(index, element)
-        return element
+        throw unsupportedMutation()
     }
 
     override fun add(element: ITimePeriod): Boolean {
+        if (containsPeriod(element)) {
+            return false
+        }
         this.lastOrNull()?.let { last ->
             assertSpaceAfter(last.end, element.duration)
             element.setup(last.end, last.end + element.duration)
         }
-        log.trace { "Add eleemnt to period chain. element=$element" }
-        return periods.add(element)
+        log.trace { "Add element to period chain. element=$element" }
+        return storage.mutable.add(element)
+    }
+
+    override fun addAll(elements: Collection<ITimePeriod>): Boolean {
+        if (elements === this || elements === periods) {
+            return false
+        }
+        return elements.toList().map(::add).any()
     }
 
     override fun add(index: Int, element: ITimePeriod) {
-        throw UnsupportedOperationException("Chain에는 중간에 삽입 기능은 지원하지 않습니다.")
+        throw unsupportedMutation()
     }
 
     override fun remove(element: ITimePeriod): Boolean {
-        throw UnsupportedOperationException("Chain에서는 remove 기능을 지원하지 않습니다.")
+        throw unsupportedMutation()
+    }
+
+    override fun removeIf(filter: Predicate<in ITimePeriod>): Boolean {
+        throw unsupportedMutation()
+    }
+
+    override fun replaceAll(operator: UnaryOperator<ITimePeriod>) {
+        throw unsupportedMutation()
+    }
+
+    override fun sort(c: Comparator<in ITimePeriod>?) {
+        throw unsupportedMutation()
     }
 
     override fun assertSpaceBefore(moment: ZonedDateTime, duration: Duration) {
@@ -89,4 +122,12 @@ open class TimePeriodChain: TimePeriodContainer(), ITimePeriodChain {
         }
         check(hasSpace) { "duration[$duration] is out of range." }
     }
+
+    private fun unsupportedMutation(): UnsupportedOperationException =
+        UnsupportedOperationException("TimePeriodChain은 끝에 기간을 추가하는 mutation만 지원합니다.")
+}
+
+private class TimePeriodChainStorage {
+    val mutable: MutableList<ITimePeriod> = mutableListOf()
+    val guarded: MutableList<ITimePeriod> = Collections.unmodifiableList(mutable)
 }

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/TimePeriodChainTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/TimePeriodChainTest.kt
@@ -1,16 +1,17 @@
 package io.bluetape4k.javatimes.period
 
-import io.bluetape4k.javatimes.MaxPeriodTime
-import io.bluetape4k.javatimes.MinPeriodTime
-import io.bluetape4k.javatimes.hours
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.SortDirection
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.javatimes.MaxPeriodTime
+import io.bluetape4k.javatimes.MinPeriodTime
+import io.bluetape4k.javatimes.hours
+import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
 import java.time.Duration
-import io.bluetape4k.assertions.assertFailsWith
 
 class TimePeriodChainTest: AbstractPeriodTest() {
 
@@ -110,8 +111,137 @@ class TimePeriodChainTest: AbstractPeriodTest() {
         val chain = TimePeriodChain()
         val block = TimeBlock(now, now + 1.hours())
         chain.add(block)
+        val before = chain.toList()
+
         assertFailsWith<UnsupportedOperationException> {
             chain.remove(chain.first())
+        }
+
+        chain.toList() shouldBeEqualTo before
+    }
+
+    @Test
+    fun `set fails before changing the chain`() {
+        val chain = chainOfThree()
+        val before = chain.toList()
+
+        assertFailsWith<UnsupportedOperationException> {
+            chain[0] = TimeBlock(now + 10.hours(), now + 11.hours())
+        }
+
+        chain.toList() shouldBeEqualTo before
+    }
+
+    @Test
+    fun `all destructive list views reject mutation without changing the chain`() {
+        val mutationCases = listOf<MutationCase>(
+            MutationCase("removeAt") { it.removeAt(0) },
+            MutationCase("clear") { it.clear() },
+            MutationCase("removeAll") { it.removeAll(listOf(it.first())) },
+            MutationCase("retainAll") { it.retainAll(listOf(it.first())) },
+            MutationCase("removeIf") { it.removeIf { true } },
+            MutationCase("replaceAll") { chain -> chain.replaceAll { it } },
+            MutationCase("iterator remove") {
+                it.iterator().apply {
+                    next()
+                    remove()
+                }
+            },
+            MutationCase("listIterator remove") {
+                it.listIterator().apply {
+                    next()
+                    remove()
+                }
+            },
+            MutationCase("listIterator set") {
+                it.listIterator().apply {
+                    next()
+                    set(TimeBlock(now + 10.hours(), now + 11.hours()))
+                }
+            },
+            MutationCase("listIterator add") {
+                it.listIterator().add(TimeBlock(now + 10.hours(), now + 11.hours()))
+            },
+            MutationCase("subList clear") { it.subList(0, 1).clear() },
+            MutationCase("subList set") {
+                it.subList(0, 1)[0] = TimeBlock(now + 10.hours(), now + 11.hours())
+            },
+            MutationCase("subList add") {
+                it.subList(0, 1).add(TimeBlock(now + 10.hours(), now + 11.hours()))
+            },
+            MutationCase("indexed addAll") {
+                it.addAll(1, listOf(TimeBlock(now + 10.hours(), now + 11.hours())))
+            },
+            MutationCase("reset") { it.reset() },
+            MutationCase("periods add") {
+                it.periods.add(TimeBlock(now + 10.hours(), now + 11.hours()))
+            },
+            MutationCase("periods clear") { it.periods.clear() },
+            MutationCase("periods iterator remove") {
+                it.periods.iterator().apply {
+                    next()
+                    remove()
+                }
+            },
+            MutationCase("sortByStart") { it.sortByStart(SortDirection.DESC) },
+            MutationCase("sortByEnd") { it.sortByEnd(SortDirection.DESC) },
+            MutationCase("sortByDuration") { it.sortByDuration(SortDirection.DESC) },
+        )
+
+        mutationCases.forEach { mutationCase ->
+            val chain = chainOfThree()
+            val before = chain.toList()
+
+            try {
+                assertFailsWith<UnsupportedOperationException> {
+                    mutationCase.mutate(chain)
+                }
+            } catch (failure: AssertionError) {
+                throw AssertionError("${mutationCase.name} mutation must be rejected.", failure)
+            }
+
+            chain.toList() shouldBeEqualTo before
+        }
+    }
+
+    @Test
+    fun `Java default mutation callbacks are rejected before invocation`() {
+        val callbacks = listOf<MutationCallbackCase>(
+            MutationCallbackCase("removeIf") { chain, invoked ->
+                chain.removeIf {
+                    invoked()
+                    true
+                }
+            },
+            MutationCallbackCase("replaceAll") { chain, invoked ->
+                chain.replaceAll {
+                    invoked()
+                    it
+                }
+            },
+            MutationCallbackCase("sort") { chain, invoked ->
+                chain.sortWith { _, _ ->
+                    invoked()
+                    0
+                }
+            },
+        )
+
+        callbacks.forEach { callbackCase ->
+            val chain = chainOfThree()
+            val before = chain.map { it.start to it.end }
+            var invoked = false
+
+            try {
+                assertFailsWith<UnsupportedOperationException> {
+                    callbackCase.mutate(chain) { invoked = true }
+                }
+            } catch (failure: AssertionError) {
+                throw AssertionError("${callbackCase.name} must fail before callback invocation.", failure)
+            }
+
+            invoked.shouldBeFalse()
+            chain.map { it.start to it.end } shouldBeEqualTo before
         }
     }
 
@@ -147,4 +277,69 @@ class TimePeriodChainTest: AbstractPeriodTest() {
         chain shouldHaveSize 3
         chain.end shouldBeEqualTo now + 4.hours()
     }
+
+    @Test
+    fun `adding an existing period does not move or duplicate it`() {
+        val chain = chainOfThree()
+        val before = chain.map { it.start to it.end }
+
+        chain.add(chain.first()).shouldBeFalse()
+
+        chain.map { it.start to it.end } shouldBeEqualTo before
+        chain shouldHaveSize 3
+    }
+
+    @Test
+    fun `adding the chain or its periods to itself is a no-op`() {
+        listOf<Pair<String, (TimePeriodChain) -> Collection<ITimePeriod>>>(
+            "chain" to { it },
+            "periods" to { it.periods },
+        ).forEach { (name, source) ->
+            val chain = chainOfThree()
+            val before = chain.map { it.start to it.end }
+
+            try {
+                chain.addAll(source(chain)).shouldBeFalse()
+            } catch (failure: AssertionError) {
+                throw AssertionError("$name self-add must be a no-op.", failure)
+            }
+
+            chain.map { it.start to it.end } shouldBeEqualTo before
+            chain shouldHaveSize 3
+        }
+    }
+
+    @Test
+    fun `subclass using inherited periods keeps the mutation guard`() {
+        val chain = DerivedTimePeriodChain().apply {
+            add(TimeBlock(now, now + 1.hours()))
+        }
+        val before = chain.map { it.start to it.end }
+
+        assertFailsWith<UnsupportedOperationException> {
+            chain.periods.clear()
+        }
+
+        chain.map { it.start to it.end } shouldBeEqualTo before
+    }
+
+    private fun chainOfThree(): TimePeriodChain = TimePeriodChain(
+        listOf(
+            TimeBlock(now, now + 1.hours()),
+            TimeBlock(now + 1.hours(), now + 3.hours()),
+            TimeBlock(now + 3.hours(), now + 6.hours()),
+        )
+    )
+
+    private data class MutationCase(
+        val name: String,
+        val mutate: (TimePeriodChain) -> Unit,
+    )
+
+    private data class MutationCallbackCase(
+        val name: String,
+        val mutate: (TimePeriodChain, invoked: () -> Unit) -> Unit,
+    )
+
+    private class DerivedTimePeriodChain: TimePeriodChain()
 }


### PR DESCRIPTION
## 문제

`TimePeriodChain`은 `MutableList`를 공개하지만, 기존 `set`은 원소를 먼저 제거한 뒤 지원하지 않는 indexed `add`에서 실패해 chain을 파괴했습니다. 또한 delegate, iterator, `subList`, Java default method를 통한 교체·삭제·정렬이 contiguity 불변식을 우회할 수 있었습니다.

## 변경 사항

- 기존 public `MutableList` 및 no-arg constructor ABI를 유지했습니다.
- base delegate와 공개 `periods`에는 동일한 unmodifiable view를 제공하고, private backing은 검증된 끝 append에서만 변경합니다.
- `set`, indexed add/addAll, remove 계열, clear/reset, iterator/listIterator/subList mutation을 상태 변경 전에 거부합니다.
- `removeIf`, `replaceAll`, `sort`는 callback 호출 전에 즉시 거부합니다.
- 기존 원소 재추가와 `addAll(chain)`, `addAll(chain.periods)`는 no-op으로 처리합니다.
- 상속 계약과 collection mutation 경계를 lesson으로 기록했습니다.

## 검증

- targeted `TimePeriodChainTest`: 20/20 통과
- `bluetape4k-javatimes`: 696 passed, 기존 pending 36, failures/errors 0
- `check`, Kover verify/XML, detekt 통과
- `javap -public`: public no-arg constructor와 `MutableList` bridge 유지
- `git diff --check` 통과
- exact head `c5cb54fbc43b788477cd8056db31cdfb83fecaf0`: GitHub Actions 24개 terminal, 11 success, 13 path skip, failure 0

## 검토

- 독립 Architecture/API exact-head review: P0/P1/P2 = 0/0/0, `CLEAR`
- 독립 comprehensive exact-head review: P0/P1/P2 = 0/0/2, `CLEAR`
- 비차단 P2: conformance test의 `LongMethod`, open subclass가 custom periods를 주입할 수 있는 상속 seam
- live GitHub review thread: 0, unresolved 0

Closes #1658

## DoD Status

- [x] 실패 mutation의 원자성과 chain 보존 회귀 테스트
- [x] delegate, iterator, listIterator, subList, Java default mutation 경계 검증
- [x] alias/self-add 및 상속 기본 경로 검증
- [x] 공개 ABI 확인
- [x] 로컬 테스트·정적 분석·coverage 검증
- [x] 독립 Architecture/API 및 comprehensive review `CLEAR`
- [x] exact-head GitHub Actions 통과
- [x] live review/thread read-back 및 mergeability `CLEAN`
- [ ] merge — 사용자가 다섯 PR을 함께 수행
