### PR TITLE
fix: JDK21·25 구조화 작업의 원래 실패 우선 계약 통일

### DIFF
--- a/docs/lessons/2026-09-08-handler-failure-priority.md
+++ b/docs/lessons/2026-09-08-handler-failure-priority.md
@@ -17,3 +17,7 @@ JDK21은 handler 예외가 원래 실패를 대체했고 JDK25는 handler 실패
 ## 검증
 
 이 PR의 회귀 테스트에서 수정 전 동작 실패를 확인했다. 수정 후 테스트와 관련 모듈 검증 결과는 PR의 `DoD Status`에 기록한다.
+
+## test fixture의 배포 의존성 검증
+
+공통 fixture의 junit5 의존성은 Gradle 테스트에서는 통과했지만 Maven POM에서 junit5 → virtualthread-api → junit5 순환을 만들었다. 테스트 전용 variant라도 배포 모델의 optional 의존성에 포함될 수 있으므로 컴파일 성공만으로 의존성 경계를 판단하지 않는다. fixture에서 실제 필요한 assertions 모듈만 사용하고, 공유 fixture를 추가할 때 POM과 Gradle module metadata 생성·검증을 함께 실행한다.

--- a/docs/lessons/2026-09-08-handler-failure-priority.md
+++ b/docs/lessons/2026-09-08-handler-failure-priority.md
@@ -1,0 +1,19 @@
+# 실패 handler의 예외 우선순위를 런타임 간 고정한다
+
+관련 이슈: https://github.com/bluetape4k/bluetape4k-projects/issues/1700
+
+## 실패한 가정과 근거
+
+JDK21은 handler 예외가 원래 실패를 대체했고 JDK25는 handler 실패를 버렸다.
+
+## 결정
+
+원래 작업 실패를 주 예외로 유지하고 handler의 별도 실패는 suppressed에 보존한다. 동일 객체 재전파는 self-suppression에서 제외한다.
+
+## 재발 방지
+
+같은 공통 테스트를 JDK21과 JDK25에서 실행한다. handler 안의 assertion은 삼켜질 수 있으므로 관찰값을 저장하고 handler 밖에서 검증한다.
+
+## 검증
+
+이 PR의 회귀 테스트에서 수정 전 동작 실패를 확인했다. 수정 후 테스트와 관련 모듈 검증 결과는 PR의 `DoD Status`에 기록한다.

--- a/virtualthread/api/README.ko.md
+++ b/virtualthread/api/README.ko.md
@@ -261,3 +261,7 @@ class VirtualThreadsTest {
 - [JEP 444: Virtual Threads (Java 21)](https://openjdk.org/jeps/444)
 - [JEP 462: Structured Concurrency (Second Preview, Java 21)](https://openjdk.org/jeps/462)
 - [Java ServiceLoader Documentation](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/ServiceLoader.html)
+
+## 실패와 생명주기 계약
+
+throwIfFailed는 handler를 한 번 호출하고 원래 작업 실패를 전파합니다. handler의 별도 실패는 suppressed에 보존하며 원래 예외 자체를 다시 던진 경우 self-suppression을 추가하지 않습니다. JDK21과 JDK25에서 같은 계약 테스트를 실행합니다.

--- a/virtualthread/api/README.md
+++ b/virtualthread/api/README.md
@@ -263,3 +263,7 @@ class VirtualThreadsTest {
 - [JEP 444: Virtual Threads (Java 21)](https://openjdk.org/jeps/444)
 - [JEP 462: Structured Concurrency (Second Preview, Java 21)](https://openjdk.org/jeps/462)
 - [Java ServiceLoader Documentation](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/ServiceLoader.html)
+
+## Failure and lifecycle contract
+
+throwIfFailed invokes the handler once and rethrows the original task failure. A distinct handler failure is retained as a suppressed exception; rethrowing the original exception does not add self-suppression. JDK21 and JDK25 run the same contract tests.

--- a/virtualthread/api/build.gradle.kts
+++ b/virtualthread/api/build.gradle.kts
@@ -1,8 +1,13 @@
+plugins {
+    `java-test-fixtures`
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
 
 dependencies {
+    testFixturesApi(project(":bluetape4k-junit5"))
     implementation(project(":bluetape4k-logging"))
     testImplementation(project(":bluetape4k-junit5"))
     // Java 21 compatibility island의 test runtime provider

--- a/virtualthread/api/build.gradle.kts
+++ b/virtualthread/api/build.gradle.kts
@@ -7,7 +7,8 @@ configurations {
 }
 
 dependencies {
-    testFixturesApi(project(":bluetape4k-junit5"))
+    // junit5는 이 API에 의존하므로 fixture는 순환이 없는 최소 검증 모듈만 사용합니다.
+    testFixturesApi(project(":bluetape4k-assertions"))
     implementation(project(":bluetape4k-logging"))
     testImplementation(project(":bluetape4k-junit5"))
     // Java 21 compatibility island의 test runtime provider

--- a/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/api/StructuredScopes.kt
+++ b/virtualthread/api/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/api/StructuredScopes.kt
@@ -118,7 +118,11 @@ interface StructuredTaskScopeAll: AutoCloseable {
      */
     fun joinUntil(deadline: java.time.Instant): StructuredTaskScopeAll
 
-    /** 실패한 subtask가 있으면 [handler]를 호출한 뒤 예외를 전파합니다. */
+    /**
+     * 실패한 subtask가 있으면 [handler]를 한 번 호출한 뒤 원래 예외를 전파합니다.
+     * handler가 다른 예외를 던지면 원래 예외의 suppressed에 추가합니다.
+     * 원래 예외 자체를 다시 던진 경우에는 self-suppression을 하지 않습니다.
+     */
     fun throwIfFailed(handler: (e: Throwable) -> Unit = {}): StructuredTaskScopeAll
 
     /** scope 자원을 정리합니다. */

--- a/virtualthread/api/src/testFixtures/kotlin/io/bluetape4k/concurrent/virtualthread/api/StructuredTaskScopeAllContractTest.kt
+++ b/virtualthread/api/src/testFixtures/kotlin/io/bluetape4k/concurrent/virtualthread/api/StructuredTaskScopeAllContractTest.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.concurrent.virtualthread.api
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/** 두 JDK provider에서 실패 handler의 예외 우선순위를 동일하게 검증합니다. */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class StructuredTaskScopeAllContractTest {
+    protected abstract val provider: StructuredTaskScopeProvider
+
+    @Test
+    fun `실패 handler는 원래 작업 예외를 한 번 전달받는다`() {
+        verifyHandler(null)
+    }
+
+    @Test
+    fun `handler 실패는 원래 작업 예외의 suppressed에 보존된다`() {
+        verifyHandler(AssertionError("handler failure"))
+    }
+
+    @Test
+    fun `handler의 취소 예외도 원래 실패를 가리지 않는다`() {
+        verifyHandler(CancellationException("handler cancellation"))
+    }
+
+    @Test
+    fun `handler가 원래 예외를 재전파해도 self suppression이 발생하지 않는다`() {
+        verifyHandler(null, rethrowPrimary = true)
+    }
+
+    private fun verifyHandler(handlerFailure: Throwable?, rethrowPrimary: Boolean = false) {
+        val primary = IllegalStateException("task failure")
+        val received = AtomicReference<Throwable>()
+        val calls = AtomicInteger()
+        val actual = assertFailsWith<IllegalStateException> {
+            provider.withAll { scope ->
+                scope.fork<Int> { throw primary }
+                scope.join().throwIfFailed {
+                    received.set(it)
+                    calls.incrementAndGet()
+                    if (rethrowPrimary) throw it
+                    if (handlerFailure != null) throw handlerFailure
+                }
+            }
+        }
+        actual shouldBeEqualTo primary
+        received.get() shouldBeEqualTo primary
+        calls.get() shouldBeEqualTo 1
+        actual.suppressed.toList() shouldBeEqualTo listOfNotNull(handlerFailure)
+    }
+}

--- a/virtualthread/jdk21/README.ko.md
+++ b/virtualthread/jdk21/README.ko.md
@@ -258,3 +258,7 @@ dependencies {
 - [JEP 444: Virtual Threads](https://openjdk.org/jeps/444)
 - [JEP 462: Structured Concurrency (Second Preview)](https://openjdk.org/jeps/462)
 - [Java 21 Release Notes](https://www.oracle.com/java/technologies/javase/21-relnote-issues.html)
+
+## 실패와 생명주기 계약
+
+throwIfFailed는 handler를 한 번 호출하고 원래 작업 실패를 전파합니다. handler의 별도 실패는 suppressed에 보존하며 원래 예외 자체를 다시 던진 경우 self-suppression을 추가하지 않습니다. JDK21과 JDK25에서 같은 계약 테스트를 실행합니다.

--- a/virtualthread/jdk21/README.md
+++ b/virtualthread/jdk21/README.md
@@ -259,3 +259,7 @@ dependencies {
 - [JEP 444: Virtual Threads](https://openjdk.org/jeps/444)
 - [JEP 462: Structured Concurrency (Second Preview)](https://openjdk.org/jeps/462)
 - [Java 21 Release Notes](https://www.oracle.com/java/technologies/javase/21-relnote-issues.html)
+
+## Failure and lifecycle contract
+
+throwIfFailed invokes the handler once and rethrows the original task failure. A distinct handler failure is retained as a suppressed exception; rethrowing the original exception does not add self-suppression. JDK21 and JDK25 run the same contract tests.

--- a/virtualthread/jdk21/build.gradle.kts
+++ b/virtualthread/jdk21/build.gradle.kts
@@ -32,6 +32,7 @@ tasks.withType<Test>().configureEach {
 }
 
 dependencies {
+    testImplementation(testFixtures(project(":bluetape4k-virtualthread-api")))
     api(project(":bluetape4k-virtualthread-api"))
     implementation(project(":bluetape4k-logging"))
     testImplementation(project(":bluetape4k-junit5"))

--- a/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk21/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProvider.kt
@@ -149,8 +149,7 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
 
         override fun throwIfFailed(handler: (e: Throwable) -> Unit): StructuredTaskScopeAll {
             delegate.throwIfFailed {
-                handler(it)
-                throw it
+                rethrowAfterHandler(it, handler)
             }
             return this
         }
@@ -262,4 +261,15 @@ class Jdk21StructuredTaskScopeProvider: StructuredTaskScopeProvider {
             delegate.close()
         }
     }
+}
+
+/** handler가 던진 Error나 취소 예외도 원래 작업 실패의 suppressed로 보존합니다. */
+@Suppress("TooGenericExceptionCaught")
+private fun rethrowAfterHandler(primary: Throwable, handler: (Throwable) -> Unit): Nothing {
+    try {
+        handler(primary)
+    } catch (handlerFailure: Throwable) {
+        if (handlerFailure !== primary) primary.addSuppressed(handlerFailure)
+    }
+    throw primary
 }

--- a/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk21/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk21/Jdk21StructuredTaskScopeProviderTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.concurrent.virtualthread.jdk21
 
+import io.bluetape4k.concurrent.virtualthread.api.StructuredTaskScopeAllContractTest
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
@@ -14,11 +15,11 @@ import java.time.Instant
 import java.util.concurrent.TimeoutException
 
 @EnabledForJreRange(min = JRE.JAVA_21)
-class Jdk21StructuredTaskScopeProviderTest {
+class Jdk21StructuredTaskScopeProviderTest: StructuredTaskScopeAllContractTest() {
 
     companion object: KLoggingChannel()
 
-    private val provider = Jdk21StructuredTaskScopeProvider()
+    override val provider = Jdk21StructuredTaskScopeProvider()
 
     @Test
     fun `ServiceLoader가 JDK 21 virtual thread runtime을 선택해야 한다`() {

--- a/virtualthread/jdk25/README.ko.md
+++ b/virtualthread/jdk25/README.ko.md
@@ -313,3 +313,7 @@ dependencies {
 - [JEP 462: Structured Concurrency (Second Preview)](https://openjdk.org/jeps/462)
 - [Java 25 Release Notes](https://www.oracle.com/java/technologies/javase/25-relnote-issues.html)
 - [Project Loom](https://openjdk.org/projects/loom/)
+
+## 실패와 생명주기 계약
+
+throwIfFailed는 handler를 한 번 호출하고 원래 작업 실패를 전파합니다. handler의 별도 실패는 suppressed에 보존하며 원래 예외 자체를 다시 던진 경우 self-suppression을 추가하지 않습니다. JDK21과 JDK25에서 같은 계약 테스트를 실행합니다.

--- a/virtualthread/jdk25/README.md
+++ b/virtualthread/jdk25/README.md
@@ -315,3 +315,7 @@ No code changes are required. Any code that uses the API module continues to wor
 - [JEP 462: Structured Concurrency (Second Preview)](https://openjdk.org/jeps/462)
 - [Java 25 Release Notes](https://www.oracle.com/java/technologies/javase/25-relnote-issues.html)
 - [Project Loom](https://openjdk.org/projects/loom/)
+
+## Failure and lifecycle contract
+
+throwIfFailed invokes the handler once and rethrows the original task failure. A distinct handler failure is retained as a suppressed exception; rethrowing the original exception does not add self-suppression. JDK21 and JDK25 run the same contract tests.

--- a/virtualthread/jdk25/build.gradle.kts
+++ b/virtualthread/jdk25/build.gradle.kts
@@ -27,6 +27,7 @@ tasks.withType<Test>().configureEach {
 }
 
 dependencies {
+    testImplementation(testFixtures(project(":bluetape4k-virtualthread-api")))
     api(project(":bluetape4k-virtualthread-api"))
     implementation(project(":bluetape4k-logging"))
     testImplementation(project(":bluetape4k-junit5"))

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -261,8 +261,7 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
                 ?: subtasks.firstNotNullOfOrNull { it.exceptionOrNull() }
 
             if (firstFailure != null) {
-                runCatching { handler(firstFailure) }
-                throw firstFailure
+                rethrowAfterHandler(firstFailure, handler)
             }
             return this
         }
@@ -395,4 +394,15 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
             }
         }
     }
+}
+
+/** handler가 던진 Error나 취소 예외도 원래 작업 실패의 suppressed로 보존합니다. */
+@Suppress("TooGenericExceptionCaught")
+private fun rethrowAfterHandler(primary: Throwable, handler: (Throwable) -> Unit): Nothing {
+    try {
+        handler(primary)
+    } catch (handlerFailure: Throwable) {
+        if (handlerFailure !== primary) primary.addSuppressed(handlerFailure)
+    }
+    throw primary
 }

--- a/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
+++ b/virtualthread/jdk25/src/test/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProviderTest.kt
@@ -11,14 +11,15 @@ import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.time.Instant
 import java.util.concurrent.TimeoutException
+import io.bluetape4k.concurrent.virtualthread.api.StructuredTaskScopeAllContractTest
 import io.bluetape4k.assertions.assertFailsWith
 
 @EnabledForJreRange(min = JRE.JAVA_25)
-class Jdk25StructuredTaskScopeProviderTest {
+class Jdk25StructuredTaskScopeProviderTest: StructuredTaskScopeAllContractTest() {
 
     companion object: KLoggingChannel()
 
-    private val provider = Jdk25StructuredTaskScopeProvider()
+    override val provider = Jdk25StructuredTaskScopeProvider()
 
     @Test
     fun `ServiceLoader가 JDK 25 virtual thread runtime을 선택해야 한다`() {


### PR DESCRIPTION
## 요약

Fixes #1700

throwIfFailed handler가 실패해도 원래 작업 예외를 다시 던지고, handler의 별도 실패는 suppressed로 보존하도록 JDK21과 JDK25 동작을 통일합니다.

## 배경과 변경

#1701 모듈별 리뷰의 후속 수정입니다. 공통 API test fixture를 두 provider 테스트에 연결했습니다. handler 1회 호출, 원래 예외 identity, 별도 Error/취소 예외의 suppressed 보존과 self-suppression 회피를 같은 계약으로 검증합니다.

## 검증

- 변경 전: JDK21은 handler 예외가 원래 실패를 가리고, JDK25는 handler 예외가 유실돼 회귀 테스트 실패
- 변경 후: JDK21 34개, JDK25 48개, API 74개 전체 테스트 통과
- 세 모듈 `test`, `detekt --no-configuration-cache` 순차 실행
- 새 외부 의존성 없이 API의 test fixture를 JDK21·25에서 재사용
- `git diff --check` 통과
- 배포 메타데이터 생성 후 POM 79개와 Gradle Module Metadata 79개 검증: 실패 0
- 의존성 수정 후 API 74개, JDK21 34개, JDK25 48개 전체 테스트 재실행 통과

기존 CI에서 공통 fixture의 `junit5 -> virtualthread-api -> junit5` Maven 의존성 순환을 발견했습니다. fixture가 사용하는 기존 `assertions` 모듈로 직접 의존성을 좁혔고, 독립 architect(`gpt-5.6-sol`, `high`) 검토에서 P0/P1 없이 CLEAR를 받았습니다.

## 리뷰 참고

- 독립 코드 리뷰: `code-reviewer`, `gpt-5.6-luna`, `max`. 소스·호출자·API·회귀 테스트·문서를 검토했으며 P0/P1은 0건입니다.
- architect CLEAR, code-reviewer P0/P1=0. handler의 모든 Throwable은 원래 작업 실패보다 우선하지 않는 계약입니다. 리뷰 P2에 따라 취소 예외 fixture와 의도한 catch의 scoped detekt suppression을 추가했습니다.
- 교훈: `docs/lessons/2026-09-08-handler-failure-priority.md`. 격리 GNO 인덱스에서 추가와 검색을 검증했으며, 머지 후 기본 develop 파일의 GNO 갱신과 대표 검색도 확인했습니다.
- README EN/KO 계약 대조와 한국어 문서 검토를 완료했습니다.

## 메타데이터

- 이슈: #1700; milestone `2.1.0`; 담당자 `debop`
- 저장소: `bluetape4k/bluetape4k-projects`; base `develop`; head `fix/1700-handler-contract`
- 커밋: `7c45d862d87b2fa28784f92af02efa253dab9869`; 로컬/원격 SHA 일치 확인
- CI: 현재 head에서 12개 job 성공. 변경 경로 밖 12개 job은 실행 대상 제외이며 테스트 통과로 계산하지 않습니다. [검증 실행](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34188659607). 다른 자식 PR과 함께 마지막에 머지합니다.

- 머지 커밋: `ca87d3f3c8a373f977f1ec2178803c2923b3ed2f`; 연결 이슈 CLOSED 확인
- 로컬 develop/upstream: `ca87d3f3c8a373f977f1ec2178803c2923b3ed2f`, clean; 9개 머지 커밋 포함 확인. 브랜치와 worktree는 보존했습니다.

## DoD Status

Required checks: 28/28; N/A: 1; Blocked: 0

| Check | 수행 내용 | 상태 | 근거 / 다음 작업 |
|---|---|---|---|
| CG-01 | 기준 정보와 승인 범위 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-02 | GNO 이력 및 live 이슈 확인 | PASS | 위 검증 및 현재 커밋 |
| CG-03 | 독립 worktree와 이슈별 브랜치 | PASS | 위 검증 및 현재 커밋 |
| CG-04 | 한국어 GitHub 및 README 언어 정책 | PASS | 위 검증 및 현재 커밋 |
| CG-05 | 기존 Kotlin 패턴 재사용 | PASS | 위 검증 및 현재 커밋 |
| CG-06 | 공개 계약과 README EN/KO 대조 | PASS | 위 검증 및 현재 커밋 |
| CG-07 | RED/GREEN 및 영향 모듈 테스트 | PASS | 위 검증 및 현재 커밋 |
| CG-08 | 무거운 검증 순차 실행 | PASS | 위 검증 및 현재 커밋 |
| CG-09 | 교훈 기록과 격리 인덱스 검색 | PASS | 위 검증 및 현재 커밋 |
| CG-10 | 최종 리뷰와 검증 후 커밋 | PASS | 위 검증 및 현재 커밋 |
| CG-11 | 승인된 저장소/base/head PR 생성 범위 | PASS | 위 검증 및 현재 커밋 |
| CG-12 | 정확한 head push 및 원격 조회 | PASS | 위 검증 및 현재 커밋 |
| CG-12A | AGENTS 계층·leaf·common·template·이슈 재조회 | PASS | 위 검증 및 현재 커밋 |
| CG-13 | PR 생성과 메타데이터 live 조회 | PASS | live URL, head SHA, 담당자/라벨/milestone/본문 확인 |
| CG-14 | head CI와 최신 리뷰/스레드 확인 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| CG-15 | 정확한 head의 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| CG-16 | 마지막 일괄 머지의 새 승인 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-17 | 승인된 head 머지와 결과 검증 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| CG-18 | 머지 후 로컬 동기화 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |
| C-01 | 원인과 영향 범위 확인 | PASS | 위 회귀 테스트와 검토 근거 |
| C-02 | 이슈별 수정 범위 확정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-03 | 결함 재현 RED | PASS | 위 회귀 테스트와 검토 근거 |
| C-04 | 최소 수정 | PASS | 위 회귀 테스트와 검토 근거 |
| C-05 | GREEN 및 영향 검증 | PASS | 위 회귀 테스트와 검토 근거 |
| C-06 | 교훈과 재발 방지 | PASS | 위 회귀 테스트와 검토 근거 |
| C-07 | PR CI/리뷰 수렴 | PASS | 현재 head CI 성공, 리뷰/스레드 blocker 없음 |
| C-08 | 머지 준비 보고 | PASS | 9개 PR 현재 head/CI/리뷰/교훈을 모아 머지 준비 보고 |
| C-09 | 승인 후 최종 완료 | PASS | 최종 head 승인 후 squash merge·develop 동기화 확인 |

별도 인간 리뷰: N/A (single-developer lane, debop 단독 유지관리 범위). CI와 코드 리뷰는 필수입니다.

Final status: DONE — 승인된 head squash merge 및 develop 동기화 완료

Unchecked required items: 없음
