### PR TITLE
outbound 오류 정제 정책을 공용 HTTP API로 승격한다

### DIFF
--- a/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
+++ b/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
@@ -44,7 +44,7 @@
 
 - [ ] **Step 1: constants와 credential regex 작성**
 
-  `MAX_LENGTH = 240`, marker regex와 `credentialPattern = Regex("(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[:=]\\s*(?:Bearer\\s+)?(?:\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'|[^\\s,;]+)")`를 private immutable constant로 둔다. marker/value match 개수와 시작 위치가 다르면 해당 first line을 status-only로 버린다. replacement는 captured key의 표기를 유지하는 `"\$1:[redacted]"`를 사용한다. comma/semicolon은 기존 consumer처럼 unquoted token의 경계로 보존한다.
+  `MAX_LENGTH = 240`, marker regex와 `credentialPattern = Regex("(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[:=]\\s*(?:Bearer\\s+)?(?:\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'|[^\\s,;\"']+)")`를 private immutable constant로 둔다. unquoted branch는 quote를 제외해 열린 quote를 삼키지 않으며, quote branch는 escape를 해석해 닫힌 quote만 허용한다. marker/value match 개수와 시작 위치가 다르면 해당 first line을 status-only로 버린다. replacement는 captured key의 표기를 유지하는 `"\$1:[redacted]"`를 사용한다. comma/semicolon은 기존 consumer처럼 unquoted token의 경계로 보존하고, quoted value 안에서는 값의 일부로 redaction한다.
 
 - [ ] **Step 2: 순수 함수 구현**
 

--- a/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
+++ b/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
@@ -25,11 +25,11 @@
 
 - [ ] **Step 1: exact output cases 작성**
 
-  `null/blank는 HTTP prefix만 반환`, `첫 줄과 양 끝 공백만 보존`, `Authorization/Cookie/Token/Secret/API-Key`의 대소문자·`:`·`=`·Bearer·space/hyphen/underscore 변형을 `[redacted]`로 바꿈`, `여러 credential을 모두 치환`, `multiline은 첫 줄만 남김`을 exact string으로 검증한다.
+  `null/blank는 HTTP prefix만 반환`, `첫 줄과 양 끝 공백을 trim`, `Authorization/Cookie/Token/Secret/API-Key`의 대소문자·`:`·`=`·Bearer·space/hyphen/underscore 변형을 `[redacted]`로 바꿈`, `여러 credential을 모두 치환`, `multiline은 첫 줄만 남김`을 exact string으로 검증한다.
 
 - [ ] **Step 2: boundary/security cases 작성**
 
-  `결과가 정확히 240자에서 잘림`, `status prefix가 긴 값이어도 음수 take 오류가 없음`, `Unicode 문자를 포함해 240 Kotlin Char 이내`, `malformed/no-delimiter input은 예외 없이 반환`, `입력 secret이 결과에 절대 포함되지 않음`을 검증한다.
+  `결과가 정확히 240 UTF-16 Char 이내이며 surrogate pair를 자르지 않음`, `Int status prefix가 항상 보존됨`, `Unicode 문자를 포함해 경계가 안전함`, `malformed marker/empty Bearer는 status-only fail-closed`, `입력 secret이 결과에 절대 포함되지 않음`을 검증한다.
 
 - [ ] **Step 3: RED 실행**
 
@@ -44,11 +44,11 @@
 
 - [ ] **Step 1: constants와 credential regex 작성**
 
-  `MAX_LENGTH = 240`, `credentialPattern = Regex("(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[:=]\\s*(?:Bearer\\s+)?[^\\s,;]+")`를 private immutable constant로 둔다. replacement는 captured key의 표기를 유지하는 `"\$1:[redacted]"`를 사용한다.
+  `MAX_LENGTH = 240`, `credentialPattern = Regex("(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[:=]\\s*(?:Bearer\\s+)?[^\\s]+")`를 private immutable constant로 둔다. 별도의 marker regex로 key-value가 malformed/empty인지 검사해 해당 first line을 status-only로 버린다. replacement는 captured key의 표기를 유지하는 `"\$1:[redacted]"`를 사용한다.
 
 - [ ] **Step 2: 순수 함수 구현**
 
-  `prefix = "HTTP $statusCode"`를 만들고 `rawMessage?.lineSequence()?.firstOrNull()?.trim()`을 redaction한 뒤 `MAX_LENGTH - prefix.length`를 `coerceAtLeast(0)`으로 계산한다. blank/empty는 prefix only, 모든 반환 경로는 `.take(MAX_LENGTH)`로 마무리한다. 함수는 로그·예외·외부 상태를 만들지 않는다.
+  `prefix = "HTTP $statusCode"`를 만들고 `rawMessage?.lineSequence()?.firstOrNull()?.trim()`을 redaction한 뒤 malformed marker이면 버린다. `MAX_LENGTH - prefix.length`를 `coerceAtLeast(0)`으로 계산하고, surrogate-safe helper로 body를 자른다. blank/empty는 prefix only, 모든 반환 경로는 prefix를 보존한다. 함수는 로그·예외·외부 상태를 만들지 않는다.
 
 - [ ] **Step 3: GREEN 실행**
 
@@ -94,7 +94,7 @@
 
 - [ ] **Step 1: verify current consumer call sites**
 
-  Before provider publication, only read/record Spring and Ktor call sites. Do not edit them in this branch. Confirm status/retry/transaction/cancellation remain outside the sanitizer.
+  Before provider publication, only read/record Spring and Ktor call sites. Do not edit them in this branch. Confirm status/retry/transaction/cancellation remain outside the sanitizer and record that caller tests must log/persist the sanitized result rather than the original Throwable.
 
 - [ ] **Step 2: record dependency hold**
 

--- a/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
+++ b/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
@@ -29,7 +29,7 @@
 
 - [ ] **Step 2: boundary/security cases 작성**
 
-  다음 grammar table을 exact test로 고정한다. `service token unavailable`은 marker가 없어 원문 첫 줄을 보존하고, `token=secret, retrying`은 `token:[redacted], retrying`을 반환한다. `Authorization : secret`은 redaction하고, `Authorization:`, `Authorization: Bearer`, `Authorization: "unterminated`는 status-only로 fail-closed한다. JSON/quoted/escaped value와 duplicate credential도 모두 검증한다. 결과는 최대 240 UTF-16 Char이며 surrogate pair를 자르지 않고, `Int` status prefix는 항상 보존된다. 입력 secret이 결과에 절대 포함되지 않음도 검증한다.
+  다음 grammar table을 exact test로 고정한다. `service token unavailable`은 marker가 없어 원문 첫 줄을 보존하고, `token=secret, retrying`은 `token:[redacted], retrying`을 반환한다. `Authorization : secret`은 redaction하고, `Authorization:`, `Authorization: Bearer`, `token=""`, `token=''`, `token="unterminated`, `token=secret\\`, `token=secret\\,raw-secret`는 status-only로 fail-closed한다. JSON quoted key/value, quoted/escaped value와 duplicate credential도 모두 검증한다. 결과는 prefix separator를 포함해 최대 240 UTF-16 Char이며 surrogate pair를 자르지 않고, `Int` status prefix는 항상 보존된다. 입력 secret이 결과에 절대 포함되지 않음도 검증한다.
 
 - [ ] **Step 3: RED 실행**
 
@@ -44,11 +44,11 @@
 
 - [ ] **Step 1: constants와 credential regex 작성**
 
-  `MAX_LENGTH = 240`, marker regex와 `credentialPattern = Regex("(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[:=]\\s*(?:Bearer\\s+)?(?:\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'|[^\\s,;\"']+)")`를 private immutable constant로 둔다. unquoted branch는 quote를 제외해 열린 quote를 삼키지 않으며, quote branch는 escape를 해석해 닫힌 quote만 허용한다. marker/value match 개수와 시작 위치가 다르면 해당 first line을 status-only로 버린다. replacement는 captured key의 표기를 유지하는 `"\$1:[redacted]"`를 사용한다. comma/semicolon은 기존 consumer처럼 unquoted token의 경계로 보존하고, quoted value 안에서는 값의 일부로 redaction한다.
+  `MAX_LENGTH = 240`과 key marker regex를 private immutable constant로 두고, marker마다 작은 수동 parser를 적용한다. parser는 JSON-like quoted key, `:`/`=`, optional `Bearer`, unquoted token, single/double quoted escaped value를 처리한다. unquoted branch는 quote와 backslash를 거부하므로 열린 quote, dangling escape, escaped comma/semicolon이 raw suffix를 남기지 않는다. `Bearer` 단독, empty quoted value, 닫히지 않은 quote는 malformed로 판정한다. marker 하나라도 malformed이거나 replacement range가 겹치면 first line 전체를 status-only로 버린다. replacement는 captured key의 표기를 유지하는 `key:[redacted]`를 사용하고, comma/semicolon은 unquoted token의 경계로 보존하며 quoted value 안에서는 값의 일부로 처리한다.
 
 - [ ] **Step 2: 순수 함수 구현**
 
-  `prefix = "HTTP $statusCode"`를 만들고 `rawMessage?.lineSequence()?.firstOrNull()?.trim()`을 redaction한 뒤 malformed marker이면 버린다. `MAX_LENGTH - prefix.length`를 `coerceAtLeast(0)`으로 계산하고, surrogate-safe helper로 body를 자른다. blank/empty는 prefix only, 모든 반환 경로는 prefix를 보존한다. 함수는 로그·예외·외부 상태를 만들지 않는다.
+  `prefix = "HTTP $statusCode"`를 만들고 `rawMessage?.lineSequence()?.firstOrNull()?.trim()`을 redaction한 뒤 malformed marker이면 버린다. `MAX_LENGTH - prefix.length - 1`을 `coerceAtLeast(0)`으로 계산해 separator까지 포함한 최종 길이를 보장하고, surrogate-safe helper로 body를 자른다. blank/empty는 prefix only, 모든 반환 경로는 prefix를 보존한다. 함수는 로그·예외·외부 상태를 만들지 않는다.
 
 - [ ] **Step 3: GREEN 실행**
 
@@ -62,23 +62,33 @@
 
   Run: `./gradlew :bluetape4k-http:compileKotlin :bluetape4k-http:compileTestKotlin :bluetape4k-http:detekt`
 
-  Expected: Kotlin compile/detekt PASS; sanitizer source imports only Kotlin/JDK APIs.
+  Expected: Kotlin compile/detekt PASS; sanitizer source imports only Kotlin/JDK APIs. Existing unrelated module findings are recorded separately.
 
 - [ ] **Step 2: JAR/POM/module metadata 생성**
 
   Run: `./gradlew :bluetape4k-http:jar :bluetape4k-http:generateMetadataFileForBluetape4kPublication :bluetape4k-http:generatePomFileForBluetape4kPublication :bluetape4k-http:checkPomFileForBluetape4kPublication`
 
-  Expected: public function appears in JAR and no Spring/Ktor dependency is introduced by the new file or provider POM.
+  Expected: public function appears in JAR and provider POM has no new Spring/Ktor dependency compared with the provider baseline.
 
 - [ ] **Step 3: bytecode/ABI guard**
 
   Run:
 
   ```bash
+  set -euo pipefail
   artifact_jar="$(find io/http/build/libs -maxdepth 1 -type f -name 'bluetape4k-http-*.jar' ! -name '*-sources.jar' | head -n 1)"
   test -n "$artifact_jar"
   jar tf "$artifact_jar" | rg 'OutboundErrorSanitizer'
-  if jdeps --multi-release 21 --recursive --ignore-missing-deps "$artifact_jar" | rg -q 'org.springframework|io.ktor'; then exit 1; fi
+  guard_dir="$(mktemp -d)"
+  guard_jar="$guard_dir/bluetape4k-http-sanitizer-guard.jar"
+  trap 'rm -rf "$guard_dir"' EXIT
+  test -f io/http/build/classes/kotlin/main/io/bluetape4k/http/OutboundErrorSanitizerKt.class
+  jar --create --file "$guard_jar" \
+    -C io/http/build/classes/kotlin/main io/bluetape4k/http/OutboundErrorSanitizerKt.class
+  jdeps_output="$guard_dir/jdeps.txt"
+  jdeps --multi-release 21 --recursive --ignore-missing-deps "$guard_jar" > "$jdeps_output"
+  if rg -n 'org.springframework|io.ktor' "$jdeps_output"; then exit 1; fi
+  mkdir -p build
   javap -classpath "$artifact_jar" -public io.bluetape4k.http.OutboundErrorSanitizerKt > build/outbound-sanitizer-public-api.txt
   ```
 

--- a/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
+++ b/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
@@ -25,11 +25,11 @@
 
 - [ ] **Step 1: exact output cases 작성**
 
-  `null/blank는 HTTP prefix만 반환`, `첫 줄과 양 끝 공백을 trim`, `Authorization/Cookie/Token/Secret/API-Key`의 대소문자·`:`·`=`·Bearer·space/hyphen/underscore 변형을 `[redacted]`로 바꿈`, `여러 credential을 모두 치환`, `multiline은 첫 줄만 남김`을 exact string으로 검증한다.
+  `null/blank는 HTTP prefix만 반환`, `첫 줄과 양 끝 공백을 trim`, `Authorization/Cookie/Token/Secret/API-Key`의 대소문자·`:`·`=`·Bearer·space/hyphen/underscore 변형을 `[redacted]`로 바꿈`, quoted/escaped value와 여러 credential을 모두 치환, `multiline은 첫 줄만 남김`을 exact string으로 검증한다.
 
 - [ ] **Step 2: boundary/security cases 작성**
 
-  `결과가 정확히 240 UTF-16 Char 이내이며 surrogate pair를 자르지 않음`, `Int status prefix가 항상 보존됨`, `Unicode 문자를 포함해 경계가 안전함`, `malformed marker/empty Bearer는 status-only fail-closed`, `입력 secret이 결과에 절대 포함되지 않음`을 검증한다.
+  다음 grammar table을 exact test로 고정한다. `service token unavailable`은 marker가 없어 원문 첫 줄을 보존하고, `token=secret, retrying`은 `token:[redacted], retrying`을 반환한다. `Authorization : secret`은 redaction하고, `Authorization:`, `Authorization: Bearer`, `Authorization: "unterminated`는 status-only로 fail-closed한다. JSON/quoted/escaped value와 duplicate credential도 모두 검증한다. 결과는 최대 240 UTF-16 Char이며 surrogate pair를 자르지 않고, `Int` status prefix는 항상 보존된다. 입력 secret이 결과에 절대 포함되지 않음도 검증한다.
 
 - [ ] **Step 3: RED 실행**
 
@@ -44,7 +44,7 @@
 
 - [ ] **Step 1: constants와 credential regex 작성**
 
-  `MAX_LENGTH = 240`, `credentialPattern = Regex("(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[:=]\\s*(?:Bearer\\s+)?[^\\s]+")`를 private immutable constant로 둔다. 별도의 marker regex로 key-value가 malformed/empty인지 검사해 해당 first line을 status-only로 버린다. replacement는 captured key의 표기를 유지하는 `"\$1:[redacted]"`를 사용한다.
+  `MAX_LENGTH = 240`, marker regex와 `credentialPattern = Regex("(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[:=]\\s*(?:Bearer\\s+)?(?:\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'|[^\\s,;]+)")`를 private immutable constant로 둔다. marker/value match 개수와 시작 위치가 다르면 해당 first line을 status-only로 버린다. replacement는 captured key의 표기를 유지하는 `"\$1:[redacted]"`를 사용한다. comma/semicolon은 기존 consumer처럼 unquoted token의 경계로 보존한다.
 
 - [ ] **Step 2: 순수 함수 구현**
 
@@ -66,13 +66,27 @@
 
 - [ ] **Step 2: JAR/POM/module metadata 생성**
 
-  Run: `./gradlew :bluetape4k-http:jar :bluetape4k-http:generateMetadataFileForMavenJavaPublication :bluetape4k-http:generatePomFileForMavenJavaPublication`
+  Run: `./gradlew :bluetape4k-http:jar :bluetape4k-http:generateMetadataFileForBluetape4kPublication :bluetape4k-http:generatePomFileForBluetape4kPublication :bluetape4k-http:checkPomFileForBluetape4kPublication`
 
   Expected: public function appears in JAR and no Spring/Ktor dependency is introduced by the new file or provider POM.
 
-- [ ] **Step 3: security scan evidence**
+- [ ] **Step 3: bytecode/ABI guard**
 
-  Run: `git grep -n -E 'secret-token|Authorization.*\[redacted\]' -- io/http/src`; run `gitleaks detect --source . --redact --no-git --config .gitleaks.toml` when the gitleaks binary is available; run `./gradlew dependencyCheckAnalyze --no-daemon` and record its advisory result separately because the provider workflow marks Dependency Check `continue-on-error: true`.
+  Run:
+
+  ```bash
+  artifact_jar="$(find io/http/build/libs -maxdepth 1 -type f -name 'bluetape4k-http-*.jar' ! -name '*-sources.jar' | head -n 1)"
+  test -n "$artifact_jar"
+  jar tf "$artifact_jar" | rg 'OutboundErrorSanitizer'
+  if jdeps --multi-release 21 --recursive --ignore-missing-deps "$artifact_jar" | rg -q 'org.springframework|io.ktor'; then exit 1; fi
+  javap -classpath "$artifact_jar" -public io.bluetape4k.http.OutboundErrorSanitizerKt > build/outbound-sanitizer-public-api.txt
+  ```
+
+  Expected: function class/signature is present, no Spring/Ktor bytecode reference exists, and the signature snapshot shows `sanitizeOutboundError(int, java.lang.String)`.
+
+- [ ] **Step 4: security scan evidence**
+
+  Run: `git grep -n -E 'secret-token|Authorization.*\[redacted\]' -- io/http/src/main` (test fixtures are validated by runtime assertions); run `gitleaks detect --source . --redact --no-git --config .gitleaks.toml` when the gitleaks binary is available; run `./gradlew dependencyCheckAnalyze --no-daemon` and record its advisory result separately because the provider workflow marks Dependency Check `continue-on-error: true`.
 
   Expected: no hard-coded credential in production source; advisory scans are recorded as evidence and not silently treated as blocking pass when CI marks them `continue-on-error`.
 
@@ -94,7 +108,7 @@
 
 - [ ] **Step 1: verify current consumer call sites**
 
-  Before provider publication, only read/record Spring and Ktor call sites. Do not edit them in this branch. Confirm status/retry/transaction/cancellation remain outside the sanitizer and record that caller tests must log/persist the sanitized result rather than the original Throwable.
+  Before provider publication, only read/record Spring and Ktor call sites. Do not edit them in this branch. Confirm status/retry/transaction/cancellation remain outside the sanitizer and record that caller tests must log/persist the sanitized result rather than the original Throwable. The downstream #234 plan must add a log appender/capture test proving credential-bearing thrown exceptions are not passed to `log.warn(e)`, plus exact `lastError` assertions for 503/422/599 and successful retry clearing `lastError`.
 
 - [ ] **Step 2: record dependency hold**
 
@@ -116,7 +130,7 @@
 
 - [ ] **Step 3: rollback point**
 
-  If API behavior or publication metadata fails, revert the latest provider implementation/documentation commits and keep workshop #234 blocked until the spec/plan are re-reviewed.
+  If API behavior or publication metadata fails, record dirty worktree and exact HEAD, revert only the implementation/documentation commit SHA with `git revert <sha>`, and keep workshop #234 blocked. If a snapshot/catalog was already published, stop its consumption and restore the prior immutable artifact/catalog SHA; git revert alone cannot recall Maven metadata.
 
 ## 수용 기준 추적
 

--- a/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
+++ b/docs/superpowers/plans/2026-09-07-outbound-error-sanitizer-plan.md
@@ -1,0 +1,137 @@
+# outbound 오류 정제 공용 API 구현 계획
+
+> **For agentic workers:** 이 계획은 Type-A gate를 통과한 뒤 task-by-task로 실행한다. 각 단계는 체크박스로 추적하고 Kotlin pattern/TDD 규칙을 따른다.
+
+**Goal:** `bluetape4k-http`에 credential-safe outbound 오류 문자열 sanitizer를 추가한다.
+
+**Architecture:** `io.bluetape4k.http.sanitizeOutboundError`는 status prefix와 한 줄 메시지를 조합하는 순수 함수다. credential-like key를 case-insensitive regex로 redaction하고, caller의 retry/status/transaction/cancellation을 전혀 소유하지 않는다.
+
+**Tech Stack:** Kotlin 2.x, JUnit 5, bluetape4k assertions, Gradle module `:bluetape4k-http`, Spring/Ktor downstream compile/test.
+
+---
+
+## 변경 파일 지도
+
+- Create: `io/http/src/main/kotlin/io/bluetape4k/http/OutboundErrorSanitizer.kt` — public pure API and KDoc.
+- Create: `io/http/src/test/kotlin/io/bluetape4k/http/OutboundErrorSanitizerTest.kt` — exact contract and no-secret tests.
+- Modify: `io/http/README.md` — English API contract/example.
+- Modify: `io/http/README.ko.md` — Korean equivalent contract/example.
+- No provider dependency, catalog, Spring/Ktor source, or workflow changes in this provider PR.
+
+### Task 1: RED 테스트로 redaction contract를 고정한다
+
+**Files:**
+- Create: `io/http/src/test/kotlin/io/bluetape4k/http/OutboundErrorSanitizerTest.kt`
+
+- [ ] **Step 1: exact output cases 작성**
+
+  `null/blank는 HTTP prefix만 반환`, `첫 줄과 양 끝 공백만 보존`, `Authorization/Cookie/Token/Secret/API-Key`의 대소문자·`:`·`=`·Bearer·space/hyphen/underscore 변형을 `[redacted]`로 바꿈`, `여러 credential을 모두 치환`, `multiline은 첫 줄만 남김`을 exact string으로 검증한다.
+
+- [ ] **Step 2: boundary/security cases 작성**
+
+  `결과가 정확히 240자에서 잘림`, `status prefix가 긴 값이어도 음수 take 오류가 없음`, `Unicode 문자를 포함해 240 Kotlin Char 이내`, `malformed/no-delimiter input은 예외 없이 반환`, `입력 secret이 결과에 절대 포함되지 않음`을 검증한다.
+
+- [ ] **Step 3: RED 실행**
+
+  Run: `./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.OutboundErrorSanitizerTest"`
+
+  Expected: sanitizer 함수가 없어 compile failure.
+
+### Task 2: 최소 public sanitizer 구현
+
+**Files:**
+- Create: `io/http/src/main/kotlin/io/bluetape4k/http/OutboundErrorSanitizer.kt`
+
+- [ ] **Step 1: constants와 credential regex 작성**
+
+  `MAX_LENGTH = 240`, `credentialPattern = Regex("(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[:=]\\s*(?:Bearer\\s+)?[^\\s,;]+")`를 private immutable constant로 둔다. replacement는 captured key의 표기를 유지하는 `"\$1:[redacted]"`를 사용한다.
+
+- [ ] **Step 2: 순수 함수 구현**
+
+  `prefix = "HTTP $statusCode"`를 만들고 `rawMessage?.lineSequence()?.firstOrNull()?.trim()`을 redaction한 뒤 `MAX_LENGTH - prefix.length`를 `coerceAtLeast(0)`으로 계산한다. blank/empty는 prefix only, 모든 반환 경로는 `.take(MAX_LENGTH)`로 마무리한다. 함수는 로그·예외·외부 상태를 만들지 않는다.
+
+- [ ] **Step 3: GREEN 실행**
+
+  Run: `./gradlew :bluetape4k-http:test --tests "io.bluetape4k.http.OutboundErrorSanitizerTest"`
+
+  Expected: sanitizer unit tests PASS.
+
+### Task 3: provider 경계와 publication surface 확인
+
+- [ ] **Step 1: compile/static checks**
+
+  Run: `./gradlew :bluetape4k-http:compileKotlin :bluetape4k-http:compileTestKotlin :bluetape4k-http:detekt`
+
+  Expected: Kotlin compile/detekt PASS; sanitizer source imports only Kotlin/JDK APIs.
+
+- [ ] **Step 2: JAR/POM/module metadata 생성**
+
+  Run: `./gradlew :bluetape4k-http:jar :bluetape4k-http:generateMetadataFileForMavenJavaPublication :bluetape4k-http:generatePomFileForMavenJavaPublication`
+
+  Expected: public function appears in JAR and no Spring/Ktor dependency is introduced by the new file or provider POM.
+
+- [ ] **Step 3: security scan evidence**
+
+  Run: `git grep -n -E 'secret-token|Authorization.*\[redacted\]' -- io/http/src`; run `gitleaks detect --source . --redact --no-git --config .gitleaks.toml` when the gitleaks binary is available; run `./gradlew dependencyCheckAnalyze --no-daemon` and record its advisory result separately because the provider workflow marks Dependency Check `continue-on-error: true`.
+
+  Expected: no hard-coded credential in production source; advisory scans are recorded as evidence and not silently treated as blocking pass when CI marks them `continue-on-error`.
+
+### Task 4: locale documentation
+
+**Files:**
+- Modify: `io/http/README.md`
+- Modify: `io/http/README.ko.md`
+
+- [ ] **Step 1: identical API section 추가**
+
+  두 README에 root-package import, status-only/null, first-line, supported credential patterns, `[redacted]`, 240-character limit, caller ownership example을 같은 순서로 추가한다.
+
+- [ ] **Step 2: docs validation**
+
+  Run: `git diff --check` and inspect code fences/English-Korean structure side by side.
+
+### Task 5: downstream compatibility proof (publication hold)
+
+- [ ] **Step 1: verify current consumer call sites**
+
+  Before provider publication, only read/record Spring and Ktor call sites. Do not edit them in this branch. Confirm status/retry/transaction/cancellation remain outside the sanitizer.
+
+- [ ] **Step 2: record dependency hold**
+
+  The consumer migration waits for provider exact-head publication and central BOM/catalog update. This is an explicit PENDING gate, not a reason to add a direct arbitrary version to workshop.
+
+### Task 6: verifier and rollback
+
+- [ ] **Step 1: full provider validation**
+
+  Run: `./gradlew :bluetape4k-http:test :bluetape4k-http:koverVerify`
+
+  Expected: targeted and module regression tests PASS.
+
+- [ ] **Step 2: scope/diff validation**
+
+  Run: `git diff --check`, `git status --short`, `git diff --name-only origin/develop...HEAD`
+
+  Expected: only provider source/test/README files in the change map; no workshop/catalog mutation.
+
+- [ ] **Step 3: rollback point**
+
+  If API behavior or publication metadata fails, revert the latest provider implementation/documentation commits and keep workshop #234 blocked until the spec/plan are re-reviewed.
+
+## 수용 기준 추적
+
+| Spec 기준 | 검증 task |
+| --- | --- |
+| prefix/first-line/null/blank/240 | Task 1, 2 |
+| all credential variants and malformed input | Task 1, 2 |
+| no raw secret and no exception leakage | Task 1, 2, 3 |
+| no header/OTel/API dependency conflict | Task 3 |
+| caller behavior unchanged | Task 5 |
+| README locale parity | Task 4 |
+
+## 위험 예측
+
+- Regex가 `API-Key`, `API_Key`, `API Key`를 모두 잡지 못하면 raw secret이 남으므로 변형별 exact table test를 유지한다.
+- `statusCode`가 비정상적으로 긴 문자열을 만들 수 있어 prefix 길이 계산 전에 `coerceAtLeast(0)`을 적용한다.
+- `String.take(240)`은 Kotlin Char 기준이므로 Unicode surrogate/경계 test를 포함하고 DB schema와의 계약을 문서화한다.
+- Spring consumer는 현재 HTTP artifact를 사용하지 않으므로 provider publication 후 `implementation(libs.bluetape4k.http)`와 resolved graph/POM을 별도 downstream PR에서 검증한다.

--- a/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
+++ b/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
@@ -34,16 +34,22 @@ fun sanitizeOutboundError(statusCode: Int, rawMessage: String?): String
 
 동작 순서는 다음과 같다.
 
-1. 항상 `HTTP <statusCode>`를 prefix로 만들고, prefix 자체도 최종 240자
-   상한을 넘지 않도록 자른다.
+1. 항상 `HTTP <statusCode>`를 prefix로 만든다. `Int` status의 prefix는
+   240자보다 짧으므로 prefix 자체는 자르지 않는다.
 2. `null`, blank, 빈 첫 줄은 prefix만 반환한다.
 3. 원문의 첫 줄만 취하고 양 끝 공백을 제거한다. 개행 이후 내용은 결과에
-   포함하지 않는다.
+   포함하지 않는다. 이 trim은 기존 두 consumer의 저장값에서 허용되는
+   의도적인 정규화이며 exact test와 README에 고정한다.
 4. 다음 key를 case-insensitive하게 찾아 `key:[redacted]`로 치환한다.
    `Authorization`, `Cookie`, `Token`, `Secret`, `API-Key`와 `API_Key`,
    `API Key` 변형을 지원하며 `:`/`=` 구분자와 선택적인 `Bearer`를 허용한다.
-5. prefix 길이를 제외한 남은 길이만큼 첫 줄을 자른 뒤 최종 결과를 240자로
-   제한한다. 함수는 예외를 던지지 않는 순수 함수다.
+   key 표기의 원래 대소문자는 replacement에서 보존한다. key-value marker는
+   있지만 값이 비어 있거나 문법이 깨진 경우에는 전체 first line을 버리고
+   status-only를 반환해 fail-closed한다. 인식된 credential value는 공백 전까지
+   하나의 토큰으로 redaction한다.
+5. prefix 길이를 제외한 남은 길이만큼 첫 줄을 자르되 UTF-16 surrogate pair를
+   분할하지 않는 Kotlin `Char` 상한을 적용한다. 최종 결과는 240 UTF-16
+   code units 이내이며 함수는 예외를 던지지 않는 순수 함수다.
 
 예:
 
@@ -69,16 +75,25 @@ sanitizeOutboundError(422, null)
 3. **Spring/Ktor별 공용 base class에 helper 추가**
    - 기각: 두 framework를 provider API에 결합하고 다른 caller 재사용을 막는다.
 
+## 로그와 예외 경계
+
+이 함수가 보장하는 secret-free 범위는 반환 문자열이다. caller는 원본
+`Throwable`을 `log.warn(e)`나 DB/exception payload로 전달하지 않고 이 함수의
+결과를 로그와 persistence에 사용해야 한다. `CancellationException`은 기존
+caller 규칙대로 재전파하고 원본을 로그하지 않는다. provider API 자체는
+Throwable을 받지 않으며 원본 예외를 만들거나 기록하지 않는다.
+
 ## 실패 모드와 대응
 
 1. credential key의 대소문자·separator·Bearer 변형은 모두 동일한 replacement로
-   처리해 raw secret이 남지 않게 한다.
+   처리해 인식된 credential raw value가 남지 않게 한다. marker가 있으나
+   malformed인 경우 status-only로 내려 fail-closed한다.
 2. multiline 예외의 두 번째 줄에 secret이 있어도 첫 줄만 반환하여 저장하지
    않는다.
 3. null/blank/malformed input은 예외 대신 status-only 또는 redacted first line을
    반환한다.
-4. status prefix가 길거나 message가 매우 길어도 `take` 인자 음수 오류 없이
-   결과를 240자 이내로 만든다.
+4. message가 매우 길어도 `take` 인자 음수 오류 없이 결과를 240자 이내로
+   만들고, surrogate pair를 중간에서 자르지 않는다.
 5. 정제 함수는 원본 예외를 log/throw하지 않으므로 caller가 retry/status/
    transaction/cancellation을 기존대로 제어한다.
 
@@ -99,7 +114,8 @@ sanitizeOutboundError(422, null)
       240자 계약을 설명한다.
 - [ ] 모든 key 변형, `:`/`=`, Bearer, boundary whitespace, multiline,
       malformed, Unicode/240자 경계가 exact unit test로 고정된다.
-- [ ] 출력·예외·테스트 결과에 raw secret이 남지 않는다.
+- [ ] 반환 문자열에 인식된 raw secret이 남지 않으며, caller migration이 원본
+      Throwable을 로그/예외/DB payload로 전달하지 않음을 별도 테스트한다.
 - [ ] 기존 HTTP header/OTel API 및 Spring/Ktor dependency 경계와 충돌하지
       않는다.
 - [ ] 함수가 예외를 던지지 않고 caller retry/status/transaction/cancellation을

--- a/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
+++ b/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
@@ -43,8 +43,10 @@ fun sanitizeOutboundError(statusCode: Int, rawMessage: String?): String
 4. 다음 key를 case-insensitive하게 찾아 `key:[redacted]`로 치환한다.
    `Authorization`, `Cookie`, `Token`, `Secret`, `API-Key`와 `API_Key`,
    `API Key` 변형을 지원하며 `:`/`=` 구분자와 선택적인 `Bearer`를 허용한다.
-   key 표기의 원래 대소문자는 replacement에서 보존한다. 값은 공백 전까지의
-   token 또는 escaped quote를 지원하는 single/double quoted value로 인식한다.
+   key 표기의 원래 대소문자는 replacement에서 보존한다. 값은 comma/semicolon/
+   공백 전까지의 unquoted token 또는 escaped quote를 지원하는
+   single/double quoted value로 인식한다. unquoted parser는 quote를 값으로
+   허용하지 않으며, 열린 quote·dangling escape는 malformed로 처리한다.
    key-value marker는 있지만 값이 비어 있거나 quote가 닫히지 않는 등 문법이
    깨진 경우에는 전체 first line을 버리고 status-only를 반환해 fail-closed한다.
 5. prefix 길이를 제외한 남은 길이만큼 첫 줄을 자르되 UTF-16 surrogate pair를

--- a/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
+++ b/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
@@ -1,0 +1,112 @@
+# outbound 오류 정제 공용 API 설계
+
+## 목표
+
+`bluetape4k-http`에 framework-neutral한 순수 함수를 추가하여 outbound 호출
+실패를 DB에 저장할 때 필요한 최소 진단 정보만 남기고 credential-like 값을
+항상 `[redacted]`로 치환한다. Spring/Ktor caller의 HTTP 호출, retry, status
+분류, transaction, cancellation 정책은 그대로 유지한다.
+
+## 현재 근거
+
+- workshop의 Spring·Ktor repository가 동일한 private regex와 240자/첫 줄/
+  `HTTP <status>` 로직을 복사하고 있다.
+- provider `io/http`에는 OkHttp header logging redaction과 OTel telemetry
+  redaction은 있지만 persisted outbound-error 문자열 계약은 없다.
+- 두 consumer 모두 `lastError`를 `varchar(240)`에 저장하므로 결과 상한은
+  Kotlin `Char` 240자로 유지해야 한다.
+- #1650은 `Authorization`, `Cookie`, `Token`, `Secret`, `API-Key`의 `:`/`=`와
+  Bearer 변형, multiline, null/blank, raw secret 비노출을 public API/KDoc와
+  테스트로 고정하도록 요구한다.
+
+## 선택한 설계
+
+파일: `io/http/src/main/kotlin/io/bluetape4k/http/OutboundErrorSanitizer.kt`
+
+```kotlin
+package io.bluetape4k.http
+
+/**
+ * outbound 오류를 DB/log에 보관할 수 있는 제한된 한 줄 요약으로 변환합니다.
+ */
+fun sanitizeOutboundError(statusCode: Int, rawMessage: String?): String
+```
+
+동작 순서는 다음과 같다.
+
+1. 항상 `HTTP <statusCode>`를 prefix로 만들고, prefix 자체도 최종 240자
+   상한을 넘지 않도록 자른다.
+2. `null`, blank, 빈 첫 줄은 prefix만 반환한다.
+3. 원문의 첫 줄만 취하고 양 끝 공백을 제거한다. 개행 이후 내용은 결과에
+   포함하지 않는다.
+4. 다음 key를 case-insensitive하게 찾아 `key:[redacted]`로 치환한다.
+   `Authorization`, `Cookie`, `Token`, `Secret`, `API-Key`와 `API_Key`,
+   `API Key` 변형을 지원하며 `:`/`=` 구분자와 선택적인 `Bearer`를 허용한다.
+5. prefix 길이를 제외한 남은 길이만큼 첫 줄을 자른 뒤 최종 결과를 240자로
+   제한한다. 함수는 예외를 던지지 않는 순수 함수다.
+
+예:
+
+```kotlin
+sanitizeOutboundError(503, "Authorization:=secret-token temporary outage")
+// HTTP 503 Authorization:[redacted] temporary outage
+
+sanitizeOutboundError(599, "timeout\nAuthorization: secret-token")
+// HTTP 599 timeout
+
+sanitizeOutboundError(422, null)
+// HTTP 422
+```
+
+## 대안과 기각
+
+1. **기존 `okhttp3` header redaction 재사용**
+   - 기각: header 전용 marker와 범위가 다르고 HTTP client dependency 및
+     logging semantics를 persisted error API에 끌어온다.
+2. **OpenTelemetry exception redaction을 확장**
+   - 기각: telemetry event의 보존 정책과 DB 저장 계약은 다르며 원본
+     Throwable 재전파 의미를 바꾸면 caller 동작이 깨진다.
+3. **Spring/Ktor별 공용 base class에 helper 추가**
+   - 기각: 두 framework를 provider API에 결합하고 다른 caller 재사용을 막는다.
+
+## 실패 모드와 대응
+
+1. credential key의 대소문자·separator·Bearer 변형은 모두 동일한 replacement로
+   처리해 raw secret이 남지 않게 한다.
+2. multiline 예외의 두 번째 줄에 secret이 있어도 첫 줄만 반환하여 저장하지
+   않는다.
+3. null/blank/malformed input은 예외 대신 status-only 또는 redacted first line을
+   반환한다.
+4. status prefix가 길거나 message가 매우 길어도 `take` 인자 음수 오류 없이
+   결과를 240자 이내로 만든다.
+5. 정제 함수는 원본 예외를 log/throw하지 않으므로 caller가 retry/status/
+   transaction/cancellation을 기존대로 제어한다.
+
+## 호환성과 migration
+
+- `bluetape4k-http`의 additive API이며 기존 header/OTel redaction을 변경하지
+  않는다.
+- Ktor consumer는 기존 HTTP dependency를 재사용한다. Spring consumer는
+  중앙 catalog의 기존 `bluetape4k-http` alias를 `implementation`으로 추가한다.
+- 두 consumer에서 private regex/constants/helper만 제거하고, outbound result의
+  status·retry·DB update 및 transaction 경계는 그대로 둔다.
+- provider artifact publication과 catalog/BOM 갱신이 끝나기 전에는 consumer
+  PR을 만들지 않는다.
+
+## 수용 기준
+
+- [ ] public KDoc와 영/국문 README가 prefix, first-line, null/blank, redaction,
+      240자 계약을 설명한다.
+- [ ] 모든 key 변형, `:`/`=`, Bearer, boundary whitespace, multiline,
+      malformed, Unicode/240자 경계가 exact unit test로 고정된다.
+- [ ] 출력·예외·테스트 결과에 raw secret이 남지 않는다.
+- [ ] 기존 HTTP header/OTel API 및 Spring/Ktor dependency 경계와 충돌하지
+      않는다.
+- [ ] 함수가 예외를 던지지 않고 caller retry/status/transaction/cancellation을
+      변경하지 않는다.
+
+## DoD
+
+provider 구현·단위 테스트·문서·ABI/POM·정적/보안 검사 결과가 exact head에서
+확인되고, CI와 독립 리뷰가 수렴한 뒤 PR merge-ready 상태로 보고한다.
+publication, catalog 갱신, downstream consumer merge는 별도 후속 gate다.

--- a/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
+++ b/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
@@ -40,18 +40,20 @@ fun sanitizeOutboundError(statusCode: Int, rawMessage: String?): String
 3. 원문의 첫 줄만 취하고 양 끝 공백을 제거한다. 개행 이후 내용은 결과에
    포함하지 않는다. 이 trim은 기존 두 consumer의 저장값에서 허용되는
    의도적인 정규화이며 exact test와 README에 고정한다.
-4. 다음 key를 case-insensitive하게 찾아 `key:[redacted]`로 치환한다.
-   `Authorization`, `Cookie`, `Token`, `Secret`, `API-Key`와 `API_Key`,
-   `API Key` 변형을 지원하며 `:`/`=` 구분자와 선택적인 `Bearer`를 허용한다.
-   key 표기의 원래 대소문자는 replacement에서 보존한다. 값은 comma/semicolon/
-   공백 전까지의 unquoted token 또는 escaped quote를 지원하는
-   single/double quoted value로 인식한다. unquoted parser는 quote를 값으로
-   허용하지 않으며, 열린 quote·dangling escape는 malformed로 처리한다.
+4. 다음 key marker를 case-insensitive하게 찾아 `key:[redacted]`로 치환한다.
+  `Authorization`, `Cookie`, `Token`, `Secret`, `API-Key`와 `API_Key`,
+  `API Key` 변형을 지원하며 `:`/`=` 구분자와 선택적인 `Bearer`를 허용한다.
+  JSON처럼 key를 quote로 감싼 형태도 인식하며 key 표기의 원래 대소문자는
+  replacement에서 보존한다. 값은 comma/semicolon/공백 전까지의 unquoted
+  token 또는 escaped quote를 지원하는 single/double quoted value로 인식한다.
+  unquoted parser는 quote와 backslash를 값으로 허용하지 않으며, `Bearer`가
+  단독으로 끝나거나 empty quoted value, 열린 quote, dangling/escaped delimiter는
+  malformed로 처리한다.
    key-value marker는 있지만 값이 비어 있거나 quote가 닫히지 않는 등 문법이
    깨진 경우에는 전체 first line을 버리고 status-only를 반환해 fail-closed한다.
-5. prefix 길이를 제외한 남은 길이만큼 첫 줄을 자르되 UTF-16 surrogate pair를
-   분할하지 않는 Kotlin `Char` 상한을 적용한다. 최종 결과는 240 UTF-16
-   code units 이내이며 함수는 예외를 던지지 않는 순수 함수다.
+5. prefix와 그 뒤 separator 한 칸을 제외한 남은 길이만큼 첫 줄을 자르되
+   UTF-16 surrogate pair를 분할하지 않는 Kotlin `Char` 상한을 적용한다. 최종
+   결과는 240 UTF-16 code units 이내이며 함수는 예외를 던지지 않는 순수 함수다.
 
 예:
 

--- a/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
+++ b/docs/superpowers/specs/2026-09-07-outbound-error-sanitizer-design.md
@@ -43,10 +43,10 @@ fun sanitizeOutboundError(statusCode: Int, rawMessage: String?): String
 4. 다음 key를 case-insensitive하게 찾아 `key:[redacted]`로 치환한다.
    `Authorization`, `Cookie`, `Token`, `Secret`, `API-Key`와 `API_Key`,
    `API Key` 변형을 지원하며 `:`/`=` 구분자와 선택적인 `Bearer`를 허용한다.
-   key 표기의 원래 대소문자는 replacement에서 보존한다. key-value marker는
-   있지만 값이 비어 있거나 문법이 깨진 경우에는 전체 first line을 버리고
-   status-only를 반환해 fail-closed한다. 인식된 credential value는 공백 전까지
-   하나의 토큰으로 redaction한다.
+   key 표기의 원래 대소문자는 replacement에서 보존한다. 값은 공백 전까지의
+   token 또는 escaped quote를 지원하는 single/double quoted value로 인식한다.
+   key-value marker는 있지만 값이 비어 있거나 quote가 닫히지 않는 등 문법이
+   깨진 경우에는 전체 first line을 버리고 status-only를 반환해 fail-closed한다.
 5. prefix 길이를 제외한 남은 길이만큼 첫 줄을 자르되 UTF-16 surrogate pair를
    분할하지 않는 Kotlin `Char` 상한을 적용한다. 최종 결과는 240 UTF-16
    code units 이내이며 함수는 예외를 던지지 않는 순수 함수다.
@@ -85,9 +85,9 @@ Throwable을 받지 않으며 원본 예외를 만들거나 기록하지 않는�
 
 ## 실패 모드와 대응
 
-1. credential key의 대소문자·separator·Bearer 변형은 모두 동일한 replacement로
-   처리해 인식된 credential raw value가 남지 않게 한다. marker가 있으나
-   malformed인 경우 status-only로 내려 fail-closed한다.
+1. credential key의 대소문자·separator·Bearer·quoted/escaped 변형은 모두
+   동일한 replacement로 처리해 인식된 credential raw value가 남지 않게 한다.
+   marker가 있으나 malformed인 경우 status-only로 내려 fail-closed한다.
 2. multiline 예외의 두 번째 줄에 secret이 있어도 첫 줄만 반환하여 저장하지
    않는다.
 3. null/blank/malformed input은 예외 대신 status-only 또는 redacted first line을

--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -544,6 +544,33 @@ Ktor CIO만 1 thread로 낮춘 예외 행이 아니며, CIO 3.5가 pipelining �
 | 범용 고성능 동기 | **HC5 Classic VirtualThread** | `productionVirtualThreadHttpClientOf()` |
 | 고지연 비동기 대량 요청 | **HC5 Async Coroutines** | `productionHttpAsyncClientOf()` |
 
+## Outbound 오류 정제
+
+`sanitizeOutboundError`는 outbound 실패를 저장하거나 log에 남길 때 사용하는
+framework-neutral 순수 함수입니다. 항상 `HTTP <status>` prefix를 유지하고,
+양 끝을 정리한 첫 줄만 사용하며, null·blank·문법이 깨진 credential marker는
+prefix만 반환합니다. `Authorization`, `Cookie`, `Token`, `Secret`,
+`API-Key`/`API_Key`/`API Key` marker를 `:`/`=` 구분자, 선택적 `Bearer`,
+quoted/escaped value와 함께 인식해 `[redacted]`로 치환합니다. 최종 결과는
+최대 240 UTF-16 code units이며 surrogate pair를 분할하지 않습니다.
+
+```kotlin
+import io.bluetape4k.http.sanitizeOutboundError
+
+val summary = sanitizeOutboundError(
+    503,
+    "Authorization: Bearer secret-token temporary outage",
+)
+// HTTP 503 Authorization:[redacted] temporary outage
+
+val statusOnly = sanitizeOutboundError(422, "Authorization: Bearer")
+// HTTP 422
+```
+
+호출자가 retry, status 분류, transaction, cancellation 동작을 소유합니다.
+원본 `Throwable`을 log나 persistence에 전달하지 말고 반환된 summary를
+사용해야 합니다.
+
 ## Coroutines 지원
 
 모든 비동기 HTTP 클라이언트는 `executeSuspending` 확장 함수를 통해 Coroutines 환경에서 자연스럽게 사용할 수 있습니다.

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -532,6 +532,34 @@ Ktor CIO is no longer a one-thread exception, but the whole benchmark uses a sho
 | High-latency async bulk requests | **HC5 Async Coroutines** — `productionHttpAsyncClientOf()` |
 | Ktor-based apps / coroutine-first calls | Ktor CIO |
 
+## Outbound Error Sanitization
+
+`sanitizeOutboundError` is a framework-neutral pure function for storing or
+logging a bounded outbound failure summary. It always keeps the `HTTP <status>`
+prefix, uses only the trimmed first line, and returns the prefix alone for
+null, blank, or malformed credential markers. `Authorization`, `Cookie`,
+`Token`, `Secret`, and `API-Key`/`API_Key`/`API Key` markers are redacted to
+`[redacted]`, including `:`/`=` separators, optional `Bearer`, and quoted or
+escaped values. The final result is at most 240 UTF-16 code units and does not
+split a surrogate pair.
+
+```kotlin
+import io.bluetape4k.http.sanitizeOutboundError
+
+val summary = sanitizeOutboundError(
+    503,
+    "Authorization: Bearer secret-token temporary outage",
+)
+// HTTP 503 Authorization:[redacted] temporary outage
+
+val statusOnly = sanitizeOutboundError(422, "Authorization: Bearer")
+// HTTP 422
+```
+
+The caller owns retry, status classification, transaction, and cancellation
+behavior. Do not pass the original `Throwable` to logging or persistence; use
+the returned summary instead.
+
 ## Backend Comparison
 
 | Client | Protocol | Characteristics | Use case |

--- a/io/http/src/main/kotlin/io/bluetape4k/http/OutboundErrorSanitizer.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/OutboundErrorSanitizer.kt
@@ -1,0 +1,183 @@
+package io.bluetape4k.http
+
+private const val MAX_OUTBOUND_ERROR_LENGTH = 240
+
+private val credentialMarkerPattern = Regex(
+    "(?i)\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b\\s*[\\\"']?\\s*[:=]\\s*",
+)
+
+private data class CredentialReplacement(
+    val start: Int,
+    val endExclusive: Int,
+    val replacement: String,
+)
+
+private data class ParsedCredentialValue(
+    val endExclusive: Int,
+    val unquoted: Boolean,
+    val value: String,
+)
+
+/**
+ * outbound 오류를 DB 또는 log에 보관할 수 있는 제한된 한 줄 요약으로 변환합니다.
+ *
+ * 첫 줄만 사용하고 credential-like marker의 값을 `[redacted]`로 치환합니다.
+ * marker가 존재하지만 값이 비어 있거나 quote/escape 문법이 깨진 경우에는
+ * status prefix만 반환해 fail-closed로 동작합니다. 호출자는 원본 Throwable을
+ * 별도로 log하거나 persistence payload에 포함하지 않아야 합니다.
+ */
+fun sanitizeOutboundError(statusCode: Int, rawMessage: String?): String {
+    val prefix = "HTTP $statusCode"
+    val sanitizedLine = rawMessage
+        ?.lineSequence()
+        ?.firstOrNull()
+        ?.trim()
+        ?.takeUnless { it.isBlank() }
+        ?.let(::sanitizeFirstLine)
+    return formatSanitizedError(prefix, sanitizedLine)
+}
+
+private fun formatSanitizedError(prefix: String, sanitizedLine: String?): String {
+    if (sanitizedLine == null) return prefix
+    val availableBodyLength = (MAX_OUTBOUND_ERROR_LENGTH - prefix.length - 1).coerceAtLeast(0)
+    val body = sanitizedLine.takeUtf16Safe(availableBodyLength)
+    return if (body.isEmpty()) prefix else "$prefix $body"
+}
+
+private fun sanitizeFirstLine(line: String): String? {
+    val replacements = credentialMarkerPattern.findAll(line).map { marker ->
+        parseReplacement(line, marker)
+    }.toList()
+    return if (replacements.any { it == null }) {
+        null
+    } else {
+        applyReplacements(line, replacements.filterNotNull())
+    }
+}
+
+private fun applyReplacements(line: String, replacements: List<CredentialReplacement>): String? {
+    if (replacements.isEmpty()) return line
+
+    val result = StringBuilder(line.length)
+    var cursor = 0
+    var overlapping = false
+    replacements.forEach { replacement ->
+        if (replacement.start < cursor) {
+            overlapping = true
+        } else {
+            result.append(line, cursor, replacement.start)
+            result.append(replacement.replacement)
+            cursor = replacement.endExclusive
+        }
+    }
+    if (!overlapping) result.append(line, cursor, line.length)
+    return if (overlapping) null else result.toString()
+}
+
+private fun parseReplacement(line: String, marker: MatchResult): CredentialReplacement? {
+    val key = marker.groupValues[1]
+    val firstValue = parseValue(line, marker.range.last + 1)
+    val parsedValue = firstValue?.let { value ->
+        if (value.unquoted && value.value.equals("Bearer", ignoreCase = true)) {
+            parseValue(line, skipWhitespace(line, value.endExclusive))
+        } else {
+            value
+        }
+    }
+    return parsedValue
+        ?.takeIf { isValueBoundary(line, it.endExclusive) }
+        ?.let {
+            CredentialReplacement(
+                start = marker.range.first,
+                endExclusive = it.endExclusive,
+                replacement = "$key:[redacted]",
+            )
+        }
+}
+
+private fun parseValue(line: String, start: Int): ParsedCredentialValue? {
+    if (start >= line.length) return null
+    return when (line[start]) {
+        '\'', '"' -> parseQuotedValue(line, start)
+        else -> parseUnquotedValue(line, start)
+    }
+}
+
+private fun parseQuotedValue(line: String, start: Int): ParsedCredentialValue? {
+    val quote = line[start]
+    var index = start + 1
+    var contentLength = 0
+    var malformed = false
+    var parsed: ParsedCredentialValue? = null
+    while (index < line.length && !malformed && parsed == null) {
+        when (line[index]) {
+            '\\' -> {
+                if (index + 1 >= line.length) {
+                    malformed = true
+                } else {
+                    index += 2
+                    contentLength++
+                }
+            }
+
+            quote -> {
+                if (contentLength == 0) {
+                    malformed = true
+                } else {
+                    parsed = ParsedCredentialValue(index + 1, unquoted = false, value = "")
+                }
+            }
+
+            else -> {
+                index++
+                contentLength++
+            }
+        }
+    }
+    return parsed
+}
+
+private fun parseUnquotedValue(line: String, start: Int): ParsedCredentialValue? {
+    var index = start
+    var malformed = false
+    while (index < line.length && !malformed) {
+        when (val character = line[index]) {
+            '\\', '\'', '"' -> malformed = true
+            else -> {
+                if (character.isWhitespace() || character == ',' || character == ';') break
+                index++
+            }
+        }
+    }
+    return if (!malformed && index > start) {
+        ParsedCredentialValue(index, unquoted = true, value = line.substring(start, index))
+    } else {
+        null
+    }
+}
+
+private fun skipWhitespace(line: String, start: Int): Int {
+    var index = start
+    while (index < line.length && line[index].isWhitespace()) index++
+    return index
+}
+
+private fun isValueBoundary(line: String, index: Int): Boolean =
+    index >= line.length || line[index].isWhitespace() || line[index] in ",;}]})"
+
+private fun String.takeUtf16Safe(maxLength: Int): String {
+    val result = when {
+        maxLength <= 0 || isEmpty() -> ""
+        length <= maxLength -> this
+        else -> {
+            var end = maxLength
+            if (end > 0 && end < length) {
+                val previous = this[end - 1]
+                val next = this[end]
+                if (previous.isHighSurrogate() && next.isLowSurrogate()) end--
+            }
+            substring(0, end)
+        }
+    }
+    return result
+}

--- a/io/http/src/main/kotlin/io/bluetape4k/http/OutboundErrorSanitizer.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/OutboundErrorSanitizer.kt
@@ -138,6 +138,8 @@ private fun parseQuotedValue(line: String, start: Int): ParsedCredentialValue? {
 }
 
 private fun parseUnquotedValue(line: String, start: Int): ParsedCredentialValue? {
+    if (start >= line.length || line[start] == ':' || line[start] == '=') return null
+
     var index = start
     var malformed = false
     while (index < line.length && !malformed) {

--- a/io/http/src/test/kotlin/io/bluetape4k/http/OutboundErrorSanitizerTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/OutboundErrorSanitizerTest.kt
@@ -1,0 +1,96 @@
+package io.bluetape4k.http
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class OutboundErrorSanitizerTest {
+
+    @Test
+    fun `null blank and empty first line keep only status prefix`() {
+        sanitizeOutboundError(503, null) shouldBeEqualTo "HTTP 503"
+        sanitizeOutboundError(503, "   ") shouldBeEqualTo "HTTP 503"
+        sanitizeOutboundError(503, "\nAuthorization: secret-token") shouldBeEqualTo "HTTP 503"
+    }
+
+    @Test
+    fun `only the trimmed first line is retained`() {
+        sanitizeOutboundError(599, "  timeout from service  \nAuthorization: secret-token") shouldBeEqualTo
+            "HTTP 599 timeout from service"
+    }
+
+    @Test
+    fun `credential markers and bearer variants are redacted`() {
+        val message =
+            "Authorization: Bearer authorization-secret Cookie= cookie-secret " +
+                "Token:token-secret Secret : Bearer secret-value " +
+                "API-Key=api-secret API_Key:other-secret API Key = third-secret"
+
+        sanitizeOutboundError(503, message) shouldBeEqualTo
+            "HTTP 503 Authorization:[redacted] Cookie:[redacted] Token:[redacted] " +
+            "Secret:[redacted] API-Key:[redacted] API_Key:[redacted] API Key:[redacted]"
+    }
+
+    @Test
+    fun `quoted escaped and json values are redacted`() {
+        val message =
+            "token=\"secret,with,comma\" cookie='secret\\'quote' " +
+                "{\"Authorization\":\"json-secret\",\"Token\":\"second-secret\"}"
+
+        sanitizeOutboundError(422, message) shouldBeEqualTo
+            "HTTP 422 token:[redacted] cookie:[redacted] {\"Authorization:[redacted],\"Token:[redacted]}"
+    }
+
+    @Test
+    fun `unquoted separators remain outside the redaction`() {
+        sanitizeOutboundError(503, "token=secret-token, retrying") shouldBeEqualTo
+            "HTTP 503 token:[redacted], retrying"
+        sanitizeOutboundError(503, "token=secret-token; retrying") shouldBeEqualTo
+            "HTTP 503 token:[redacted]; retrying"
+        sanitizeOutboundError(503, "service token unavailable") shouldBeEqualTo
+            "HTTP 503 service token unavailable"
+    }
+
+    @Test
+    fun `malformed credential markers fail closed`() {
+        val malformed = listOf(
+            "Authorization:",
+            "Authorization: Bearer",
+            "token=\"\"",
+            "token=''",
+            "token=\"unterminated",
+            "token=secret\\",
+            "token=secret\\,raw-secret",
+        )
+
+        malformed.forEach { message ->
+            val actual = sanitizeOutboundError(422, message)
+            actual shouldBeEqualTo "HTTP 422"
+            actual.contains("secret").shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `raw credential values never survive redaction`() {
+        val rawSecret = "secret-token"
+        val result = sanitizeOutboundError(503, "Authorization: $rawSecret temporary outage")
+
+        result.contains(rawSecret).shouldBeFalse()
+        result shouldBeEqualTo "HTTP 503 Authorization:[redacted] temporary outage"
+    }
+
+    @Test
+    fun `output is capped at 240 UTF-16 code units without splitting surrogate pairs`() {
+        val longResult = sanitizeOutboundError(599, "x".repeat(500))
+        longResult.length shouldBeEqualTo 240
+        longResult.startsWith("HTTP 599 ").shouldBeTrue()
+
+        val surrogateBoundary = "a".repeat(230) + "😀"
+        val unicodeResult = sanitizeOutboundError(599, surrogateBoundary)
+        unicodeResult.length shouldBeEqualTo 239
+        unicodeResult.endsWith("a").shouldBeTrue()
+        unicodeResult.last().isHighSurrogate().shouldBeFalse()
+        unicodeResult.startsWith("HTTP 599 ").shouldBeTrue()
+    }
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/OutboundErrorSanitizerTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/OutboundErrorSanitizerTest.kt
@@ -62,6 +62,8 @@ class OutboundErrorSanitizerTest {
             "token=\"unterminated",
             "token=secret\\",
             "token=secret\\,raw-secret",
+            "Authorization: : raw-secret",
+            "Authorization: = raw-secret",
         )
 
         malformed.forEach { message ->


### PR DESCRIPTION
## 문제

Closes #1650

Spring·Ktor production integration이 DB에 저장할 outbound 오류 문자열을 각 consumer에서 반복 정제하고 있어 credential redaction과 길이 계약의 drift 위험이 있었습니다.

## 변경 사항

- `bluetape4k-http`에 `sanitizeOutboundError(statusCode, rawMessage)` public API를 추가했습니다.
- 항상 `HTTP <status>` prefix와 첫 줄만 보존하며, 결과를 240 UTF-16 code unit 이내로 surrogate-safe truncation합니다.
- `Authorization`, `Cookie`, `Token`, `Secret`, `API-Key`의 `:`/`=`·Bearer·JSON quoted key/value 변형을 수동 parser로 redaction합니다.
- malformed marker, empty quote, dangling escape, escaped delimiter, 반복 delimiter, Bearer 단독 입력은 전체 line을 status-only로 만드는 fail-closed 계약입니다.
- 원문 `Throwable` logging/persistence와 HTTP status 분류/retry/transaction은 caller 책임으로 두고, API KDoc과 English/Korean README·설계·계획 문서를 추가했습니다.

## 검증

- `:bluetape4k-http:test --tests "io.bluetape4k.http.OutboundErrorSanitizerTest"`: PASS (8/8; 반복 delimiter 회귀 포함)
- `:bluetape4k-http:test --tests "io.bluetape4k.http.OutboundErrorSanitizerTest" :bluetape4k-http:detekt`: BUILD SUCCESSFUL (신규 sanitizer 경고 없음; 기존 unrelated finding만 존재)
- `:bluetape4k-http:koverVerify -x :bluetape4k-http:test`: BUILD SUCCESSFUL (targeted test coverage artifact 기준)
- `jar`, publication metadata/POM 생성 및 `checkPomFileForBluetape4kPublication`: BUILD SUCCESSFUL
- sanitizer-only `jdeps` guard: PASS (Spring/Ktor 의존성 없음)
- `javap -public` ABI guard: PASS (public API는 `sanitizeOutboundError`만 노출)
- `gitleaks detect --source . --redact --no-git --config .gitleaks.toml`: PASS (no leaks found)
- `git diff --check`: PASS
- 전체 `:bluetape4k-http:test`는 기존 `bluetape4k/mock-web-server:2.1.0` Docker image pull 404로 외부 차단되어 완료하지 못했습니다. sanitizer targeted test에는 영향이 없습니다.

## 검토 및 범위

- 독립 security review에서 확인된 반복 delimiter redaction bypass를 fail-closed parser 경계와 회귀 테스트로 보완했습니다.
- Spring·Ktor consumer log/persistence migration은 이 PR에 포함하지 않으며, workshop #234에서 공용 API와 raw Throwable 비노출을 별도 검증합니다.
- HTTP 호출·retry 분류·DB 저장·transaction/cancellation 정책은 기존 caller 동작을 유지합니다.

## Metadata

- Issue: #1650, milestone `2.1.0`, assignee `debop`
- PR: #1676
- Base: `develop`
- Head: `feat/issue-1650-outbound-sanitizer` (`2f80bdaa0b2d2c7015d1a7b8b05dc0e73710af03`)

## DoD Status

- [x] status prefix, first-line, 240자 cap, null/blank 계약 고정
- [x] credential marker/Bearer/quoted·escaped/repeated-delimiter 변형과 malformed fail-closed 검증
- [x] raw secret 비노출, jdeps/ABI/POM 및 gitleaks 검증
- [x] API KDoc와 English/Korean 문서 반영
- [ ] 전체 모듈 테스트 — 기존 Docker image 404 blocker
- [ ] workshop consumer migration 및 log gate (#234)
- [x] exact-head GitHub Actions CI 및 live review/thread read-back
- [x] merge — merge commit `10df478058b629c08008686c3109416f57082141`