### PR TITLE
경계 동시성 계약을 실패 경로까지 보존한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,39 @@
   제거하거나 `3.2.0`으로 정렬해야 한다
   ([#1640](https://github.com/bluetape4k/bluetape4k-projects/issues/1640)).
 
+### 버그 수정
+
+- `ConcurrentReducer`가 active promise의 caller cancellation을 source stage로
+  전달한다. source가 원본 취소를 지원하면 active slot을 즉시 회수하고, 취소를
+  지원하지 않으면 실제 terminal 상태까지 permit을 유지해 동시성 한도를 보존한다
+  ([#1684](https://github.com/bluetape4k/bluetape4k-projects/issues/1684)).
+- `Int.quarterPeriod()`와 `Long.quarterPeriod()`가 분기를 월로 환산한 결과의
+  `Int` 범위를 정확히 검사한다. 큰 양수·음수 입력이 반대 부호의 `Period`로
+  조용히 바뀌지 않는다
+  ([#1685](https://github.com/bluetape4k/bluetape4k-projects/issues/1685)).
+- `TenantConnectionPoolRegistry.closeSuspending()`이 caller cancellation을 주 예외로
+  유지하면서 pool cleanup 실패를 suppressed chain에 보존한다
+  ([#1686](https://github.com/bluetape4k/bluetape4k-projects/issues/1686)).
+- `LettuceMap`의 모든 command dispatch와 lock-owned transaction을 connection 단위로
+  직렬화해 같은 connection의 일반 sync/async 명령과 `WATCH/MULTI/EXEC`가 섞이면서
+  command output이 어긋나는 경합을 제거했다
+  ([#1687](https://github.com/bluetape4k/bluetape4k-projects/issues/1687)).
+
+### 마이그레이션
+
+- `ConcurrentReducer.add()`가 반환한 promise를 취소하면 해당 호출이 반환한 source
+  `CompletionStage.toCompletableFuture()`에 취소를 요청한다. 원본 stage가 bridge의
+  취소를 전파하지 않으면 source terminal 전까지 active permit이 유지된다. 여러 호출이
+  하나의 cancellable stage를 공유하는 사용자는 lifecycle을 분리해야 한다.
+- `quarterPeriod()`의 월 환산 결과가 `Int` 범위를 벗어나면 이제 잘못된 `Period` 대신
+  `IllegalArgumentException`을 던진다. wrap-around 결과에 의존한 코드는 입력 범위를
+  검증해야 한다.
+- `LettuceMap`의 lock-owned transaction과 같은 connection을 공유할 때는
+  `LettuceMap`/`LettuceSuspendMap`을 통해 명령을 보내야 한다. raw connection 명령이나
+  다른 wrapper의 동시 명령은 공용 gate를 우회하므로 지원하지 않는다. 사용자 정의 하위
+  클래스는 sync dispatch에 `withConnectionLock`, async dispatch에 `dispatchAsync`를 사용해야
+  한다. sync API는 Netty event-loop에서 호출하지 않아야 한다.
+
 ### 제거
 
 - `2.1.0` 개발선부터 Apache Ignite 2 runtime 의존성, 전용 Testcontainers image

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/ConcurrentReducer.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/concurrent/ConcurrentReducer.kt
@@ -70,6 +70,8 @@ class ConcurrentReducer<T> internal constructor(
      * 비동기 작업을 추가합니다.
      * 큐가 꽉 찬 경우에는 [CapacityReachedException]이 발생합니다.
      * task invocation과 queue polling은 전용 executor에서 수행하므로 이 함수는 enqueue 후 즉시 반환합니다.
+     * 반환 promise가 취소되면 source의 [CompletionStage.toCompletableFuture]에 취소를 요청합니다.
+     * source가 원본 취소를 지원하지 않으면 실제 terminal 상태까지 active permit을 유지합니다.
      *
      * @param task 작업을 수행할 람다
      * @return 작업 결과를 받아볼 [CompletableFuture] 인스턴스
@@ -88,6 +90,11 @@ class ConcurrentReducer<T> internal constructor(
                 )
 
                 else -> {
+                    promise.whenComplete { _, _ ->
+                        if (promise.isCancelled && cancelJob(job, requirePromiseCancellation = true) && !closed.value) {
+                            schedulePump()
+                        }
+                    }
                     schedulePump()
                     promise
                 }
@@ -173,15 +180,14 @@ class ConcurrentReducer<T> internal constructor(
                 complete(job, error = NullPointerException("task result is null."))
             } else {
                 job.stage = future
+                future.whenComplete { result, error ->
+                    complete(job, result, error)
+
+                    // whenComplete()는 현재 스레드에서 실행될 수 있으므로 coalesced pump를 executor에 위임한다.
+                    if (!closed.value) schedulePump()
+                }
                 if (job.isCancellationRequested) {
                     cancelStage(job)
-                } else {
-                    future.whenComplete { result, error ->
-                        complete(job, result, error)
-
-                        // whenComplete()는 현재 스레드에서 실행될 수 있으므로 coalesced pump를 executor에 위임한다.
-                        if (!closed.value) schedulePump()
-                    }
                 }
             }
         }
@@ -189,13 +195,11 @@ class ConcurrentReducer<T> internal constructor(
 
     private fun complete(job: Job<T>, result: T? = null, error: Throwable? = null) {
         val completed = synchronized(admissionLock) {
-            if (!job.tryComplete()) {
-                false
-            } else {
-                activeJobs.remove(job)
+            val completesPromise = job.tryComplete()
+            if (activeJobs.remove(job)) {
                 limit.release()
-                true
             }
+            completesPromise
         }
         if (!completed) return
 
@@ -217,15 +221,19 @@ class ConcurrentReducer<T> internal constructor(
         return cancelled
     }
 
-    private fun cancelJobLocked(job: Job<T>, requirePromiseCancellation: Boolean): Boolean {
+    private fun cancelJobLocked(
+        job: Job<T>,
+        requirePromiseCancellation: Boolean,
+        releaseRunningJob: Boolean = false,
+    ): Boolean {
         val canCancel = !requirePromiseCancellation || job.promise.isCancelled
-        val cancelled = canCancel && job.tryCancel()
-        if (cancelled) {
-            if (activeJobs.remove(job)) {
-                limit.release()
-            }
+        val cancelledFrom = if (canCancel) job.tryCancel() else null
+        val canRelease = cancelledFrom == CancellationPhase.BEFORE_START || releaseRunningJob
+        val released = canRelease && activeJobs.remove(job)
+        if (released) {
+            limit.release()
         }
-        return cancelled
+        return cancelledFrom != null || released
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -255,7 +263,9 @@ class ConcurrentReducer<T> internal constructor(
 
             val activeJobs = activeJobs.toList()
             val jobs = queuedJobs + activeJobs
-            val cancelledJobs = jobs.filter { cancelJobLocked(it, requirePromiseCancellation = false) }
+            val cancelledJobs = jobs.filter {
+                cancelJobLocked(it, requirePromiseCancellation = false, releaseRunningJob = true)
+            }
             pumpExecutor.shutdown()
             cancelledJobs
         }
@@ -293,15 +303,25 @@ class ConcurrentReducer<T> internal constructor(
 
         fun tryCancelStage(): Boolean = stageCancellationRequested.compareAndSet(false, true)
 
-        fun tryCancel(): Boolean {
+        fun tryCancel(): CancellationPhase? {
             while (true) {
-                when (val current = state.value) {
-                    NEW, RUNNING -> if (state.compareAndSet(current, CANCELLED)) return true
-                    else -> return false
+                val current = state.value
+                val phase = when (current) {
+                    NEW -> CancellationPhase.BEFORE_START
+                    RUNNING -> CancellationPhase.RUNNING
+                    else -> return null
+                }
+                if (state.compareAndSet(current, CANCELLED)) {
+                    return phase
                 }
             }
         }
 
+    }
+
+    private enum class CancellationPhase {
+        BEFORE_START,
+        RUNNING,
     }
 
     class CapacityReachedException: BluetapeException {

--- a/bluetape4k/core/src/main/kotlin/io/bluetape4k/javatimes/NumberExtensions.kt
+++ b/bluetape4k/core/src/main/kotlin/io/bluetape4k/javatimes/NumberExtensions.kt
@@ -323,8 +323,10 @@ fun Int.monthPeriod(): Period = Period.ofMonths(this)
  * ```kotlin
  * val p = 2.quarterPeriod()  // Period.ofMonths(6)
  * ```
+ *
+ * @throws IllegalArgumentException 월 환산 결과가 [Int] 범위를 벗어나는 경우
  */
-fun Int.quarterPeriod(): Period = Period.ofMonths(this * MonthsPerQuarter)
+fun Int.quarterPeriod(): Period = Period.ofMonths(toLong().toQuarterMonths())
 
 /**
  * [Int] 값을 년 단위의 [Period]로 변환합니다.
@@ -526,13 +528,21 @@ fun Long.monthPeriod(): Period = Period.ofMonths(toIntExact())
 /**
  * [Long] 값을 분기 단위의 [Period]로 변환합니다.
  *
- * `java.time.Period`가 [Int] 구성 요소를 사용하므로 [Long] 값은 [Int] 범위 안에서만 변환됩니다.
+ * `java.time.Period`가 [Int] 구성 요소를 사용하므로 월로 환산한 결과가 [Int] 범위 안일 때만 변환됩니다.
  *
  * ```kotlin
  * val p = 2L.quarterPeriod()  // Period.ofMonths(6)
  * ```
+ *
+ * @throws IllegalArgumentException 월 환산 결과가 [Int] 범위를 벗어나는 경우
  */
-fun Long.quarterPeriod(): Period = Period.ofMonths(toIntExact() * MonthsPerQuarter)
+fun Long.quarterPeriod(): Period = Period.ofMonths(toQuarterMonths())
+
+private fun Long.toQuarterMonths(): Int = try {
+    Math.multiplyExact(this, MonthsPerQuarter.toLong()).toIntExact()
+} catch (e: ArithmeticException) {
+    throw IllegalArgumentException("Quarter value is out of Period month range. value=$this", e)
+}
 
 /**
  * [Long] 값을 년 단위의 [Period]로 변환합니다.

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ConcurrentReducerTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/concurrent/ConcurrentReducerTest.kt
@@ -152,6 +152,70 @@ class ConcurrentReducerTest {
     }
 
     @Test
+    fun `active promise 취소는 source stage를 취소하고 다음 작업을 실행한다`() {
+        val reducer = concurrentReducerOf<String>(1, 1)
+        val source = CompletableFuture<String>()
+        try {
+            val promise = reducer.add { source }
+
+            await until { reducer.activeCount == 1 }
+            promise.cancel(false).shouldBeTrue()
+
+            await until { source.isCancelled && reducer.activeCount == 0 }
+            val next = reducer.add { completableFutureOf("next") }
+            await until { next.isDone }
+
+            next.get() shouldBeEqualTo "next"
+            reducer.remainingActiveCapacity shouldBeEqualTo 1
+        } finally {
+            reducer.close()
+        }
+    }
+
+    @Test
+    fun `취소 전파를 보장하지 않는 stage는 terminal 전까지 active slot을 유지한다`() {
+        val reducer = concurrentReducerOf<String>(1, 1)
+        val source = CompletableFuture<String>()
+        try {
+            val promise = reducer.add { source.minimalCompletionStage() }
+
+            await until { reducer.activeCount == 1 }
+            promise.cancel(false).shouldBeTrue()
+            val next = reducer.add { completableFutureOf("next") }
+
+            source.isCancelled.shouldBeFalse()
+            reducer.activeCount shouldBeEqualTo 1
+            next.isDone.shouldBeFalse()
+
+            source.complete("ignored")
+            await until { next.isDone }
+            next.get() shouldBeEqualTo "next"
+            reducer.remainingActiveCapacity shouldBeEqualTo 1
+        } finally {
+            reducer.close()
+        }
+    }
+
+    @Test
+    fun `취소 전파를 보장하지 않는 active stage도 close에서 permit을 정리한다`() {
+        val reducer = concurrentReducerOf<String>(1, 1)
+        val source = CompletableFuture<String>()
+        try {
+            val promise = reducer.add { source.minimalCompletionStage() }
+
+            await until { reducer.activeCount == 1 }
+            promise.cancel(false).shouldBeTrue()
+            reducer.close()
+
+            reducer.activeCount shouldBeEqualTo 0
+            reducer.remainingActiveCapacity shouldBeEqualTo 1
+            source.isCancelled.shouldBeFalse()
+        } finally {
+            reducer.close()
+        }
+    }
+
+    @Test
     fun `grab 직후 caller 취소 경합에서도 active job과 permit이 누수되지 않는다`() {
         repeat(64) {
             val reducer = concurrentReducerOf<String>(1, 1)

--- a/bluetape4k/core/src/test/kotlin/io/bluetape4k/javatimes/NumberExtensionsTest.kt
+++ b/bluetape4k/core/src/test/kotlin/io/bluetape4k/javatimes/NumberExtensionsTest.kt
@@ -91,6 +91,22 @@ class NumberExtensionsTest {
     }
 
     @Test
+    fun `quarterPeriod는 월 환산 결과가 Int 범위를 넘으면 거부한다`() {
+        val maxQuarter = Int.MAX_VALUE / 3
+        val minQuarter = Int.MIN_VALUE / 3
+
+        maxQuarter.quarterPeriod() shouldBeEqualTo Period.ofMonths(maxQuarter * 3)
+        minQuarter.quarterPeriod() shouldBeEqualTo Period.ofMonths(minQuarter * 3)
+        maxQuarter.toLong().quarterPeriod() shouldBeEqualTo Period.ofMonths(maxQuarter * 3)
+        minQuarter.toLong().quarterPeriod() shouldBeEqualTo Period.ofMonths(minQuarter * 3)
+
+        assertFailsWith<IllegalArgumentException> { (maxQuarter + 1).quarterPeriod() }
+        assertFailsWith<IllegalArgumentException> { (minQuarter - 1).quarterPeriod() }
+        assertFailsWith<IllegalArgumentException> { (maxQuarter.toLong() + 1).quarterPeriod() }
+        assertFailsWith<IllegalArgumentException> { (minQuarter.toLong() - 1).quarterPeriod() }
+    }
+
+    @Test
     fun `millisToNanos 변환`() {
         1.millisToNanos() shouldBeEqualTo 1_000_000
         10.millisToNanos() shouldBeEqualTo 10_000_000

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
@@ -337,6 +337,37 @@ class LettuceJCacheTest {
     }
 
     @Test
+    fun `invoke serializes repeated read modify write on one cache instance`() {
+        val mapName = "invoke-shared-connection-" + UUID.randomUUID().toString().take(8)
+        val target = standaloneCache(mapName)
+        val totalInvocations = 12 * 20
+
+        try {
+            target.put("counter", 0)
+
+            MultithreadingTester()
+                .workers(12)
+                .rounds(20)
+                .add {
+                    target.invoke(
+                        "counter",
+                        EntryProcessor<String, Int, Int> { entry: MutableEntry<String, Int>, _: Array<out Any?> ->
+                            val updated = (entry.value ?: 0) + 1
+                            entry.setValue(updated)
+                            updated
+                        },
+                    )
+                }
+                .run()
+
+            target.get("counter") shouldBeEqualTo totalInvocations
+        } finally {
+            runCatching { target.clear() }
+            runCatching { target.close() }
+        }
+    }
+
+    @Test
     fun `invoke rejects stale commit after lease expiry and lock handoff`() {
         val mapName = "invoke-lease-expiry-" + UUID.randomUUID().toString().take(8)
         val first = standaloneCache(mapName, lockLeaseSeconds = 1)

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistry.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistry.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.r2dbc.pool
 
 import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.spi.ConnectionFactory
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -175,12 +176,31 @@ class TenantConnectionPoolRegistry<K: Any>(
      * 이미 취소된 caller에서도 [NonCancellable] 경계에서 cleanup을 완료한 뒤 caller cancellation을
      * 다시 전파합니다. concurrent 종료, idempotency와 실패 전파 계약은 [close]와 같습니다.
      */
+    @Suppress("TooGenericExceptionCaught")
     suspend fun closeSuspending() {
         val callerContext = currentCoroutineContext()
-        withContext(NonCancellable + closeDispatcher) {
-            close()
+        val closeFailure: Exception? = withContext(NonCancellable + closeDispatcher) {
+            try {
+                close()
+                null
+            } catch (failure: Error) {
+                throw failure
+            } catch (failure: Exception) {
+                failure
+            }
         }
-        callerContext.ensureActive()
+        try {
+            callerContext.ensureActive()
+        } catch (cancellation: CancellationException) {
+            if (closeFailure != null &&
+                closeFailure !== cancellation &&
+                cancellation.suppressed.none { it === closeFailure }
+            ) {
+                cancellation.addSuppressed(closeFailure)
+            }
+            throw cancellation
+        }
+        throwFailure(closeFailure)
     }
 
     private fun ensureOpen() {

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistryTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/pool/TenantConnectionRegistryTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.r2dbc.pool
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -11,6 +12,7 @@ import io.mockk.verify
 import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.spi.ConnectionFactory
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.launch
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 class TenantConnectionRegistryTest {
 
@@ -182,6 +185,71 @@ class TenantConnectionRegistryTest {
 
         caller.isCancelled shouldBeEqualTo true
         verify(exactly = 1) { pool.dispose() }
+    }
+
+    @Test
+    fun `closeSuspending은 취소를 primary로 유지하고 cleanup 실패를 보존한다`() = runSuspendIO {
+        val tenantA = mockk<ConnectionPool>(relaxed = true)
+        val tenantB = mockk<ConnectionPool>(relaxed = true)
+        val firstFailure = IllegalStateException("tenant-a close failed")
+        val secondFailure = IllegalArgumentException("tenant-b close failed")
+        every { tenantA.dispose() } throws firstFailure
+        every { tenantB.dispose() } throws secondFailure
+        val registry = TenantConnectionPoolRegistry(
+            mapOf(
+                TenantKey("tenant-a") to tenantA,
+                TenantKey("tenant-b") to tenantB,
+            ),
+        )
+        val observed = AtomicReference<Throwable>()
+        val expectedCancellation = CancellationException("caller cancelled")
+
+        val caller = launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                currentCoroutineContext().cancel(expectedCancellation)
+                registry.closeSuspending()
+            } catch (failure: Throwable) {
+                observed.set(failure)
+            }
+        }
+        caller.join()
+
+        val cancellation = observed.get()
+        cancellation shouldBeInstanceOf CancellationException::class
+        cancellation shouldBeSameInstanceAs expectedCancellation
+        val cleanupFailure = cancellation.suppressed.single()
+        cleanupFailure shouldBeSameInstanceAs firstFailure
+        cleanupFailure.suppressed.single() shouldBeSameInstanceAs secondFailure
+        verify(exactly = 1) { tenantA.dispose() }
+        verify(exactly = 1) { tenantB.dispose() }
+    }
+
+    @Test
+    fun `closeSuspending은 정상 caller에서 cleanup 실패 identity와 집계를 유지한다`() = runSuspendIO {
+        val tenantA = mockk<ConnectionPool>(relaxed = true)
+        val tenantB = mockk<ConnectionPool>(relaxed = true)
+        val firstFailure = IllegalStateException("tenant-a close failed")
+        val secondFailure = IllegalArgumentException("tenant-b close failed")
+        every { tenantA.dispose() } throws firstFailure
+        every { tenantB.dispose() } throws secondFailure
+        val registry = TenantConnectionPoolRegistry(
+            mapOf(
+                TenantKey("tenant-a") to tenantA,
+                TenantKey("tenant-b") to tenantB,
+            ),
+        )
+
+        val failure = try {
+            registry.closeSuspending()
+            null
+        } catch (expected: Exception) {
+            expected
+        }
+
+        failure shouldBeSameInstanceAs firstFailure
+        failure?.suppressed?.single() shouldBeSameInstanceAs secondFailure
+        verify(exactly = 1) { tenantA.dispose() }
+        verify(exactly = 1) { tenantB.dispose() }
     }
 
     @Test

--- a/docs/lessons/2026-09-07-issues-1684-1687-boundary-concurrency-contracts.md
+++ b/docs/lessons/2026-09-07-issues-1684-1687-boundary-concurrency-contracts.md
@@ -1,0 +1,65 @@
+# Issues #1684–#1687: 경계 상태는 최종 효과까지 검증한다
+
+## 맥락
+
+2.1.0 개발선의 7-Tier 리뷰에서 기존 테스트가 모두 통과했지만 네 가지 경계 결함이
+남아 있었다. caller가 취소한 promise와 내부 stage의 lifecycle, 단위 환산 뒤의 숫자
+범위, coroutine cleanup 실패와 cancellation의 우선순위, Redis transaction과 공유
+connection의 command stream이 각각 분리돼 검증되고 있었다.
+
+## 결정
+
+- `ConcurrentReducer`는 수락한 promise의 cancellation을 내부 job 상태 전이와 source
+  stage 취소 요청에 연결한다. 원본 취소가 보장되지 않는 `CompletionStage`는 terminal
+  상태까지 active permit을 유지하고, 기존 CAS와 admission lock으로 registry와 permit을
+  exactly-once 정리한다.
+- `quarterPeriod()`는 입력 타입의 범위가 아니라 월 환산 결과의 범위를 검사한다.
+  `Int`와 `Long` overload는 같은 exact arithmetic 계약을 사용한다.
+- `closeSuspending()`은 `NonCancellable` cleanup의 일반 예외를 값으로 회수한 뒤 caller
+  cancellation을 먼저 확인한다. cancellation은 primary, cleanup 실패는 suppressed로
+  남기며 `Error`는 즉시 전파한다.
+- Redis transaction 상태는 connection 전체에 적용되므로 `LettuceMap`의 모든 sync/async
+  command dispatch, `LettuceSuspendMap`의 coroutine dispatch, lock-owned transaction을
+  같은 connection gate로 조정한다. sync 호출은 caller thread에서 gate를 기다리지만,
+  async/suspend 호출은 경합 시 virtual thread에서 대기해 Netty event-loop를 막지 않는다.
+  distributed-lock 대기와 사용자 callback은 gate 밖에서 실행한다. raw connection과 다른
+  wrapper는 gate를 우회하므로 transaction과의 동시 사용을 지원하지 않는다.
+
+## 결과
+
+active cancellation 뒤 cancellable source는 취소되고 다음 reducer 작업이 실행된다. 취소를
+전파하지 않는 source는 실제 terminal 전까지 permit을 유지해 동시성 상한을 넘지 않는다.
+분기 환산은 양수·음수 양쪽 경계 밖을 명시적으로 거부한다. 취소된 coroutine의 pool
+cleanup이 실패해도 cancellation 의미와 cleanup 진단 정보가 함께 보존된다. 같은 Lettuce
+connection을 여러 thread가 사용하는 반복 `EntryProcessor` 호출은 transaction response와
+lock command response를 서로 다른 output decoder로 읽지 않는다.
+
+## 검증
+
+- #1684: 수정 전 source 미취소와 active slot 점유로 10초 timeout, 수정 후 회귀 테스트 통과.
+  취소 전파를 보장하지 않는 stage는 terminal까지 permit을 유지하고 close에서 정리됨을 함께 검증.
+- #1685: 수정 전 월 환산 overflow 입력이 예외 없이 wrap-around, 수정 후 양수·음수 경계 통과.
+- #1686: 수정 전 cleanup 예외가 cancellation을 대체, 수정 후 cancellation identity와
+  두 cleanup 실패의 suppressed chain 검증 통과.
+- #1687: 같은 cache instance에서 12 workers × 20 rounds를 실행하면 수정 전
+  `StatusOutput does not support set(long)` 재현, connection 직렬화 후 같은 stress와
+  두 cache instance 회귀 테스트 통과. 동일 connection의 일반 sync/async command 및
+  `LettuceSuspendMap` command와 transaction을 섞은 회귀 테스트도 통과. sync 응답 대기 중
+  event-loop 역할 callback의 async 호출이 500ms 안에 pending future를 반환하는 liveness
+  테스트는 수정 전 실패하고 비차단 gate 적용 후 통과. gate 대기 중 취소된 async 요청이
+  lock 해제 뒤 뒤늦게 dispatch되는 회귀도 수정 전 재현하고 취소 전파 후 통과.
+- 전체 모듈 재실행: core 1,683건, R2DBC 220건, Lettuce 940건, cache-lettuce 462건,
+  합계 3,305건 통과. Lettuce 첫 전체 실행의 기존 write-behind 500ms timeout 1건은
+  단독 재실행과 두 번째 전체 실행에서 통과했다.
+- 네 모듈 Detekt task는 exit 0으로 완료됐다. 기존 대형 파일·magic number baseline
+  진단은 남아 있으며 exact-head CI와 Full Nightly는 push 전이므로 아직 검증하지 않았다.
+
+## 향후 지침
+
+비동기 API는 반환 객체의 terminal 상태뿐 아니라 upstream 작업, permit, registry까지
+최종 효과가 수렴하는지 확인한다. 숫자 변환은 입력 검증 뒤의 산술도 exact해야 한다.
+취소 불가능한 cleanup은 실패를 버리지 않되 원래 cancellation을 교체하지 않는다.
+Redis의 `WATCH/MULTI/EXEC`처럼 connection-scoped 상태를 사용하는 기능은 logical lock만
+검증하지 말고 같은 connection의 일반 sync/async command를 포함한 dispatch 교차 가능성을
+stress 테스트로 고정한다. sync transaction을 직렬화하더라도 event-loop callback은 lock을
+기다리지 않고 pending future를 반환해야 하며, sync API 자체는 event-loop에서 호출하지 않는다.

--- a/infra/lettuce/README.ko.md
+++ b/infra/lettuce/README.ko.md
@@ -438,6 +438,19 @@ val p = suspendMap.get("p1")                       // suspend fun
 suspendMap.put("p2", Product(2L, "Gadget"))
 ```
 
+`LettuceMap`과 `LettuceSuspendMap`은 같은 connection을 공유할 때 command dispatch를
+공용 gate로 직렬화합니다. transaction이 진행 중일 때 async/suspend 호출은 Netty
+event-loop를 막지 않고 pending future로 대기합니다. sync API는 Redis 응답을 기다리므로
+Netty event-loop에서 호출하지 말고 async/suspend API를 사용해야 합니다.
+`putTtlIfLockOwned` 또는 `removeIfLockOwned`를 사용한다면 raw
+`connection.sync()`/`connection.async()`나 다른 wrapper의 명령을 동시에 보내지 않아야
+합니다. 사용자 정의 `LettuceMap` 하위 클래스는 sync dispatch에 `withConnectionLock`, async
+dispatch에 `dispatchAsync`를 사용하고, `LettuceSuspendMap` 하위 클래스도 protected
+`dispatchAsync`를 사용해야 합니다. `WATCH/MULTI/EXEC` 중 이 gate를 우회하는 사용법은
+지원하지 않습니다. `withDistributedLock` callback에서 시작한 async 작업은 callback이 반환되기
+전에 terminal 상태가 될 때까지 기다린 경우에만 임계 구간에 포함됩니다. callback에서 완료되지
+않은 async 작업을 남기는 fire-and-forget 사용은 지원하지 않습니다.
+
 > **String 기본값 이유**: Lettuce 기본 코덱은 `StringCodec.UTF8`입니다.
 > `LettuceMap<V>`처럼 단순 저장/조회(HGET/HSET)는 바이너리 코덱 사용이 가능하지만,
 > `LettuceAtomicLong`/`LettuceSemaphore`는 Redis의 `INCR`/`DECR` 명령이 10진수 문자열을 요구하므로

--- a/infra/lettuce/README.md
+++ b/infra/lettuce/README.md
@@ -440,6 +440,21 @@ val p = suspendMap.get("p1")                       // suspend fun
 suspendMap.put("p2", Product(2L, "Gadget"))
 ```
 
+`LettuceMap` and `LettuceSuspendMap` coordinate command dispatch when they share
+the same connection through a shared gate. While a transaction is active,
+async/suspend calls wait as pending futures without blocking the Netty event
+loop. Sync APIs wait for Redis responses and must not be invoked from the Netty
+event loop; use the async or suspend APIs there. If `putTtlIfLockOwned` or
+`removeIfLockOwned` is used, do not concurrently dispatch commands through the
+raw `connection.sync()`/`connection.async()` facade or another wrapper. Custom
+`LettuceMap` subclasses must use `withConnectionLock` for sync dispatch and
+`dispatchAsync` for async dispatch; `LettuceSuspendMap` subclasses must also use
+their protected `dispatchAsync` helper. Bypassing this gate while
+`WATCH/MULTI/EXEC` is active is unsupported. Async work started inside a
+`withDistributedLock` callback belongs to the critical section only when the
+callback waits for it to reach a terminal state before returning; fire-and-forget
+async work from that callback is unsupported.
+
 > **Why String is the default**: Lettuce's default codec is `StringCodec.UTF8`.
 > While `LettuceMap<V>` supports binary codecs for simple HGET/HSET operations,
 > `LettuceAtomicLong` and `LettuceSemaphore` rely on Redis's `INCR`/

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMap.kt
@@ -1,17 +1,22 @@
 package io.bluetape4k.redis.lettuce.map
 
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.HSetExArgs
+import io.lettuce.core.RedisFuture
 import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
 import java.time.Duration
+import java.util.WeakHashMap
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.locks.LockSupport
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * Lettuce Redis 클라이언트를 이용한 분산 Map(Distributed Map) 구현체입니다.
@@ -35,7 +40,9 @@ import java.util.concurrent.locks.LockSupport
  * ```
  *
  * @param V 값 타입
- * @param connection Lettuce StatefulRedisConnection (LettuceBinaryCodec<V> 기반)
+ * @param connection Lettuce StatefulRedisConnection (LettuceBinaryCodec<V> 기반). lock-owned transaction을
+ * 사용할 때 같은 connection의 명령은 이 클래스 또는 [LettuceSuspendMap]을 통해 dispatch해야 합니다.
+ * raw connection이나 다른 wrapper의 동시 명령은 공용 gate를 우회하므로 지원하지 않습니다.
  * @param mapKey Redis에 저장될 Hash 키
  */
 open class LettuceMap<V: Any>(
@@ -55,8 +62,18 @@ open class LettuceMap<V: Any>(
         mapKey.requireNotBlank("mapKey")
     }
 
+    private val connectionGate = LettuceConnectionGate.of(connection)
+
+    /** 하위 클래스는 sync command dispatch를 [withConnectionLock] 안에서 수행해야 합니다. */
     protected val syncCommands: RedisCommands<String, V> get() = connection.sync()
     private val asyncCommands: RedisAsyncCommands<String, V> get() = connection.async()
+
+    /** 같은 connection의 transaction-aware sync command와 직렬화합니다. */
+    protected fun <R> withConnectionLock(block: () -> R): R = connectionGate.call(block)
+
+    /** lock 경합 시 caller를 막지 않고 같은 connection의 async command를 직렬화합니다. */
+    protected fun <R> dispatchAsync(block: () -> RedisFuture<R>): CompletableFuture<R> =
+        connectionGate.dispatch(block)
 
     // =========================================================================
     // 동기 API
@@ -78,7 +95,7 @@ open class LettuceMap<V: Any>(
      * @return 필드 값 (존재하지 않으면 null)
      */
     fun get(field: String): V? =
-        syncCommands.hget(mapKey, field)
+        withConnectionLock { syncCommands.hget(mapKey, field) }
 
     /**
      * 필드에 값을 설정합니다.
@@ -96,7 +113,7 @@ open class LettuceMap<V: Any>(
      * @return 새 필드가 추가됐으면 true, 기존 필드가 업데이트됐으면 false
      */
     fun put(field: String, value: V): Boolean {
-        val result = syncCommands.hset(mapKey, field, value)
+        val result = withConnectionLock { syncCommands.hset(mapKey, field, value) }
         log.debug { "LettuceMap put: mapKey=$mapKey, field=$field, isNew=$result" }
         return result
     }
@@ -109,7 +126,7 @@ open class LettuceMap<V: Any>(
      * @return 설정 성공 여부 (이미 존재하면 false)
      */
     fun putIfAbsent(field: String, value: V): Boolean {
-        val result = syncCommands.hsetnx(mapKey, field, value)
+        val result = withConnectionLock { syncCommands.hsetnx(mapKey, field, value) }
         log.debug { "LettuceMap putIfAbsent: mapKey=$mapKey, field=$field, result=$result" }
         return result
     }
@@ -128,7 +145,7 @@ open class LettuceMap<V: Any>(
     fun putIfAbsentTtl(field: String, value: V, ttl: Duration?): Boolean {
         val added = putIfAbsent(field, value)
         if (added && ttl != null) {
-            syncCommands.expire(mapKey, ttl)
+            withConnectionLock { syncCommands.expire(mapKey, ttl) }
         }
         return added
     }
@@ -149,7 +166,7 @@ open class LettuceMap<V: Any>(
      * @return 삭제된 필드 수
      */
     fun remove(field: String): Long {
-        val count = syncCommands.hdel(mapKey, field)
+        val count = withConnectionLock { syncCommands.hdel(mapKey, field) }
         log.debug { "LettuceMap remove: mapKey=$mapKey, field=$field, count=$count" }
         return count
     }
@@ -161,7 +178,7 @@ open class LettuceMap<V: Any>(
      * @return 존재하면 true
      */
     fun containsKey(field: String): Boolean =
-        syncCommands.hexists(mapKey, field)
+        withConnectionLock { syncCommands.hexists(mapKey, field) }
 
     /**
      * Map의 필드 수(크기)를 반환합니다.
@@ -169,7 +186,7 @@ open class LettuceMap<V: Any>(
      * @return 필드 수
      */
     fun size(): Long =
-        syncCommands.hlen(mapKey)
+        withConnectionLock { syncCommands.hlen(mapKey) }
 
     /**
      * Map이 비어있는지 확인합니다.
@@ -184,7 +201,7 @@ open class LettuceMap<V: Any>(
      * @return 필드명 목록
      */
     fun keySet(): List<String> =
-        syncCommands.hkeys(mapKey)
+        withConnectionLock { syncCommands.hkeys(mapKey) }
 
     /**
      * 모든 값을 반환합니다.
@@ -192,7 +209,7 @@ open class LettuceMap<V: Any>(
      * @return 값 목록
      */
     fun values(): List<V> =
-        syncCommands.hvals(mapKey)
+        withConnectionLock { syncCommands.hvals(mapKey) }
 
     /**
      * 모든 필드-값 쌍을 반환합니다.
@@ -200,7 +217,7 @@ open class LettuceMap<V: Any>(
      * @return 필드-값 Map
      */
     fun entries(): Map<String, V> =
-        syncCommands.hgetall(mapKey)
+        withConnectionLock { syncCommands.hgetall(mapKey) }
 
     /**
      * 여러 필드-값 쌍을 한번에 설정합니다.
@@ -209,7 +226,7 @@ open class LettuceMap<V: Any>(
      */
     fun putAll(map: Map<String, V>) {
         if (map.isEmpty()) return
-        syncCommands.hset(mapKey, map)
+        withConnectionLock { syncCommands.hset(mapKey, map) }
         log.debug { "LettuceMap putAll: mapKey=$mapKey, count=${map.size}" }
     }
 
@@ -229,7 +246,7 @@ open class LettuceMap<V: Any>(
      */
     fun getAll(fields: Collection<String>): Map<String, V?> {
         if (fields.isEmpty()) return emptyMap()
-        val kvList = syncCommands.hmget(mapKey, *fields.toTypedArray())
+        val kvList = withConnectionLock { syncCommands.hmget(mapKey, *fields.toTypedArray()) }
         return kvList.associate { kv -> kv.key to (if (kv.hasValue()) kv.value else null) }
     }
 
@@ -239,7 +256,7 @@ open class LettuceMap<V: Any>(
      * @return 삭제된 키 수 (키가 존재했으면 1, 없었으면 0)
      */
     fun clear(): Long {
-        val count = syncCommands.del(mapKey)
+        val count = withConnectionLock { syncCommands.del(mapKey) }
         log.debug { "LettuceMap clear: mapKey=$mapKey" }
         return count
     }
@@ -251,7 +268,7 @@ open class LettuceMap<V: Any>(
      * hash 키 수명 계약을 사용하는 상위 캐시가 필요할 때 이 메서드를 함께 호출합니다.
      */
     fun refreshTtl(ttl: Duration?) {
-        if (ttl != null) syncCommands.expire(mapKey, ttl)
+        if (ttl != null) withConnectionLock { syncCommands.expire(mapKey, ttl) }
     }
 
     /**
@@ -261,6 +278,12 @@ open class LettuceMap<V: Any>(
      * 따라서 서로 다른 Lettuce 연결을 사용하는 호출도 같은 [mapKey] 범위에서
      * read-modify-write 구간을 직렬화할 수 있습니다. [leaseTime]은 호출자가 장애로
      * 중단된 경우를 위한 상한이므로, 블록 실행 시간보다 충분히 길게 설정해야 합니다.
+     * 같은 connection의 Redis transaction 상태는 connection 전체에 적용되므로, command dispatch와
+     * lock-owned transaction을 connection gate로 직렬화합니다. 사용자 [block] 실행 중에는 gate를
+     * 유지하지 않습니다. 동기 API는 Redis 응답을 기다리므로 Netty event-loop에서 호출하지 말고
+     * 비동기 API 또는 [LettuceSuspendMap]을 사용해야 합니다. [block]에서 시작한 비동기 작업을
+     * 분산 락의 임계 구간에 포함하려면 [block]이 반환되기 전에 해당 작업이 terminal 상태가 될 때까지
+     * 기다려야 합니다. 완료되지 않은 비동기 작업을 남기는 fire-and-forget 사용은 지원하지 않습니다.
      *
      * @param token 호출마다 새로 생성해야 하는 락 소유 토큰
      * @param leaseTime 락 자동 만료 시간 (기본 1분)
@@ -287,7 +310,7 @@ open class LettuceMap<V: Any>(
         val leaseMillis = leaseTime.toMillis()
         val lockArgs = SetArgs().nx().px(leaseMillis)
 
-        while (syncCommands.set(lockKey, token, lockArgs) == null) {
+        while (withConnectionLock { syncCommands.set(lockKey, token, lockArgs) } == null) {
             if (System.nanoTime() >= deadline) {
                 throw IllegalStateException("LettuceMap[$mapKey] 분산 락 획득 시간이 초과되었습니다.")
             }
@@ -341,16 +364,19 @@ open class LettuceMap<V: Any>(
         }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun executeIfLockOwned(token: V, block: () -> Unit): Boolean {
+    private fun executeIfLockOwned(token: V, block: () -> Unit): Boolean = withConnectionLock {
         val lockKey = "$mapKey$LOCK_SUFFIX"
         var transactionStarted = false
         syncCommands.watch(lockKey)
-        return try {
-            if (!lockTokenMatches(syncCommands.get(lockKey), token)) return false
-            syncCommands.multi()
-            transactionStarted = true
-            block()
-            commitWatchedTransaction()
+        try {
+            if (!lockTokenMatches(syncCommands.get(lockKey), token)) {
+                false
+            } else {
+                syncCommands.multi()
+                transactionStarted = true
+                block()
+                commitWatchedTransaction()
+            }
         } catch (error: Exception) {
             if (transactionStarted) runCatching { syncCommands.discard() }
             throw error
@@ -375,12 +401,14 @@ open class LettuceMap<V: Any>(
         }
 
     private fun releaseDistributedLock(lockKey: String, token: V) {
-        val released = syncCommands.eval<Long>(
-            RELEASE_LOCK_SCRIPT,
-            ScriptOutputType.INTEGER,
-            arrayOf(lockKey),
-            token,
-        )
+        val released = withConnectionLock {
+            syncCommands.eval<Long>(
+                RELEASE_LOCK_SCRIPT,
+                ScriptOutputType.INTEGER,
+                arrayOf(lockKey),
+                token,
+            )
+        }
         check(released == 1L) {
             "LettuceMap[$mapKey] 분산 락 해제에 실패했습니다. 토큰이 만료되었거나 소유자가 아닙니다."
         }
@@ -394,9 +422,9 @@ open class LettuceMap<V: Any>(
      * @param ttl Hash key TTL 설정 (null이면 TTL 없음)
      * @return 저장 성공 여부
      */
-    fun putTtl(field: String, value: V, ttl: Duration?): Boolean {
+    fun putTtl(field: String, value: V, ttl: Duration?): Boolean = withConnectionLock {
         if (ttl == null) {
-            return put(field, value).also {
+            return@withConnectionLock put(field, value).also {
                 log.debug { "LettuceMap putTtl: mapKey=$mapKey, field=$field, ttl=null" }
             }
         }
@@ -413,7 +441,7 @@ open class LettuceMap<V: Any>(
             ok
         }
         log.debug { "LettuceMap putTtl: mapKey=$mapKey, field=$field, ttl=$ttl, hsetex=$supportsHSetEx" }
-        return added
+        added
     }
 
     /**
@@ -422,11 +450,11 @@ open class LettuceMap<V: Any>(
      * @param entries 설정할 필드-값 쌍
      * @param ttl Hash key TTL 설정 (null이면 TTL 없음)
      */
-    fun putAllTtl(entries: Map<String, V>, ttl: Duration?) {
-        if (entries.isEmpty()) return
+    fun putAllTtl(entries: Map<String, V>, ttl: Duration?): Unit = withConnectionLock {
+        if (entries.isEmpty()) return@withConnectionLock
         if (ttl == null) {
             putAll(entries)
-            return
+            return@withConnectionLock
         }
         // 개선: HSETEX 는 필드-레벨 TTL 이므로 별도 EXPIRE 를 호출하지 않는다.
         //       미지원 시에만 HSET + EXPIRE 로 키 전체 만료 설정.
@@ -450,7 +478,7 @@ open class LettuceMap<V: Any>(
      * @return 필드 값을 담은 CompletableFuture (없으면 null)
      */
     fun getAsync(field: String): CompletableFuture<V?> =
-        asyncCommands.hget(mapKey, field).toCompletableFuture()
+        dispatchAsync { asyncCommands.hget(mapKey, field) }
 
     /**
      * 필드에 값을 비동기로 설정합니다.
@@ -460,7 +488,7 @@ open class LettuceMap<V: Any>(
      * @return 새 필드 추가 여부를 담은 CompletableFuture
      */
     fun putAsync(field: String, value: V): CompletableFuture<Boolean> =
-        asyncCommands.hset(mapKey, field, value).toCompletableFuture()
+        dispatchAsync { asyncCommands.hset(mapKey, field, value) }
             .thenApply { result ->
                 log.debug { "LettuceMap putAsync: mapKey=$mapKey, field=$field, isNew=$result" }
                 result
@@ -474,7 +502,7 @@ open class LettuceMap<V: Any>(
      * @return 설정 성공 여부를 담은 CompletableFuture
      */
     fun putIfAbsentAsync(field: String, value: V): CompletableFuture<Boolean> =
-        asyncCommands.hsetnx(mapKey, field, value).toCompletableFuture()
+        dispatchAsync { asyncCommands.hsetnx(mapKey, field, value) }
 
     /**
      * 지정한 필드를 비동기로 삭제합니다.
@@ -483,7 +511,7 @@ open class LettuceMap<V: Any>(
      * @return 삭제된 필드 수를 담은 CompletableFuture
      */
     fun removeAsync(field: String): CompletableFuture<Long> =
-        asyncCommands.hdel(mapKey, field).toCompletableFuture()
+        dispatchAsync { asyncCommands.hdel(mapKey, field) }
 
     /**
      * 지정한 필드가 존재하는지 비동기로 확인합니다.
@@ -492,7 +520,7 @@ open class LettuceMap<V: Any>(
      * @return 존재 여부를 담은 CompletableFuture
      */
     fun containsKeyAsync(field: String): CompletableFuture<Boolean> =
-        asyncCommands.hexists(mapKey, field).toCompletableFuture()
+        dispatchAsync { asyncCommands.hexists(mapKey, field) }
 
     /**
      * Map의 필드 수를 비동기로 반환합니다.
@@ -500,7 +528,7 @@ open class LettuceMap<V: Any>(
      * @return 필드 수를 담은 CompletableFuture
      */
     fun sizeAsync(): CompletableFuture<Long> =
-        asyncCommands.hlen(mapKey).toCompletableFuture()
+        dispatchAsync { asyncCommands.hlen(mapKey) }
 
     /**
      * Map이 비어있는지 비동기로 확인합니다.
@@ -516,7 +544,7 @@ open class LettuceMap<V: Any>(
      * @return 필드명 목록을 담은 CompletableFuture
      */
     fun keySetAsync(): CompletableFuture<List<String>> =
-        asyncCommands.hkeys(mapKey).toCompletableFuture()
+        dispatchAsync { asyncCommands.hkeys(mapKey) }
 
     /**
      * 모든 값을 비동기로 반환합니다.
@@ -524,7 +552,7 @@ open class LettuceMap<V: Any>(
      * @return 값 목록을 담은 CompletableFuture
      */
     fun valuesAsync(): CompletableFuture<List<V>> =
-        asyncCommands.hvals(mapKey).toCompletableFuture()
+        dispatchAsync { asyncCommands.hvals(mapKey) }
 
     /**
      * 모든 필드-값 쌍을 비동기로 반환합니다.
@@ -532,7 +560,7 @@ open class LettuceMap<V: Any>(
      * @return 필드-값 Map을 담은 CompletableFuture
      */
     fun entriesAsync(): CompletableFuture<Map<String, V>> =
-        asyncCommands.hgetall(mapKey).toCompletableFuture()
+        dispatchAsync { asyncCommands.hgetall(mapKey) }
 
     /**
      * 여러 필드-값 쌍을 비동기로 설정합니다.
@@ -542,7 +570,7 @@ open class LettuceMap<V: Any>(
      */
     fun putAllAsync(map: Map<String, V>): CompletableFuture<Unit> {
         if (map.isEmpty()) return CompletableFuture.completedFuture(Unit)
-        return asyncCommands.hset(mapKey, map).toCompletableFuture()
+        return dispatchAsync { asyncCommands.hset(mapKey, map) }
             .thenApply {
                 log.debug { "LettuceMap putAllAsync: mapKey=$mapKey, count=${map.size}" }
             }
@@ -556,7 +584,7 @@ open class LettuceMap<V: Any>(
      */
     fun getAllAsync(fields: Collection<String>): CompletableFuture<Map<String, V?>> {
         if (fields.isEmpty()) return CompletableFuture.completedFuture(emptyMap())
-        return asyncCommands.hmget(mapKey, *fields.toTypedArray()).toCompletableFuture()
+        return dispatchAsync { asyncCommands.hmget(mapKey, *fields.toTypedArray()) }
             .thenApply { kvList ->
                 kvList.associate { kv -> kv.key to (if (kv.hasValue()) kv.value else null) }
             }
@@ -568,9 +596,65 @@ open class LettuceMap<V: Any>(
      * @return 삭제된 키 수를 담은 CompletableFuture
      */
     fun clearAsync(): CompletableFuture<Long> =
-        asyncCommands.del(mapKey).toCompletableFuture()
+        dispatchAsync { asyncCommands.del(mapKey) }
             .thenApply { count ->
                 log.debug { "LettuceMap clearAsync: mapKey=$mapKey" }
                 count
             }
+}
+
+/**
+ * 같은 Lettuce connection을 공유하는 map wrapper의 command dispatch를 직렬화합니다.
+ *
+ * sync 호출은 caller thread에서 lock을 기다리지만 async 호출은 경합 시 virtual thread로 대기 작업을
+ * 넘겨 Netty event-loop를 막지 않습니다. gate는 command dispatch만 보호하며 async 응답 대기 중에는
+ * lock을 유지하지 않습니다.
+ */
+internal class LettuceConnectionGate private constructor() {
+
+    private val lock = ReentrantLock(true)
+
+    fun <R> call(block: () -> R): R = lock.withLock(block)
+
+    @Suppress("TooGenericExceptionCaught")
+    fun <R> dispatch(block: () -> RedisFuture<R>): CompletableFuture<R> {
+        if (lock.tryLock()) {
+            return try {
+                block().toCompletableFuture()
+            } finally {
+                lock.unlock()
+            }
+        }
+
+        val promise = CompletableFuture<R>()
+        VirtualThreadExecutor.execute {
+            val source = try {
+                lock.withLock {
+                    if (promise.isCancelled) null else block().toCompletableFuture()
+                }
+            } catch (error: Throwable) {
+                promise.completeExceptionally(error)
+                null
+            }
+
+            if (source != null) {
+                promise.whenComplete { _, _ ->
+                    if (promise.isCancelled) source.cancel(true)
+                }
+                source.whenComplete { result, error ->
+                    if (error != null) promise.completeExceptionally(error)
+                    else promise.complete(result)
+                }
+            }
+        }
+        return promise
+    }
+
+    companion object {
+        private val gates = WeakHashMap<StatefulRedisConnection<*, *>, LettuceConnectionGate>()
+
+        @Synchronized
+        fun of(connection: StatefulRedisConnection<*, *>): LettuceConnectionGate =
+            gates.getOrPut(connection) { LettuceConnectionGate() }
+    }
 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendMap.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendMap.kt
@@ -3,9 +3,11 @@ package io.bluetape4k.redis.lettuce.map
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requireNotBlank
+import io.lettuce.core.RedisFuture
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import kotlinx.coroutines.future.await
+import java.util.concurrent.CompletionStage
 
 /**
  * Lettuce Redis 클라이언트를 이용한 분산 Map의 코루틴 구현체입니다.
@@ -24,7 +26,8 @@ import kotlinx.coroutines.future.await
  * ```
  *
  * @param V 값 타입
- * @param connection Lettuce StatefulRedisConnection (LettuceBinaryCodec<V> 기반)
+ * @param connection Lettuce StatefulRedisConnection (LettuceBinaryCodec<V> 기반). [LettuceMap]과 공유할 수
+ * 있지만 raw connection이나 다른 wrapper의 동시 명령은 공용 gate를 우회하므로 지원하지 않습니다.
  * @param mapKey Redis에 저장될 Hash 키
  */
 open class LettuceSuspendMap<V: Any>(
@@ -38,6 +41,11 @@ open class LettuceSuspendMap<V: Any>(
     }
 
     private val asyncCommands: RedisAsyncCommands<String, V> get() = connection.async()
+    private val connectionGate = LettuceConnectionGate.of(connection)
+
+    /** 같은 connection의 transaction-aware command와 직렬화합니다. */
+    protected fun <R> dispatchAsync(block: () -> RedisFuture<R>): CompletionStage<R> =
+        connectionGate.dispatch(block)
 
     /**
      * 지정한 필드의 값을 코루틴으로 반환합니다.
@@ -54,7 +62,7 @@ open class LettuceSuspendMap<V: Any>(
      * @param field 조회할 필드명
      * @return 필드 값 (존재하지 않으면 null)
      */
-    suspend fun get(field: String): V? = asyncCommands.hget(mapKey, field).await()
+    suspend fun get(field: String): V? = dispatchAsync { asyncCommands.hget(mapKey, field) }.await()
 
     /**
      * 필드에 값을 코루틴으로 설정합니다.
@@ -67,7 +75,7 @@ open class LettuceSuspendMap<V: Any>(
         field: String,
         value: V,
     ): Boolean {
-        val result = asyncCommands.hset(mapKey, field, value).await()
+        val result = dispatchAsync { asyncCommands.hset(mapKey, field, value) }.await()
         log.debug { "LettuceSuspendMap put: mapKey=$mapKey, field=$field, isNew=$result" }
         return result
     }
@@ -82,7 +90,7 @@ open class LettuceSuspendMap<V: Any>(
     suspend fun putIfAbsent(
         field: String,
         value: V,
-    ): Boolean = asyncCommands.hsetnx(mapKey, field, value).await()
+    ): Boolean = dispatchAsync { asyncCommands.hsetnx(mapKey, field, value) }.await()
 
     /**
      * 지정한 필드를 코루틴으로 삭제합니다.
@@ -90,7 +98,7 @@ open class LettuceSuspendMap<V: Any>(
      * @param field 삭제할 필드명
      * @return 삭제된 필드 수
      */
-    suspend fun remove(field: String): Long = asyncCommands.hdel(mapKey, field).await()
+    suspend fun remove(field: String): Long = dispatchAsync { asyncCommands.hdel(mapKey, field) }.await()
 
     /**
      * 지정한 필드가 존재하는지 코루틴으로 확인합니다.
@@ -98,14 +106,14 @@ open class LettuceSuspendMap<V: Any>(
      * @param field 확인할 필드명
      * @return 존재하면 true
      */
-    suspend fun containsKey(field: String): Boolean = asyncCommands.hexists(mapKey, field).await()
+    suspend fun containsKey(field: String): Boolean = dispatchAsync { asyncCommands.hexists(mapKey, field) }.await()
 
     /**
      * Map의 필드 수를 코루틴으로 반환합니다.
      *
      * @return 필드 수
      */
-    suspend fun size(): Long = asyncCommands.hlen(mapKey).await()
+    suspend fun size(): Long = dispatchAsync { asyncCommands.hlen(mapKey) }.await()
 
     /**
      * Map이 비어있는지 코루틴으로 확인합니다.
@@ -119,21 +127,21 @@ open class LettuceSuspendMap<V: Any>(
      *
      * @return 필드명 목록
      */
-    suspend fun keySet(): List<String> = asyncCommands.hkeys(mapKey).await()
+    suspend fun keySet(): List<String> = dispatchAsync { asyncCommands.hkeys(mapKey) }.await()
 
     /**
      * 모든 값을 코루틴으로 반환합니다.
      *
      * @return 값 목록
      */
-    suspend fun values(): List<V> = asyncCommands.hvals(mapKey).await()
+    suspend fun values(): List<V> = dispatchAsync { asyncCommands.hvals(mapKey) }.await()
 
     /**
      * 모든 필드-값 쌍을 코루틴으로 반환합니다.
      *
      * @return 필드-값 Map
      */
-    suspend fun entries(): Map<String, V> = asyncCommands.hgetall(mapKey).await()
+    suspend fun entries(): Map<String, V> = dispatchAsync { asyncCommands.hgetall(mapKey) }.await()
 
     /**
      * 여러 필드-값 쌍을 코루틴으로 설정합니다.
@@ -142,7 +150,7 @@ open class LettuceSuspendMap<V: Any>(
      */
     suspend fun putAll(map: Map<String, V>) {
         if (map.isEmpty()) return
-        asyncCommands.hset(mapKey, map).await()
+        dispatchAsync { asyncCommands.hset(mapKey, map) }.await()
         log.debug { "LettuceSuspendMap putAll: mapKey=$mapKey, count=${map.size}" }
     }
 
@@ -162,7 +170,7 @@ open class LettuceSuspendMap<V: Any>(
      */
     suspend fun getAll(fields: Collection<String>): Map<String, V?> {
         if (fields.isEmpty()) return emptyMap()
-        val kvList = asyncCommands.hmget(mapKey, *fields.toTypedArray()).await()
+        val kvList = dispatchAsync { asyncCommands.hmget(mapKey, *fields.toTypedArray()) }.await()
         return kvList.associate { kv -> kv.key to (if (kv.hasValue()) kv.value else null) }
     }
 
@@ -172,7 +180,7 @@ open class LettuceSuspendMap<V: Any>(
      * @return 삭제된 키 수 (키가 존재했으면 1, 없었으면 0)
      */
     suspend fun clear(): Long {
-        val count = asyncCommands.del(mapKey).await()
+        val count = dispatchAsync { asyncCommands.del(mapKey) }.await()
         log.debug { "LettuceSuspendMap clear: mapKey=$mapKey" }
         return count
     }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceMapTest.kt
@@ -1,11 +1,14 @@
 package io.bluetape4k.redis.lettuce.map
 
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.redis.lettuce.AbstractLettuceTest
 import io.bluetape4k.redis.lettuce.LettuceClients
 import io.bluetape4k.redis.lettuce.LettuceTestUtils
 import io.lettuce.core.HSetExArgs
+import io.lettuce.core.RedisFuture
 import io.lettuce.core.TransactionResult
+import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.codec.StringCodec
@@ -24,6 +27,13 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
 
 class LettuceMapTest: AbstractLettuceTest() {
 
@@ -238,6 +248,113 @@ class LettuceMapTest: AbstractLettuceTest() {
     }
 
     @Test
+    fun `transaction과 일반 sync async command는 shared connection에서 교차하지 않는다`() {
+        val nextOperation = AtomicInteger()
+        val committed = AtomicInteger()
+        map.put("counter", "0")
+
+        MultithreadingTester()
+            .workers(12)
+            .rounds(50)
+            .add {
+                when (nextOperation.getAndIncrement() % 3) {
+                    0 -> {
+                        val token = UUID.randomUUID().toString()
+                        map.withDistributedLock(token) {
+                            val updated = (map.get("counter")?.toInt() ?: 0) + 1
+                            map.putTtlIfLockOwned("counter", updated.toString(), ttl = null, token = token)
+                                .shouldBeTrue()
+                            committed.incrementAndGet()
+                        }
+                    }
+
+                    1 -> map.get("counter")
+                    else -> map.getAsync("counter").get()
+                }
+            }
+            .run()
+
+        map.get("counter")?.toInt() shouldBeEqualTo committed.get()
+    }
+
+    @Test
+    fun `sync 응답 대기는 event loop의 async dispatch를 막지 않는다`() {
+        val commands = mockk<RedisCommands<String, String>>()
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>()
+        val mockedConnection = mockk<StatefulRedisConnection<String, String>>()
+        val syncCommandStarted = CountDownLatch(1)
+        val releaseSyncCommand = CountDownLatch(1)
+        val eventLoopCallbackReturned = CountDownLatch(1)
+
+        every { mockedConnection.sync() } returns commands
+        every { mockedConnection.async() } returns asyncCommands
+        every { commands.hget("mock-map", "sync") } answers {
+            syncCommandStarted.countDown()
+            releaseSyncCommand.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            "sync-value"
+        }
+        every { asyncCommands.hget("mock-map", "async") } answers {
+            completedRedisFuture("async-value")
+        }
+
+        val testedMap = LettuceMap(mockedConnection, "mock-map")
+        val executor = Executors.newFixedThreadPool(2)
+        val syncCall = executor.submit<String?> { testedMap.get("sync") }
+
+        try {
+            syncCommandStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            lateinit var asyncResult: CompletableFuture<String?>
+            executor.execute {
+                asyncResult = testedMap.getAsync("async")
+                eventLoopCallbackReturned.countDown()
+            }
+
+            eventLoopCallbackReturned.await(500, TimeUnit.MILLISECONDS).shouldBeTrue()
+            releaseSyncCommand.countDown()
+            asyncResult.get(1, TimeUnit.SECONDS) shouldBeEqualTo "async-value"
+        } finally {
+            releaseSyncCommand.countDown()
+            syncCall.get(1, TimeUnit.SECONDS) shouldBeEqualTo "sync-value"
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `gate에서 대기 중 취소된 async command는 dispatch하지 않는다`() {
+        val commands = mockk<RedisCommands<String, String>>()
+        val asyncCommands = mockk<RedisAsyncCommands<String, String>>(relaxed = true)
+        val mockedConnection = mockk<StatefulRedisConnection<String, String>>()
+        val syncCommandStarted = CountDownLatch(1)
+        val releaseSyncCommand = CountDownLatch(1)
+
+        every { mockedConnection.sync() } returns commands
+        every { mockedConnection.async() } returns asyncCommands
+        every { commands.hget("mock-map", "sync") } answers {
+            syncCommandStarted.countDown()
+            releaseSyncCommand.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            "sync-value"
+        }
+
+        val testedMap = LettuceMap(mockedConnection, "mock-map")
+        val executor = Executors.newSingleThreadExecutor()
+        val syncCall = executor.submit<String?> { testedMap.get("sync") }
+
+        try {
+            syncCommandStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            testedMap.getAsync("cancelled").cancel(true).shouldBeTrue()
+            releaseSyncCommand.countDown()
+            syncCall.get(1, TimeUnit.SECONDS) shouldBeEqualTo "sync-value"
+
+            verify(timeout = 500, exactly = 0) {
+                asyncCommands.hget("mock-map", "cancelled")
+            }
+        } finally {
+            releaseSyncCommand.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `락 소유권 검증 트랜잭션은 Redis 명령 실패 후 discard`() {
         connection.sync().set(map.mapKey, "wrong-type")
 
@@ -418,5 +535,22 @@ class LettuceMapTest: AbstractLettuceTest() {
         map.putAllAsync(mapOf("f1" to "v1", "f2" to "v2")).get()
         map.clearAsync().get() shouldBeEqualTo 1L
         map.isEmptyAsync().get().shouldBeTrue()
+    }
+
+    private fun <T> completedRedisFuture(value: T): RedisFuture<T> =
+        TestRedisFuture<T>().apply { complete(value) }
+
+    private class TestRedisFuture<T>: CompletableFuture<T>(), RedisFuture<T> {
+
+        override fun getError(): String? =
+            if (isCompletedExceptionally) "completed exceptionally" else null
+
+        override fun await(timeout: Long, unit: TimeUnit): Boolean =
+            try {
+                get(timeout, unit)
+                true
+            } catch (_: TimeoutException) {
+                false
+            }
     }
 }

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendMapTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/map/LettuceSuspendMapTest.kt
@@ -17,6 +17,8 @@ import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
 class LettuceSuspendMapTest: AbstractLettuceTest() {
 
@@ -159,5 +161,30 @@ class LettuceSuspendMapTest: AbstractLettuceTest() {
         jobs.awaitAll()
 
         map.size() shouldBeEqualTo itemCount.toLong()
+    }
+
+    @Test
+    fun `sync transaction과 suspend command는 shared connection에서 교차하지 않는다`() = runSuspendIO {
+        val syncMap = LettuceMap<String>(connection, map.mapKey)
+        val committed = AtomicInteger()
+        syncMap.put("counter", "0")
+
+        List(300) { index ->
+            async {
+                if (index % 3 == 0) {
+                    val token = UUID.randomUUID().toString()
+                    syncMap.withDistributedLock(token) {
+                        val updated = (syncMap.get("counter")?.toInt() ?: 0) + 1
+                        syncMap.putTtlIfLockOwned("counter", updated.toString(), ttl = null, token = token)
+                            .shouldBeTrue()
+                        committed.incrementAndGet()
+                    }
+                } else {
+                    map.get("counter")
+                }
+            }
+        }.awaitAll()
+
+        map.get("counter")?.toInt() shouldBeEqualTo committed.get()
     }
 }


### PR DESCRIPTION
## 요약

Fixes #1684
Fixes #1685
Fixes #1686
Fixes #1687

milestone `2.1.0`의 7-Tier 리뷰에서 확인한 네 가지 경계 동시성 결함을 수정합니다. caller 취소, 정수 overflow, cleanup 실패, 공유 Lettuce connection 경합에서 기존 공개 계약과 자원 수명 주기를 보존합니다.

## 배경

- `ConcurrentReducer`의 active caller 취소가 source stage와 permit 회수로 이어지지 않았습니다.
- `Long.quarterPeriod()`가 quarter-to-month 곱셈에서 `Int` overflow를 조용히 허용했습니다.
- `TenantConnectionPoolRegistry.closeSuspending()`은 취소된 caller의 cleanup이 실패하면 cancellation 대신 cleanup 예외를 주 예외로 노출했습니다.
- `LettuceMap`의 공유 connection에서 `WATCH/MULTI/EXEC`와 다른 명령이 교차해 `StatusOutput does not support set(long)`이 발생했습니다.

## 해결 내용

- active promise 취소를 source stage 취소 및 exactly-once permit 반환에 연결했습니다.
- quarter-to-month 변환을 exact arithmetic으로 수행하고 양수·음수 경계를 회귀 테스트로 고정했습니다.
- caller cancellation을 primary로 유지하면서 cleanup 실패를 suppressed 예외로 보존했습니다.
- 공유 Lettuce connection의 트랜잭션 및 dispatch 경계를 직렬화하고 sync event-loop 호출과 fire-and-forget lock callback의 지원 범위를 문서화했습니다.
- 공개 README 영문/한국어와 `CHANGELOG.md`, 재발 방지 lesson을 함께 갱신했습니다.

## 검증

- `./gradlew :bluetape4k-core:test --rerun-tasks`: PASS (`1683/1683`, 실패·오류·skip 0)
- `./gradlew :bluetape4k-r2dbc:test --rerun-tasks`: PASS (`220/220`, 실패·오류·skip 0)
- `./gradlew :bluetape4k-lettuce:test --rerun-tasks`: PASS (`940/940`, 실패·오류·skip 0)
- `./gradlew :bluetape4k-cache-lettuce:test --rerun-tasks`: PASS (`462/462`, 실패·오류·skip 0)
- `LettuceJCache` 두 `invoke serializes*` 회귀 테스트: PASS (각 3회 연속)
- `ConcurrentReducerTest`: PASS (3회 연속, 회당 20개)
- 영향 모듈 Detekt 및 `git diff --check`: PASS
- `javap` 비교: 기존 public callable descriptor 변경 없음. `withConnectionLock`와 `dispatchAsync` protected helper만 추가됨

## 리뷰 메모

- P0/P1/P2: `0/0/0`
- 리뷰 근거: exact commit `0714bf927eeaba4bc61556b9a7c9014c2c6d0ea7`, diff digest `88d208325b21635628df34124b348a2e863ebdad347d7af6c50fc95beaaf3bb9`
- `gpt-5.6-luna max` 독립 리뷰 lane은 15분 내 사용 가능한 verdict를 반환하지 못했습니다. 동일 exact diff에 대한 main-session inline 7-Tier fallback 결과만 현재 verdict로 사용하며 독립 리뷰 provenance를 주장하지 않습니다.
- Security는 사용자 지시에 따라 다른 세션에서 처리 중이므로 이 PR의 리뷰 범위에서 제외했습니다.
- LSP 진단은 도구 부재로 `PENDING`이며, compile/test/Detekt를 대체 증거로 기록했습니다.

## 메타데이터

- Issues: #1684, #1685, #1686, #1687; milestone `2.1.0`; assignee `debop`
- PR: 이 PR; head `0714bf927eeaba4bc61556b9a7c9014c2c6d0ea7`; base `develop`; milestone `2.1.0`; assignee `debop`
- CI: PR CI run `34071974499` `success` (`14 success`, `10 path-filtered skipped`, 실패 0)
- Full Nightly: run `34072052604`, `scope=full`, `46/46 success`, 실패·skip 0

## DoD Status

Required checks: 5/9; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-11 - PR 전달 권한 | 저장소/base/head/action을 승인 범위와 대조 | PASS | `bluetape4k/bluetape4k-projects`, `develop`, `fix/milestone-2.1-review-findings`, push/PR/CI/Full Nightly 승인 | 없음 |
| CG-12 - exact head 게시 | 비강제 push 후 원격 SHA read-back | PASS | local/remote `0714bf927eeaba4bc61556b9a7c9014c2c6d0ea7` 일치 | 없음 |
| CG-12A - 가이드 갱신 | 현재 `AGENTS.md` 계층, Type C/Kotlin skill, common gates, PR template, 이슈 #1684~#1687 재확인 | PASS | current hashes 및 이슈 `OPEN`, milestone `2.1.0`, assignee `debop` read-back | 없음 |
| CG-13 - PR 생성 및 검증 | 한국어 PR, 이슈 연결, assignee/milestone/labels 설정 및 live read-back | PASS | 이 PR의 live metadata | metadata 불일치 시 즉시 수정 |
| CG-14 - CI 및 리뷰 | exact-head CI, Full Nightly, review/thread read-back | PASS | CI `34071974499` success; Full Nightly `34072052604` 46/46 success; reviews/comments/threads 0; P0/P1 0 | 없음 |
| CG-14 human subgate | 추가 maintainer가 없는 single-developer lane | N/A | repository maintainer scope: `debop` 단독 작업 | 별도 human review 요청 시 재개 |
| CG-15 - merge-ready 보고 | CI와 리뷰 수렴 후 exact PR/head DoD 보고 | PENDING | CG-14 완료 후 진행 | 증거 누락 시 보고 금지 |
| CG-16 - fresh merge approval | merge-ready 보고 뒤 exact PR/head 승인 대기 | PENDING | 아직 요청하지 않음 | 승인 전 병합 금지 |
| CG-17 - 병합 | 승인된 exact head를 rebase merge하고 live 검증 | PENDING | CG-16 이후 | auto-merge 금지 |
| CG-18 - 동기화·정리 | 병합 확인 뒤 로컬 동기화 및 승인된 범위 정리 | PENDING | CG-17 이후 | 불명확한 작업 보존 |

Final status: `PENDING` — merge-ready 보고 뒤 exact PR/head의 fresh merge approval을 기다립니다.

Unchecked required items: `CG-15`, `CG-16`, `CG-17`, `CG-18`
