### PR TITLE
[P1][7-Tier][jdbc] rollback 실패 뒤 autoCommit 복구로 실패한 작업이 커밋되는 경로를 차단한다

### DIFF
--- a/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
+++ b/data/jdbc/src/main/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensions.kt
@@ -6,10 +6,12 @@ import java.sql.SQLException
 /**
  * JDBC transaction 안에서 [block]을 실행합니다.
  *
- * connection의 `autoCommit`, isolation level, read-only flag는 복구됩니다
- * independently to their original values. Any [Throwable] from the block or
- * commit path triggers rollback and is rethrown unchanged. Rollback or restore
- * failures are attached as suppressed exceptions to the primary failure.
+ * connection의 `autoCommit`, isolation level, read-only flag는 원래 값으로
+ * 각각 복구됩니다. 블록 또는 commit 경로의 [Throwable]은 rollback을 실행한
+ * 뒤 변경 없이 다시 던집니다. rollback 또는 복구 실패는 원래 예외에 suppressed
+ * 예외로 추가됩니다. rollback이 실패하면 끝나지 않은 transaction이 암묵적으로
+ * commit되지 않도록 `autoCommit`을 비활성 상태로 두며, 호출자가 connection을
+ * 폐기해야 합니다.
  *
  * If the block and commit succeed but state restoration fails, the restore
  * failure is thrown instead of returning a successful result.
@@ -36,6 +38,7 @@ inline fun <T> Connection.withTransaction(
     val originalIsolationLevel = this.transactionIsolation
     val originalReadOnly = this.isReadOnly
     var primaryFailure: Throwable? = null
+    var rollbackSucceeded = true
 
     return try {
         this.autoCommit = false
@@ -49,16 +52,23 @@ inline fun <T> Connection.withTransaction(
         try {
             this.rollback()
         } catch (rollbackEx: Throwable) {
+            rollbackSucceeded = false
             e.addSuppressed(rollbackEx)
         }
         throw e
     } finally {
+        // A driver may commit when transaction state is changed after a failed
+        // rollback. Leave the connection untouched and let the caller discard it.
         val restoreFailure =
-            restoreTransactionState(
-                originalAutoCommit = originalAutoCommit,
-                originalIsolationLevel = originalIsolationLevel,
-                originalReadOnly = originalReadOnly,
-            )
+            if (rollbackSucceeded) {
+                restoreTransactionState(
+                    originalAutoCommit = originalAutoCommit,
+                    originalIsolationLevel = originalIsolationLevel,
+                    originalReadOnly = originalReadOnly,
+                )
+            } else {
+                null
+            }
 
         if (restoreFailure != null) {
             primaryFailure?.addSuppressed(restoreFailure) ?: throw restoreFailure

--- a/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensionsTest.kt
+++ b/data/jdbc/src/test/kotlin/io/bluetape4k/jdbc/sql/TransactionExtensionsTest.kt
@@ -12,6 +12,7 @@ import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import java.sql.Connection
+import java.sql.DriverManager
 import java.sql.ResultSet
 import java.sql.SQLException
 
@@ -160,6 +161,52 @@ class TransactionExtensionsTest: AbstractJdbcSqlTest() {
             }
 
         thrown shouldBeEqualTo restoreFailure
+    }
+
+    @Test
+    fun `withTransaction does not commit when rollback fails`() {
+        val marker = "rollback-failure-${System.nanoTime()}"
+        val url = "jdbc:h2:mem:rollback-failure-${System.nanoTime()};DB_CLOSE_DELAY=-1"
+        DriverManager.getConnection(url).use { realConnection ->
+            realConnection.createStatement().use { statement ->
+                statement.executeUpdate("CREATE TABLE records (payload VARCHAR(255))")
+            }
+            val failingConnection =
+                Proxy.newProxyInstance(
+                    Connection::class.java.classLoader,
+                    arrayOf(Connection::class.java),
+                ) { _, method, args ->
+                    if (method.name == "rollback") {
+                        throw SQLException("injected rollback failure")
+                    }
+                    try {
+                        method.invoke(realConnection, *(args ?: emptyArray()))
+                    } catch (error: java.lang.reflect.InvocationTargetException) {
+                        throw error.targetException
+                    }
+                } as Connection
+
+            assertFailsWith<IllegalStateException> {
+                failingConnection.withTransaction { connection ->
+                    connection.executeUpdate(
+                        "INSERT INTO records (payload) VALUES ('$marker')",
+                    )
+                    error("work failed")
+                }
+            }
+            realConnection.autoCommit.shouldBeFalse()
+
+            val committedRows =
+                DriverManager.getConnection(url).use { observer ->
+                    observer.createStatement()
+                        .executeQuery("SELECT COUNT(*) FROM records WHERE payload = '$marker'")
+                        .use { resultSet ->
+                            resultSet.next()
+                            resultSet.getInt(1)
+                        }
+                }
+            committedRows shouldBeEqualTo 0
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1734

Part of #1728

JDBC rollback 실패 뒤 미완료 transaction이 autoCommit으로 암묵적 commit되지 않게 합니다.

## Background

Epic #1728의 하위 이슈 #1734에 대한 구현 PR입니다. 7-Tier 리뷰에서 확인된 모듈 계약과 bluetape-kotlin-patterns 적용 범위를 이슈 단위로 정리했습니다.

## What This Solves

- rollback 실패 시 원래 예외와 안전한 connection 상태를 보존합니다.
- 기존 호출자와 모듈 간 재사용 경계에서 확인된 위험을 해당 모듈의 검증 가능한 계약으로 고정합니다.

## Work Done

- rollback 성공 여부를 추적해 실패 시 상태 복구를 건너뛰고 primary/suppressed 예외 회귀 테스트를 추가했습니다.
- 공개 API·KDoc·회귀 테스트는 변경 범위에 맞춰 함께 갱신했습니다.

## Validation

- TransactionExtensionsTest → 21 passing
- git diff --check: PASS

## Review Notes

- P0/P1: 0
- P2/P3: P2 없음; CI/review pending
- Review evidence: 로컬 inline fallback review와 이슈별 테스트 증거를 PR에 기록했으며 독립 reviewer는 CG-14에서 다시 확인합니다.

## Metadata

- Issue: #1734, milestone `2.1.0`, assignee `debop`, labels `bug, test`
- PR: #1765, head `64dd80b3669c061971b0773e954b1ae87be91a99`, milestone `2.1.0`, assignee `debop`
- CI: exact-head hosted CI는 PR 생성 후 진행

## DoD Status

Required checks: 3/7; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - Pre-PR proof | 이슈 범위 구현·로컬 테스트·Lore 커밋 완료 | PASS | local head 64dd80b3669c061971b0773e954b1ae87be91a99 | none |
| CG-12 - Exact head publication | authorized branch를 원격에 게시하고 SHA 비교 | PASS | remote head 64dd80b3669c061971b0773e954b1ae87be91a99 | none |
| CG-12A - Guidance refresh | PR 생성 직전 현재 가이드·skill·common gates·template·linked issue를 재독해 | PASS | refresh snapshot과 issue #1734 live metadata | none |
| CG-13 - PR metadata/body | 한국어 본문·Closes·Part of·labels·milestone·assignee를 반영하고 live readback | PASS | PR #1765, head 64dd80b3669c061971b0773e954b1ae87be91a99 | none |
| CG-14 - Exact-head CI/review | exact head CI·reviews·threads와 최종 코드 리뷰 확인 | PENDING | PR 생성 후 수행 | await/repair |
| CG-15 - Merge-ready report | merge-ready 증거를 사용자에게 보고 | PENDING | CG-14 이후 수행 | await |
| CG-16/17 - Approval and merge | 새 병합 승인 후 match-head 병합 및 develop 동기화 | PENDING | 전체 PR 게이트 이후 수행 | await fresh approval |

Final status: PENDING (PR #1765 created; hosted CI·review·병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16/17
