### PR TITLE
tenant별 ConnectionFactory registry 공용 API를 제공한다

### DIFF
--- a/data/r2dbc/README.ko.md
+++ b/data/r2dbc/README.ko.md
@@ -422,8 +422,8 @@ class UserRepositoryTest: AbstractR2dbcTest() {
 
 `R2dbcConnectionFactoryRegistry`는 tenant와 `ConnectionFactory`의 불변
 snapshot을 제공합니다. 등록되지 않은 key를 조회하면
-`NoSuchElementException`으로 즉시 실패하고, `routingMap`은 매핑 결과가
-중복될 때 실패합니다.
+`NoSuchElementException`으로 즉시 실패하지만 configured key 집합은
+노출하지 않습니다. `routingMap`은 매핑 결과가 중복될 때 실패합니다.
 
 ```kotlin
 import io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistry

--- a/data/r2dbc/README.ko.md
+++ b/data/r2dbc/README.ko.md
@@ -418,6 +418,41 @@ class UserRepositoryTest: AbstractR2dbcTest() {
 }
 ```
 
+## ConnectionFactory 레지스트리
+
+`R2dbcConnectionFactoryRegistry`는 tenant와 `ConnectionFactory`의 불변
+snapshot을 제공합니다. 등록되지 않은 key를 조회하면
+`NoSuchElementException`으로 즉시 실패하고, `routingMap`은 매핑 결과가
+중복될 때 실패합니다.
+
+```kotlin
+import io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistry
+import io.r2dbc.spi.ConnectionFactory
+
+val borrowed = R2dbcConnectionFactoryRegistry.borrowed(
+    mapOf(
+        "primary" to primaryFactory,
+        "reporting" to reportingFactory,
+    ),
+)
+
+val primary: ConnectionFactory = borrowed["primary"]
+val routes: Map<String, ConnectionFactory> = borrowed.routingMap { it.lowercase() }
+
+// borrowed resource의 소유권은 caller에 있으며 registry는 종료하지 않습니다.
+borrowed.close().block()
+
+// registry가 resource를 종료해야 할 때만 owned entry를 사용합니다.
+val owned = R2dbcConnectionFactoryRegistry.owned(mapOf("primary" to pooledFactory))
+owned.close().block() // 비동기 종료 오류를 관찰합니다.
+owned.dispose() // lifecycle callback용 fire-and-forget adapter입니다.
+```
+
+custom 비동기 종료 동작이 필요한 factory는
+`R2dbcConnectionFactoryEntry.owned(factory, closeAction)`을 사용합니다.
+레지스트리는 factory identity가 같은 alias를 한 번만 종료합니다. `keys`는
+생성 시점 snapshot을 유지하고, close 이후에는 lookup과 map 접근을 거부합니다.
+
 ## 참고 자료
 
 - [R2DBC 공식 문서](https://r2dbc.io/)

--- a/data/r2dbc/README.md
+++ b/data/r2dbc/README.md
@@ -434,7 +434,8 @@ class UserRepositoryTest: AbstractR2dbcTest() {
 
 `R2dbcConnectionFactoryRegistry` provides an immutable tenant-to-
 `ConnectionFactory` snapshot. Lookup is fail-fast: an unknown key throws
-`NoSuchElementException`, and `routingMap` rejects duplicate mapped keys.
+`NoSuchElementException` without exposing the configured key set, and
+`routingMap` rejects duplicate mapped keys.
 
 ```kotlin
 import io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistry

--- a/data/r2dbc/README.md
+++ b/data/r2dbc/README.md
@@ -430,6 +430,40 @@ class UserRepositoryTest: AbstractR2dbcTest() {
 }
 ```
 
+## ConnectionFactory Registry
+
+`R2dbcConnectionFactoryRegistry` provides an immutable tenant-to-
+`ConnectionFactory` snapshot. Lookup is fail-fast: an unknown key throws
+`NoSuchElementException`, and `routingMap` rejects duplicate mapped keys.
+
+```kotlin
+import io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistry
+import io.r2dbc.spi.ConnectionFactory
+
+val borrowed = R2dbcConnectionFactoryRegistry.borrowed(
+    mapOf(
+        "primary" to primaryFactory,
+        "reporting" to reportingFactory,
+    ),
+)
+
+val primary: ConnectionFactory = borrowed["primary"]
+val routes: Map<String, ConnectionFactory> = borrowed.routingMap { it.lowercase() }
+
+// borrowed resources remain owned by the caller; this is a no-op for them.
+borrowed.close().block()
+
+// Use owned entries only when the registry must close the resources.
+val owned = R2dbcConnectionFactoryRegistry.owned(mapOf("primary" to pooledFactory))
+owned.close().block() // observe asynchronous close errors
+owned.dispose() // fire-and-forget adapter for lifecycle callbacks
+```
+
+Use `R2dbcConnectionFactoryEntry.owned(factory, closeAction)` when a factory
+has a custom asynchronous close operation. The registry deduplicates aliases
+by factory identity and closes each owned resource once. `keys` remains a
+creation-time snapshot, while lookup and map access are rejected after close.
+
 ## References
 
 - [R2DBC Official Documentation](https://r2dbc.io/)

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistry.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistry.kt
@@ -152,7 +152,7 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
         checkOpen()
         return entries[key]?.connectionFactory
             ?: throw NoSuchElementException(
-                "No ConnectionFactory configured for key '$key'. Configured keys: $keySnapshot",
+                "No ConnectionFactory configured for the requested key.",
             )
     }
 
@@ -203,7 +203,10 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
     /** 종료 signal을 구독하는 fire-and-forget lifecycle adapter입니다. */
     override fun dispose() {
         close().subscribe({}, { failure ->
-            log.warn(failure) { "R2DBC ConnectionFactory registry dispose failed" }
+            log.warn {
+                "R2DBC ConnectionFactory registry dispose failed: " +
+                    (failure::class.qualifiedName ?: "unknown failure")
+            }
         })
     }
 
@@ -230,7 +233,9 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
                     if (primary == null) {
                         Mono.empty()
                     } else {
-                        failures.drop(1).forEach(primary::addSuppressed)
+                        failures.drop(1).forEach { failure ->
+                            if (failure !== primary) primary.addSuppressed(failure)
+                        }
                         Mono.error(primary)
                     }
                 },

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistry.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistry.kt
@@ -1,0 +1,280 @@
+package io.bluetape4k.r2dbc.pool
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.r2dbc.spi.Closeable as R2dbcCloseable
+import io.r2dbc.spi.ConnectionFactory
+import reactor.core.Disposable
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.LinkedHashMap
+import java.util.LinkedHashSet
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
+
+/** registry가 각 [ConnectionFactory]를 종료할 책임을 가지는지 나타냅니다. */
+enum class ConnectionFactoryOwnership {
+    /** factory의 lifecycle은 caller가 소유하므로 registry가 종료하지 않습니다. */
+    BORROWED,
+
+    /** factory의 lifecycle을 registry가 소유하고 종료합니다. */
+    OWNED,
+}
+
+/**
+ * registry에 등록할 factory와 lifecycle 정책을 함께 표현합니다.
+ *
+ * [borrowed]는 조회만 허용하고 resource를 종료하지 않습니다. [owned]는
+ * R2DBC [R2dbcCloseable] 또는 Reactor [Disposable] resource를 종료하며,
+ * closeable 구현이 없는 factory는 명시적인 close action을 받아야 합니다.
+ */
+sealed interface R2dbcConnectionFactoryEntry {
+    val connectionFactory: ConnectionFactory
+    val ownership: ConnectionFactoryOwnership
+
+    companion object {
+        /** caller가 resource를 소유하는 entry를 만듭니다. */
+        fun borrowed(connectionFactory: ConnectionFactory): R2dbcConnectionFactoryEntry =
+            BorrowedEntry(connectionFactory)
+
+        /** closeable/disposable resource를 registry가 소유하는 entry를 만듭니다. */
+        fun owned(connectionFactory: ConnectionFactory): R2dbcConnectionFactoryEntry {
+            val closeAction: () -> Mono<Void>
+            when (connectionFactory) {
+                is R2dbcCloseable -> {
+                    closeAction = { Mono.from(connectionFactory.close()).then() }
+                }
+
+                is Disposable -> {
+                    closeAction = {
+                        connectionFactory.dispose()
+                        Mono.empty()
+                    }
+                }
+
+                else ->
+                    throw IllegalArgumentException(
+                        "An owned ConnectionFactory must implement " +
+                            "io.r2dbc.spi.Closeable or reactor.core.Disposable. " +
+                            "Use owned(connectionFactory, closeAction) for a custom lifecycle.",
+                    )
+            }
+            return OwnedEntry(connectionFactory, closeAction, connectionFactory)
+        }
+
+        /** caller가 비동기 종료 동작을 명시하는 owned entry를 만듭니다. */
+        fun owned(
+            connectionFactory: ConnectionFactory,
+            closeAction: () -> Mono<Void>,
+        ): R2dbcConnectionFactoryEntry {
+            requireNotNull(closeAction) { "closeAction must not be null" }
+            return OwnedEntry(connectionFactory, closeAction, closeAction)
+        }
+    }
+}
+
+private val borrowedLifecycleIdentity = Any()
+
+private class BorrowedEntry(
+    override val connectionFactory: ConnectionFactory,
+) : R2dbcConnectionFactoryEntry {
+    override val ownership: ConnectionFactoryOwnership = ConnectionFactoryOwnership.BORROWED
+}
+
+private class OwnedEntry(
+    override val connectionFactory: ConnectionFactory,
+    val closeAction: () -> Mono<Void>,
+    val lifecycleIdentity: Any,
+) : R2dbcConnectionFactoryEntry {
+    override val ownership: ConnectionFactoryOwnership = ConnectionFactoryOwnership.OWNED
+}
+
+private fun R2dbcConnectionFactoryEntry.lifecycleIdentity(): Any =
+    when (this) {
+        is BorrowedEntry -> borrowedLifecycleIdentity
+        is OwnedEntry -> lifecycleIdentity
+    }
+
+private fun R2dbcConnectionFactoryEntry.closeResource(): Mono<Void> =
+    when (this) {
+        is BorrowedEntry -> Mono.empty()
+        is OwnedEntry -> closeAction()
+    }
+
+/**
+ * 임의의 non-null key를 R2DBC [ConnectionFactory]에 매핑하는 정적 registry입니다.
+ *
+ * registry는 생성 시점의 map을 snapshot으로 보관합니다. key parsing, tenant
+ * authorization, request context, transaction, pool 생성은 caller 책임입니다.
+ * resource를 종료할 책임은 [R2dbcConnectionFactoryEntry.ownership]으로
+ * 명시해야 하며, 등록된 factory의 identity가 중복되면 ownership와 lifecycle
+ * action이 일치해야 합니다.
+ */
+class R2dbcConnectionFactoryRegistry<K : Any>(
+    entries: Map<K, R2dbcConnectionFactoryEntry>,
+) : R2dbcCloseable, Disposable {
+
+    private val entries: Map<K, R2dbcConnectionFactoryEntry>
+    private val factories: Map<K, ConnectionFactory>
+    private val keySnapshot: Set<K>
+    private val ownedEntries: List<R2dbcConnectionFactoryEntry>
+    private val closeSignal = AtomicReference<Mono<Void>?>(null)
+
+    init {
+        val entrySnapshot = LinkedHashMap<K, R2dbcConnectionFactoryEntry>(entries.size)
+        entrySnapshot.putAll(entries)
+        validateAliases(entrySnapshot.values)
+
+        this.entries = Collections.unmodifiableMap(entrySnapshot)
+        this.factories = Collections.unmodifiableMap(
+            LinkedHashMap<K, ConnectionFactory>(entrySnapshot.size).apply {
+                entrySnapshot.forEach { (key, entry) -> put(key, entry.connectionFactory) }
+            },
+        )
+        this.keySnapshot = Collections.unmodifiableSet(LinkedHashSet(entrySnapshot.keys))
+        this.ownedEntries = distinctOwnedEntries(entrySnapshot.values)
+    }
+
+    /** 생성 당시 등록된 key의 immutable snapshot입니다. */
+    val keys: Set<K>
+        get() = keySnapshot
+
+    /**
+     * 열린 registry에서 key에 해당하는 factory를 반환합니다.
+     *
+     * 등록되지 않은 key는 다른 factory로 fallback하지 않고
+     * [NoSuchElementException]을 던집니다. 종료가 시작된 뒤의 lookup은
+     * [IllegalStateException]으로 거부합니다.
+     */
+    operator fun get(key: K): ConnectionFactory {
+        checkOpen()
+        return entries[key]?.connectionFactory
+            ?: throw NoSuchElementException(
+                "No ConnectionFactory configured for key '$key'. Configured keys: $keySnapshot",
+            )
+    }
+
+    /** 열린 registry의 key-to-factory immutable snapshot을 반환합니다. */
+    fun asMap(): Map<K, ConnectionFactory> {
+        checkOpen()
+        return factories
+    }
+
+    /**
+     * key mapper를 적용한 routing map을 만듭니다.
+     *
+     * mapper 결과가 중복되면 한 factory가 조용히 덮어써지지 않도록
+     * [IllegalArgumentException]으로 실패합니다.
+     */
+    fun <R : Any> routingMap(keyMapper: (K) -> R): Map<R, ConnectionFactory> {
+        checkOpen()
+        val mapped = LinkedHashMap<R, ConnectionFactory>(entries.size)
+        entries.forEach { (key, entry) ->
+            val mappedKey = keyMapper(key)
+            require(!mapped.containsKey(mappedKey)) {
+                "Routing key '$mappedKey' is produced more than once."
+            }
+            mapped[mappedKey] = entry.connectionFactory
+        }
+        return Collections.unmodifiableMap(mapped)
+    }
+
+    /**
+     * owned resource를 모두 종료하는 cached signal을 반환합니다.
+     *
+     * 모든 종료를 시도한 후 첫 오류를 반환하며, 이후 오류는 첫 오류의
+     * suppressed 예외로 보존합니다. 동시 호출은 동일한 종료 signal을 공유합니다.
+     */
+    override fun close(): Mono<Void> {
+        val existing = closeSignal.get()
+        if (existing != null) return existing
+
+        val signal = Mono.defer { closeOwnedEntries() }.cache()
+        val selected = if (closeSignal.compareAndSet(null, signal)) {
+            signal
+        } else {
+            closeSignal.get() ?: signal
+        }
+        return selected
+    }
+
+    /** 종료 signal을 구독하는 fire-and-forget lifecycle adapter입니다. */
+    override fun dispose() {
+        close().subscribe({}, { failure ->
+            log.warn(failure) { "R2DBC ConnectionFactory registry dispose failed" }
+        })
+    }
+
+    /** close가 시작되었거나 완료되었는지 반환합니다. */
+    override fun isDisposed(): Boolean = closeSignal.get() != null
+
+    private fun checkOpen() {
+        check(closeSignal.get() == null) { "ConnectionFactory registry is closed" }
+    }
+
+    private fun closeOwnedEntries(): Mono<Void> {
+        val failures = CopyOnWriteArrayList<Throwable>()
+        return Flux.fromIterable(ownedEntries)
+            .concatMap { entry ->
+                Mono.defer { entry.closeResource() }
+                    .onErrorResume { failure ->
+                        failures += failure
+                        Mono.empty()
+                    }
+            }
+            .then(
+                Mono.defer {
+                    val primary = failures.firstOrNull()
+                    if (primary == null) {
+                        Mono.empty()
+                    } else {
+                        failures.drop(1).forEach(primary::addSuppressed)
+                        Mono.error(primary)
+                    }
+                },
+            )
+    }
+
+    private fun validateAliases(values: Collection<R2dbcConnectionFactoryEntry>) {
+        val aliases = IdentityHashMap<ConnectionFactory, R2dbcConnectionFactoryEntry>()
+        values.forEach { entry ->
+            val previous = aliases.putIfAbsent(entry.connectionFactory, entry)
+            if (previous != null) {
+                require(previous.ownership == entry.ownership) {
+                    "The same ConnectionFactory cannot be both borrowed and owned."
+                }
+                require(previous.lifecycleIdentity() === entry.lifecycleIdentity()) {
+                    "The same ConnectionFactory must use one lifecycle action."
+                }
+            }
+        }
+    }
+
+    private fun distinctOwnedEntries(
+        values: Collection<R2dbcConnectionFactoryEntry>,
+    ): List<R2dbcConnectionFactoryEntry> {
+        val seen = Collections.newSetFromMap(IdentityHashMap<ConnectionFactory, Boolean>())
+        return values.filter { it.ownership == ConnectionFactoryOwnership.OWNED }
+            .filter { seen.add(it.connectionFactory) }
+    }
+
+    companion object : KLogging() {
+        /** 모든 factory를 borrowed entry로 감싸는 registry를 만듭니다. */
+        fun <K : Any> borrowed(
+            entries: Map<K, ConnectionFactory>,
+        ): R2dbcConnectionFactoryRegistry<K> {
+            val wrapped = entries.mapValues { (_, factory) -> R2dbcConnectionFactoryEntry.borrowed(factory) }
+            return R2dbcConnectionFactoryRegistry(wrapped)
+        }
+
+        /** 모든 factory를 owned entry로 감싸는 registry를 만듭니다. */
+        fun <K : Any> owned(
+            entries: Map<K, ConnectionFactory>,
+        ): R2dbcConnectionFactoryRegistry<K> {
+            val wrapped = entries.mapValues { (_, factory) -> R2dbcConnectionFactoryEntry.owned(factory) }
+            return R2dbcConnectionFactoryRegistry(wrapped)
+        }
+    }
+}

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistryTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistryTest.kt
@@ -1,0 +1,204 @@
+package io.bluetape4k.r2dbc.pool
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.r2dbc.spi.Closeable as R2dbcCloseable
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.ConnectionFactoryMetadata
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import reactor.core.Disposable
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.util.concurrent.atomic.AtomicInteger
+
+class R2dbcConnectionFactoryRegistryTest {
+
+    @Test
+    fun `borrowed registry는 lookup과 immutable snapshot을 제공한다`() {
+        val factory = FakeConnectionFactory("primary")
+        val source = linkedMapOf("primary" to factory)
+        val registry = R2dbcConnectionFactoryRegistry.borrowed(source)
+
+        source["late"] = FakeConnectionFactory("late")
+
+        registry.keys shouldBeEqualTo setOf("primary")
+        registry["primary"] shouldBeSameInstanceAs factory
+        registry.asMap()["primary"] shouldBeSameInstanceAs factory
+        registry.routingMap(String::uppercase)["PRIMARY"] shouldBeSameInstanceAs factory
+
+        registry.close().block()
+        factory.closeCalls.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `unknown key는 configured keys와 함께 fail fast한다`() {
+        val registry = R2dbcConnectionFactoryRegistry.borrowed(
+            mapOf("primary" to FakeConnectionFactory("primary")),
+        )
+
+        val failure = assertFailsWith<NoSuchElementException> {
+            registry["missing"]
+        }
+
+        failure.message shouldBeEqualTo
+            "No ConnectionFactory configured for key 'missing'. Configured keys: [primary]"
+    }
+
+    @Test
+    fun `routing map의 mapped key 충돌을 거부한다`() {
+        val registry = R2dbcConnectionFactoryRegistry.borrowed(
+            linkedMapOf(
+                "one" to FakeConnectionFactory("one"),
+                "two" to FakeConnectionFactory("two"),
+            ),
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            registry.routingMap { "same" }
+        }
+    }
+
+    @Test
+    fun `같은 owned resource alias는 한 번만 종료한다`() {
+        val factory = FakeConnectionFactory("shared")
+        val registry = R2dbcConnectionFactoryRegistry(
+            linkedMapOf(
+                "one" to R2dbcConnectionFactoryEntry.owned(factory),
+                "two" to R2dbcConnectionFactoryEntry.owned(factory),
+            ),
+        )
+
+        registry.close().block()
+        registry.dispose()
+
+        factory.closeCalls.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `borrowed와 owned alias 혼합을 생성 시 거부한다`() {
+        val factory = FakeConnectionFactory("shared")
+
+        assertFailsWith<IllegalArgumentException> {
+            R2dbcConnectionFactoryRegistry(
+                linkedMapOf(
+                    "borrowed" to R2dbcConnectionFactoryEntry.borrowed(factory),
+                    "owned" to R2dbcConnectionFactoryEntry.owned(factory),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `close 이후 lookup과 map access를 거부한다`() {
+        val registry = R2dbcConnectionFactoryRegistry.borrowed(
+            mapOf("primary" to FakeConnectionFactory("primary")),
+        )
+        registry.close().block()
+
+        assertFailsWith<IllegalStateException> { registry["primary"] }
+        assertFailsWith<IllegalStateException> { registry.asMap() }
+        assertFailsWith<IllegalStateException> { registry.routingMap { it } }
+    }
+
+    @Test
+    fun `close는 모든 오류를 시도하고 후속 오류를 suppressed로 보존한다`() {
+        val first = IllegalStateException("first close failure")
+        val second = IllegalArgumentException("second close failure")
+        val firstCalls = AtomicInteger()
+        val secondCalls = AtomicInteger()
+        val firstFactory = PlainConnectionFactory("first")
+        val secondFactory = PlainConnectionFactory("second")
+        val registry = R2dbcConnectionFactoryRegistry(
+            linkedMapOf(
+                "first" to R2dbcConnectionFactoryEntry.owned(firstFactory) {
+                    firstCalls.incrementAndGet()
+                    Mono.error(first)
+                },
+                "second" to R2dbcConnectionFactoryEntry.owned(secondFactory) {
+                    secondCalls.incrementAndGet()
+                    Mono.error(second)
+                },
+            ),
+        )
+
+        registry.dispose()
+
+        StepVerifier.create(registry.close())
+            .expectErrorSatisfies { failure ->
+                firstCalls.get() shouldBeEqualTo 1
+                secondCalls.get() shouldBeEqualTo 1
+                failure shouldBeSameInstanceAs first
+                failure.suppressed shouldHaveSize 1
+                failure.suppressed.first() shouldBeSameInstanceAs second
+            }
+            .verify()
+    }
+
+    @Test
+    fun `concurrent lookup은 A와 B factory를 교차하지 않는다`() {
+        val factoryA = FakeConnectionFactory("A")
+        val factoryB = FakeConnectionFactory("B")
+        val registry = R2dbcConnectionFactoryRegistry.borrowed(
+            linkedMapOf("A" to factoryA, "B" to factoryB),
+        )
+        val counter = AtomicInteger()
+
+        MultithreadingTester()
+            .workers(8)
+            .rounds(30)
+            .add {
+                if (counter.incrementAndGet() % 2 == 0) {
+                    registry["A"] shouldBeSameInstanceAs factoryA
+                } else {
+                    registry["B"] shouldBeSameInstanceAs factoryB
+                }
+            }
+            .run()
+    }
+
+    @Test
+    fun `concurrent close는 cached signal로 한 번만 종료한다`() {
+        val factory = FakeConnectionFactory("shared")
+        val registry = R2dbcConnectionFactoryRegistry.owned(mapOf("primary" to factory))
+
+        MultithreadingTester()
+            .workers(8)
+            .rounds(4)
+            .add { registry.close().block() }
+            .run()
+
+        factory.closeCalls.get() shouldBeEqualTo 1
+    }
+
+    private open class PlainConnectionFactory(
+        private val name: String,
+    ) : ConnectionFactory {
+        override fun create(): Publisher<out Connection> = Mono.error(UnsupportedOperationException(name))
+
+        override fun getMetadata(): ConnectionFactoryMetadata = object : ConnectionFactoryMetadata {
+            override fun getName(): String = name
+        }
+    }
+
+    private class FakeConnectionFactory(
+        name: String,
+    ) : PlainConnectionFactory(name), R2dbcCloseable, Disposable {
+        val closeCalls = AtomicInteger()
+        private val disposed = AtomicInteger()
+
+        override fun close(): Mono<Void> = Mono.fromRunnable {
+            closeCalls.incrementAndGet()
+        }
+
+        override fun dispose() {
+            disposed.incrementAndGet()
+        }
+
+        override fun isDisposed(): Boolean = disposed.get() > 0
+    }
+}

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistryTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistryTest.kt
@@ -36,7 +36,7 @@ class R2dbcConnectionFactoryRegistryTest {
     }
 
     @Test
-    fun `unknown key는 configured keys와 함께 fail fast한다`() {
+    fun `unknown key는 configured key를 노출하지 않고 fail fast한다`() {
         val registry = R2dbcConnectionFactoryRegistry.borrowed(
             mapOf("primary" to FakeConnectionFactory("primary")),
         )
@@ -45,8 +45,7 @@ class R2dbcConnectionFactoryRegistryTest {
             registry["missing"]
         }
 
-        failure.message shouldBeEqualTo
-            "No ConnectionFactory configured for key 'missing'. Configured keys: [primary]"
+        failure.message shouldBeEqualTo "No ConnectionFactory configured for the requested key."
     }
 
     @Test
@@ -135,6 +134,26 @@ class R2dbcConnectionFactoryRegistryTest {
                 failure shouldBeSameInstanceAs first
                 failure.suppressed shouldHaveSize 1
                 failure.suppressed.first() shouldBeSameInstanceAs second
+            }
+            .verify()
+    }
+
+    @Test
+    fun `close가 같은 Throwable identity를 반복해도 self suppression으로 실패하지 않는다`() {
+        val shared = IllegalStateException("shared close failure")
+        val firstFactory = PlainConnectionFactory("first")
+        val secondFactory = PlainConnectionFactory("second")
+        val registry = R2dbcConnectionFactoryRegistry(
+            linkedMapOf(
+                "first" to R2dbcConnectionFactoryEntry.owned(firstFactory) { Mono.error(shared) },
+                "second" to R2dbcConnectionFactoryEntry.owned(secondFactory) { Mono.error(shared) },
+            ),
+        )
+
+        StepVerifier.create(registry.close())
+            .expectErrorSatisfies { failure ->
+                failure shouldBeSameInstanceAs shared
+                failure.suppressed shouldHaveSize 0
             }
             .verify()
     }

--- a/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
+++ b/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
@@ -29,7 +29,7 @@
 
 - [ ] **Step 2: 다음 실패 테스트 작성**
 
-  `borrowed registry는 lookup/keys/asMap snapshot을 제공한다`, `unknown key는 configured keys를 포함한 NoSuchElementException을 던진다`, `routingMap은 mapped key 충돌을 거부한다`, `owned registry는 같은 resource alias를 한 번만 닫는다`, `borrowed registry는 close 후에도 resource를 닫지 않는다`, `close는 모든 오류를 시도하고 후속 오류를 suppressed로 보존한다`, `concurrent lookup은 A/B factory를 교차하지 않는다`, `동시 close는 cached operation으로 한 번만 실행된다`를 exact assertion으로 작성한다.
+  `borrowed registry는 lookup/keys/asMap snapshot을 제공한다`, `unknown key는 configured keys를 포함한 NoSuchElementException을 던진다`, `routingMap은 mapped key 충돌을 거부한다`, `owned registry는 같은 resource alias를 한 번만 닫는다`, `borrowed/owned alias 충돌은 생성 시 거부한다`, `borrowed registry는 close 후에도 resource를 닫지 않는다`, `close 후 lookup/map은 IllegalStateException을 던진다`, `close는 모든 오류를 시도하고 후속 오류를 suppressed로 보존한다`, `concurrent lookup은 A/B factory를 교차하지 않는다`, `동시 close는 cached operation으로 한 번만 실행된다`를 exact assertion으로 작성한다.
 
 - [ ] **Step 3: RED 실행**
 
@@ -44,15 +44,15 @@
 
 - [ ] **Step 1: ownership entry 구현**
 
-  `ConnectionFactoryOwnership`는 `BORROWED`와 `OWNED`만 가진다. `borrowed(factory)`는 no-op close action을 만들고, 기본 `owned(factory)`는 R2DBC `Closeable`을 우선 사용하고 Reactor `Disposable`을 fallback으로 사용하며 둘 다 아니면 `IllegalArgumentException`을 던진다. 두 번째 `owned(factory, closeAction)`는 caller가 비동기 종료 동작을 명시한다.
+  `ConnectionFactoryOwnership`는 `BORROWED`와 `OWNED`만 가진다. `borrowed(factory)`는 no-op close action을 만들고, 기본 `owned(factory)`는 R2DBC `Closeable`을 우선 사용하고 Reactor `Disposable`을 fallback으로 사용하며 둘 다 아니면 `IllegalArgumentException`을 던진다. 두 번째 `owned(factory, closeAction)`는 caller가 비동기 종료 동작을 명시한다. callback은 private/internal로 숨기고 registry만 호출한다.
 
 - [ ] **Step 2: immutable lookup 구현**
 
-  생성자에서 `entries.toMap()`으로 snapshot을 만들고 `keys`/`asMap()`은 읽기 전용 copy를 반환한다. `operator fun get`은 누락 key를 `NoSuchElementException`으로 fail-fast한다. `routingMap`은 mapper 결과 중복을 `IllegalArgumentException`으로 거부하고 insertion order를 보존한다.
+  생성 시 `LinkedHashMap`/unmodifiable wrapper로 snapshot을 만들고 `keys`/`asMap()`은 내부 변경이 외부에 노출되지 않는 읽기 전용 copy를 반환한다. close state가 설치되면 `get`, `asMap`, `routingMap`은 `IllegalStateException`으로 거부하고 `keys`만 유지한다. `operator fun get`은 열린 registry에서 누락 key를 `NoSuchElementException`으로 fail-fast한다. `routingMap`은 mapper 결과 중복을 `IllegalArgumentException`으로 거부하고 관찰된 snapshot iteration order를 보존한다.
 
 - [ ] **Step 3: lifecycle 구현**
 
-  owned entry를 resource identity로 deduplicate한다. `close()`는 `AtomicReference<Mono<Void>>`에 `cache()`된 operation을 한 번만 설치하고, 각 close action을 순차 실행하면서 오류를 수집한 뒤 첫 오류에 나머지를 suppressed로 붙인다. `dispose()`는 같은 operation을 subscribe하는 fire-and-forget adapter이며 `isDisposed()`는 close state를 반영한다.
+  owned entry를 resource identity로 deduplicate한다. 같은 identity의 alias는 ownership와 custom close-action identity가 같아야 하며, 혼합이면 생성 시 fail-fast한다. `close()`는 `AtomicReference<Mono<Void>>` compare-and-set으로 `cache()`된 operation을 한 번만 설치하고, 각 close action을 순차 실행하면서 synchronous throw와 `Mono.error`를 모두 수집한 뒤 첫 오류에 나머지를 suppressed로 붙인다. `dispose()`는 같은 operation을 subscribe하는 fire-and-forget adapter이며 `isDisposed()`는 close state를 반영한다.
 
 - [ ] **Step 4: companion convenience factory 구현**
 

--- a/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
+++ b/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
@@ -25,11 +25,11 @@
 
 - [ ] **Step 1: fake factory/resource fixture 작성**
 
-  `ConnectionFactory`의 `create()`는 `Mono.error(UnsupportedOperationException())`를 반환하고 `ConnectionFactoryMetadata`는 고정 이름을 반환한다. owned fixture는 R2DBC `Closeable`과 Reactor `Disposable`을 구현하고 close/dispose 호출 횟수와 지정 오류를 `AtomicInteger`/`AtomicReference`에 기록한다.
+  `ConnectionFactory`의 `create()`는 `Mono.error(UnsupportedOperationException())`를 반환하고 `ConnectionFactoryMetadata`는 고정 이름을 반환한다. owned fixture는 R2DBC `Closeable`과 Reactor `Disposable`을 구현하고 close/dispose 호출 횟수와 지정 오류를 `AtomicInteger`/`AtomicReference`에 기록한다. dispose-first 오류 경로가 후속 `close()`에서 같은 cached error와 suppressed chain을 보존하는지도 고정한다.
 
 - [ ] **Step 2: 다음 실패 테스트 작성**
 
-  `borrowed registry는 lookup/keys/asMap snapshot을 제공한다`, `unknown key는 configured keys를 포함한 NoSuchElementException을 던진다`, `routingMap은 mapped key 충돌을 거부한다`, `owned registry는 같은 resource alias를 한 번만 닫는다`, `borrowed/owned alias 충돌은 생성 시 거부한다`, `borrowed registry는 close 후에도 resource를 닫지 않는다`, `close 후 lookup/map은 IllegalStateException을 던진다`, `close는 모든 오류를 시도하고 후속 오류를 suppressed로 보존한다`, `concurrent lookup은 A/B factory를 교차하지 않는다`, `동시 close는 cached operation으로 한 번만 실행된다`를 exact assertion으로 작성한다.
+  `borrowed registry는 lookup/keys/asMap snapshot을 제공한다`, `unknown key는 configured keys를 포함한 NoSuchElementException을 던진다`, `routingMap은 mapped key 충돌을 거부한다`, `owned registry는 같은 resource alias를 한 번만 닫는다`, `borrowed/owned alias 충돌은 생성 시 거부한다`, `borrowed registry는 close 후에도 resource를 닫지 않는다`, `close 후 lookup/map은 IllegalStateException을 던진다`, `close는 모든 오류를 시도하고 후속 오류를 suppressed로 보존한다`, `dispose-first 오류도 후속 close 관찰성을 유지한다`, `concurrent lookup은 A/B factory를 교차하지 않는다`, `동시 close는 cached operation으로 한 번만 실행된다`를 exact assertion으로 작성한다.
 
 - [ ] **Step 3: RED 실행**
 
@@ -44,7 +44,7 @@
 
 - [ ] **Step 1: ownership entry 구현**
 
-  `ConnectionFactoryOwnership`는 `BORROWED`와 `OWNED`만 가진다. `borrowed(factory)`는 no-op close action을 만들고, 기본 `owned(factory)`는 R2DBC `Closeable`을 우선 사용하고 Reactor `Disposable`을 fallback으로 사용하며 둘 다 아니면 `IllegalArgumentException`을 던진다. 두 번째 `owned(factory, closeAction)`는 caller가 비동기 종료 동작을 명시한다. callback은 private/internal로 숨기고 registry만 호출한다.
+  `ConnectionFactoryOwnership`는 `BORROWED`와 `OWNED`만 가진다. `borrowed(factory)`는 no-op close action을 만들고, 기본 `owned(factory)`는 R2DBC `Closeable`을 우선 사용하고 Reactor `Disposable`을 fallback으로 사용하며 둘 다 아니면 `IllegalArgumentException`을 던진다. 두 번째 `owned(factory, closeAction)`는 caller가 비동기 종료 동작을 명시한다. public entry는 factory/ownership만 노출하고 lifecycle callback과 identity는 private implementation/helper에 둔다. `javap -public`에 callback backdoor가 생기지 않는지 검증한다.
 
 - [ ] **Step 2: immutable lookup 구현**
 
@@ -52,11 +52,11 @@
 
 - [ ] **Step 3: lifecycle 구현**
 
-  owned entry를 resource identity로 deduplicate한다. 같은 identity의 alias는 ownership와 custom close-action identity가 같아야 하며, 혼합이면 생성 시 fail-fast한다. `close()`는 `AtomicReference<Mono<Void>>` compare-and-set으로 `cache()`된 operation을 한 번만 설치하고, 각 close action을 순차 실행하면서 synchronous throw와 `Mono.error`를 모두 수집한 뒤 첫 오류에 나머지를 suppressed로 붙인다. `dispose()`는 같은 operation을 subscribe하는 fire-and-forget adapter이며 `isDisposed()`는 close state를 반영한다.
+  owned entry를 resource identity로 deduplicate한다. 같은 identity의 alias는 ownership와 custom close-action identity가 같아야 하며, 혼합이면 생성 시 fail-fast한다. `close()`는 `AtomicReference<Mono<Void>>` compare-and-set으로 `cache()`된 operation을 한 번만 설치하고, 그 reference를 lifecycle state의 단일 source of truth로 사용한다. 각 close action을 순차 실행하면서 synchronous throw와 `Mono.error`를 모두 수집한 뒤 첫 오류에 나머지를 suppressed로 붙인다. `dispose()`는 같은 operation을 subscribe하는 fire-and-forget adapter이고 오류를 logger에 기록하며, `isDisposed()`는 close signal 설치 여부를 반영한다.
 
 - [ ] **Step 4: companion convenience factory 구현**
 
-  `R2dbcConnectionFactoryRegistry.borrowed(entries: Map<K, out ConnectionFactory>)`와 `owned(entries: Map<K, out ConnectionFactory>)`가 entry map을 생성하도록 한다.
+  `R2dbcConnectionFactoryRegistry.borrowed(entries: Map<K, ConnectionFactory>)`와 `owned(entries: Map<K, ConnectionFactory>)`가 entry map을 생성하도록 한다. Kotlin `Map` 자체가 값 타입에 공변이므로 subtype factory map도 호출부에서 허용된다.
 
 ### Task 3: GREEN 및 동시성/ABI 경계 검증
 
@@ -70,30 +70,39 @@
 
   Run: `./gradlew :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:detekt`
 
-  Expected: compile/detekt PASS, Spring/Ktor import 없음.
+  Expected: compile/detekt PASS, 새 registry source에 Spring/Ktor import 없음. 기존 module baseline의 unrelated detekt finding은 별도로 기록한다.
 
 - [ ] **Step 3: publication surface 확인**
 
   Run: `./gradlew :bluetape4k-r2dbc:jar :bluetape4k-r2dbc:generateMetadataFileForBluetape4kPublication :bluetape4k-r2dbc:generatePomFileForBluetape4kPublication :bluetape4k-r2dbc:checkPomFileForBluetape4kPublication`
 
-  Expected: JAR/POM/module metadata 생성과 POM check 성공; `jar tf`와 POM dependency 목록에 workshop framework가 없음.
+  Expected: JAR/POM/module metadata 생성과 POM check 성공; 생성된 POM은 provider baseline과 비교해 새 framework dependency를 추가하지 않는다.
 
 - [ ] **Step 4: bytecode/dependency guard**
 
   Run:
 
   ```bash
-  artifact_jar="$(find data/r2dbc/build/libs -maxdepth 1 -type f -name 'bluetape4k-r2dbc-*.jar' ! -name '*-sources.jar' | head -n 1)"
-  test -n "$artifact_jar"
-  jar tf "$artifact_jar" | rg 'R2dbcConnectionFactoryRegistry|R2dbcConnectionFactoryEntry'
-  if jdeps --multi-release 21 --recursive --ignore-missing-deps "$artifact_jar" | rg -q 'org.springframework|io.ktor'; then exit 1; fi
+  set -euo pipefail
+  guard_dir="$(mktemp -d)"
+  guard_jar="$guard_dir/bluetape4k-r2dbc-registry-guard.jar"
+  trap 'rm -rf "$guard_dir"' EXIT
+  test -f data/r2dbc/build/classes/kotlin/main/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistry.class
+  jar --create --file "$guard_jar" \
+    -C data/r2dbc/build/classes/kotlin/main io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistry.class \
+    -C data/r2dbc/build/classes/kotlin/main io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryEntry.class \
+    -C data/r2dbc/build/classes/kotlin/main io/bluetape4k/r2dbc/pool/ConnectionFactoryOwnership.class
+  jar tf "$guard_jar" | rg 'R2dbcConnectionFactoryRegistry|R2dbcConnectionFactoryEntry'
+  jdeps_output="$guard_dir/jdeps.txt"
+  jdeps --multi-release 21 --recursive --ignore-missing-deps "$guard_jar" > "$jdeps_output"
+  if rg -n 'org.springframework|io.ktor' "$jdeps_output"; then exit 1; fi
   ```
 
   Expected: public classes are in the JAR and no Spring/Ktor bytecode reference exists. `Mono`/Reactor linkage is checked through the generated POM and the workshop compile gate, not by adding a framework dependency to this PR.
 
 - [ ] **Step 5: public signature snapshot**
 
-  Run: `javap -classpath "$artifact_jar" -public io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistry io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryEntry > build/registry-public-api.txt` and inspect that the documented methods (`get`, `asMap`, `routingMap`, `close`, `dispose`, `isDisposed`) are present. If the repository ABI plugin becomes available, run its canonical task in addition; otherwise retain this exact signature output as the additive ABI evidence.
+  Run: `set -euo pipefail; artifact_jar="$(find data/r2dbc/build/libs -maxdepth 1 -type f -name 'bluetape4k-r2dbc-*.jar' ! -name '*-sources.jar' | head -n 1)"; test -n "$artifact_jar"; mkdir -p build; javap -classpath "$artifact_jar" -public io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistry io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryEntry > build/registry-public-api.txt; if rg -n 'closeResource\\$|lifecycleIdentity\\$|synthetic' build/registry-public-api.txt; then exit 1; fi` and inspect that the documented methods (`get`, `asMap`, `routingMap`, `close`, `dispose`, `isDisposed`) are present. If the repository ABI plugin becomes available, run its canonical task in addition; otherwise retain this exact signature output as the additive ABI evidence.
 
 ### Task 4: README locale parity 문서화
 
@@ -139,12 +148,12 @@
 | borrowed/owned/custom lifecycle | Task 1, 2 |
 | idempotency/dedup/concurrent close/suppressed | Task 1, 2, 3 |
 | A/B concurrent isolation | Task 1, 3 |
-| no Spring/Ktor in artifact | Task 3 |
+| 새 registry bytecode에 Spring/Ktor 없음, baseline 대비 새 framework dependency 없음 | Task 3 |
 | README 영/국문 parity | Task 4 |
 
 ## 위험 예측
 
 - Reactor `Mono`를 public API로 노출하므로 `close()`가 cold/cached 동작인지 테스트에서 subscription까지 확인한다.
-- `Disposable.dispose()`는 오류를 동기 throw하지 않는 fire-and-forget adapter이므로 오류 관찰 계약은 `close()`에만 둔다.
+- `Disposable.dispose()`는 오류를 동기 throw하지 않는 fire-and-forget adapter이므로 logger에 기록하고, 상세 원인/suppressed chain 관찰 계약은 cached `close()`에 둔다.
 - `ConnectionFactory` alias가 identity dedup되지 않으면 pool double-close가 발생하므로 동일 인스턴스 fixture를 반드시 사용한다.
 - `Map.toMap()`이 caller 변경을 노출하지 않는지 원본 map mutate 후 snapshot을 확인한다.

--- a/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
+++ b/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
@@ -74,9 +74,26 @@
 
 - [ ] **Step 3: publication surface 확인**
 
-  Run: `./gradlew :bluetape4k-r2dbc:jar :bluetape4k-r2dbc:generateMetadataFileForMavenJavaPublication :bluetape4k-r2dbc:generatePomFileForMavenJavaPublication`
+  Run: `./gradlew :bluetape4k-r2dbc:jar :bluetape4k-r2dbc:generateMetadataFileForBluetape4kPublication :bluetape4k-r2dbc:generatePomFileForBluetape4kPublication :bluetape4k-r2dbc:checkPomFileForBluetape4kPublication`
 
-  Expected: JAR/POM/module metadata 생성 성공; `jar tf`와 POM dependency 목록에 workshop framework가 없음.
+  Expected: JAR/POM/module metadata 생성과 POM check 성공; `jar tf`와 POM dependency 목록에 workshop framework가 없음.
+
+- [ ] **Step 4: bytecode/dependency guard**
+
+  Run:
+
+  ```bash
+  artifact_jar="$(find data/r2dbc/build/libs -maxdepth 1 -type f -name 'bluetape4k-r2dbc-*.jar' ! -name '*-sources.jar' | head -n 1)"
+  test -n "$artifact_jar"
+  jar tf "$artifact_jar" | rg 'R2dbcConnectionFactoryRegistry|R2dbcConnectionFactoryEntry'
+  if jdeps --multi-release 21 --recursive --ignore-missing-deps "$artifact_jar" | rg -q 'org.springframework|io.ktor'; then exit 1; fi
+  ```
+
+  Expected: public classes are in the JAR and no Spring/Ktor bytecode reference exists. `Mono`/Reactor linkage is checked through the generated POM and the workshop compile gate, not by adding a framework dependency to this PR.
+
+- [ ] **Step 5: public signature snapshot**
+
+  Run: `javap -classpath "$artifact_jar" -public io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistry io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryEntry > build/registry-public-api.txt` and inspect that the documented methods (`get`, `asMap`, `routingMap`, `close`, `dispose`, `isDisposed`) are present. If the repository ABI plugin becomes available, run its canonical task in addition; otherwise retain this exact signature output as the additive ABI evidence.
 
 ### Task 4: README locale parity 문서화
 
@@ -98,7 +115,7 @@
 
   Run: `./gradlew :bluetape4k-r2dbc:test :bluetape4k-r2dbc:koverVerify`
 
-  Expected: targeted 및 모듈 회귀 테스트 PASS. Docker-backed DB가 필요한 기존 테스트 실패 시 해당 환경/로그를 기록하고 registry 테스트 결과와 혼동하지 않는다.
+  Expected: targeted 및 모듈 회귀 테스트 PASS. Docker-backed DB가 필요한 기존 테스트가 실패하면 환경과 코드 원인을 분리 진단하고 재실행하며, 실패가 남아 있는 동안 provider 완료 상태를 `PENDING`으로 유지한다. registry 테스트만 성공한 상태로 전체 provider를 완료로 선언하지 않는다.
 
 - [ ] **Step 2: diff/ownership 확인**
 
@@ -108,7 +125,11 @@
 
 - [ ] **Step 3: rollback 지점**
 
-  provider contract가 publication/CI에서 실패하면 이 branch의 latest commit 전까지 revert하고 downstream migration을 시작하지 않는다. public API를 바꾸면 spec/plan과 테스트를 먼저 갱신하고 review gate를 다시 연다.
+  provider contract가 publication/CI에서 실패하면 dirty worktree와 현재 HEAD를 먼저 기록한 뒤, 정확한 implementation commit SHA만 `git revert <sha>`로 되돌린다. 이미 게시된 artifact는 git revert로 회수되지 않으므로 snapshot/catalog 소비를 중단하고 immutable 이전 version/SHA로 되돌린다. downstream migration은 차단하고 상태를 `PENDING`으로 남긴다. public API를 바꾸면 spec/plan과 테스트를 먼저 갱신하고 review gate를 다시 연다.
+
+- [ ] **Step 4: downstream security hold 기록**
+
+  provider PR에서는 consumer를 수정하지 않지만, 후속 #233 plan은 인증 tenant와 요청 tenant 불일치 및 미인증 요청이 `registry.get` 전에 401/403으로 끝나는 negative integration test를 포함해야 한다. 이 증거가 없으면 provider publication 이후에도 consumer gate를 열지 않는다.
 
 ## 수용 기준 추적
 

--- a/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
+++ b/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
@@ -1,0 +1,129 @@
+# tenant ConnectionFactory registry 구현 계획
+
+> **For agentic workers:** 이 계획은 Type-A gate를 통과한 뒤 task-by-task로 실행한다. 각 단계는 체크박스로 추적하고, Kotlin pattern/TDD 규칙을 따른다.
+
+**Goal:** `bluetape4k-r2dbc`에 불변 key registry와 명시적 borrowed/owned lifecycle을 추가한다.
+
+**Architecture:** `R2dbcConnectionFactoryEntry`가 factory와 ownership/close action을 감싸고, `R2dbcConnectionFactoryRegistry<K>`가 immutable snapshot을 조회한다. registry는 R2DBC `Closeable`과 Reactor `Disposable` adapter만 제공하며 Spring/Ktor 타입은 참조하지 않는다.
+
+**Tech Stack:** Kotlin 2.x, R2DBC SPI, Reactor Mono/Flux, JUnit 5, bluetape4k assertions, Gradle module `:bluetape4k-r2dbc`.
+
+---
+
+## 변경 파일 지도
+
+- Create: `data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistry.kt` — entry, ownership, registry public API.
+- Create: `data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistryTest.kt` — lookup, snapshot, routing, lifecycle, concurrency tests.
+- Modify: `data/r2dbc/README.md` — English public API contract and example.
+- Modify: `data/r2dbc/README.ko.md` — Korean equivalent contract and example.
+- No Spring/Ktor, catalog, or dependency file changes are allowed in this provider PR.
+
+### Task 1: RED 테스트로 public contract를 고정한다
+
+**Files:**
+- Create: `data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistryTest.kt`
+
+- [ ] **Step 1: fake factory/resource fixture 작성**
+
+  `ConnectionFactory`의 `create()`는 `Mono.error(UnsupportedOperationException())`를 반환하고 `ConnectionFactoryMetadata`는 고정 이름을 반환한다. owned fixture는 R2DBC `Closeable`과 Reactor `Disposable`을 구현하고 close/dispose 호출 횟수와 지정 오류를 `AtomicInteger`/`AtomicReference`에 기록한다.
+
+- [ ] **Step 2: 다음 실패 테스트 작성**
+
+  `borrowed registry는 lookup/keys/asMap snapshot을 제공한다`, `unknown key는 configured keys를 포함한 NoSuchElementException을 던진다`, `routingMap은 mapped key 충돌을 거부한다`, `owned registry는 같은 resource alias를 한 번만 닫는다`, `borrowed registry는 close 후에도 resource를 닫지 않는다`, `close는 모든 오류를 시도하고 후속 오류를 suppressed로 보존한다`, `concurrent lookup은 A/B factory를 교차하지 않는다`, `동시 close는 cached operation으로 한 번만 실행된다`를 exact assertion으로 작성한다.
+
+- [ ] **Step 3: RED 실행**
+
+  Run: `./gradlew :bluetape4k-r2dbc:test --tests "io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistryTest"`
+
+  Expected: registry 타입/함수가 없어 compile failure.
+
+### Task 2: entry와 registry의 최소 구현
+
+**Files:**
+- Create: `data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/R2dbcConnectionFactoryRegistry.kt`
+
+- [ ] **Step 1: ownership entry 구현**
+
+  `ConnectionFactoryOwnership`는 `BORROWED`와 `OWNED`만 가진다. `borrowed(factory)`는 no-op close action을 만들고, 기본 `owned(factory)`는 R2DBC `Closeable`을 우선 사용하고 Reactor `Disposable`을 fallback으로 사용하며 둘 다 아니면 `IllegalArgumentException`을 던진다. 두 번째 `owned(factory, closeAction)`는 caller가 비동기 종료 동작을 명시한다.
+
+- [ ] **Step 2: immutable lookup 구현**
+
+  생성자에서 `entries.toMap()`으로 snapshot을 만들고 `keys`/`asMap()`은 읽기 전용 copy를 반환한다. `operator fun get`은 누락 key를 `NoSuchElementException`으로 fail-fast한다. `routingMap`은 mapper 결과 중복을 `IllegalArgumentException`으로 거부하고 insertion order를 보존한다.
+
+- [ ] **Step 3: lifecycle 구현**
+
+  owned entry를 resource identity로 deduplicate한다. `close()`는 `AtomicReference<Mono<Void>>`에 `cache()`된 operation을 한 번만 설치하고, 각 close action을 순차 실행하면서 오류를 수집한 뒤 첫 오류에 나머지를 suppressed로 붙인다. `dispose()`는 같은 operation을 subscribe하는 fire-and-forget adapter이며 `isDisposed()`는 close state를 반영한다.
+
+- [ ] **Step 4: companion convenience factory 구현**
+
+  `R2dbcConnectionFactoryRegistry.borrowed(entries: Map<K, out ConnectionFactory>)`와 `owned(entries: Map<K, out ConnectionFactory>)`가 entry map을 생성하도록 한다.
+
+### Task 3: GREEN 및 동시성/ABI 경계 검증
+
+- [ ] **Step 1: targeted test 실행**
+
+  Run: `./gradlew :bluetape4k-r2dbc:test --tests "io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistryTest"`
+
+  Expected: 모든 registry 테스트 PASS.
+
+- [ ] **Step 2: module compile/static checks**
+
+  Run: `./gradlew :bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:detekt`
+
+  Expected: compile/detekt PASS, Spring/Ktor import 없음.
+
+- [ ] **Step 3: publication surface 확인**
+
+  Run: `./gradlew :bluetape4k-r2dbc:jar :bluetape4k-r2dbc:generateMetadataFileForMavenJavaPublication :bluetape4k-r2dbc:generatePomFileForMavenJavaPublication`
+
+  Expected: JAR/POM/module metadata 생성 성공; `jar tf`와 POM dependency 목록에 workshop framework가 없음.
+
+### Task 4: README locale parity 문서화
+
+**Files:**
+- Modify: `data/r2dbc/README.md`
+- Modify: `data/r2dbc/README.ko.md`
+
+- [ ] **Step 1: 동일 예제 추가**
+
+  두 README에 `R2dbcConnectionFactoryRegistry`의 borrowed/owned 생성, `registry[key]`, `routingMap`, `close()`/`dispose()` 차이와 unknown-key fail-fast를 같은 구조로 추가한다. 코드·URL·명령은 그대로 두고 설명 언어만 locale에 맞춘다.
+
+- [ ] **Step 2: 문서/공백 검증**
+
+  Run: `git diff --check` 및 README code fence/locale diff를 확인한다.
+
+### Task 5: verifier 및 rollback
+
+- [ ] **Step 1: 전체 provider 검증**
+
+  Run: `./gradlew :bluetape4k-r2dbc:test :bluetape4k-r2dbc:koverVerify`
+
+  Expected: targeted 및 모듈 회귀 테스트 PASS. Docker-backed DB가 필요한 기존 테스트 실패 시 해당 환경/로그를 기록하고 registry 테스트 결과와 혼동하지 않는다.
+
+- [ ] **Step 2: diff/ownership 확인**
+
+  Run: `git diff --check`, `git status --short`, `git diff --stat`, `git diff --name-only origin/develop...HEAD`
+
+  Expected: 위 지도에 있는 provider 파일만 변경되고, downstream/catalog 변경은 없다.
+
+- [ ] **Step 3: rollback 지점**
+
+  provider contract가 publication/CI에서 실패하면 이 branch의 latest commit 전까지 revert하고 downstream migration을 시작하지 않는다. public API를 바꾸면 spec/plan과 테스트를 먼저 갱신하고 review gate를 다시 연다.
+
+## 수용 기준 추적
+
+| Spec 기준 | 검증 task |
+| --- | --- |
+| lookup/keys/snapshot/routing/unknown key | Task 1, 2, 3 |
+| borrowed/owned/custom lifecycle | Task 1, 2 |
+| idempotency/dedup/concurrent close/suppressed | Task 1, 2, 3 |
+| A/B concurrent isolation | Task 1, 3 |
+| no Spring/Ktor in artifact | Task 3 |
+| README 영/국문 parity | Task 4 |
+
+## 위험 예측
+
+- Reactor `Mono`를 public API로 노출하므로 `close()`가 cold/cached 동작인지 테스트에서 subscription까지 확인한다.
+- `Disposable.dispose()`는 오류를 동기 throw하지 않는 fire-and-forget adapter이므로 오류 관찰 계약은 `close()`에만 둔다.
+- `ConnectionFactory` alias가 identity dedup되지 않으면 pool double-close가 발생하므로 동일 인스턴스 fixture를 반드시 사용한다.
+- `Map.toMap()`이 caller 변경을 노출하지 않는지 원본 map mutate 후 snapshot을 확인한다.

--- a/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
+++ b/docs/superpowers/plans/2026-09-07-tenant-connection-factory-registry-plan.md
@@ -29,7 +29,7 @@
 
 - [ ] **Step 2: 다음 실패 테스트 작성**
 
-  `borrowed registry는 lookup/keys/asMap snapshot을 제공한다`, `unknown key는 configured keys를 포함한 NoSuchElementException을 던진다`, `routingMap은 mapped key 충돌을 거부한다`, `owned registry는 같은 resource alias를 한 번만 닫는다`, `borrowed/owned alias 충돌은 생성 시 거부한다`, `borrowed registry는 close 후에도 resource를 닫지 않는다`, `close 후 lookup/map은 IllegalStateException을 던진다`, `close는 모든 오류를 시도하고 후속 오류를 suppressed로 보존한다`, `dispose-first 오류도 후속 close 관찰성을 유지한다`, `concurrent lookup은 A/B factory를 교차하지 않는다`, `동시 close는 cached operation으로 한 번만 실행된다`를 exact assertion으로 작성한다.
+  `borrowed registry는 lookup/keys/asMap snapshot을 제공한다`, `unknown key는 configured key 집합을 노출하지 않는 NoSuchElementException을 던진다`, `routingMap은 mapped key 충돌을 거부한다`, `owned registry는 같은 resource alias를 한 번만 닫는다`, `borrowed/owned alias 충돌은 생성 시 거부한다`, `borrowed registry는 close 후에도 resource를 닫지 않는다`, `close 후 lookup/map은 IllegalStateException을 던진다`, `close는 모든 오류를 시도하고 후속 오류를 suppressed로 보존한다`, `dispose-first 오류도 후속 close 관찰성을 유지한다`, `concurrent lookup은 A/B factory를 교차하지 않는다`, `동시 close는 cached operation으로 한 번만 실행된다`를 exact assertion으로 작성한다.
 
 - [ ] **Step 3: RED 실행**
 
@@ -52,7 +52,7 @@
 
 - [ ] **Step 3: lifecycle 구현**
 
-  owned entry를 resource identity로 deduplicate한다. 같은 identity의 alias는 ownership와 custom close-action identity가 같아야 하며, 혼합이면 생성 시 fail-fast한다. `close()`는 `AtomicReference<Mono<Void>>` compare-and-set으로 `cache()`된 operation을 한 번만 설치하고, 그 reference를 lifecycle state의 단일 source of truth로 사용한다. 각 close action을 순차 실행하면서 synchronous throw와 `Mono.error`를 모두 수집한 뒤 첫 오류에 나머지를 suppressed로 붙인다. `dispose()`는 같은 operation을 subscribe하는 fire-and-forget adapter이고 오류를 logger에 기록하며, `isDisposed()`는 close signal 설치 여부를 반영한다.
+  owned entry를 resource identity로 deduplicate한다. 같은 identity의 alias는 ownership와 custom close-action identity가 같아야 하며, 혼합이면 생성 시 fail-fast한다. `close()`는 `AtomicReference<Mono<Void>>` compare-and-set으로 `cache()`된 operation을 한 번만 설치하고, 그 reference를 lifecycle state의 단일 source of truth로 사용한다. 각 close action을 순차 실행하면서 synchronous throw와 `Mono.error`를 모두 수집한 뒤 첫 오류에 나머지를 suppressed로 붙이되 같은 Throwable identity는 self-suppression하지 않는다. `dispose()`는 같은 operation을 subscribe하는 fire-and-forget adapter이고 오류 타입만 logger에 기록하며, `isDisposed()`는 close signal 설치 여부를 반영한다.
 
 - [ ] **Step 4: companion convenience factory 구현**
 
@@ -154,6 +154,6 @@
 ## 위험 예측
 
 - Reactor `Mono`를 public API로 노출하므로 `close()`가 cold/cached 동작인지 테스트에서 subscription까지 확인한다.
-- `Disposable.dispose()`는 오류를 동기 throw하지 않는 fire-and-forget adapter이므로 logger에 기록하고, 상세 원인/suppressed chain 관찰 계약은 cached `close()`에 둔다.
+- `Disposable.dispose()`는 오류를 동기 throw하지 않는 fire-and-forget adapter이므로 안정적인 오류 타입만 logger에 기록하고, 상세 원인/suppressed chain 관찰 계약은 cached `close()`에 둔다.
 - `ConnectionFactory` alias가 identity dedup되지 않으면 pool double-close가 발생하므로 동일 인스턴스 fixture를 반드시 사용한다.
 - `Map.toMap()`이 caller 변경을 노출하지 않는지 원본 map mutate 후 snapshot을 확인한다.

--- a/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
+++ b/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
@@ -28,12 +28,10 @@ package io.bluetape4k.r2dbc.pool
 
 enum class ConnectionFactoryOwnership { BORROWED, OWNED }
 
-class R2dbcConnectionFactoryEntry private constructor(
-    val connectionFactory: ConnectionFactory,
-    val ownership: ConnectionFactoryOwnership,
-    private val closeAction: () -> Mono<Void>,
-) {
-    internal fun closeResource(): Mono<Void>
+sealed interface R2dbcConnectionFactoryEntry {
+    val connectionFactory: ConnectionFactory
+    val ownership: ConnectionFactoryOwnership
+
     companion object {
         fun borrowed(connectionFactory: ConnectionFactory): R2dbcConnectionFactoryEntry
         fun owned(connectionFactory: ConnectionFactory): R2dbcConnectionFactoryEntry
@@ -56,8 +54,8 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
     override fun isDisposed(): Boolean
 
     companion object {
-        fun <K : Any> borrowed(entries: Map<K, out ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
-        fun <K : Any> owned(entries: Map<K, out ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
+        fun <K : Any> borrowed(entries: Map<K, ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
+        fun <K : Any> owned(entries: Map<K, ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
     }
 }
 ```
@@ -70,9 +68,8 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
 
 ### 조회와 routing
 
-- `get(key)`는 등록되지 않은 key에
-  `NoSuchElementException("No ConnectionFactory configured for key '$key'")`를
-  던진다.
+- `get(key)`는 등록되지 않은 key에 configured key 목록을 포함한
+  `NoSuchElementException("No ConnectionFactory configured for key '$key'. Configured keys: [...]")`를 던진다.
 - `keys`는 입력 map의 insertion order를 유지하는 읽기 전용 집합이다.
 - `routingMap`은 key mapper가 만든 결과 key가 충돌하면 조용히 덮어쓰지 않고
   `IllegalArgumentException`으로 실패한다. tenant parsing이나 authorization은
@@ -87,10 +84,10 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
   오류를 주 오류로 유지하고 후속 오류를 `Throwable.addSuppressed`로 붙인다.
 - `dispose()`는 Reactor의 fire-and-forget adapter다. 동일한 atomic close state를
   사용하므로 double-close가 없으며, 관찰 가능한 오류가 필요한 caller는
-  `close()`를 subscribe한다. `close()`의 `Mono` 생성과 atomic state 설치는
-  하나의 `AtomicReference` compare-and-set으로 묶고, `dispose()`도 같은 cached
-  signal을 subscribe한다. `dispose()`의 오류는 adapter의 error consumer에서
-  소비하며, 원인 보존이 필요하면 `close()` 결과를 사용한다.
+  `close()`를 subscribe한다. `close()`의 cached `Mono` 설치가 lifecycle state의
+  단일 source of truth이므로 state 확인과 signal 설치 사이에 lookup race가
+  생기지 않는다. `dispose()`도 같은 signal을 subscribe하고 오류를 logger에
+  기록하며, 원인과 suppressed chain은 cached `close()` 결과에 보존한다.
 - borrowed entry는 `close()`와 `dispose()` 어느 쪽에서도 종료하지 않는다.
 - close state가 설치된 뒤에는 `get`, `asMap`, `routingMap`이
   `IllegalStateException("ConnectionFactory registry is closed")`로 실패한다.
@@ -153,7 +150,8 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
 - [ ] close/dispose idempotency, identity deduplication, concurrent close,
       suppressed failure가 테스트된다.
 - [ ] tenant A/B concurrent lookup가 서로의 factory를 반환하지 않는다.
-- [ ] provider JAR/POM/metadata에 Spring/Ktor 의존성이 유입되지 않는다.
+- [ ] 새 registry bytecode에 Spring/Ktor 참조가 없고, 생성된 POM에는
+      provider baseline 대비 새 framework dependency가 추가되지 않는다.
 - [ ] README 영문/국문에 동일한 API 계약과 예제가 추가된다.
 
 ## DoD

--- a/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
+++ b/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
@@ -68,8 +68,8 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
 
 ### 조회와 routing
 
-- `get(key)`는 등록되지 않은 key에 configured key 목록을 포함한
-  `NoSuchElementException("No ConnectionFactory configured for key '$key'. Configured keys: [...]")`를 던진다.
+- `get(key)`는 등록되지 않은 key에 configured key 집합을 노출하지 않는
+  `NoSuchElementException("No ConnectionFactory configured for the requested key.")`를 던진다.
 - `keys`는 입력 map의 insertion order를 유지하는 읽기 전용 집합이다.
 - `routingMap`은 key mapper가 만든 결과 key가 충돌하면 조용히 덮어쓰지 않고
   `IllegalArgumentException`으로 실패한다. tenant parsing이나 authorization은
@@ -87,7 +87,9 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
   `close()`를 subscribe한다. `close()`의 cached `Mono` 설치가 lifecycle state의
   단일 source of truth이므로 state 확인과 signal 설치 사이에 lookup race가
   생기지 않는다. `dispose()`도 같은 signal을 subscribe하고 오류를 logger에
-  기록하며, 원인과 suppressed chain은 cached `close()` 결과에 보존한다.
+  기록하되 오류 타입만 남기며, 원인과 suppressed chain은 cached `close()`
+  결과에 보존한다. 같은 Throwable identity가 반복되면 self-suppression을
+  시도하지 않는다.
 - borrowed entry는 `close()`와 `dispose()` 어느 쪽에서도 종료하지 않는다.
 - close state가 설치된 뒤에는 `get`, `asMap`, `routingMap`이
   `IllegalStateException("ConnectionFactory registry is closed")`로 실패한다.

--- a/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
+++ b/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
@@ -55,8 +55,8 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
     override fun isDisposed(): Boolean
 
     companion object {
-        fun <K : Any> borrowed(entries: Map<K, ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
-        fun <K : Any> owned(entries: Map<K, ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
+        fun <K : Any> borrowed(entries: Map<K, out ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
+        fun <K : Any> owned(entries: Map<K, out ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
     }
 }
 ```

--- a/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
+++ b/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
@@ -1,0 +1,145 @@
+# tenant별 ConnectionFactory registry 공용 API 설계
+
+## 목표
+
+`bluetape4k-r2dbc`가 tenant와 프레임워크를 알지 못한 채, 임의의 non-null
+key를 `ConnectionFactory`로 조회하고 Spring routing map으로 변환할 수 있는
+정적 registry 계약을 제공한다. 현재 두 WebFlux 예제가 복사한 lookup 및
+lifecycle 규칙을 provider에서 한 번만 검증한다.
+
+## 현재 근거
+
+- provider의 `data/r2dbc`에는 `connectionPoolOf`와 `r2dbcConnectionPool`만
+  있고 tenant registry는 없다.
+- 두 workshop consumer는 `Map<Tenant, ConnectionPool>`을 직접 보유하고
+  `DisposableBean.destroy()`에서 pool을 dispose한다.
+- issue #1648은 pool 생성, tenant parsing, 인증/인가, request context,
+  transaction/rollback, 동적 onboarding을 caller 책임으로 명시한다.
+- `ConnectionPool`은 `ConnectionFactory`, R2DBC `Closeable`, Reactor
+  `Disposable`을 함께 구현하므로 core에서 Spring 타입을 참조하지 않고도
+  pool lifecycle을 감쌀 수 있다.
+
+## 선택한 설계
+
+### 공개 타입
+
+```kotlin
+package io.bluetape4k.r2dbc.pool
+
+enum class ConnectionFactoryOwnership { BORROWED, OWNED }
+
+class R2dbcConnectionFactoryEntry private constructor(
+    val connectionFactory: ConnectionFactory,
+    val ownership: ConnectionFactoryOwnership,
+    val closeAction: () -> Mono<Void>,
+) {
+    companion object {
+        fun borrowed(connectionFactory: ConnectionFactory): R2dbcConnectionFactoryEntry
+        fun owned(connectionFactory: ConnectionFactory): R2dbcConnectionFactoryEntry
+        fun owned(
+            connectionFactory: ConnectionFactory,
+            closeAction: () -> Mono<Void>,
+        ): R2dbcConnectionFactoryEntry
+    }
+}
+
+class R2dbcConnectionFactoryRegistry<K : Any>(
+    entries: Map<K, R2dbcConnectionFactoryEntry>,
+) : io.r2dbc.spi.Closeable, reactor.core.Disposable {
+    val keys: Set<K>
+    operator fun get(key: K): ConnectionFactory
+    fun asMap(): Map<K, ConnectionFactory>
+    fun <R : Any> routingMap(keyMapper: (K) -> R): Map<R, ConnectionFactory>
+    override fun close(): Mono<Void>
+    override fun dispose()
+    override fun isDisposed(): Boolean
+
+    companion object {
+        fun <K : Any> borrowed(entries: Map<K, ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
+        fun <K : Any> owned(entries: Map<K, ConnectionFactory>): R2dbcConnectionFactoryRegistry<K>
+    }
+}
+```
+
+`borrowed`는 조회만 하고 종료하지 않는다. `owned`는 registry가 종료를
+책임지며, closeable/disposable resource가 아니면 생성 시 fail-fast한다.
+사용자 정의 factory는 두 번째 `owned` overload로 명시적인 `closeAction`을
+제공할 수 있다. `entries`, `keys`, `asMap`, `routingMap`의 결과는 registry의
+생성 당시 snapshot이며 이후 caller가 원본 map을 바꿔도 변경되지 않는다.
+
+### 조회와 routing
+
+- `get(key)`는 등록되지 않은 key에
+  `NoSuchElementException("No ConnectionFactory configured for key '$key'")`를
+  던진다.
+- `keys`는 입력 map의 insertion order를 유지하는 읽기 전용 집합이다.
+- `routingMap`은 key mapper가 만든 결과 key가 충돌하면 조용히 덮어쓰지 않고
+  `IllegalArgumentException`으로 실패한다. tenant parsing이나 authorization은
+  mapper와 caller context에서 수행한다.
+- registry에는 `register`, `unregister`, `Mutex`, global singleton을 넣지 않는다.
+
+### lifecycle
+
+- 같은 factory가 여러 key에 연결되어도 identity 기준으로 한 번만 종료한다.
+- `close()`는 첫 호출에서 종료 `Mono`를 만들고, 동시/후속 호출은 같은
+  cached `Mono`를 반환한다. 모든 owned resource를 순서대로 시도한 뒤 첫
+  오류를 주 오류로 유지하고 후속 오류를 `Throwable.addSuppressed`로 붙인다.
+- `dispose()`는 Reactor의 fire-and-forget adapter다. 동일한 atomic close state를
+  사용하므로 double-close가 없으며, 관찰 가능한 오류가 필요한 caller는
+  `close()`를 subscribe한다.
+- borrowed entry는 `close()`와 `dispose()` 어느 쪽에서도 종료하지 않는다.
+- lifecycle API는 R2DBC/Project Reactor만 사용하며 Spring `DisposableBean`은
+  consumer adapter에 남긴다.
+
+## 대안과 기각
+
+1. **Spring `DisposableBean`을 provider registry에 직접 구현**
+   - 기각: core artifact의 framework coupling이 생기고 Ktor caller가 Spring
+     타입을 끌어오게 된다.
+2. **`Map<K, ConnectionFactory>`만 받고 모든 resource를 무조건 종료**
+   - 기각: caller-owned factory를 닫는 파괴적 기본값이며 issue의 ownership
+     경계를 위반한다.
+3. **mutable registry와 동적 register/unregister 제공**
+   - 기각: 이번 issue는 정적 snapshot이며 동시성/인증 경계를 불필요하게
+     확장한다. 동적 onboarding은 별도 issue로 남긴다.
+
+## 실패 모드와 대응
+
+1. 알 수 없는 tenant key가 들어오면 즉시 `NoSuchElementException`을 던져
+   다른 tenant pool로 fallback하지 않는다.
+2. mapper가 두 key를 같은 routing key로 만들면 생성 결과를 덮어쓰지 않고
+   `IllegalArgumentException`을 던진다.
+3. 동일 pool alias가 여러 key에 등록되어도 identity deduplication으로 한 번만
+   종료한다.
+4. 복수 pool close가 실패해도 나머지 close를 시도하고 첫 오류와 suppressed
+   chain을 보존한다.
+5. concurrent lookup은 immutable snapshot만 읽고 close state와 분리하여
+   tenant A/B 결과가 교차되지 않는다.
+
+## 호환성과 migration
+
+- 새 API는 `bluetape4k-r2dbc`의 additive public API이며 기존 pool builder와
+  ABI를 바꾸지 않는다.
+- workshop consumer는 `R2dbcConnectionFactoryRegistry.owned(pools)`를 만들고
+  `registry[tenant]`, `registry.routingMap(Tenant::id)`, `registry.keys`를
+  사용한다. Spring destroy adapter는 `registry.dispose()`만 호출한다.
+- provider artifact가 publication/catalog에 반영되기 전에는 consumer migration
+  PR을 만들지 않는다. 중앙 catalog의 기존 alias와 BOM version만 사용한다.
+
+## 수용 기준
+
+- [ ] key lookup, keys, snapshot map, routing map, unknown-key 메시지가 public
+      KDoc와 테스트로 고정된다.
+- [ ] borrowed/owned 및 custom close action의 lifecycle 차이가 테스트된다.
+- [ ] close/dispose idempotency, identity deduplication, concurrent close,
+      suppressed failure가 테스트된다.
+- [ ] tenant A/B concurrent lookup가 서로의 factory를 반환하지 않는다.
+- [ ] provider JAR/POM/metadata에 Spring/Ktor 의존성이 유입되지 않는다.
+- [ ] README 영문/국문에 동일한 API 계약과 예제가 추가된다.
+
+## DoD
+
+provider 코드·단위 테스트·문서·ABI/POM 검증이 exact head에서 통과하고,
+PR은 CI와 독립 리뷰가 수렴한 뒤에만 merge-ready로 보고한다. publication,
+catalog 갱신, downstream consumer merge는 이 PR의 구현 증거와 분리된 후속
+gate다.

--- a/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
+++ b/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
@@ -31,8 +31,9 @@ enum class ConnectionFactoryOwnership { BORROWED, OWNED }
 class R2dbcConnectionFactoryEntry private constructor(
     val connectionFactory: ConnectionFactory,
     val ownership: ConnectionFactoryOwnership,
-    val closeAction: () -> Mono<Void>,
+    private val closeAction: () -> Mono<Void>,
 ) {
+    internal fun closeResource(): Mono<Void>
     companion object {
         fun borrowed(connectionFactory: ConnectionFactory): R2dbcConnectionFactoryEntry
         fun owned(connectionFactory: ConnectionFactory): R2dbcConnectionFactoryEntry
@@ -86,8 +87,21 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
   오류를 주 오류로 유지하고 후속 오류를 `Throwable.addSuppressed`로 붙인다.
 - `dispose()`는 Reactor의 fire-and-forget adapter다. 동일한 atomic close state를
   사용하므로 double-close가 없으며, 관찰 가능한 오류가 필요한 caller는
-  `close()`를 subscribe한다.
+  `close()`를 subscribe한다. `close()`의 `Mono` 생성과 atomic state 설치는
+  하나의 `AtomicReference` compare-and-set으로 묶고, `dispose()`도 같은 cached
+  signal을 subscribe한다. `dispose()`의 오류는 adapter의 error consumer에서
+  소비하며, 원인 보존이 필요하면 `close()` 결과를 사용한다.
 - borrowed entry는 `close()`와 `dispose()` 어느 쪽에서도 종료하지 않는다.
+- close state가 설치된 뒤에는 `get`, `asMap`, `routingMap`이
+  `IllegalStateException("ConnectionFactory registry is closed")`로 실패한다.
+  `keys`는 생성 당시 snapshot이므로 계속 읽을 수 있다.
+- 같은 resource identity가 alias된 entry는 ownership가 모두 같아야 한다.
+  borrowed/owned 혼합 또는 서로 다른 custom close action은 생성 시
+  `IllegalArgumentException`으로 거부한다. 기본 `owned(factory)`의 action은
+  factory identity를 action identity로 사용한다.
+- 입력 map은 생성 시 iteration 순서대로 별도 `LinkedHashMap`에 복사하고
+  unmodifiable wrapper를 사용한다. API는 입력이 `HashMap`일 때의 임의 순서를
+  insertion order라고 재해석하지 않고, 관찰된 snapshot 순서만 보장한다.
 - lifecycle API는 R2DBC/Project Reactor만 사용하며 Spring `DisposableBean`은
   consumer adapter에 남긴다.
 
@@ -113,8 +127,9 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
    종료한다.
 4. 복수 pool close가 실패해도 나머지 close를 시도하고 첫 오류와 suppressed
    chain을 보존한다.
-5. concurrent lookup은 immutable snapshot만 읽고 close state와 분리하여
-   tenant A/B 결과가 교차되지 않는다.
+5. concurrent lookup은 immutable snapshot만 읽고 close state를 먼저 확인하여
+   종료 시작 이후 새 lookup을 거부한다. 종료 시작 전의 lookup은 A/B factory를
+   교차시키지 않는다.
 
 ## 호환성과 migration
 

--- a/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
+++ b/docs/superpowers/specs/2026-09-07-tenant-connection-factory-registry-design.md
@@ -138,6 +138,10 @@ class R2dbcConnectionFactoryRegistry<K : Any>(
 - workshop consumer는 `R2dbcConnectionFactoryRegistry.owned(pools)`를 만들고
   `registry[tenant]`, `registry.routingMap(Tenant::id)`, `registry.keys`를
   사용한다. Spring destroy adapter는 `registry.dispose()`만 호출한다.
+- consumer migration은 인증된 tenant claim과 요청 tenant가 일치하는지 먼저
+  검증한 뒤에만 registry lookup을 수행한다. 미인증·불일치 요청은 DB lookup
+  전에 401/403으로 종료되는 negative integration test를 각 WebFlux consumer에
+  추가한다. provider는 raw header parsing이나 authorization을 수행하지 않는다.
 - provider artifact가 publication/catalog에 반영되기 전에는 consumer migration
   PR을 만들지 않는다. 중앙 catalog의 기존 alias와 BOM version만 사용한다.
 


### PR DESCRIPTION
## 문제

Closes #1648

두 WebFlux multi-tenant 예제가 tenant별 `ConnectionPool` registry와 종료 규칙을 각각 복사하고 있어, lookup·routing·lifecycle 계약이 drift될 위험이 있었습니다.

## 변경 사항

- `bluetape4k-r2dbc`에 tenant key → `ConnectionFactory` lookup, configured keys, immutable routing map API를 추가했습니다.
- `BORROWED`와 `OWNED` lifecycle ownership을 public sealed contract로 구분하고, owned resource의 중복 alias·mixed ownership을 fail-fast 처리했습니다.
- `close()`/`dispose()`를 idempotent하게 만들고 순차 종료, 전체 오류 수집, suppressed cause 보존 및 dispose-first 관찰 계약을 고정했습니다.
- unknown-key 오류에서 configured tenant key 집합을 제거하고, dispose 로그에는 안정적인 오류 타입만 남겨 tenant/credential 정보 노출을 막았습니다.
- 같은 Throwable identity가 반복되는 close 실패에서 self-suppression을 건너뛰도록 했습니다.
- API KDoc, English/Korean README, 설계·계획 문서를 함께 갱신했습니다.

## 검증

- `:bluetape4k-r2dbc:test --tests "io.bluetape4k.r2dbc.pool.R2dbcConnectionFactoryRegistryTest"`: PASS (10/10)
- `:bluetape4k-r2dbc:test :bluetape4k-r2dbc:koverVerify`: PASS (206/206, Kover verify PASS)
- `:bluetape4k-r2dbc:compileKotlin :bluetape4k-r2dbc:compileTestKotlin :bluetape4k-r2dbc:detekt`: BUILD SUCCESSFUL (신규 registry 경고 없음; 기존 unrelated finding만 존재)
- `jar`, publication metadata/POM 생성 및 `checkPomFileForBluetape4kPublication`: BUILD SUCCESSFUL
- registry-only `jdeps` guard: PASS (Spring/Ktor 의존성 없음)
- `javap -public` ABI guard: PASS (lifecycle helper/synthetic public ABI 없음)
- `git diff --check`: PASS

## 검토 및 범위

- 독립 security review에서 확인된 configured-key enumeration, full lifecycle throwable logging, repeated-Throwable self-suppression 경로를 보완했습니다.
- consumer migration은 이 PR에 포함하지 않으며, workshop #233에서 published provider API로 별도 검증합니다.
- catalog/release publication은 이 구현 PR의 범위 밖이며 release authority에서 별도로 수행합니다.

## Metadata

- Issue: #1648, milestone `2.1.0`, assignee `debop`
- PR: #1677
- Base: `develop`
- Head: `feat/issue-1648-tenant-registry` (`13b57e4bfa4a561406ea4a3e72bdb568a7c8e1ce`)

## DoD Status

- [x] tenant lookup, configured key, routing map, unknown-key fail-fast 계약 고정
- [x] caller-owned/registry-owned lifecycle 및 close/dispose idempotency 검증
- [x] concurrent lookup/close, alias, suppressed error, self-suppression 회귀 테스트
- [x] registry-only dependency/ABI/POM guard 통과
- [x] API KDoc와 English/Korean 문서 반영
- [x] exact-head GitHub Actions CI 및 live review/thread read-back
- [ ] workshop consumer migration (#233)
- [x] merge — merge commit `529a681f126200269e94a9775c24777b0731e6cb`