### PR TITLE
[P2][7-Tier][qdrant] 입력 검증과 코루틴 테스트의 공용 헬퍼 재사용

### DIFF
--- a/infra/qdrant/src/main/kotlin/io/bluetape4k/qdrant/QdrantCoroutines.kt
+++ b/infra/qdrant/src/main/kotlin/io/bluetape4k/qdrant/QdrantCoroutines.kt
@@ -5,6 +5,8 @@ import com.google.common.util.concurrent.MoreExecutors
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireInRange
+import io.bluetape4k.support.requireEquals
+import io.bluetape4k.support.requireLe
 import io.bluetape4k.support.requirePositiveNumber
 import io.qdrant.client.QdrantClient
 import io.qdrant.client.grpc.Points.DeletePoints
@@ -95,13 +97,13 @@ fun QdrantClient.upsertBatches(
 ): Flow<UpdateResult> {
     maxBatchItems.requirePositiveNumber("maxBatchItems")
     maxBatchBytes.requirePositiveNumber("maxBatchBytes")
-    require(request.pointsCount == 0) { "request must not contain points" }
-    require(request.serializedSize <= maxBatchBytes) { "request exceeds maxBatchBytes" }
+    request.pointsCount.requireEquals(0, "request.pointsCount")
+    request.serializedSize.requireLe(maxBatchBytes, "request.serializedSize")
     return flow {
         var batch = request.toBuilder()
         points.collect { point ->
             val single = request.toBuilder().addPoints(point).build()
-            require(single.serializedSize <= maxBatchBytes) { "point exceeds maxBatchBytes" }
+            single.serializedSize.requireLe(maxBatchBytes, "point.serializedSize")
             val candidate = batch.clone().addPoints(point).build()
             if (batch.pointsCount > 0 && candidate.serializedSize > maxBatchBytes) {
                 emit(upsertSuspending(batch.build(), timeout))

--- a/infra/qdrant/src/test/kotlin/io/bluetape4k/qdrant/QdrantCoroutinesTest.kt
+++ b/infra/qdrant/src/test/kotlin/io/bluetape4k/qdrant/QdrantCoroutinesTest.kt
@@ -29,10 +29,11 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 import java.time.Duration
 
@@ -79,10 +80,9 @@ class QdrantCoroutinesTest {
         val client = mockk<QdrantClient>()
         every { client.scrollAsync(any<ScrollPoints>(), any<Duration>()) } returns
             Futures.immediateFuture(ScrollResponse.newBuilder().setNextPageOffset(id(2)).build())
-        val error = runCatching {
+        assertFailsWith<IllegalStateException> {
             client.scrollAsFlow(ScrollPoints.newBuilder().setLimit(2).build()).toList()
-        }.exceptionOrNull()
-        assertInstanceOf(IllegalStateException::class.java, error)
+        }
         verify(exactly = 2) { client.scrollAsync(any<ScrollPoints>(), any<Duration>()) }
     }
 
@@ -105,10 +105,9 @@ class QdrantCoroutinesTest {
         val client = mockk<QdrantClient>()
         val template = UpsertPoints.newBuilder().setCollectionName("vectors").build()
         val point = PointStruct.newBuilder().setId(id(1)).build()
-        val error = runCatching {
+        assertFailsWith<IllegalArgumentException> {
             client.upsertBatches(listOf(point).asFlow(), template, maxBatchBytes = 1).toList()
-        }.exceptionOrNull()
-        assertInstanceOf(IllegalArgumentException::class.java, error)
+        }
         verify(exactly = 0) { client.upsertAsync(any<UpsertPoints>(), any<Duration>()) }
     }
 
@@ -117,13 +116,14 @@ class QdrantCoroutinesTest {
         val client = mockk<QdrantClient>()
         val failure = Status.DEADLINE_EXCEEDED.asRuntimeException()
         every { client.queryAsync(any<QueryPoints>(), any<Duration>()) } returns Futures.immediateFailedFuture(failure)
-        assertSame(failure, runCatching { client.querySuspending(QueryPoints.getDefaultInstance()) }.exceptionOrNull())
+        assertFailsWith<StatusRuntimeException> {
+            client.querySuspending(QueryPoints.getDefaultInstance())
+        } shouldBeSameInstanceAs failure
         val pending = SettableFuture.create<List<ScoredPoint>>()
         every { client.queryAsync(any<QueryPoints>(), any<Duration>()) } returns pending
-        val error = runCatching {
+        assertFailsWith<kotlinx.coroutines.TimeoutCancellationException> {
             withTimeout(10) { client.querySuspending(QueryPoints.getDefaultInstance()) }
-        }.exceptionOrNull()
-        assertInstanceOf(kotlinx.coroutines.TimeoutCancellationException::class.java, error)
+        }
         (pending.isCancelled).shouldBeTrue()
     }
 
@@ -138,8 +138,9 @@ class QdrantCoroutinesTest {
         }
         val request = ScrollPoints.newBuilder().setCollectionName("vectors").setLimit(5)
             .setFilter(io.qdrant.client.grpc.Common.Filter.newBuilder()).build()
-        assertInstanceOf(IllegalStateException::class.java,
-            runCatching { client.scrollAsFlow(request, timeout, maxPages = 3).toList() }.exceptionOrNull())
+        assertFailsWith<IllegalStateException> {
+            client.scrollAsFlow(request, timeout, maxPages = 3).toList()
+        }
         (requests.size) shouldBeEqualTo 3
         (requests.all {
             it.collectionName == request.collectionName && it.limit == 5 && it.filter == request.filter
@@ -155,17 +156,17 @@ class QdrantCoroutinesTest {
         val template = UpsertPoints.newBuilder().setCollectionName("vectors").build()
         val points = (1L..3L).map { PointStruct.newBuilder().setId(id(it)).build() }
         val results = mutableListOf<UpdateResult>()
-        val batchFailure = runCatching {
+        val batchFailure = assertFailsWith<IllegalStateException> {
             client.upsertBatches(points.asFlow(), template, maxBatchItems = 1).collect { results.add(it) }
-        }.exceptionOrNull()
-        assertInstanceOf(IllegalStateException::class.java, batchFailure)
-        (batchFailure?.message) shouldBeEqualTo failure.message
+        }
+        (batchFailure.message) shouldBeEqualTo failure.message
         (results.size) shouldBeEqualTo 1
         verify(exactly = 2) { client.upsertAsync(any<UpsertPoints>(), any<Duration>()) }
         val brokenInput = flow { emit(points.first()); throw failure }
-        val inputFailure = runCatching { client.upsertBatches(brokenInput, template).toList() }.exceptionOrNull()
-        assertInstanceOf(IllegalStateException::class.java, inputFailure)
-        (inputFailure?.message) shouldBeEqualTo failure.message
+        val inputFailure = assertFailsWith<IllegalStateException> {
+            client.upsertBatches(brokenInput, template).toList()
+        }
+        (inputFailure.message) shouldBeEqualTo failure.message
         verify(exactly = 2) { client.upsertAsync(any<UpsertPoints>(), any<Duration>()) }
     }
 
@@ -224,7 +225,7 @@ class QdrantCoroutinesTest {
             { client.scrollAsFlow(ScrollPoints.newBuilder().setLimit(1).build(), maxPages = 0) },
         )
         invalidCalls.forEach { call ->
-            assertInstanceOf(IllegalArgumentException::class.java, runCatching(call).exceptionOrNull())
+            assertFailsWith<IllegalArgumentException> { call() }
         }
         verify { client wasNot Called }
     }

--- a/infra/qdrant/src/test/kotlin/io/bluetape4k/qdrant/QdrantIntegrationTest.kt
+++ b/infra/qdrant/src/test/kotlin/io/bluetape4k/qdrant/QdrantIntegrationTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.qdrant
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.testcontainers.storage.QdrantServer
 import io.grpc.StatusRuntimeException
@@ -40,7 +41,7 @@ class QdrantIntegrationTest {
 
     @Test
     fun `real server supports filtered query paginated scroll and deletion`() = runSuspendIO {
-        val name = "coroutines_${UUID.randomUUID().toString().replace("-", "")}"
+        val name = "coroutines_${Base58.randomString(16)}"
         val grpcClient = QdrantGrpcClient.newBuilder(server.host, server.grpcPort, false).build()
         QdrantClient(grpcClient).use { client ->
             val vectorParams = VectorParams.newBuilder().setSize(3).setDistance(Distance.Cosine).build()
@@ -70,7 +71,7 @@ class QdrantIntegrationTest {
 
     @Test
     fun `UUID IDs named vectors and dimension errors preserve SDK semantics`() = runSuspendIO {
-        val name = "named_${UUID.randomUUID().toString().replace("-", "")}"
+        val name = "named_${Base58.randomString(16)}"
         val grpcClient = QdrantGrpcClient.newBuilder(server.host, server.grpcPort, false).build()
         QdrantClient(grpcClient).use { client ->
             val params = VectorParams.newBuilder().setSize(3).setDistance(Distance.Cosine).build()


### PR DESCRIPTION
## Summary

Closes #1727

Part of #1728

Qdrant 입력 검증과 coroutine 테스트가 공용 Kotlin 패턴을 사용하도록 맞춥니다.

## Background

Epic #1728의 하위 이슈 #1727에 대한 구현 PR입니다. 7-Tier 리뷰에서 확인된 모듈 계약과 bluetape-kotlin-patterns 적용 범위를 이슈 단위로 정리했습니다.

## What This Solves

- 모듈별 사설 검증·JUnit 예외 패턴을 공용 helper와 Bluetape assertion으로 통일합니다.
- 기존 호출자와 모듈 간 재사용 경계에서 확인된 위험을 해당 모듈의 검증 가능한 계약으로 고정합니다.

## Work Done

- requireEquals/requireLe/requirePositiveNumber과 assertion helper를 적용하고 integration 이름 생성도 안전한 helper로 통일했습니다.
- 공개 API·KDoc·회귀 테스트는 변경 범위에 맞춰 함께 갱신했습니다.

## Validation

- ./gradlew :bluetape4k-qdrant:test -PexcludeIntegrationTests=true --no-configuration-cache → 13 passing; detekt → BUILD SUCCESSFUL
- git diff --check: PASS

## Review Notes

- P0/P1: 0
- P2/P3: P2 없음; #1726과 Qdrant 파일이 겹치므로 병합 시 재검증
- Review evidence: 로컬 inline fallback review와 이슈별 테스트 증거를 PR에 기록했으며 독립 reviewer는 CG-14에서 다시 확인합니다.

## Metadata

- Issue: #1727, milestone `2.1.0`, assignee `debop`, labels `test, infra/io, refactor, coroutines`
- PR: #1760, head `c870c0c5ffc9895fbf052d7b3faf56d542702e6b`, milestone `2.1.0`, assignee `debop`
- CI: exact-head hosted CI는 PR 생성 후 진행

## Merge Repair Readback

- 최신 `develop` 병합 시 #1759와 같은 파일에서 발생한 충돌을 해소했습니다.
- `QdrantCoroutines`에는 protobuf field tag·length prefix를 포함한 누적 바이트 계산과 `requireEquals`·`requireLe` 공용 검증을 함께 보존했습니다.
- `QdrantCoroutinesTest`에는 기존 취소·실패 계약과 대용량/varint 경계 회귀 테스트를 함께 유지했습니다.
- 새 exact head: `da8b3325202b85711d36c4e4dbe5fcd2d275dc7d`
- Hosted CI: [run 34315161813](https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34315161813) — 12개 SUCCESS, 13개 path-filtered SKIPPED, 실패 0
- Local validation: `:bluetape4k-qdrant:test` 17/17 및 `:bluetape4k-qdrant:detekt` PASS

## DoD Status

Required checks: 3/7; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - Pre-PR proof | 이슈 범위 구현·로컬 테스트·Lore 커밋 완료 | PASS | local head c870c0c5ffc9895fbf052d7b3faf56d542702e6b | none |
| CG-12 - Exact head publication | authorized branch를 원격에 게시하고 SHA 비교 | PASS | remote head c870c0c5ffc9895fbf052d7b3faf56d542702e6b | none |
| CG-12A - Guidance refresh | PR 생성 직전 현재 가이드·skill·common gates·template·linked issue를 재독해 | PASS | refresh snapshot과 issue #1727 live metadata | none |
| CG-13 - PR metadata/body | 한국어 본문·Closes·Part of·labels·milestone·assignee를 반영하고 live readback | PASS | PR #1760, head c870c0c5ffc9895fbf052d7b3faf56d542702e6b | none |
| CG-14 - Exact-head CI/review | exact head CI·reviews·threads와 최종 코드 리뷰 확인 | PENDING | PR 생성 후 수행 | await/repair |
| CG-15 - Merge-ready report | merge-ready 증거를 사용자에게 보고 | PENDING | CG-14 이후 수행 | await |
| CG-16/17 - Approval and merge | 새 병합 승인 후 match-head 병합 및 develop 동기화 | PENDING | 전체 PR 게이트 이후 수행 | await fresh approval |

Final status: PENDING (PR #1760 created; hosted CI·review·병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16/17

