### PR TITLE
feat(tink): SHA-256 hex digest API를 추가한다

### DIFF
--- a/io/tink/README.ko.md
+++ b/io/tink/README.ko.md
@@ -204,12 +204,25 @@ import io.bluetape4k.tink.digest.matchesTinkDigest
 val hash = TinkDigesters.SHA256.digest("Hello, World!")
 val matches = TinkDigesters.SHA256.matches("Hello, World!", hash) // true
 
+// 저장 키나 token fingerprint용 UTF-8 lowercase hex
+val hex = TinkDigesters.SHA256.digestHex("public-event-id")
+val hexMatches = TinkDigesters.SHA256.matchesHex("public-event-id", hex) // true
+
 // 확장 함수
 val hash2 = "Hello, World!".tinkDigest(TinkDigesters.SHA256)
 "Hello, World!".matchesTinkDigest(hash2, TinkDigesters.SHA256) // true
 
 // 사용 가능 알고리즘: MD5, SHA1, SHA256, SHA384, SHA512
 ```
+
+기존 `digest(String)`과 `matches(String, String)`은 표준 Base64 계약을 유지합니다.
+`digestHex(String)`은 digest byte마다 두 자리 lowercase hex를 반환하므로 SHA-256은 항상
+64자입니다. `matchesHex`는 길이가 다르거나 `0-9a-f` 이외의 문자, uppercase가 포함된
+기대값을 예외 없이 `false`로 처리하고, 올바른 형식은 `MessageDigest.isEqual`로 비교합니다.
+형식 검사는 fail-fast이며 constant-time이 아니고, canonical digest byte 비교만
+`MessageDigest.isEqual`의 timing-safe 경계를 사용합니다.
+Raw token을 로그나 예외에 남기지 말고, password 저장에는 plain digest 대신 전용
+password hashing 알고리즘을 사용하세요.
 
 ### Encrypt — 통합 암호화 인터페이스
 

--- a/io/tink/README.md
+++ b/io/tink/README.md
@@ -212,12 +212,25 @@ import io.bluetape4k.tink.digest.matchesTinkDigest
 val hash = TinkDigesters.SHA256.digest("Hello, World!")
 val matches = TinkDigesters.SHA256.matches("Hello, World!", hash) // true
 
+// UTF-8 lowercase hex for storage keys or token fingerprints
+val hex = TinkDigesters.SHA256.digestHex("public-event-id")
+val hexMatches = TinkDigesters.SHA256.matchesHex("public-event-id", hex) // true
+
 // Extension functions
 val hash2 = "Hello, World!".tinkDigest(TinkDigesters.SHA256)
 "Hello, World!".matchesTinkDigest(hash2, TinkDigesters.SHA256) // true
 
 // Available algorithms: MD5, SHA1, SHA256, SHA384, SHA512
 ```
+
+The existing `digest(String)` and `matches(String, String)` methods retain their
+standard Base64 contract. `digestHex(String)` emits two lowercase hex characters
+per digest byte, so SHA-256 is always 64 characters. `matchesHex` returns `false`
+without throwing for a wrong length, characters outside `0-9a-f`, or uppercase
+input. Format validation is fail-fast rather than constant-time; only canonical digest
+bytes enter the timing-safe `MessageDigest.isEqual` comparison. Never log raw tokens,
+and use a dedicated password-hashing algorithm rather than a plain digest for
+password storage.
 
 ### Encrypt — Unified Encryption Interface
 

--- a/io/tink/src/main/kotlin/io/bluetape4k/tink/digest/TinkDigester.kt
+++ b/io/tink/src/main/kotlin/io/bluetape4k/tink/digest/TinkDigester.kt
@@ -10,7 +10,7 @@ import java.util.*
  * BouncyCastle 없이 순수 JDK만으로 MD5, SHA-1, SHA-256, SHA-384, SHA-512 등
  * 표준 해시 알고리즘을 지원합니다.
  *
- * String 입출력 시 내부적으로 UTF-8 인코딩과 Base64 변환을 처리합니다.
+ * 문자열 입력은 UTF-8로 인코딩하며 Base64 또는 lowercase hex 결과를 제공합니다.
  *
  * ```kotlin
  * val digester = TinkDigester("SHA-256")
@@ -47,6 +47,18 @@ class TinkDigester(
     }
 
     /**
+     * 문자열의 해시 다이제스트를 lowercase hex 문자열로 반환합니다.
+     *
+     * 입력은 UTF-8로 인코딩하며 각 digest 바이트를 정확히 두 자리 hex로 변환합니다.
+     * 따라서 SHA-256 결과 길이는 항상 64자입니다.
+     *
+     * @param data 해시할 문자열
+     * @return lowercase hex로 인코딩한 해시 문자열
+     */
+    fun digestHex(data: String): String =
+        HexFormat.of().formatHex(digest(data.toByteArray(Charsets.UTF_8)))
+
+    /**
      * 바이트 배열의 해시가 기대값과 일치하는지 constant-time으로 비교합니다.
      *
      * @param data 원본 바이트 배열
@@ -81,6 +93,30 @@ class TinkDigester(
         }.getOrElse {
             return false
         }
+        return MessageDigest.isEqual(dataHashBytes, expectedBytes)
+    }
+
+    /**
+     * 문자열의 해시가 lowercase hex 기대값과 일치하는지 검증합니다.
+     *
+     * [expected]는 현재 알고리즘의 digest 길이와 정확히 일치해야 하며 `0-9`, `a-f`만
+     * 허용합니다. 길이가 다르거나 malformed 또는 uppercase 값이면 예외를 던지지 않고
+     * `false`를 반환합니다. 형식 검사는 fail-fast이며 constant-time이 아닙니다. 길이와
+     * 형식이 올바른 canonical digest byte 비교에만 [MessageDigest.isEqual]을 사용합니다.
+     *
+     * @param data 원본 문자열
+     * @param expected 기대하는 lowercase hex 해시 문자열
+     * @return 일치하면 `true`, 아니면 `false`
+     */
+    fun matchesHex(
+        data: String,
+        expected: String,
+    ): Boolean {
+        val dataHashBytes = digest(data.toByteArray(Charsets.UTF_8))
+        if (expected.length != dataHashBytes.size * 2 || expected.any { it !in '0'..'9' && it !in 'a'..'f' }) {
+            return false
+        }
+        val expectedBytes = HexFormat.of().parseHex(expected)
         return MessageDigest.isEqual(dataHashBytes, expectedBytes)
     }
 

--- a/io/tink/src/test/kotlin/io/bluetape4k/tink/digest/TinkDigesterTest.kt
+++ b/io/tink/src/test/kotlin/io/bluetape4k/tink/digest/TinkDigesterTest.kt
@@ -74,6 +74,47 @@ class TinkDigesterTest {
     }
 
     @Test
+    fun `문자열을 UTF-8 lowercase hex digest로 변환한다`() {
+        val hash = digester.digestHex("abc")
+
+        hash shouldBeEqualTo "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        hash.length shouldBeEqualTo 64
+    }
+
+    @Test
+    fun `선행 0 바이트를 두 자리 hex로 보존한다`() {
+        digester.digestHex("286") shouldBeEqualTo
+            "00328ce57bbc14b33bd6695bc8eb32cdf2fb5f3a7d89ec14a42825e15d39df60"
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "한글 테스트", "special chars !@#\$%^&*()"])
+    fun `hex digest verifier 라운드트립`(data: String) {
+        val hash = digester.digestHex(data)
+
+        digester.matchesHex(data, hash).shouldBeTrue()
+        digester.matchesHex("다른 입력", hash).shouldBeFalse()
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "",
+            "not-hex",
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015a",
+            "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD",
+        ],
+    )
+    fun `잘못된 hex expected hash는 false를 반환한다`(expected: String) {
+        digester.matchesHex("abc", expected).shouldBeFalse()
+    }
+
+    @Test
+    fun `기존 문자열 digest는 Base64 계약을 유지한다`() {
+        digester.digest("abc") shouldBeEqualTo "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
+    }
+
+    @Test
     fun `빈 입력 digest`() {
         val hash = digester.digest(ByteArray(0))
         hash shouldNotBeEqualTo ByteArray(0)


### PR DESCRIPTION
## 요약

- 기존 Base64 API를 유지하면서 UTF-8 문자열의 lowercase hex digest API를 추가합니다.
- `matchesHex`는 canonical lowercase·정확한 길이만 허용하고 실제 byte 비교는 `MessageDigest.isEqual`에 위임합니다.
- malformed 입력은 예외 없이 `false`를 반환하며, fail-fast validation과 constant-time byte 비교의 경계를 문서화합니다.

## 검증

- `bluetape4k-tink`: 150 tests, failures/errors 0
- Detekt, JAR, POM 생성 통과
- SHA-256 known vector, empty/Unicode, leading zero, wrong/malformed/uppercase 회귀 테스트
- 기존 Base64 API 회귀 테스트, security/performance 리뷰, `git diff --check` 통과
- exact head `6b0d058e23478460cd504b135d261e693919b630`: GitHub Actions 12 success, 12 path-filtered skipped, failure 0

Closes #1649

## DoD Status

- [x] lowercase hex digest/verifier API 구현
- [x] malformed·case·length·known vector 계약 검증
- [x] 기존 Base64 계약과 publication 검증
- [x] exact-head GitHub Actions 확인 (`6b0d058e`, 성공 12 / 건너뜀 12)
- [ ] downstream consumer migration — 별도 작업으로 추적
