### PR TITLE
fix: memoizer clear 이후 이전 계산의 캐시 재등록 방지

### DIFF
--- a/cache/cache-core/README.ko.md
+++ b/cache/cache-core/README.ko.md
@@ -536,3 +536,7 @@ class ResilientMyProviderTest : AbstractNearCacheOperationsTest<String>() {
     override fun anotherValue(): String = "world"
 }
 ```
+
+## 실패와 생명주기 계약
+
+Caffeine suspend, Hazelcast suspend, Redisson suspend/async memoizer는 캐시 저장과 clear의 순서를 보장합니다. clear 이전 계산은 원래 호출자에게 결과를 반환할 수 있지만 캐시를 다시 채우거나 새 세대 값을 덮어쓰지 않습니다. 이 보장은 같은 memoizer 인스턴스에 한정되며 분산 무효화 프로토콜은 아닙니다.

--- a/cache/cache-core/README.md
+++ b/cache/cache-core/README.md
@@ -328,3 +328,7 @@ val value = memo("recover")      // recomputes and returns 7
 ## `testFixtures` Usage Guide
 
 `cache-core` is also suitable for shared test helpers and fixtures in modules that need consistent cache contracts during tests. Reuse the abstractions from this module rather than duplicating provider-neutral helpers in each backend-specific module.
+
+## Failure and lifecycle contract
+
+The affected Caffeine suspend, Hazelcast suspend, and Redisson suspend/async memoizers order cache publication with clear. An evaluation started before clear can still return to its original caller, but cannot repopulate the cleared cache or overwrite a newer generation. This guarantee is local to the memoizer instance, not a distributed invalidation protocol.

--- a/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineSuspendMemoizer.kt
+++ b/cache/cache-core/src/main/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineSuspendMemoizer.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.cache.memoizer.caffeine
 import com.github.benmanes.caffeine.cache.Cache
 import io.bluetape4k.cache.memoizer.SuspendMemoizer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -42,6 +43,9 @@ fun <T: Any, R: Any> (suspend (T) -> R).withSuspendMemoizer(cache: Cache<T, R>):
  * 단순 getIfPresent + put 패턴은 동시 호출 시 동일 키에 대해 evaluator가 여러 번 실행될 수 있다.
  * `Caffeine.computeIfAbsent`는 suspend 람다를 지원하지 않으므로 per-key [Deferred] 패턴을 사용한다.
  *
+ * `clear`는 이전 계산의 저장 권한만 폐기하며, 진행 중인 호출은 계산 결과를 그대로 받습니다.
+ * 저장과 삭제는 같은 Mutex로 순서를 보장합니다.
+ *
  * ## 재귀 안전성
  * 전역 Mutex를 evaluator 실행 중에 보유하면 재귀 memoizer(factorial, fibonacci)에서 데드락이 발생한다.
  * Kotlin Mutex는 재진입(reentrant)을 지원하지 않기 때문이다.
@@ -63,6 +67,7 @@ class CaffeineSuspendMemoizer<T: Any, R: Any>(
     // Kotlin Mutex는 재진입을 지원하지 않아 재귀 evaluator에서 데드락이 발생하므로 이 방식을 택한다.
     private val inflightMap = ConcurrentHashMap<T, Deferred<R>>()
     private val clearMutex = Mutex()
+    private var generation = 0L
 
     override suspend fun invoke(input: T): R {
         // 1단계: 빠른 경로 — 이미 캐시된 결과는 lock/Deferred 없이 즉시 반환
@@ -73,15 +78,20 @@ class CaffeineSuspendMemoizer<T: Any, R: Any>(
         // evaluator는 Deferred 내부에서 실행되므로 lock을 보유하지 않아 재귀 호출이 안전하다.
         return coroutineScope {
             var createdByThisCall = false
-            val deferred = inflightMap.computeIfAbsent(input) {
-                createdByThisCall = true
-                async {
-                    evaluator(input)
+            var capturedGeneration = 0L
+            val deferred = clearMutex.withLock {
+                capturedGeneration = generation
+                inflightMap.computeIfAbsent(input) {
+                    createdByThisCall = true
+                    async(start = CoroutineStart.LAZY) { evaluator(input) }
                 }
             }
+            deferred.start()
             try {
                 val result = deferred.await()
-                cache.put(input, result)
+                clearMutex.withLock {
+                    if (capturedGeneration == generation) cache.put(input, result)
+                }
                 result
             } finally {
                 // 실패/취소된 Deferred를 제거해야 같은 키의 다음 호출이 새 계산으로 복구할 수 있다.
@@ -94,6 +104,7 @@ class CaffeineSuspendMemoizer<T: Any, R: Any>(
 
     override suspend fun clear() {
         clearMutex.withLock {
+            generation++
             inflightMap.clear()
             // cleanUp()은 만료된 항목만 제거하므로, 전체 초기화에는 invalidateAll()을 사용해야 한다.
             cache.invalidateAll()

--- a/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineSuspendMemoizerTest.kt
+++ b/cache/cache-core/src/test/kotlin/io/bluetape4k/cache/memoizer/caffeine/CaffeineSuspendMemoizerTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.cache.memoizer.caffeine
 
+import io.bluetape4k.cache.memoizer.verifySuspendMemoizerClear
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import io.bluetape4k.cache.caffeine.cache
@@ -47,6 +48,14 @@ class CaffeineSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
      * clear()는 cleanUp()이 아닌 invalidateAll()을 호출해야 한다.
      * cleanUp()은 만료된 항목만 제거하므로 아직 살아있는 항목은 남아 있게 된다.
      */
+    @Test
+    fun `clear 이전 계산은 캐시를 다시 채우거나 새 값을 덮어쓰지 않는다`() = runSuspendDefault {
+        listOf(false, true).forEach { newFirst ->
+            val local = caffeine.cache<Int, Int>()
+            verifySuspendMemoizerClear(newFirst, { local.suspendMemoizer(it) }, { local.getIfPresent(1) })
+        }
+    }
+
     @Test
     fun `clear - 살아있는 캐시 항목도 모두 제거된다`() = runSuspendDefault {
         val localCache = caffeine.cache<String, Int>()

--- a/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/memoizer/SuspendMemoizerClearContract.kt
+++ b/cache/cache-core/src/testFixtures/kotlin/io/bluetape4k/cache/memoizer/SuspendMemoizerClearContract.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.cache.memoizer
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * 이전 계산과 clear의 순서를 고정해 stale 저장과 새 세대 덮어쓰기를 검증합니다.
+ * 스트레스 테스터와 달리 두 장벽으로 결함이 발생하는 순서를 결정적으로 재현합니다.
+ */
+suspend fun verifySuspendMemoizerClear(
+    publishNewBeforeOld: Boolean,
+    create: (suspend (Int) -> Int) -> SuspendMemoizer<Int, Int>,
+    read: suspend () -> Int?,
+) = coroutineScope {
+    val started = CompletableDeferred<Unit>()
+    val release = CompletableDeferred<Unit>()
+    val calls = AtomicInteger()
+    val memo = create {
+        if (calls.incrementAndGet() == 1) {
+            started.complete(Unit)
+            release.await()
+            10
+        } else 20
+    }
+    val old = async { memo(1) }
+    try {
+        withTimeout(5_000) { started.await() }
+        memo.clear()
+        read().shouldBeNull()
+        if (publishNewBeforeOld) withTimeout(5_000) { memo(1) } shouldBeEqualTo 20
+        release.complete(Unit)
+        withTimeout(5_000) { old.await() } shouldBeEqualTo 10
+        if (publishNewBeforeOld) read() shouldBeEqualTo 20 else read().shouldBeNull()
+        memo(1) shouldBeEqualTo 20
+        calls.get() shouldBeEqualTo 2
+    } finally {
+        release.complete(Unit)
+        old.cancelAndJoin()
+    }
+}

--- a/cache/cache-hazelcast/README.ko.md
+++ b/cache/cache-hazelcast/README.ko.md
@@ -399,3 +399,7 @@ com.hazelcast.cache.HazelcastCachingProvider
 ```kotlin
 val provider = Caching.getCachingProvider("com.hazelcast.cache.HazelcastCachingProvider")
 ```
+
+## 실패와 생명주기 계약
+
+Caffeine suspend, Hazelcast suspend, Redisson suspend/async memoizer는 캐시 저장과 clear의 순서를 보장합니다. clear 이전 계산은 원래 호출자에게 결과를 반환할 수 있지만 캐시를 다시 채우거나 새 세대 값을 덮어쓰지 않습니다. 이 보장은 같은 memoizer 인스턴스에 한정되며 분산 무효화 프로토콜은 아닙니다.

--- a/cache/cache-hazelcast/README.md
+++ b/cache/cache-hazelcast/README.md
@@ -192,3 +192,7 @@ Resilient configuration extends the normal near-cache configuration with queue s
 ## Registered `CachingProvider` List
 
 When multiple JCache providers are present on the classpath, explicitly choose the Hazelcast provider when needed, especially in Spring or shared umbrella-module setups.
+
+## Failure and lifecycle contract
+
+The affected Caffeine suspend, Hazelcast suspend, and Redisson suspend/async memoizers order cache publication with clear. An evaluation started before clear can still return to its original caller, but cannot repopulate the cleared cache or overwrite a newer generation. This guarantee is local to the memoizer instance, not a distributed invalidation protocol.

--- a/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/memoizer/HazelcastSuspendMemoizer.kt
+++ b/cache/cache-hazelcast/src/main/kotlin/io/bluetape4k/cache/memoizer/HazelcastSuspendMemoizer.kt
@@ -3,6 +3,9 @@ package io.bluetape4k.cache.memoizer
 import com.hazelcast.map.IMap
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -69,12 +72,17 @@ class SuspendHazelcastMemoizer<K: Any, V: Any>(
     companion object: KLoggingChannel()
 
     private val inFlight = ConcurrentHashMap<K, Deferred<V>>()
+    // evaluator는 lock 밖에서 실행하고, 세대 변경과 캐시 저장/삭제만 직렬화합니다.
+    private val mutationMutex = Mutex()
+    private var generation = 0L
 
     override suspend fun invoke(key: K): V {
-        inFlight[key]?.let { return it.await() }
-
         val deferred = CompletableDeferred<V>()
-        val existing = inFlight.putIfAbsent(key, deferred)
+        var capturedGeneration = 0L
+        val existing = mutationMutex.withLock {
+            capturedGeneration = generation
+            inFlight.putIfAbsent(key, deferred)
+        }
         if (existing != null) return existing.await()
 
         try {
@@ -85,9 +93,16 @@ class SuspendHazelcastMemoizer<K: Any, V: Any>(
             }
 
             val evaluated = evaluator(key)
-            val winner = withContext(Dispatchers.IO) { imap.putIfAbsent(key, evaluated) } ?: evaluated
+            val winner = mutationMutex.withLock {
+                if (capturedGeneration == generation) {
+                    withContext(Dispatchers.IO) { imap.putIfAbsent(key, evaluated) } ?: evaluated
+                } else evaluated
+            }
             deferred.complete(winner)
             return winner
+        } catch (e: CancellationException) {
+            deferred.completeExceptionally(e)
+            throw e
         } catch (e: Throwable) {
             deferred.completeExceptionally(e)
             throw e
@@ -98,6 +113,10 @@ class SuspendHazelcastMemoizer<K: Any, V: Any>(
 
     override suspend fun clear() {
         log.debug { "모든 메모이제이션 값 삭제: map=${imap.name}" }
-        withContext(Dispatchers.IO) { imap.clear() }
+        mutationMutex.withLock {
+            generation++
+            inFlight.clear()
+            withContext(Dispatchers.IO) { imap.clear() }
+        }
     }
 }

--- a/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/memoizer/HazelcastSuspendMemoizerTest.kt
+++ b/cache/cache-hazelcast/src/test/kotlin/io/bluetape4k/cache/memoizer/HazelcastSuspendMemoizerTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.cache.memoizer
 
+import io.bluetape4k.cache.memoizer.verifySuspendMemoizerClear
 import com.hazelcast.map.IMap
 import io.bluetape4k.cache.HazelcastServers.hazelcastClient
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -39,6 +40,22 @@ class HazelcastSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
     override val fibonacci = object: SuspendFibonacciProvider {
         override val cachedCalc: suspend (Long) -> Long = newMap<Long, Long>("fibonacci")
             .suspendMemoizer { calc(it) }
+    }
+
+    @Test
+    fun `clear 이전 계산은 캐시를 다시 채우거나 새 값을 덮어쓰지 않는다`() = runSuspendIO {
+        listOf(false, true).forEach { newFirst ->
+            val local = newMap<Int, Int>()
+            try {
+                verifySuspendMemoizerClear(
+                    newFirst,
+                    { local.suspendMemoizer(it) },
+                    { local.getAsync(1).toCompletableFuture().get() },
+                )
+            } finally {
+                local.destroy()
+            }
+        }
     }
 
     @Test

--- a/cache/cache-redisson/README.ko.md
+++ b/cache/cache-redisson/README.ko.md
@@ -155,3 +155,7 @@ evaluator가 실패하거나 취소되면 in-flight 항목은 예외 완료 후 
 - native near-cache read/write/clear/stat 동작.
 - `MultithreadingTester`, `StructuredTaskScopeTester`, `SuspendedJobTester` 기반 memoizer thread, virtual-thread, coroutine 경합.
 - suspend memoizer evaluator 실패, 명시적 cancellation, 실제 `Job.cancel()` 복구.
+
+## 실패와 생명주기 계약
+
+Caffeine suspend, Hazelcast suspend, Redisson suspend/async memoizer는 캐시 저장과 clear의 순서를 보장합니다. clear 이전 계산은 원래 호출자에게 결과를 반환할 수 있지만 캐시를 다시 채우거나 새 세대 값을 덮어쓰지 않습니다. 이 보장은 같은 memoizer 인스턴스에 한정되며 분산 무효화 프로토콜은 아닙니다.

--- a/cache/cache-redisson/README.md
+++ b/cache/cache-redisson/README.md
@@ -157,3 +157,7 @@ Relevant test coverage includes:
 - Native near-cache read/write/clear/stat behavior.
 - Memoizer thread, virtual-thread, and coroutine contention using `MultithreadingTester`, `StructuredTaskScopeTester`, and `SuspendedJobTester`.
 - Suspend memoizer evaluator failure, explicit cancellation, and real `Job.cancel()` recovery.
+
+## Failure and lifecycle contract
+
+The affected Caffeine suspend, Hazelcast suspend, and Redisson suspend/async memoizers order cache publication with clear. An evaluation started before clear can still return to its original caller, but cannot repopulate the cleared cache or overwrite a newer generation. This guarantee is local to the memoizer instance, not a distributed invalidation protocol.

--- a/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/memoizer/RedissonAsyncMemoizer.kt
+++ b/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/memoizer/RedissonAsyncMemoizer.kt
@@ -7,6 +7,11 @@ import org.redisson.api.RMap
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CompletionException
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * [RMap]을 사용하는 비동기 메모이저 확장 함수입니다.
@@ -65,6 +70,9 @@ class RedissonAsyncMemoizer<T: Any, R: Any>(
     companion object: KLoggingChannel()
 
     private val inFlight = ConcurrentHashMap<T, CompletableFuture<R>>()
+    private val registrationLock = ReentrantLock()
+    private val generation = AtomicLong()
+    private val mutationTail = AtomicReference(CompletableFuture.completedFuture(Unit))
 
     /**
      * 주어진 [key]에 대한 비동기 결과를 반환한다.
@@ -79,7 +87,11 @@ class RedissonAsyncMemoizer<T: Any, R: Any>(
     override fun invoke(key: T): CompletableFuture<R> {
         // 1. in-flight 확인 또는 신규 등록
         val promise = CompletableFuture<R>()
-        val existing = inFlight.putIfAbsent(key, promise)
+        var capturedGeneration = 0L
+        val existing = registrationLock.withLock {
+            capturedGeneration = generation.get()
+            inFlight.putIfAbsent(key, promise)
+        }
         if (existing != null) return existing
 
         // 2. Redis에서 캐시 조회 후, miss 시 evaluator 실행 (Virtual Thread-safe)
@@ -101,8 +113,11 @@ class RedissonAsyncMemoizer<T: Any, R: Any>(
                                         inFlight.remove(key, promise)
                                         promise.completeExceptionally(evalError)
                                     } else {
-                                        map.putIfAbsentAsync(key, value)
-                                            .whenComplete { _, putError ->
+                                        enqueueMutation {
+                                            if (capturedGeneration == generation.get()) {
+                                                map.putIfAbsentAsync(key, value)
+                                            } else CompletableFuture.completedFuture(null)
+                                        }.whenComplete { _, putError ->
                                                 if (putError != null) {
                                                     log.warn(putError) {
                                                         "Failed to cache value: map=${map.name}, key=$key"
@@ -133,7 +148,29 @@ class RedissonAsyncMemoizer<T: Any, R: Any>(
      */
     override fun clear() {
         log.debug { "모든 메모이제이션 값 삭제: map=${map.name}" }
-        inFlight.clear()
-        map.clear()
+        try {
+            enqueueMutation {
+                registrationLock.withLock {
+                    generation.incrementAndGet()
+                    inFlight.clear()
+                }
+                map.clearAsync()
+            }.join()
+        } catch (e: CompletionException) {
+            throw e.cause ?: e
+        }
+    }
+
+    /** callback을 기다리며 스레드 lock을 보유하지 않고 서버 쓰기/삭제 완료 순서를 보장합니다. */
+    private fun enqueueMutation(action: () -> CompletionStage<*>): CompletableFuture<Unit> {
+        val completion = CompletableFuture<Unit>()
+        val previous = mutationTail.getAndSet(completion)
+        previous.handle { _, _ -> Unit }
+            .thenCompose { action().toCompletableFuture().thenApply { Unit } }
+            .whenComplete { _, error ->
+                if (error == null) completion.complete(Unit)
+                else completion.completeExceptionally(error)
+            }
+        return completion
     }
 }

--- a/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendMemoizer.kt
+++ b/cache/cache-redisson/src/main/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendMemoizer.kt
@@ -3,8 +3,14 @@ package io.bluetape4k.cache.memoizer
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.future.await
 import org.redisson.api.RMap
 import java.util.concurrent.ConcurrentHashMap
@@ -78,6 +84,9 @@ class RedissonSuspendMemoizer<T: Any, R: Any>(
     companion object: KLoggingChannel()
 
     private val inFlight = ConcurrentHashMap<T, Deferred<R>>()
+    // evaluator는 lock 밖에서 실행하고, 세대 변경과 캐시 저장/삭제만 직렬화합니다.
+    private val mutationMutex = Mutex()
+    private var generation = 0L
 
     /**
      * 주어진 [key]에 대한 결과를 suspend 방식으로 반환한다.
@@ -91,10 +100,12 @@ class RedissonSuspendMemoizer<T: Any, R: Any>(
      * @return 키에 대응하는 값
      */
     override suspend fun invoke(key: T): R {
-        inFlight[key]?.let { return it.await() }
-
         val deferred = CompletableDeferred<R>()
-        val existing = inFlight.putIfAbsent(key, deferred)
+        var capturedGeneration = 0L
+        val existing = mutationMutex.withLock {
+            capturedGeneration = generation
+            inFlight.putIfAbsent(key, deferred)
+        }
         if (existing != null) return existing.await()
 
         try {
@@ -105,7 +116,13 @@ class RedissonSuspendMemoizer<T: Any, R: Any>(
             }
 
             val evaluated = evaluator(key)
-            val winner = map.putIfAbsentAsync(key, evaluated).await() ?: evaluated
+            val winner = mutationMutex.withLock {
+                if (capturedGeneration == generation) {
+                    // 서버 쓰기가 끝나기 전에 취소로 lock을 풀면 clear와 순서가 뒤집힐 수 있습니다.
+                    withContext(NonCancellable) { map.putIfAbsentAsync(key, evaluated).await() } ?: evaluated
+                } else evaluated
+            }
+            currentCoroutineContext().ensureActive()
             deferred.complete(winner)
             return winner
         } catch (e: CancellationException) {
@@ -125,6 +142,11 @@ class RedissonSuspendMemoizer<T: Any, R: Any>(
      */
     override suspend fun clear() {
         log.debug { "모든 메모이제이션 값 삭제: map=${map.name}" }
-        map.clearAsync().await()
+        mutationMutex.withLock {
+            generation++
+            inFlight.clear()
+            withContext(NonCancellable) { map.clearAsync().await() }
+        }
+        currentCoroutineContext().ensureActive()
     }
 }

--- a/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/memoizer/RedissonAsyncMemoizerTest.kt
+++ b/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/memoizer/RedissonAsyncMemoizerTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.cache.RedisServers.redisson
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeLessThan
 import org.awaitility.kotlin.await
@@ -45,6 +46,37 @@ class RedissonAsyncMemoizerTest: AbstractAsyncMemoizerTest() {
         override val cachedCalc: (Long) -> CompletableFuture<Long> = redisson
             .getMap<Long, Long>("asyncMemoizer:fibonacci", LongCodec())
             .asyncMemoizer { calc(it) }
+    }
+
+    @Test
+    fun `clear 이전 Future는 캐시를 다시 채우거나 새 값을 덮어쓰지 않는다`() {
+        listOf(false, true).forEach { newFirst ->
+            val local = redisson.getMap<Int, Int>(randomName(), IntegerCodec())
+            val started = CompletableFuture<Unit>()
+            val release = CompletableFuture<Int>()
+            val calls = AtomicInteger()
+            val memo = local.asyncMemoizer {
+                if (calls.incrementAndGet() == 1) {
+                    started.complete(Unit)
+                    release
+                } else CompletableFuture.completedFuture(20)
+            }
+            val old = memo(1)
+            try {
+                started.get(5, TimeUnit.SECONDS)
+                memo.clear()
+                local[1].shouldBeNull()
+                if (newFirst) memo(1).get(5, TimeUnit.SECONDS) shouldBeEqualTo 20
+                release.complete(10)
+                old.get(5, TimeUnit.SECONDS) shouldBeEqualTo 10
+                if (newFirst) local[1] shouldBeEqualTo 20 else local[1].shouldBeNull()
+                memo(1).get(5, TimeUnit.SECONDS) shouldBeEqualTo 20
+                calls.get() shouldBeEqualTo 2
+            } finally {
+                release.complete(10)
+                local.delete()
+            }
+        }
     }
 
     @Test

--- a/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendMemoizerTest.kt
+++ b/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendMemoizerTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.cache.memoizer
 
+import io.bluetape4k.cache.memoizer.verifySuspendMemoizerClear
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.cache.RedisServers.randomName
@@ -43,6 +44,22 @@ class RedissonSuspendMemoizerTest: AbstractSuspendMemoizerTest() {
         override val cachedCalc: suspend (Long) -> Long = redisson
             .getMap<Long, Long>("suspend:memoizer:fibonacci", LongCodec())
             .suspendMemoizer { calc(it) }
+    }
+
+    @Test
+    fun `clear 이전 계산은 캐시를 다시 채우거나 새 값을 덮어쓰지 않는다`() = runSuspendIO {
+        listOf(false, true).forEach { newFirst ->
+            val local = redisson.getMap<Int, Int>(randomName(), IntegerCodec())
+            try {
+                verifySuspendMemoizerClear(
+                    newFirst,
+                    { local.suspendMemoizer(it) },
+                    { local.getAsync(1).toCompletableFuture().get() },
+                )
+            } finally {
+                local.delete()
+            }
+        }
     }
 
     @Test

--- a/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendPublicationCancellationTest.kt
+++ b/cache/cache-redisson/src/test/kotlin/io/bluetape4k/cache/memoizer/RedissonSuspendPublicationCancellationTest.kt
@@ -1,0 +1,77 @@
+package io.bluetape4k.cache.memoizer
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Test
+import org.redisson.api.RMap
+import org.redisson.misc.CompletableFutureWrapper
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RedissonSuspendPublicationCancellationTest {
+
+    @Test
+    fun `저장 중 취소는 서버 완료를 기다리되 호출자에게 값을 반환하지 않는다`() = runTest(timeout = 30.seconds) {
+        val map = mockk<RMap<Int, Int>>()
+        val put = CompletableFuture<Int?>()
+        every { map.name } returns "cancellation-test"
+        every { map.getAsync(1) } returns CompletableFutureWrapper(CompletableFuture.completedFuture(null))
+        every { map.putIfAbsentAsync(1, 10) } returns CompletableFutureWrapper(put)
+        every { map.clearAsync() } returns CompletableFutureWrapper(CompletableFuture.completedFuture(null))
+        val returned = AtomicBoolean()
+        val memo = RedissonSuspendMemoizer(map) { 10 }
+        val caller = launch {
+            memo(1)
+            returned.set(true)
+        }
+        try {
+            runCurrent()
+            verify(exactly = 1) { map.putIfAbsentAsync(1, 10) }
+            caller.cancel()
+            val clear = async { memo.clear() }
+            runCurrent()
+            verify(exactly = 0) { map.clearAsync() }
+            put.complete(null)
+            caller.join()
+            clear.await()
+            returned.get().shouldBeFalse()
+            verify(exactly = 1) { map.clearAsync() }
+        } finally {
+            put.complete(null)
+        }
+    }
+
+    @Test
+    fun `삭제 중 취소도 서버 완료 후 호출자에게 전파한다`() = runTest(timeout = 30.seconds) {
+        val map = mockk<RMap<Int, Int>>()
+        val deletion = CompletableFuture<Boolean>()
+        every { map.name } returns "clear-cancellation-test"
+        every { map.clearAsync() } returns CompletableFutureWrapper(deletion)
+        val returned = AtomicBoolean()
+        val memo = RedissonSuspendMemoizer(map) { 10 }
+        val caller = launch {
+            memo.clear()
+            returned.set(true)
+        }
+        try {
+            runCurrent()
+            verify(exactly = 1) { map.clearAsync() }
+            caller.cancel()
+            deletion.complete(true)
+            caller.join()
+            returned.get().shouldBeFalse()
+        } finally {
+            deletion.complete(true)
+        }
+    }
+
+}

--- a/docs/lessons/2026-09-08-memoizer-clear.md
+++ b/docs/lessons/2026-09-08-memoizer-clear.md
@@ -1,0 +1,27 @@
+# clear와 이전 계산의 저장 순서를 보장한다
+
+관련 이슈: https://github.com/bluetape4k/bluetape4k-projects/issues/1694
+
+## 실패한 가정과 근거
+
+Caffeine, Hazelcast, Redisson suspend/async 모두 clear 뒤 이전 값 10이 다시 저장됐다.
+
+## 결정
+
+계산은 잠금 밖에서 실행한다. 세대 확인과 저장, 세대 변경과 삭제를 동일한 순서 경계에 둔다. suspend는 Mutex, async는 완료 순서를 연결한 Future를 사용한다.
+
+## 재발 방지
+
+세대 번호 확인 직후 clear가 끼어드는 순서를 고려한다. 이전 호출 결과, backing cache 부재, 새 세대 값 보존을 별도로 검증한다. 보장 범위는 같은 memoizer 인스턴스이며 다중 JVM 무효화가 아니다.
+
+## 검증
+
+이 PR의 회귀 테스트에서 수정 전 동작 실패를 확인했다. 수정 후 테스트와 관련 모듈 검증 결과는 PR의 `DoD Status`에 기록한다.
+
+## 리뷰에서 보완한 취소 계약
+
+서버 연산의 순서를 지키려고 NonCancellable을 사용하면 원래 호출자의 취소가 자동으로 복구된다는 가정은 틀리다. 저장 중 취소 회귀 테스트에서 호출자가 값을 받은 것으로 확인됐다. 서버 연산 완료 후 ensureActive로 취소를 다시 전파하며 저장과 삭제 양쪽을 테스트한다. 원격 mutation 직렬화는 서로 다른 키의 쓰기 처리량을 제한하므로 성능 변경 시 순서 테스트와 별도 측정을 함께 수행한다.
+
+## 테스트 fixture의 실패 시 종료
+
+여러 테스트가 같은 mock 호출 이력을 공유하면 순서 검증이 오염된다. 수동 완료 Future를 NonCancellable 작업에 연결한 테스트는 assertion 실패 시에도 finally에서 Future를 완료해야 테스트 종료를 보장할 수 있다. 테스트별 mock과 명시적 timeout을 사용하고, success 경로 외의 정리 경로도 점검한다.


### PR DESCRIPTION
## 요약

Fixes #1694

Caffeine·Hazelcast·Redisson 메모이저에서 clear 이전에 시작한 계산이 캐시를 다시 채우거나 이후 계산 값을 덮어쓰지 않도록 저장 순서를 보장합니다.

## 배경과 변경

#1701 모듈별 리뷰의 후속 수정입니다. 기존 호출은 계산 결과를 받을 수 있지만 이전 세대의 값은 저장하지 않습니다. 세대 확인과 저장/삭제를 함께 직렬화하고 공통 suspend 테스트 fixture로 두 완료 순서를 검증합니다. Redisson 원격 연산은 완료를 기다린 뒤 원래 호출자의 취소를 전파합니다.

## 검증

- 변경 전: 네 backend 경로에서 clear 후 이전 값이 backing cache에 남아 회귀 테스트 실패
- 변경 후: cache-core 720개, cache-hazelcast 230개, cache-redisson 446개 전체 테스트 통과
- 세 모듈 `test`, `detekt --no-configuration-cache` 순차 실행
- Redisson 저장 중 취소 RED 후 ensureActive 보완; 저장·삭제 취소 계약 GREEN
- `BLUETAPE4K_MANUAL_ROOT`에 기존 central manual checkout을 지정해 문서 계약 테스트까지 실행
- `git diff --check` 통과

## 리뷰 참고

- 독립 코드 리뷰: `code-reviewer`, `gpt-5.6-luna`, `max`. 소스·호출자·API·회귀 테스트·문서를 검토했으며 P0/P1은 0건입니다.
- architect의 취소 전파 P1을 수정했고 code-reviewer P0/P1은 0건입니다. P2 테스트 map 정리를 반영했습니다. 원격 mutation 직렬화는 서로 다른 키의 쓰기 처리량을 제한할 수 있습니다. 정합성을 우선한 선택이며 성능 개선을 주장하지 않습니다. 기존 detekt 진단은 전체 제거하지 않았습니다.
- 교훈: `docs/lessons/2026-09-08-memoizer-clear.md`. 격리 GNO 인덱스에서 추가와 검색을 검증했으며, 머지 후 기본 develop 파일의 GNO 갱신과 대표 검색도 확인했습니다.
- README EN/KO 계약 대조와 한국어 문서 검토를 완료했습니다.

## 메타데이터

- 이슈: #1694; milestone `2.1.0`; 담당자 `debop`
- 저장소: `bluetape4k/bluetape4k-projects`; base `develop`; head `fix/1694-memoizer-clear`
- 커밋: `f641aaa6c5ff171c260a6ec170d55f09299cd63e`; 로컬/원격 SHA 일치 확인
- CI: 현재 head에서 13개 job 성공. 변경 경로 밖 11개 job은 실행 대상 제외이며 테스트 통과로 계산하지 않습니다. [검증 실행](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34187778815). 다른 자식 PR과 함께 마지막에 머지합니다.

- 머지 커밋: `a5a7fc0c78fd5a5ab6dced2d543b36c71babf03b`; 연결 이슈 CLOSED 확인
- 로컬 develop/upstream: `ca87d3f3c8a373f977f1ec2178803c2923b3ed2f`, clean; 9개 머지 커밋 포함 확인. 브랜치와 worktree는 보존했습니다.

## DoD Status

Required checks: 28/28; N/A: 1; Blocked: 0

| Check | 수행 내용 | 상태 | 근거 / 다음 작업 |
|---|---|---|---|
| CG-01 | 기준 정보와 승인 범위 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-02 | GNO 이력 및 live 이슈 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-03 | 독립 worktree와 이슈별 브랜치 | PASS | 위 검증 및 현재 커밋 |
| CG-04 | 한국어 GitHub 및 README 언어 정책 | PASS | 위 검증 및 현재 커밋 |
| CG-05 | 기존 Kotlin 패턴 재사용 | PASS | 위 검증 및 현재 커밋 |
| CG-06 | 공개 계약과 README EN/KO 대조 | PASS | 위 검증 및 현재 커밋 |
| CG-07 | RED/GREEN 및 영향 모듈 테스트 | PASS | 위 검증 및 현재 커밋 |
| CG-08 | 무거운 검증 순차 실행 | PASS | 위 검증 및 현재 커밋 |
| CG-09 | 교훈 기록과 격리 인덱스 검색 | PASS | 위 검증 및 현재 커밋 |
| CG-10 | 최종 리뷰와 검증 후 커밋 | PASS | 위 검증 및 현재 커밋 |
| CG-11 | 승인된 저장소/base/head PR 생성 범위 | PASS | 위 검증 및 현재 커밋 |
| CG-12 | 정확한 head push 및 원격 조회 | PASS | 위 검증 및 현재 커밋 |
| CG-12A | AGENTS 계층·leaf·common·template·이슈 재조회 | PASS | 위 검증 및 현재 커밋 |
| CG-13 | PR 생성과 메타데이터 live 조회 | PASS | live URL, head SHA, 담당자/라벨/milestone/본문 확인 |
| CG-14 | head CI와 최신 리뷰/스레드 확인 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| CG-15 | 정확한 head의 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| CG-16 | 마지막 일괄 머지의 새 승인 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-17 | 승인된 head 머지와 결과 검증 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-18 | 머지 후 로컬 동기화 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| C-01 | 원인과 영향 범위 확인 | PASS | 위 회귀 테스트와 검토 근거 |
| C-02 | 이슈별 수정 범위 확정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-03 | 결함 재현 RED | PASS | 위 회귀 테스트와 검토 근거 |
| C-04 | 최소 수정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-05 | GREEN 및 영향 검증 | PASS | 위 회귀 테스트와 검토 근거 |
| C-06 | 교훈과 재발 방지 | PASS | 위 회귀 테스트와 검토 근거 |
| C-07 | PR CI/리뷰 수렴 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| C-08 | 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| C-09 | 승인 후 최종 완료 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |

별도 인간 리뷰: N/A (single-developer lane, debop 단독 유지관리 범위). CI와 코드 리뷰는 필수입니다.

Final status: DONE — 승인된 head squash merge 및 develop 동기화 완료

Unchecked required items: 없음
