### PR TITLE
fix(testcontainers): Ignite2Server 2.1.x 호환 API를 복원한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@
 
 ### 제거
 
-- `2.1.0` 개발선부터 Apache Ignite 2 runtime 지원을 종료했다.
-  `Ignite2Server`, 전용 Testcontainers image family와 arm64 Nightly gate,
-  legacy thin-client 의존성과 Java 25 `--add-opens` 예외를 함께 제거했다.
-  이미 공개된 `2.0.0` artifact와 migration 문서는 변경하지 않는다
-  ([#1600](https://github.com/bluetape4k/bluetape4k-projects/issues/1600)).
+- `2.1.0` 개발선부터 Apache Ignite 2 runtime 의존성, 전용 Testcontainers image
+  family와 arm64 Nightly gate, legacy thin-client 의존성과 Java 25 `--add-opens`
+  예외를 제거했다. 다만 `2.0.0`에서 공개한 `Ignite2Server`는 deprecated 호환성
+  facade로 유지하며 public API 제거는 `3.0.0` breaking 경계에서 수행한다
+  ([#1600](https://github.com/bluetape4k/bluetape4k-projects/issues/1600),
+  [#1619](https://github.com/bluetape4k/bluetape4k-projects/issues/1619)).
 
 ## [2.0.0] — 2026-09-01
 

--- a/WIP.md
+++ b/WIP.md
@@ -9,9 +9,10 @@
 ## 현재 상태
 
 `2.0.0` artifact와 GitHub Release 배포를 완료했다. `develop`은 minor upgrade인
-`2.1.0` 개발선을 사용한다. Apache Ignite 2 runtime 지원 제거는 `2.0.0` 이후
-지원 종료 정책에 따른 후속 정리이며, 이번 개발선을 major version으로 올리는
-근거로 사용하지 않는다.
+`2.1.0` 개발선을 사용한다. Apache Ignite 2 runtime 의존성과 전용 검증 gate는
+정리하되, `2.0.0`에서 공개한 `Ignite2Server`는 deprecated 호환성 facade로 유지한다.
+public API 제거는 다음 breaking 경계인 `3.0.0`에서 수행하므로 이번 개발선을 major
+version으로 올리는 근거로 사용하지 않는다.
 
 ## 다음 개발선 규칙
 

--- a/scripts/test_ignite2_removal.py
+++ b/scripts/test_ignite2_removal.py
@@ -7,11 +7,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-class Ignite2RemovalTest(unittest.TestCase):
-    def test_runtime_source_and_test_are_removed(self) -> None:
+class Ignite2CompatibilityBoundaryTest(unittest.TestCase):
+    def test_deprecated_facade_and_compatibility_test_remain_until_3_0(self) -> None:
         storage = ROOT / "testing/testcontainers/src"
-        self.assertFalse((storage / "main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt").exists())
+        facade = storage / "main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt"
+        compatibility_test = storage / "test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerApiCompatibilityTest.kt"
+        self.assertTrue(facade.is_file())
+        self.assertTrue(compatibility_test.is_file())
         self.assertFalse((storage / "test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerTest.kt").exists())
+        source = facade.read_text(encoding="utf-8")
+        self.assertIn("@Deprecated", source)
+        self.assertIn("3.0.0", source)
 
     def test_image_manifest_and_workflows_have_no_ignite2_gate(self) -> None:
         manifest = json.loads((ROOT / "scripts/testcontainers_image_gate_manifest.json").read_text(encoding="utf-8"))
@@ -41,17 +47,21 @@ class Ignite2RemovalTest(unittest.TestCase):
         ):
             self.assertNotIn(f"{alias} =", catalog)
 
-    def test_current_docs_record_removal_and_keep_2_0_history(self) -> None:
-        for relative in (
-            "testing/testcontainers/README.md",
-            "testing/testcontainers/README.ko.md",
-            "cache/cache-core/README.ko.md",
-        ):
-            self.assertNotIn("Ignite2Server", (ROOT / relative).read_text(encoding="utf-8"), relative)
+    def test_current_docs_record_2_1_facade_and_3_0_removal_boundary(self) -> None:
+        for relative in ("testing/testcontainers/README.md", "testing/testcontainers/README.ko.md"):
+            current = (ROOT / relative).read_text(encoding="utf-8")
+            self.assertIn("Ignite2Server", current, relative)
+            self.assertIn("3.0.0", current, relative)
+        self.assertNotIn(
+            "Ignite2Server",
+            (ROOT / "cache/cache-core/README.ko.md").read_text(encoding="utf-8"),
+        )
         for relative in ("CHANGELOG.md", "WIP.md"):
             current = (ROOT / relative).read_text(encoding="utf-8")
             self.assertIn("Ignite 2", current, relative)
             self.assertIn("2.1.0", current, relative)
+            self.assertIn("Ignite2Server", current, relative)
+            self.assertIn("3.0.0", current, relative)
         history = ROOT / "docs/release/2.0.0-ignite2-migration.md"
         self.assertTrue(history.is_file())
         self.assertIn("Ignite2Server", history.read_text(encoding="utf-8"))

--- a/scripts/test_testcontainers_contract.py
+++ b/scripts/test_testcontainers_contract.py
@@ -144,7 +144,7 @@ class TestTestcontainersContract(unittest.TestCase):
 
         for path in (README_EN, README_KO):
             content = read(path)
-            self.assertNotIn("Ignite2Server", content, path.as_posix())
+            self.assertIn("Ignite2Server", content, path.as_posix())
             self.assertIn("Ignite3Server", content, path.as_posix())
 
     def test_ministack_disabled_inventory_matches_pinned_tag_and_known_errors(self) -> None:

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from scripts.testcontainers_image_gate import (
     EXPECTED_FAMILY_COUNT,
     EXPECTED_RELEASE_FAMILY_COUNT,
+    NON_IMAGE_GATE_SERVERS,
     NON_RELEASE_RUNTIME_SERVERS,
     SelectionError,
     load_manifest,
@@ -29,6 +30,10 @@ class TestTestcontainersImageGate(unittest.TestCase):
     def test_manifest_covers_every_image_family_and_has_required_fields(self) -> None:
         self.assertEqual(EXPECTED_FAMILY_COUNT, len(self.entries))
         self.assertEqual([], validate_manifest(self.entries, self.root))
+
+    def test_deprecated_compatibility_facade_is_not_an_image_gate_family(self) -> None:
+        self.assertEqual({"Ignite2Server"}, set(NON_IMAGE_GATE_SERVERS))
+        self.assertNotIn("Ignite2Server", {entry["server"] for entry in self.entries})
 
     def test_disabled_families_are_support_inventory_not_release_runtime(self) -> None:
         disabled = set(NON_RELEASE_RUNTIME_SERVERS)

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -15,6 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "scripts/testcontainers_image_gate_manifest.json"
 EXPECTED_FAMILY_COUNT = 51
 EXPECTED_RELEASE_FAMILY_COUNT = 47
+NON_IMAGE_GATE_SERVERS = frozenset({"Ignite2Server"})
 NON_RELEASE_RUNTIME_SERVERS = frozenset(
     {"ChromaDBServer", "OllamaServer", "RedpandaServer", "Ignite3Server"}
 )
@@ -255,7 +256,7 @@ def validate_manifest(entries: list[dict[str, Any]], root: Path = ROOT) -> list[
     names: set[str] = set()
     ids: set[str] = set()
     expected_readme = readme_tag_table(root / "testing/testcontainers/README.md")
-    expected_servers = set(source_servers)
+    expected_servers = set(source_servers) - NON_IMAGE_GATE_SERVERS
 
     for index, entry in enumerate(entries):
         prefix = f"families[{index}]"

--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -24,7 +24,7 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 - **Graph DB 서버 지원**: Neo4j, Memgraph, FalkorDB, PostgreSQL + Apache AGE
 - **Storage 서버 지원**: Redis/Redis Cluster, MongoDB, Cassandra, Elasticsearch/OSS/OpenSearch, MinIO, InfluxDB
 - `MinIOServer`는 명시적인 MinIO 호환성 테스트용으로 유지하며, 신규 AWS/S3 에뮬레이터 테스트는 `FlociServer` 또는 `MiniStackServer`를 사용하세요.
-- **분산 캐시/그리드**: `HazelcastServer` (5.x slim), `Ignite3Server` (클러스터 자동 초기화)
+- **분산 캐시/그리드**: `HazelcastServer` (5.x slim), deprecated `Ignite2Server` 호환성 facade, `Ignite3Server` (클러스터 자동 초기화)
 - **MQ 서버 지원**: Kafka, RabbitMQ, Pulsar, Nats, Redpanda
 - **Infra 서버 지원**: Consul, Vault, Prometheus, Jaeger, Zipkin, ZooKeeper, Toxiproxy, Keycloak
 - **분산 SQL 엔진**: Trino
@@ -85,6 +85,7 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 | JaegerServer           | `jaeger`            | `host`, `port`, `url`, `frontend-port`, `zipkin-port`, `config-port`, `thrift-port`                                                                                  |
 | ElasticsearchOssServer | `elasticsearch-oss` | `host`, `port`, `url`                                                                                                                                                |
 | HazelcastServer        | `hazelcast`         | `host`, `port`, `url`                                                                                                                                                |
+| Ignite2Server          | `ignite2`           | `host`, `port`, `url`                                                                                                                                                |
 | Ignite3Server          | `ignite3`           | `host`, `port`, `url`, `rest-port`                                                                                                                                   |
 | ZipkinServer           | `zipkin`            | `host`, `port`, `url`                                                                                                                                                |
 | NginxServer            | `nginx`             | `host`, `port`, `url`                                                                                                                                                |
@@ -98,6 +99,33 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 아래 기본값은 2026-08-10에 확인한 최신 안정 이미지 태그를 고정한 것입니다.
 재현 가능한 로컬·CI 실행을 위해 변경 가능한 `latest`, major-only, rolling minor
 태그는 사용하지 않습니다.
+
+<!-- issue-1619-ignite2-compatibility:start -->
+### `Ignite2Server` 호환성 facade
+
+`Ignite2Server`는 2.0.0 public API와의 호환성을 위해 2.1.x minor line에서
+deprecated facade로 유지됩니다. 이 facade는 3.0.0 breaking 경계에서 제거될
+예정입니다. 신규 테스트는 `Ignite3Server`를 사용하고, 기존 Ignite 2 사용처는
+3.0.0 전에 마이그레이션하세요.
+
+canonical `apacheignite/ignite` 이미지는 지연 해석됩니다.
+`x86_64`/`amd64`에서는 `2.18.0`, `aarch64`/`arm64`에서는 `2.18.0-arm64`를
+사용합니다. Custom image에는 명시적인 immutable tag가 필요하며 tag가 없거나
+`latest`인 호출은 fail-fast로 실패합니다.
+
+```kotlin
+@Suppress("DEPRECATION")
+Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom").use { ignite2 ->
+    ignite2.start()
+    // Ignite 2 thin client를 ignite2.url에 연결합니다.
+}
+```
+
+호환성 facade는 2.0.0의 constructor overload, `DEFAULT_TAG`/`TAG`/`IMAGE`/`NAME`/`PORT`
+상수, `url`, `Launcher` singleton을 유지합니다. 이미지 선택 계약은
+[`docs/release/2.0.0-ignite2-migration.md`](../../docs/release/2.0.0-ignite2-migration.md)를
+참고하세요.
+<!-- issue-1619-ignite2-compatibility:end -->
 
 | 그룹 | 서버 | 이미지 | 기본 태그 |
 |---|---|---|---|
@@ -145,6 +173,7 @@ Testcontainers `2.0.3` 기반 통합 테스트를 빠르게 구성하기 위한 
 | Storage | `ElasticsearchOssServer` | `docker.elastic.co/elasticsearch/elasticsearch-oss` | `7.10.2` |
 | Storage | `ElasticsearchServer` | `docker.elastic.co/elasticsearch/elasticsearch` | `9.5.0` |
 | Storage | `HazelcastServer` | `hazelcast/hazelcast` | `5.7.0-slim-jdk25` |
+| Storage | `Ignite2Server` | `apacheignite/ignite` | `2.18.0` (x86_64/amd64) 또는 `2.18.0-arm64` (aarch64/arm64), deprecated facade |
 | Storage | `Ignite3Server` | `apacheignite/ignite` | `3.1.0` |
 | Storage | `InfluxDBServer` | `influxdb` | `2.9.1` |
 | Storage | `MinIOServer` | `minio/minio` | `RELEASE.2025-07-23T15-54-02Z` (호환성 fixture) |
@@ -460,6 +489,13 @@ val hazelcast = HazelcastServer.Launcher.hazelcast
 val client = HazelcastClient.newHazelcastClient(
     ClientConfig().apply { networkConfig.addAddress("${hazelcast.host}:${hazelcast.port}") }
 )
+
+// Apache Ignite 2.x — deprecated 2.0.0 호환성 facade, 씬 클라이언트 포트 10800
+@Suppress("DEPRECATION")
+Ignite2Server().use { ignite2 ->
+    ignite2.start()
+    // Ignite 2 thin client를 ignite2.url에 연결합니다.
+}
 
 // Apache Ignite 3.x — 클러스터 자동 초기화, 씬 클라이언트 포트 10800
 val ignite3 = Ignite3Server.Launcher.ignite3

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -28,7 +28,7 @@ A server wrapper and utility library for building integration tests quickly on t
 - **Embedded SQS**: `ElasticMqServer` runs an in-process SQS server — no Docker needed
 - **Mail testing**: `MailpitServer` provides SMTP + Web UI for email integration tests
 - **LLM support**: `ChromaDBServer` (vector DB, port 8000), `OllamaServer` (local LLM inference, port 11434)
-- **Distributed cache/grid**: `HazelcastServer` (5.x slim), `Ignite3Server` (auto cluster-init)
+- **Distributed cache/grid**: `HazelcastServer` (5.x slim), deprecated `Ignite2Server` compatibility facade, `Ignite3Server` (auto cluster-init)
 -
 
 **Observability**: `ZipkinServer` (distributed tracing, `openzipkin/zipkin-slim:2.23`), `GrafanaServer` (dashboards + datasource provisioning, `grafana/grafana:13.1.3`), `K3sServer` (lightweight Kubernetes cluster, `rancher/k3s`; requires `--privileged` Docker mode)
@@ -80,6 +80,7 @@ Every server implements
 | JaegerServer           | `jaeger`            | `host`, `port`, `url`, `frontend-port`, `zipkin-port`, `config-port`, `thrift-port`                                                                                  |
 | ElasticsearchOssServer | `elasticsearch-oss` | `host`, `port`, `url`                                                                                                                                                |
 | HazelcastServer        | `hazelcast`         | `host`, `port`, `url`                                                                                                                                                |
+| Ignite2Server          | `ignite2`           | `host`, `port`, `url`                                                                                                                                                |
 | Ignite3Server          | `ignite3`           | `host`, `port`, `url`, `rest-port`                                                                                                                                   |
 | ZipkinServer           | `zipkin`            | `host`, `port`, `url`                                                                                                                                                |
 | NginxServer            | `nginx`             | `host`, `port`, `url`                                                                                                                                                |
@@ -93,6 +94,32 @@ Every server implements
 The defaults below are pinned to the latest stable image tag verified on
 2026-08-10. Mutable `latest`, major-only, and rolling minor tags are avoided so
 that Testcontainers runs remain reproducible across local machines and CI.
+
+<!-- issue-1619-ignite2-compatibility:start -->
+### `Ignite2Server` compatibility facade
+
+`Ignite2Server` remains available in the 2.1.x minor line as a deprecated
+compatibility facade for the 2.0.0 public API. The facade will be removed at
+the 3.0.0 breaking boundary. New tests should use `Ignite3Server`; existing
+Ignite 2 consumers should migrate before 3.0.0.
+
+The canonical `apacheignite/ignite` image resolves lazily: `x86_64`/`amd64`
+uses `2.18.0`, while `aarch64`/`arm64` uses `2.18.0-arm64`. Custom images must
+provide an explicit immutable tag; tagless or `latest` calls fail fast.
+
+```kotlin
+@Suppress("DEPRECATION")
+Ignite2Server(image = "custom/ignite", tag = "2.18.0-custom").use { ignite2 ->
+    ignite2.start()
+    // Connect an Ignite 2 thin client to ignite2.url.
+}
+```
+
+The compatibility facade preserves the 2.0.0 constructor overloads,
+`DEFAULT_TAG`/`TAG`/`IMAGE`/`NAME`/`PORT` constants, `url`, and the `Launcher`
+singleton. See [`docs/release/2.0.0-ignite2-migration.md`](../../docs/release/2.0.0-ignite2-migration.md)
+for the image-selection contract.
+<!-- issue-1619-ignite2-compatibility:end -->
 
 | Group | Server | Image | Default tag |
 |---|---|---|---|
@@ -140,6 +167,7 @@ that Testcontainers runs remain reproducible across local machines and CI.
 | Storage | `ElasticsearchOssServer` | `docker.elastic.co/elasticsearch/elasticsearch-oss` | `7.10.2` |
 | Storage | `ElasticsearchServer` | `docker.elastic.co/elasticsearch/elasticsearch` | `9.5.0` |
 | Storage | `HazelcastServer` | `hazelcast/hazelcast` | `5.7.0-slim-jdk25` |
+| Storage | `Ignite2Server` | `apacheignite/ignite` | `2.18.0` (x86_64/amd64) or `2.18.0-arm64` (aarch64/arm64), deprecated facade |
 | Storage | `Ignite3Server` | `apacheignite/ignite` | `3.1.0` |
 | Storage | `InfluxDBServer` | `influxdb` | `2.9.1` |
 | Storage | `MinIOServer` | `minio/minio` | `RELEASE.2025-07-23T15-54-02Z` (compatibility fixture) |
@@ -498,6 +526,13 @@ val hazelcast = HazelcastServer.Launcher.hazelcast
 val client = HazelcastClient.newHazelcastClient(
     ClientConfig().apply { networkConfig.addAddress("${hazelcast.host}:${hazelcast.port}") }
 )
+
+// Apache Ignite 2.x — deprecated 2.0.0 compatibility facade, thin-client port 10800
+@Suppress("DEPRECATION")
+Ignite2Server().use { ignite2 ->
+    ignite2.start()
+    // Connect an Ignite 2 thin client to ignite2.url.
+}
 
 // Apache Ignite 3.x — auto cluster-init, thin client port 10800
 val ignite3 = Ignite3Server.Launcher.ignite3

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/storage/Ignite2Server.kt
@@ -1,0 +1,195 @@
+package io.bluetape4k.testcontainers.storage
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.testcontainers.GenericServer
+import io.bluetape4k.testcontainers.PropertyExportingServer
+import io.bluetape4k.testcontainers.exposeCustomPorts
+import io.bluetape4k.utils.ShutdownQueue
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.time.Duration
+
+/**
+ * [Apache Ignite 2.x](https://ignite.apache.org/) 서버 컨테이너입니다.
+ *
+ * 이 클래스는 2.0.0에서 공개한 호출 경계를 2.1.x에서 유지하기 위한
+ * 호환성 facade입니다. Apache Ignite 2.x는 3.0.0에서 지원이 종료되므로,
+ * 신규 테스트는 [Ignite3Server]를 사용하고 기존 사용처는 3.0.0 전에
+ * 마이그레이션해야 합니다.
+ *
+ * 테스트 환경에서 Ignite 2.x 서버를 Docker로 실행하여 씬 클라이언트(기본 포트 `10800`)로 연결할 수 있습니다.
+ *
+ * Docker Hub: [apacheignite/ignite](https://hub.docker.com/r/apacheignite/ignite/tags)
+ *
+ * **사용 예시:**
+ * ```kotlin
+ * @Suppress("DEPRECATION")
+ * Ignite2Server().use { ignite2 ->
+ *     ignite2.start()
+ *     // Ignite 2 thin client를 ignite2.url에 연결합니다.
+ * }
+ * ```
+ *
+ * canonical 이미지는 `x86_64`/`amd64`에서 `2.18.0`, `aarch64`/`arm64`에서
+ * `2.18.0-arm64`로 지연 해석됩니다. canonical tag를 생략한 상태에서 지원하지
+ * 않는 아키텍처를 만나면 즉시 실패합니다. Custom image는 명시적인 tag가
+ * 필요하며, 명시한 custom tag는 canonical resolver를 우회합니다.
+ *
+ * ```kotlin
+ * @Suppress("DEPRECATION")
+ * val server = Ignite2Server(image = "custom/ignite", tag = "2.18.0")
+ * ```
+ *
+ * `Ignite2Server(image = "custom/ignite")`는 `IllegalArgumentException`으로
+ * 실패하며 canonical tag fallback을 제공하지 않습니다.
+ *
+ * @param imageName Docker 이미지 이름 ([DockerImageName])
+ * @param useDefaultPort 기본 포트(10800)를 그대로 사용할지 여부. `false`이면 임의 포트가 할당됩니다.
+ * @param reuse 컨테이너 재사용 여부
+ */
+@Deprecated(
+    message = "Apache Ignite 2.x 호환성 facade는 3.0.0에서 제거됩니다. 신규 테스트는 Ignite3Server를 사용하고 기존 사용처는 3.0.0 전에 마이그레이션하세요.",
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("DEPRECATION")
+class Ignite2Server private constructor(
+    imageName: DockerImageName,
+    useDefaultPort: Boolean,
+    reuse: Boolean,
+): GenericContainer<Ignite2Server>(imageName), GenericServer, PropertyExportingServer {
+
+    companion object: KLogging() {
+        /** Apache Ignite 2.x Docker Hub 이미지 이름 */
+        const val IMAGE = "apacheignite/ignite"
+
+        /** 기본 태그 (안정 버전) */
+        const val TAG = "2.18.0"
+
+        /**
+         * 현재 아키텍처에 맞는 기본 태그.
+         * arm64(Apple Silicon 등)에서는 에뮬레이션 없이 실행하기 위해 `2.18.0-arm64` 태그를 사용합니다.
+         * 지원하지 않는 아키텍처에서는 기본 생성자 경로를 조용히 다른 이미지로 완화하지 않습니다.
+         */
+        val DEFAULT_TAG: String
+            get() = defaultTagForArchitecture(System.getProperty("os.arch"))
+
+        private const val DEFAULT_TAG_SENTINEL = "__ignite2_default_tag__"
+        private const val STARTUP_TIMEOUT_MINUTES = 5L
+
+        private fun defaultTagForArchitecture(architecture: String?): String = when (architecture?.lowercase()) {
+            "x86_64", "amd64" -> TAG
+            "aarch64", "arm64" -> "$TAG-arm64"
+            else -> error("Unsupported Ignite2 default image architecture: $architecture")
+        }
+
+        /** 시스템 프로퍼티 등록 시 사용하는 서버 이름 */
+        const val NAME = "ignite2"
+
+        /** Ignite 2.x 씬 클라이언트 기본 포트 */
+        const val PORT = 10800
+
+        /**
+         * [DockerImageName]으로 [Ignite2Server]를 생성합니다.
+         *
+         * @param imageName Docker 이미지 이름
+         * @param useDefaultPort `true`면 10800 포트를 고정 바인딩합니다.
+         * @param reuse 컨테이너 재사용 여부입니다.
+         */
+        @JvmStatic
+        operator fun invoke(
+            imageName: DockerImageName,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = false,
+        ): Ignite2Server {
+            val resolvedImageName = if (
+                imageName.getUnversionedPart() == IMAGE && imageName.getVersionPart() == "latest"
+            ) {
+                imageName.withTag(DEFAULT_TAG)
+            } else {
+                require(imageName.getVersionPart() != "latest" || imageName.getUnversionedPart() == IMAGE) {
+                    "Custom Ignite2 DockerImageName must include an explicit tag"
+                }
+                imageName
+            }
+            return Ignite2Server(resolvedImageName, useDefaultPort, reuse)
+        }
+
+        /**
+         * 이미지 이름과 태그로 [Ignite2Server]를 생성합니다.
+         *
+         * @param image Docker 이미지 이름, blank이면 [IllegalArgumentException]이 발생합니다.
+         * @param tag Docker 이미지 태그 (기본: [DEFAULT_TAG]; aarch64 canonical image는 [TAG]-arm64).
+         *   blank이거나 `latest`이면 [IllegalArgumentException]이 발생하며, custom image는
+         *   immutable tag를 명시해야 합니다.
+         * @param useDefaultPort `true`면 10800 포트를 고정 바인딩합니다.
+         * @param reuse 컨테이너 재사용 여부입니다.
+         */
+        @JvmStatic
+        operator fun invoke(
+            image: String = IMAGE,
+            tag: String = DEFAULT_TAG_SENTINEL,
+            useDefaultPort: Boolean = false,
+            reuse: Boolean = false,
+        ): Ignite2Server {
+            image.requireNotBlank("image")
+            val resolvedTag = if (tag == DEFAULT_TAG_SENTINEL) {
+                require(image == IMAGE) {
+                    "Custom Ignite2 image requires an explicit tag"
+                }
+                DEFAULT_TAG
+            } else {
+                tag.requireNotBlank("tag")
+                require(tag != "latest") { "Ignite2 image tag must be immutable, not latest" }
+                tag
+            }
+            val imageName = DockerImageName.parse(image).withTag(resolvedTag)
+            return Ignite2Server(imageName, useDefaultPort, reuse)
+        }
+    }
+
+    /** 씬 클라이언트 연결 포트 (매핑된 포트) */
+    override val port: Int get() = getMappedPort(PORT)
+
+    /** 씬 클라이언트 연결 주소 (`host:port` 형식) */
+    override val url: String get() = "$host:$port"
+
+    override val propertyNamespace: String = NAME
+
+    override fun propertyKeys(): Set<String> = setOf("host", "port", "url")
+
+    override fun properties(): Map<String, String> = mapOf(
+        "host" to host,
+        "port" to port.toString(),
+        "url" to url,
+    )
+
+    init {
+        addExposedPorts(PORT)
+        withReuse(reuse)
+        waitingFor(
+            Wait.forLogMessage(".*Ignite node started OK.*", 1)
+                .withStartupTimeout(Duration.ofMinutes(STARTUP_TIMEOUT_MINUTES)),
+        )
+
+        if (useDefaultPort) {
+            exposeCustomPorts(PORT)
+        }
+    }
+
+    override fun start() {
+        super.start()
+        writeToSystemProperties()
+    }
+
+    /** 테스트 환경에서 공유하는 싱글턴 [Ignite2Server] 인스턴스를 제공합니다. */
+    object Launcher {
+        val ignite2: Ignite2Server by lazy {
+            Ignite2Server().apply {
+                start()
+                ShutdownQueue.register(this)
+            }
+        }
+    }
+}

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerApiCompatibilityTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/storage/Ignite2ServerApiCompatibilityTest.kt
@@ -1,0 +1,77 @@
+package io.bluetape4k.testcontainers.storage
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * 2.0.0에서 공개했던 [Ignite2Server] 호출 경계를 2.1.x에서도 컴파일할 수 있는지 검증합니다.
+ */
+@Suppress("DEPRECATION")
+class Ignite2ServerApiCompatibilityTest {
+
+    @Test
+    fun `2_0_0 public constructors remain source compatible`() {
+        Ignite2Server().use { server ->
+            server.configuredImageName().toString() shouldBeEqualTo
+                "${Ignite2Server.IMAGE}:${Ignite2Server.DEFAULT_TAG}"
+            server.propertyNamespace shouldBeEqualTo Ignite2Server.NAME
+            server.propertyKeys() shouldBeEqualTo setOf("host", "port", "url")
+        }
+
+        Ignite2Server(DockerImageName.parse(Ignite2Server.IMAGE)).use { server ->
+            server.configuredImageName().toString() shouldBeEqualTo
+                "${Ignite2Server.IMAGE}:${Ignite2Server.DEFAULT_TAG}"
+        }
+
+        Ignite2Server(
+            DockerImageName.parse("custom/ignite:2.18.0-custom"),
+            useDefaultPort = true,
+            reuse = true,
+        ).use { server ->
+            server.configuredImageName().toString() shouldBeEqualTo "custom/ignite:2.18.0-custom"
+        }
+
+        Ignite2Server(
+            image = "custom/ignite",
+            tag = "2.18.0-custom",
+            useDefaultPort = true,
+            reuse = true,
+        ).use { server ->
+            server.configuredImageName().toString() shouldBeEqualTo "custom/ignite:2.18.0-custom"
+        }
+    }
+
+    @Test
+    fun `tagless custom images remain rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Ignite2Server(image = "custom/ignite")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Ignite2Server(DockerImageName.parse("custom/ignite"))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Ignite2Server(image = "custom/ignite", tag = "latest")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Ignite2Server(image = Ignite2Server.IMAGE, tag = "latest")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Ignite2Server(DockerImageName.parse("custom/ignite:latest"))
+        }
+    }
+
+    private fun Ignite2Server.configuredImageName(): DockerImageName {
+        val imageField = GenericContainer::class.java.getDeclaredField("image").apply {
+            isAccessible = true
+        }
+        val remoteImage = imageField.get(this)
+        val imageNameFutureField = remoteImage.javaClass.getDeclaredField("imageNameFuture").apply {
+            isAccessible = true
+        }
+        val imageNameFuture = imageNameFutureField.get(remoteImage) as java.util.concurrent.Future<*>
+        return imageNameFuture.get() as DockerImageName
+    }
+}


### PR DESCRIPTION
## 요약

- 2.1.x에서 제거됐던 `Ignite2Server` 공개 API를 deprecated facade로 복원합니다.
- 기본 이미지 태그는 architecture별 canonical tag로 고정하고, custom image는 명시적인 immutable non-latest tag만 허용합니다.
- 3.0.0 제거 경계와 호환성 검증 스크립트·한영 문서를 일치시킵니다.
- facade는 source/docs 계약에는 포함하되 release image gate runtime family에서는 명시적으로 제외합니다.

## 검증

- `bluetape4k-testcontainers`: 451 tests, failures/errors 0, skipped 22
- Detekt, JAR, POM 생성 통과
- Testcontainers image gate·Ignite2 compatibility·source/docs Python 계약 32 tests 통과
- `git diff --check` 및 추가 라인 secret scan 통과
- exact head `119d6b74f0c8e0d8e183152a662114bcbb7d81e2`: GitHub Actions 26 success, failure 0

Closes #1619

## DoD Status

- [x] `Ignite2Server` source compatibility 복원
- [x] image tag와 3.0 제거 계약 문서화
- [x] facade/source 계약과 release image gate 경계 분리
- [x] 회귀 테스트 및 모듈 검증
- [x] exact-head GitHub Actions 확인 (`119d6b74`, 성공 26 / 건너뜀 0)
