### PR TITLE
CodeQL ReDoS 및 릴리스 캐시 오염 경고를 해소한다

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.resolve-version.outputs.target_sha }}
+          ref: ${{ github.workflow_sha }}
           fetch-depth: 0
 
       - name: Verify immutable release target
@@ -101,7 +101,6 @@ jobs:
           TARGET_SHA: ${{ needs.resolve-version.outputs.target_sha }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
           python3 scripts/ci/resolve_release_target.py verify \
             --version "$VERSION" \
             --expected-sha "$TARGET_SHA"
@@ -111,9 +110,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.resolve-version.outputs.target_sha }}
         run: |
           set -euo pipefail
-          TARGET_SHA="$(git rev-parse HEAD)"
           run_pages="$RUNNER_TEMP/nightly-runs.json"
           run_json="$RUNNER_TEMP/nightly-run.json"
           jobs_json="$RUNNER_TEMP/nightly-jobs.json"

--- a/docs/lessons/2026-09-08-codeql-security-boundaries.md
+++ b/docs/lessons/2026-09-08-codeql-security-boundaries.md
@@ -1,0 +1,67 @@
+# CodeQL 보안 경계는 실행 코드와 입력 데이터를 분리한다
+
+## 맥락
+
+정기 CodeQL 분석은 `develop`의
+`23f60647ef53503a3dcbb9a7ac331abb83401db9`에서 다음 high 심각도 경고 세 건을
+보고했다.
+
+- [`py/redos` #52](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/52):
+  `scripts/testcontainers_image_gate.py`의 Kotlin 테스트 메서드 탐색 정규식
+- [`actions/cache-poisoning/poisonable-step` #53](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/53)
+- [`actions/cache-poisoning/poisonable-step` #54](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/54)
+
+릴리스 두 경고는 `workflow_dispatch` 입력으로 선택한 release tag의 commit을
+`verify-full-nightly` job에서 checkout한 뒤, 그 commit에 포함된 Python script를 기본 브랜치
+권한과 cache write 권한으로 실행하는 경로를 가리켰다. tag가 저장소 내부 참조라는 사실만으로
+workflow 실행 코드의 신뢰 경계가 보장되지는 않는다.
+
+정규식은 `\s*`, 줄바꿈, 반복되는 `\s*`가 중첩돼 실패 입력에서 backtracking 경로가
+급격히 증가했다. `@Test` 뒤에 줄바꿈 28개와 함수가 아닌 문자열을 넣은 bounded regression은
+기존 구현에서 1초 안에 끝나지 않았다.
+
+## 결정
+
+release 검증 job은 `${{ github.workflow_sha }}`를 checkout해 workflow와 같은 trusted revision의
+검증 script만 실행한다. 선택된 release commit SHA는 checkout 대상이 아니라 `TARGET_SHA` 데이터로
+전달한다. tag가 여전히 그 SHA를 가리키는지는 trusted `resolve_release_target.py verify`가 검사하고,
+실제 publication job만 검증된 SHA를 checkout한다.
+
+정규식은 수평 공백과 줄바꿈을 구분하고 각 문자가 하나의 반복 경로에만 속하도록 바꾼다.
+annotation 인자와 backtick 함수명도 줄 경계를 넘지 못하게 해 기존 탐색 범위를 유지한다.
+
+## 결과
+
+- release 검증 단계는 사용자가 선택한 release commit의 코드를 cache-write 권한으로 실행하지 않는다.
+- release target의 immutable tag/SHA 검증과 exact-head Full Nightly 증거 확인은 유지된다.
+- 병적인 실패 입력도 bounded subprocess test의 1초 제한 안에서 종료된다.
+- workflow policy test는 검증 job이 다시 target SHA를 checkout하면 명시적으로 실패한다.
+
+## 검증
+
+- `scripts.test_testcontainers_image_gate`: 23개 통과
+- `scripts.ci.resolve_release_target_test`: 9개 통과
+- `scripts.test_release_workflow_policy`: 53개 통과
+- `actionlint .github/workflows/release.yml`: 통과
+- 변경 Python 파일 `py_compile`: 통과
+
+`ruff` 전체 변경 파일 검사는 기존 파일에 있던 shebang permission, implicit concatenation,
+`Optional`, import-order 규칙 위반 때문에 실패했다. 이번 변경에서 새 규칙 위반이 생기지 않았는지는
+해당 기존 rule을 제외한 별도 검사로 확인한다.
+
+## 놓친 점
+
+처음 patch 경로를 integration checkout 기준으로 적용해 승인된 linked worktree 밖의 같은 파일 두 개를
+일시적으로 수정했다. 즉시 해당 hunk만 되돌리고 integration checkout이 clean임을 확인한 뒤, 모든
+후속 patch를 절대 worktree 경로로 제한했다. 공유 저장소에서 `workdir`은 command 실행 위치만 바꾸며
+patch 대상 경로를 자동으로 바꾸지 않는다는 점을 작업 규칙으로 고정한다.
+
+## 향후 지침
+
+1. 권한이 높은 GitHub Actions job에서는 외부 입력이 고른 ref의 코드를 실행하지 말고 trusted workflow
+   revision의 code와 검증 대상 data를 분리한다.
+2. release target code 실행이 필요하면 cache write, secret, protected environment 같은 권한 경계를 먼저
+   제거하거나 별도 job으로 격리한다.
+3. 정규식 보안 수정은 매칭 결과뿐 아니라 adversarial non-match의 실행 시간 상한도 regression으로 고정한다.
+4. linked worktree에서 patch할 때는 대상 파일을 절대 경로로 지정하고 integration checkout의 clean 상태를
+   다시 확인한다.

--- a/scripts/ci/resolve_release_target_test.py
+++ b/scripts/ci/resolve_release_target_test.py
@@ -177,12 +177,28 @@ class ResolveReleaseTargetCliTest(unittest.TestCase):
 
 
 class ReleaseWorkflowPolicyTest(unittest.TestCase):
+    def test_nightly_verification_uses_trusted_workflow_revision(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        verify_block = workflow.split("  verify-full-nightly:\n", 1)[1].split(
+            "\n  publish:\n", 1
+        )[0]
+
+        self.assertIn("ref: ${{ github.workflow_sha }}", verify_block)
+        self.assertNotIn(
+            "ref: ${{ needs.resolve-version.outputs.target_sha }}",
+            verify_block,
+        )
+        self.assertIn(
+            "TARGET_SHA: ${{ needs.resolve-version.outputs.target_sha }}",
+            verify_block,
+        )
+
     def test_release_jobs_checkout_and_verify_one_immutable_target(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
 
         self.assertIn("target_sha: ${{ steps.resolve.outputs.target_sha }}", workflow)
         self.assertEqual(
-            2,
+            1,
             workflow.count("ref: ${{ needs.resolve-version.outputs.target_sha }}"),
         )
         self.assertNotIn("needs.resolve-version.outputs.ref", workflow)

--- a/scripts/test_release_workflow_policy.py
+++ b/scripts/test_release_workflow_policy.py
@@ -577,10 +577,7 @@ def release_policy_errors(workflow: str) -> list[str]:
         "verify-full-nightly",
     }:
         errors.append("publish must depend on exact-head Full Nightly")
-    exact_head_jobs = (
-        "verify-full-nightly",
-        "publish",
-    )
+    exact_head_jobs = ("verify-full-nightly", "publish")
     exact_head_contract = True
     for job_id in exact_head_jobs:
         records = workflow_step_records(workflow, job_id)
@@ -596,17 +593,32 @@ def release_policy_errors(workflow: str) -> list[str]:
             if len(verify_steps) == 1 and verify_steps[0][3] is not None
             else ""
         )
-        if not (
+        expected_checkout_ref = (
+            "${{ github.workflow_sha }}"
+            if job_id == "verify-full-nightly"
+            else "${{ needs.resolve-version.outputs.target_sha }}"
+        )
+        checkout_contract = (
             len(checkout_steps) == 1
             and not checkout_steps[0][4]
             and workflow_step_field_values(checkout_steps[0][2], "ref")
-            == ["${{ needs.resolve-version.outputs.target_sha }}"]
+            == [expected_checkout_ref]
             and workflow_step_field_values(checkout_steps[0][2], "fetch-depth") == ["0"]
+        )
+        if job_id == "verify-full-nightly" and not checkout_contract:
+            errors.append("release verification must execute trusted workflow source")
+        head_checkout_contract = (
+            'test "$(git rev-parse HEAD)" = "$TARGET_SHA"' not in verify_script
+            if job_id == "verify-full-nightly"
+            else 'test "$(git rev-parse HEAD)" = "$TARGET_SHA"' in verify_script
+        )
+        if not (
+            checkout_contract
             and len(verify_steps) == 1
             and not verify_steps[0][4]
             and workflow_step_field_values(verify_steps[0][2], "TARGET_SHA")
             == ["${{ needs.resolve-version.outputs.target_sha }}"]
-            and 'test "$(git rev-parse HEAD)" = "$TARGET_SHA"' in verify_script
+            and head_checkout_contract
             and "scripts/ci/resolve_release_target.py verify" in verify_script
             and '--expected-sha "$TARGET_SHA"' in verify_script
         ):
@@ -1336,6 +1348,24 @@ class ReleaseWorkflowPolicyTest(unittest.TestCase):
 
         self.assertIn("Publish RELEASE to Maven Central Portal", workflow)
         self.assertEqual([], release_policy_errors(workflow))
+
+    def test_release_workflow_rejects_untrusted_nightly_verification_checkout(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        verify_block = workflow_job_block(workflow, "verify-full-nightly")
+        mutated = workflow.replace(
+            verify_block,
+            verify_block.replace(
+                "ref: ${{ github.workflow_sha }}",
+                "ref: ${{ needs.resolve-version.outputs.target_sha }}",
+                1,
+            ),
+            1,
+        )
+
+        self.assertIn(
+            "release verification must execute trusted workflow source",
+            release_policy_errors(mutated),
+        )
 
     def test_release_workflow_blocks_publish_without_exact_head_nightly(self) -> None:
         workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")

--- a/scripts/test_testcontainers_image_gate.py
+++ b/scripts/test_testcontainers_image_gate.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import re
+import subprocess
+import sys
 import unittest
 from pathlib import Path
 
@@ -30,6 +32,27 @@ class TestTestcontainersImageGate(unittest.TestCase):
     def test_manifest_covers_every_image_family_and_has_required_fields(self) -> None:
         self.assertEqual(EXPECTED_FAMILY_COUNT, len(self.entries))
         self.assertEqual([], validate_manifest(self.entries, self.root))
+
+    def test_method_declaration_pattern_rejects_pathological_newlines_promptly(self) -> None:
+        script = (
+            "from scripts.testcontainers_image_gate import "
+            "TEST_METHOD_DECLARATION_PATTERN as pattern; "
+            "assert pattern.search('@Test' + '\\n' * 28 + 'not_a_function') is None"
+        )
+
+        try:
+            result = subprocess.run(
+                [sys.executable, "-B", "-c", script],
+                cwd=self.root,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=1,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail("test method declaration matching exceeded the one-second bound")
+
+        self.assertEqual(0, result.returncode, result.stderr)
 
     def test_deprecated_compatibility_facade_is_not_an_image_gate_family(self) -> None:
         self.assertEqual({"Ignite2Server"}, set(NON_IMAGE_GATE_SERVERS))

--- a/scripts/testcontainers_image_gate.py
+++ b/scripts/testcontainers_image_gate.py
@@ -43,8 +43,10 @@ TAG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 WORKLOAD_PATTERN = re.compile(r"^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+\.[A-Za-z_$][\w$]*(?:\(\))?$")
 TEST_METHOD_DECLARATION_PATTERN = re.compile(
-    r"(?ms)^\s*@Test(?:\s*\([^)]*\))?\s*(?:\r?\n\s*)+"
-    r"fun\s+(`(?P<quoted>[^`]+)`|(?P<identifier>[A-Za-z_][A-Za-z0-9_]*))\s*\("
+    r"(?m)^[^\S\r\n]*@Test(?:[^\S\r\n]*\([^\r\n)]*\))?"
+    r"[^\S\r\n]*(?:\r?\n[^\S\r\n]*)+"
+    r"fun[^\S\r\n]+(`(?P<quoted>[^`\r\n]+)`|(?P<identifier>[A-Za-z_][A-Za-z0-9_]*))"
+    r"[^\S\r\n]*\("
 )
 TEST_SELECTOR_WILDCARDS = frozenset("*?[]{}")
 


### PR DESCRIPTION
## Summary

Code scanning alerts [#52](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/52),
[#53](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/53),
[#54](https://github.com/bluetape4k/bluetape4k-projects/security/code-scanning/54)를 해소한다.
병적인 정규식 입력의 실행 시간을 제한하고, 권한이 높은 release 검증 job에서 선택된 tag의
코드를 실행하지 않도록 신뢰 경계를 분리한다.

## Background

정기 CodeQL 분석은 Kotlin 테스트 메서드 탐색 정규식의 exponential backtracking과
`workflow_dispatch` 입력이 고른 release commit의 script를 cache-write 권한으로 실행하는
두 경로를 high 심각도로 보고했다. 별도 GitHub issue는 승인 범위에 없으며 세 code scanning
alert를 결함 식별자로 사용한다.

## What This Solves

- `@Test` 뒤 병적인 non-match 입력이 정규식 backtracking으로 CPU를 장시간 점유하는 경로
- default-branch 권한의 release 검증 job이 선택된 target commit의 Python script를 실행하는 경로
- 같은 신뢰 경계가 되돌아오는 것을 놓치던 release workflow policy 공백

## Work Done

- 정규식에서 수평 공백과 줄바꿈의 중첩 반복을 분리하고 1초 bounded regression을 추가했다.
- `verify-full-nightly`는 `${{ github.workflow_sha }}`를 checkout하고 release SHA는
  `TARGET_SHA` 데이터로만 검증하도록 변경했다.
- publication job의 검증된 target SHA checkout과 exact-head 검사는 유지했다.
- trusted workflow checkout을 강제하는 positive/negative policy test와 재발 방지 lesson을 추가했다.

## Validation

- `python3 -B -m unittest -v scripts.test_testcontainers_image_gate`: PASS (23개)
- `python3 -B -m unittest -v scripts.ci.resolve_release_target_test`: PASS (9개)
- `python3 -B -m unittest -v scripts.test_release_workflow_policy`: PASS (53개)
- `actionlint .github/workflows/release.yml`: PASS
- `python3 -m py_compile ...`: PASS
- `ruff check --ignore EXE001,ISC004,UP045,FURB188,I001 ...`: PASS
- `ruff check ...`, `ruff format --check ...`: 기존 파일의 formatting·typing·shebang 부채로 FAIL;
  변경분은 위 제외 범위 검사와 독립 리뷰로 확인했다.
- `pytest ...`: 실행 환경에 `pytest`가 없어 exit 127; 기존 `unittest` suite 85개로 대체했다.
- `git diff --check`: PASS
- 격리 GNO index/embed/search: PASS (lesson 1건, 검색 hit 1건)
- exact-head GitHub Actions CI: PASS (26/26)
- default-branch CodeQL: Actions/Python PASS, alerts #52~#54 `fixed`

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: 독립 `code-reviewer` 보안 리뷰 PASS
- GitHub review/thread: review 0건, 미해결 thread 0건
- 잔여 위험: 없음. 수동 CodeQL run의 비대상 Java/Kotlin job은 계속 실행 중이다.

## Metadata

- Issue: N/A (승인 범위는 code scanning alerts #52, #53, #54이며 별도 issue 생성 없음)
- PR: #1711, reviewed head `28a38b19ef9d6e9a3c3c60a83e161edb85febea6`, merge commit `6dcfa0b504401155c7f035e5859bab5c5908ffbd`
- Milestone/assignee: `2.1.0`, `debop`
- Labels: `bug`, `security`, `github_actions`, `test`
- CI: [run 34201131990](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34201131990) PASS (26/26)
- CodeQL: [run 34204304534](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34204304534), target Actions/Python jobs PASS

## DoD Status

Required checks: 52/52; N/A: 4; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CL-01~08 - Checklist contract | 사전 구성, 순서, fail-closed, current count 확인 | PASS | run `20260908T054734Z-fbe671f1`; 52/52 | none |
| CG-01~07 - Preflight/targeted proof | authority, GNO/live evidence, isolation, RED/GREEN 확인 | PASS | isolated branch; regex timeout과 workflow assertion RED | none |
| CG-08 - Heavy checks | runtime Testcontainers/DB 변경 여부 확인 | N/A | Python parser와 workflow policy만 변경 | none |
| CG-09 - Lesson | 재발 방지 lesson 작성·격리 index/search | PASS | committed lesson, GNO hit 1건 | 기본 collection 재색인은 후속 maintenance 범위 |
| CG-10 - Pre-PR proof | 최종 diff, P0/P1=0, 검증 후 commit | PASS | `28a38b19ef9d6e9a3c3c60a83e161edb85febea6` | none |
| CG-11~12 - Delivery authority/head | 승인된 repo/base/head를 non-force push하고 read-back | PASS | local=remote reviewed head | none |
| CG-12A - Guidance refresh | current AGENTS/leaf/common/PR template 재확인 | PASS | 2026-09-08 current content hashes, linked issue N/A | none |
| CG-13 - PR metadata | assignee/labels/milestone/body/head live read-back | PASS | PR #1711 metadata | none |
| CG-14 - CI/review | exact-head CI와 review/thread 확인 | PASS | run 34201131990 26/26; review 0건; thread 0건; human subgate N/A | none |
| CG-15 - Merge-ready | exact-head merge-ready 보고 | PASS | `MERGEABLE/CLEAN`; 사용자 보고 완료 | none |
| CG-16~17 - Merge | fresh 승인 후 exact-head squash merge와 develop 동기화 | PASS | merge `6dcfa0b504401155c7f035e5859bab5c5908ffbd`; local=remote develop | none |
| CG-18 - Closeout | default-branch alert와 보존 자산 상태 확인 | PASS | alerts #52~#54 `fixed`; branch/worktree는 삭제 승인 전 보존 | none |
| C-01~09 - Bugfix proof/delivery/closeout | root cause부터 default-branch CodeQL까지 검증 | PASS | 85 tests; actionlint; review; CI 26/26; alerts 3건 fixed | none |
| PY-01,03,04,06,07 - Python | internal scope, bounded timeout, validation, verdict 확인 | PASS | unittest 85개; P0=0/P1=0 | none |
| PY-02,05 - Public/packaging | 공개 API·async·package metadata 변경 여부 확인 | N/A | internal stdlib scripts only | none |
| SPW-01~05 - Lesson contract | 독자/근거/구조/traceability/read-back 확인 | PASS | lesson sections와 source 대조 | none |
| KO-01~07 - Korean register | 사실·용어·링크·전체 reader surface 감사 | PASS | terminology findings 0 | none |

Final status: DONE

Unchecked required items: none
