### PR TITLE
test: 실제 publication 서명과 Base64 입력 경계 검증

### DIFF
--- a/buildSrc/src/test/kotlin/io/bluetape4k/gradle/PublishingSigningIntegrationTest.kt
+++ b/buildSrc/src/test/kotlin/io/bluetape4k/gradle/PublishingSigningIntegrationTest.kt
@@ -1,0 +1,183 @@
+package io.bluetape4k.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.Base64
+import java.util.Properties
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** 실제 배포 키 대신 임시 키로 Projects 서명 어댑터의 산출물을 검증한다. */
+class PublishingSigningIntegrationTest {
+
+    @Test
+    fun `메모리 키와 GPG fallback으로 실제 publication을 서명한다`() {
+        withFixture { fixture ->
+            fixture.generateKey()
+            val armor = fixture.exportKey()
+            val encoded = Base64.getEncoder().encodeToString(armor.toByteArray())
+            for ((name, key) in listOf("armor" to armor, "base64" to encoded, "gpg" to "")) {
+                val project = fixture.project(name, key, useGpg = name == "gpg")
+                val result = fixture.runner(project).build()
+
+                assertEquals(TaskOutcome.SUCCESS, result.task(":signReleasePublication")?.outcome)
+                fixture.assertNoSecrets(result.output, armor, encoded)
+                val artifact = project.resolve("payload.txt")
+                val signature = project.resolve("payload.txt.asc")
+                assertTrue(signature.isFile, "publication 서명 파일이 필요하다")
+                fixture.verify(signature, artifact)
+
+                artifact.appendText("변조")
+                fixture.verify(signature, artifact, expectedSuccess = false)
+            }
+        }
+    }
+
+    @Test
+    fun `잘못된 private key는 서명에 실패하며 비밀 입력을 출력하지 않는다`() {
+        withFixture { fixture ->
+            val malformed = "malformed-private-key-sentinel"
+            val project = fixture.project("malformed", malformed)
+
+            val result = fixture.runner(project).buildAndFail()
+
+            fixture.assertNoSecrets(result.output, malformed, "malformed-private-key-sentinel")
+            assertFalse(project.resolve("payload.txt.asc").exists())
+            assertTrue(result.output.contains("Could not read PGP secret key"), "PGP 키 파싱 실패여야 한다")
+        }
+    }
+
+    private fun withFixture(block: (SigningFixture) -> Unit) {
+        // macOS 기본 임시 경로는 gpg-agent Unix 소켓 경로 제한을 넘을 수 있다.
+        val root = createTempDirectory(Path.of("/tmp"), "signing-").toFile()
+        try {
+            SigningFixture(root).use(block)
+        } finally {
+            assertTrue(root.deleteRecursively(), "합성 서명 임시 파일을 정리해야 한다")
+        }
+    }
+
+    private class SigningFixture(private val root: File): AutoCloseable {
+        private val home = root.resolve("gnupg").apply {
+            mkdirs()
+            Files.setPosixFilePermissions(toPath(), PosixFilePermissions.fromString("rwx------"))
+        }
+        private val password = "synthetic-signing-regression-password"
+        private val identity = "Signing Fixture <signing-fixture@example.invalid>"
+        private val gpg = executable("gpg")
+        private val gpgconf = executable("gpgconf")
+        private val environment = System.getenv().filterKeys {
+            !it.startsWith("SIGNING_") && !it.startsWith("GPG_") &&
+                !it.startsWith("ORG_GRADLE_PROJECT_") && it != "GNUPGHOME" &&
+                it != "GRADLE_USER_HOME" && it != "GRADLE_OPTS" && it != "JAVA_TOOL_OPTIONS"
+        } + mapOf("GNUPGHOME" to home.absolutePath)
+
+        fun generateKey() {
+            command(gpg, "--batch", "--pinentry-mode", "loopback", "--passphrase-fd", "0",
+                "--quick-generate-key", identity, "rsa2048", "sign", "0", input = "$password\n")
+        }
+
+        fun exportKey(): String =
+            command(gpg, "--batch", "--pinentry-mode", "loopback", "--passphrase-fd", "0",
+                "--armor", "--export-secret-keys", identity, input = "$password\n")
+
+        fun project(name: String, key: String, useGpg: Boolean = false): File {
+            val dir = root.resolve(name).apply { mkdirs() }
+            dir.resolve("settings.gradle").writeText("rootProject.name = 'signing-fixture'\n")
+            dir.resolve("payload.txt").writeText("합성 publication 산출물\n")
+            val properties = Properties().apply {
+                setProperty("signingKey", key)
+                setProperty("signingKeyId", "")
+                setProperty("signingPassword", if (useGpg) "" else password)
+                setProperty("signingUseGpgCmd", useGpg.toString())
+                setProperty("signing.gnupg.executable", gpg)
+                setProperty("signing.gnupg.keyName", identity)
+                setProperty("signing.gnupg.homeDir", home.absolutePath)
+                setProperty("signing.gnupg.passphrase", password)
+            }
+            dir.resolve("signing-fixture.properties").outputStream().use { properties.store(it, null) }
+            // 복사한 helper가 아니라 현재 buildSrc가 컴파일한 어댑터와 helper를 로드한다.
+            val classpath = listOf(PublishingSigningConfig::class.java, Unit::class.java)
+                .map { File(it.protectionDomain.codeSource.location.toURI()).absolutePath }
+                .joinToString(", ") { "'" + it.replace("\\", "\\\\").replace("'", "\\'") + "'" }
+            dir.resolve("build.gradle").writeText(
+                """
+                buildscript { dependencies { classpath files($classpath) } }
+                apply plugin: 'maven-publish'
+                apply plugin: 'signing'
+                group = 'io.bluetape4k.fixture'
+                version = '1.0'
+                def inputs = new Properties()
+                file('signing-fixture.properties').withInputStream { inputs.load(it) }
+                inputs.each { key, value -> project.ext.set(key, value) }
+                publishing {
+                    publications {
+                        release(MavenPublication) { artifact(file('payload.txt')) }
+                    }
+                }
+                io.bluetape4k.gradle.PublishingSigningSupportKt.configurePublishingSigning(
+                    project, 'release', true, '서명 키가 필요합니다')
+                """.trimIndent() + "\n",
+            )
+            return dir
+        }
+
+        fun runner(project: File): GradleRunner = GradleRunner.create()
+            .withProjectDir(project)
+            .withTestKitDir(root.resolve("testkit"))
+            .withEnvironment(environment)
+            .withArguments("signReleasePublication", "--offline", "--no-configuration-cache",
+                "--no-build-cache", "--max-workers=1", "--console=plain", "--stacktrace")
+
+        fun verify(signature: File, artifact: File, expectedSuccess: Boolean = true) {
+            command(gpg, "--batch", "--verify", signature.absolutePath, artifact.absolutePath,
+                expectedSuccess = expectedSuccess)
+        }
+
+        fun assertNoSecrets(output: String, vararg secrets: String) {
+            val secretLines = secrets.flatMap { it.lines() }.filter { it.length >= 24 }
+            for (secret in listOf(password, "-----BEGIN PGP PRIVATE KEY BLOCK-----") + secrets + secretLines) {
+                assertFalse(output.contains(secret), "서명 출력에 비밀 입력이 노출되어서는 안 된다")
+            }
+        }
+
+        private fun command(vararg arguments: String, input: String = "", expectedSuccess: Boolean = true): String {
+            val output = File.createTempFile("command-", ".log", root)
+            val process = ProcessBuilder(*arguments).apply {
+                environment().clear()
+                environment().putAll(environment)
+                redirectErrorStream(true)
+                redirectOutput(output)
+            }.start()
+            try {
+                process.outputStream.bufferedWriter().use { it.write(input) }
+                assertTrue(process.waitFor(60, TimeUnit.SECONDS), "합성 GPG 작업이 제한 시간 안에 끝나야 한다")
+                assertEquals(expectedSuccess, process.exitValue() == 0, "합성 GPG 작업의 종료 상태가 예상과 다르다")
+                return output.readText()
+            } finally {
+                if (process.isAlive) {
+                    process.destroyForcibly()
+                    process.waitFor(10, TimeUnit.SECONDS)
+                }
+                output.delete()
+            }
+        }
+
+        override fun close() {
+            command(gpgconf, "--homedir", home.absolutePath, "--kill", "gpg-agent")
+        }
+
+        private fun executable(name: String): String =
+            System.getenv("PATH").orEmpty().split(File.pathSeparator)
+                .map { File(it, name) }.firstOrNull { it.isFile && it.canExecute() }?.absolutePath
+                ?: error("서명 회귀 검증에 $name 실행 파일이 필요합니다")
+    }
+}

--- a/buildSrc/src/test/kotlin/io/bluetape4k/gradle/PublishingSigningSupportTest.kt
+++ b/buildSrc/src/test/kotlin/io/bluetape4k/gradle/PublishingSigningSupportTest.kt
@@ -106,6 +106,48 @@ class PublishingSigningSupportTest {
         )
     }
 
+    @Test
+    fun `필요한 Base64 padding을 모두 제공하면 armor로 디코딩한다`() {
+        for (padding in listOf("=", "==")) {
+            val armor = (0..2).map { privateKeyArmor() + "\n".repeat(it) }
+                .first { Base64.getEncoder().encodeToString(it.toByteArray()).takeLastWhile { it == '=' } == padding }
+            val encoded = Base64.getEncoder().encodeToString(armor.toByteArray())
+
+            assertEquals(armor, resolveSigningKey(encoded))
+            assertEquals(armor, resolveSigningKey("  $encoded\n"))
+        }
+    }
+
+    @Test
+    fun `필요한 Base64 padding이 누락되면 원본 입력을 보존한다`() {
+        for (padding in listOf("=", "==")) {
+            val armor = (0..2).map { privateKeyArmor() + "\n".repeat(it) }
+                .first { Base64.getEncoder().encodeToString(it.toByteArray()).takeLastWhile { it == '=' } == padding }
+            val unpadded = Base64.getEncoder().encodeToString(armor.toByteArray()).trimEnd('=')
+
+            assertEquals(unpadded, resolveSigningKey(unpadded))
+            assertEquals("  $unpadded\n", resolveSigningKey("  $unpadded\n"))
+        }
+    }
+
+    @Test
+    fun `원본 바이트가 세 배수이면 padding 없는 완전한 Base64를 허용한다`() {
+        val armor = (0..2).map { privateKeyArmor() + "\n".repeat(it) }
+            .first { it.toByteArray().size % 3 == 0 }
+        val encoded = Base64.getEncoder().encodeToString(armor.toByteArray())
+
+        assertTrue(!encoded.endsWith("="))
+        assertEquals(armor, resolveSigningKey(encoded))
+    }
+
+    @Test
+    fun `잘못된 Base64와 armor가 아닌 디코딩 결과는 원본을 보존한다`() {
+        val invalidUtf8 = Base64.getEncoder().encodeToString(byteArrayOf(0xC3.toByte(), 0x28))
+        for (raw in listOf("not-base64!", "Zm9v", "Zg=", "Zg===", invalidUtf8)) {
+            assertEquals(raw, resolveSigningKey(raw))
+        }
+    }
+
     private fun privateKeyArmor(): String =
         "-----BEGIN PGP PRIVATE KEY BLOCK-----\n" +
             "Version: test\n\n" +

--- a/docs/lessons/2026-09-08-issue-1691-publication-signing.md
+++ b/docs/lessons/2026-09-08-issue-1691-publication-signing.md
@@ -1,0 +1,29 @@
+# publication 서명은 생성된 서명 파일로 검증한다
+
+## 배경과 결정
+
+[#1691](https://github.com/bluetape4k/bluetape4k-projects/issues/1691)의 기존 테스트는 가짜 GPG 실행 파일과 존재하지 않는 publication으로 설정값만 확인했다. 이 결과는 실제 `sign(publication)` 실행이나 `.asc`의 유효성을 증명하지 못한다.
+
+회귀 테스트는 저장소가 빌드한 `configurePublishingSigning`과 생성된 `PublishingSigningKeySupport.kt`를 그대로 사용한다. 임시 키와 격리된 GPG home으로 로컬 publication을 서명하고 `gpg --verify`로 산출물을 확인한다. 실제 배포 키, 원격 publication과 release는 검증 범위에 포함하지 않는다. 잘못된 키의 실패 경로에서는 비밀번호와 private armor가 출력에 노출되지 않는지도 확인한다.
+
+## Base64 입력 계약
+
+`resolveSigningKey`의 현재 strict Base64 정책을 유지한다.
+
+- 원본 바이트 길이에 따라 필요한 `=` 또는 `==`가 모두 있으면 디코딩한다.
+- 필요한 padding을 제거한 입력은 디코딩하지 않고 공백까지 포함한 원본을 반환한다. 입력을 자동 복구하지 않는다.
+- 원본 바이트 길이가 3의 배수이면 padding이 필요 없으므로 `=` 없는 완전한 Base64도 허용한다.
+- Base64 형식이 잘못됐거나 디코딩 결과가 유효한 UTF-8 ASCII private armor가 아니면 원본을 반환한다.
+- armor 외형의 정규화와 실제 PGP 키 검증은 다르다. PGP 키 파싱과 서명은 Gradle signing 단계에서 검증한다.
+
+padding이 필요한 키를 padding 없이 저장한 소비자는 표준 Base64 인코더로 다시 인코딩하거나 raw armor를 제공해야 한다. 공통 helper를 변경해야 할 때는 생성 파일을 직접 고치지 않고 중앙 원본과 동기화 절차를 사용한다.
+
+## 검증과 재발 방지
+
+`PublishingSigningSupportTest`는 padding 경계를 고정하며 실제 서명 테스트는 Projects 어댑터의 publication 경로를 검증한다. 중앙 helper의 단위 테스트를 이 어댑터의 통합 검증으로 대체하지 않는다. 실행 결과는 연결 PR의 검증 항목에서 확인한다.
+
+`buildSrc`는 애플리케이션 프로젝트보다 먼저 빌드되므로 기존 `kotlin.test`와 Gradle TestKit을 사용한다. 프로젝트의 assertions 모듈을 추가해 빌드 부트스트랩에 순환 의존성을 만들지 않는다.
+
+작업 기록 초기화에서도 추정한 경로와 식별자 대신 helper의 입력 계약을 먼저 확인한다. 소유자 파일은 state-root의 `handles` 아래에 두고, lane write scope는 저장소 기준 상대 경로로 지정한다. 초기화 성공은 테스트나 리뷰 성공의 근거가 아니다.
+
+macOS 기본 임시 디렉터리에 긴 fixture 이름을 붙이면 GPG agent의 Unix 소켓 연결이 실패할 수 있다. 최초 실행의 `IPC connect call failed`와 `No agent running`을 같은 경로의 키 생성 명령으로 재현했다. 짧은 `/tmp/signing-*` 디렉터리와 GPG home의 `0700` 권한을 사용하며, 종료 시 해당 home의 agent와 임시 키를 정리한다. 테스트 실패를 실제 서명 어댑터 결함으로 분류하기 전에 키 생성 단계부터 분리해 확인한다.


### PR DESCRIPTION
## 요약

Fixes #1691

서명 설정 속성만 확인하던 검증을 실제 publication 산출물까지 확장합니다. 합성 GPG 키로 raw armor·Base64·GPG fallback을 실행하고 서명 유효성과 실패 경로를 고정합니다.

## 변경과 검증

- `./gradlew -p buildSrc cleanTest check --no-build-cache --max-workers=2 --console=plain`: 최종 30/30 성공, 실패/오류/비활성 0.
- 실제 `signReleasePublication` SUCCESS 및 `.asc`를 `gpg --verify`로 확인. 산출물 변조 후 검증 실패까지 세 경로에서 확인.
- malformed key의 `Could not read PGP secret key` 실패, `.asc` 부재, 비밀번호/private armor/Base64 출력 비노출 확인.
- 필요한 `=`/`==`와 실제 padding 불필요 입력은 decode, padding 누락 및 잘못된 Base64/UTF-8/non-armor는 raw fallback.
- 현재 컴파일된 generated helper와 기존 `configurePublishingSigning` API 사용. 생산 소스와 의존성 변경 없음.
- `git diff --check` 및 `gitleaks git --log-opts=develop..HEAD --redact --no-banner` 통과.

## 리뷰 참고

- 독립 code-reviewer는 응답 시간 초과로 중단했고 main session inline fallback review로 대체했습니다. P0/P1=0. 독립 코드 리뷰로 표시하지 않습니다.
- 독립 architect `gpt-5.6-sol/high`: CLEAR, P0/P1=0. 실제 classpath, API/ABI, Base64 계약, 프로세스·비밀정보 경계, 최종 XML 30/30을 검토했습니다.

테스트에는 POSIX 환경과 gpg/gpgconf가 필요합니다. macOS에서는 긴 임시 경로의 agent 소켓 실패를 재현해 짧은 /tmp 경로와 home 0700 권한을 적용했습니다. 원격 배포와 실제 배포 키는 검증 범위 밖입니다. buildSrc 부트스트랩 순환 의존성을 피하려고 기존 kotlin.test/Gradle TestKit을 재사용합니다.

교훈: `docs/lessons/2026-09-08-issue-1691-publication-signing.md`. 한국어 용어 검사와 격리 GNO 인덱스의 추가·검색을 검증했습니다. 머지 후 develop 문서의 GNO 갱신과 대표 검색도 확인했습니다.

## 메타데이터

- 저장소 `bluetape4k/bluetape4k-projects`, base `develop`, head `chore/1691-signing-regression`
- 커밋 `15ba9815ca9c7f019c00bd23cf2d9a80816f628d`: 로컬과 원격 SHA 일치
- 이슈 #1691, milestone `2.1.0`, 담당자 `debop`
- CI: [34228971039](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34228971039), 현재 head 성공 26개. 리뷰 변경 요청 및 미해결 스레드 없음.

- 머지 커밋: `6ef928462d85f1c4f17ee9db40e29e31cf9ca74d`; 이슈 CLOSED 확인
- develop/upstream: `083417e5748724453dfb8415091ad7861092f9d8`, clean. 작업 브랜치와 worktree는 보존했습니다.
- 머지 후 [CI](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34229977945)와 [Dependency Submission](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34229977940): 동일 최종 커밋 SUCCESS.

## DoD Status

Required checks: 29/29; N/A: 1; Blocked: 0

공통 게이트와 Type B 실행 항목 기준입니다. WF-00~WF-04A 및 Kotlin 사전 지침 확인을 완료했습니다.

| Check | 수행 내용 | 상태 | 근거 / 다음 작업 |
|---|---|---|---|
| CG-01 | 기준 정보와 승인 범위 | PASS | 위 검증 근거 |
| CG-02 | GNO 및 live 이슈 | PASS | 위 검증 근거 |
| CG-03 | 격리 worktree | PASS | 위 검증 근거 |
| CG-04 | 언어 및 범위 정책 | PASS | 위 검증 근거 |
| CG-05 | 기존 패턴 재사용 | PASS | 위 검증 근거 |
| CG-06 | 계약과 문서 | PASS | 위 검증 근거 |
| CG-07 | 회귀 및 영향 테스트 | PASS | 위 검증 근거 |
| CG-08 | 무거운 검증 순차 실행 | PASS | 위 검증 근거 |
| CG-09 | 교훈과 인덱스 검색 | PASS | 위 검증 근거 |
| CG-10 | 최종 리뷰 및 커밋 | PASS | 위 검증 근거 |
| CG-11 | 승인된 repo/base/head PR 범위 | PASS | 위 검증 근거 |
| CG-12 | 정확한 head push | PASS | 위 검증 근거 |
| CG-12A | 현재 지침과 이슈 재조회 | PASS | 위 검증 근거 |
| CG-13 | PR 생성 및 live 확인 | PASS | 현재 head CI와 메타데이터·리뷰/스레드 재조회 |
| CG-14 | 현재 head CI 및 리뷰 스레드 | PASS | 현재 head CI와 메타데이터·리뷰/스레드 재조회 |
| CG-15 | 머지 준비 보고 | PASS | 현재 head CI와 메타데이터·리뷰/스레드 재조회 |
| CG-16 | 최신 head 머지 승인 | PASS | 최신 head 승인 후 squash 머지와 develop 동기화 확인 |
| CG-17 | 머지와 결과 확인 | PASS | 최신 head 승인 후 squash 머지와 develop 동기화 확인 |
| CG-18 | 로컬 동기화 및 상태 보존 | PASS | 최신 head 승인 후 squash 머지와 develop 동기화 확인 |
| B-01 | Type B 범위 | PASS | 위 검증 근거 |
| B-02 | 기존 패턴 | PASS | 위 검증 근거 |
| B-03 | 구현·검증 계획 | PASS | 위 검증 근거 |
| B-04 | 최소 구현 | PASS | 위 검증 근거 |
| B-05 | 대상 동작 검증 | PASS | 위 검증 근거 |
| B-06 | 영향 범위 리뷰 | PASS | 위 검증 근거 |
| B-07 | 교훈 | PASS | 위 검증 근거 |
| B-08 | PR CI/리뷰 | PASS | 공통 CI·리뷰 확인 완료 |
| B-09 | 머지 준비 | PASS | 공통 CI·리뷰 확인 완료 |
| B-10 | 승인 후 완료 | PASS | 공통 머지 및 동기화 완료 |

별도 인간 리뷰: N/A (single-developer lane, debop 단독 유지관리 범위). CI와 코드 리뷰는 필수입니다.

Final status: DONE — 승인된 커밋 squash 머지, 이슈 종료, develop 동기화 및 머지 후 CI 검증 완료

Unchecked required items: 없음
