### PR TITLE
fix: JDBC password provider 예외에서 비밀값 노출 차단

### DIFF
--- a/data/jdbc/README.ko.md
+++ b/data/jdbc/README.ko.md
@@ -565,3 +565,7 @@ class MyJdbcTest : AbstractJdbcTest() {
 ## 라이선스
 
 MIT License
+
+## 실패와 생명주기 계약
+
+password provider 실패는 원문 예외 체인을 제외한 안전한 SQLException으로 전달합니다. null password는 설정한 메시지를 유지하며 JDBC driver 연결 오류의 동작은 유지합니다.

--- a/data/jdbc/README.md
+++ b/data/jdbc/README.md
@@ -562,3 +562,7 @@ class MyJdbcTest : AbstractJdbcTest() {
 ## License
 
 MIT License
+
+## Failure and lifecycle contract
+
+Password-provider failures are reported with a sanitized SQLException without the original provider exception chain. A null password retains the configured null-password message; driver connection errors retain their existing behavior.

--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSource.kt
@@ -158,15 +158,15 @@ class RefreshingJdbcPasswordDataSource(
     override fun toString(): String =
         "RefreshingJdbcPasswordDataSource(url=$urlSummary, username=<redacted>)"
 
-    private fun currentPassword(): String =
-        try {
+    private fun currentPassword(): String {
+        val password = try {
             passwordProvider.currentPassword()
-                ?: throw SQLException(nullPasswordMessage)
-        } catch (e: SQLException) {
-            throw e
-        } catch (e: Exception) {
-            throw SQLException("JDBC password provider failed.", e)
+        } catch (_: Exception) {
+            // provider 예외의 메시지, cause, suppressed에는 비밀값이 포함될 수 있습니다.
+            throw SQLException("JDBC password provider failed.")
         }
+        return password ?: throw SQLException(nullPasswordMessage)
+    }
 
     private companion object {
         private const val REJECT_CALLER_CREDENTIALS_MESSAGE =

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSourceTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/datasource/RefreshingJdbcPasswordDataSourceTest.kt
@@ -243,8 +243,22 @@ class RefreshingJdbcPasswordDataSourceTest {
             dataSource.connection
         }
 
-        ex.cause shouldBeEqualTo failure
+        ex.stackTraceToString() shouldNotContain "provider-secret"
         ex.message shouldNotContain "provider-secret"
+    }
+
+    @Test
+    fun `provider SQLException의 원인과 suppressed에 포함된 비밀값을 제거한다`() {
+        val failure = SQLException("provider-secret", IllegalStateException("cause-secret"))
+        failure.addSuppressed(IllegalArgumentException("suppressed-secret"))
+        val dataSource = dataSourceFor("jdbc:bluetape4k-refresh-test:provider-sql-failure") { throw failure }
+
+        val ex = assertFailsWith<SQLException> { dataSource.connection }
+
+        ex.message shouldBeEqualTo "JDBC password provider failed."
+        ex.stackTraceToString() shouldNotContain "provider-secret"
+        ex.stackTraceToString() shouldNotContain "cause-secret"
+        ex.stackTraceToString() shouldNotContain "suppressed-secret"
     }
 
     @Test

--- a/docs/lessons/2026-09-08-provider-error-secrets.md
+++ b/docs/lessons/2026-09-08-provider-error-secrets.md
@@ -1,0 +1,19 @@
+# provider 예외의 전체 체인을 비밀값 경계로 취급한다
+
+관련 이슈: https://github.com/bluetape4k/bluetape4k-projects/issues/1695
+
+## 실패한 가정과 근거
+
+상위 메시지만 정리해도 원래 cause와 provider SQLException에서 비밀값이 노출됐다.
+
+## 결정
+
+provider 실행 경계에서 안전한 SQLException을 새로 만든다. null 결과 메시지와 JDBC driver 예외 경계는 유지한다.
+
+## 재발 방지
+
+비밀값 비노출 테스트는 message뿐 아니라 stackTraceToString으로 cause와 suppressed까지 확인한다. 디버깅 편의로 원문 cause를 다시 연결하지 않는다.
+
+## 검증
+
+이 PR의 회귀 테스트에서 수정 전 동작 실패를 확인했다. 수정 후 테스트와 관련 모듈 검증 결과는 PR의 `DoD Status`에 기록한다.

--- a/docs/superpowers/plans/2026-06-30-refreshing-jdbc-datasource-plan.md
+++ b/docs/superpowers/plans/2026-06-30-refreshing-jdbc-datasource-plan.md
@@ -44,8 +44,8 @@ Test cases:
 - Wrapper methods: `isWrapperFor`, successful `unwrap`, and failed `unwrap`
   with stable `SQLException("Not a wrapper for <fqcn>.")`.
 - Secret-free `toString()`: provider is not called and output excludes full URL query strings, URL userinfo, `password`, `token`, and `sslpassword` sentinel values.
-- Provider failure: provider exception is wrapped in a secret-free `SQLException`
-  with the cause preserved.
+- #1695 보안 계약 수정: provider 실패는 고정 메시지의 `SQLException`으로 변환하고 원본 cause와 suppressed를 제거한다.
+  원본 SQLException도 같은 경계를 적용하며 출력된 전체 stack trace에 비밀값이 없는지 검사한다.
 - Driver class load failure: failure includes the class name but not URL, properties, or credentials.
 - DriverManager global methods: log writer and login timeout delegate to process-wide `DriverManager`; save and restore original state.
 
@@ -69,7 +69,7 @@ Implementation rules:
 - Load optional `driverClassName` in the constructor.
 - Build a fresh per-call `Properties` object and write base properties first, then `user`, then `password`.
 - Reject caller-supplied credentials before invoking the provider.
-- Wrap provider failures as secret-free `SQLException` with cause.
+- #1695: provider 실패를 원본 cause와 suppressed가 없는 고정 메시지의 `SQLException`으로 변환한다.
 - Propagate `DriverManager.getConnection` `SQLException` unchanged.
 - Delegate log writer/login timeout to `DriverManager`.
 - Implement wrapper methods only for the helper instance.

--- a/docs/superpowers/specs/2026-06-30-refreshing-jdbc-datasource-design.md
+++ b/docs/superpowers/specs/2026-06-30-refreshing-jdbc-datasource-design.md
@@ -145,8 +145,9 @@ AWS migration after the helper is released:
     - Config validation failures throw `IllegalArgumentException`.
     - Optional driver class loading uses `Class.forName(driverClassName)` in the constructor. `ClassNotFoundException` may propagate directly or be wrapped in `IllegalArgumentException` with the driver class name and cause, but the message must not include URL, properties, or credentials.
     - Null password throws `SQLException(config.nullPasswordMessage)`.
-    - Provider failure is wrapped as a secret-free `SQLException` with cause, so
-      `DataSource.getConnection()` consistently exposes connection acquisition failure as `SQLException`.
+    - #1695 보안 계약 수정: provider 실패는 고정 메시지의 `SQLException`으로 변환한다.
+      원본 message, cause, suppressed, SQLState, errorCode는 비밀값을 포함할 수 있으므로 전달하지 않는다.
+      `DataSource.getConnection()`은 연결 획득 실패를 일관되게 `SQLException`으로 노출한다.
     - `DriverManager.getConnection(...)` `SQLException` is propagated unchanged.
     - Rejected caller credentials throw the stable `SQLException` message above.
     - `unwrap` failure throws `SQLException("Not a wrapper for <fqcn>.")`.


### PR DESCRIPTION
## 요약

Fixes #1695

password provider의 일반 Exception과 SQLException을 고정 메시지의 SQLException으로 정규화해 원문 예외 체인의 비밀값 노출을 차단합니다.

## 배경과 변경

#1701 모듈별 리뷰의 후속 수정입니다. 원본 cause/suppressed/SQLState/errorCode를 전달하지 않는 정책으로 기존 설계·계획 문서를 수정했습니다. null password 메시지, DriverManager 연결 예외와 Error 전파 경계는 유지합니다.

## 검증

- 변경 전: 원본 cause 및 provider SQLException에 테스트용 secret이 남아 회귀 테스트 실패
- 변경 후: JDBC 전체 164개 테스트 통과
- `:bluetape4k-jdbc:test :bluetape4k-jdbc:detekt --no-configuration-cache` 성공
- `git diff --check` 통과

## 리뷰 참고

- 독립 코드 리뷰: `code-reviewer`, `gpt-5.6-luna`, `max`. 소스·호출자·API·회귀 테스트·문서를 검토했으며 P0/P1은 0건입니다.
- 초기 리뷰의 cause 보존 문서 불일치를 수정한 후 APPROVE. 비밀값 차단을 위해 provider의 상세 진단 정보를 외부 SQLException에 보존하지 않습니다. detekt는 저장소의 기존 ignoreFailures 정책으로 실행되며 기존 진단을 모두 제거했다는 의미는 아닙니다.
- 교훈: `docs/lessons/2026-09-08-provider-error-secrets.md`. 격리 GNO 인덱스에서 추가와 검색을 검증했으며, 머지 후 기본 develop 파일의 GNO 갱신과 대표 검색도 확인했습니다.
- README EN/KO 계약 대조와 한국어 문서 검토를 완료했습니다.

## 메타데이터

- 이슈: #1695; milestone `2.1.0`; 담당자 `debop`
- 저장소: `bluetape4k/bluetape4k-projects`; base `develop`; head `fix/1695-jdbc-secret-errors`
- 커밋: `baaeddc8ff57177fd5b9deadcb947d34de516dfa`; 로컬/원격 SHA 일치 확인
- CI: 현재 head에서 12개 job 성공. 변경 경로 밖 12개 job은 실행 대상 제외이며 테스트 통과로 계산하지 않습니다. [검증 실행](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34186609138). 다른 자식 PR과 함께 마지막에 머지합니다.

- 머지 커밋: `734dc7c7f093112f1a93cb87008a100eeafd350a`; 연결 이슈 CLOSED 확인
- 로컬 develop/upstream: `ca87d3f3c8a373f977f1ec2178803c2923b3ed2f`, clean; 9개 머지 커밋 포함 확인. 브랜치와 worktree는 보존했습니다.

## DoD Status

Required checks: 28/28; N/A: 1; Blocked: 0

| Check | 수행 내용 | 상태 | 근거 / 다음 작업 |
|---|---|---|---|
| CG-01 | 기준 정보와 승인 범위 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-02 | GNO 이력 및 live 이슈 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-03 | 독립 worktree와 이슈별 브랜치 | PASS | 위 검증 및 현재 커밋 |
| CG-04 | 한국어 GitHub 및 README 언어 정책 | PASS | 위 검증 및 현재 커밋 |
| CG-05 | 기존 Kotlin 패턴 재사용 | PASS | 위 검증 및 현재 커밋 |
| CG-06 | 공개 계약과 README EN/KO 대조 | PASS | 위 검증 및 현재 커밋 |
| CG-07 | RED/GREEN 및 영향 모듈 테스트 | PASS | 위 검증 및 현재 커밋 |
| CG-08 | 무거운 검증 순차 실행 | PASS | 위 검증 및 현재 커밋 |
| CG-09 | 교훈 기록과 격리 인덱스 검색 | PASS | 위 검증 및 현재 커밋 |
| CG-10 | 최종 리뷰와 검증 후 커밋 | PASS | 위 검증 및 현재 커밋 |
| CG-11 | 승인된 저장소/base/head PR 생성 범위 | PASS | 위 검증 및 현재 커밋 |
| CG-12 | 정확한 head push 및 원격 조회 | PASS | 위 검증 및 현재 커밋 |
| CG-12A | AGENTS 계층·leaf·common·template·이슈 재조회 | PASS | 위 검증 및 현재 커밋 |
| CG-13 | PR 생성과 메타데이터 live 조회 | PASS | live URL, head SHA, 담당자/라벨/milestone/본문 확인 |
| CG-14 | head CI와 최신 리뷰/스레드 확인 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| CG-15 | 정확한 head의 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| CG-16 | 마지막 일괄 머지의 새 승인 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-17 | 승인된 head 머지와 결과 검증 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-18 | 머지 후 로컬 동기화 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| C-01 | 원인과 영향 범위 확인 | PASS | 위 회귀 테스트와 검토 근거 |
| C-02 | 이슈별 수정 범위 확정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-03 | 결함 재현 RED | PASS | 위 회귀 테스트와 검토 근거 |
| C-04 | 최소 수정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-05 | GREEN 및 영향 검증 | PASS | 위 회귀 테스트와 검토 근거 |
| C-06 | 교훈과 재발 방지 | PASS | 위 회귀 테스트와 검토 근거 |
| C-07 | PR CI/리뷰 수렴 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| C-08 | 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| C-09 | 승인 후 최종 완료 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |

별도 인간 리뷰: N/A (single-developer lane, debop 단독 유지관리 범위). CI와 코드 리뷰는 필수입니다.

Final status: DONE — 승인된 head squash merge 및 develop 동기화 완료

Unchecked required items: 없음
