### PR TITLE
fix: Testcontainers 서버 로그의 민감 값 노출 차단

### DIFF
--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/GenericServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/GenericServer.kt
@@ -65,12 +65,6 @@ fun <T: GenericServer> T.writeToSystemProperties(
     properties.forEach { (key, value) -> System.setProperty(key, value) }
 
     log.info {
-        buildString {
-            appendLine()
-            appendLine("Start $name Server:")
-            properties.forEach { (key, value) ->
-                appendLine("\t$key=$value")
-            }
-        }
+        "Start $name Server: ${properties.toPropertyLogSummary()}"
     }
 }

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/PropertyExportingServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/PropertyExportingServer.kt
@@ -1,5 +1,14 @@
 package io.bluetape4k.testcontainers
 
+import io.bluetape4k.logging.KotlinLogging
+import io.bluetape4k.logging.info
+
+private val propertyExportLog by lazy { KotlinLogging.logger {} }
+
+/** 로그에 프로퍼티 값 대신 안전하게 사용할 키 요약을 생성합니다. */
+internal fun Map<String, *>.toPropertyLogSummary(): String =
+    "keys=${keys.sorted()}, count=$size"
+
 /**
  * 시스템 프로퍼티 export 계약을 정의하는 인터페이스.
  *
@@ -96,9 +105,12 @@ interface PropertyExportingServer {
      */
     fun writeToSystemProperties() {
         val prefix = "$SERVER_PREFIX.$propertyNamespace"
-        properties().forEach { (key, value) ->
+        val props = properties()
+        props.forEach { (key, value) ->
             System.setProperty("$prefix.$key", value)
-            println("$prefix.$key=$value")
+        }
+        propertyExportLog.info {
+            "Exported server properties: namespace=$propertyNamespace, ${props.toPropertyLogSummary()}"
         }
     }
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/GenericServerSupportTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/GenericServerSupportTest.kt
@@ -2,11 +2,15 @@ package io.bluetape4k.testcontainers
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets.UTF_8
 
 class GenericServerSupportTest {
 
@@ -63,5 +67,29 @@ class GenericServerSupportTest {
         assertFailsWith<IllegalArgumentException> {
             server.writeToSystemProperties(" ")
         }
+    }
+
+    @Test
+    fun `writeToSystemProperties 로그는 extra 프로퍼티 값을 노출하지 않는다`() {
+        val canary = "REVIEW_GENERIC_PASSWORD_CANARY"
+        val server = mockk<GenericServer>(relaxed = true) {
+            every { host } returns "127.0.0.1"
+            every { port } returns 6379
+            every { url } returns "127.0.0.1:6379"
+        }
+        val originalOut = System.out
+        val captured = ByteArrayOutputStream()
+
+        try {
+            System.setOut(PrintStream(captured, true, UTF_8.name()))
+            server.writeToSystemProperties("redaction", mapOf("password" to canary))
+        } finally {
+            System.setOut(originalOut)
+            listOf("host", "port", "url", "password").forEach {
+                System.clearProperty("$SERVER_PREFIX.redaction.$it")
+            }
+        }
+
+        captured.toString(UTF_8).contains(canary).shouldBeFalse()
     }
 }

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/PropertyExportingServerContractTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/PropertyExportingServerContractTest.kt
@@ -10,6 +10,9 @@ import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.testcontainers.http.BluetapeHttpServer
 import io.bluetape4k.testcontainers.http.BluetapeWebfluxServer
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets.UTF_8
 
 /**
  * [PropertyExportingServer] 계약 테스트.
@@ -173,6 +176,32 @@ class PropertyExportingServerContractTest {
             System.clearProperty("$SERVER_PREFIX.$namespace.host")
             System.clearProperty("$SERVER_PREFIX.$namespace.port")
         }
+    }
+
+    @Test
+    fun `writeToSystemProperties 는 프로퍼티 값을 표준 출력에 기록하지 않는다`() {
+        val namespace = "redaction-contract-test"
+        val canary = "REVIEW_CANARY_NOT_A_SECRET"
+        val server = MockServer(
+            propertyNamespace = namespace,
+            keys = setOf("password", "host"),
+            props = mapOf("password" to canary, "host" to "localhost"),
+        )
+        val originalOut = System.out
+        val captured = ByteArrayOutputStream()
+
+        try {
+            System.setOut(PrintStream(captured, true, UTF_8.name()))
+            server.writeToSystemProperties()
+        } finally {
+            System.setOut(originalOut)
+            System.clearProperty("$SERVER_PREFIX.$namespace.password")
+            System.clearProperty("$SERVER_PREFIX.$namespace.host")
+        }
+
+        val output = captured.toString(UTF_8)
+        output.contains(canary).shouldBeFalse()
+        output.contains("keys=[host, password]").shouldBeTrue()
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #1737

Part of #1728

공용 Testcontainers 서버 로그가 password와 token 값을 노출하지 않도록 시스템 프로퍼티 export와 시작 로그를 키·개수 요약으로 바꿉니다.

## Background

Epic #1728의 7-Tier 리뷰에서 `PropertyExportingServer`와 `GenericServer`가 credential 값을 `println`/`info`로 남기는 P1 보안 결함을 확인했습니다.

## What This Solves

- 서버 시작과 프로퍼티 export 로그에서 민감한 값이 stdout/로그에 기록되지 않습니다.
- 시스템 프로퍼티 설정과 비민감한 키 식별 정보는 유지됩니다.

## Work Done

- 값 대신 정렬된 키 목록과 개수만 기록하는 공용 내부 요약 helper를 추가했습니다.
- `println`을 KLogging으로 교체하고 password canary가 노출되지 않는 회귀 테스트를 추가했습니다.

## Validation

- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.PropertyExportingServerContractTest.writeToSystemProperties 는 프로퍼티 값을 표준 출력에 기록하지 않는다' --no-configuration-cache`: PASS (1/1)
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.GenericServerSupportTest.writeToSystemProperties 로그는 extra 프로퍼티 값을 노출하지 않는다' --no-configuration-cache`: PASS (1/1)
- `./gradlew :bluetape4k-testcontainers:test --no-configuration-cache`: TIMEOUT (Toxiproxy 컨테이너 종료 중 Docker API read 대기로 5분 이상 진행되어 중단)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0 (현재 PR 범위)
- P2/P3: 전체 suite timeout은 환경의 Toxiproxy 종료 경로로 재현되었으며 변경된 두 계약 테스트는 통과했습니다.
- Review evidence: 대상 diff·호출 경로·Kotlin logging 규칙을 확인한 로컬 inline fallback review

## Metadata

- Issue: #1737, milestone `2.1.0`, assignee `debop`
- PR: #1752, head `d35aeccc51e3699338ad87212fabeaacccc1a2d6`, milestone `2.1.0`, assignee `debop`
- CI: PR 생성 후 exact head 기준으로 확인합니다.

## DoD Status

Required checks: 13/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|----------|----------|-----------------------|
| CG-01~CG-10 | 지침·이력·격리·구현·RED/GREEN·최종 diff 검증 | PASS | 현재 AGENTS/skill, isolated worktree, 대상 테스트, exact local head | none |
| CG-11 - PR delivery authority | 저장소 `bluetape4k-projects`, base `develop`, head 브랜치 확인 | PASS | 사용자 요청과 Type C 실행 authority | none |
| CG-12 - Exact head publish | 수렴 브랜치를 force 없이 push하고 원격 SHA 확인 | PASS | local/remote `d35aeccc51e3699338ad87212fabeaacccc1a2d6` | none |
| CG-12A - Guidance refresh | PR 직전 AGENTS/skill/common gates/template/issue를 재확인 | PASS | 현재 파일 hash와 `gh issue view 1737` live read-back | none |
| CG-13 - Create and verify PR | PR 생성·assignee/label/milestone 동기화·본문 read-back | PASS | PR 생성 후 번호·head·metadata 확인 | none |
| CG-14 - CI and review | exact-head CI·reviews·threads 확인 | PENDING | hosted CI와 thread read-back 필요; 단일 개발자 lane human review는 N/A | CI·thread 완료 후 갱신 |
| CG-15 - Merge-ready report | merge-ready evidence 보고 | PENDING | CG-14 완료 후 산출 | CG-14 통과 |
| CG-16 - Fresh merge approval | 전체 PR exact head에 대한 새 병합 승인 | PENDING | 모든 PR 생성·검증 후 요청 | 사용자 승인 대기 |
| CG-17 - Match-head merge | 승인된 exact head 병합 | PENDING | CG-16 이후 수행 | 승인 전 실행 금지 |
| CG-18 - Sync and cleanup | develop sync와 proven merged worktree 정리 | PENDING | 전체 병합 후 수행 | 병합 검증 후 수행 |
| CG-X01 - Irreversible actions | tag/release/delete 등 조건부 작업 | N/A | 이번 PR에 해당 작업 없음 | none |

Final status: PENDING (exact-head CI·리뷰와 전체 병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18

