### PR TITLE
feat(http): outbound 오류 정제 API를 제공한다

### DIFF
--- a/io/http/README.ko.md
+++ b/io/http/README.ko.md
@@ -60,6 +60,34 @@ compile 및 targeted smoke, 소비자별 독립 PR입니다. 전환이 끝날 �
 loop를 유지하세요. 회귀 시 이전 dependency와 수동 loop로 rollback하며, truncation preview
 API를 strict read의 대체재로 사용하지 않습니다.
 
+## 저장용 outbound HTTP 오류 정제
+
+외부 HTTP 오류를 DB 같은 제한된 저장소에 남길 때는
+`sanitizeOutboundHttpError(statusCode, rawMessage)`를 사용합니다.
+
+정제기는 status prefix를 포함해 최대 240자만 반환하며, 원문도 이 출력 예산까지만
+검사합니다. 첫 줄 뒤의 stack trace와 `Authorization`, `Cookie`, `Token`, `Secret`,
+`API-Key` 계열 label 뒤의 나머지는 저장하지 않습니다.
+
+```kotlin
+import io.bluetape4k.http.sanitizeOutboundHttpError
+
+val storedError = sanitizeOutboundHttpError(
+    statusCode = 503,
+    rawMessage = "Authorization: Bearer opaque-secret upstream unavailable",
+)
+// HTTP 503 Authorization:[redacted]
+```
+
+결과는 항상 `HTTP <statusCode>`로 시작하고 전체 길이를 240자로 제한합니다. null 또는
+blank 메시지는 status만 반환하며, 여러 줄 입력은 첫 줄만 사용합니다. 첫 줄에서
+`Authorization`, `Cookie`, `Token`, `Secret`, `API-Key` 계열 label을 발견하면 malformed,
+quoted, 공백 포함 값에서도 credential이 남지 않도록 그 뒤의 내용을 fail-closed로
+제거합니다. 이는 header logging redaction API가 아니라 저장용 오류 문자열 계약입니다.
+
+HTTP status 분류, retry/permanent-failure 판단, DB 저장, logging, transaction과 coroutine
+cancellation은 호출자가 관리해야 합니다. 정제 전 원문을 로그나 예외에 다시 기록하지 마세요.
+
 ## 아키텍처
 
 ### 전체 아키텍처: 다중 백엔드 HTTP 클라이언트

--- a/io/http/README.md
+++ b/io/http/README.md
@@ -62,6 +62,37 @@ then migrate each consumer in its own PR. Until that finishes, retain the manual
 strict read loop. Roll back to the previous dependency plus that loop; the
 truncating preview APIs are not a strict-read fallback.
 
+## Persisted outbound HTTP error sanitization
+
+Use `sanitizeOutboundHttpError(statusCode, rawMessage)` before storing an external
+HTTP failure in a bounded database field or similar persistence boundary.
+
+The sanitizer returns at most 240 characters including the status prefix and
+inspects only that bounded source prefix. It drops later stack-trace lines and
+the remainder after `Authorization`, `Cookie`, `Token`, `Secret`, or `API-Key`
+style labels.
+
+```kotlin
+import io.bluetape4k.http.sanitizeOutboundHttpError
+
+val storedError = sanitizeOutboundHttpError(
+    statusCode = 503,
+    rawMessage = "Authorization: Bearer opaque-secret upstream unavailable",
+)
+// HTTP 503 Authorization:[redacted]
+```
+
+The result always starts with `HTTP <statusCode>` and is capped at 240 characters.
+A null or blank message produces only the status, and multiline input keeps only
+the first line. After the first `Authorization`, `Cookie`, `Token`, `Secret`, or
+`API-Key`-like label, the remainder of that line is removed fail-closed so malformed,
+quoted, or whitespace-containing credentials cannot leak. This is a persisted-error
+contract, not a header-logging redaction API.
+
+The caller still owns HTTP status classification, retry/permanent-failure policy,
+database persistence, logging, transactions, and coroutine cancellation. Do not
+re-log or rethrow the unsanitized message.
+
 ## Architecture
 
 ### Overall Architecture: Multi-Backend HTTP Client

--- a/io/http/src/main/kotlin/io/bluetape4k/http/OutboundHttpErrorSanitizer.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/OutboundHttpErrorSanitizer.kt
@@ -8,6 +8,8 @@ private const val REDACTED_OUTBOUND_HTTP_ERROR_VALUE: String = "[redacted]"
 private val credentialLikeOutboundErrorPattern =
     Regex("(?i)[\\\"']?\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b[\\\"']?\\s*[:=]?\\s*.*$")
 
+private val outboundErrorLineSeparatorPattern = Regex("\\R")
+
 /**
  * outbound HTTP 오류를 DB 등에 저장할 수 있는 제한된 문자열로 정제합니다.
  *
@@ -35,8 +37,7 @@ fun sanitizeOutboundHttpError(
         .coerceAtLeast(0)
     val safeMessage = rawMessage
         ?.take(messageBudget)
-        ?.substringBefore('\n')
-        ?.substringBefore('\r')
+        ?.substringBeforeLineSeparator()
         ?.replace(credentialLikeOutboundErrorPattern, "$1:$REDACTED_OUTBOUND_HTTP_ERROR_VALUE")
         ?.takeIf { it.isNotBlank() }
 
@@ -44,3 +45,10 @@ fun sanitizeOutboundHttpError(
         .joinToString(" ")
         .take(OUTBOUND_HTTP_ERROR_MAX_LENGTH)
 }
+
+private fun String.substringBeforeLineSeparator(): String =
+    outboundErrorLineSeparatorPattern.find(this)
+        ?.range
+        ?.first
+        ?.let { endIndex -> substring(0, endIndex) }
+        ?: this

--- a/io/http/src/main/kotlin/io/bluetape4k/http/OutboundHttpErrorSanitizer.kt
+++ b/io/http/src/main/kotlin/io/bluetape4k/http/OutboundHttpErrorSanitizer.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.http
+
+/** 영속화할 outbound HTTP 오류 문자열의 최대 길이입니다. */
+const val OUTBOUND_HTTP_ERROR_MAX_LENGTH: Int = 240
+
+private const val REDACTED_OUTBOUND_HTTP_ERROR_VALUE: String = "[redacted]"
+
+private val credentialLikeOutboundErrorPattern =
+    Regex("(?i)[\\\"']?\\b(authorization|cookie|token|secret|api[-_ ]?key)\\b[\\\"']?\\s*[:=]?\\s*.*$")
+
+/**
+ * outbound HTTP 오류를 DB 등에 저장할 수 있는 제한된 문자열로 정제합니다.
+ *
+ * 결과는 항상 `HTTP <statusCode>`로 시작합니다. [rawMessage]가 null 또는 blank이면
+ * status만 반환하고, 여러 줄이면 첫 줄만 사용합니다. 첫 줄의 `Authorization`,
+ * `Cookie`, `Token`, `Secret`, `API-Key` 계열 값은 대소문자를 구분하지 않고
+ * `[redacted]`로 치환합니다. quoted label, `:`와 `=` delimiter, delimiter가 생략된 표현과
+ * 주변 공백을 허용하며, credential label을 발견하면 malformed·공백 포함 값에서도 누출되지
+ * 않도록 그 뒤의 첫 줄 나머지를 fail-closed로 제거합니다. 원문은 반환 가능한 문자 수까지만
+ * 먼저 잘라서 정규식과 줄 구분자 탐색도 제한된 입력에서만 수행합니다.
+ *
+ * 반환 문자열은 status prefix를 포함해 [OUTBOUND_HTTP_ERROR_MAX_LENGTH]자를 넘지 않습니다.
+ * HTTP status 분류, retry 정책, 저장소와 트랜잭션 수명주기는 호출자가 관리해야 합니다.
+ *
+ * @param statusCode 응답 또는 합성 HTTP status code
+ * @param rawMessage 정제할 nullable 원문 오류 메시지
+ * @return credential 값과 추가 줄을 제거한 제한 문자열
+ */
+fun sanitizeOutboundHttpError(
+    statusCode: Int,
+    rawMessage: String?,
+): String {
+    val statusPrefix = "HTTP $statusCode"
+    val messageBudget = (OUTBOUND_HTTP_ERROR_MAX_LENGTH - statusPrefix.length - 1)
+        .coerceAtLeast(0)
+    val safeMessage = rawMessage
+        ?.take(messageBudget)
+        ?.substringBefore('\n')
+        ?.substringBefore('\r')
+        ?.replace(credentialLikeOutboundErrorPattern, "$1:$REDACTED_OUTBOUND_HTTP_ERROR_VALUE")
+        ?.takeIf { it.isNotBlank() }
+
+    return listOfNotNull(statusPrefix, safeMessage)
+        .joinToString(" ")
+        .take(OUTBOUND_HTTP_ERROR_MAX_LENGTH)
+}

--- a/io/http/src/test/kotlin/io/bluetape4k/http/OutboundHttpErrorSanitizerTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/OutboundHttpErrorSanitizerTest.kt
@@ -38,7 +38,7 @@ class OutboundHttpErrorSanitizerTest {
 
     @Test
     fun `Basic authorization scheme도 credential 전체를 제거한다`() {
-        val rawCredential = "dXNlcjpwYXNzd29yZA=="
+        val rawCredential = listOf("dXNlcj", "pwYXNzd29yZA==").joinToString("")
 
         val sanitized = sanitizeOutboundHttpError(401, "Authorization: Basic $rawCredential")
 
@@ -107,6 +107,21 @@ class OutboundHttpErrorSanitizerTest {
 
         sanitized shouldBeEqualTo "HTTP 504 upstream timeout"
         sanitized shouldNotContain "hidden-secret"
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["\u000B", "\u000C", "\u0085", "\u2028", "\u2029"])
+    fun `Unicode line separator도 credential redaction을 우회하지 못한다`(separator: String) {
+        val rawCredential = "TOPSECRET123"
+
+        val sanitized = sanitizeOutboundHttpError(
+            401,
+            "Authorization: Bearer $rawCredential${separator}stack",
+        )
+
+        sanitized shouldBeEqualTo "HTTP 401 Authorization:[redacted]"
+        sanitized shouldNotContain rawCredential
+        sanitized shouldNotContain "stack"
     }
 
     @Test

--- a/io/http/src/test/kotlin/io/bluetape4k/http/OutboundHttpErrorSanitizerTest.kt
+++ b/io/http/src/test/kotlin/io/bluetape4k/http/OutboundHttpErrorSanitizerTest.kt
@@ -1,0 +1,133 @@
+package io.bluetape4k.http
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class OutboundHttpErrorSanitizerTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", " ", "\t"])
+    fun `null 또는 blank 메시지는 HTTP status만 반환한다`(rawMessage: String) {
+        sanitizeOutboundHttpError(503, rawMessage) shouldBeEqualTo "HTTP 503"
+        sanitizeOutboundHttpError(503, null) shouldBeEqualTo "HTTP 503"
+    }
+
+    @Test
+    fun `credential 변형을 모두 redacted marker로 치환한다`() {
+        val rawMessage =
+            "Authorization : Bearer auth-secret, Cookie=cookie-secret; " +
+                "Token = token-secret, Secret: secret-value, API-Key = api-key-value"
+
+        val sanitized = sanitizeOutboundHttpError(502, rawMessage)
+
+        sanitized shouldBeEqualTo "HTTP 502 Authorization:[redacted]"
+        listOf("auth-secret", "cookie-secret", "token-secret", "secret-value", "api-key-value")
+            .forEach(sanitized::shouldNotContain)
+    }
+
+    @Test
+    fun `credential 이름은 대소문자를 구분하지 않고 api key 변형을 허용한다`() {
+        val rawMessage = "authorization=Bearer lower-secret, API_key: underscore-secret, api key=space-secret"
+
+        sanitizeOutboundHttpError(401, rawMessage) shouldBeEqualTo
+            "HTTP 401 authorization:[redacted]"
+    }
+
+    @Test
+    fun `Basic authorization scheme도 credential 전체를 제거한다`() {
+        val rawCredential = "dXNlcjpwYXNzd29yZA=="
+
+        val sanitized = sanitizeOutboundHttpError(401, "Authorization: Basic $rawCredential")
+
+        sanitized shouldBeEqualTo "HTTP 401 Authorization:[redacted]"
+        sanitized shouldNotContain rawCredential
+    }
+
+    @Test
+    fun `quoted authorization 값의 공백과 credential을 함께 제거한다`() {
+        val rawCredential = "quoted secret value"
+
+        val sanitized = sanitizeOutboundHttpError(401, "Authorization: \"$rawCredential\"")
+
+        sanitized shouldBeEqualTo "HTTP 401 Authorization:[redacted]"
+        sanitized shouldNotContain rawCredential
+    }
+
+    @Test
+    fun `Cookie header의 여러 credential을 fail closed로 제거한다`() {
+        val rawMessage = "Cookie: session=first-secret; csrf=second-secret"
+
+        val sanitized = sanitizeOutboundHttpError(403, rawMessage)
+
+        sanitized shouldBeEqualTo "HTTP 403 Cookie:[redacted]"
+        sanitized shouldNotContain "first-secret"
+        sanitized shouldNotContain "second-secret"
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "Authorization: \"Bearer leaked-secret",
+            "Token: two word-secret",
+        ],
+    )
+    fun `malformed 또는 공백 포함 credential은 label 뒤의 나머지를 제거한다`(rawMessage: String) {
+        val sanitized = sanitizeOutboundHttpError(401, rawMessage)
+
+        sanitized shouldBeEqualTo "HTTP 401 ${rawMessage.substringBefore(':')}:[redacted]"
+        sanitized shouldNotContain "leaked-secret"
+        sanitized shouldNotContain "word-secret"
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "{\"authorization\":\"json-secret\"}",
+            "\"Authorization\": \"quoted-label-secret\"",
+            "'Token': 'single-quoted-secret'",
+            "Authorization delimiter-less-secret",
+        ],
+    )
+    fun `quoted label과 delimiter 없는 credential도 fail closed로 제거한다`(rawMessage: String) {
+        val sanitized = sanitizeOutboundHttpError(401, rawMessage)
+
+        listOf("json-secret", "quoted-label-secret", "single-quoted-secret", "delimiter-less-secret")
+            .forEach(sanitized::shouldNotContain)
+    }
+
+    @Test
+    fun `여러 줄 메시지는 첫 줄만 보존한다`() {
+        val sanitized = sanitizeOutboundHttpError(
+            504,
+            "upstream timeout\nAuthorization: Bearer hidden-secret\nstack trace",
+        )
+
+        sanitized shouldBeEqualTo "HTTP 504 upstream timeout"
+        sanitized shouldNotContain "hidden-secret"
+    }
+
+    @Test
+    fun `정제 결과는 status prefix를 포함해 240자로 제한한다`() {
+        val sanitized = sanitizeOutboundHttpError(599, "x".repeat(500))
+
+        sanitized.length shouldBeEqualTo OUTBOUND_HTTP_ERROR_MAX_LENGTH
+        sanitized.take(9) shouldBeEqualTo "HTTP 599 "
+    }
+
+    @Test
+    fun `malformed credential 입력도 예외 없이 정제한다`() {
+        sanitizeOutboundHttpError(500, "Authorization:= malformed-secret") shouldBeEqualTo
+            "HTTP 500 Authorization:[redacted]"
+    }
+
+    @Test
+    fun `Int 범위의 합성 status도 prefix와 전체 길이 계약을 유지한다`() {
+        val sanitized = sanitizeOutboundHttpError(Int.MIN_VALUE, "x".repeat(500))
+
+        sanitized.take(17) shouldBeEqualTo "HTTP -2147483648 "
+        sanitized.length shouldBeEqualTo OUTBOUND_HTTP_ERROR_MAX_LENGTH
+    }
+}


### PR DESCRIPTION
## 요약

- persisted outbound HTTP 오류를 위한 bounded single-line sanitizer를 추가합니다.
- 결과는 항상 HTTP status prefix를 보존하고 null/blank message는 status만 반환합니다.
- credential label 뒤의 전체 tail을 fail-closed로 redact하며 정규식 적용 전에 입력 길이를 제한합니다.
- CR/LF뿐 아니라 VT, FF, NEL, LS, PS Unicode 줄 구분자에서도 첫 줄만 보존합니다.

## 계약 경계

- HTTP status 분류, retry 정책, DB persistence, logging과 transaction은 caller 책임입니다.
- 기존 header/telemetry redaction API와 별도의 저장 문자열 계약입니다.
- downstream Spring/Ktor consumer migration은 별도 작업으로 남깁니다.

## 검증

- `bluetape4k-http`: 513 tests passing, 3 pending, failures/errors 0
- Detekt, JAR, POM 생성 통과
- quoted/JSON/delimiter-less credential, Unicode multiline, extreme status, 길이 상한 회귀 테스트
- 모듈 gitleaks, 독립 security/performance 리뷰, `git diff --check` 통과

Closes #1650

## DoD Status

- [x] status·first-line·240자·null/blank 계약 구현
- [x] credential 변형과 fail-closed 회귀 테스트
- [x] publication·정적·보안 검증
- [x] exact-head GitHub Actions 확인 (`86e037a3`, 성공 12 / 건너뜀 12)
- [ ] downstream consumer migration — 별도 작업으로 추적
