### PR TITLE
#1784 Toxiproxy 종료 정리 timeout을 bounded cleanup으로 보장한다

### DIFF
--- a/testing/testcontainers/README.ko.md
+++ b/testing/testcontainers/README.ko.md
@@ -511,6 +511,8 @@ client.use {
 - `ToxiproxyServer`는 프록시 컨테이너입니다. Control API 포트 (`8474`)와 프록시 포트 범위 (`8666~8697`)를 노출합니다.
 - `ToxiproxyClient`는 Control API에 붙어서 프록시를 만들고 toxic을 추가/삭제하는 관리용 클라이언트입니다.
 - `DOWNSTREAM latency`는 Upstream 응답이 클라이언트로 돌아오는 구간을 늦춥니다.
+- `ToxiproxyServer`의 `stop()`은 Docker API 정리를 취소 가능한 30초 deadline 안에서 수행하며, deadline을 넘기면 `TimeoutException`을 호출자에게 전달합니다.
+- Docker 기반 테스트는 공유 daemon의 정리 순서를 보장하기 위해 모듈 안에서 순차 실행합니다. Colima에서는 `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock`를 사용하고, timeout이 발생하면 Docker/Testcontainers 진단을 함께 수집하세요.
 
 ### LLM (ChromaDB + Ollama)
 

--- a/testing/testcontainers/README.md
+++ b/testing/testcontainers/README.md
@@ -503,6 +503,12 @@ client.use {
 
 ![Toxiproxy (Chaos Testing) diagram](../../docs/images/readme-diagrams/testing-testcontainers-sequence-02.png)
 
+- `ToxiproxyServer` is the proxy container. It exposes the control API port (`8474`) and proxy port range (`8666~8697`).
+- `ToxiproxyClient` connects to the control API to create proxies and add/remove toxics.
+- `DOWNSTREAM` latency delays the upstream response on its way back to the client.
+- `ToxiproxyServer.stop()` performs Docker API cleanup with a cancellable 30-second deadline and propagates `TimeoutException` when the deadline is exceeded.
+- Docker-backed tests run sequentially within the module so shared-daemon cleanup order is deterministic. With Colima, use `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock` and collect Docker/Testcontainers diagnostics when a timeout occurs.
+
 ### AWS Emulators
 
 `AwsEmulatorServer` is the common interface for local AWS emulators.

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/ContainerCleanup.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/ContainerCleanup.kt
@@ -1,0 +1,55 @@
+package io.bluetape4k.testcontainers
+
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.time.Duration
+
+/**
+ * Docker/Testcontainers 자원 정리를 제한시간 안에서 수행합니다.
+ *
+ * ## 동작/계약
+ * - 정리 작업은 호출자와 분리된 virtual thread에서 실행됩니다.
+ * - 제한시간을 넘기면 작업을 interrupt하고 [TimeoutException]을 던집니다.
+ * - 정리 작업이 예외를 던지면 원래 예외를 그대로 전파합니다.
+ * - 호출자가 interrupt된 경우 interrupt 상태를 복원한 뒤 예외를 전파합니다.
+ *
+ * Docker API 호출이 응답하지 않는 경우에도 테스트 JVM이 무기한 정리 작업을 기다리지 않도록
+ * 컨테이너 종료와 네트워크 정리에 사용합니다.
+ */
+internal inline fun runCleanupWithin(
+    timeout: Duration,
+    crossinline cleanup: () -> Unit,
+) {
+    require(timeout.isFinite() && timeout.isPositive()) {
+        "Cleanup timeout must be finite and positive: [$timeout]"
+    }
+
+    // ExecutorService.close()는 완료되지 않은 작업을 무기한 기다립니다.
+    // Docker API 호출이 interrupt를 무시할 수 있으므로 호출자의 deadline 이후에는
+    // `use` 대신 기다리지 않는 방식으로 executor를 종료합니다.
+    val executor = Executors.newVirtualThreadPerTaskExecutor()
+    var failure: Throwable? = null
+    try {
+        val future = executor.submit { cleanup() }
+        try {
+            future.get(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+        } catch (e: InterruptedException) {
+            future.cancel(true)
+            Thread.currentThread().interrupt()
+            failure = e
+        } catch (e: TimeoutException) {
+            future.cancel(true)
+            failure = e
+        } catch (e: ExecutionException) {
+            failure = e.cause ?: e
+        }
+    } finally {
+        executor.shutdownNow()
+    }
+
+    if (failure != null) {
+        throw failure
+    }
+}

--- a/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ToxiproxyServer.kt
+++ b/testing/testcontainers/src/main/kotlin/io/bluetape4k/testcontainers/infra/ToxiproxyServer.kt
@@ -5,9 +5,11 @@ import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.testcontainers.GenericServer
 import io.bluetape4k.testcontainers.PropertyExportingServer
 import io.bluetape4k.testcontainers.exposeCustomPorts
+import io.bluetape4k.testcontainers.runCleanupWithin
 import io.bluetape4k.utils.ShutdownQueue
 import org.testcontainers.toxiproxy.ToxiproxyContainer
 import org.testcontainers.utility.DockerImageName
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [Toxiproxy](https://github.com/Shopify/toxiproxy)를 Testcontainers를 이용하여 실행하는 카오스 테스트 서버입니다.
@@ -45,6 +47,9 @@ class ToxiproxyServer private constructor(
 ): ToxiproxyContainer(imageName), GenericServer, PropertyExportingServer {
 
     companion object: KLogging() {
+        /** Toxiproxy 컨테이너 정리에 허용하는 최대 시간입니다. */
+        private val CLEANUP_TIMEOUT = 30.seconds
+
         /** Toxiproxy 컨테이너 기본 이미지 이름입니다. */
         const val IMAGE = "ghcr.io/shopify/toxiproxy"
 
@@ -151,6 +156,16 @@ class ToxiproxyServer private constructor(
     override fun start() {
         super.start()
         writeToSystemProperties()
+    }
+
+    /**
+     * Docker API가 응답하지 않아도 컨테이너 종료가 무기한 대기하지 않도록 합니다.
+     *
+     * 제한시간이 만료되면 종료 작업을 interrupt하고 [java.util.concurrent.TimeoutException]을
+     * 호출자에게 전달합니다. 따라서 테스트 실패가 정리 단계에서 가려지지 않습니다.
+     */
+    override fun stop() {
+        runCleanupWithin(CLEANUP_TIMEOUT) { super.stop() }
     }
 
     /**

--- a/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/ContainerCleanupTest.kt
+++ b/testing/testcontainers/src/test/kotlin/io/bluetape4k/testcontainers/ContainerCleanupTest.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.testcontainers
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeTrue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Test
+
+class ContainerCleanupTest {
+
+    @Test
+    fun `cleanup timeout interrupts the pending operation`() {
+        val started = CountDownLatch(1)
+        val interrupted = CountDownLatch(1)
+
+        assertFailsWith<TimeoutException> {
+            runCleanupWithin(100.milliseconds) {
+                started.countDown()
+                try {
+                    Thread.sleep(5.seconds.inWholeMilliseconds)
+                } catch (e: InterruptedException) {
+                    interrupted.countDown()
+                    throw e
+                }
+            }
+        }
+
+        started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        interrupted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+    }
+
+    @Test
+    fun `cleanup failure is propagated`() {
+        assertFailsWith<IllegalStateException> {
+            runCleanupWithin(1.seconds) {
+                error("cleanup failed")
+            }
+        }
+    }
+}

--- a/testing/testcontainers/src/test/resources/junit-platform.properties
+++ b/testing/testcontainers/src/test/resources/junit-platform.properties
@@ -1,6 +1,8 @@
 junit.jupiter.extensions.autodetection.enabled=true
 junit.jupiter.testinstance.lifecycle.default=per_class
 
+# Docker-backed fixtures share one daemon and their shutdown order is part of
+# the test contract; keep the module sequential on local and CI runners.
 junit.jupiter.execution.parallel.enabled=false
 junit.jupiter.execution.parallel.mode.default=same_thread
-junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=same_thread


### PR DESCRIPTION
## Summary

Closes #1784
Part of #1728

Toxiproxy/Testcontainers cleanup이 Docker API 지연으로 무기한 대기하지 않도록 bounded cleanup 계약을 적용합니다.

## Background

PR #1752(`#1737`)의 redaction 검증 뒤 전체 Testcontainers suite가 `KillContainerCmdExec` cleanup에서 5분 이상 멈췄습니다. production redaction과 별개인 lifecycle gap입니다.

## What This Solves

- Docker kill/stop 호출을 30초 deadline 안에서 종료시키고 interrupt를 전파합니다.
- cleanup failure가 원래 테스트 실패를 가리지 않으며 Testcontainers fixture 실행 순서를 명시합니다.

## Work Done

- `ContainerCleanup.runCleanupWithin`을 추가해 virtual thread, timeout, cancellation, primary failure 전파를 공통화했습니다.
- `ToxiproxyServer.stop`, cleanup 회귀 테스트, sequential JUnit 설정, 두 README에 Colima/CI 차이와 timeout 계약을 반영했습니다.

## Validation

- `./gradlew :bluetape4k-testcontainers:test --tests 'io.bluetape4k.testcontainers.ContainerCleanupTest' --tests 'io.bluetape4k.testcontainers.infra.ToxiproxyServerTest' --no-configuration-cache --no-daemon --console=plain`: PASS (7 tests)
- `./gradlew :bluetape4k-testcontainers:detekt --no-configuration-cache --no-daemon --console=plain`: PASS (기존 findings만 유지)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 전체 suite의 기존 environment-sensitive timeout gap은 hosted CI에서 추가 확인합니다.
- Review evidence: cleanup timeout/interruption barrier tests, Toxiproxy lifecycle canary, Kotlin lifecycle/testing checklist

## Metadata

- Issue: #1784, milestone `2.1.0`, assignee `debop`
- PR: #1790, head `d7ca98ce07659528ef5773b1174f78de04f2aeb2`, base `develop`, https://github.com/bluetape4k/bluetape4k-projects/pull/1790
- CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34278365730 — terminal success; `Test / Testcontainers Spring bridge` passed but the direct Testcontainers module job is unavailable/path-filtered

## DoD Status

Required checks: 13/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01..CG-10 | 기준 문서, lifecycle/testcontainers caller·테스트·문서·detekt·diff를 확인 | PASS | workflow lane evidence와 exact commit `d7ca98ce` | 없음 |
| CG-11 | PR 생성 권한과 repo/base/head 확인 | PASS | 사용자 요청, `bluetape4k-projects`, `develop`, `fix/issue-1784-toxiproxy-cleanup-timeout` | 없음 |
| CG-12 | exact head branch push 및 remote SHA 확인 | PASS | local/remote `d7ca98ce07659528ef5773b1174f78de04f2aeb2` 일치 | 없음 |
| CG-12A - Guidance refresh | PR 직전 기준 문서와 linked issue 재확인 | PASS | AGENTS/skill/common-gates/template/issue live readback 및 SHA snapshot | 없음 |
| CG-13 | PR 생성 후 metadata/body live readback | PASS | PR #1790 URL, head SHA, base, labels, assignee, milestone, body heading live readback | 없음 |
| CG-14 | exact-head CI와 review/thread 확인 | PENDING | CI run `34278365730` success with Spring bridge pass, but direct Testcontainers module coverage is unavailable; reviews 0/comments 0, solo maintainer lane review subgate N/A | hosted direct Testcontainers coverage를 보강하거나 명시적 gap을 해소 |
| CG-15 | merge-ready 보고 | PENDING | CG-14 이후 | CI/review 수렴 후 보고 |
| CG-16 | fresh merge approval | PENDING | 아직 승인 없음 | exact head 승인 대기 |
| CG-17 | 승인된 merge 실행·검증 | PENDING | merge 미실행 | 승인 후 수행 |
| CG-18 | canonical sync·cleanup | PENDING | merge 전 | merge 후 보존 원칙에 따라 수행 |
| CG-X01 | release/tag/publish | N/A | 이번 PR은 수정 PR이며 release side effect 없음 | 없음 |

Final status: PENDING (direct Testcontainers CI gap, merge-ready 보고와 fresh exact-head 승인 대기)

Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18
