### PR TITLE
fix: TLS 입력 스트림 소유권 보장

### DIFF
--- a/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/config/HttpsConfiguration.kt
+++ b/testing/mock-web-server/src/main/kotlin/io/bluetape4k/mockserver/config/HttpsConfiguration.kt
@@ -12,6 +12,8 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
 
 /**
  * Tomcat에 HTTPS 추가 커넥터를 등록하는 설정.
@@ -49,7 +51,7 @@ class HttpsConfiguration {
             ?: error("certs/localhost.p12 를 classpath에서 찾을 수 없습니다")
 
         val tmpFile = File.createTempFile("bluetape4k-https-", ".p12").also { it.deleteOnExit() }
-        tmpFile.outputStream().use { out -> p12Stream.copyTo(out) }
+        tmpFile.outputStream().use { out -> copyHttpsKeyStore(p12Stream, out) }
 
         val connector = Connector("org.apache.coyote.http11.Http11NioProtocol")
         connector.scheme = "https"
@@ -70,4 +72,9 @@ class HttpsConfiguration {
 
         return connector
     }
+}
+
+/** 소유한 PKCS12 입력 스트림을 복사한 뒤 항상 닫습니다. */
+internal fun copyHttpsKeyStore(input: InputStream, output: OutputStream) {
+    input.use { it.copyTo(output) }
 }

--- a/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/config/HttpsConfigurationContractTest.kt
+++ b/testing/mock-web-server/src/test/kotlin/io/bluetape4k/mockserver/config/HttpsConfigurationContractTest.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.mockserver.config
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+
+class HttpsConfigurationContractTest {
+
+    @Test
+    fun `키 저장소 입력 스트림은 복사 후 닫힌다`() {
+        val input = TrackingInputStream()
+        val output = ByteArrayOutputStream()
+
+        copyHttpsKeyStore(input, output)
+
+        input.closeCount shouldBeEqualTo 1
+        output.toByteArray() shouldBeEqualTo PAYLOAD
+    }
+
+    @Test
+    fun `키 저장소 복사에 실패해도 입력 스트림은 닫힌다`() {
+        val input = TrackingInputStream(failOnRead = true)
+
+        assertFailsWith<IOException> {
+            copyHttpsKeyStore(input, ByteArrayOutputStream())
+        }
+
+        input.closeCount shouldBeEqualTo 1
+    }
+
+    private class TrackingInputStream(failOnRead: Boolean = false): InputStream() {
+        private val delegate = ByteArrayInputStream(PAYLOAD)
+        private val failOnRead = failOnRead
+        var closeCount = 0
+            private set
+
+        override fun read(): Int {
+            if (failOnRead) throw IOException("read failed")
+            return delegate.read()
+        }
+
+        override fun close() {
+            closeCount++
+            delegate.close()
+        }
+    }
+
+    private companion object {
+        val PAYLOAD = "p12-payload".toByteArray()
+    }
+}

--- a/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/config/HttpsServerLifecycle.kt
+++ b/testing/mock-webflux-server/src/main/kotlin/io/bluetape4k/mockwebflux/config/HttpsServerLifecycle.kt
@@ -10,6 +10,7 @@ import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter
 import org.springframework.stereotype.Component
 import reactor.netty.DisposableServer
 import reactor.netty.http.server.HttpServer
+import java.io.InputStream
 import java.security.KeyStore
 import javax.net.ssl.KeyManagerFactory
 
@@ -59,8 +60,7 @@ class HttpsServerLifecycle(
         val p12Stream = HttpsServerLifecycle::class.java.getResourceAsStream("/certs/localhost.p12")
             ?: error("certs/localhost.p12 를 classpath에서 찾을 수 없습니다")
 
-        val keyStore = KeyStore.getInstance("PKCS12")
-        keyStore.load(p12Stream, keyStorePassword.toCharArray())
+        val keyStore = loadHttpsKeyStore(p12Stream, keyStorePassword)
 
         val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
         kmf.init(keyStore, keyStorePassword.toCharArray())
@@ -68,3 +68,9 @@ class HttpsServerLifecycle(
         return SslContextBuilder.forServer(kmf).build()
     }
 }
+
+/** 소유한 PKCS12 입력 스트림을 로드한 뒤 항상 닫습니다. */
+internal fun loadHttpsKeyStore(input: InputStream, password: String): KeyStore =
+    KeyStore.getInstance("PKCS12").also { keyStore ->
+        input.use { keyStore.load(it, password.toCharArray()) }
+    }

--- a/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/config/HttpsKeyStoreLoadingContractTest.kt
+++ b/testing/mock-webflux-server/src/test/kotlin/io/bluetape4k/mockwebflux/config/HttpsKeyStoreLoadingContractTest.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.mockwebflux.config
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+
+class HttpsKeyStoreLoadingContractTest {
+
+    @Test
+    fun `키 저장소 입력 스트림은 로드 후 닫힌다`() {
+        val bytes = requireNotNull(HttpsKeyStoreLoadingContractTest::class.java.getResourceAsStream("/certs/localhost.p12"))
+            .use { it.readBytes() }
+        val input = TrackingInputStream(bytes)
+
+        loadHttpsKeyStore(input, "changeit")
+
+        input.closeCount shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `키 저장소 로드에 실패해도 입력 스트림은 닫힌다`() {
+        val input = TrackingInputStream(failOnRead = true)
+
+        assertFailsWith<IOException> {
+            loadHttpsKeyStore(input, "changeit")
+        }
+
+        input.closeCount shouldBeEqualTo 1
+    }
+
+    private class TrackingInputStream(
+        bytes: ByteArray = ByteArray(0),
+        private val failOnRead: Boolean = false,
+    ): InputStream() {
+        private val delegate = ByteArrayInputStream(bytes)
+        var closeCount = 0
+            private set
+
+        override fun read(): Int {
+            if (failOnRead) throw IOException("read failed")
+            return delegate.read()
+        }
+
+        override fun close() {
+            closeCount++
+            delegate.close()
+        }
+    }
+}

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeSslContext.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/http/BluetapeSslContext.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.testcontainers.http
 
 import io.bluetape4k.logging.KLogging
 import okhttp3.OkHttpClient
+import java.io.InputStream
 import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
@@ -36,8 +37,13 @@ object BluetapeSslContext: KLogging() {
         val caStream = BluetapeSslContext::class.java.getResourceAsStream(CA_CERT_RESOURCE)
             ?: error("$CA_CERT_RESOURCE 를 classpath에서 찾을 수 없습니다")
 
+        return createTrustManagerFrom(caStream)
+    }
+
+    /** 제공된 CA 입력 스트림을 사용한 뒤 닫아 trust manager를 생성한다. */
+    internal fun createTrustManagerFrom(caStream: InputStream): X509TrustManager {
         val cf = CertificateFactory.getInstance("X.509")
-        val caCert = cf.generateCertificate(caStream) as X509Certificate
+        val caCert = caStream.use { cf.generateCertificate(it) as X509Certificate }
 
         val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).also {
             it.load(null, null)

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/http/BluetapeSslContextContractTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/http/BluetapeSslContextContractTest.kt
@@ -1,0 +1,33 @@
+package io.bluetape4k.testcontainers.http
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+class BluetapeSslContextContractTest {
+
+    @Test
+    fun `CA 인증서 입력 스트림은 trust manager 생성 후 닫힌다`() {
+        val bytes = requireNotNull(BluetapeSslContextContractTest::class.java.getResourceAsStream("/certs/rootCA.pem"))
+            .use { it.readBytes() }
+        val input = TrackingInputStream(bytes)
+
+        BluetapeSslContext.createTrustManagerFrom(input)
+
+        input.closeCount shouldBeEqualTo 1
+    }
+
+    private class TrackingInputStream(bytes: ByteArray): InputStream() {
+        private val delegate = ByteArrayInputStream(bytes)
+        var closeCount = 0
+            private set
+
+        override fun read(): Int = delegate.read()
+
+        override fun close() {
+            closeCount++
+            delegate.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1742

Part of #1728

세 HTTPS 초기화 경로가 인증서 입력 스트림을 사용한 뒤 반드시 닫도록 해 TLS 리소스 누수를 제거합니다.

## Background

Epic #1728의 7-Tier 리뷰에서 mock-web-server, mock-webflux-server, Testcontainers CA 초기화가 출력 스트림만 닫거나 입력 스트림 소유권을 명시하지 않는 P2 결함을 확인했습니다.

## What This Solves

- PKCS12 복사·로드와 CA 인증서 파싱의 정상·실패 경로에서 입력 스트림이 닫힙니다.
- 기존 HTTPS 서버 포트·키 저장소·trust manager 동작은 그대로 유지됩니다.

## Work Done

- 세 모듈의 TLS 초기화 경계를 `use` 기반 helper로 정리했습니다.
- close 추적 스트림으로 정상 처리와 읽기 실패 시 close 계약을 검증하는 회귀 테스트를 추가했습니다.

## Validation

- `./gradlew :bluetape4k-mock-web-server:test --no-configuration-cache --no-daemon --max-workers=1`: PASS (123/123)
- `./gradlew :bluetape4k-mock-webflux-server:test --no-configuration-cache --no-daemon --max-workers=1`: PASS (58/58)
- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.http.BluetapeSslContextContractTest' --no-configuration-cache`: PASS (1/1)
- `./gradlew :bluetape4k-mock-web-server:jibDockerBuild --no-configuration-cache`: PASS
- `./gradlew :bluetape4k-mock-webflux-server:jibDockerBuild --no-configuration-cache`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: 세 초기화 호출자와 close 추적 회귀 테스트를 확인한 로컬 inline fallback review

## Metadata

- Issue: #1742, milestone `2.1.0`, assignee `debop`
- PR: #1753, head `aaa257469b52b5cad824eee0aa960793efd7cfd4`, milestone `2.1.0`, assignee `debop`
- CI: PR 생성 후 exact head 기준으로 확인합니다.

## DoD Status

Required checks: 13/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|----------|----------|-----------------------|
| CG-01~CG-10 | 지침·이력·격리·구현·RED/GREEN·모듈/Jib 검증 | PASS | 현재 AGENTS/skill, isolated worktree, 테스트·Docker 빌드, exact local head | none |
| CG-11 - PR delivery authority | 저장소 `bluetape4k-projects`, base `develop`, head 브랜치 확인 | PASS | 사용자 요청과 Type C 실행 authority | none |
| CG-12 - Exact head publish | 수렴 브랜치를 force 없이 push하고 원격 SHA 확인 | PASS | local/remote `aaa257469b52b5cad824eee0aa960793efd7cfd4` | none |
| CG-12A - Guidance refresh | PR 직전 AGENTS/skill/common gates/template/issue를 재확인 | PASS | 현재 파일 hash와 `gh issue view 1742` live read-back | none |
| CG-13 - Create and verify PR | PR 생성·assignee/label/milestone 동기화·본문 read-back | PASS | PR 생성 후 번호·head·metadata 확인 | none |
| CG-14 - CI and review | exact-head CI·reviews·threads 확인 | PENDING | hosted CI와 thread read-back 필요; 단일 개발자 lane human review는 N/A | CI·thread 완료 후 갱신 |
| CG-15 - Merge-ready report | merge-ready evidence 보고 | PENDING | CG-14 완료 후 산출 | CG-14 통과 |
| CG-16 - Fresh merge approval | 전체 PR exact head에 대한 새 병합 승인 | PENDING | 모든 PR 생성·검증 후 요청 | 사용자 승인 대기 |
| CG-17 - Match-head merge | 승인된 exact head 병합 | PENDING | CG-16 이후 수행 | 승인 전 실행 금지 |
| CG-18 - Sync and cleanup | develop sync와 proven merged worktree 정리 | PENDING | 전체 병합 후 수행 | 병합 검증 후 수행 |
| CG-X01 - Irreversible actions | tag/release/delete 등 조건부 작업 | N/A | 이번 PR에 해당 작업 없음 | none |

Final status: PENDING (exact-head CI·리뷰와 전체 병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18

