### PR TITLE
[P2][7-Tier][r2dbc] SQL 바인딩 값 전체를 trace 로그에 남기지 않는다

### DIFF
--- a/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupport.kt
+++ b/data/r2dbc/src/main/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupport.kt
@@ -14,6 +14,8 @@ private val log by lazy { KotlinLogging.logger {} }
  * Raw null values are rejected because they do not carry R2DBC type
  * information. Use [typedNullParameter] or an explicit `Parameter` value when
  * binding nullable map entries.
+ * Trace logging records only the parameter name and runtime value type; the
+ * bound value is never included.
  *
  * ```kotlin
  * val sql = "SELECT * FROM users WHERE username = :username AND active = :active"
@@ -40,7 +42,9 @@ private val log by lazy { KotlinLogging.logger {} }
  */
 fun DatabaseClient.GenericExecuteSpec.bindMap(parameters: Map<String, Any?>): DatabaseClient.GenericExecuteSpec =
     parameters.entries.fold(this) { spec, entry ->
-        log.trace { "bind map. name=${entry.key}, value=${entry.value}" }
+        log.trace {
+            "bind map. name=${entry.key}, valueType=${entry.value?.javaClass?.name ?: "null"}"
+        }
         when (val value = entry.value) {
             null -> throw rawNullBindingException(entry.key)
             else -> spec.bind(entry.key, value.toParameter())
@@ -55,6 +59,8 @@ fun DatabaseClient.GenericExecuteSpec.bindMap(parameters: Map<String, Any?>): Da
  * Raw null values are rejected because they do not carry R2DBC type
  * information. Use [typedNullParameter] or an explicit `Parameter` value when
  * binding nullable map entries.
+ * Trace logging records only the parameter index and runtime value type; the
+ * bound value is never included.
  *
  * ```kotlin
  * val sql = "SELECT * FROM users WHERE username = ? AND active = ?"
@@ -83,7 +89,9 @@ fun DatabaseClient.GenericExecuteSpec.bindMap(parameters: Map<String, Any?>): Da
 fun DatabaseClient.GenericExecuteSpec.bindIndexedMap(parameters: Map<Int, Any?>): DatabaseClient.GenericExecuteSpec =
     parameters.entries.fold(this) { spec, entry ->
         val index = entry.key.requireZeroOrPositiveNumber("index")
-        log.trace { "bind indexed map. index=$index, value=${entry.value}" }
+        log.trace {
+            "bind indexed map. index=$index, valueType=${entry.value?.javaClass?.name ?: "null"}"
+        }
         when (val value = entry.value) {
             null -> throw rawNullBindingException("index $index")
             else -> spec.bind(index, value.toParameter())

--- a/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupportTest.kt
+++ b/data/r2dbc/src/test/kotlin/io/bluetape4k/r2dbc/support/DatabaseClientSupportTest.kt
@@ -1,12 +1,17 @@
 package io.bluetape4k.r2dbc.support
 
+import ch.qos.logback.classic.Level
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import org.springframework.r2dbc.core.DatabaseClient
 
 class DatabaseClientSupportTest {
@@ -85,5 +90,36 @@ class DatabaseClientSupportTest {
 
         spec.bindNullable<String>("username", "john") shouldBeSameInstanceAs spec
         spec.bindNullable<String>(0, null) shouldBeSameInstanceAs spec
+    }
+
+    @Test
+    fun `bind map logs omit values while preserving binding metadata`() {
+        val loggerName = "io.bluetape4k.r2dbc.support.DatabaseClientSupport"
+        val logger = LoggerFactory.getLogger(loggerName) as ch.qos.logback.classic.Logger
+        val previousLevel = logger.level
+        val spec = mockk<DatabaseClient.GenericExecuteSpec>()
+        val namedSecret = "named-binding-secret"
+        val indexedSecret = "indexed-binding-secret"
+
+        every { spec.bind("password", any()) } returns spec
+        every { spec.bind(0, any()) } returns spec
+
+        InMemoryLogbackAppender(loggerName).use { appender ->
+            try {
+                logger.level = Level.TRACE
+                spec.bindMap(mapOf("password" to namedSecret))
+                spec.bindIndexedMap(mapOf(0 to indexedSecret))
+
+                val messages = appender.messages.joinToString("\n")
+                messages shouldContain "name=password"
+                messages shouldContain "index=0"
+                messages shouldNotContain namedSecret
+                messages shouldNotContain indexedSecret
+            } finally {
+                logger.level = previousLevel
+            }
+        }
+        verify(exactly = 1) { spec.bind("password", any()) }
+        verify(exactly = 1) { spec.bind(0, any()) }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1740

Part of #1728

R2DBC bind trace 로그에서 실제 parameter 값을 제거합니다.

## Background

Epic #1728의 하위 이슈 #1740에 대한 구현 PR입니다. 7-Tier 리뷰에서 확인된 모듈 계약과 bluetape-kotlin-patterns 적용 범위를 이슈 단위로 정리했습니다.

## What This Solves

- SQL 로그가 개인정보·자격증명 등 bound value payload를 기록하지 않게 합니다.
- 기존 호출자와 모듈 간 재사용 경계에서 확인된 위험을 해당 모듈의 검증 가능한 계약으로 고정합니다.

## Work Done

- named/index bind 모두 parameter 식별자와 runtime type만 기록하도록 바꾸고 binding 회귀 테스트를 추가했습니다.
- 공개 API·KDoc·회귀 테스트는 변경 범위에 맞춰 함께 갱신했습니다.

## Validation

- DatabaseClientSupportTest → 8 passing
- git diff --check: PASS

## Review Notes

- P0/P1: 0
- P2/P3: P2 없음; CI/review pending
- Review evidence: 로컬 inline fallback review와 이슈별 테스트 증거를 PR에 기록했으며 독립 reviewer는 CG-14에서 다시 확인합니다.

## Metadata

- Issue: #1740, milestone `2.1.0`, assignee `debop`, labels `test, security`
- PR: #1770, head `3e20580f29938feaf022753acd031547443e0620`, milestone `2.1.0`, assignee `debop`
- CI: exact-head hosted CI는 PR 생성 후 진행

## DoD Status

Required checks: 3/7; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-10 - Pre-PR proof | 이슈 범위 구현·로컬 테스트·Lore 커밋 완료 | PASS | local head 3e20580f29938feaf022753acd031547443e0620 | none |
| CG-12 - Exact head publication | authorized branch를 원격에 게시하고 SHA 비교 | PASS | remote head 3e20580f29938feaf022753acd031547443e0620 | none |
| CG-12A - Guidance refresh | PR 생성 직전 현재 가이드·skill·common gates·template·linked issue를 재독해 | PASS | refresh snapshot과 issue #1740 live metadata | none |
| CG-13 - PR metadata/body | 한국어 본문·Closes·Part of·labels·milestone·assignee를 반영하고 live readback | PASS | PR #1770, head 3e20580f29938feaf022753acd031547443e0620 | none |
| CG-14 - Exact-head CI/review | exact head CI·reviews·threads와 최종 코드 리뷰 확인 | PENDING | PR 생성 후 수행 | await/repair |
| CG-15 - Merge-ready report | merge-ready 증거를 사용자에게 보고 | PENDING | CG-14 이후 수행 | await |
| CG-16/17 - Approval and merge | 새 병합 승인 후 match-head 병합 및 develop 동기화 | PENDING | 전체 PR 게이트 이후 수행 | await fresh approval |

Final status: PENDING (PR #1770 created; hosted CI·review·병합 게이트 대기)
Unchecked required items: CG-14, CG-15, CG-16/17
