### PR TITLE
#1780 rule-engine 규칙·스크립트 로그의 민감 문자열 노출을 줄인다

### DIFF
--- a/utils/rule-engine/README.ko.md
+++ b/utils/rule-engine/README.ko.md
@@ -51,6 +51,13 @@ Kotlin 기반의 경량 Rule Engine 라이브러리입니다. Easy Rules 패턴�
 - **Composite Rule**: `ActivationRuleGroup`, `ConditionalRuleGroup`, `UnitRuleGroup`으로 복합 Rule 조합
 - **Forward Chaining**: `InferenceRuleEngine`으로 조건 만족 시 반복 실행
 
+## 로깅과 민감 정보
+
+Rule 정의 표현식과 Action 스크립트에는 자격증명 등 민감한 값이 포함될 수 있습니다. 기본 Rule Engine 로거는
+engine, Rule 이름, fact 개수, source 길이만 기록하며 source payload와 예외 상세 정보는 로그 메시지에서
+제외합니다. 새로운 Rule Engine 로그를 추가할 때도 공용 `toRuleSourceLogContext()` helper를 사용해 이 경계를
+유지하세요.
+
 ## 사용 예시
 
 ### DSL 기반 Rule

--- a/utils/rule-engine/README.md
+++ b/utils/rule-engine/README.md
@@ -51,6 +51,13 @@ A `Rule` has a **condition** (predicate on `Facts`) and an **action** (mutates `
 - **Composite rules**: combine multiple rules with `ActivationRuleGroup`, `ConditionalRuleGroup`, and `UnitRuleGroup`
 - **Forward chaining**: repeatedly execute while conditions are satisfied through `InferenceRuleEngine`
 
+## Logging and Sensitive Data
+
+Rule definition expressions and action scripts can contain credentials or other sensitive values. The built-in
+rule-engine logger therefore records only the engine, rule name, fact count, and source length; source payloads and
+exception details are omitted from log messages. Keep this boundary when adding new rule-engine log statements by
+using the shared `toRuleSourceLogContext()` helper.
+
 ## Usage Examples
 
 ### DSL-Based Rule

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/DefaultRuleEngine.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/DefaultRuleEngine.kt
@@ -151,7 +151,7 @@ open class DefaultRuleEngine(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    log.debug { "Rule '$name' evaluation failed with exception: ${e.message}" }
+                    log.debug { "Rule '$name' evaluation failed. exceptionType=${e.javaClass.name}" }
                     onAfterEvaluate(rule, facts, false)
                     if (config.skipOnFirstFailedRule) {
                         log.debug { "나머지 Rule들은 무시됩니다. (skipOnFirstFailedRule=true)" }
@@ -212,7 +212,7 @@ open class DefaultRuleEngine(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    log.debug { "Rule '${rule.name}' evaluation failed with exception: ${e.message}" }
+                    log.debug { "Rule '${rule.name}' evaluation failed. exceptionType=${e.javaClass.name}" }
                     false
                 }
             }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/DefaultRuleListener.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/DefaultRuleListener.kt
@@ -43,7 +43,7 @@ class DefaultRuleListener: RuleListener {
         if (exception == null) {
             log.debug { "Rule '${rule.name}' performed successfully." }
         } else {
-            log.warn(exception) { "Rule '${rule.name}' performed with exception." }
+            log.warn { "Rule '${rule.name}' performed with exception. exceptionType=${exception.javaClass.name}" }
         }
     }
 }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/DefaultSuspendRuleEngine.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/DefaultSuspendRuleEngine.kt
@@ -58,7 +58,7 @@ open class DefaultSuspendRuleEngine(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                log.debug { "Suspend rule '$name' failed with exception: ${e.message}" }
+                log.debug { "Suspend rule '$name' failed. exceptionType=${e.javaClass.name}" }
                 if (config.skipOnFirstFailedRule) {
                     log.debug { "Remaining suspend rules skipped. (skipOnFirstFailedRule=true)" }
                     return
@@ -75,7 +75,7 @@ open class DefaultSuspendRuleEngine(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                log.debug { "Suspend rule '${rule.name}' evaluate failed with exception: ${e.message}" }
+                log.debug { "Suspend rule '${rule.name}' evaluate failed. exceptionType=${e.javaClass.name}" }
                 false
             }
         }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/RuleLogging.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/core/RuleLogging.kt
@@ -1,0 +1,9 @@
+package io.bluetape4k.rule.core
+
+/**
+ * 규칙 정의 source를 로그에 남길 때 payload를 제외한 요약을 반환합니다.
+ *
+ * 사용자가 제공한 조건식과 실행 스크립트는 민감한 값을 포함할 수 있으므로
+ * 로그에는 원문 대신 길이만 남겨야 합니다.
+ */
+internal fun String.toRuleSourceLogContext(): String = "sourceLength=$length"

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/groovy/GroovyAction.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/groovy/GroovyAction.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.rule.api.Action
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.rule.exception.RuleException
 import io.bluetape4k.support.requireNotBlank
 import org.codehaus.groovy.control.CompilerConfiguration
@@ -54,7 +55,10 @@ class GroovyAction(val script: String): Action {
                 facts[key as String] = converted
             }
         } catch (e: Exception) {
-            log.error(e) { "Fail to execute Groovy script '$script' on facts=$facts" }
+            log.error {
+                "Fail to execute Groovy script. ${script.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             throw RuleException("Fail to execute Groovy script", e)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/groovy/GroovyCondition.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/groovy/GroovyCondition.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.support.requireNotBlank
 import org.codehaus.groovy.control.CompilerConfiguration
 
@@ -44,7 +45,10 @@ class GroovyCondition(val expression: String): Condition {
             parsedScript.binding = binding
             parsedScript.run() as Boolean
         } catch (e: Exception) {
-            log.warn(e) { "Fail to evaluate Groovy expression '$expression' with facts=$facts" }
+            log.warn {
+                "Fail to evaluate Groovy expression. ${expression.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             false
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/groovy/GroovyRule.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/groovy/GroovyRule.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.rule.DEFAULT_RULE_PRIORITY
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
 import io.bluetape4k.rule.core.AbstractRule
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.support.requireNotBlank
 import java.util.*
 
@@ -41,7 +42,7 @@ class GroovyRule(
      */
     fun whenever(conditionExpr: String) = apply {
         conditionExpr.requireNotBlank("conditionExpr")
-        log.debug { "Set rule condition. condition=$conditionExpr" }
+        log.debug { "Set rule condition. engine=Groovy, ${conditionExpr.toRuleSourceLogContext()}" }
         this.condition = GroovyCondition(conditionExpr)
     }
 
@@ -49,7 +50,7 @@ class GroovyRule(
      * [GroovyCondition]으로 조건을 설정합니다.
      */
     fun whenever(condition: GroovyCondition) = apply {
-        log.debug { "Set rule condition. condition=$condition" }
+        log.debug { "Set rule condition. engine=Groovy, ${condition.expression.toRuleSourceLogContext()}" }
         this.condition = condition
     }
 
@@ -58,7 +59,7 @@ class GroovyRule(
      */
     fun then(script: String) = apply {
         script.requireNotBlank("script")
-        log.debug { "Add rule action. script=$script" }
+        log.debug { "Add rule action. engine=Groovy, ${script.toRuleSourceLogContext()}" }
         actions.add(GroovyAction(script))
     }
 
@@ -66,18 +67,18 @@ class GroovyRule(
      * [GroovyAction]을 추가합니다.
      */
     fun then(action: GroovyAction) = apply {
-        log.debug { "Add rule action. action=$action" }
+        log.debug { "Add rule action. engine=Groovy, ${action.script.toRuleSourceLogContext()}" }
         actions.add(action)
     }
 
     override fun evaluate(facts: Facts): Boolean {
-        log.debug { "Evaluate condition '$condition' with facts=$facts" }
+        log.debug { "Evaluate rule. name='$name', engine=Groovy, factCount=${facts.size}" }
         return condition.evaluate(facts)
     }
 
     override fun execute(facts: Facts) {
         actions.forEach { action ->
-            log.debug { "Execute action '$action' with facts=$facts" }
+            log.debug { "Execute action. name='$name', engine=Groovy, factCount=${facts.size}" }
             action.execute(facts)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/janino/JaninoAction.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/janino/JaninoAction.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.rule.api.Action
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.rule.exception.RuleException
 import io.bluetape4k.support.requireNotBlank
 import org.codehaus.janino.ScriptEvaluator
@@ -47,7 +48,10 @@ class JaninoAction(val script: String): Action {
                 facts[key] = value
             }
         } catch (e: Exception) {
-            log.error(e) { "Fail to execute Janino script '$script' on facts=$facts" }
+            log.error {
+                "Fail to execute Janino script. ${script.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             throw RuleException("Fail to execute Janino script", e)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/janino/JaninoCondition.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/janino/JaninoCondition.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.support.requireNotBlank
 import org.codehaus.janino.ExpressionEvaluator
 
@@ -40,7 +41,10 @@ class JaninoCondition(val expression: String): Condition {
         return try {
             evaluator.evaluate(arrayOf<Any?>(facts.asMap())) as Boolean
         } catch (e: Exception) {
-            log.warn(e) { "Fail to evaluate Janino expression '$expression' with facts=$facts" }
+            log.warn {
+                "Fail to evaluate Janino expression. ${expression.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             false
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/janino/JaninoRule.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/janino/JaninoRule.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.rule.DEFAULT_RULE_PRIORITY
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
 import io.bluetape4k.rule.core.AbstractRule
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.support.requireNotBlank
 import java.util.*
 
@@ -41,7 +42,7 @@ class JaninoRule(
      */
     fun whenever(conditionExpr: String) = apply {
         conditionExpr.requireNotBlank("conditionExpr")
-        log.debug { "Set rule condition. condition=$conditionExpr" }
+        log.debug { "Set rule condition. engine=Janino, ${conditionExpr.toRuleSourceLogContext()}" }
         this.condition = JaninoCondition(conditionExpr)
     }
 
@@ -49,7 +50,7 @@ class JaninoRule(
      * [JaninoCondition]으로 조건을 설정합니다.
      */
     fun whenever(condition: JaninoCondition) = apply {
-        log.debug { "Set rule condition. condition=$condition" }
+        log.debug { "Set rule condition. engine=Janino, ${condition.expression.toRuleSourceLogContext()}" }
         this.condition = condition
     }
 
@@ -58,7 +59,7 @@ class JaninoRule(
      */
     fun then(script: String) = apply {
         script.requireNotBlank("script")
-        log.debug { "Add rule action. script=$script" }
+        log.debug { "Add rule action. engine=Janino, ${script.toRuleSourceLogContext()}" }
         actions.add(JaninoAction(script))
     }
 
@@ -66,18 +67,18 @@ class JaninoRule(
      * [JaninoAction]을 추가합니다.
      */
     fun then(action: JaninoAction) = apply {
-        log.debug { "Add rule action. action=$action" }
+        log.debug { "Add rule action. engine=Janino, ${action.script.toRuleSourceLogContext()}" }
         actions.add(action)
     }
 
     override fun evaluate(facts: Facts): Boolean {
-        log.debug { "Evaluate condition '$condition' with facts=$facts" }
+        log.debug { "Evaluate rule. name='$name', engine=Janino, factCount=${facts.size}" }
         return condition.evaluate(facts)
     }
 
     override fun execute(facts: Facts) {
         actions.forEach { action ->
-            log.debug { "Execute action '$action' with facts=$facts" }
+            log.debug { "Execute action. name='$name', engine=Janino, factCount=${facts.size}" }
             action.execute(facts)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/kotlinscript/KotlinScriptAction.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/kotlinscript/KotlinScriptAction.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.rule.api.Action
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.rule.exception.RuleException
 import io.bluetape4k.support.requireNotBlank
 
@@ -33,8 +34,11 @@ class KotlinScriptAction private constructor(val script: String): Action {
         try {
             KotlinScriptEngine.evaluate(script, facts.asMap())
         } catch (e: Exception) {
-            log.error(e) { "Unable to execute kotlin script '$script' on facts=$facts" }
-            throw RuleException("Fail to execute kotlin script '$script' on facts=$facts", e)
+            log.error {
+                "Unable to execute Kotlin script. ${script.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
+            throw RuleException("Fail to execute Kotlin script", e)
         }
     }
 

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/kotlinscript/KotlinScriptCondition.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/kotlinscript/KotlinScriptCondition.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 
 /**
  * Kotlin Script를 이용한 [Condition] 구현체입니다.
@@ -28,7 +29,10 @@ class KotlinScriptCondition(val script: String): Condition {
         return try {
             KotlinScriptEngine.evaluate(script, facts.asMap()) as? Boolean ?: false
         } catch (e: Exception) {
-            log.warn(e) { "Unable to evaluate kotlin script '$script' on facts=$facts" }
+            log.warn {
+                "Unable to evaluate Kotlin script. ${script.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             false
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/kotlinscript/KotlinScriptEngine.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/kotlinscript/KotlinScriptEngine.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.rule.engines.kotlinscript
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.rule.exception.RuleException
 import kotlin.script.experimental.api.KotlinType
 import kotlin.script.experimental.api.ResultValue
@@ -41,7 +42,9 @@ object KotlinScriptEngine: KLogging() {
      * @return 스크립트 실행 결과
      */
     fun evaluate(script: String, bindings: Map<String, Any?> = emptyMap()): Any? {
-        log.debug { "Evaluate kotlin script: $script" }
+        log.debug {
+            "Evaluate Kotlin script. ${script.toRuleSourceLogContext()}, bindingCount=${bindings.size}"
+        }
 
         val compilationConfig = ScriptCompilationConfiguration {
             jvm {
@@ -60,12 +63,12 @@ object KotlinScriptEngine: KLogging() {
 
         val result = host.eval(script.toScriptSource(), compilationConfig, evaluationConfig)
         val evalResult = result.valueOrNull()
-            ?: throw RuleException("Fail to evaluate kotlin script: $script. reports=${result.reports.joinToString()}")
+            ?: throw RuleException("Fail to evaluate Kotlin script. reportCount=${result.reports.size}")
 
         return when (val rv = evalResult.returnValue) {
             is ResultValue.Value -> rv.value
             is ResultValue.Unit  -> Unit
-            is ResultValue.Error -> throw RuleException("Kotlin script error: ${rv.error.message}", rv.error)
+            is ResultValue.Error -> throw RuleException("Kotlin script evaluation error", rv.error)
             is ResultValue.NotEvaluated -> null
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/kotlinscript/KotlinScriptRule.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/kotlinscript/KotlinScriptRule.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.rule.DEFAULT_RULE_PRIORITY
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
 import io.bluetape4k.rule.core.AbstractRule
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.support.requireNotBlank
 import java.util.*
 
@@ -37,7 +38,7 @@ class KotlinScriptRule(
      * Kotlin 스크립트 표현식으로 조건을 설정합니다.
      */
     fun whenever(conditionExpr: String) = apply {
-        log.debug { "Set rule condition. condition=$conditionExpr" }
+        log.debug { "Set rule condition. engine=KotlinScript, ${conditionExpr.toRuleSourceLogContext()}" }
         this.condition = KotlinScriptCondition(conditionExpr)
     }
 
@@ -45,7 +46,7 @@ class KotlinScriptRule(
      * [KotlinScriptCondition]으로 조건을 설정합니다.
      */
     fun whenever(condition: KotlinScriptCondition) = apply {
-        log.debug { "Set rule condition. condition=$condition" }
+        log.debug { "Set rule condition. engine=KotlinScript, ${condition.script.toRuleSourceLogContext()}" }
         this.condition = condition
     }
 
@@ -54,7 +55,7 @@ class KotlinScriptRule(
      */
     fun then(actionExpr: String) = apply {
         actionExpr.requireNotBlank("actionExpr")
-        log.debug { "Add rule action. action=$actionExpr" }
+        log.debug { "Add rule action. engine=KotlinScript, ${actionExpr.toRuleSourceLogContext()}" }
         actions.add(KotlinScriptAction(actionExpr))
     }
 
@@ -62,19 +63,19 @@ class KotlinScriptRule(
      * [KotlinScriptAction]을 추가합니다.
      */
     fun then(action: KotlinScriptAction) = apply {
-        log.debug { "Add rule action. action=$action" }
+        log.debug { "Add rule action. engine=KotlinScript, ${action.script.toRuleSourceLogContext()}" }
         actions.add(action)
     }
 
     override fun evaluate(facts: Facts): Boolean {
-        log.debug { "Evaluate condition '$condition' with facts=$facts" }
+        log.debug { "Evaluate rule. name='$name', engine=KotlinScript, factCount=${facts.size}" }
         return condition.evaluate(facts)
     }
 
     override fun execute(facts: Facts) {
-        log.debug { "Execute actions with facts=$facts" }
+        log.debug { "Execute actions. name='$name', engine=KotlinScript, factCount=${facts.size}" }
         actions.forEach { action ->
-            log.debug { "Execute action '$action' with facts=$facts" }
+            log.debug { "Execute action. name='$name', engine=KotlinScript, factCount=${facts.size}" }
             action.execute(facts)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/mvel2/MvelAction.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/mvel2/MvelAction.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.rule.api.Action
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.rule.exception.RuleException
 import io.bluetape4k.support.requireNotBlank
 import org.mvel2.MVEL
@@ -35,7 +36,10 @@ class MvelAction(val expression: String): Action {
         try {
             MVEL.executeExpression(compiledExpression, facts.asMap())
         } catch (e: Exception) {
-            log.error(e) { "Fail to execute expression '$expression' on facts=$facts" }
+            log.error {
+                "Fail to execute MVEL expression. ${expression.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             throw RuleException("Fail to execute MVEL expression", e)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/mvel2/MvelCondition.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/mvel2/MvelCondition.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import org.mvel2.MVEL
 
 /**
@@ -30,7 +31,10 @@ class MvelCondition(val expression: String): Condition {
         return try {
             MVEL.executeExpression(compiledExpression, facts.asMap()) as Boolean
         } catch (e: Exception) {
-            log.warn(e) { "Fail to evaluate expression '$expression' with facts=$facts" }
+            log.warn {
+                "Fail to evaluate MVEL expression. ${expression.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             false
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/mvel2/MvelRule.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/mvel2/MvelRule.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.rule.DEFAULT_RULE_PRIORITY
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
 import io.bluetape4k.rule.core.AbstractRule
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.support.requireNotBlank
 import java.util.*
 
@@ -37,7 +38,7 @@ class MvelRule(
      * MVEL2 표현식으로 조건을 설정합니다.
      */
     fun whenever(conditionExpr: String) = apply {
-        log.debug { "Set rule condition. condition=$conditionExpr" }
+        log.debug { "Set rule condition. engine=MVEL, ${conditionExpr.toRuleSourceLogContext()}" }
         this.condition = MvelCondition(conditionExpr)
     }
 
@@ -45,7 +46,7 @@ class MvelRule(
      * [MvelCondition]으로 조건을 설정합니다.
      */
     fun whenever(condition: MvelCondition) = apply {
-        log.debug { "Set rule condition. condition=$condition" }
+        log.debug { "Set rule condition. engine=MVEL, ${condition.expression.toRuleSourceLogContext()}" }
         this.condition = condition
     }
 
@@ -54,7 +55,7 @@ class MvelRule(
      */
     fun then(actionExpr: String) = apply {
         actionExpr.requireNotBlank("actionExpr")
-        log.debug { "Add rule action. action=$actionExpr" }
+        log.debug { "Add rule action. engine=MVEL, ${actionExpr.toRuleSourceLogContext()}" }
         actions.add(MvelAction(actionExpr))
     }
 
@@ -62,18 +63,18 @@ class MvelRule(
      * [MvelAction]을 추가합니다.
      */
     fun then(action: MvelAction) = apply {
-        log.debug { "Add rule action. action=$action" }
+        log.debug { "Add rule action. engine=MVEL, ${action.expression.toRuleSourceLogContext()}" }
         actions.add(action)
     }
 
     override fun evaluate(facts: Facts): Boolean {
-        log.debug { "Evaluate condition '$condition' with facts=$facts" }
+        log.debug { "Evaluate rule. name='$name', engine=MVEL, factCount=${facts.size}" }
         return condition.evaluate(facts)
     }
 
     override fun execute(facts: Facts) {
         actions.forEach { action ->
-            log.debug { "Execute action '$action' with facts=$facts" }
+            log.debug { "Execute action. name='$name', engine=MVEL, factCount=${facts.size}" }
             action.execute(facts)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/spel/SpelAction.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/spel/SpelAction.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.error
 import io.bluetape4k.rule.api.Action
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.rule.exception.RuleException
 import io.bluetape4k.support.requireNotBlank
 import org.springframework.expression.BeanResolver
@@ -55,7 +56,10 @@ class SpelAction private constructor(
             beanResolver?.run { context.setBeanResolver(this) }
             compiledExpr.getValue(context)
         } catch (e: Exception) {
-            log.error(e) { "Fail to execute SpEL expression '$expression' on facts=$facts" }
+            log.error {
+                "Fail to execute SpEL expression. ${expression.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             throw RuleException("Fail to execute SpEL expression", e)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/spel/SpelCondition.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/spel/SpelCondition.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.support.requireNotBlank
 import org.springframework.expression.BeanResolver
 import org.springframework.expression.Expression
@@ -53,7 +54,10 @@ class SpelCondition private constructor(
             beanResolver?.run { context.setBeanResolver(this) }
             compiledExpr.getValue(context, Boolean::class.java) ?: false
         } catch (e: Exception) {
-            log.warn(e) { "Fail to evaluate SpEL expression '$expression' with facts=$facts" }
+            log.warn {
+                "Fail to evaluate SpEL expression. ${expression.toRuleSourceLogContext()}, " +
+                        "exceptionType=${e.javaClass.name}, factCount=${facts.size}"
+            }
             false
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/spel/SpelRule.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/engines/spel/SpelRule.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.rule.DEFAULT_RULE_PRIORITY
 import io.bluetape4k.rule.api.Condition
 import io.bluetape4k.rule.api.Facts
 import io.bluetape4k.rule.core.AbstractRule
+import io.bluetape4k.rule.core.toRuleSourceLogContext
 import io.bluetape4k.support.requireNotBlank
 import org.springframework.expression.BeanResolver
 import org.springframework.expression.ParserContext
@@ -55,7 +56,7 @@ class SpelRule private constructor(
         parserContext: ParserContext? = null,
         beanResolver: BeanResolver? = null,
     ) = apply {
-        log.debug { "Set rule condition. expression=$expression" }
+        log.debug { "Set rule condition. engine=SpEL, ${expression.toRuleSourceLogContext()}" }
         this.condition = SpelCondition(expression, parserContext, beanResolver)
     }
 
@@ -63,7 +64,7 @@ class SpelRule private constructor(
      * [SpelCondition]으로 조건을 설정합니다.
      */
     fun whenever(condition: SpelCondition) = apply {
-        log.debug { "Set rule condition. condition=$condition" }
+        log.debug { "Set rule condition. engine=SpEL, ${condition.expression.toRuleSourceLogContext()}" }
         this.condition = condition
     }
 
@@ -77,7 +78,7 @@ class SpelRule private constructor(
         beanResolver: BeanResolver? = null,
     ) = apply {
         expression.requireNotBlank("expression")
-        log.debug { "Add rule action. expression=$expression" }
+        log.debug { "Add rule action. engine=SpEL, ${expression.toRuleSourceLogContext()}" }
         actions.add(SpelAction(expression, parserContext, beanResolver))
     }
 
@@ -85,7 +86,7 @@ class SpelRule private constructor(
      * [SpelAction]을 추가합니다.
      */
     fun then(action: SpelAction) = apply {
-        log.debug { "Add rule action. action=$action" }
+        log.debug { "Add rule action. engine=SpEL, ${action.expression.toRuleSourceLogContext()}" }
         actions.add(action)
     }
 
@@ -95,7 +96,7 @@ class SpelRule private constructor(
 
     override fun execute(facts: Facts) {
         actions.forEach { action ->
-            log.debug { "Execute action '$action' with facts=$facts" }
+            log.debug { "Execute action. name='$name', engine=SpEL, factCount=${facts.size}" }
             action.execute(facts)
         }
     }

--- a/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/readers/RuleReader.kt
+++ b/utils/rule-engine/src/main/kotlin/io/bluetape4k/rule/readers/RuleReader.kt
@@ -78,7 +78,11 @@ interface RuleReader<Source> {
         return try {
             createRuleDefinition(map)
         } catch (e: Exception) {
-            log.warn(e) { "Fail to convert map to RuleDefinition. map=$map" }
+            log.warn {
+                "Fail to convert map to RuleDefinition. " +
+                        "ruleName=${map["name"] ?: DEFAULT_RULE_NAME}, fieldCount=${map.size}, " +
+                        "exceptionType=${e.javaClass.name}"
+            }
             null
         }
     }

--- a/utils/rule-engine/src/test/kotlin/io/bluetape4k/rule/core/RuleScriptLoggingRedactionTest.kt
+++ b/utils/rule-engine/src/test/kotlin/io/bluetape4k/rule/core/RuleScriptLoggingRedactionTest.kt
@@ -1,0 +1,96 @@
+package io.bluetape4k.rule.core
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
+import io.bluetape4k.rule.api.Facts
+import io.bluetape4k.rule.engines.groovy.GroovyAction
+import io.bluetape4k.rule.engines.groovy.GroovyCondition
+import io.bluetape4k.rule.engines.groovy.GroovyRule
+import io.bluetape4k.rule.engines.janino.JaninoAction
+import io.bluetape4k.rule.engines.janino.JaninoCondition
+import io.bluetape4k.rule.engines.janino.JaninoRule
+import io.bluetape4k.rule.engines.kotlinscript.KotlinScriptAction
+import io.bluetape4k.rule.engines.kotlinscript.KotlinScriptCondition
+import io.bluetape4k.rule.engines.kotlinscript.KotlinScriptRule
+import io.bluetape4k.rule.engines.mvel2.MvelAction
+import io.bluetape4k.rule.engines.mvel2.MvelCondition
+import io.bluetape4k.rule.engines.mvel2.MvelRule
+import io.bluetape4k.rule.engines.spel.SpelAction
+import io.bluetape4k.rule.engines.spel.SpelCondition
+import io.bluetape4k.rule.engines.spel.SpelRule
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+class RuleScriptLoggingRedactionTest {
+
+    @Test
+    fun `all script engine definition logs summarize source`() {
+        val source = "source-rule-definition-secret"
+        val rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger
+        val previousLevel = rootLogger.level
+
+        InMemoryLogbackAppender("root").use { appender ->
+            try {
+                rootLogger.level = Level.TRACE
+
+                GroovyRule(name = "groovy")
+                    .whenever(source)
+                    .then(source)
+                JaninoRule(name = "janino")
+                    .whenever(source)
+                    .then(source)
+                KotlinScriptRule(name = "kotlin-script")
+                    .whenever(source)
+                    .then(source)
+                MvelRule(name = "mvel")
+                    .whenever(source)
+                    .then(source)
+                SpelRule(name = "spel")
+                    .whenever(source)
+                    .then(source)
+
+                val messages = appender.messages.joinToString("\n")
+                messages shouldNotContain source
+                messages shouldContain "sourceLength=${source.length}"
+            } finally {
+                rootLogger.level = previousLevel
+            }
+        }
+    }
+
+    @Test
+    fun `all script engine failures omit source payload`() {
+        val source = "source-rule-failure-secret"
+        val facts = Facts.empty()
+        val rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger
+        val previousLevel = rootLogger.level
+
+        InMemoryLogbackAppender("root").use { appender ->
+            try {
+                rootLogger.level = Level.TRACE
+
+                listOf<() -> Unit>(
+                    { GroovyCondition(source).evaluate(facts) },
+                    { JaninoCondition(source).evaluate(facts) },
+                    { KotlinScriptCondition(source).evaluate(facts) },
+                    { MvelCondition(source).evaluate(facts) },
+                    { SpelCondition(source).evaluate(facts) },
+                    { GroovyAction(source).execute(facts) },
+                    { JaninoAction(source).execute(facts) },
+                    { KotlinScriptAction(source).execute(facts) },
+                    { MvelAction(source).execute(facts) },
+                    { SpelAction(source).execute(facts) },
+                ).forEach { runCatching { it() } }
+
+                val messages = appender.messages.joinToString("\n")
+                messages shouldNotContain source
+                messages shouldContain "sourceLength=${source.length}"
+            } finally {
+                rootLogger.level = previousLevel
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1780
Part of #1728

rule-engine의 규칙 정의와 script 원문이 운영 로그에 남는 P2 잔여 위험을 공통 요약 경계로 줄입니다.

## Background

Epic #1728의 선행 PR #1771은 facts와 실행 인자 payload를 요약했지만 Groovy, Janino, Kotlin Script, MVEL, SpEL 경로의 정의·script 문자열은 남아 있었습니다.

## What This Solves

- 규칙 정의·script 원문과 secret-like 문자열의 로그 노출을 차단합니다.
- engine type, rule name, fact count, result 같은 low-cardinality 운영 정보는 보존합니다.

## Work Done

- `RuleLogging` 공통 요약 helper를 추가하고 다섯 script engine의 로그 caller가 이를 재사용하도록 정리했습니다.
- 원문 redaction 회귀 테스트와 `README.md`/`README.ko.md` logging 계약을 추가했습니다.

## Validation

- `./gradlew :bluetape4k-rule-engine:test --no-configuration-cache --no-daemon --console=plain`: PASS (358 tests, 5 pending)
- `./gradlew :bluetape4k-rule-engine:detekt --no-configuration-cache --no-daemon --console=plain`: PASS (기존 findings만 유지)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 수정 완료. 기존 PR #1771의 `RuleLogging.kt`와 겹치므로 merge 시 helper를 통합합니다.
- Review evidence: `utils/rule-engine` 전체 caller inventory, redaction regression, Kotlin checklist

## Metadata

- Issue: #1780, milestone `2.1.0`, assignee `debop`
- PR: #1786, head `8894b5865a38aefcbd76d81c57fcf3c02ddf8c65`, base `develop`, https://github.com/bluetape4k/bluetape4k-projects/pull/1786
- CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34278239918 — terminal success, but `Test / Key Utils` is `SKIPPED`; local rule-engine proof is recorded and hosted module coverage remains a gap

## DoD Status

Required checks: 13/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01..CG-10 | 기준 문서, 이슈, caller·재사용, 테스트·detekt·diff를 확인 | PASS | workflow lane evidence와 exact commit `8894b586` | 없음 |
| CG-11 | PR 생성 권한과 repo/base/head 확인 | PASS | 사용자 요청, `bluetape4k-projects`, `develop`, `fix/issue-1780-rule-logging` | 없음 |
| CG-12 | exact head branch push 및 remote SHA 확인 | PASS | local/remote `8894b5865a38aefcbd76d81c57fcf3c02ddf8c65` 일치 | 없음 |
| CG-12A - Guidance refresh | PR 직전 기준 문서와 linked issue 재확인 | PASS | AGENTS/skill/common-gates/template/issue live readback 및 SHA snapshot | 없음 |
| CG-13 | PR 생성 후 metadata/body live readback | PASS | PR #1786 URL, head SHA, base, labels, assignee, milestone, body heading live readback | 없음 |
| CG-14 | exact-head CI와 review/thread 확인 | PENDING | CI run `34278239918` success but rule-engine `Test / Key Utils` is `SKIPPED`; reviews 0/comments 0, solo maintainer lane review subgate N/A | hosted rule-engine test coverage를 보강하거나 명시적 gap을 해소 |
| CG-15 | merge-ready 보고 | PENDING | CG-14 이후 | CI/review 수렴 후 보고 |
| CG-16 | fresh merge approval | PENDING | 아직 승인 없음 | exact head 승인 대기 |
| CG-17 | 승인된 merge 실행·검증 | PENDING | merge 미실행 | 승인 후 수행 |
| CG-18 | canonical sync·cleanup | PENDING | merge 전 | merge 후 보존 원칙에 따라 수행 |
| CG-X01 | release/tag/publish | N/A | 이번 PR은 수정 PR이며 release side effect 없음 | 없음 |

Final status: PENDING (path-filtered rule-engine CI gap, merge-ready 보고와 fresh exact-head 승인 대기)

Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18
