### PR TITLE
#1781 Redis URI query·semicolon 자격증명 redaction 계약을 확장한다

### DIFF
--- a/cache/cache-lettuce/README.ko.md
+++ b/cache/cache-lettuce/README.ko.md
@@ -87,6 +87,15 @@ Caffeine(로컬) + Redis(분산) 2단계 캐시로, RESP3 CLIENT TRACKING을 통
 | `CaffeineLocalCache<K, V>`              | Caffeine 기반 LocalCache 구현                          |
 | `TrackingInvalidationListener<V>`       | RESP3 CLIENT TRACKING push 리스너                     |
 
+## Redis URI 로깅
+
+Provider는 Redis URI의 user information, query와 semicolon option을 로그에 남기기 전에 redaction합니다. 진단에
+필요한 host, port, path와 민감하지 않은 option은 유지하고 percent encoded 값을 포함한 자격증명 값은
+`<redacted>`로 치환합니다. URI가 malformed이거나 구조가 모호하면 `<redacted-uri>`로 기록합니다.
+
+이 경계는 Lettuce Provider의 URI 로깅에 적용됩니다. JDBC/R2DBC URL 정책을 다루는
+[bluetape4k-leader#892](https://github.com/bluetape4k/bluetape4k-leader/issues/892)와는 별도입니다.
+
 ### Near-Cache Capability
 
 Lettuce native/JCache NearCache는 공통 conformance suite에서 supported로 검증됩니다.

--- a/cache/cache-lettuce/README.md
+++ b/cache/cache-lettuce/README.md
@@ -42,6 +42,15 @@ dependencies {
 - JCache-based `NearJCache` / `SuspendNearJCache`
 - RESP3 `CLIENT TRACKING` invalidation support
 
+## Redis URI Logging
+
+The provider redacts Redis URI user information, query and semicolon options before logging. Host, port, path,
+and non-sensitive options remain available for diagnostics; credential values, including percent-encoded values,
+are replaced with `<redacted>`. Malformed or ambiguous URIs are logged as `<redacted-uri>`.
+
+This boundary covers URI logging in the Lettuce provider. It is separate from the JDBC/R2DBC URL policy tracked
+by [bluetape4k-leader#892](https://github.com/bluetape4k/bluetape4k-leader/issues/892).
+
 ## Near-Cache Capability
 
 Lettuce native and JCache near-cache variants are fully supported by the shared

--- a/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCachingProvider.kt
+++ b/cache/cache-lettuce/src/main/kotlin/io/bluetape4k/cache/jcache/LettuceCachingProvider.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.cache.jcache
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
+import io.bluetape4k.redis.lettuce.redactUriCredentials
+import io.bluetape4k.redis.lettuce.toRedactedLogString
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisURI
 import java.net.URI
@@ -44,7 +46,9 @@ class LettuceCachingProvider: CachingProvider {
         val cacheUri = uri ?: defaultUri
         val cacheClassLoader = classLoader ?: defaultClassLoader
 
-        log.debug { "Get LettuceCacheManager. uri=$cacheUri, classLoader=$cacheClassLoader" }
+        log.debug {
+            "Get LettuceCacheManager. uri=${cacheUri.toRedactedLogString()}, classLoader=$cacheClassLoader"
+        }
 
         // 동시 RedisClient 생성을 방지하기 위해 lock으로 조회 및 생성 로직 전체를 보호
         return lock.withLock {
@@ -57,7 +61,7 @@ class LettuceCachingProvider: CachingProvider {
                 cacheUri.toString()
             }
 
-            log.debug { "Create RedisClient. redisUri=$redisUri" }
+            log.debug { "Create RedisClient. redisUri=${redisUri.redactUriCredentials()}" }
             val redisClient = RedisClient.create(RedisURI.create(redisUri))
 
             val manager = LettuceCacheManager(
@@ -70,7 +74,7 @@ class LettuceCachingProvider: CachingProvider {
             )
 
             uri2manager[cacheUri] = manager
-            log.info { "Created LettuceCacheManager. uri=$cacheUri" }
+            log.info { "Created LettuceCacheManager. uri=${cacheUri.toRedactedLogString()}" }
             manager
         }
     }
@@ -103,7 +107,9 @@ class LettuceCachingProvider: CachingProvider {
     }
 
     override fun close(uri: URI, classLoader: ClassLoader) {
-        log.info { "Close LettuceCachingProvider. uri=$uri, classLoader=$classLoader" }
+        log.info {
+            "Close LettuceCachingProvider. uri=${uri.toRedactedLogString()}, classLoader=$classLoader"
+        }
         managers[classLoader]?.let { uri2manager ->
             uri2manager.remove(uri)?.let { manager ->
                 runCatching { manager.close() }

--- a/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceCachingProviderTest.kt
+++ b/cache/cache-lettuce/src/test/kotlin/io/bluetape4k/cache/jcache/LettuceCachingProviderTest.kt
@@ -1,12 +1,19 @@
 package io.bluetape4k.cache.jcache
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldNotContain
+import io.bluetape4k.junit5.output.InMemoryLogbackAppender
 import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.slf4j.LoggerFactory
+import java.net.URI
 import javax.cache.Caching
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -54,5 +61,33 @@ class LettuceCachingProviderTest {
     @Test
     fun `defaultClassLoader is not null`() {
         provider.defaultClassLoader.shouldNotBeNull()
+    }
+
+    @Test
+    fun `query와 semicolon credential은 provider 로그에서 redaction된다`() {
+        val logger = LoggerFactory.getLogger(LettuceCachingProvider::class.java.name) as Logger
+        val previousLevel = logger.level
+        val querySecret = "provider-query-secret"
+        val semicolonSecret = "provider-semicolon-secret"
+        val uri = URI(
+            "redis://cache-user:authority-secret@localhost:6379/0" +
+                    "?database=1;password=$semicolonSecret&password=$querySecret"
+        )
+
+        InMemoryLogbackAppender(LettuceCachingProvider::class.java.name).use { appender ->
+            try {
+                logger.level = Level.DEBUG
+                provider.getCacheManager(uri, provider.defaultClassLoader)
+                provider.close(uri, provider.defaultClassLoader)
+
+                val messages = appender.messages.joinToString("\n")
+                messages shouldContain "redis://<redacted>@localhost:6379/0?database=1;password=<redacted>&password=<redacted>"
+                messages shouldNotContain "authority-secret"
+                messages shouldNotContain querySecret
+                messages shouldNotContain semicolonSecret
+            } finally {
+                logger.level = previousLevel
+            }
+        }
     }
 }

--- a/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisUriRedaction.kt
+++ b/infra/lettuce/src/main/kotlin/io/bluetape4k/redis/lettuce/RedisUriRedaction.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.redis.lettuce
+
+import java.net.URI
+import java.net.URISyntaxException
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+private const val REDACTED_URI = "<redacted-uri>"
+
+private val SENSITIVE_PARAMETER = Regex(
+    "(?i)^(?:auth|api[_-]?key|access[_-]?token|credential(?:s)?|pass(?:word|wd)?|pwd|" +
+            "refresh[_-]?token|secret|token|user(?:name)?)$"
+)
+
+/**
+ * Redis URI를 로그에 남길 수 있는 형태로 변환합니다.
+ *
+ * authority userinfo와 query/semicolon 옵션의 민감한 값을 제거하고 호스트, 포트,
+ * 경로와 안전한 옵션은 보존합니다. URI를 해석할 수 없거나 구조가 모호하면 전체를
+ * [REDACTED_URI]로 치환해 fail-closed 동작을 보장합니다.
+ */
+fun String.redactUriCredentials(): String {
+    if (isEmpty() || any { it.isWhitespace() || it.isISOControl() }) {
+        return REDACTED_URI
+    }
+
+    val uri = try {
+        URI(this)
+    } catch (_: URISyntaxException) {
+        return REDACTED_URI
+    }
+
+    val authority = uri.rawAuthority
+    if (authority != null && (authority.count { it == '@' } > 1 || uri.host == null)) {
+        return REDACTED_URI
+    }
+
+    return try {
+        val rawSchemeSpecificPart = uri.rawSchemeSpecificPart
+        val redactedSchemeSpecificPart = if (authority != null) {
+            if (!rawSchemeSpecificPart.startsWith("//$authority")) {
+                return REDACTED_URI
+            }
+
+            val authorityEnd = 2 + authority.length
+            val redactedAuthority = authority.substringAfterLast('@', authority)
+                .let { hostAuthority ->
+                    if (uri.rawUserInfo == null) hostAuthority else "<redacted>@$hostAuthority"
+                }
+            "//$redactedAuthority" + redactPathAndQuery(rawSchemeSpecificPart.substring(authorityEnd))
+        } else {
+            redactPathAndQuery(rawSchemeSpecificPart)
+        }
+
+        val fragment = uri.rawFragment?.let { "#<redacted>" }.orEmpty()
+        uri.scheme?.let { "$it:$redactedSchemeSpecificPart$fragment" }
+            ?: "$redactedSchemeSpecificPart$fragment"
+    } catch (_: IllegalArgumentException) {
+        REDACTED_URI
+    }
+}
+
+/** 로그용 URI 문자열을 반환하며 Redis 연결 자격증명을 제거합니다. */
+fun URI.toRedactedLogString(): String = toString().redactUriCredentials()
+
+private fun redactPathAndQuery(value: String): String {
+    val queryStart = value.indexOf('?')
+    if (queryStart < 0) {
+        return redactDelimited(value, ';')
+    }
+
+    val path = redactDelimited(value.substring(0, queryStart), ';')
+    val query = redactDelimited(value.substring(queryStart + 1), '&', ';')
+    return "$path?$query"
+}
+
+private fun redactDelimited(value: String, vararg delimiters: Char): String {
+    val redacted = StringBuilder(value.length)
+    var segmentStart = 0
+
+    value.forEachIndexed { index, character ->
+        if (character in delimiters) {
+            redacted.append(redactParameter(value.substring(segmentStart, index)))
+            redacted.append(character)
+            segmentStart = index + 1
+        }
+    }
+    redacted.append(redactParameter(value.substring(segmentStart)))
+    return redacted.toString()
+}
+
+private fun redactParameter(parameter: String): String {
+    if (parameter.isEmpty()) return parameter
+
+    val equalsIndex = parameter.indexOf('=')
+    val rawName = if (equalsIndex < 0) parameter else parameter.substring(0, equalsIndex)
+    val decodedName = URLDecoder.decode(rawName, StandardCharsets.UTF_8)
+    if (!SENSITIVE_PARAMETER.matches(decodedName)) return parameter
+
+    return if (equalsIndex < 0) {
+        "$rawName=<redacted>"
+    } else {
+        parameter.substring(0, equalsIndex + 1) + "<redacted>"
+    }
+}

--- a/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisUriRedactionTest.kt
+++ b/infra/lettuce/src/test/kotlin/io/bluetape4k/redis/lettuce/RedisUriRedactionTest.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.redis.lettuce
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotContain
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class RedisUriRedactionTest {
+
+    @Test
+    fun `정상 URI는 호스트 포트와 안전한 옵션을 보존한다`() {
+        "redis://localhost:6379/0?database=1".redactUriCredentials() shouldBeEqualTo
+            "redis://localhost:6379/0?database=1"
+    }
+
+    @Test
+    fun `authority 자격증명과 percent encoded password를 숨긴다`() {
+        val redacted = "redis://cache-user:p%40ssword@localhost:6379/0".redactUriCredentials()
+
+        redacted shouldBeEqualTo "redis://<redacted>@localhost:6379/0"
+        redacted shouldNotContain "p%40ssword"
+    }
+
+    @Test
+    fun `query와 semicolon 옵션의 credential을 반복해서 숨긴다`() {
+        val uri = "redis://localhost:6379/0;password=path-secret;tls=true" +
+                "?user=cache-user&password=query%2Dsecret&token=token-secret&password=second-secret"
+
+        val redacted = uri.redactUriCredentials()
+
+        redacted shouldBeEqualTo "redis://localhost:6379/0;password=<redacted>;tls=true" +
+                "?user=<redacted>&password=<redacted>&token=<redacted>&password=<redacted>"
+        redacted shouldNotContain "path-secret"
+        redacted shouldNotContain "query%2Dsecret"
+        redacted shouldNotContain "token-secret"
+        redacted shouldNotContain "second-secret"
+    }
+
+    @Test
+    fun `URI 확장은 동일한 공용 redaction 정책을 사용한다`() {
+        URI("redis://cache-user:secret@localhost:6379/0?api_key=key-secret").toRedactedLogString() shouldBeEqualTo
+            "redis://<redacted>@localhost:6379/0?api_key=<redacted>"
+    }
+
+    @Test
+    fun `malformed와 ambiguous URI는 fail closed 결과를 반환한다`() {
+        "redis://localhost:6379/%ZZ?password=secret".redactUriCredentials() shouldBeEqualTo "<redacted-uri>"
+        "redis://cache-user:secret@localhost:6379@evil".redactUriCredentials() shouldBeEqualTo "<redacted-uri>"
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1781
Part of #1728

Redis/Lettuce URI의 query·semicolon·percent-encoded credential도 provider 로그에서 fail-closed로 redaction합니다.

## Background

선행 PR #1769(`#1739`)는 authority userinfo를 숨겼지만 query와 semicolon 옵션의 credential은 P2 잔여 범위였습니다. JDBC/R2DBC 공통 이슈 #892와 분리된 Redis/Lettuce 계약입니다.

## What This Solves

- query, semicolon, encoded credential이 로그에 평문으로 나타나는 경로를 제거합니다.
- malformed 또는 ambiguous URI도 안전한 redacted 결과를 반환하면서 host/port 관찰성은 유지합니다.

## Work Done

- `RedisUriRedaction` 공통 helper가 authority, query, semicolon, percent-encoded key/value를 처리하고 malformed 입력은 fail-closed 하도록 했습니다.
- `LettuceCachingProvider`와 회귀 테스트·README 두 locale을 helper 계약에 맞췄습니다.

## Validation

- `./gradlew :bluetape4k-cache-lettuce:test --no-configuration-cache --no-daemon --console=plain`: PASS (463 tests)
- `./gradlew :bluetape4k-lettuce:test --no-configuration-cache --no-daemon --console=plain`: PASS (945 tests, 0 failures)
- `./gradlew :bluetape4k-cache-lettuce:detekt :bluetape4k-lettuce:detekt --no-configuration-cache --no-daemon --console=plain`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 수정 완료. PR #1769의 authority helper/provider/test와 겹치므로 merge 시 parser 경계를 통합합니다.
- Review evidence: URI input matrix, provider caller inventory, synthetic credential canaries, Kotlin checklist

## Metadata

- Issue: #1781, milestone `2.1.0`, assignee `debop`
- PR: #1787, head `24dd94121fd7e160731d055604d0636ddb9e92d0`, base `develop`, https://github.com/bluetape4k/bluetape4k-projects/pull/1787
- CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34278245985 — PASS (exact head, terminal success; path-filtered jobs are recorded as skipped)

## DoD Status

Required checks: 14/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01..CG-10 | 기준 문서, 이슈, URI caller·재사용, 테스트·detekt·diff를 확인 | PASS | workflow lane evidence와 exact commit `24dd9412` | 없음 |
| CG-11 | PR 생성 권한과 repo/base/head 확인 | PASS | 사용자 요청, `bluetape4k-projects`, `develop`, `fix/issue-1781-redis-query-redaction` | 없음 |
| CG-12 | exact head branch push 및 remote SHA 확인 | PASS | local/remote `24dd94121fd7e160731d055604d0636ddb9e92d0` 일치 | 없음 |
| CG-12A - Guidance refresh | PR 직전 기준 문서와 linked issue 재확인 | PASS | AGENTS/skill/common-gates/template/issue live readback 및 SHA snapshot | 없음 |
| CG-13 | PR 생성 후 metadata/body live readback | PASS | PR #1787 URL, head SHA, base, labels, assignee, milestone, body heading live readback | 없음 |
| CG-14 | exact-head CI와 review/thread 확인 | PASS | CI run `34278245985` success; reviews 0/comments 0, solo maintainer lane review subgate N/A | 없음 |
| CG-15 | merge-ready 보고 | PENDING | CG-14 이후 | CI/review 수렴 후 보고 |
| CG-16 | fresh merge approval | PENDING | 아직 승인 없음 | exact head 승인 대기 |
| CG-17 | 승인된 merge 실행·검증 | PENDING | merge 미실행 | 승인 후 수행 |
| CG-18 | canonical sync·cleanup | PENDING | merge 전 | merge 후 보존 원칙에 따라 수행 |
| CG-X01 | release/tag/publish | N/A | 이번 PR은 수정 PR이며 release side effect 없음 | 없음 |

Final status: PENDING (merge-ready 보고와 fresh exact-head 승인 대기)

Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18
