### PR TITLE
TimeLineMomentCollection의 불변식을 immutable snapshot으로 보호한다

### DIFF
--- a/docs/lessons/2026-09-06-issue-1659-timeline-moment-mutations.md
+++ b/docs/lessons/2026-09-06-issue-1659-timeline-moment-mutations.md
@@ -1,0 +1,67 @@
+# TimeLineMomentCollection mutation 경계 교훈
+
+## 문제
+
+`TimeLineMomentCollection`은 domain API로 period를 추가할 때 moment를 만들고 정렬했지만,
+동시에 `MutableList<ITimeLineMoment>` 전체를 raw list에 위임했다. 호출자는 raw `add`, `set`,
+iterator와 `subList` mutation으로 정렬·endpoint pairing·count 계약을 우회할 수 있었다.
+
+Outer list만 unmodifiable view로 감싸는 첫 접근도 충분하지 않았다. 공개 moment의 `periods`를
+변경하거나 collection에 추가한 원본 period를 나중에 `move` 또는 `setup`하면
+`startCount`/`endCount`와 moment 시각이 다시 어긋났다.
+
+## 선택
+
+- 기존 `ITimeLineMomentCollection : MutableList<ITimeLineMoment>`와 protected JVM `(List)`
+  constructor, companion `invoke(List)`, protected mutation hook은 유지한다.
+- 원본 period의 `start`와 `end`를 mutation 전에 한 번씩 capture하고 `start < end`를 검증한다.
+- collection은 period를 canonical immutable snapshot으로 소유하고 moment를 endpoint bucket에서
+  재구성한다.
+- 원본 period reference는 계산에 사용하지 않고 legacy `equals` 기반 occurrence와 remove semantics를
+  판정하는 대표값으로만 보존한다. 같은 endpoint라도 다른 구현 또는 `readonly` 값이면 별도
+  occurrence로 유지한다.
+- 공개 moment와 그 `periods`도 immutable snapshot으로 제공한다.
+- snapshot 전환 뒤에도 outer moment와 nested period의 `contains`/`indexOf` 조회는 기존
+  timestamp/equality 의미로 연결한다.
+- raw outer mutation과 Java default mutation은 상태 변경이나 callback 전에 거부한다.
+- constructor input은 duplicate timestamp, empty/unrelated moment, endpoint 누락·중복을 검증한 뒤
+  정렬된 canonical snapshot으로 복사한다.
+- `addAll`은 전체 입력을 snapshot·검증한 뒤 한 번에 반영해 mixed input의 부분 추가를 막는다.
+- equality 대표값 lookup은 set/map index를 사용해 대량 입력의 반복 선형 탐색을 피한다.
+- immutable snapshot 내부 holder도 `Serializable` 그래프를 유지하며 Java round-trip 뒤에도
+  mutation 경계와 period 기반 변경을 동일하게 보장한다.
+- Java raw `containsAll(Collection<?>)`은 호환되지 않는 element를 cast하지 않고 `false`로 처리한다.
+
+입력 moment와 period의 객체 identity는 더 이상 collection 내부 identity가 아니다. 이는 mutable
+alias가 계산 상태를 사후 변경하지 못하게 하는 의도된 migration이다. private holder primary
+constructor 도입으로 protected JVM descriptor는 유지되지만 Kotlin reflection에서 관찰하는
+`primaryConstructor`는 달라질 수 있다.
+
+Java serialization은 같은 라이브러리 버전 안의 round-trip만 지원한다. 기존 `moments` field가
+immutable `storage` graph로 바뀌었으므로 이전 버전에서 만든 cache/stream은 호환 대상으로 보지
+않으며, 라이브러리 업그레이드 시 폐기하고 다시 생성해야 한다.
+
+## 검증
+
+- RED: 기존 구현에서 신규 계약 5건 실패
+- targeted `TimeLineMomentCollectionTest`: 26 passed, failures/errors/skipped 0
+- javatimes 전체: 706 passed, 기존 pending 36, failures/errors 0
+- `:bluetape4k-javatimes:check`, Kover verify/XML, detekt: 성공
+- `combinePeriods`, `intersectPeriods`, `calculateGap`: validated constructor input 회귀 통과
+- Java serialization round-trip 및 outer/nested collection mutation conformance matrix 통과
+- `javap -protected`: protected `(java.util.List)` constructor와 기존 public bridge 유지
+- `git diff --check`: 통과
+
+## Review Miss
+
+Domain collection의 불변식은 container 구조만 막는다고 보존되지 않는다. 반환 element가 다시
+mutable collection을 노출하거나 입력 객체 자체가 mutable이면 alias를 따라 invariant가
+우회된다. mutation surface 검토는 outer collection, nested collection, element lifecycle을 한
+경계로 다뤄야 한다.
+
+## 다음 변경 시 지킬 점
+
+1. 계산용 snapshot에는 caller-owned mutable object를 그대로 저장하지 않는다.
+2. 여러 endpoint를 갱신하는 작업은 입력 전체를 먼저 검증한 뒤 commit한다.
+3. legacy mutable ABI를 유지할 때 허용된 domain mutation과 raw mutation을 명시적으로 분리한다.
+4. protected extension hook도 public invariant보다 약한 부분 상태를 만들지 않게 한다.

--- a/utils/javatimes/src/main/kotlin/io/bluetape4k/javatimes/period/timelines/TimeLineMomentCollection.kt
+++ b/utils/javatimes/src/main/kotlin/io/bluetape4k/javatimes/period/timelines/TimeLineMomentCollection.kt
@@ -1,11 +1,36 @@
 package io.bluetape4k.javatimes.period.timelines
 
+import io.bluetape4k.AbstractValueObject
+import io.bluetape4k.ToStringBuilder
 import io.bluetape4k.javatimes.period.ITimePeriod
+import io.bluetape4k.javatimes.period.ITimePeriodCollection
+import io.bluetape4k.javatimes.period.PeriodRelation
+import io.bluetape4k.javatimes.period.TimePeriodContainer
+import io.bluetape4k.javatimes.period.hasInsideWith
+import io.bluetape4k.javatimes.period.intersectWith
+import io.bluetape4k.javatimes.period.overlapWith
+import io.bluetape4k.javatimes.period.relationWith
 import io.bluetape4k.logging.KLogging
+import java.io.Serializable
+import java.time.Duration
 import java.time.ZonedDateTime
+import java.util.Collections
+import java.util.Comparator
+import java.util.function.Predicate
+import java.util.function.UnaryOperator
 
 /**
- * [ITimeLineMomentCollection] 의 기본 구현체
+ * [ITimeLineMomentCollection]의 기본 구현체입니다.
+ *
+ * Moment list는 immutable snapshot으로 노출하며, [ITimePeriod] 기반 [add], [addAll], [remove]만
+ * timeline 불변식을 유지하면서 내부 상태를 변경합니다. `MutableList` mutation은 기존 ABI를
+ * 위해 남아 있지만 상태 변경이나 callback 호출 전에 [UnsupportedOperationException]을 던집니다.
+ *
+ * Protected constructor와 [addPeriod], [removePeriod]를 사용하는 subclass도 전체 endpoint pair를
+ * 원자적으로 추가·제거하는 동일한 계약을 따릅니다.
+ *
+ * Java serialization은 같은 라이브러리 버전의 round-trip을 지원합니다. 내부 field layout이
+ * 변경됐으므로 이전 버전에서 직렬화한 cache/stream은 업그레이드 시 폐기하고 다시 생성해야 합니다.
  *
  * ```kotlin
  * val now = ZonedDateTime.now()
@@ -18,9 +43,11 @@ import java.time.ZonedDateTime
  * ```
  */
 @Suppress("JavaDefaultMethodsNotOverriddenByDelegation")
-open class TimeLineMomentCollection protected constructor(
-    private val moments: MutableList<ITimeLineMoment>,
-): ITimeLineMomentCollection, MutableList<ITimeLineMoment> by moments {
+open class TimeLineMomentCollection private constructor(
+    private val storage: TimeLineMomentCollectionStorage,
+): ITimeLineMomentCollection, MutableList<ITimeLineMoment> by storage.guarded {
+
+    protected constructor(moments: MutableList<ITimeLineMoment>): this(TimeLineMomentCollectionStorage(moments))
 
     companion object: KLogging() {
         @JvmStatic
@@ -29,49 +56,401 @@ open class TimeLineMomentCollection protected constructor(
         }
     }
 
-    override fun minOrNull(): ITimeLineMoment? = moments.minOrNull()
+    override fun minOrNull(): ITimeLineMoment? = storage.mutable.minOrNull()
 
-    override fun maxOrNull(): ITimeLineMoment? = moments.maxOrNull()
+    override fun maxOrNull(): ITimeLineMoment? = storage.mutable.maxOrNull()
 
     override fun add(period: ITimePeriod) {
-        addPeriod(period.start, period)
-        addPeriod(period.end, period)
+        storage.addAll(listOf(period))
     }
 
     override fun addAll(periods: Collection<ITimePeriod>) {
-        periods.forEach { add(it) }
+        storage.addAll(periods)
     }
 
     override fun remove(period: ITimePeriod) {
-        removePeriod(period.start, period)
-        removePeriod(period.end, period)
+        storage.remove(period)
     }
 
-    override fun find(moment: ZonedDateTime): ITimeLineMoment? {
-        return moments.find { it.moment == moment }
+    override fun find(moment: ZonedDateTime): ITimeLineMoment? =
+        storage.mutable.find { it.moment == moment }
+
+    override fun contains(moment: ZonedDateTime): Boolean =
+        storage.mutable.any { it.moment == moment }
+
+    override fun contains(element: ITimeLineMoment): Boolean =
+        storage.indexOf(element) >= 0
+
+    override fun containsAll(elements: Collection<ITimeLineMoment>): Boolean =
+        (elements as Collection<*>).all { it is ITimeLineMoment && contains(it) }
+
+    override fun indexOf(element: ITimeLineMoment): Int =
+        storage.indexOf(element)
+
+    override fun lastIndexOf(element: ITimeLineMoment): Int =
+        storage.lastIndexOf(element)
+
+    override fun removeIf(filter: Predicate<in ITimeLineMoment>): Boolean {
+        throw unsupportedMutation()
     }
 
-    override fun contains(moment: ZonedDateTime): Boolean {
-        return moments.any { it.moment == moment }
+    override fun replaceAll(operator: UnaryOperator<ITimeLineMoment>) {
+        throw unsupportedMutation()
+    }
+
+    override fun sort(c: Comparator<in ITimeLineMoment>?) {
+        throw unsupportedMutation()
     }
 
     protected fun addPeriod(moment: ZonedDateTime, period: ITimePeriod) {
-        var item = find(moment)
-        if (item == null) {
-            item = TimeLineMoment(moment)
-            moments.add(item)
-            moments.sort()
+        require(moment == period.start || moment == period.end) {
+            "Period는 요청한 timeline moment에서 시작하거나 끝나야 합니다. moment=$moment, period=$period"
         }
-        item.periods.add(period)
+        storage.addAll(listOf(period))
     }
 
     protected fun removePeriod(moment: ZonedDateTime, period: ITimePeriod) {
-        val item = find(moment)
-        if (item != null && item.periods.contains(period)) {
-            item.periods.remove(period)
-            if (item.periods.isEmpty()) {
-                moments.remove(item)
+        require(moment == period.start || moment == period.end) {
+            "Period는 요청한 timeline moment에서 시작하거나 끝나야 합니다. moment=$moment, period=$period"
+        }
+        storage.remove(period)
+    }
+
+    private fun unsupportedMutation(): UnsupportedOperationException =
+        UnsupportedOperationException("TimeLineMomentCollection은 period 기반 mutation만 지원합니다.")
+}
+
+private class TimeLineMomentCollectionStorage(
+    initialMoments: Collection<ITimeLineMoment>,
+): Serializable {
+    private var nextOccurrenceId: Long = 0
+    private val periods: MutableList<StoredPeriod> = mutableListOf()
+    val mutable: MutableList<ITimeLineMoment> = mutableListOf()
+    val guarded: MutableList<ITimeLineMoment> = Collections.unmodifiableList(mutable)
+
+    init {
+        periods.addAll(validateAndSnapshot(initialMoments))
+        rebuildMoments()
+    }
+
+    fun addAll(source: Collection<ITimePeriod>) {
+        val additions = source.map(::capture)
+        val uniqueAdditions = mutableListOf<StoredPeriod>()
+        val representatives = periods.mapTo(mutableSetOf()) { it.representative }
+        additions.forEach { candidate ->
+            if (representatives.add(candidate.representative)) {
+                uniqueAdditions += store(candidate)
             }
         }
+        if (uniqueAdditions.isNotEmpty()) {
+            periods.addAll(uniqueAdditions)
+            rebuildMoments()
+        }
     }
+
+    fun remove(period: ITimePeriod) {
+        val index = periods.indexOfFirst { period == it.representative }
+        if (index >= 0) {
+            periods.removeAt(index)
+            rebuildMoments()
+        }
+    }
+
+    fun indexOf(moment: ITimeLineMoment): Int =
+        mutable.indexOfFirst { it.moment == moment.moment }
+
+    fun lastIndexOf(moment: ITimeLineMoment): Int =
+        mutable.indexOfLast { it.moment == moment.moment }
+
+    private fun validateAndSnapshot(initialMoments: Collection<ITimeLineMoment>): List<StoredPeriod> {
+        require(initialMoments.distinctBy { it.moment }.size == initialMoments.size) {
+            "Timeline moment는 같은 시각에 하나만 존재해야 합니다."
+        }
+
+        val groups = linkedMapOf<ITimePeriod, InitialPeriodGroup>()
+        initialMoments.forEach { moment ->
+            require(moment.periods.isNotEmpty()) {
+                "Timeline moment는 하나 이상의 period를 가져야 합니다. moment=${moment.moment}"
+            }
+            moment.periods.forEach { period ->
+                val captured = capture(period)
+                require(moment.moment == captured.bounds.start || moment.moment == captured.bounds.end) {
+                    "Timeline moment의 period는 해당 시각에서 시작하거나 끝나야 합니다. moment=${moment.moment}"
+                }
+                val group = groups.getOrPut(captured.representative) { InitialPeriodGroup(captured) }
+                require(group.captured.bounds == captured.bounds) {
+                    "동일한 period는 모든 moment에서 같은 endpoint를 가져야 합니다."
+                }
+                group.endpointCounts[moment.moment] = group.endpointCounts.getOrDefault(moment.moment, 0) + 1
+            }
+        }
+
+        groups.values.forEach { group ->
+            val bounds = group.captured.bounds
+            val counts = group.endpointCounts
+            require(counts.size == 2 && counts[bounds.start] == 1 && counts[bounds.end] == 1) {
+                "Period는 시작과 종료 moment에 정확히 한 번씩 연결되어야 합니다. period=$bounds"
+            }
+        }
+        return groups.values.map { store(it.captured) }
+    }
+
+    private fun capture(period: ITimePeriod): CapturedPeriod {
+        val start = period.start
+        val end = period.end
+        require(start < end) { "Timeline period는 start가 end보다 빨라야 합니다. start=$start, end=$end" }
+        return CapturedPeriod(period, PeriodBounds(start, end))
+    }
+
+    private fun store(captured: CapturedPeriod): StoredPeriod {
+        val occurrenceId = nextOccurrenceId++
+        return StoredPeriod(
+            captured.representative,
+            ImmutableTimePeriodSnapshot(captured.bounds.start, captured.bounds.end, occurrenceId),
+        )
+    }
+
+    private fun rebuildMoments() {
+        val buckets = sortedMapOf<ZonedDateTime, MutableList<StoredPeriod>>()
+        periods.forEach { period ->
+            buckets.getOrPut(period.snapshot.start) { mutableListOf() }.add(period)
+            buckets.getOrPut(period.snapshot.end) { mutableListOf() }.add(period)
+        }
+
+        val rebuilt = buckets.map { (moment, linkedPeriods) ->
+            ImmutableTimeLineMomentSnapshot(moment, linkedPeriods)
+        }
+        var balance = 0L
+        rebuilt.forEach { moment ->
+            balance += moment.startCount
+            balance -= moment.endCount
+            check(balance >= 0) { "Timeline balance는 음수가 될 수 없습니다. moment=${moment.moment}, balance=$balance" }
+        }
+        check(balance == 0L) { "Timeline balance는 0으로 끝나야 합니다. balance=$balance" }
+
+        mutable.clear()
+        mutable.addAll(rebuilt)
+    }
+}
+
+private data class PeriodBounds(
+    val start: ZonedDateTime,
+    val end: ZonedDateTime,
+): Serializable
+
+private data class CapturedPeriod(
+    val representative: ITimePeriod,
+    val bounds: PeriodBounds,
+)
+
+private class StoredPeriod(
+    val representative: ITimePeriod,
+    val snapshot: ImmutableTimePeriodSnapshot,
+): Serializable
+
+private class InitialPeriodGroup(
+    val captured: CapturedPeriod,
+) {
+    val endpointCounts: MutableMap<ZonedDateTime, Int> = mutableMapOf()
+}
+
+private class ImmutableTimePeriodSnapshot(
+    override val start: ZonedDateTime,
+    override val end: ZonedDateTime,
+    private val occurrenceId: Long,
+): AbstractValueObject(), ITimePeriod {
+
+    private val bounds: PeriodBounds = PeriodBounds(start, end)
+
+    override val readonly: Boolean = true
+
+    override fun setup(newStart: ZonedDateTime?, newEnd: ZonedDateTime?) {
+        throw unsupportedMutation()
+    }
+
+    override fun copy(offset: Duration): ITimePeriod {
+        val shiftedStart = if (hasStart) start + offset else start
+        val shiftedEnd = if (hasEnd) end + offset else end
+        return ImmutableTimePeriodSnapshot(shiftedStart, shiftedEnd, occurrenceId)
+    }
+
+    override fun move(offset: Duration) {
+        throw unsupportedMutation()
+    }
+
+    override fun isSamePeriod(other: ITimePeriod?): Boolean =
+        other != null && start == other.start && end == other.end
+
+    override fun reset() {
+        throw unsupportedMutation()
+    }
+
+    override fun compareTo(other: ITimePeriod): Int =
+        compareValuesBy(this, other, ITimePeriod::start, ITimePeriod::end)
+
+    override fun equalProperties(other: Any): Boolean =
+        other is ImmutableTimePeriodSnapshot && occurrenceId == other.occurrenceId && bounds == other.bounds
+
+    override fun equals(other: Any?): Boolean = other != null && super.equals(other)
+
+    override fun hashCode(): Int = 31 * bounds.hashCode() + occurrenceId.hashCode()
+
+    override fun buildStringHelper(): ToStringBuilder =
+        super.buildStringHelper()
+            .add("start", start)
+            .add("end", end)
+            .add("readonly", readonly)
+
+    private fun unsupportedMutation(): UnsupportedOperationException =
+        UnsupportedOperationException("Timeline period snapshot은 변경할 수 없습니다.")
+}
+
+private class ImmutableTimeLineMomentSnapshot(
+    override val moment: ZonedDateTime,
+    linkedPeriods: Collection<StoredPeriod>,
+): AbstractValueObject(), ITimeLineMoment {
+
+    override val periods: ITimePeriodCollection = ImmutableTimePeriodCollection(linkedPeriods)
+
+    override val startCount: Long = periods.count { it.start == moment }.toLong()
+
+    override val endCount: Long = periods.count { it.end == moment }.toLong()
+
+    override fun compareTo(other: ITimeLineMoment): Int =
+        moment.compareTo(other.moment)
+
+    override fun equalProperties(other: Any): Boolean =
+        other is ITimeLineMoment && moment == other.moment
+
+    override fun equals(other: Any?): Boolean = other != null && super.equals(other)
+
+    override fun hashCode(): Int = moment.hashCode()
+
+    override fun buildStringHelper(): ToStringBuilder =
+        super.buildStringHelper()
+            .add("moment", moment)
+            .add("startCount", startCount)
+            .add("endCount", endCount)
+            .add("periods", periods)
+}
+
+private class ImmutableTimePeriodCollection private constructor(
+    private val storage: ImmutableTimePeriodCollectionStorage,
+): TimePeriodContainer(storage.guarded), ITimePeriodCollection {
+
+    constructor(periods: Collection<StoredPeriod>): this(ImmutableTimePeriodCollectionStorage(periods))
+
+    override val readonly: Boolean = true
+
+    override fun contains(element: ITimePeriod): Boolean =
+        storage.entries.any { element == it.representative || element == it.snapshot }
+
+    override fun containsPeriod(target: ITimePeriod): Boolean =
+        contains(target)
+
+    override fun containsAll(elements: Collection<ITimePeriod>): Boolean =
+        (elements as Collection<*>).all { it is ITimePeriod && contains(it) }
+
+    override fun indexOf(element: ITimePeriod): Int =
+        storage.entries.indexOfFirst { element == it.representative || element == it.snapshot }
+
+    override fun lastIndexOf(element: ITimePeriod): Int =
+        storage.entries.indexOfLast { element == it.representative || element == it.snapshot }
+
+    override fun add(element: ITimePeriod): Boolean {
+        throw unsupportedMutation()
+    }
+
+    override fun add(index: Int, element: ITimePeriod) {
+        throw unsupportedMutation()
+    }
+
+    override fun addAll(elements: Collection<ITimePeriod>): Boolean {
+        throw unsupportedMutation()
+    }
+
+    override fun addAll(index: Int, elements: Collection<ITimePeriod>): Boolean {
+        throw unsupportedMutation()
+    }
+
+    override fun set(index: Int, element: ITimePeriod): ITimePeriod {
+        throw unsupportedMutation()
+    }
+
+    override fun remove(element: ITimePeriod): Boolean {
+        throw unsupportedMutation()
+    }
+
+    override fun removeAt(index: Int): ITimePeriod {
+        throw unsupportedMutation()
+    }
+
+    override fun removeAll(elements: Collection<ITimePeriod>): Boolean {
+        throw unsupportedMutation()
+    }
+
+    override fun retainAll(elements: Collection<ITimePeriod>): Boolean {
+        throw unsupportedMutation()
+    }
+
+    override fun clear() {
+        throw unsupportedMutation()
+    }
+
+    override fun move(offset: Duration) {
+        throw unsupportedMutation()
+    }
+
+    override fun reset() {
+        throw unsupportedMutation()
+    }
+
+    override fun removeIf(filter: Predicate<in ITimePeriod>): Boolean {
+        throw unsupportedMutation()
+    }
+
+    override fun replaceAll(operator: UnaryOperator<ITimePeriod>) {
+        throw unsupportedMutation()
+    }
+
+    override fun sort(c: Comparator<in ITimePeriod>?) {
+        throw unsupportedMutation()
+    }
+
+    override fun hasInsidePeriods(that: ITimePeriod): Boolean =
+        periods.any { it.hasInsideWith(that) }
+
+    override fun hasOverlapPeriods(that: ITimePeriod): Boolean =
+        periods.any { it.overlapWith(that) }
+
+    override fun hasIntersectionPeriods(moment: ZonedDateTime): Boolean =
+        periods.any { it.hasInsideWith(moment) }
+
+    override fun hasIntersectionPeriods(that: ITimePeriod): Boolean =
+        periods.any { it.intersectWith(that) }
+
+    override fun insidePeriods(target: ITimePeriod): List<ITimePeriod> =
+        periods.filter { it.hasInsideWith(target) }
+
+    override fun overlapPeriods(target: ITimePeriod): List<ITimePeriod> =
+        periods.filter { it.overlapWith(target) }
+
+    override fun intersectionPeriod(moment: ZonedDateTime): List<ITimePeriod> =
+        periods.filter { it.hasInsideWith(moment) }
+
+    override fun intersectionPeriod(target: ITimePeriod): List<ITimePeriod> =
+        periods.filter { it.intersectWith(target) }
+
+    override fun relationPeriods(target: ITimePeriod, vararg relations: PeriodRelation): List<ITimePeriod> =
+        periods.filter { relations.contains(it.relationWith(target)) }
+
+    private fun unsupportedMutation(): UnsupportedOperationException =
+        UnsupportedOperationException("Timeline period snapshot collection은 변경할 수 없습니다.")
+}
+
+private class ImmutableTimePeriodCollectionStorage(
+    periods: Collection<StoredPeriod>,
+): Serializable {
+    val entries: List<StoredPeriod> = periods.toList()
+    val guarded: MutableList<ITimePeriod> = Collections.unmodifiableList(entries.map { it.snapshot }.toMutableList())
 }

--- a/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/timelines/TimeLineMomentCollectionTest.kt
+++ b/utils/javatimes/src/test/kotlin/io/bluetape4k/javatimes/period/timelines/TimeLineMomentCollectionTest.kt
@@ -1,15 +1,28 @@
 package io.bluetape4k.javatimes.period.timelines
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.javatimes.period.AbstractPeriodTest
+import io.bluetape4k.javatimes.period.ITimePeriod
+import io.bluetape4k.javatimes.period.TimeBlock
+import io.bluetape4k.javatimes.period.TimePeriod
 import io.bluetape4k.javatimes.period.TimeRange
+import io.bluetape4k.javatimes.MaxPeriodTime
+import io.bluetape4k.javatimes.MinPeriodTime
+import io.bluetape4k.javatimes.days
 import io.bluetape4k.javatimes.zonedDateTimeOf
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.util.Comparator
 
 class TimeLineMomentCollectionTest: AbstractPeriodTest() {
 
@@ -105,5 +118,404 @@ class TimeLineMomentCollectionTest: AbstractPeriodTest() {
         collection.add(p2)
 
         collection.find(start)?.startCount shouldBeEqualTo 2L
+    }
+
+    @Test
+    fun `same endpoints preserve distinct period equality occurrences`() {
+        val range = TimeRange(start, end)
+        val readonlyRange = TimeRange(start, end, readonly = true)
+        val block = TimeBlock(start, end)
+        val collection = TimeLineMomentCollection()
+
+        collection.addAll(listOf(range, readonlyRange, block, range))
+
+        collection.find(start)?.startCount shouldBeEqualTo 3L
+        collection.find(end)?.endCount shouldBeEqualTo 3L
+        collection.find(start)?.periods?.contains(range).shouldBeTrue()
+        collection.find(start)?.periods?.containsPeriod(range).shouldBeTrue()
+        collection.find(start)?.periods?.contains(readonlyRange).shouldBeTrue()
+        collection.find(start)?.periods?.contains(block).shouldBeTrue()
+
+        collection.remove(readonlyRange)
+
+        collection.find(start)?.startCount shouldBeEqualTo 2L
+        collection.find(start)?.periods?.contains(readonlyRange).shouldBeFalse()
+        collection.find(start)?.periods?.contains(range).shouldBeTrue()
+        collection.find(start)?.periods?.contains(block).shouldBeTrue()
+    }
+
+    @Test
+    fun `moment contains and indexOf keep timestamp lookup semantics`() {
+        val collection = TimeLineMomentCollection().apply { add(TimeRange(start, end)) }
+        val equivalentMoment = TimeLineMoment(start)
+
+        collection.contains(equivalentMoment).shouldBeTrue()
+        collection.containsAll(listOf(equivalentMoment)).shouldBeTrue()
+        collection.indexOf(equivalentMoment) shouldBeEqualTo 0
+        collection.lastIndexOf(equivalentMoment) shouldBeEqualTo 0
+    }
+
+    @Suppress("UNCHECKED_CAST", "PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+    @Test
+    fun `Java containsAll returns false for incompatible element types`() {
+        val collection = collectionOfTwoMoments()
+        val rawMoments = collection as java.util.List<Any?>
+        val rawPeriods = collection.first().periods as java.util.List<Any?>
+
+        rawMoments.containsAll(listOf("not-a-moment")).shouldBeFalse()
+        rawPeriods.containsAll(listOf("not-a-period")).shouldBeFalse()
+    }
+
+    @Test
+    fun `raw MutableList mutation paths fail before changing moments`() {
+        val mutations = listOf<RawMutationCase>(
+            RawMutationCase("add") { it.add(TimeLineMoment(end.plusDays(1))) },
+            RawMutationCase("indexed add") { it.add(0, TimeLineMoment(end.plusDays(1))) },
+            RawMutationCase("addAll") { it.addAll(listOf(TimeLineMoment(end.plusDays(1)))) },
+            RawMutationCase("indexed addAll") { it.addAll(0, listOf(TimeLineMoment(end.plusDays(1)))) },
+            RawMutationCase("set") { it[0] = TimeLineMoment(end.plusDays(1)) },
+            RawMutationCase("removeAt") { it.removeAt(0) },
+            RawMutationCase("remove") { it.remove(it.first()) },
+            RawMutationCase("removeAll") { it.removeAll(listOf(it.first())) },
+            RawMutationCase("retainAll") { it.retainAll(listOf(it.first())) },
+            RawMutationCase("clear") { it.clear() },
+            RawMutationCase("iterator remove") { list -> list.iterator().apply { next(); remove() } },
+            RawMutationCase("listIterator add") { list -> list.listIterator().add(TimeLineMoment(end.plusDays(1))) },
+            RawMutationCase("listIterator set") { list -> list.listIterator().apply { next(); set(TimeLineMoment(end.plusDays(1))) } },
+            RawMutationCase("listIterator remove") { list -> list.listIterator().apply { next(); remove() } },
+            RawMutationCase("subList clear") { it.subList(0, 1).clear() },
+            RawMutationCase("subList add") { it.subList(0, 1).add(TimeLineMoment(end.plusDays(1))) },
+            RawMutationCase("subList set") { it.subList(0, 1)[0] = TimeLineMoment(end.plusDays(1)) },
+            RawMutationCase("subList removeAt") { it.subList(0, 1).removeAt(0) },
+        )
+
+        mutations.forEach { mutation ->
+            val collection = collectionOfTwoMoments()
+            val before = collection.snapshot()
+
+            try {
+                assertFailsWith<UnsupportedOperationException> {
+                    mutation.mutate(collection)
+                }
+            } catch (failure: AssertionError) {
+                throw AssertionError("${mutation.name} must be rejected.", failure)
+            }
+
+            collection.snapshot() shouldBeEqualTo before
+        }
+    }
+
+    @Test
+    fun `Java default mutation callbacks fail before invocation`() {
+        val mutations = listOf<CallbackMutationCase>(
+            CallbackMutationCase("removeIf") { list, invoked ->
+                list.removeIf {
+                    invoked()
+                    true
+                }
+            },
+            CallbackMutationCase("replaceAll") { list, invoked ->
+                list.replaceAll {
+                    invoked()
+                    it
+                }
+            },
+            CallbackMutationCase("sort") { list, invoked ->
+                list.sortWith(
+                    Comparator { _, _ ->
+                        invoked()
+                        0
+                    },
+                )
+            },
+        )
+
+        mutations.forEach { mutation ->
+            val collection = collectionOfTwoMoments()
+            val before = collection.snapshot()
+            var invoked = false
+
+            assertFailsWith<UnsupportedOperationException> {
+                mutation.mutate(collection) { invoked = true }
+            }
+
+            invoked.shouldBeFalse()
+            collection.snapshot() shouldBeEqualTo before
+        }
+    }
+
+    @Test
+    fun `initial moments are copied sorted and isolated from source mutation`() {
+        val period = TimeRange(start, end)
+        val endMoment = TimeLineMoment(end).apply { periods.add(period) }
+        val startMoment = TimeLineMoment(start).apply { periods.add(period) }
+        val source = mutableListOf<ITimeLineMoment>(endMoment, startMoment)
+
+        val collection = TimeLineMomentCollection(source)
+        source.clear()
+        startMoment.periods.clear()
+        period.move(1.days())
+
+        collection.map { it.moment } shouldBeEqualTo listOf(start, end)
+        collection.first().startCount shouldBeEqualTo 1L
+        collection.last().endCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `invalid initial moments are rejected`() {
+        val period = TimeRange(start, end)
+        val empty = TimeLineMoment(start)
+        val unrelated = TimeLineMoment(start.plusDays(1)).apply { periods.add(period) }
+        val duplicated = TimeLineMoment(start).apply { periods.add(period) }
+        val missingEnd = TimeLineMoment(start).apply { periods.add(period) }
+
+        listOf(
+            listOf(empty),
+            listOf(unrelated),
+            listOf(duplicated, duplicated),
+            listOf(missingEnd),
+        ).forEach { invalid ->
+            assertFailsWith<IllegalArgumentException> {
+                TimeLineMomentCollection(invalid.toMutableList())
+            }
+        }
+    }
+
+    @Test
+    fun `moment period is rejected without changing collection`() {
+        val collection = TimeLineMomentCollection()
+
+        assertFailsWith<IllegalArgumentException> {
+            collection.add(TimeRange(start, start))
+        }
+
+        collection.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `reversed period is rejected without changing collection`() {
+        val collection = TimeLineMomentCollection()
+
+        assertFailsWith<IllegalArgumentException> {
+            collection.add(ReversedPeriod(start, end))
+        }
+
+        collection.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `mixed addAll validates all periods before changing collection`() {
+        val collection = TimeLineMomentCollection()
+
+        assertFailsWith<IllegalArgumentException> {
+            collection.addAll(listOf(TimeRange(start, end), TimeRange(end, end)))
+        }
+
+        collection.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `exposed moments and periods are immutable snapshots`() {
+        val original = TimeRange(start, end)
+        val collection = TimeLineMomentCollection().apply { add(original) }
+        val before = collection.snapshot()
+        val exposedMoment = collection.first()
+        val exposedPeriod = exposedMoment.periods.first()
+
+        exposedMoment.periods.contains(exposedPeriod).shouldBeTrue()
+        exposedMoment.periods.indexOf(exposedPeriod) shouldBeEqualTo 0
+        assertFailsWith<UnsupportedOperationException> { exposedMoment.periods.clear() }
+        assertFailsWith<UnsupportedOperationException> { exposedMoment.periods.add(TimeRange(start, end.plusDays(1))) }
+        assertFailsWith<UnsupportedOperationException> { exposedMoment.periods.add(exposedPeriod) }
+        assertFailsWith<UnsupportedOperationException> { exposedMoment.periods.remove(exposedPeriod) }
+        var nestedCallbackInvoked = false
+        assertFailsWith<UnsupportedOperationException> {
+            exposedMoment.periods.removeIf {
+                nestedCallbackInvoked = true
+                true
+            }
+        }
+        nestedCallbackInvoked.shouldBeFalse()
+        assertFailsWith<UnsupportedOperationException> { exposedPeriod.move(1.days()) }
+        assertFailsWith<UnsupportedOperationException> { exposedPeriod.setup(start.plusDays(1), end.plusDays(1)) }
+        assertFailsWith<UnsupportedOperationException> { exposedPeriod.reset() }
+
+        original.move(1.days())
+
+        collection.snapshot() shouldBeEqualTo before
+    }
+
+    @Test
+    fun `nested period collection rejects full MutableList mutation surface`() {
+        val mutations = listOf<NestedMutationCase>(
+            NestedMutationCase("add") { it.add(TimeRange(start, end.plusDays(1))) },
+            NestedMutationCase("indexed add") { it.add(0, TimeRange(start, end.plusDays(1))) },
+            NestedMutationCase("addAll") { it.addAll(listOf(TimeRange(start, end.plusDays(1)))) },
+            NestedMutationCase("indexed addAll") { it.addAll(0, listOf(TimeRange(start, end.plusDays(1)))) },
+            NestedMutationCase("set") { it[0] = TimeRange(start, end.plusDays(1)) },
+            NestedMutationCase("remove") { it.remove(it.first()) },
+            NestedMutationCase("removeAt") { it.removeAt(0) },
+            NestedMutationCase("removeAll") { it.removeAll(listOf(it.first())) },
+            NestedMutationCase("retainAll") { it.retainAll(listOf(it.first())) },
+            NestedMutationCase("clear") { it.clear() },
+            NestedMutationCase("iterator remove") { list -> list.iterator().apply { next(); remove() } },
+            NestedMutationCase("listIterator add") { list -> list.listIterator().add(TimeRange(start, end.plusDays(1))) },
+            NestedMutationCase("listIterator set") { list -> list.listIterator().apply { next(); set(TimeRange(start, end.plusDays(1))) } },
+            NestedMutationCase("listIterator remove") { list -> list.listIterator().apply { next(); remove() } },
+            NestedMutationCase("subList clear") { it.subList(0, 1).clear() },
+            NestedMutationCase("subList add") { it.subList(0, 1).add(TimeRange(start, end.plusDays(1))) },
+            NestedMutationCase("subList set") { it.subList(0, 1)[0] = TimeRange(start, end.plusDays(1)) },
+            NestedMutationCase("subList removeAt") { it.subList(0, 1).removeAt(0) },
+            NestedMutationCase("removeIf") { it.removeIf { true } },
+            NestedMutationCase("replaceAll") { it.replaceAll { period -> period } },
+            NestedMutationCase("sort") { it.sortWith(compareByDescending(ITimePeriod::end)) },
+        )
+
+        mutations.forEach { mutation ->
+            val collection = collectionWithTwoPeriodsAtStart()
+            val periods = collection.first().periods
+            val before = collection.snapshot()
+
+            try {
+                assertFailsWith<UnsupportedOperationException> { mutation.mutate(periods) }
+            } catch (failure: AssertionError) {
+                throw AssertionError("${mutation.name} must be rejected.", failure)
+            }
+
+            collection.snapshot() shouldBeEqualTo before
+        }
+    }
+
+    @Test
+    fun `snapshot copy preserves open period boundaries`() {
+        val collection = TimeLineMomentCollection().apply { add(TimePeriod.AnyTime) }
+
+        val copy = collection.first().periods.first().copy(1.days())
+
+        copy.start shouldBeEqualTo MinPeriodTime
+        copy.end shouldBeEqualTo MaxPeriodTime
+    }
+
+    @Test
+    fun `collection remains serializable with immutable snapshots`() {
+        val original = TimeLineMomentCollection().apply {
+            addAll(
+                listOf(
+                    TimeRange(start, end),
+                    TimeBlock(end, end.plusDays(2)),
+                ),
+            )
+        }
+
+        val bytes = ByteArrayOutputStream().use { output ->
+            ObjectOutputStream(output).use { it.writeObject(original) }
+            output.toByteArray()
+        }
+        val restored = ObjectInputStream(ByteArrayInputStream(bytes)).use {
+            it.readObject() as TimeLineMomentCollection
+        }
+
+        restored.snapshot() shouldBeEqualTo original.snapshot()
+        assertFailsWith<UnsupportedOperationException> { restored.clear() }
+        restored.add(TimeRange(end.plusDays(2), end.plusDays(3)))
+        restored.map { it.moment } shouldBeEqualTo
+            listOf(start, end, end.plusDays(2), end.plusDays(3))
+    }
+
+    @Test
+    fun `validated constructor input remains compatible with timeline algorithms`() {
+        val first = TimeRange(start, end)
+        val second = TimeRange(end.minusDays(2), end.plusDays(3))
+        val source = TimeLineMomentCollection().apply { addAll(listOf(first, second)) }
+        val collection = TimeLineMomentCollection(source.toMutableList())
+
+        val combined = TimeLines.combinePeriods(collection)
+        val intersections = TimeLines.intersectPeriods(collection)
+        val gaps = TimeLines.calculateGap(collection, TimeRange(start.minusDays(1), end.plusDays(4)))
+
+        combined shouldHaveSize 1
+        combined.first().start shouldBeEqualTo start
+        combined.first().end shouldBeEqualTo end.plusDays(3)
+        intersections shouldHaveSize 1
+        intersections.first().start shouldBeEqualTo end.minusDays(2)
+        intersections.first().end shouldBeEqualTo end
+        gaps shouldHaveSize 2
+        gaps.first().start shouldBeEqualTo start.minusDays(1)
+        gaps.last().end shouldBeEqualTo end.plusDays(4)
+    }
+
+    @Test
+    fun `protected constructor and mutation hooks preserve canonical pairs`() {
+        val period = TimeRange(start, end)
+        val startMoment = TimeLineMoment(start).apply { periods.add(period) }
+        val endMoment = TimeLineMoment(end).apply { periods.add(period) }
+        val collection = DerivedMomentCollection(mutableListOf(endMoment, startMoment))
+        val next = TimeRange(end, end.plusDays(3))
+
+        collection.addThroughProtected(end, next)
+
+        collection.map { it.moment } shouldBeEqualTo
+            listOf(start, end, end.plusDays(3))
+
+        collection.removeThroughProtected(start, period)
+
+        collection.map { it.moment } shouldBeEqualTo listOf(end, end.plusDays(3))
+        collection.find(end)?.startCount shouldBeEqualTo 1L
+        collection.find(end)?.endCount shouldBeEqualTo 0L
+    }
+
+    private fun collectionOfTwoMoments(): TimeLineMomentCollection =
+        TimeLineMomentCollection().apply {
+            add(TimeRange(start, end))
+        }
+
+    private fun collectionWithTwoPeriodsAtStart(): TimeLineMomentCollection =
+        TimeLineMomentCollection().apply {
+            addAll(listOf(TimeRange(start, end), TimeRange(start, end.plusDays(1))))
+        }
+
+    private fun TimeLineMomentCollection.snapshot(): List<MomentSnapshot> =
+        map { MomentSnapshot(it.moment, it.startCount, it.endCount, it.periods.toList()) }
+
+    private data class RawMutationCase(
+        val name: String,
+        val mutate: (MutableList<ITimeLineMoment>) -> Unit,
+    )
+
+    private data class CallbackMutationCase(
+        val name: String,
+        val mutate: (MutableList<ITimeLineMoment>, invoked: () -> Unit) -> Unit,
+    )
+
+    private data class NestedMutationCase(
+        val name: String,
+        val mutate: (MutableList<ITimePeriod>) -> Unit,
+    )
+
+    private data class MomentSnapshot(
+        val moment: java.time.ZonedDateTime,
+        val startCount: Long,
+        val endCount: Long,
+        val periods: List<ITimePeriod>,
+    )
+
+    private class ReversedPeriod(
+        earlier: java.time.ZonedDateTime,
+        later: java.time.ZonedDateTime,
+    ): ITimePeriod by TimeRange(earlier, later) {
+        override val start: java.time.ZonedDateTime = later
+        override val end: java.time.ZonedDateTime = earlier
+    }
+
+    private class DerivedMomentCollection(
+        moments: MutableList<ITimeLineMoment>,
+    ): TimeLineMomentCollection(moments) {
+        fun addThroughProtected(moment: java.time.ZonedDateTime, period: ITimePeriod) {
+            addPeriod(moment, period)
+        }
+
+        fun removeThroughProtected(moment: java.time.ZonedDateTime, period: ITimePeriod) {
+            removePeriod(moment, period)
+        }
     }
 }


### PR DESCRIPTION
## 문제

`TimeLineMomentCollection`이 `MutableList<ITimeLineMoment>`의 raw mutation을 내부 list에 위임해 정렬, endpoint pair, count 불변식을 우회할 수 있었습니다. 공개 moment의 nested `periods`와 caller-owned mutable period alias도 계산 상태를 사후 변경할 수 있었습니다.

## 변경 사항

- period의 endpoint를 먼저 검증·capture하고 equality occurrence를 보존하는 immutable snapshot storage로 moment를 재구성합니다.
- outer/nested `MutableList` mutation과 Java default mutation을 상태 변경 및 callback 호출 전에 거부합니다.
- `addAll`은 전체 입력을 먼저 검증한 뒤 원자적으로 반영하며, equality lookup을 set/map으로 바꿔 반복 선형 탐색을 제거합니다.
- protected `addPeriod`/`removePeriod`도 항상 전체 endpoint pair를 추가·제거합니다.
- Java raw `containsAll(Collection<?>)`은 호환되지 않는 element에 `false`를 반환합니다.
- snapshot storage의 같은 버전 Java serialization round-trip을 복구했습니다.

## 호환성 및 마이그레이션

- `ITimeLineMomentCollection : MutableList<ITimeLineMoment>`, protected JVM `(java.util.List)` constructor와 기존 public bridge는 유지합니다.
- 입력 moment/period의 객체 identity는 내부 identity가 아니며, 공개 값은 immutable snapshot입니다.
- private holder 도입으로 Kotlin reflection의 `primaryConstructor` 관찰 결과는 달라질 수 있습니다.
- 내부 serialized field layout이 변경됐으므로 이전 버전에서 만든 Java serialization cache/stream은 업그레이드 시 폐기하고 다시 생성해야 합니다. 같은 버전 round-trip은 지원합니다.

## 검증

- RED: 기존 계약 회귀 5건 및 `NotSerializableException` 1건 재현
- `TimeLineMomentCollectionTest`: 26/26 통과
- `:bluetape4k-javatimes`: 706 통과, 기존 pending 36, failures/errors 0
- `check`, Kover verify/XML, detekt 통과
- `javap -protected`: protected `(java.util.List)` constructor와 public bridge 유지
- exact head `9dd715a854d97adc094571bdbe13b825a6c2bcdf`: GitHub Actions 24개 terminal, 11 success, 13 path skip, failure 0

## 검토

- 독립 architecture review: P0/P1/P2 = 0/0/0, `CLEAR`
- 독립 comprehensive review: P0/P1/P2 = 0/0/0, `CLEAR`
- live GitHub review thread: 0, unresolved 0

Closes #1659

## DoD Status

- [x] public API만으로 invalid timeline state를 만들 수 없음
- [x] 정렬, endpoint pair, balance/count 계약 회귀 검증
- [x] source/ABI 영향 및 serialization migration 문서화
- [x] raw/nested/Java mutation conformance test 추가
- [x] 로컬 exact-head 검증 및 독립 리뷰 통과
- [x] exact-head GitHub Actions 통과
- [x] live review/thread read-back 및 mergeability `CLEAN`
- [ ] merge — 사용자가 다섯 PR을 함께 수행
