### PR TITLE
[P2][7-Tier][qdrant] 배치 구성의 누적 protobuf 복사·크기 계산 비용 축소

### DIFF
--- a/infra/qdrant/src/main/kotlin/io/bluetape4k/qdrant/QdrantCoroutines.kt
+++ b/infra/qdrant/src/main/kotlin/io/bluetape4k/qdrant/QdrantCoroutines.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.qdrant
 
+import com.google.protobuf.CodedOutputStream
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -99,18 +100,28 @@ fun QdrantClient.upsertBatches(
     require(request.serializedSize <= maxBatchBytes) { "request exceeds maxBatchBytes" }
     return flow {
         var batch = request.toBuilder()
+        val requestSerializedSize = request.serializedSize.toLong()
+        var batchSerializedSize = requestSerializedSize
         points.collect { point ->
-            val single = request.toBuilder().addPoints(point).build()
-            require(single.serializedSize <= maxBatchBytes) { "point exceeds maxBatchBytes" }
-            val candidate = batch.clone().addPoints(point).build()
-            if (batch.pointsCount > 0 && candidate.serializedSize > maxBatchBytes) {
+            // points는 protobuf field 1이며 반복 message마다 tag와 length prefix가 추가됩니다.
+            val pointSerializedSize = CodedOutputStream.computeMessageSize(
+                UpsertPoints.POINTS_FIELD_NUMBER,
+                point,
+            ).toLong()
+            require(requestSerializedSize + pointSerializedSize <= maxBatchBytes) {
+                "point exceeds maxBatchBytes"
+            }
+            if (batch.pointsCount > 0 && batchSerializedSize + pointSerializedSize > maxBatchBytes) {
                 emit(upsertSuspending(batch.build(), timeout))
                 batch = request.toBuilder()
+                batchSerializedSize = requestSerializedSize
             }
             batch.addPoints(point)
+            batchSerializedSize += pointSerializedSize
             if (batch.pointsCount == maxBatchItems) {
                 emit(upsertSuspending(batch.build(), timeout))
                 batch = request.toBuilder()
+                batchSerializedSize = requestSerializedSize
             }
         }
         if (batch.pointsCount > 0) emit(upsertSuspending(batch.build(), timeout))

--- a/infra/qdrant/src/test/kotlin/io/bluetape4k/qdrant/QdrantCoroutinesTest.kt
+++ b/infra/qdrant/src/test/kotlin/io/bluetape4k/qdrant/QdrantCoroutinesTest.kt
@@ -17,6 +17,8 @@ import io.qdrant.client.grpc.Points.RetrievedPoint
 import io.qdrant.client.grpc.Points.UpsertPoints
 import io.qdrant.client.grpc.Points.UpdateResult
 import io.qdrant.client.grpc.Points.PointStruct
+import io.qdrant.client.VectorFactory.vector
+import io.qdrant.client.VectorsFactory.vectors
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.asFlow
@@ -28,11 +30,14 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import io.grpc.Status
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
 
@@ -243,5 +248,67 @@ class QdrantCoroutinesTest {
         result.await().size shouldBeEqualTo 1
         verify(exactly = 1) { client.upsertAsync(any<UpsertPoints>(), any<Duration>()) }
         verify(exactly = 0) { client.close() }
+    }
+
+    @Test
+    fun `large batches complete within a bounded construction time`() {
+        val client = mockk<QdrantClient>()
+        every { client.upsertAsync(any<UpsertPoints>(), any<Duration>()) } returns
+            Futures.immediateFuture(UpdateResult.getDefaultInstance())
+        val template = UpsertPoints.newBuilder().setCollectionName("vectors").build()
+        val points = (1L..50_000L).map { number ->
+            PointStruct.newBuilder().setId(id(number)).setVectors(
+                vectors(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f)
+            ).build()
+        }
+
+        assertTimeoutPreemptively(Duration.ofSeconds(10)) {
+            val result = runBlocking {
+                client.upsertBatches(points.asFlow(), template, maxBatchItems = points.size).toList()
+            }
+            result.size shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `varint length boundaries keep the exact serialized byte limit`() = runTest {
+        val template = UpsertPoints.newBuilder().setCollectionName("vectors").setWait(true).build()
+        val vectorData = FloatArray(32) { it.toFloat() }
+        val points = listOf(127L, 128L).map { number ->
+            PointStruct.newBuilder().setId(id(number)).setVectors(vectors(*vectorData)).build()
+        }
+        (points[0].serializedSize < points[1].serializedSize).shouldBeTrue()
+        assertTrue(points.all { it.serializedSize >= 128 })
+
+        val exactLimit = template.toBuilder().addAllPoints(points).build().serializedSize
+        val requestsAtExactLimit = mutableListOf<UpsertPoints>()
+        val exactClient = mockk<QdrantClient>()
+        every { exactClient.upsertAsync(capture(requestsAtExactLimit), any<Duration>()) } returns
+            Futures.immediateFuture(UpdateResult.getDefaultInstance())
+
+        exactClient.upsertBatches(
+            points.asFlow(),
+            template,
+            maxBatchItems = points.size,
+            maxBatchBytes = exactLimit,
+        ).toList()
+
+        (requestsAtExactLimit.map { it.pointsCount }) shouldBeEqualTo listOf(2)
+        (requestsAtExactLimit.single().serializedSize) shouldBeEqualTo exactLimit
+
+        val requestsBelowLimit = mutableListOf<UpsertPoints>()
+        val belowLimitClient = mockk<QdrantClient>()
+        every { belowLimitClient.upsertAsync(capture(requestsBelowLimit), any<Duration>()) } returns
+            Futures.immediateFuture(UpdateResult.getDefaultInstance())
+
+        belowLimitClient.upsertBatches(
+            points.asFlow(),
+            template,
+            maxBatchItems = points.size,
+            maxBatchBytes = exactLimit - 1,
+        ).toList()
+
+        (requestsBelowLimit.map { it.pointsCount }) shouldBeEqualTo listOf(1, 1)
+        (requestsBelowLimit.all { it.serializedSize <= exactLimit - 1 }).shouldBeTrue()
     }
 }


### PR DESCRIPTION
## Summary

Closes #1726

Part of #1728

Qdrant 대량 upsert의 protobuf 복사·크기 계산을 누적 방식으로 제한합니다.

## Background

Epic #1728의 하위 이슈 #1726에 대한 구현 PR입니다. 7-Tier 리뷰에서 확인된 모듈 계약과 bluetape-kotlin-patterns 적용 범위를 이슈 단위로 정리했습니다.

## What This Solves

- 배치 크기가 커질수록 반복 clone/build로 증가하던 비용과 바이트 제한 검증 부담을 줄입니다.
- 기존 호출자와 모듈 간 재사용 경계에서 확인된 위험을 해당 모듈의 검증 가능한 계약으로 고정합니다.

## Work Done

- protobuf message size 누적 계산과 50,000건·varint 경계 회귀 테스트를 추가했습니다.
- 공개 API·KDoc·회귀 테스트는 변경 범위에 맞춰 함께 갱신했습니다.

## Validation

- ./gradlew :bluetape4k-qdrant:test -PexcludeIntegrationTests=true --no-configuration-cache → 14 passing
- git diff --check: PASS

## Review Notes

- P0/P1: 0
- P2/P3: P2 없음; #1727과 Qdrant 파일이 겹치므로 병합 시 재검증
- Review evidence: 로컬 inline fallback review와 이슈별 테스트 증거를 PR에 기록했으며 독립 reviewer는 CG-14에서 다시 확인합니다.

## Metadata

- Issue: #1726, milestone `2.1.0`, assignee `debop`, labels `test, performance, infra/io`
- PR: #1759, head `495ba903e917ae8fca0c11d7dd6733c7a940e7ba`, milestone `2.1.0`, assignee `debop`
- CI: exact-head hosted CI는 PR 생성 후 진행

## DoD Status

Required checks: 3/7; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - Pre-PR proof | 이슈 범위 구현·로컬 테스트·Lore 커밋 완료 | PASS | local head 495ba903e917ae8fca0c11d7dd6733c7a940e7ba | none |
| CG-12 - Exact head publication | authorized branch를 원격에 게시하고 SHA 비교 | PASS | remote head 495ba903e917ae8fca0c11d7dd6733c7a940e7ba | none |
| CG-12A - Guidance refresh | PR 생성 직전 현재 가이드·skill·common gates·template·linked issue를 재독해 | PASS | refresh snapshot과 issue #1726 live metadata | none |
| CG-13 - PR metadata/body | 한국어 본문·Closes·Part of·labels·milestone·assignee를 반영하고 live readback | PASS | PR #1759, head 495ba903e917ae8fca0c11d7dd6733c7a940e7ba | none |
| CG-14 - Exact-head CI/review | exact head CI·reviews·threads와 최종 코드 리뷰 확인 | PENDING | PR 생성 후 수행 | await/repair |
| CG-15 - Merge-ready report | merge-ready 증거를 사용자에게 보고 | PENDING | CG-14 이후 수행 | await |
| CG-16/17 - Approval and merge | 새 병합 승인 후 match-head 병합 및 develop 동기화 | PENDING | 전체 PR 게이트 이후 수행 | await fresh approval |

Final status: PENDING (PR #1759 created; hosted CI·review·병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16/17
