### PR TITLE
fix: Ktor TimeLimiter가 소유한 timeout만 정책 실패로 변환

### DIFF
--- a/docs/lessons/2026-09-08-timeout-ownership.md
+++ b/docs/lessons/2026-09-08-timeout-ownership.md
@@ -1,0 +1,19 @@
+# timeout 소유권과 취소 전파
+
+관련 이슈: https://github.com/bluetape4k/bluetape4k-projects/issues/1692
+
+## 실패한 가정과 근거
+
+상위 timeout과 핸들러 내부 timeout이 정책 TimeoutException으로 변환됐다. 두 회귀 테스트가 잘못된 예외 타입으로 실패했다.
+
+## 결정
+
+withTimeoutOrNull이 소유한 timeout만 정책 실패로 변환한다. 다른 CancellationException은 그대로 전파한다.
+
+## 재발 방지
+
+timeout 테스트는 정책 자체, 상위 요청, 내부 작업의 세 가지 소유자를 각각 검증하고 정책 이벤트 수도 확인한다.
+
+## 검증
+
+이 PR의 회귀 테스트에서 수정 전 동작 실패를 확인했다. 수정 후 테스트와 관련 모듈 검증 결과는 PR의 `DoD Status`에 기록한다.

--- a/ktor/resilience4j/README.ko.md
+++ b/ktor/resilience4j/README.ko.md
@@ -80,3 +80,7 @@ fun Application.module() {
 - 애플리케이션 설정 바인딩을 제공하지 않습니다.
 - 인증, 로깅, tracing, OpenAPI 통합을 포함하지 않습니다.
 - client 전용 facade를 제공하지 않습니다.
+
+## 실패와 생명주기 계약
+
+TimeLimiter가 소유한 timeout만 정책 timeout으로 변환합니다. 상위 요청과 내부 작업의 timeout은 정책 실패 이벤트 없이 취소로 전파합니다.

--- a/ktor/resilience4j/README.md
+++ b/ktor/resilience4j/README.md
@@ -77,3 +77,7 @@ Messages are generic and safe for clients. Policy names remain in the caller-own
 - No application configuration binding.
 - No authentication, logging, tracing, or OpenAPI integration.
 - No client-specific facade.
+
+## Failure and lifecycle contract
+
+Only the TimeLimiter's own timeout becomes a policy timeout. Parent and nested coroutine timeouts propagate as cancellation without policy failure events.

--- a/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupport.kt
+++ b/ktor/resilience4j/src/main/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupport.kt
@@ -12,8 +12,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Executes [block] through caller-owned Resilience4j policies.
@@ -133,20 +132,17 @@ internal suspend fun <T: Any> withCircuitBreakerPreservingCancellation(
     }
 }
 
+/** 정책이 소유한 timeout만 변환하며 상위 및 핸들러 내부의 취소는 그대로 전파합니다. */
 internal suspend fun <T: Any> withTimeLimiterPreservingStatusMapping(
     timeLimiter: TimeLimiter,
     block: suspend () -> T,
 ): T {
     return try {
-        val result = withTimeout(timeLimiter.timeLimiterConfig.timeoutDuration.toMillis()) {
+        val result = withTimeoutOrNull(timeLimiter.timeLimiterConfig.timeoutDuration.toMillis()) {
             block()
-        }
+        } ?: throw TimeLimiter.createdTimeoutExceptionWithName(timeLimiter.name, null)
         timeLimiter.onSuccess()
         result
-    } catch (e: TimeoutCancellationException) {
-        val timeout = TimeLimiter.createdTimeoutExceptionWithName(timeLimiter.name, e)
-        timeLimiter.onError(timeout)
-        throw timeout
     } catch (e: CancellationException) {
         throw e
     } catch (e: Throwable) {

--- a/ktor/resilience4j/src/test/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupportTest.kt
+++ b/ktor/resilience4j/src/test/kotlin/io/bluetape4k/ktor/resilience4j/KtorResilienceSupportTest.kt
@@ -29,6 +29,10 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -250,6 +254,38 @@ class KtorResilienceSupportTest {
 
         circuitBreaker.metrics.numberOfFailedCalls shouldBeEqualTo 0
         circuitBreaker.state shouldBeEqualTo CircuitBreaker.State.CLOSED
+    }
+
+    @Test
+    fun `상위 timeout을 정책 실패로 변환하지 않는다`() = runTest(timeout = 30.seconds) {
+        val limiter = TimeLimiter.of(
+            "outer", TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(5)).build()
+        )
+        val events = AtomicInteger()
+        limiter.eventPublisher.onTimeout { events.incrementAndGet() }
+        limiter.eventPublisher.onError { events.incrementAndGet() }
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(30) {
+                withKtorResilience(KtorResiliencePolicies(timeLimiter = limiter)) { delay(1_000) }
+            }
+        }
+        events.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `핸들러 내부 timeout을 정책 실패로 변환하지 않는다`() = runTest(timeout = 30.seconds) {
+        val limiter = TimeLimiter.of(
+            "nested", TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(5)).build()
+        )
+        val events = AtomicInteger()
+        limiter.eventPublisher.onTimeout { events.incrementAndGet() }
+        limiter.eventPublisher.onError { events.incrementAndGet() }
+        assertFailsWith<TimeoutCancellationException> {
+            withKtorResilience(KtorResiliencePolicies(timeLimiter = limiter)) {
+                withTimeout(30) { delay(1_000) }
+            }
+        }
+        events.get() shouldBeEqualTo 0
     }
 
     private fun io.ktor.server.application.Application.installResilienceTestStatusPages() {


### PR DESCRIPTION
## 요약

Fixes #1692

상위 요청과 handler 내부의 timeout을 TimeLimiter 실패로 오인하지 않고 원래 취소로 전파합니다.

## 배경과 변경

#1701 모듈별 리뷰의 후속 수정입니다. withTimeoutOrNull로 TimeLimiter 자신의 timeout만 식별합니다. 외부·중첩 취소에는 정책 실패 이벤트를 기록하지 않으며 기존 정책 timeout 매핑은 유지합니다.

## 검증

- 변경 전: 외부/중첩 TimeoutCancellationException이 TimeoutException으로 바뀌어 두 회귀 테스트 실패
- 변경 후: Ktor resilience4j 전체 11개 테스트 및 detekt 통과
- `:bluetape4k-ktor-resilience4j:test :bluetape4k-ktor-resilience4j:detekt --no-configuration-cache`
- 가상 시간과 명시적 runTest timeout으로 취소 소유권과 이벤트 0건 검증
- `git diff --check` 통과

## 리뷰 참고

- 독립 코드 리뷰: `code-reviewer`, `gpt-5.6-luna`, `max`. 소스·호출자·API·회귀 테스트·문서를 검토했으며 P0/P1은 0건입니다.
- 리뷰 P2의 테스트 timeout 명시를 반영했습니다. detekt의 기존 광범위 catch 진단은 남아 있으며 실행 성공이 진단 0건이라는 의미는 아닙니다.
- 교훈: `docs/lessons/2026-09-08-timeout-ownership.md`. 격리 GNO 인덱스에서 추가와 검색을 검증했으며, 머지 후 기본 develop 파일의 GNO 갱신과 대표 검색도 확인했습니다.
- README EN/KO 계약 대조와 한국어 문서 검토를 완료했습니다.

## 메타데이터

- 이슈: #1692; milestone `2.1.0`; 담당자 `debop`
- 저장소: `bluetape4k/bluetape4k-projects`; base `develop`; head `fix/1692-timeout-ownership`
- 커밋: `5b81fb6348de9450078a45ad9ef31e4176b7caab`; 로컬/원격 SHA 일치 확인
- CI: 현재 head에서 12개 job 성공. 변경 경로 밖 12개 job은 실행 대상 제외이며 테스트 통과로 계산하지 않습니다. [검증 실행](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34187635889). 다른 자식 PR과 함께 마지막에 머지합니다.

- 머지 커밋: `e8eccc4b6fa04efadf5ba146ddc157b410cacc47`; 연결 이슈 CLOSED 확인
- 로컬 develop/upstream: `ca87d3f3c8a373f977f1ec2178803c2923b3ed2f`, clean; 9개 머지 커밋 포함 확인. 브랜치와 worktree는 보존했습니다.

## DoD Status

Required checks: 28/28; N/A: 1; Blocked: 0

| Check | 수행 내용 | 상태 | 근거 / 다음 작업 |
|---|---|---|---|
| CG-01 | 기준 정보와 승인 범위 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-02 | GNO 이력 및 live 이슈 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-03 | 독립 worktree와 이슈별 브랜치 | PASS | 위 검증 및 현재 커밋 |
| CG-04 | 한국어 GitHub 및 README 언어 정책 | PASS | 위 검증 및 현재 커밋 |
| CG-05 | 기존 Kotlin 패턴 재사용 | PASS | 위 검증 및 현재 커밋 |
| CG-06 | 공개 계약과 README EN/KO 대조 | PASS | 위 검증 및 현재 커밋 |
| CG-07 | RED/GREEN 및 영향 모듈 테스트 | PASS | 위 검증 및 현재 커밋 |
| CG-08 | 무거운 검증 순차 실행 | PASS | 위 검증 및 현재 커밋 |
| CG-09 | 교훈 기록과 격리 인덱스 검색 | PASS | 위 검증 및 현재 커밋 |
| CG-10 | 최종 리뷰와 검증 후 커밋 | PASS | 위 검증 및 현재 커밋 |
| CG-11 | 승인된 저장소/base/head PR 생성 범위 | PASS | 위 검증 및 현재 커밋 |
| CG-12 | 정확한 head push 및 원격 조회 | PASS | 위 검증 및 현재 커밋 |
| CG-12A | AGENTS 계층·leaf·common·template·이슈 재조회 | PASS | 위 검증 및 현재 커밋 |
| CG-13 | PR 생성과 메타데이터 live 조회 | PASS | live URL, head SHA, 담당자/라벨/milestone/본문 확인 |
| CG-14 | head CI와 최신 리뷰/스레드 확인 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| CG-15 | 정확한 head의 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| CG-16 | 마지막 일괄 머지의 새 승인 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-17 | 승인된 head 머지와 결과 검증 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-18 | 머지 후 로컬 동기화 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| C-01 | 원인과 영향 범위 확인 | PASS | 위 회귀 테스트와 검토 근거 |
| C-02 | 이슈별 수정 범위 확정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-03 | 결함 재현 RED | PASS | 위 회귀 테스트와 검토 근거 |
| C-04 | 최소 수정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-05 | GREEN 및 영향 검증 | PASS | 위 회귀 테스트와 검토 근거 |
| C-06 | 교훈과 재발 방지 | PASS | 위 회귀 테스트와 검토 근거 |
| C-07 | PR CI/리뷰 수렴 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| C-08 | 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| C-09 | 승인 후 최종 완료 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |

별도 인간 리뷰: N/A (single-developer lane, debop 단독 유지관리 범위). CI와 코드 리뷰는 필수입니다.

Final status: DONE — 승인된 head squash merge 및 develop 동기화 완료

Unchecked required items: 없음
