### PR TITLE
fix: 잔여 Kotlin 강제 단언 제거

### DIFF
--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceJCache.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceJCache.kt
@@ -114,7 +114,12 @@ class LettuceJCache<K: Any, V: Any>(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun decodeValue(bytes: ByteArray): V = codec.serializer.deserialize(bytes)!!
+    private fun decodeValue(bytes: ByteArray): V {
+        val decoded = codec.serializer.deserialize<V>(bytes)
+        return decoded ?: throw CacheException(
+            "LettuceCache[$cacheName] 값 역직렬화 결과가 null입니다."
+        )
+    }
 
     override fun getName(): String = cacheName
 

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceJCacheTest.kt
@@ -1,23 +1,27 @@
 package io.bluetape4k.cache.jcache
 
 import io.bluetape4k.cache.RedisServers
+import io.bluetape4k.io.serializer.BinarySerializer
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
-import io.bluetape4k.redis.lettuce.map.LettuceMap
-import io.lettuce.core.codec.StringCodec
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.every
+import io.mockk.mockk
+import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodecs
+import io.bluetape4k.redis.lettuce.codec.LettuceBinaryCodec
+import io.bluetape4k.redis.lettuce.map.LettuceMap
+import io.lettuce.core.codec.StringCodec
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import io.bluetape4k.assertions.assertFailsWith
 import java.net.URI
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
@@ -68,6 +72,27 @@ class LettuceJCacheTest {
     @Test
     fun `get returns null for missing key`() {
         cache.get("nonexistent").shouldBeNull()
+    }
+
+    @Test
+    fun `null serializer result is reported as CacheException without payload`() {
+        val map = mockk<LettuceMap<ByteArray>>()
+        every { map.mapKey } returns "null-deserialize-cache"
+        every { map.get("key") } returns byteArrayOf(0x5a)
+        val serializer = object: BinarySerializer {
+            override fun serialize(graph: Any?): ByteArray = byteArrayOf(0x01)
+
+            override fun <T: Any> deserialize(bytes: ByteArray?): T? = null
+        }
+        val brokenCache = LettuceJCache<String, String>(
+            map = map,
+            codec = LettuceBinaryCodec<Any>(serializer),
+            cacheManager = manager as LettuceCacheManager,
+            configuration = lettuceCacheConfigOf(),
+        )
+
+        val exception = assertFailsWith<CacheException> { brokenCache.get("key") }
+        exception.message shouldBeEqualTo "LettuceCache[null-deserialize-cache] 값 역직렬화 결과가 null입니다."
     }
 
     @Test

--- a/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
+++ b/infra/kafka/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
@@ -42,7 +42,8 @@ suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): Rec
     suspendCancellableCoroutine { cont ->
         val future = send(record) { metadata, exception ->
             if (exception != null) cont.resumeWithException(exception)
-            else cont.resume(metadata!!)
+            else metadata?.let(cont::resume)
+                ?: cont.resumeWithException(IllegalStateException("Kafka callback returned no metadata"))
         }
         cont.invokeOnCancellation { future.cancel(true) }
     }

--- a/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutinesContractTest.kt
+++ b/infra/kafka/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutinesContractTest.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.kafka.coroutines
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.apache.kafka.clients.producer.Callback
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+
+class ProducerCoroutinesContractTest {
+
+    @Test
+    fun `성공 callback에 metadata가 없으면 명시적인 실패를 반환한다`() = runTest {
+        val producer = mockk<Producer<String, String>>()
+        every { producer.send(any(), any()) } answers {
+            secondArg<Callback>().onCompletion(null, null)
+            CompletableFuture<RecordMetadata>().apply { complete(null) }
+        }
+
+        assertFailsWith<IllegalStateException> {
+            producer.suspendSend(ProducerRecord("topic", "key", "value"))
+        }
+    }
+}

--- a/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
+++ b/infra/kafka4/src/main/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutines.kt
@@ -42,7 +42,8 @@ suspend fun <K, V> Producer<K, V>.suspendSend(record: ProducerRecord<K, V>): Rec
     suspendCancellableCoroutine { cont ->
         val future = send(record) { metadata, exception ->
             if (exception != null) cont.resumeWithException(exception)
-            else cont.resume(metadata!!)
+            else metadata?.let(cont::resume)
+                ?: cont.resumeWithException(IllegalStateException("Kafka callback returned no metadata"))
         }
         cont.invokeOnCancellation { future.cancel(true) }
     }

--- a/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutinesContractTest.kt
+++ b/infra/kafka4/src/test/kotlin/io/bluetape4k/kafka/coroutines/ProducerCoroutinesContractTest.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.kafka.coroutines
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.apache.kafka.clients.producer.Callback
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+
+class ProducerCoroutinesContractTest {
+
+    @Test
+    fun `성공 callback에 metadata가 없으면 명시적인 실패를 반환한다`() = runTest {
+        val producer = mockk<Producer<String, String>>()
+        every { producer.send(any(), any()) } answers {
+            secondArg<Callback>().onCompletion(null, null)
+            CompletableFuture<RecordMetadata>().apply { complete(null) }
+        }
+
+        assertFailsWith<IllegalStateException> {
+            producer.suspendSend(ProducerRecord("topic", "key", "value"))
+        }
+    }
+}

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvSettings.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/CsvSettings.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.csv
 
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireEquals
+import io.bluetape4k.support.requireNotEmpty
+import io.bluetape4k.support.requirePositiveNumber
 import java.io.Serializable
 
 /**
@@ -89,22 +92,14 @@ data class CsvSettings(
         require(delimiter != quote) {
             "delimiter($delimiter)와 quote($quote)는 달라야 합니다"
         }
-        require(quoteEscape == quote) {
+        quoteEscape.requireEquals(quote) {
             "V1은 RFC 4180 doubled-quote 이스케이프만 지원합니다. " +
                     "quoteEscape는 quote와 동일해야 합니다. " +
                     "임의 이스케이프 문자는 V2 이후 지원 예정입니다"
         }
-        require(maxCharsPerColumn > 0) {
-            "maxCharsPerColumn($maxCharsPerColumn)은 양수여야 합니다"
-        }
-        require(maxColumns > 0) {
-            "maxColumns($maxColumns)은 양수여야 합니다"
-        }
-        require(bufferSize > 0) {
-            "bufferSize($bufferSize)은 양수여야 합니다"
-        }
-        require(lineSeparator.isNotEmpty()) {
-            "lineSeparator는 비어 있을 수 없습니다"
-        }
+        maxCharsPerColumn.requirePositiveNumber { "maxCharsPerColumn($maxCharsPerColumn)은 양수여야 합니다" }
+        maxColumns.requirePositiveNumber { "maxColumns($maxColumns)은 양수여야 합니다" }
+        bufferSize.requirePositiveNumber { "bufferSize($bufferSize)은 양수여야 합니다" }
+        lineSeparator.requireNotEmpty { "lineSeparator는 비어 있을 수 없습니다" }
     }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvSettings.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/TsvSettings.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.csv
 
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotEmpty
+import io.bluetape4k.support.requirePositiveNumber
 import java.io.Serializable
 
 /**
@@ -64,17 +66,9 @@ data class TsvSettings(
     }
 
     init {
-        require(maxCharsPerColumn > 0) {
-            "maxCharsPerColumn은 양수여야 합니다"
-        }
-        require(maxColumns > 0) {
-            "maxColumns은 양수여야 합니다"
-        }
-        require(bufferSize > 0) {
-            "bufferSize은 양수여야 합니다"
-        }
-        require(lineSeparator.isNotEmpty()) {
-            "lineSeparator는 비어 있을 수 없습니다"
-        }
+        maxCharsPerColumn.requirePositiveNumber { "maxCharsPerColumn은 양수여야 합니다" }
+        maxColumns.requirePositiveNumber { "maxColumns은 양수여야 합니다" }
+        bufferSize.requirePositiveNumber { "bufferSize은 양수여야 합니다" }
+        lineSeparator.requireNotEmpty { "lineSeparator는 비어 있을 수 없습니다" }
     }
 }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/CsvLexer.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/CsvLexer.kt
@@ -150,7 +150,7 @@ internal class CsvLexer(
 
     override fun next(): ArrayRecord {
         if (!hasNext()) throw NoSuchElementException("더 이상 읽을 레코드가 없습니다")
-        val record = nextRecord!!
+        val record = nextRecord ?: throw NoSuchElementException("더 이상 읽을 레코드가 없습니다")
         nextRecord = null
         return record
     }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/OkioCsvLexer.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/OkioCsvLexer.kt
@@ -96,7 +96,7 @@ internal class OkioCsvLexer(
 
     override fun next(): ArrayRecord {
         if (!hasNext()) throw NoSuchElementException("더 이상 읽을 레코드가 없습니다")
-        val record = nextRecord!!
+        val record = nextRecord ?: throw NoSuchElementException("더 이상 읽을 레코드가 없습니다")
         nextRecord = null
         return record
     }

--- a/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/TsvLexer.kt
+++ b/io/csv/src/main/kotlin/io/bluetape4k/csv/internal/TsvLexer.kt
@@ -65,8 +65,9 @@ internal class TsvLexer(
         if (skipHeaders) {
             val firstRow = parseRow()
             if (firstRow != null && firstRow.isNotEmpty()) {
-                headers = firstRow.map { it ?: "" }.toTypedArray()
-                headerIndex = HeaderIndex.of(headers!!)
+                val parsedHeaders = firstRow.map { it ?: "" }.toTypedArray()
+                headers = parsedHeaders
+                headerIndex = HeaderIndex.of(parsedHeaders)
             }
         }
     }
@@ -87,7 +88,7 @@ internal class TsvLexer(
      */
     override fun next(): ArrayRecord {
         if (!hasNext()) throw NoSuchElementException("더 이상 레코드가 없습니다")
-        val record = nextRecord!!
+        val record = nextRecord ?: throw NoSuchElementException("더 이상 읽을 레코드가 없습니다")
         nextRecord = null
         return record
     }

--- a/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/KotlinSafetyContractTest.kt
+++ b/io/csv/src/test/kotlin/io/bluetape4k/csv/internal/KotlinSafetyContractTest.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.csv.internal
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.csv.CsvSettings
+import io.bluetape4k.csv.TsvSettings
+import okio.buffer
+import okio.source
+import org.junit.jupiter.api.Test
+
+class KotlinSafetyContractTest {
+
+    @Test
+    fun `all lexer implementations preserve Iterator EOF contract`() {
+        CsvLexer("".reader(), CsvSettings.DEFAULT).use { lexer ->
+            lexer.hasNext().shouldBeFalse()
+            assertFailsWith<NoSuchElementException> { lexer.next() }
+        }
+        TsvLexer("".reader(), TsvSettings.DEFAULT).use { lexer ->
+            lexer.hasNext().shouldBeFalse()
+            assertFailsWith<NoSuchElementException> { lexer.next() }
+        }
+        OkioCsvLexer("".byteInputStream().source().buffer(), CsvSettings.DEFAULT).use { lexer ->
+            lexer.hasNext().shouldBeFalse()
+            assertFailsWith<NoSuchElementException> { lexer.next() }
+        }
+    }
+
+    @Test
+    fun `settings reject invalid limits through the shared validation contract`() {
+        assertFailsWith<IllegalArgumentException> { CsvSettings(maxCharsPerColumn = 0) }
+        assertFailsWith<IllegalArgumentException> { CsvSettings(maxColumns = 0) }
+        assertFailsWith<IllegalArgumentException> { CsvSettings(bufferSize = 0) }
+        assertFailsWith<IllegalArgumentException> { CsvSettings(lineSeparator = "") }
+        assertFailsWith<IllegalArgumentException> { CsvSettings(quoteEscape = '\\') }
+
+        assertFailsWith<IllegalArgumentException> { TsvSettings(maxCharsPerColumn = 0) }
+        assertFailsWith<IllegalArgumentException> { TsvSettings(maxColumns = 0) }
+        assertFailsWith<IllegalArgumentException> { TsvSettings(bufferSize = 0) }
+        assertFailsWith<IllegalArgumentException> { TsvSettings(lineSeparator = "") }
+    }
+
+    @Test
+    fun `valid settings continue to support both lexer paths`() {
+        val csv = CsvLexer("name\nvalue".reader(), CsvSettings.DEFAULT, skipHeaders = true)
+        val okio = OkioCsvLexer(
+            "name\nvalue".byteInputStream().source().buffer(),
+            CsvSettings.DEFAULT,
+            skipHeaders = true,
+        )
+        csv.use { lexer -> lexer.hasNext().shouldBeTrue() }
+        okio.use { lexer -> lexer.hasNext().shouldBeTrue() }
+    }
+}

--- a/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
+++ b/virtualthread/jdk25/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/jdk25/Jdk25StructuredTaskScopeProvider.kt
@@ -379,7 +379,11 @@ class Jdk25StructuredTaskScopeProvider: StructuredTaskScopeProvider {
                 StructuredTaskScope.Subtask.State.SUCCESS ->
                     Result.success(subtask.get())
                 StructuredTaskScope.Subtask.State.FAILED  ->
-                    Result.failure(subtask.exceptionOrNull()!!)
+                    Result.failure(
+                        checkNotNull(subtask.exceptionOrNull()) {
+                            "FAILED subtask did not expose an exception"
+                        }
+                    )
                 else ->
                     // UNAVAILABLE: 취소되거나 join 이전 상태 — 결과를 가져오면 IllegalStateException 발생
                     Result.failure(java.util.concurrent.CancellationException("Subtask was cancelled or unavailable"))


### PR DESCRIPTION
## Summary

Closes #475

Part of #1728

잔여 Kotlin 강제 단언을 명시적인 실패 처리와 공용 검증 헬퍼로 교체해 잘못된 null 결과가 NPE로 누락되지 않도록 합니다.

## Background

Epic #1728의 모듈별 7-Tier 리뷰에서 재확인한 #475의 잔여 범위입니다. Kafka/Kafka4 callback, Lettuce serializer, CSV lexer/settings, virtualthread JDK25 경계의 `!!`만 다루며 기존 완료 항목은 건드리지 않았습니다.

## What This Solves

- Kafka callback의 null metadata와 Lettuce 역직렬화 null 결과를 진단 가능한 예외 계약으로 처리합니다.
- CSV EOF/header 불변식과 JDK25 FAILED subtask 결과를 강제 단언 없이 보장합니다.
- CSV 입력 검증에서 기존 메시지와 `IllegalArgumentException` 계약을 유지하면서 공용 helper를 재사용합니다.

## Work Done

- Kafka와 Kafka4의 `suspendSend`에 null metadata 실패 경로와 회귀 테스트를 추가했습니다.
- Lettuce cache, CSV Reader/Okio lexer/settings, virtualthread JDK25의 강제 단언을 명시적 검증으로 교체하고 계약 테스트를 추가했습니다.

## Validation

- `./gradlew :bluetape4k-kafka:test --no-configuration-cache`: PASS (266/266)
- `./gradlew :bluetape4k-kafka4:test --no-configuration-cache`: PASS (298/298)
- `./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache`: PASS (463/463)
- `./gradlew :bluetape4k-csv:test --no-configuration-cache`: PASS (278/278)
- `./gradlew :bluetape4k-virtualthread-jdk25:test --no-configuration-cache`: PASS (48/48)
- `./gradlew :bluetape4k-kafka:detekt :bluetape4k-kafka4:detekt :bluetape4k-cache-lettuce:detekt :bluetape4k-csv:detekt :bluetape4k-virtualthread-jdk25:detekt --no-configuration-cache`: PASS (기존 detekt 경고 출력)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 기존 detekt 경고는 범위 밖으로 유지했습니다.
- Review evidence: 변경 diff와 대상 모듈 회귀 테스트를 기준으로 한 로컬 inline fallback review

## Metadata

- Issue: #475, milestone `2.1.0`, assignee `debop`
- PR: #1751, head `5ffee45c42c5b9824448ac1c9c4bd1c5e83d062f`, milestone `2.1.0`, assignee `debop`
- CI: [CI run](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34255679209) 진행 중이며 exact head `5ffee45c42c5b9824448ac1c9c4bd1c5e83d062f` 기준으로 확인합니다.

## DoD Status

Required checks: 13/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|----------|----------|-----------------------|
| CG-01~CG-10 | 지침·이력·격리·구현·테스트·최종 diff 검증 | PASS | 현재 AGENTS/skill, isolated worktree, RED/GREEN, 모듈 테스트, exact local head | none |
| CG-11 - PR delivery authority | 요청된 저장소 `bluetape4k-projects`, base `develop`, head `fix/issue-475-residual-kotlin-safety` 확인 | PASS | 사용자 요청 및 승인된 Type C 실행 | none |
| CG-12 - Exact head publish | 수렴한 브랜치를 force 없이 push하고 원격 SHA 확인 | PASS | local/remote `5ffee45c42c5b9824448ac1c9c4bd1c5e83d062f` | none |
| CG-12A - Guidance refresh | PR 생성 직전 적용 지침·skill·common gates·template·이슈를 재확인 | PASS | 현재 파일 hash와 `gh issue view 475` live read-back | none |
| CG-13 - Create and verify PR | PR 생성, assignee/label/milestone 동기화, 본문 read-back | PASS | PR 생성 후 번호·head·metadata를 live 확인 | none |
| CG-14 - CI and review | exact-head CI·리뷰·threads 확인 | PENDING | PR 생성 후 확인 필요; 단일 개발자 lane human review는 N/A | CI와 thread read-back 후 갱신 |
| CG-15 - Merge-ready report | merge-ready evidence 보고 | PENDING | CG-14 완료 후 산출 | CG-14 통과 |
| CG-16 - Fresh merge approval | exact PR/head에 대한 새 병합 승인 | PENDING | 모든 PR 생성·검증 후 별도 요청 | 사용자 승인 대기 |
| CG-17 - Match-head merge | 승인된 exact head 병합 | PENDING | CG-16 이후 수행 | 승인 전 실행 금지 |
| CG-18 - Sync and cleanup | develop sync 및 proven merged worktree 정리 | PENDING | 전체 병합 후 수행 | 병합 검증 후 수행 |
| CG-X01 - Irreversible actions | tag/release/delete 등 조건부 작업 | N/A | 이번 PR은 해당 작업을 포함하지 않음 | none |

Final status: PENDING (PR 생성 후 exact-head CI·리뷰 및 전체 병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18

