### PR TITLE
feat(r2dbc): tenant 연결 registry API를 제공한다

### DIFF
--- a/data/r2dbc/README.ko.md
+++ b/data/r2dbc/README.ko.md
@@ -148,6 +148,52 @@ contention benchmark는 `64` JMH threads에서 동시성보다 작은 `maxSize`�
 - 운영 드라이버가 로컬 검증을 지원한다면 `ValidationDepth.LOCAL`과 `validationQuery = null`을 우선하세요. 배포 환경에서 `SELECT 1`이 명시적으로 필요할 때는 benchmark의 `sql` mode를 사용하세요. SQL 검증은 커넥션 획득마다 DB 왕복을 추가합니다.
 - 위 수치는 로컬 기준선이지 보편적 한계값이 아닙니다. 쿼리 latency, 트랜잭션 시간, 인스턴스 수, DB 커넥션 한도가 바뀌면 DB별 pool acquire benchmark를 다시 실행하세요.
 
+### Tenant connection registry
+
+tenant registry는 조회 대상과 lifecycle ownership을 분리해 제공합니다.
+
+- `TenantConnectionFactoryRegistry<K>`는 caller-owned registry입니다.
+  `Map<K, ConnectionFactory>`의 생성 시점 복사본만 보관하고, 값이
+  `ConnectionPool`이어도 종료하지 않습니다.
+- `TenantConnectionPoolRegistry<K>`는 registry-owned registry입니다.
+  `Map<K, ConnectionPool>`을 보관하고 `AutoCloseable`을 구현합니다.
+  `close()`는 동일 pool instance를 최대 한 번만 `dispose`합니다.
+
+두 registry 모두 `configuredKeys`, `get(key)`, `asRoutingMap()`을 제공하며,
+구성되지 않은 key를 조회하면 `NoSuchElementException`으로 즉시 실패합니다.
+adapter의 key 형식이 다르면 `asRoutingMap(keyMapper)`에 key mapper를 전달할
+수 있습니다.
+
+```kotlin
+data class TenantKey(val id: String)
+
+val factories = TenantConnectionFactoryRegistry(
+    mapOf(TenantKey("tenant-a") to tenantAFactory, TenantKey("tenant-b") to tenantBFactory),
+)
+val routes: Map<String, ConnectionFactory> = factories.asRoutingMap { tenant -> tenant.id }
+
+val pools = TenantConnectionPoolRegistry(
+    mapOf("tenant-a" to tenantAPool, "tenant-b" to tenantBPool),
+)
+try {
+    val factory: ConnectionFactory = pools["tenant-a"]
+} finally {
+    pools.close()
+}
+```
+
+pool 생성, tenant parsing, request context, 인증·인가, transaction, framework
+lifecycle callback은 caller의 책임입니다. pool 하나의 종료가 실패해도 나머지
+pool 정리를 계속하며, 첫 실패를 다시 던지고 이후 실패는 suppressed exception으로
+연결합니다. `close()` 시작 후 조회는 `IllegalStateException`으로 실패하며, lifecycle
+adapter는 진행 중인 조회와 종료를 직렬화해야 합니다. `close()`는 동기 API이므로
+event-loop가 아닌 blocking lifecycle executor에서 실행하거나 coroutine에서는
+`closeSuspending()`을 사용하세요. concurrent `close()`는 첫 종료 완료까지 직렬화되며
+같은 실패를 관찰합니다. 동적
+`register`/`unregister`는 이 정적 registry API의 범위가 아닙니다. JVM `Error`는
+복구 가능한 종료 실패로 집계하지 않고 즉시 전파합니다. `close()` 전에 얻은 routing
+map도 종료 후에는 disposed pool을 가리킬 수 있으므로 함께 폐기해야 합니다.
+
 ### 2. DatabaseClient SQL 실행
 
 ```kotlin

--- a/data/r2dbc/README.ko.md
+++ b/data/r2dbc/README.ko.md
@@ -188,8 +188,9 @@ pool 정리를 계속하며, 첫 실패를 다시 던지고 이후 실패는 sup
 연결합니다. `close()` 시작 후 조회는 `IllegalStateException`으로 실패하며, lifecycle
 adapter는 진행 중인 조회와 종료를 직렬화해야 합니다. `close()`는 동기 API이므로
 event-loop가 아닌 blocking lifecycle executor에서 실행하거나 coroutine에서는
-`closeSuspending()`을 사용하세요. concurrent `close()`는 첫 종료 완료까지 직렬화되며
-같은 실패를 관찰합니다. 동적
+`closeSuspending()`을 사용하세요. suspending 경로는 non-cancellable 경계에서 cleanup을
+마친 뒤 caller cancellation을 다시 전파합니다. concurrent `close()`는 JVM monitor 대신
+`ReentrantLock`으로 첫 종료 완료까지 직렬화되며 같은 실패를 관찰합니다. 동적
 `register`/`unregister`는 이 정적 registry API의 범위가 아닙니다. JVM `Error`는
 복구 가능한 종료 실패로 집계하지 않고 즉시 전파합니다. `close()` 전에 얻은 routing
 map도 종료 후에는 disposed pool을 가리킬 수 있으므로 함께 폐기해야 합니다.

--- a/data/r2dbc/README.md
+++ b/data/r2dbc/README.md
@@ -202,8 +202,10 @@ of this static registry API. Lookups after `close()` starts fail with
 `IllegalStateException`; lifecycle adapters must serialize in-flight lookups
 against shutdown. Because `close()` is synchronous, invoke it from a blocking
 lifecycle executor rather than an event loop, or use `closeSuspending()` from a
-coroutine. Concurrent `close()` calls serialize until the first close completes
-and observe the same failure. JVM `Error` values propagate immediately instead
+coroutine. The suspending path completes cleanup in a non-cancellable boundary,
+then propagates caller cancellation. Concurrent `close()` calls serialize with
+a `ReentrantLock` rather than a JVM monitor until the first close completes and
+observe the same failure. JVM `Error` values propagate immediately instead
 of entering the recoverable cleanup aggregation. Discard routing maps obtained
 before `close()` because they can still reference disposed pools.
 

--- a/data/r2dbc/README.md
+++ b/data/r2dbc/README.md
@@ -161,6 +161,52 @@ the acquired/failed trial counts.
   `SELECT 1`; it adds one database round trip to every connection acquisition.
 - Treat benchmark numbers as local baselines, not universal limits. Re-run the DB-specific pool acquire benchmark against your driver/database shape when query latency, transaction duration, instance count, or DB connection limits change.
 
+### Tenant connection registries
+
+The tenant registries keep lookup and lifecycle ownership explicit:
+
+- `TenantConnectionFactoryRegistry<K>` is caller-owned. It snapshots a
+  `Map<K, ConnectionFactory>` and never closes its values, including values that
+  happen to be `ConnectionPool` instances.
+- `TenantConnectionPoolRegistry<K>` is registry-owned. It snapshots a
+  `Map<K, ConnectionPool>` and implements `AutoCloseable`; `close()` disposes
+  each distinct pool at most once.
+
+Both registries expose `configuredKeys`, `get(key)`, and `asRoutingMap()`.
+An unknown key fails fast with `NoSuchElementException`. Pass a key mapper to
+`asRoutingMap(keyMapper)` when the adapter uses a different key shape.
+
+```kotlin
+data class TenantKey(val id: String)
+
+val factories = TenantConnectionFactoryRegistry(
+    mapOf(TenantKey("tenant-a") to tenantAFactory, TenantKey("tenant-b") to tenantBFactory),
+)
+val routes: Map<String, ConnectionFactory> = factories.asRoutingMap { tenant -> tenant.id }
+
+val pools = TenantConnectionPoolRegistry(
+    mapOf("tenant-a" to tenantAPool, "tenant-b" to tenantBPool),
+)
+try {
+    val factory: ConnectionFactory = pools["tenant-a"]
+} finally {
+    pools.close()
+}
+```
+
+Pool creation, tenant parsing, request context, authentication, transactions,
+and framework lifecycle callbacks remain caller responsibilities. Pool cleanup
+continues after a failure: the first failure is rethrown and later failures are
+attached as suppressed exceptions. Dynamic `register`/`unregister` is not part
+of this static registry API. Lookups after `close()` starts fail with
+`IllegalStateException`; lifecycle adapters must serialize in-flight lookups
+against shutdown. Because `close()` is synchronous, invoke it from a blocking
+lifecycle executor rather than an event loop, or use `closeSuspending()` from a
+coroutine. Concurrent `close()` calls serialize until the first close completes
+and observe the same failure. JVM `Error` values propagate immediately instead
+of entering the recoverable cleanup aggregation. Discard routing maps obtained
+before `close()` because they can still reference disposed pools.
+
 ### 2. Executing SQL with DatabaseClient
 
 ```kotlin

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistry.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistry.kt
@@ -1,0 +1,198 @@
+package io.bluetape4k.r2dbc.pool
+
+import io.r2dbc.pool.ConnectionPool
+import io.r2dbc.spi.ConnectionFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.LinkedHashMap
+import java.util.LinkedHashSet
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * 정적으로 구성된 tenant key와 R2DBC connection factory를 연결하는 조회 계약입니다.
+ *
+ * registry는 생성 시 전달받은 map의 복사본만 보관하므로 조회와 routing map 변환은
+ * 동시 호출에서 서로의 상태를 오염시키지 않습니다. key가 없으면 [NoSuchElementException]을
+ * 즉시 던집니다. 등록/해제나 요청 context 해석은 이 계약의 책임이 아닙니다.
+ *
+ * 구현체가 factory 또는 pool의 lifecycle을 소유하는지는 구현체의 API와 KDoc에서 명시합니다.
+ * [TenantConnectionFactoryRegistry]는 caller-owned factory 조회만 제공하며, 실제 pool을
+ * 종료하지 않습니다. [TenantConnectionPoolRegistry]는 전달받은 pool을 소유하고 `close()`합니다.
+ */
+interface TenantConnectionRegistry<K: Any, out F: ConnectionFactory> {
+
+    /** registry 생성 시 구성된 tenant key의 불변 복사본입니다. */
+    val configuredKeys: Set<K>
+
+    /**
+     * [key]에 해당하는 factory를 반환합니다.
+     *
+     * @throws NoSuchElementException [key]가 구성되어 있지 않을 때
+     */
+    operator fun get(key: K): F
+
+    /**
+     * registry가 보관한 key와 factory를 framework-neutral routing map으로 반환합니다.
+     * 반환된 map은 registry의 내부 상태를 변경하지 않는 복사본입니다.
+     */
+    fun asRoutingMap(): Map<K, F>
+
+    /**
+     * 외부 routing key로 변환한 routing map을 생성합니다.
+     *
+     * key parsing이나 request context 해석은 하지 않고, 호출자가 제공한 mapper만 적용합니다.
+     * 서로 다른 tenant key가 같은 routing key로 변환되면 무음 덮어쓰기를 허용하지 않고
+     * [IllegalArgumentException]을 던집니다.
+     */
+    fun <R: Any> asRoutingMap(keyMapper: (K) -> R): Map<R, F> {
+        val mappedRoutes = LinkedHashMap<R, F>()
+        asRoutingMap().forEach { (key, factory) ->
+            val routingKey = keyMapper(key)
+            require(!mappedRoutes.containsKey(routingKey)) {
+                "Duplicate routing key mapped from configured tenant keys."
+            }
+            mappedRoutes[routingKey] = factory
+        }
+        return mappedRoutes
+    }
+
+}
+
+/**
+ * caller가 lifecycle을 소유하는 connection factory 조회 registry입니다.
+ *
+ * 전달된 [factories]의 복사본을 보관하며, 값이 [ConnectionPool]이어도 이 타입은 pool을
+ * 종료하지 않습니다. pool을 registry lifecycle에 맡겨야 한다면 [TenantConnectionPoolRegistry]를
+ * 사용하세요. 이 타입은 [AutoCloseable]을 구현하지 않으므로 ownership을 API에서 구분합니다.
+ */
+class TenantConnectionFactoryRegistry<K: Any>(
+    factories: Map<K, ConnectionFactory>,
+): TenantConnectionRegistry<K, ConnectionFactory> {
+
+    private val routes = RegistryRoutes(factories)
+
+    override val configuredKeys: Set<K>
+        get() = routes.configuredKeys
+
+    override fun get(key: K): ConnectionFactory = routes[key]
+
+    override fun asRoutingMap(): Map<K, ConnectionFactory> = routes.asMap()
+}
+
+/**
+ * registry가 lifecycle을 소유하는 tenant별 [ConnectionPool] 조회 registry입니다.
+ *
+ * [pools]는 생성 시 복사되며 동적 tenant onboarding을 지원하지 않습니다. [close]는
+ * registry가 소유한 각 pool의 [ConnectionPool.dispose]를 최대 한 번 호출하고, 한 pool의
+ * 종료가 실패해도 나머지 pool을 계속 정리합니다. 여러 종료가 실패하면 첫 실패를 그대로
+ * 던지고 이후 실패를 suppressed exception으로 연결합니다. 단, JVM [Error]는 복구 가능한
+ * 종료 실패로 집계하지 않고 즉시 전파하므로 이후 pool 정리를 중단합니다.
+ *
+ * `close()`가 시작되면 registry는 닫힌 것으로 표시되고 이후 조회는 [IllegalStateException]으로
+ * 실패합니다. 첫 종료가 실패해도 이후 `close()`는 재시도하지 않고 같은 실패를 다시 던집니다.
+ * 동일한 pool instance가 여러 key에 연결된 경우에도 identity 기준으로 한 번만 종료합니다. 진행
+ * 중인 조회와 `close()`의 동시 실행은 지원하지 않으므로 lifecycle adapter가 둘을 직렬화해야
+ * 합니다. 여러 thread가 `close()`를 호출하면 첫 종료가 끝날 때까지 직렬화되고 같은 실패 결과를
+ * 관찰합니다.
+ */
+class TenantConnectionPoolRegistry<K: Any>(
+    pools: Map<K, ConnectionPool>,
+): TenantConnectionRegistry<K, ConnectionPool>, AutoCloseable {
+
+    private val poolSnapshot = LinkedHashMap(pools)
+    private val routes = RegistryRoutes(poolSnapshot)
+    private val ownedPools = distinctByIdentity(poolSnapshot.values)
+    private val closed = AtomicBoolean(false)
+    private var closeFailure: Throwable? = null
+
+    override val configuredKeys: Set<K>
+        get() = routes.configuredKeys
+
+    override fun get(key: K): ConnectionPool {
+        ensureOpen()
+        return routes[key]
+    }
+
+    override fun asRoutingMap(): Map<K, ConnectionPool> {
+        ensureOpen()
+        return routes.asMap()
+    }
+
+    /**
+     * 소유한 pool을 순서대로 종료합니다.
+     *
+     * 종료는 동기적으로 실행되며, 첫 실패 이후에도 모든 pool을 시도합니다. 이 메서드는
+     * framework lifecycle callback에 직접 결합되지 않으므로 caller가 적절한 adapter에서
+     * 호출해야 합니다. event-loop에서 직접 호출하지 말고 blocking lifecycle executor에서
+     * 실행해야 합니다. 여기서 실패는 [Exception]을 뜻하며 [Error]는 즉시 전파합니다.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    @Synchronized
+    override fun close() {
+        closeFailure?.let { throw it }
+        if (!closed.compareAndSet(false, true)) {
+            return
+        }
+
+        var firstFailure: Throwable? = null
+        ownedPools.forEach { pool ->
+            try {
+                pool.dispose()
+            } catch (failure: Error) {
+                closeFailure = failure
+                throw failure
+            } catch (failure: Exception) {
+                val primary = firstFailure
+                if (primary == null) {
+                    firstFailure = failure
+                } else if (primary !== failure) {
+                    primary.addSuppressed(failure)
+                }
+            }
+        }
+
+        closeFailure = firstFailure
+        firstFailure?.let { throw it }
+    }
+
+    /**
+     * coroutine caller의 event-loop를 차단하지 않도록 [close]를 [Dispatchers.IO]에서 실행합니다.
+     * concurrent 종료, idempotency와 실패 전파 계약은 [close]와 같습니다.
+     */
+    suspend fun closeSuspending() {
+        withContext(Dispatchers.IO) {
+            close()
+        }
+    }
+
+    private fun ensureOpen() {
+        check(!closed.get()) { "Tenant connection pool registry is closed." }
+    }
+
+    private companion object {
+        fun distinctByIdentity(pools: Collection<ConnectionPool>): List<ConnectionPool> {
+            val seen = IdentityHashMap<ConnectionPool, Boolean>()
+            return pools.filter { seen.put(it, true) == null }
+        }
+    }
+}
+
+private class RegistryRoutes<K: Any, F: ConnectionFactory>(
+    factories: Map<K, F>,
+) {
+
+    private val routes: Map<K, F> = LinkedHashMap(factories)
+
+    private val configuredKeySnapshot: Set<K> =
+        Collections.unmodifiableSet(LinkedHashSet(routes.keys))
+
+    val configuredKeys: Set<K>
+        get() = configuredKeySnapshot
+
+    operator fun get(key: K): F = routes[key]
+        ?: throw NoSuchElementException("No connection factory is configured for the requested tenant key.")
+
+    fun asMap(): Map<K, F> = LinkedHashMap(routes)
+}

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistry.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistry.kt
@@ -2,13 +2,19 @@ package io.bluetape4k.r2dbc.pool
 
 import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.spi.ConnectionFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.util.Collections
 import java.util.IdentityHashMap
 import java.util.LinkedHashMap
 import java.util.LinkedHashSet
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * 정적으로 구성된 tenant key와 R2DBC connection factory를 연결하는 조회 계약입니다.
@@ -96,15 +102,19 @@ class TenantConnectionFactoryRegistry<K: Any>(
  * 중인 조회와 `close()`의 동시 실행은 지원하지 않으므로 lifecycle adapter가 둘을 직렬화해야
  * 합니다. 여러 thread가 `close()`를 호출하면 첫 종료가 끝날 때까지 직렬화되고 같은 실패 결과를
  * 관찰합니다.
+ *
+ * @param closeDispatcher [closeSuspending]에서 blocking pool dispose를 격리할 dispatcher
  */
 class TenantConnectionPoolRegistry<K: Any>(
     pools: Map<K, ConnectionPool>,
+    private val closeDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ): TenantConnectionRegistry<K, ConnectionPool>, AutoCloseable {
 
     private val poolSnapshot = LinkedHashMap(pools)
     private val routes = RegistryRoutes(poolSnapshot)
     private val ownedPools = distinctByIdentity(poolSnapshot.values)
     private val closed = AtomicBoolean(false)
+    private val closeLock = ReentrantLock()
     private var closeFailure: Throwable? = null
 
     override val configuredKeys: Set<K>
@@ -128,14 +138,19 @@ class TenantConnectionPoolRegistry<K: Any>(
      * 호출해야 합니다. event-loop에서 직접 호출하지 말고 blocking lifecycle executor에서
      * 실행해야 합니다. 여기서 실패는 [Exception]을 뜻하며 [Error]는 즉시 전파합니다.
      */
-    @Suppress("TooGenericExceptionCaught")
-    @Synchronized
-    override fun close() {
-        closeFailure?.let { throw it }
+    override fun close() = closeLock.withLock {
+        throwFailure(closeFailure)
         if (!closed.compareAndSet(false, true)) {
-            return
+            return@withLock
         }
 
+        val failure = disposeOwnedPools()
+        closeFailure = failure
+        throwFailure(failure)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun disposeOwnedPools(): Throwable? {
         var firstFailure: Throwable? = null
         ownedPools.forEach { pool ->
             try {
@@ -152,23 +167,30 @@ class TenantConnectionPoolRegistry<K: Any>(
                 }
             }
         }
-
-        closeFailure = firstFailure
-        firstFailure?.let { throw it }
+        return firstFailure
     }
 
     /**
      * coroutine caller의 event-loop를 차단하지 않도록 [close]를 [Dispatchers.IO]에서 실행합니다.
-     * concurrent 종료, idempotency와 실패 전파 계약은 [close]와 같습니다.
+     * 이미 취소된 caller에서도 [NonCancellable] 경계에서 cleanup을 완료한 뒤 caller cancellation을
+     * 다시 전파합니다. concurrent 종료, idempotency와 실패 전파 계약은 [close]와 같습니다.
      */
     suspend fun closeSuspending() {
-        withContext(Dispatchers.IO) {
+        val callerContext = currentCoroutineContext()
+        withContext(NonCancellable + closeDispatcher) {
             close()
         }
+        callerContext.ensureActive()
     }
 
     private fun ensureOpen() {
         check(!closed.get()) { "Tenant connection pool registry is closed." }
+    }
+
+    private fun throwFailure(failure: Throwable?) {
+        if (failure != null) {
+            throw failure
+        }
     }
 
     private companion object {

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistryTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistryTest.kt
@@ -10,6 +10,10 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.spi.ConnectionFactory
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -162,6 +166,21 @@ class TenantConnectionRegistryTest {
 
         registry.closeSuspending()
 
+        verify(exactly = 1) { pool.dispose() }
+    }
+
+    @Test
+    fun `closeSuspending은 취소된 caller에서도 pool cleanup을 완료하고 취소를 전파한다`() = runSuspendIO {
+        val pool = mockk<ConnectionPool>(relaxed = true)
+        val registry = TenantConnectionPoolRegistry(mapOf(TenantKey("tenant-a") to pool))
+
+        val caller = launch(start = CoroutineStart.UNDISPATCHED) {
+            currentCoroutineContext().cancel()
+            registry.closeSuspending()
+        }
+        caller.join()
+
+        caller.isCancelled shouldBeEqualTo true
         verify(exactly = 1) { pool.dispose() }
     }
 

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistryTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistryTest.kt
@@ -1,0 +1,234 @@
+package io.bluetape4k.r2dbc.pool
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.r2dbc.pool.ConnectionPool
+import io.r2dbc.spi.ConnectionFactory
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class TenantConnectionRegistryTest {
+
+    @Test
+    fun `caller-owned factory registry routes configured keys without taking lifecycle ownership`() {
+        val tenantA = mockk<ConnectionPool>(relaxed = true)
+        val tenantB = mockk<ConnectionFactory>(relaxed = true)
+        val registry = TenantConnectionFactoryRegistry(
+            mapOf(
+                TenantKey("tenant-a") to tenantA,
+                TenantKey("tenant-b") to tenantB,
+            ),
+        )
+
+        registry[TenantKey("tenant-a")] shouldBeSameInstanceAs tenantA
+        registry.get(TenantKey("tenant-b")) shouldBeSameInstanceAs tenantB
+        registry.configuredKeys shouldBeEqualTo setOf(TenantKey("tenant-a"), TenantKey("tenant-b"))
+        registry.asRoutingMap()[TenantKey("tenant-a")] shouldBeSameInstanceAs tenantA
+        registry.asRoutingMap { it.id }["tenant-b"] shouldBeSameInstanceAs tenantB
+
+        registry[TenantKey("tenant-a")]
+        verify(exactly = 0) { tenantA.dispose() }
+    }
+
+    @Test
+    fun `unknown tenant lookup fails fast`() {
+        val registry = TenantConnectionFactoryRegistry(
+            mapOf(TenantKey("tenant-a") to mockk<ConnectionFactory>(relaxed = true)),
+        )
+
+        val failure = assertFailsWith<NoSuchElementException> {
+            registry[TenantKey("unknown")]
+        }
+
+        failure.message.orEmpty().contains("tenant key") shouldBeEqualTo true
+    }
+
+    @Test
+    fun `routing key mapper 충돌은 무음 덮어쓰기 대신 즉시 실패한다`() {
+        val registry = TenantConnectionFactoryRegistry(
+            mapOf(
+                TenantKey("tenant-a") to mockk<ConnectionFactory>(relaxed = true),
+                TenantKey("tenant-b") to mockk<ConnectionFactory>(relaxed = true),
+            ),
+        )
+
+        val failure = assertFailsWith<IllegalArgumentException> {
+            registry.asRoutingMap { "shared-route" }
+        }
+
+        failure.message.orEmpty().contains("Duplicate routing key") shouldBeEqualTo true
+    }
+
+    @Test
+    fun `concurrent tenant lookups remain isolated`() {
+        val tenantA = mockk<ConnectionFactory>(relaxed = true)
+        val tenantB = mockk<ConnectionFactory>(relaxed = true)
+        val registry = TenantConnectionFactoryRegistry(
+            mapOf(
+                TenantKey("tenant-a") to tenantA,
+                TenantKey("tenant-b") to tenantB,
+            ),
+        )
+
+        MultithreadingTester()
+            .workers(2)
+            .rounds(256)
+            .add { registry[TenantKey("tenant-a")] shouldBeSameInstanceAs tenantA }
+            .add { registry[TenantKey("tenant-b")] shouldBeSameInstanceAs tenantB }
+            .run()
+    }
+
+    @Test
+    fun `registry-owned pools are disposed exactly once`() {
+        val tenantA = mockk<ConnectionPool>(relaxed = true)
+        val tenantB = mockk<ConnectionPool>(relaxed = true)
+        val registry = TenantConnectionPoolRegistry(
+            mapOf(
+                TenantKey("tenant-a") to tenantA,
+                TenantKey("tenant-b") to tenantB,
+            ),
+        )
+
+        registry.close()
+        registry.close()
+
+        verify(exactly = 1) { tenantA.dispose() }
+        verify(exactly = 1) { tenantB.dispose() }
+    }
+
+    @Test
+    fun `concurrent close는 첫 종료가 완료될 때까지 기다린다`() {
+        val disposeStarted = CountDownLatch(1)
+        val allowDispose = CountDownLatch(1)
+        val concurrentCloseStarted = CountDownLatch(1)
+        val pool = mockk<ConnectionPool>(relaxed = true)
+        every { pool.dispose() } answers {
+            disposeStarted.countDown()
+            allowDispose.await()
+        }
+        val registry = TenantConnectionPoolRegistry(mapOf(TenantKey("tenant-a") to pool))
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val firstClose = executor.submit(registry::close)
+            disposeStarted.await(5, TimeUnit.SECONDS) shouldBeEqualTo true
+            val concurrentClose = executor.submit {
+                concurrentCloseStarted.countDown()
+                registry.close()
+            }
+
+            concurrentCloseStarted.await(5, TimeUnit.SECONDS) shouldBeEqualTo true
+            concurrentClose.isDone shouldBeEqualTo false
+            allowDispose.countDown()
+            firstClose.get(5, TimeUnit.SECONDS)
+            concurrentClose.get(5, TimeUnit.SECONDS)
+        } finally {
+            allowDispose.countDown()
+            executor.shutdownNow()
+        }
+
+        verify(exactly = 1) { pool.dispose() }
+    }
+
+    @Test
+    fun `registry-owned pool은 close 시작 후 조회를 거부한다`() {
+        val pool = mockk<ConnectionPool>(relaxed = true)
+        val registry = TenantConnectionPoolRegistry(
+            mapOf(TenantKey("tenant-a") to pool),
+        )
+
+        registry.close()
+
+        assertFailsWith<IllegalStateException> {
+            registry[TenantKey("tenant-a")]
+        }
+        assertFailsWith<IllegalStateException> {
+            registry.asRoutingMap()
+        }
+    }
+
+    @Test
+    fun `closeSuspending은 coroutine caller의 blocking 작업을 IO dispatcher로 격리한다`() = runSuspendIO {
+        val pool = mockk<ConnectionPool>(relaxed = true)
+        val registry = TenantConnectionPoolRegistry(mapOf(TenantKey("tenant-a") to pool))
+
+        registry.closeSuspending()
+
+        verify(exactly = 1) { pool.dispose() }
+    }
+
+    @Test
+    fun `registry-owned pool cleanup continues and suppresses later failures`() {
+        val tenantA = mockk<ConnectionPool>(relaxed = true)
+        val tenantB = mockk<ConnectionPool>(relaxed = true)
+        val tenantC = mockk<ConnectionPool>(relaxed = true)
+        val firstFailure = IllegalStateException("tenant-a close failed")
+        val secondFailure = IllegalArgumentException("tenant-b close failed")
+        every { tenantA.dispose() } throws firstFailure
+        every { tenantB.dispose() } throws secondFailure
+
+        val registry = TenantConnectionPoolRegistry(
+            mapOf(
+                TenantKey("tenant-a") to tenantA,
+                TenantKey("tenant-b") to tenantB,
+                TenantKey("tenant-c") to tenantC,
+            ),
+        )
+
+        val failure = assertFailsWith<IllegalStateException> { registry.close() }
+        val repeatedFailure = assertFailsWith<IllegalStateException> { registry.close() }
+
+        failure shouldBeSameInstanceAs firstFailure
+        repeatedFailure shouldBeSameInstanceAs firstFailure
+        failure.suppressed.single() shouldBeSameInstanceAs secondFailure
+        verify(exactly = 1) { tenantA.dispose() }
+        verify(exactly = 1) { tenantB.dispose() }
+        verify(exactly = 1) { tenantC.dispose() }
+    }
+
+    @Test
+    fun `registry-owned pool cleanup은 Error를 suppressed 처리하지 않고 즉시 전파한다`() {
+        val tenantA = mockk<ConnectionPool>(relaxed = true)
+        val tenantB = mockk<ConnectionPool>(relaxed = true)
+        val tenantC = mockk<ConnectionPool>(relaxed = true)
+        every { tenantA.dispose() } throws IllegalStateException("ordinary close failure")
+        every { tenantB.dispose() } throws AssertionError("fatal close failure")
+        val registry = TenantConnectionPoolRegistry(
+            mapOf(
+                TenantKey("tenant-a") to tenantA,
+                TenantKey("tenant-b") to tenantB,
+                TenantKey("tenant-c") to tenantC,
+            ),
+        )
+
+        val failure = assertFailsWith<AssertionError> { registry.close() }
+
+        failure.message shouldBeEqualTo "fatal close failure"
+        verify(exactly = 0) { tenantC.dispose() }
+    }
+
+    @Test
+    fun `same pool shared by tenants is disposed once`() {
+        val pool = mockk<ConnectionPool>(relaxed = true)
+        val registry = TenantConnectionPoolRegistry(
+            mapOf(
+                TenantKey("tenant-a") to pool,
+                TenantKey("tenant-b") to pool,
+            ),
+        )
+
+        registry.close()
+
+        verify(exactly = 1) { pool.dispose() }
+    }
+
+    private data class TenantKey(val id: String)
+}


### PR DESCRIPTION
## 요약

- 정적 tenant key lookup과 routing map 변환을 제공하는 최소 registry 계약을 추가합니다.
- caller-owned `ConnectionFactory`와 registry-owned `ConnectionPool` 경로를 타입으로 분리합니다.
- registry-owned pool의 idempotent close, 동시 종료 barrier, 예외 집계와 JVM `Error` 즉시 전파 계약을 고정합니다.
- `closeSuspending`은 caller cancellation과 독립적으로 pool cleanup을 완료한 뒤 취소를 다시 전파합니다.

## 계약 경계

- pool 생성, tenant parsing, 인증·인가, request context와 transaction은 caller 책임입니다.
- Spring/Ktor 타입이나 동적 onboarding 정책은 core API에 포함하지 않습니다.
- close 전에 내보낸 routing map은 close 이후 caller가 폐기해야 합니다.
- downstream Workshop migration은 별도 consumer 작업으로 남깁니다.

## 검증

- `bluetape4k-r2dbc`: 208 tests, failures/errors 0
- Detekt, JAR, POM 생성 통과
- tenant 격리, mapper collision, concurrent close, 취소 cleanup, 동일 실패 재전파, `Error` 경계 회귀 테스트
- 독립 architecture/security/performance/API/stability/caller 리뷰 및 `git diff --check` 통과

Closes #1648

## DoD Status

- [x] caller-owned/registry-owned public API 구현
- [x] lookup·routing·close lifecycle 회귀 테스트
- [x] framework dependency 비유입 및 publication 검증
- [x] exact-head GitHub Actions 확인 (`a92af9c5`, 성공 12 / 건너뜀 12)
- [ ] downstream consumer migration — 별도 작업으로 추적
