### PR TITLE
fix(lettuce): suspended write-behind 최신 값 순서를 보존한다

### DIFF
--- a/docs/lessons/2026-09-06-issue-1657-write-behind-retry-order.md
+++ b/docs/lessons/2026-09-06-issue-1657-write-behind-retry-order.md
@@ -22,10 +22,30 @@
 - retry count 소진과 queue 포화 dead-letter 테스트를 함께 실행해 기존 경계를 확인했다.
 - `:bluetape4k-lettuce:test` 926개와 `:bluetape4k-lettuce:detekt`가 통과했다.
 
+## Suspended channel 후속 결정
+
+Issue #1664에서 append-only `Channel` 뒤에 실패 batch를 다시 보내는 방식도 같은 키의
+최신 순서를 깨뜨린다는 점을 재현했다. 실패 처리 중 `(key, C)`가 도착하면 channel이
+`C, A, B`가 되고, 다음 batch에서 오래된 `A`가 `C`를 덮을 수 있었다.
+
+- consumer coroutine만 접근하는 retry queue에 실패 batch를 원래 순서대로 보관한다.
+- consumer는 retry queue를 신규 channel entry보다 먼저 비운다.
+- 이미 channel에 accepted된 entry는 재시도 시 channel 용량과 다시 경쟁시키지 않는다.
+- shutdown timeout이나 caller cancellation로 consumer를 취소할 때는 처리 중 batch를
+  `NonCancellable` 경계에서 dead-letter에 기록한 뒤 retry queue와 channel 잔여분도
+  latest-key-wins로 병합해 보존한다.
+- retry count, dead-letter 한계와 public API는 변경하지 않는다.
+
+회귀 테스트는 첫 실패 batch가 `B`로 병합되고 재시도도 `B`, 실패 중 도착한 신규 값은
+그 뒤의 `C`로 기록되는 순서를 고정한다. channel이 가득 찬 경우에도 accepted retry가
+내부 queue에 남고 dead-letter로 조기 이동하지 않는 계약을 함께 검증했다.
+또한 `close()`와 `suspendClose()` timeout, `suspendClose()` caller cancellation에서도
+처리 중 entry와 channel 잔여분이 dead-letter recovery value로 남는지 검증했다.
+
 ## 향후 지침
 
 FIFO batch를 deque의 앞쪽에 복원할 때는 `addFirst`나 `offerFirst` 호출 순서만 보지
 말고, 복원 뒤 전체 queue 순서와 동일 키 병합 결과를 함께 검증한다. append-only
 channel은 앞쪽 삽입을 지원하지 않으므로 같은 정책을 그대로 적용하지 않는다. channel
-기반 구현은 accepted entry 보존, 용량 상한, close와 retry의 경합을 먼저 정의한 뒤
-별도 회귀 테스트로 고정한다. 이 후속 작업은 Issue #1664에서 추적한다.
+기반 구현에서는 consumer 전용 retry queue를 우선 처리하고, accepted entry 보존과
+close·retry 경합을 별도 회귀 테스트로 고정한다.

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
@@ -13,6 +13,7 @@ import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.codec.StringCodec
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -21,14 +22,17 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.time.delay
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.Closeable
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Lettuce(Redis) 기반 코루틴 네이티브 Read-through / Write-through / Write-behind Map.
@@ -107,6 +111,10 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
         writeBehindChannel?.let {
             ownedScope.launch { consumeWriteBehindChannel() }
         }
+
+    // 호출자 취소/timeout과 독립적으로 accepted entry 보존과 resource cleanup을 끝까지 수행한다.
+    private val shutdownScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val shutdownAttempt = AtomicReference<CompletableDeferred<Result<Unit>>?>()
 
     private fun redisKey(key: K): String = "${config.keyPrefix}:${keySerializer(key)}"
 
@@ -344,18 +352,12 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
     private suspend fun writeToDeadLetter(batch: Map<K, V>) {
         // HSET (recovery values) first; LPUSH (monitoring keys) only on success.
         // Two commands use different codec connections so MULTI/EXEC is not possible.
-        try {
-            val deadLetterKey = "${config.keyPrefix}:dead-letter"
-            val deadLetterValuesKey = "${config.keyPrefix}:dead-letter:values"
-            val valueMap = batch.entries.associate { (k, v) -> keySerializer(k) to v }
-            asyncCommands.hset(deadLetterValuesKey, valueMap).await()
-            val serializedKeys = batch.keys.map { keySerializer(it) }
-            strAsyncCommands.lpush(deadLetterKey, *serializedKeys.toTypedArray()).await()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            log.error(e) { "Dead letter 기록 실패" }
-        }
+        val deadLetterKey = "${config.keyPrefix}:dead-letter"
+        val deadLetterValuesKey = "${config.keyPrefix}:dead-letter:values"
+        val valueMap = batch.entries.associate { (k, v) -> keySerializer(k) to v }
+        asyncCommands.hset(deadLetterValuesKey, valueMap).await()
+        val serializedKeys = batch.keys.map { keySerializer(it) }
+        strAsyncCommands.lpush(deadLetterKey, *serializedKeys.toTypedArray()).await()
     }
 
     private suspend fun flushBatch(entries: List<Triple<K, V, Int>>) {
@@ -365,9 +367,7 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
         try {
             writer?.write(batch)
         } catch (e: CancellationException) {
-            withContext(NonCancellable) {
-                writeToDeadLetter(batch)
-            }
+            latestEntries.forEach(writeBehindRetryQueue::addLast)
             throw e
         } catch (e: Exception) {
             val attempts = latestEntries.map { it.third + 1 }
@@ -382,15 +382,29 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
                 }
             }
             if (deadLetters.isNotEmpty()) {
-                writeToDeadLetter(deadLetters)
+                try {
+                    writeToDeadLetter(deadLetters)
+                } catch (failure: CancellationException) {
+                    enqueueDeadLetterRetry(deadLetters)
+                    throw failure
+                } catch (failure: Exception) {
+                    enqueueDeadLetterRetry(deadLetters)
+                    log.error(failure) { "Dead letter 기록 실패; accepted entry를 retry queue에 보존합니다" }
+                }
             }
         }
     }
 
-    private suspend fun awaitWriteBehindDrain(shutdownMethod: String) {
+    private fun enqueueDeadLetterRetry(deadLetters: Map<K, V>) {
+        deadLetters.forEach { (key, value) ->
+            writeBehindRetryQueue.addLast(Triple(key, value, MAX_DEAD_LETTER_RETRY - 1))
+        }
+    }
+
+    private suspend fun awaitWriteBehindDrain(shutdownMethod: String, timeoutMillis: Long) {
         writeBehindChannel?.close()
         val drained = writeBehindJob?.let { job ->
-            withTimeoutOrNull(config.writeBehindShutdownTimeout.toMillis()) {
+            withTimeoutOrNull(timeoutMillis) {
                 job.join()
                 true
             }
@@ -403,23 +417,67 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
     private suspend fun cancelAndPersistPendingWriteBehind() {
         writeBehindJob?.cancelAndJoin()
 
-        val pendingEntries = buildList {
-            addAll(writeBehindRetryQueue)
-            writeBehindRetryQueue.clear()
-            val channel = writeBehindChannel
-            if (channel != null) {
-                while (true) {
-                    add(channel.tryReceive().getOrNull() ?: break)
-                }
+        val channel = writeBehindChannel
+        if (channel != null) {
+            while (true) {
+                writeBehindRetryQueue.addLast(channel.tryReceive().getOrNull() ?: break)
             }
         }
-        val latestPending = pendingEntries
+        val latestPending = writeBehindRetryQueue
             .associateBy { it.first }
             .values
             .associate { (key, value, _) -> key to value }
         if (latestPending.isNotEmpty()) {
             writeToDeadLetter(latestPending)
+            writeBehindRetryQueue.clear()
         }
+    }
+
+    private suspend fun shutdown(shutdownMethod: String) {
+        val timeoutMillis = config.writeBehindShutdownTimeout.toMillis().coerceAtLeast(1L)
+        while (true) {
+            val activeAttempt = shutdownAttempt.get()
+            if (activeAttempt != null) {
+                awaitShutdownAttempt(activeAttempt, timeoutMillis)
+                return
+            }
+
+            val newAttempt = CompletableDeferred<Result<Unit>>()
+            if (!shutdownAttempt.compareAndSet(null, newAttempt)) {
+                continue
+            }
+
+            shutdownScope.launch {
+                val result = runCatching {
+                    performShutdown(shutdownMethod, timeoutMillis)
+                }
+                newAttempt.complete(result)
+                if (result.isFailure) {
+                    // performShutdown이 완전히 끝난 뒤에만 retry를 허용해 shutdown 경합을 막는다.
+                    shutdownAttempt.compareAndSet(newAttempt, null)
+                }
+            }
+            awaitShutdownAttempt(newAttempt, timeoutMillis)
+            return
+        }
+    }
+
+    private suspend fun awaitShutdownAttempt(
+        attempt: CompletableDeferred<Result<Unit>>,
+        timeoutMillis: Long,
+    ) {
+        withTimeout(timeoutMillis) {
+            attempt.await().getOrThrow()
+        }
+    }
+
+    private suspend fun performShutdown(shutdownMethod: String, timeoutMillis: Long) {
+        val drainTimeout = (timeoutMillis / 2L).coerceAtLeast(1L)
+        awaitWriteBehindDrain(shutdownMethod, drainTimeout)
+        cancelAndPersistPendingWriteBehind()
+        ownedJob.cancel()
+        if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
+        connection.close()
     }
 
     /**
@@ -432,23 +490,19 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
     override fun close() {
         try {
             runBlocking(Dispatchers.IO) {
-                try {
-                    awaitWriteBehindDrain("close()")
-                } finally {
-                    withContext(NonCancellable) {
-                        cancelAndPersistPendingWriteBehind()
-                    }
-                }
+                shutdown("close()")
             }
         } catch (e: InterruptedException) {
+            // runBlocking 진입 전 interrupt도 cleanup 시작을 막지 않도록 잠시 상태를 지운다.
+            Thread.interrupted()
+            val cleanupResult = runCatching {
+                runBlocking(Dispatchers.IO) {
+                    shutdown("close() interrupted")
+                }
+            }
             Thread.currentThread().interrupt()
-            log.warn(e) { "Write-behind job drain interrupted during close(); interrupt status restored" }
-        } catch (e: Exception) {
-            log.warn(e) { "Write-behind job drain timed out or failed during close()" }
-        } finally {
-            ownedJob.cancel()
-            if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
-            connection.close()
+            log.warn(e) { "Write-behind job drain interrupted during close(); cleanup completed and interrupt status restored" }
+            cleanupResult.getOrThrow()
         }
     }
 
@@ -457,21 +511,14 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
      *
      * This is the coroutine-safe alternative to [close]. Call this from a coroutine
      * context to avoid thread blocking while waiting for the write-behind job to drain.
+     * 호출 대기 시간이 shutdown timeout을 넘으면 [kotlinx.coroutines.TimeoutCancellationException]을
+     * 던지지만, 이미 시작한 cleanup은 독립 scope에서 계속되며 후속 호출은 같은 결과를 기다립니다.
      */
     suspend fun suspendClose() {
-        try {
-            awaitWriteBehindDrain("suspendClose()")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            log.warn(e) { "Write-behind job drain failed during suspendClose()" }
-        } finally {
-            withContext(NonCancellable) {
-                cancelAndPersistPendingWriteBehind()
-                ownedJob.cancel()
-                if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
-                connection.close()
-            }
+        val callerContext = currentCoroutineContext()
+        withContext(NonCancellable + Dispatchers.IO) {
+            shutdown("suspendClose()")
         }
+        callerContext.ensureActive()
     }
 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMap.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.isActive
@@ -26,7 +27,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.time.delay
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.Closeable
 
@@ -99,6 +99,9 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
         } else {
             null
         }
+
+    // Consumer coroutine만 접근한다. 이미 accepted된 실패 batch를 신규 channel entry보다 먼저 재시도한다.
+    private val writeBehindRetryQueue = ArrayDeque<Triple<K, V, Int>>()
 
     private val writeBehindJob =
         writeBehindChannel?.let {
@@ -314,12 +317,23 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
         val channel = writeBehindChannel ?: return
         while (currentCoroutineContext().isActive) {
             val batch = mutableListOf<Triple<K, V, Int>>()
-            // 첫 아이템은 blocking receive
-            val first = channel.receiveCatching().getOrNull() ?: break
+            // 실패한 accepted entry를 신규 channel entry보다 먼저 처리한다.
+            val isRetryBatch = writeBehindRetryQueue.isNotEmpty()
+            val first = if (isRetryBatch) {
+                writeBehindRetryQueue.removeFirst()
+            } else {
+                channel.receiveCatching().getOrNull()
+            }
+                ?: break
             batch.add(first)
-            // 나머지는 non-blocking tryReceive로 batch 수집
+            // retry와 신규 entry를 한 batch에 섞지 않아 실패 batch를 먼저 재시도한다.
             while (batch.size < config.writeBehindBatchSize) {
-                val next = channel.tryReceive().getOrNull() ?: break
+                val next = if (isRetryBatch) {
+                    writeBehindRetryQueue.removeFirstOrNull()
+                } else {
+                    channel.tryReceive().getOrNull()
+                }
+                    ?: break
                 batch.add(next)
             }
             flushBatch(batch)
@@ -346,23 +360,23 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
 
     private suspend fun flushBatch(entries: List<Triple<K, V, Int>>) {
         if (entries.isEmpty()) return
-        val batch = entries.associate { it.first to it.second }
+        val latestEntries = entries.associateBy { it.first }.values
+        val batch = latestEntries.associate { it.first to it.second }
         try {
             writer?.write(batch)
         } catch (e: CancellationException) {
+            withContext(NonCancellable) {
+                writeToDeadLetter(batch)
+            }
             throw e
         } catch (e: Exception) {
-            val attempts = entries.map { it.third + 1 }
+            val attempts = latestEntries.map { it.third + 1 }
             log.error(e) { "Write-behind flush 실패 (attempts=$attempts): ${batch.keys}" }
             val deadLetters = mutableMapOf<K, V>()
-            entries.forEach { (k, v, retryCount) ->
+            latestEntries.forEach { (k, v, retryCount) ->
                 val nextRetryCount = retryCount + 1
                 if (nextRetryCount < MAX_DEAD_LETTER_RETRY) {
-                    val result = writeBehindChannel?.trySend(Triple(k, v, nextRetryCount))
-                    if (result == null || result.isFailure) {
-                        log.warn { "Requeue failed for key=$k (attempt $nextRetryCount): channel full or closed" }
-                        deadLetters[k] = v
-                    }
+                    writeBehindRetryQueue.addLast(Triple(k, v, nextRetryCount))
                 } else {
                     deadLetters[k] = v
                 }
@@ -370,6 +384,41 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
             if (deadLetters.isNotEmpty()) {
                 writeToDeadLetter(deadLetters)
             }
+        }
+    }
+
+    private suspend fun awaitWriteBehindDrain(shutdownMethod: String) {
+        writeBehindChannel?.close()
+        val drained = writeBehindJob?.let { job ->
+            withTimeoutOrNull(config.writeBehindShutdownTimeout.toMillis()) {
+                job.join()
+                true
+            }
+        } ?: true
+        if (!drained) {
+            log.warn { "Write-behind job drain timed out during $shutdownMethod" }
+        }
+    }
+
+    private suspend fun cancelAndPersistPendingWriteBehind() {
+        writeBehindJob?.cancelAndJoin()
+
+        val pendingEntries = buildList {
+            addAll(writeBehindRetryQueue)
+            writeBehindRetryQueue.clear()
+            val channel = writeBehindChannel
+            if (channel != null) {
+                while (true) {
+                    add(channel.tryReceive().getOrNull() ?: break)
+                }
+            }
+        }
+        val latestPending = pendingEntries
+            .associateBy { it.first }
+            .values
+            .associate { (key, value, _) -> key to value }
+        if (latestPending.isNotEmpty()) {
+            writeToDeadLetter(latestPending)
         }
     }
 
@@ -381,15 +430,13 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
      * drain 대기 중 호출 스레드가 interrupt되면 interrupt 상태를 복원한 뒤 소유 리소스를 정리한다.
      */
     override fun close() {
-        // 1. 채널을 먼저 닫아 새 write 차단 (producer가 IllegalStateException을 던짐)
-        writeBehindChannel?.close()
-        // 2. writeBehindJob이 채널을 drain하고 자연스럽게 종료될 때까지 대기
-        //    취소 전에 join해야 남은 배치가 손실 없이 flush됨
         try {
-            writeBehindJob?.let { job ->
-                runBlocking(Dispatchers.IO) {
-                    withTimeout(config.writeBehindShutdownTimeout.toMillis()) {
-                        job.join()
+            runBlocking(Dispatchers.IO) {
+                try {
+                    awaitWriteBehindDrain("close()")
+                } finally {
+                    withContext(NonCancellable) {
+                        cancelAndPersistPendingWriteBehind()
                     }
                 }
             }
@@ -412,26 +459,15 @@ class LettuceSuspendedLoadedMap<K: Any, V: Any>(
      * context to avoid thread blocking while waiting for the write-behind job to drain.
      */
     suspend fun suspendClose() {
-        // 1. 채널을 먼저 닫아 새 write 차단
-        writeBehindChannel?.close()
-        // 2. write-behind job이 drain을 마칠 때까지 suspend로 대기.
-        //    호출자 취소는 전파하고, 내부 shutdown timeout만 graceful degradation으로 처리한다.
         try {
-            writeBehindJob?.let { job ->
-                val drained = withTimeoutOrNull(config.writeBehindShutdownTimeout.toMillis()) {
-                    job.join()
-                    true
-                } ?: false
-                if (!drained) {
-                    log.warn { "Write-behind job drain timed out during suspendClose()" }
-                }
-            }
+            awaitWriteBehindDrain("suspendClose()")
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             log.warn(e) { "Write-behind job drain failed during suspendClose()" }
         } finally {
             withContext(NonCancellable) {
+                cancelAndPersistPendingWriteBehind()
                 ownedJob.cancel()
                 if (lazyStrConnection.isInitialized()) lazyStrConnection.value.close()
                 connection.close()

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendedLoadedMapTest.kt
@@ -157,8 +157,9 @@ class LettuceSuspendedLoadedMapTest: AbstractLettuceTest() {
     @Test
     fun `suspendClose - caller cancellation is propagated before internal shutdown timeout`() = runSuspendIO {
         val writerStarted = CompletableDeferred<Unit>()
+        val prefix = "suspend-close-cancel:${randomName()}"
         val config = LettuceCacheConfig.WRITE_BEHIND.copy(
-            keyPrefix = "suspend-close-cancel:${randomName()}",
+            keyPrefix = prefix,
             writeBehindDelay = Duration.ofSeconds(5),
             writeBehindBatchSize = 1,
             writeBehindShutdownTimeout = Duration.ofSeconds(2),
@@ -190,6 +191,9 @@ class LettuceSuspendedLoadedMapTest: AbstractLettuceTest() {
         }
 
         elapsedMillis shouldBeLessThan config.writeBehindShutdownTimeout.toMillis()
+        client.connect(StringCodec.UTF8).use { connection ->
+            connection.sync().lrange("$prefix:dead-letter", 0L, -1L).contains("key1").shouldBeTrue()
+        }
     }
 
     @Test

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceWriteBehindRetryTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceWriteBehindRetryTest.kt
@@ -8,10 +8,16 @@ import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec
 import io.lettuce.core.codec.StringCodec
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.LinkedBlockingDeque
@@ -186,12 +192,158 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
                 )
             )
 
-            map.writeBehindChannel().tryReceive().getOrNull() shouldBeEqualTo
+            map.writeBehindRetryQueue().removeFirstOrNull() shouldBeEqualTo
                 Triple("fresh-key", "fresh-value", 1)
+            map.writeBehindRetryQueue().removeFirstOrNull().shouldBeNull()
             map.writeBehindChannel().tryReceive().getOrNull().shouldBeNull()
             client.connect(StringCodec.UTF8).use { connection ->
                 connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo listOf("retried-key")
             }
+        }
+    }
+
+    @Test
+    fun `suspend write-behind는 동일 키 최신 값의 retry count만 적용한다`() = runSuspendIO {
+        val prefix = "entry-retry-suspended-latest:${randomName()}"
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) = error("simulated write failure")
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val cancelledScope = CoroutineScope(SupervisorJob() + Dispatchers.IO).also { it.cancel() }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 2,
+        )
+
+        LettuceSuspendedLoadedMap(
+            client = client,
+            writer = writer,
+            config = config,
+            scope = cancelledScope,
+        ).use { map ->
+            map.flushBatch(
+                listOf(
+                    Triple("same-key", "old-value", 2),
+                    Triple("same-key", "latest-value", 0),
+                )
+            )
+
+            map.writeBehindRetryQueue().toList() shouldBeEqualTo
+                listOf(Triple("same-key", "latest-value", 1))
+            client.connect(StringCodec.UTF8).use { connection ->
+                connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo emptyList()
+            }
+            client.connect(LettuceBinaryCodec<String>(BinarySerializers.LZ4Fory)).use { connection ->
+                connection.sync().hget("$prefix:dead-letter:values", "same-key").shouldBeNull()
+            }
+        }
+    }
+
+    @Test
+    fun `suspend write-behind는 실패 중 도착한 최신 값을 재시도 뒤에 처리한다`() = runTest {
+        val writes = mutableListOf<Map<String, String>>()
+        val attempts = AtomicInteger()
+        lateinit var suspendedMap: LettuceSuspendedLoadedMap<String, String>
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) {
+                writes += map
+                if (attempts.getAndIncrement() == 0) {
+                    suspendedMap.writeBehindChannel()
+                        .trySend(Triple("same-key", "newest-value", 0))
+                        .isSuccess shouldBeEqualTo true
+                    error("simulated write failure")
+                }
+            }
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val consumerScope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = "suspended-latest-write-wins:${randomName()}",
+            writeBehindDelay = Duration.ofMillis(1),
+            writeBehindBatchSize = 2,
+        )
+
+        suspendedMap = LettuceSuspendedLoadedMap(
+            client = client,
+            writer = writer,
+            config = config,
+            scope = consumerScope,
+        )
+        try {
+            suspendedMap.writeBehindChannel()
+                .trySend(Triple("same-key", "latest-retried-value", 0))
+                .isSuccess shouldBeEqualTo true
+
+            runCurrent()
+            advanceUntilIdle()
+
+            writes shouldBeEqualTo listOf(
+                mapOf("same-key" to "latest-retried-value"),
+                mapOf("same-key" to "latest-retried-value"),
+                mapOf("same-key" to "newest-value"),
+            )
+        } finally {
+            suspendedMap.suspendClose()
+            consumerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `suspend write-behind는 retry 소진 뒤 도착한 최신 값을 처리한다`() = runSuspendIO {
+        val prefix = "suspended-exhausted-latest:${randomName()}"
+        val writes = mutableListOf<Map<String, String>>()
+        val latestWritten = CompletableDeferred<Unit>()
+        val attempts = AtomicInteger()
+        lateinit var suspendedMap: LettuceSuspendedLoadedMap<String, String>
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) {
+                writes += map
+                val attempt = attempts.incrementAndGet()
+                if (attempt == 1) {
+                    suspendedMap.writeBehindChannel()
+                        .trySend(Triple("same-key", "newest-value", 0))
+                        .isSuccess shouldBeEqualTo true
+                }
+                if (attempt <= 3) {
+                    error("simulated write failure")
+                }
+                latestWritten.complete(Unit)
+            }
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofMillis(1),
+            writeBehindBatchSize = 2,
+        )
+
+        suspendedMap = LettuceSuspendedLoadedMap(client = client, writer = writer, config = config)
+        try {
+            suspendedMap.writeBehindChannel().apply {
+                trySend(Triple("same-key", "old-value", 0)).isSuccess shouldBeEqualTo true
+                trySend(Triple("same-key", "latest-retried-value", 0)).isSuccess shouldBeEqualTo true
+            }
+
+            kotlinx.coroutines.withTimeout(5_000L) {
+                latestWritten.await()
+            }
+
+            writes shouldBeEqualTo listOf(
+                mapOf("same-key" to "latest-retried-value"),
+                mapOf("same-key" to "latest-retried-value"),
+                mapOf("same-key" to "latest-retried-value"),
+                mapOf("same-key" to "newest-value"),
+            )
+            client.connect(LettuceBinaryCodec<String>(BinarySerializers.LZ4Fory)).use { connection ->
+                connection.sync().hget("$prefix:dead-letter:values", "same-key") shouldBeEqualTo
+                    "latest-retried-value"
+            }
+        } finally {
+            suspendedMap.suspendClose()
         }
     }
 
@@ -233,7 +385,7 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
     }
 
     @Test
-    fun `suspend write-behind는 retry channel 포화 시 entry를 dead-letter에 보존한다`() = runSuspendIO {
+    fun `suspend write-behind는 channel 포화와 무관하게 accepted retry를 보존한다`() = runSuspendIO {
         val prefix = "entry-retry-suspended-full:${randomName()}"
         val writer = object: SuspendedMapWriter<String, String> {
             override suspend fun write(map: Map<String, String>) = error("simulated write failure")
@@ -254,19 +406,85 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
             config = config,
             scope = cancelledScope,
         ).use { map ->
-            map.writeBehindChannel().trySend(Triple("channel-blocker", "blocker-value", 0)).isSuccess shouldBeEqualTo true
+            map.writeBehindChannel()
+                .trySend(Triple("channel-blocker", "blocker-value", 0))
+                .isSuccess shouldBeEqualTo true
 
             map.flushBatch(listOf(Triple("failed-key", "failed-value", 0)))
 
             map.writeBehindChannel().tryReceive().getOrNull() shouldBeEqualTo
                 Triple("channel-blocker", "blocker-value", 0)
             map.writeBehindChannel().tryReceive().getOrNull().shouldBeNull()
+            map.writeBehindRetryQueue().toList() shouldBeEqualTo
+                listOf(Triple("failed-key", "failed-value", 1))
             client.connect(StringCodec.UTF8).use { connection ->
-                connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo listOf("failed-key")
+                connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo emptyList()
             }
             client.connect(LettuceBinaryCodec<String>(BinarySerializers.LZ4Fory)).use { connection ->
-                connection.sync().hget("$prefix:dead-letter:values", "failed-key") shouldBeEqualTo "failed-value"
+                connection.sync().hget("$prefix:dead-letter:values", "failed-key").shouldBeNull()
             }
+        }
+    }
+
+    @Test
+    fun `suspendClose timeout은 처리 중 entry와 channel 잔여분을 dead-letter에 보존한다`() = runSuspendIO {
+        val prefix = "suspend-close-recovery:${randomName()}"
+        val writerStarted = CompletableDeferred<Unit>()
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) {
+                writerStarted.complete(Unit)
+                delay(Duration.ofDays(1).toMillis())
+            }
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 1,
+            writeBehindShutdownTimeout = Duration.ofMillis(20),
+        )
+        val map = LettuceSuspendedLoadedMap(client = client, writer = writer, config = config)
+
+        map.set("in-flight", "first-value")
+        writerStarted.await()
+        map.set("queued", "second-value")
+        map.suspendClose()
+
+        client.connect(LettuceBinaryCodec<String>(BinarySerializers.LZ4Fory)).use { connection ->
+            connection.sync().hget("$prefix:dead-letter:values", "in-flight") shouldBeEqualTo "first-value"
+            connection.sync().hget("$prefix:dead-letter:values", "queued") shouldBeEqualTo "second-value"
+        }
+    }
+
+    @Test
+    fun `close timeout은 처리 중 entry와 channel 잔여분을 dead-letter에 보존한다`() = runSuspendIO {
+        val prefix = "blocking-close-recovery:${randomName()}"
+        val writerStarted = CompletableDeferred<Unit>()
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) {
+                writerStarted.complete(Unit)
+                delay(Duration.ofDays(1).toMillis())
+            }
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindDelay = Duration.ofDays(1),
+            writeBehindBatchSize = 1,
+            writeBehindShutdownTimeout = Duration.ofMillis(20),
+        )
+        val map = LettuceSuspendedLoadedMap(client = client, writer = writer, config = config)
+
+        map.set("in-flight", "first-value")
+        writerStarted.await()
+        map.set("queued", "second-value")
+        map.close()
+
+        client.connect(LettuceBinaryCodec<String>(BinarySerializers.LZ4Fory)).use { connection ->
+            connection.sync().hget("$prefix:dead-letter:values", "in-flight") shouldBeEqualTo "first-value"
+            connection.sync().hget("$prefix:dead-letter:values", "queued") shouldBeEqualTo "second-value"
         }
     }
 
@@ -287,6 +505,12 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
         javaClass.getDeclaredField("writeBehindChannel")
             .apply { isAccessible = true }
             .get(this) as Channel<Triple<String, String, Int>>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun LettuceSuspendedLoadedMap<String, String>.writeBehindRetryQueue():
+        ArrayDeque<Triple<String, String, Int>> = javaClass.getDeclaredField("writeBehindRetryQueue")
+            .apply { isAccessible = true }
+            .get(this) as ArrayDeque<Triple<String, String, Int>>
 
     private suspend fun LettuceSuspendedLoadedMap<String, String>.flushBatch(
         entries: List<Triple<String, String, Int>>,

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceWriteBehindRetryTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceWriteBehindRetryTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.redis.lettuce.map
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.io.serializer.BinarySerializers
@@ -7,6 +8,11 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec
 import io.lettuce.core.codec.StringCodec
+import io.lettuce.core.api.StatefulRedisConnection
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -14,14 +20,18 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.system.measureTimeMillis
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.jvm.isAccessible
@@ -320,14 +330,30 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
             writeBehindDelay = Duration.ofMillis(1),
             writeBehindBatchSize = 2,
         )
+        val executor = Executors.newSingleThreadExecutor()
+        val consumerDispatcher = executor.asCoroutineDispatcher()
+        val blockerStarted = CountDownLatch(1)
+        val releaseConsumer = CountDownLatch(1)
+        executor.submit {
+            blockerStarted.countDown()
+            releaseConsumer.await()
+        }
+        blockerStarted.await()
+        val consumerScope = CoroutineScope(SupervisorJob() + consumerDispatcher)
 
-        suspendedMap = LettuceSuspendedLoadedMap(client = client, writer = writer, config = config)
+        suspendedMap = LettuceSuspendedLoadedMap(
+            client = client,
+            writer = writer,
+            config = config,
+            scope = consumerScope,
+        )
         try {
             suspendedMap.writeBehindChannel().apply {
                 trySend(Triple("same-key", "old-value", 0)).isSuccess shouldBeEqualTo true
                 trySend(Triple("same-key", "latest-retried-value", 0)).isSuccess shouldBeEqualTo true
             }
 
+            releaseConsumer.countDown()
             kotlinx.coroutines.withTimeout(5_000L) {
                 latestWritten.await()
             }
@@ -343,7 +369,10 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
                     "latest-retried-value"
             }
         } finally {
+            releaseConsumer.countDown()
             suspendedMap.suspendClose()
+            consumerScope.cancel()
+            consumerDispatcher.close()
         }
     }
 
@@ -427,6 +456,118 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
     }
 
     @Test
+    fun `dead-letter HSET 실패 시 accepted entry를 retry queue에 보존한다`() = runSuspendIO {
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) = error("simulated write failure")
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val cancelledScope = CoroutineScope(SupervisorJob() + Dispatchers.IO).also { it.cancel() }
+        val map = LettuceSuspendedLoadedMap(
+            client = client,
+            writer = writer,
+            config = LettuceCacheConfig.WRITE_BEHIND,
+            scope = cancelledScope,
+        )
+        map.valueConnection().close()
+
+        map.flushBatch(listOf(Triple("failed-key", "failed-value", 2)))
+
+        map.writeBehindRetryQueue().toList() shouldBeEqualTo
+            listOf(Triple("failed-key", "failed-value", 2))
+    }
+
+    @Test
+    fun `dead-letter LPUSH 실패 시 accepted entry를 retry queue에 보존한다`() = runSuspendIO {
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) = error("simulated write failure")
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val cancelledScope = CoroutineScope(SupervisorJob() + Dispatchers.IO).also { it.cancel() }
+        val map = LettuceSuspendedLoadedMap(
+            client = client,
+            writer = writer,
+            config = LettuceCacheConfig.WRITE_BEHIND,
+            scope = cancelledScope,
+        )
+        map.stringConnection().close()
+
+        map.flushBatch(listOf(Triple("failed-key", "failed-value", 2)))
+
+        map.writeBehindRetryQueue().toList() shouldBeEqualTo
+            listOf(Triple("failed-key", "failed-value", 2))
+        map.valueConnection().close()
+    }
+
+    @Test
+    fun `close와 suspendClose 동시 호출은 하나의 shutdown 결과를 공유한다`() = runSuspendIO {
+        val prefix = "shared-shutdown:${randomName()}"
+        val cancelledScope = CoroutineScope(SupervisorJob() + Dispatchers.IO).also { it.cancel() }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = prefix,
+            writeBehindShutdownTimeout = Duration.ofSeconds(2),
+        )
+        val map = LettuceSuspendedLoadedMap<String, String>(
+            client = client,
+            config = config,
+            scope = cancelledScope,
+        )
+        map.writeBehindChannel()
+            .trySend(Triple("pending-key", "pending-value", 0))
+            .isSuccess shouldBeEqualTo true
+
+        val blockingClose = async(Dispatchers.IO) { map.close() }
+        val suspendingClose = async { map.suspendClose() }
+        blockingClose.await()
+        suspendingClose.await()
+
+        client.connect(StringCodec.UTF8).use { connection ->
+            connection.sync().lrange("$prefix:dead-letter", 0L, -1L) shouldBeEqualTo listOf("pending-key")
+        }
+    }
+
+    @Test
+    fun `non-cooperative writer에서도 shutdown timeout 상한을 지킨다`() = runSuspendIO {
+        val writerStarted = CompletableDeferred<Unit>()
+        val releaseWriter = CompletableDeferred<Unit>()
+        val writeCalls = AtomicInteger()
+        val writer = object: SuspendedMapWriter<String, String> {
+            override suspend fun write(map: Map<String, String>) {
+                writeCalls.incrementAndGet()
+                writerStarted.complete(Unit)
+                withContext(NonCancellable) {
+                    releaseWriter.await()
+                }
+            }
+
+            override suspend fun delete(keys: Collection<String>) = Unit
+        }
+        val config = LettuceCacheConfig.WRITE_BEHIND.copy(
+            keyPrefix = "bounded-shutdown:${randomName()}",
+            writeBehindShutdownTimeout = Duration.ofMillis(100),
+        )
+        val map = LettuceSuspendedLoadedMap(client = client, writer = writer, config = config)
+        map.set("in-flight", "value")
+        writerStarted.await()
+
+        val elapsedMillis = measureTimeMillis {
+            assertFailsWith<TimeoutCancellationException> {
+                map.suspendClose()
+            }
+        }
+
+        (elapsedMillis < 1_000L) shouldBeEqualTo true
+        assertFailsWith<TimeoutCancellationException> {
+            map.suspendClose()
+        }
+        writeCalls.get() shouldBeEqualTo 1
+        releaseWriter.complete(Unit)
+        map.suspendClose()
+        map.valueConnection().isOpen shouldBeEqualTo false
+    }
+
+    @Test
     fun `suspendClose timeout은 처리 중 entry와 channel 잔여분을 dead-letter에 보존한다`() = runSuspendIO {
         val prefix = "suspend-close-recovery:${randomName()}"
         val writerStarted = CompletableDeferred<Unit>()
@@ -442,7 +583,7 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
             keyPrefix = prefix,
             writeBehindDelay = Duration.ofDays(1),
             writeBehindBatchSize = 1,
-            writeBehindShutdownTimeout = Duration.ofMillis(20),
+            writeBehindShutdownTimeout = Duration.ofMillis(500),
         )
         val map = LettuceSuspendedLoadedMap(client = client, writer = writer, config = config)
 
@@ -473,7 +614,7 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
             keyPrefix = prefix,
             writeBehindDelay = Duration.ofDays(1),
             writeBehindBatchSize = 1,
-            writeBehindShutdownTimeout = Duration.ofMillis(20),
+            writeBehindShutdownTimeout = Duration.ofMillis(500),
         )
         val map = LettuceSuspendedLoadedMap(client = client, writer = writer, config = config)
 
@@ -518,5 +659,20 @@ internal class LettuceWriteBehindRetryTest: AbstractLettuceTest() {
         val method = this::class.declaredMemberFunctions.single { it.name == "flushBatch" }
         method.isAccessible = true
         method.callSuspend(this, entries)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun LettuceSuspendedLoadedMap<String, String>.valueConnection():
+        StatefulRedisConnection<String, String> = javaClass.getDeclaredField("connection")
+            .apply { isAccessible = true }
+            .get(this) as StatefulRedisConnection<String, String>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun LettuceSuspendedLoadedMap<String, String>.stringConnection():
+        StatefulRedisConnection<String, String> {
+        val connection = javaClass.getDeclaredField("lazyStrConnection")
+            .apply { isAccessible = true }
+            .get(this) as Lazy<StatefulRedisConnection<String, String>>
+        return connection.value
     }
 }


### PR DESCRIPTION
## 요약

- suspended write-behind 실패 batch를 신규 channel 항목보다 먼저 처리하는 consumer-owned retry queue를 추가합니다.
- batch와 dead-letter 경계에서 같은 key의 latest entry만 보존합니다.
- close·suspendClose·caller cancellation 시 retry/channel/in-flight 항목을 dead-letter 경로로 보존합니다.
- 모든 close caller는 하나의 shutdown attempt를 공유하고, caller timeout 뒤에도 독립 cleanup이 끝까지 진행됩니다.

## 검증

- `bluetape4k-lettuce`: 936 tests, failures/errors/skipped 0
- Detekt, JAR, POM 생성 통과
- retry 순서·소진·channel 포화·dead-letter 실패, close/suspendClose concurrency, non-cooperative writer timeout·후속 cleanup 회귀 테스트
- 독립 security/performance/API 리뷰 및 `git diff --check` 통과

Closes #1664

## DoD Status

- [x] retry 우선순위와 latest-write-wins 구현
- [x] capacity·retry exhaustion·dead-letter·종료 회귀 테스트
- [x] shared shutdown gate와 timeout 이후 cleanup 계약 검증
- [x] 전체 Lettuce 모듈 및 정적/publication 검증
- [x] exact-head GitHub Actions 확인 (`55769068`, 성공 12 / 건너뜀 12)
