### PR TITLE
fix: R2DBC PostgreSQL JSON 실패 로그에서 payload와 원인 제거

### DIFF
--- a/data/r2dbc/README.ko.md
+++ b/data/r2dbc/README.ko.md
@@ -510,3 +510,7 @@ custom 비동기 종료 동작이 필요한 factory는
 ## 라이선스
 
 MIT License
+
+## 실패와 생명주기 계약
+
+PostgreSQL JSON 변환 실패 로그는 원문 payload와 예외 상세를 제외합니다. 호출자에게 전달하는 ConversionFailedException은 source와 원래 Jackson cause를 유지하므로 민감한 입력이 포함된 예외를 그대로 로깅하지 않아야 합니다.

--- a/data/r2dbc/README.md
+++ b/data/r2dbc/README.md
@@ -523,3 +523,7 @@ creation-time snapshot, while lookup and map access are rejected after close.
 ## License
 
 MIT License
+
+## Failure and lifecycle contract
+
+PostgreSQL JSON conversion failure logs omit raw payloads and throwable details. ConversionFailedException still retains the source and original Jackson cause for the caller; applications must avoid logging that exception with sensitive input.

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/JsonToMapConverter.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/JsonToMapConverter.kt
@@ -12,11 +12,12 @@ import tools.jackson.databind.ObjectMapper
 import tools.jackson.module.kotlin.readValue
 
 /**
- * Converts a PostgreSQL [Json] value into a `Map<String, Any?>`.
+ * PostgreSQL [Json]을 `Map<String, Any?>`로 변환합니다.
  *
- * Invalid JSON is reported as a [ConversionFailedException] with the original Jackson cause.
+ * 잘못된 JSON은 원래 Jackson 원인을 포함한 [ConversionFailedException]으로 전달합니다.
+ * 운영 로그에는 payload나 예외 원문을 기록하지 않습니다.
  *
- * @property mapper Jackson object mapper used for deserialization.
+ * @property mapper 역직렬화에 사용할 Jackson mapper.
  */
 @ReadingConverter
 class JsonToMapConverter(private val mapper: ObjectMapper): Converter<Json, Map<String, Any?>> {
@@ -30,7 +31,7 @@ class JsonToMapConverter(private val mapper: ObjectMapper): Converter<Json, Map<
         return try {
             mapper.readValue(source.asString())
         } catch (e: JacksonException) {
-            log.error(e) { "Fail to parse Json: $source" }
+            log.error { "PostgreSQL JSON 역직렬화 실패" }
             throw ConversionFailedException(sourceType, targetType, source, e)
         }
     }

--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/MapToJsonConverter.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/convert/postgresql/MapToJsonConverter.kt
@@ -11,11 +11,12 @@ import tools.jackson.core.JacksonException
 import tools.jackson.databind.ObjectMapper
 
 /**
- * Converts a `Map<String, Any?>` value into a PostgreSQL [Json] value.
+ * `Map<String, Any?>`를 PostgreSQL [Json]으로 변환합니다.
  *
- * Serialization errors are reported as [ConversionFailedException] with the original Jackson cause.
+ * 직렬화 실패는 원래 Jackson 원인을 포함한 [ConversionFailedException]으로 전달합니다.
+ * 운영 로그에는 payload나 예외 원문을 기록하지 않습니다.
  *
- * @property mapper Jackson object mapper used for serialization.
+ * @property mapper 직렬화에 사용할 Jackson mapper.
  */
 @WritingConverter
 class MapToJsonConverter(
@@ -28,14 +29,14 @@ class MapToJsonConverter(
     }
 
     /**
-     * Converts [source] into PostgreSQL [Json].
+     * [source]를 PostgreSQL [Json]으로 변환합니다.
      *
-     * @throws ConversionFailedException when Jackson cannot serialize [source].
+     * @throws ConversionFailedException Jackson이 [source]를 직렬화할 수 없는 경우.
      */
     override fun convert(source: Map<String, Any?>): Json = try {
         Json.of(mapper.writeValueAsString(source))
     } catch (e: JacksonException) {
-        log.error(e) { "Fail to serialize map to Json. source=$source" }
+        log.error { "PostgreSQL JSON 직렬화 실패" }
         throw ConversionFailedException(sourceType, targetType, source, e)
     }
 }

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/convert/postgresql/PostgresJsonConvertersTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/convert/postgresql/PostgresJsonConvertersTest.kt
@@ -1,5 +1,12 @@
 package io.bluetape4k.r2dbc.convert.postgresql
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.slf4j.LoggerFactory
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
@@ -13,6 +20,39 @@ import tools.jackson.core.JacksonException
 import tools.jackson.databind.ObjectMapper
 
 class PostgresJsonConvertersTest {
+
+    @Test
+    fun `변환 실패 로그는 payload와 예외 원문의 비밀값을 포함하지 않는다`() {
+        listOf(JsonToMapConverter::class.java, MapToJsonConverter::class.java).forEach { type ->
+            val logger = LoggerFactory.getLogger(type) as Logger
+            val appender = ListAppender<ILoggingEvent>().apply { start() }
+            logger.addAppender(appender)
+            try {
+                assertFailsWith<ConversionFailedException> {
+                    if (type == JsonToMapConverter::class.java) {
+                        JsonToMapConverter(mapper).convert(Json.of("{\"password\":\"payload-secret\",broken}"))
+                    } else {
+                        val failure = JacksonException.wrapWithPath(
+                            IllegalStateException("cause-secret"), "source", "field"
+                        )
+                        val failingMapper = mockk<ObjectMapper> {
+                            every { writeValueAsString(any<Map<String, Any?>>()) } throws failure
+                        }
+                        MapToJsonConverter(failingMapper).convert(mapOf("password" to "payload-secret"))
+                    }
+                }
+                appender.list shouldHaveSize 1
+                appender.list.forEach {
+                    it.formattedMessage shouldNotContain "payload-secret"
+                    it.formattedMessage shouldNotContain "cause-secret"
+                    it.throwableProxy.shouldBeNull()
+                }
+            } finally {
+                logger.detachAppender(appender)
+                appender.stop()
+            }
+        }
+    }
 
     private val mapper = Jackson.defaultJsonMapper
 

--- a/docs/lessons/2026-09-08-safe-conversion-logs.md
+++ b/docs/lessons/2026-09-08-safe-conversion-logs.md
@@ -1,0 +1,19 @@
+# 변환 실패 로그는 원문 예외도 제외한다
+
+관련 이슈: https://github.com/bluetape4k/bluetape4k-projects/issues/1699
+
+## 실패한 가정과 근거
+
+JSON 역직렬화 실패 로그에 payload-secret이 그대로 기록됐다. 예외 메시지에도 원문이 포함될 수 있다.
+
+## 결정
+
+운영 로그는 변환 방향만 기록한다. 호출자에게 전달하는 ConversionFailedException의 원래 cause 계약은 유지한다.
+
+## 재발 방지
+
+로그 캡처에서 formattedMessage와 throwableProxy를 모두 확인한다. 로그 비밀값 제거와 호출자 예외 타입/원인 변경을 별개 계약으로 검토한다.
+
+## 검증
+
+이 PR의 회귀 테스트에서 수정 전 동작 실패를 확인했다. 수정 후 테스트와 관련 모듈 검증 결과는 PR의 `DoD Status`에 기록한다.


### PR DESCRIPTION
## 요약

Fixes #1699

PostgreSQL JSON 변환 실패 로그에 입력 payload와 Jackson 예외 상세가 포함되지 않도록 고정된 변환 방향만 기록합니다.

## 배경과 변경

#1701 모듈별 리뷰의 후속 수정입니다. 호출자에게 전달하는 ConversionFailedException의 source와 cause는 기존 계약대로 보존합니다. 운영 로그와 호출자 예외 경계를 구분해 문서화했습니다.

## 검증

- 변경 전: 로그 message 및 throwable에 테스트용 payload/cause secret이 남아 회귀 테스트 실패
- 변경 후: R2DBC 전체 221개 테스트와 detekt 실행 성공
- `:bluetape4k-r2dbc:test :bluetape4k-r2dbc:detekt --no-configuration-cache`
- ListAppender로 두 변환기의 message와 throwableProxy를 검사하고 호출자 예외 계약 유지 확인
- `git diff --check` 통과

## 리뷰 참고

- 독립 코드 리뷰: `code-reviewer`, `gpt-5.6-luna`, `max`. 소스·호출자·API·회귀 테스트·문서를 검토했으며 P0/P1은 0건입니다.
- APPROVE. 호출자 예외에는 source/cause가 남으므로 애플리케이션이 민감한 예외를 그대로 로깅하면 다시 노출될 수 있습니다. 기존 detekt 진단은 별도 범위입니다.
- 교훈: `docs/lessons/2026-09-08-safe-conversion-logs.md`. 격리 GNO 인덱스에서 추가와 검색을 검증했으며, 머지 후 기본 develop 파일의 GNO 갱신과 대표 검색도 확인했습니다.
- README EN/KO 계약 대조와 한국어 문서 검토를 완료했습니다.

## 메타데이터

- 이슈: #1699; milestone `2.1.0`; 담당자 `debop`
- 저장소: `bluetape4k/bluetape4k-projects`; base `develop`; head `fix/1699-r2dbc-safe-logging`
- 커밋: `19ae6f08de7010fb8518803d7b8c53a464f93c50`; 로컬/원격 SHA 일치 확인
- CI: 현재 head에서 12개 job 성공. 변경 경로 밖 12개 job은 실행 대상 제외이며 테스트 통과로 계산하지 않습니다. [검증 실행](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34187785646). 다른 자식 PR과 함께 마지막에 머지합니다.

- 머지 커밋: `40f9619e5ebf87bb2ba295d5a981c133f8a8f8aa`; 연결 이슈 CLOSED 확인
- 로컬 develop/upstream: `ca87d3f3c8a373f977f1ec2178803c2923b3ed2f`, clean; 9개 머지 커밋 포함 확인. 브랜치와 worktree는 보존했습니다.

## DoD Status

Required checks: 28/28; N/A: 1; Blocked: 0

| Check | 수행 내용 | 상태 | 근거 / 다음 작업 |
|---|---|---|---|
| CG-01 | 기준 정보와 승인 범위 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-02 | GNO 이력 및 live 이슈 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-03 | 독립 worktree와 이슈별 브랜치 | PASS | 위 검증 및 현재 커밋 |
| CG-04 | 한국어 GitHub 및 README 언어 정책 | PASS | 위 검증 및 현재 커밋 |
| CG-05 | 기존 Kotlin 패턴 재사용 | PASS | 위 검증 및 현재 커밋 |
| CG-06 | 공개 계약과 README EN/KO 대조 | PASS | 위 검증 및 현재 커밋 |
| CG-07 | RED/GREEN 및 영향 모듈 테스트 | PASS | 위 검증 및 현재 커밋 |
| CG-08 | 무거운 검증 순차 실행 | PASS | 위 검증 및 현재 커밋 |
| CG-09 | 교훈 기록과 격리 인덱스 검색 | PASS | 위 검증 및 현재 커밋 |
| CG-10 | 최종 리뷰와 검증 후 커밋 | PASS | 위 검증 및 현재 커밋 |
| CG-11 | 승인된 저장소/base/head PR 생성 범위 | PASS | 위 검증 및 현재 커밋 |
| CG-12 | 정확한 head push 및 원격 조회 | PASS | 위 검증 및 현재 커밋 |
| CG-12A | AGENTS 계층·leaf·common·template·이슈 재조회 | PASS | 위 검증 및 현재 커밋 |
| CG-13 | PR 생성과 메타데이터 live 조회 | PASS | live URL, head SHA, 담당자/라벨/milestone/본문 확인 |
| CG-14 | head CI와 최신 리뷰/스레드 확인 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| CG-15 | 정확한 head의 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| CG-16 | 마지막 일괄 머지의 새 승인 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-17 | 승인된 head 머지와 결과 검증 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-18 | 머지 후 로컬 동기화 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| C-01 | 원인과 영향 범위 확인 | PASS | 위 회귀 테스트와 검토 근거 |
| C-02 | 이슈별 수정 범위 확정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-03 | 결함 재현 RED | PASS | 위 회귀 테스트와 검토 근거 |
| C-04 | 최소 수정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-05 | GREEN 및 영향 검증 | PASS | 위 회귀 테스트와 검토 근거 |
| C-06 | 교훈과 재발 방지 | PASS | 위 회귀 테스트와 검토 근거 |
| C-07 | PR CI/리뷰 수렴 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| C-08 | 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| C-09 | 승인 후 최종 완료 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |

별도 인간 리뷰: N/A (single-developer lane, debop 단독 유지관리 범위). CI와 코드 리뷰는 필수입니다.

Final status: DONE — 승인된 head squash merge 및 develop 동기화 완료

Unchecked required items: 없음
