### PR TITLE
[P2][7-Tier][cache-lettuce] 캐시 공급자 로그의 Redis URI 자격증명을 숨긴다

### DIFF
--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCachingProvider.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCachingProvider.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.cache.jcache
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
+import io.bluetape4k.redis.lettuce.redactUriCredentials
+import io.bluetape4k.redis.lettuce.toRedactedLogString
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisURI
 import java.net.URI
@@ -44,7 +46,9 @@ class LettuceCachingProvider: CachingProvider {
         val cacheUri = uri ?: defaultUri
         val cacheClassLoader = classLoader ?: defaultClassLoader
 
-        log.debug { "Get LettuceCacheManager. uri=$cacheUri, classLoader=$cacheClassLoader" }
+        log.debug {
+            "Get LettuceCacheManager. uri=${cacheUri.toRedactedLogString()}, classLoader=$cacheClassLoader"
+        }
 
         // 동시 RedisClient 생성을 방지하기 위해 lock으로 조회 및 생성 로직 전체를 보호
         return lock.withLock {
@@ -57,7 +61,7 @@ class LettuceCachingProvider: CachingProvider {
                 cacheUri.toString()
             }
 
-            log.debug { "Create RedisClient. redisUri=$redisUri" }
+            log.debug { "Create RedisClient. redisUri=${redisUri.redactUriCredentials()}" }
             val redisClient = RedisClient.create(RedisURI.create(redisUri))
 
             val manager = LettuceCacheManager(
@@ -70,7 +74,7 @@ class LettuceCachingProvider: CachingProvider {
             )
 
             uri2manager[cacheUri] = manager
-            log.info { "Created LettuceCacheManager. uri=$cacheUri" }
+            log.info { "Created LettuceCacheManager. uri=${cacheUri.toRedactedLogString()}" }
             manager
         }
     }
@@ -103,7 +107,9 @@ class LettuceCachingProvider: CachingProvider {
     }
 
     override fun close(uri: URI, classLoader: ClassLoader) {
-        log.info { "Close LettuceCachingProvider. uri=$uri, classLoader=$classLoader" }
+        log.info {
+            "Close LettuceCachingProvider. uri=${uri.toRedactedLogString()}, classLoader=$classLoader"
+        }
         managers[classLoader]?.let { uri2manager ->
             uri2manager.remove(uri)?.let { manager ->
                 runCatching { manager.close() }

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceCachingProviderTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceCachingProviderTest.kt
@@ -1,12 +1,18 @@
 package io.bluetape4k.cache.jcache
 
+import ch.qos.logback.classic.Level
 import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
 import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.slf4j.LoggerFactory
+import java.net.URI
 import javax.cache.Caching
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -54,5 +60,28 @@ class LettuceCachingProviderTest {
     @Test
     fun `defaultClassLoader is not null`() {
         provider.defaultClassLoader.shouldNotBeNull()
+    }
+
+    @Test
+    fun `URI credentials are redacted in provider logs`() {
+        val loggerName = LettuceCachingProvider::class.java.name
+        val logger = LoggerFactory.getLogger(loggerName) as ch.qos.logback.classic.Logger
+        val previousLevel = logger.level
+        val password = "provider-secret"
+        val uri = URI("redis://cache-user:$password@localhost:6379/0")
+
+        InMemoryLogbackAppender(loggerName).use { appender ->
+            try {
+                logger.level = Level.DEBUG
+                provider.getCacheManager(uri, provider.defaultClassLoader)
+                provider.close(uri, provider.defaultClassLoader)
+
+                val messages = appender.messages.joinToString("\n")
+                messages shouldContain "redis://<redacted>@localhost:6379/0"
+                messages shouldNotContain password
+            } finally {
+                logger.level = previousLevel
+            }
+        }
     }
 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisUriRedaction.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisUriRedaction.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.redis.lettuce
+
+import java.net.URI
+
+private val URI_CREDENTIALS = Regex("([a-zA-Z][a-zA-Z0-9+.-]*://)([^/\\s]+)@")
+
+/** 로그에 URI를 기록할 때 authority의 자격증명을 제거합니다. */
+fun String.redactUriCredentials(): String =
+    replace(URI_CREDENTIALS) { match ->
+        "${match.groupValues[1]}<redacted>@"
+    }
+
+/** 로그용 URI 문자열을 반환하며 authority의 자격증명을 제거합니다. */
+fun URI.toRedactedLogString(): String = toString().redactUriCredentials()


### PR DESCRIPTION
## Summary

Closes #1739

Part of #1728

Lettuce cache provider의 Redis URI 로그에서 자격증명을 숨깁니다.

## Background

Epic #1728의 하위 이슈 #1739에 대한 구현 PR입니다. 7-Tier 리뷰에서 확인된 모듈 계약과 bluetape-kotlin-patterns 적용 범위를 이슈 단위로 정리했습니다.

## What This Solves

- lifecycle debug/info 로그에 password·token이 평문으로 남던 보안 위험을 제거합니다.
- 기존 호출자와 모듈 간 재사용 경계에서 확인된 위험을 해당 모듈의 검증 가능한 계약으로 고정합니다.

## Work Done

- infra/lettuce 공용 redaction helper를 추가하고 provider 전 로그 경로와 secret 부재 테스트를 연결했습니다.
- 공개 API·KDoc·회귀 테스트는 변경 범위에 맞춰 함께 갱신했습니다.

## Validation

- ./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache → 463 passing
- git diff --check: PASS

## Review Notes

- P0/P1: 0
- P2/P3: P2 없음; CI/review pending
- Review evidence: 로컬 inline fallback review와 이슈별 테스트 증거를 PR에 기록했으며 독립 reviewer는 CG-14에서 다시 확인합니다.

## Metadata

- Issue: #1739, milestone `2.1.0`, assignee `debop`, labels `test, security`
- PR: #1769, head `aa3bee63e313a2bb9efc67bb64021995c03958d6`, milestone `2.1.0`, assignee `debop`
- CI: exact-head hosted CI는 PR 생성 후 진행

## DoD Status

Required checks: 3/7; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - Pre-PR proof | 이슈 범위 구현·로컬 테스트·Lore 커밋 완료 | PASS | local head aa3bee63e313a2bb9efc67bb64021995c03958d6 | none |
| CG-12 - Exact head publication | authorized branch를 원격에 게시하고 SHA 비교 | PASS | remote head aa3bee63e313a2bb9efc67bb64021995c03958d6 | none |
| CG-12A - Guidance refresh | PR 생성 직전 현재 가이드·skill·common gates·template·linked issue를 재독해 | PASS | refresh snapshot과 issue #1739 live metadata | none |
| CG-13 - PR metadata/body | 한국어 본문·Closes·Part of·labels·milestone·assignee를 반영하고 live readback | PASS | PR #1769, head aa3bee63e313a2bb9efc67bb64021995c03958d6 | none |
| CG-14 - Exact-head CI/review | exact head CI·reviews·threads와 최종 코드 리뷰 확인 | PENDING | PR 생성 후 수행 | await/repair |
| CG-15 - Merge-ready report | merge-ready 증거를 사용자에게 보고 | PENDING | CG-14 이후 수행 | await |
| CG-16/17 - Approval and merge | 새 병합 승인 후 match-head 병합 및 develop 동기화 | PENDING | 전체 PR 게이트 이후 수행 | await fresh approval |

Final status: PENDING (PR #1769 created; hosted CI·review·병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16/17
