### PR TITLE
[P1][7-Tier][retrofit2] VertxCallFactory가 공유 기본 HttpClient를 닫지 않도록 소유권을 정리한다

### DIFF
--- a/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
+++ b/io/retrofit2/src/main/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactory.kt
@@ -26,7 +26,9 @@ import kotlin.reflect.KClass
  * Creates a Retrofit-compatible OkHttp `Call.Factory` backed by a Vert.x [HttpClient].
  *
  * ## Contract
- * - Wraps [client] without taking ownership beyond [VertxCallFactory.close].
+ * - Borrows [client] without taking ownership; [VertxCallFactory.close] does not close it.
+ * - The default shared client is managed by `closeDefaultVertxHttpClient` in the HTTP module.
+ * - A caller-provided client remains the caller's responsibility to close.
  * - Uses [callTimeout] for blocking `execute()` waits, Vert.x request timeout, and the advertised Okio timeout.
  * - A blocking timeout or interruption resets the underlying Vert.x request when one exists.
  *
@@ -101,16 +103,24 @@ class VertxCallFactory private constructor(
     }
 
     /**
-     * 내부 Vert.x HTTP 클라이언트를 종료합니다.
+     * 이 factory가 빌린 Vert.x HTTP 클라이언트를 종료하지 않고 factory를 종료합니다.
+     * 공유 기본 클라이언트는 HTTP 모듈의 `closeDefaultVertxHttpClient`로 종료하고,
+     * 주입한 클라이언트는 해당 클라이언트의 소유자가 종료해야 합니다.
      *
      * ```kotlin
-     * val factory = vertxCallFactoryOf()
+     * val callerOwnedClient = vertx.createHttpClient()
+     * val factory = VertxCallFactory(callerOwnedClient)
      * factory.close()
-     * // 내부 Vert.x HttpClient 종료됨
+     * // factory만 종료되고 callerOwnedClient는 계속 사용 가능
+     * callerOwnedClient.close()
+     *
+     * val defaultFactory = vertxCallFactoryOf()
+     * defaultFactory.close()
+     * closeDefaultVertxHttpClient() // 공유 기본 클라이언트 종료
      * ```
      */
     override fun close() {
-        client.close()
+        // The HttpClient is borrowed from the caller or the HTTP module's shared default.
     }
 
     private inner class VertxCall(

--- a/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactoryLifecycleTest.kt
+++ b/io/retrofit2/src/test/kotlin/io/bluetape4k/retrofit2/clients/vertx/VertxCallFactoryLifecycleTest.kt
@@ -1,0 +1,21 @@
+package io.bluetape4k.retrofit2.clients.vertx
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.vertx.core.Future
+import io.vertx.core.http.HttpClient
+import org.junit.jupiter.api.Test
+
+class VertxCallFactoryLifecycleTest {
+
+    @Test
+    fun `factory close does not close the caller owned client`() {
+        val client = mockk<HttpClient>()
+        every { client.close() } returns Future.succeededFuture()
+
+        vertxCallFactoryOf(client).close()
+
+        verify(exactly = 0) { client.close() }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1738

Part of #1728

VertxCallFactory가 빌린 HttpClient를 종료하지 않도록 ownership 계약을 고정합니다.

## Background

Epic #1728의 하위 이슈 #1738에 대한 구현 PR입니다. 7-Tier 리뷰에서 확인된 모듈 계약과 bluetape-kotlin-patterns 적용 범위를 이슈 단위로 정리했습니다.

## What This Solves

- caller-owned와 shared default HttpClient가 factory close로 조기 종료되던 문제를 제거합니다.
- 기존 호출자와 모듈 간 재사용 경계에서 확인된 위험을 해당 모듈의 검증 가능한 계약으로 고정합니다.

## Work Done

- factory.close를 no-op으로 조정하고 caller/default 소유권 KDoc과 lifecycle 테스트를 추가했습니다.
- 공개 API·KDoc·회귀 테스트는 변경 범위에 맞춰 함께 갱신했습니다.

## Validation

- VertxCallFactoryLifecycleTest → 1 passing; HTTP default close helper → 2 passing
- git diff --check: PASS

## Review Notes

- P0/P1: 0
- P2/P3: P2 없음; CI/review pending
- Review evidence: 로컬 inline fallback review와 이슈별 테스트 증거를 PR에 기록했으며 독립 reviewer는 CG-14에서 다시 확인합니다.

## Metadata

- Issue: #1738, milestone `2.1.0`, assignee `debop`, labels `bug, test`
- PR: #1768, head `eedb7a3fc795ce046c15bd20e8cc96147c9df90e`, milestone `2.1.0`, assignee `debop`
- CI: exact-head hosted CI는 PR 생성 후 진행

## DoD Status

Required checks: 3/7; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - Pre-PR proof | 이슈 범위 구현·로컬 테스트·Lore 커밋 완료 | PASS | local head eedb7a3fc795ce046c15bd20e8cc96147c9df90e | none |
| CG-12 - Exact head publication | authorized branch를 원격에 게시하고 SHA 비교 | PASS | remote head eedb7a3fc795ce046c15bd20e8cc96147c9df90e | none |
| CG-12A - Guidance refresh | PR 생성 직전 현재 가이드·skill·common gates·template·linked issue를 재독해 | PASS | refresh snapshot과 issue #1738 live metadata | none |
| CG-13 - PR metadata/body | 한국어 본문·Closes·Part of·labels·milestone·assignee를 반영하고 live readback | PASS | PR #1768, head eedb7a3fc795ce046c15bd20e8cc96147c9df90e | none |
| CG-14 - Exact-head CI/review | exact head CI·reviews·threads와 최종 코드 리뷰 확인 | PENDING | PR 생성 후 수행 | await/repair |
| CG-15 - Merge-ready report | merge-ready 증거를 사용자에게 보고 | PENDING | CG-14 이후 수행 | await |
| CG-16/17 - Approval and merge | 새 병합 승인 후 match-head 병합 및 develop 동기화 | PENDING | 전체 PR 게이트 이후 수행 | await fresh approval |

Final status: PENDING (PR #1768 created; hosted CI·review·병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16/17
