### PR TITLE
깨진 ServiceLoader entry 뒤의 virtual thread provider를 계속 탐색한다

### DIFF
--- a/docs/lessons/2026-09-07-issue-1660-virtual-thread-provider-discovery.md
+++ b/docs/lessons/2026-09-07-issue-1660-virtual-thread-provider-discovery.md
@@ -1,0 +1,43 @@
+# VirtualThreadRuntime provider 탐색 격리 교훈
+
+## 문제
+
+`VirtualThreads`는 `ServiceLoader` provider 하나가 깨져도 다음 후보를 계속 탐색한다고 문서화했지만,
+기존 loop는 `hasNext()`와 `next()`를 하나의 `runCatching`으로 묶었다. `next()`가
+`ServiceConfigurationError`를 던지면 종료 조건과 구분되지 않아 뒤의 유효 provider가 가려지고
+프로세스 수명 동안 `platform-fallback` 선택이 고정될 수 있었다.
+
+## 선택
+
+- 동일 저장소의 `StructuredTaskScopes` discovery 경계를 그대로 따른다.
+- `hasNext()` 실패는 iterator 자체를 더 신뢰할 수 없으므로 원인을 로그하고 탐색을 종료한다.
+- `next()` 실패는 해당 service entry만 건너뛰고 다음 provider를 계속 탐색한다.
+- `isSupported()` 실패도 provider 단위로 격리한다.
+- 지원되는 provider만 수집한 뒤 기존 계약대로 priority 내림차순으로 정렬한다.
+- 새 범용 abstraction은 만들지 않고 `VirtualThreads` 내부 helper로 테스트 seam만 분리한다.
+
+## JDK matrix
+
+`virtualthread/api` 변경은 Java 21 compatibility island와 Java 25 구현 모두에 영향을 준다.
+따라서 API의 broken-next/unsupported/failed-check/failed-hasNext 회귀뿐 아니라 각 모듈의 실제
+`META-INF/services` entry가 `jdk21`, `jdk25` runtime을 선택하는 통합 테스트를 함께 유지한다.
+
+## 검증
+
+- RED: `discoverVirtualThreadRuntimes`가 없어 신규 회귀 테스트 compile 실패
+- `bluetape4k-virtualthread-api`: 74 passed, failures/errors/skipped 0
+- `bluetape4k-virtualthread-jdk21`: 30 passed, failures/errors/skipped 0
+- `bluetape4k-virtualthread-jdk25`: 44 passed, failures/errors/skipped 0
+- 세 모듈 `check`, Kover verify/XML, detekt: 성공
+
+## Review Miss
+
+실패를 한 `runCatching`으로 감싸면 예외를 잡았다는 사실만 보이고, 실패 지점마다 다른 복구 정책이
+사라질 수 있다. 반복 탐색에서는 iterator 상태를 잃은 실패와 개별 element 생성·검증 실패를 분리해야
+뒤의 정상 entry를 안전하게 보존할 수 있다.
+
+## 다음 변경 시 지킬 점
+
+1. `hasNext`, `next`, provider capability 검사를 하나의 실패 경계로 합치지 않는다.
+2. 개별 provider 실패 로그에는 secret-bearing 설정값 대신 provider 유형과 단계만 남긴다.
+3. discovery 변경은 API unit test와 JDK 21/25 실제 service integration을 함께 검증한다.

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/api/VirtualThreads.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/api/VirtualThreads.kt
@@ -27,14 +27,28 @@ object VirtualThreads: KLogging() {
 
     private val providers: List<VirtualThreadRuntime> by lazy {
         val loader = ServiceLoader.load(VirtualThreadRuntime::class.java)
-        val iterator = loader.iterator()
+        discoverVirtualThreadRuntimes(loader.iterator())
+    }
+
+    internal fun discoverVirtualThreadRuntimes(
+        iterator: Iterator<VirtualThreadRuntime>,
+    ): List<VirtualThreadRuntime> {
         val discovered = mutableListOf<VirtualThreadRuntime>()
 
         while (true) {
-            val provider = runCatching {
-                if (!iterator.hasNext()) return@runCatching null
-                iterator.next()
+            val hasNext = runCatching {
+                iterator.hasNext()
+            }.onFailure { error ->
+                log.warn(error) { "Stopping VirtualThreadRuntime discovery after ServiceLoader.hasNext() failed." }
             }.getOrNull() ?: break
+            if (!hasNext) {
+                break
+            }
+            val provider = runCatching {
+                iterator.next()
+            }.onFailure { error ->
+                log.warn(error) { "Skipping failed VirtualThreadRuntime provider entry." }
+            }.getOrNull() ?: continue
 
             runCatching {
                 if (provider.isSupported()) {
@@ -46,7 +60,7 @@ object VirtualThreads: KLogging() {
             }
         }
 
-        discovered.sortedByDescending { it.priority }
+        return discovered.sortedByDescending { it.priority }
     }
 
     /**

--- a/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/api/VirtualThreadsTest.kt
+++ b/virtualthread/api/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/api/VirtualThreadsTest.kt
@@ -7,6 +7,10 @@ import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
+import java.util.ServiceConfigurationError
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 
 class VirtualThreadsTest {
 
@@ -61,5 +65,73 @@ class VirtualThreadsTest {
             val result = executor.submit<String> { "from-runtime" }.get()
             result shouldBeEqualTo "from-runtime"
         }
+    }
+
+    @Test
+    fun `provider discovery skips broken next entries`() {
+        val providers = VirtualThreads.discoverVirtualThreadRuntimes(
+            FailingNextThenRuntimeIterator(TestVirtualThreadRuntime("valid", priority = 10)),
+        )
+
+        providers.map { it.runtimeName } shouldBeEqualTo listOf("valid")
+    }
+
+    @Test
+    fun `provider discovery skips unsupported and failing runtime checks`() {
+        val providers = VirtualThreads.discoverVirtualThreadRuntimes(
+            listOf(
+                TestVirtualThreadRuntime("unsupported", priority = 100, supported = false),
+                TestVirtualThreadRuntime("broken-check", priority = 90, supportFailure = true),
+                TestVirtualThreadRuntime("lower", priority = 10),
+                TestVirtualThreadRuntime("higher", priority = 20),
+            ).iterator(),
+        )
+
+        providers.map { it.runtimeName } shouldBeEqualTo listOf("higher", "lower")
+    }
+
+    @Test
+    fun `provider discovery stops cleanly when hasNext fails`() {
+        val providers = VirtualThreads.discoverVirtualThreadRuntimes(FailingHasNextRuntimeIterator())
+
+        providers shouldBeEqualTo emptyList<VirtualThreadRuntime>()
+    }
+
+    private class FailingNextThenRuntimeIterator(
+        private val runtime: VirtualThreadRuntime,
+    ): Iterator<VirtualThreadRuntime> {
+        private var index = 0
+
+        override fun hasNext(): Boolean = index < 2
+
+        override fun next(): VirtualThreadRuntime =
+            when (index++) {
+                0 -> throw ServiceConfigurationError("broken runtime entry")
+                1 -> runtime
+                else -> throw NoSuchElementException()
+            }
+    }
+
+    private class FailingHasNextRuntimeIterator: Iterator<VirtualThreadRuntime> {
+        override fun hasNext(): Boolean = throw ServiceConfigurationError("broken runtime index")
+        override fun next(): VirtualThreadRuntime = throw NoSuchElementException()
+    }
+
+    private class TestVirtualThreadRuntime(
+        override val runtimeName: String,
+        override val priority: Int,
+        private val supported: Boolean = true,
+        private val supportFailure: Boolean = false,
+    ): VirtualThreadRuntime {
+        override fun isSupported(): Boolean {
+            check(!supportFailure) { "support check failed" }
+            return supported
+        }
+
+        override fun threadFactory(prefix: String): ThreadFactory =
+            Thread.ofPlatform().name(prefix, 0).factory()
+
+        override fun executorService(): ExecutorService =
+            Executors.newSingleThreadExecutor(threadFactory("test-"))
     }
 }

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.concurrent.virtualthread.api.VirtualThreads
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
@@ -18,6 +19,11 @@ class Jdk21StructuredTaskScopeProviderTest {
     companion object: KLoggingChannel()
 
     private val provider = Jdk21StructuredTaskScopeProvider()
+
+    @Test
+    fun `ServiceLoader가 JDK 21 virtual thread runtime을 선택해야 한다`() {
+        VirtualThreads.runtimeName() shouldBeEqualTo "jdk21"
+    }
 
     @Test
     fun `withAll success`() {

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.concurrent.virtualthread.api.VirtualThreads
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
@@ -18,6 +19,11 @@ class Jdk25StructuredTaskScopeProviderTest {
     companion object: KLoggingChannel()
 
     private val provider = Jdk25StructuredTaskScopeProvider()
+
+    @Test
+    fun `ServiceLoader가 JDK 25 virtual thread runtime을 선택해야 한다`() {
+        VirtualThreads.runtimeName() shouldBeEqualTo "jdk25"
+    }
 
     @Test
     fun `withAll success`() {


### PR DESCRIPTION
## 문제

`VirtualThreads`는 provider 탐색 오류 뒤에도 선택을 계속한다고 문서화했지만, 기존 구현은 `ServiceLoader.iterator().hasNext()`와 `next()`를 하나의 실패 경계로 묶었습니다. malformed entry에서 `next()`가 실패하면 뒤의 유효 provider를 보지 못하고 프로세스 수명 동안 `platform-fallback`으로 내려갈 수 있었습니다.

## 변경 사항

- `hasNext()` 실패는 iterator 자체 실패로 로그하고 탐색을 종료합니다.
- `next()` 실패는 해당 service entry만 로그하고 다음 provider를 계속 탐색합니다.
- `isSupported()` 실패와 unsupported provider는 개별 후보 단위로 건너뜁니다.
- 지원되는 provider는 기존 계약대로 priority 내림차순으로 정렬합니다.
- 동일 저장소의 `StructuredTaskScopes` 패턴을 따르되 새 범용 abstraction은 추가하지 않았습니다.

## JDK matrix

- API unit test에 broken-next, unsupported, failed-support-check, failed-hasNext, priority 정렬 회귀를 추가했습니다.
- JDK 21/25 모듈에 실제 `META-INF/services` entry가 각각 `jdk21`, `jdk25` runtime을 선택하는 통합 테스트를 추가했습니다.
- 공개 `VirtualThreadRuntime` 및 `VirtualThreads` 호출 API는 변경하지 않았고, 테스트 seam은 Kotlin `internal`입니다.

## 검증

- RED: 신규 discovery helper 부재로 회귀 테스트 compile 실패
- `bluetape4k-virtualthread-api`: 74/74 통과
- `bluetape4k-virtualthread-jdk21`: 30/30 통과
- `bluetape4k-virtualthread-jdk25`: 44/44 통과
- 세 모듈 `check`, Kover verify/XML, detekt 통과
- `javap -public`: 기존 public API 유지, internal helper만 additive mangled method로 확인
- GitHub Actions exact head `d191df785d21a65233efb16cfe82a31aed520b27`: 24개 terminal, 11 success / 13 skipped / 0 failed
- inline exact-diff review: P0/P1/P2 = 0/0/0
- 독립 architecture review: 사용량 제한으로 `PENDING`
- 독립 comprehensive review: 5분 이상 무응답으로 중단, `PENDING`
- GitHub review thread: 0개, unresolved 0개
- GitHub mergeability: `MERGEABLE` / `CLEAN`

Closes #1660

## DoD Status

- [x] `iterator.next()` 실패 후 다음 provider 탐색
- [x] `isSupported()` 실패를 provider 단위로 격리
- [x] `hasNext()` 실패 원인 기록 후 탐색 종료
- [x] 유효 provider 발견 시 fallback 방지 회귀 검증
- [x] JDK 21/25 및 API/ABI 로컬 검증 통과
- [x] GitHub Actions exact-head CI 통과
- [ ] 독립 review provenance 확보
- [ ] 병합(별도 승인 및 사용자 수행)
