### PR TITLE
#1785 UUID stress workload와 virtual-thread timeout을 bounded 검증으로 고정한다

### DIFF
--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/NamebasedUuidGeneratorTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/NamebasedUuidGeneratorTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.idgenerators.uuid
 
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
@@ -8,19 +9,21 @@ import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.trace
-import io.bluetape4k.utils.Runtimex
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.seconds
 
 class NamebasedUuidGeneratorTest {
 
     companion object: KLoggingChannel() {
         private const val REPEAT_SIZE = 5
-        private val TEST_COUNT = 512 * Runtime.getRuntime().availableProcessors()
-        private val TEST_LIST = List(TEST_COUNT) { it }
+        private const val STRESS_OPERATIONS = 10_000
+        private const val STRESS_WORKERS = 8
+        private const val STRESS_ROUNDS_PER_WORKER = STRESS_OPERATIONS / STRESS_WORKERS
+        private val STRESS_TIMEOUT = 30.seconds
     }
 
     // private val randomUuid = TimebasedUuidGenerator()
@@ -51,13 +54,15 @@ class NamebasedUuidGeneratorTest {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         MultithreadingTester()
-            .workers(2 * Runtimex.availableProcessors)
-            .rounds(TEST_COUNT)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_ROUNDS_PER_WORKER)
             .add {
                 val id = uuidGenerator.nextId()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 
     @EnabledForJreRange(min = JRE.JAVA_21)
@@ -66,25 +71,31 @@ class NamebasedUuidGeneratorTest {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         StructuredTaskScopeTester()
-            .rounds(TEST_COUNT * 2 * Runtimex.availableProcessors)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_OPERATIONS)
+            .withTimeout(STRESS_TIMEOUT)
             .add {
                 val id = uuidGenerator.nextId()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 
     @RepeatedTest(REPEAT_SIZE)
-    fun `generate timebased uuids in multi jobs`() = runSuspendDefault {
+    fun `generate timebased uuids in multi jobs`() = runSuspendDefault(timeout = STRESS_TIMEOUT) {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         SuspendedJobTester()
-            .workers(2 * Runtimex.availableProcessors)
-            .rounds(TEST_COUNT * 2 * Runtimex.availableProcessors)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_OPERATIONS)
             .add {
                 val id = uuidGenerator.nextId()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 }

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/RandomUuidGeneratorTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/RandomUuidGeneratorTest.kt
@@ -1,26 +1,31 @@
 package io.bluetape4k.idgenerators.uuid
 
+import io.bluetape4k.codec.decodeBase62AsUuid
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendDefault
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.trace
-import io.bluetape4k.utils.Runtimex
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.seconds
 
 class RandomUuidGeneratorTest {
 
     companion object: KLoggingChannel() {
         private const val REPEAT_SIZE = 5
-        private val TEST_COUNT = 512 * Runtime.getRuntime().availableProcessors()
-        private val TEST_LIST = List(TEST_COUNT) { it }
+        private const val STRESS_OPERATIONS = 10_000
+        private const val STRESS_WORKERS = 8
+        private const val STRESS_ROUNDS_PER_WORKER = STRESS_OPERATIONS / STRESS_WORKERS
+        private val STRESS_TIMEOUT = 30.seconds
     }
 
     private val uuidGenerator = Uuid.V4
@@ -33,6 +38,8 @@ class RandomUuidGeneratorTest {
         log.trace { "uuid1=$uuid1" }
         log.trace { "uuid2=$uuid2" }
         uuid2 shouldNotBeEqualTo uuid1
+        uuid1.version() shouldBeEqualTo 4
+        uuid2.version() shouldBeEqualTo 4
     }
 
     @RepeatedTest(REPEAT_SIZE)
@@ -43,6 +50,8 @@ class RandomUuidGeneratorTest {
         log.trace { "uuid1=$uuid1" }
         log.trace { "uuid2=$uuid2" }
         uuid2 shouldNotBeEqualTo uuid1
+        uuid1.decodeBase62AsUuid().version() shouldBeEqualTo 4
+        uuid2.decodeBase62AsUuid().version() shouldBeEqualTo 4
     }
 
     @RepeatedTest(REPEAT_SIZE)
@@ -50,13 +59,16 @@ class RandomUuidGeneratorTest {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         MultithreadingTester()
-            .workers(2 * Runtimex.availableProcessors)
-            .rounds(TEST_COUNT)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_ROUNDS_PER_WORKER)
             .add {
                 val id = uuidGenerator.nextId()
+                id.version() shouldBeEqualTo 4
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap shouldHaveSize STRESS_OPERATIONS
     }
 
     @EnabledForJreRange(min = JRE.JAVA_21)
@@ -65,25 +77,33 @@ class RandomUuidGeneratorTest {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         StructuredTaskScopeTester()
-            .rounds(TEST_COUNT * 2 * Runtimex.availableProcessors)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_OPERATIONS)
+            .withTimeout(STRESS_TIMEOUT)
             .add {
                 val id = uuidGenerator.nextId()
+                id.version() shouldBeEqualTo 4
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap shouldHaveSize STRESS_OPERATIONS
     }
 
     @RepeatedTest(REPEAT_SIZE)
-    fun `generate timebased uuids in multi jobs`() = runSuspendDefault {
+    fun `generate timebased uuids in multi jobs`() = runSuspendDefault(timeout = STRESS_TIMEOUT) {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         SuspendedJobTester()
-            .workers(2 * Runtimex.availableProcessors)
-            .rounds(TEST_COUNT * 2 * Runtimex.availableProcessors)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_OPERATIONS)
             .add {
                 val id = uuidGenerator.nextId()
+                id.version() shouldBeEqualTo 4
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap shouldHaveSize STRESS_OPERATIONS
     }
 }

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/base62/AbstractTimebasedUuidBase62Test.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/base62/AbstractTimebasedUuidBase62Test.kt
@@ -16,19 +16,22 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.toLongArray
 import io.bluetape4k.support.toUUID
-import io.bluetape4k.utils.Runtimex
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.seconds
 
 abstract class AbstractTimebasedUuidBase62Test {
 
     companion object: KLoggingChannel() {
         private const val REPEAT_SIZE = 5
-        private val TEST_COUNT = 1024 * Runtime.getRuntime().availableProcessors()
-        private val TEST_LIST = List(TEST_COUNT) { it }
+        private const val STRESS_OPERATIONS = 10_000
+        private const val STRESS_WORKERS = 8
+        private const val STRESS_ROUNDS_PER_WORKER = STRESS_OPERATIONS / STRESS_WORKERS
+        private val STRESS_TIMEOUT = 30.seconds
+        private val TEST_LIST = List(STRESS_OPERATIONS) { it }
     }
 
     protected abstract val uuidGenerator: IdGenerator<UUID>
@@ -52,7 +55,7 @@ abstract class AbstractTimebasedUuidBase62Test {
     @RepeatedTest(REPEAT_SIZE)
     fun `generate timebased uuid with size`() {
 
-        val uuids = uuidGenerator.nextIdsAsString(TEST_COUNT).toList()
+        val uuids = uuidGenerator.nextIdsAsString(STRESS_OPERATIONS).toList()
         val sorted = uuids.sorted()
 
         sorted.forEachIndexed { index, uuid ->
@@ -78,13 +81,15 @@ abstract class AbstractTimebasedUuidBase62Test {
         val idMap = ConcurrentHashMap<String, Int>()
 
         MultithreadingTester()
-            .workers(2 * Runtimex.availableProcessors)
-            .rounds(TEST_COUNT)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_ROUNDS_PER_WORKER)
             .add {
                 val id = uuidGenerator.nextIdAsString()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 
     @EnabledForJreRange(min = JRE.JAVA_21)
@@ -93,26 +98,32 @@ abstract class AbstractTimebasedUuidBase62Test {
         val idMap = ConcurrentHashMap<String, Int>()
 
         StructuredTaskScopeTester()
-            .rounds(TEST_COUNT * 2 * Runtimex.availableProcessors)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_OPERATIONS)
+            .withTimeout(STRESS_TIMEOUT)
             .add {
                 val id = uuidGenerator.nextIdAsString()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 
     @RepeatedTest(REPEAT_SIZE)
-    fun `generate timebased uuids in suspend jobs`() = runSuspendDefault {
+    fun `generate timebased uuids in suspend jobs`() = runSuspendDefault(timeout = STRESS_TIMEOUT) {
         val idMap = ConcurrentHashMap<String, Int>()
 
         SuspendedJobTester()
-            .workers(2 * Runtimex.availableProcessors)
-            .rounds(TEST_COUNT * 2 * Runtimex.availableProcessors)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_OPERATIONS)
             .add {
                 val id = uuidGenerator.nextIdAsString()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 
     @RepeatedTest(REPEAT_SIZE)

--- a/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/timebased/AbstractTimebasedUuidTest.kt
+++ b/utils/idgenerators/src/test/kotlin/io/bluetape4k/idgenerators/uuid/timebased/AbstractTimebasedUuidTest.kt
@@ -14,19 +14,22 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.toLongArray
 import io.bluetape4k.support.toUUID
-import io.bluetape4k.utils.Runtimex
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.seconds
 
 abstract class AbstractTimebasedUuidTest {
 
     companion object: KLoggingChannel() {
         private const val REPEAT_SIZE = 5
-        private val TEST_COUNT = 1024 * Runtime.getRuntime().availableProcessors()
-        private val TEST_LIST = List(TEST_COUNT) { it }
+        private const val STRESS_OPERATIONS = 10_000
+        private const val STRESS_WORKERS = 8
+        private const val STRESS_ROUNDS_PER_WORKER = STRESS_OPERATIONS / STRESS_WORKERS
+        private val STRESS_TIMEOUT = 30.seconds
+        private val TEST_LIST = List(STRESS_OPERATIONS) { it }
     }
 
     protected abstract val uuidGenerator: IdGenerator<UUID>
@@ -50,7 +53,7 @@ abstract class AbstractTimebasedUuidTest {
     @RepeatedTest(REPEAT_SIZE)
     fun `generate timebased uuid with size`() {
 
-        val uuids = uuidGenerator.nextIds(TEST_COUNT).toList()
+        val uuids = uuidGenerator.nextIds(STRESS_OPERATIONS).toList()
         val sorted = uuids.sorted()
 
         sorted.forEachIndexed { index, uuid ->
@@ -76,13 +79,15 @@ abstract class AbstractTimebasedUuidTest {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         MultithreadingTester()
-            .workers(2 * Runtimex.availableProcessors)
-            .rounds(TEST_COUNT)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_ROUNDS_PER_WORKER)
             .add {
                 val id = uuidGenerator.nextId()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 
     @EnabledForJreRange(min = JRE.JAVA_21)
@@ -91,26 +96,32 @@ abstract class AbstractTimebasedUuidTest {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         StructuredTaskScopeTester()
-            .rounds(TEST_COUNT * 2 * Runtimex.availableProcessors)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_OPERATIONS)
+            .withTimeout(STRESS_TIMEOUT)
             .add {
                 val id = uuidGenerator.nextId()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 
     @RepeatedTest(REPEAT_SIZE)
-    fun `generate timebased uuids in suspend jobs`() = runSuspendDefault {
+    fun `generate timebased uuids in suspend jobs`() = runSuspendDefault(timeout = STRESS_TIMEOUT) {
         val idMap = ConcurrentHashMap<UUID, Int>()
 
         SuspendedJobTester()
-            .workers(2 * Runtimex.availableProcessors)
-            .rounds(TEST_COUNT * 2 * Runtimex.availableProcessors)
+            .workers(STRESS_WORKERS)
+            .rounds(STRESS_OPERATIONS)
             .add {
                 val id = uuidGenerator.nextId()
                 idMap.putIfAbsent(id, 1).shouldBeNull()
             }
             .run()
+
+        idMap.size shouldBeEqualTo STRESS_OPERATIONS
     }
 
     @RepeatedTest(REPEAT_SIZE)


### PR DESCRIPTION
## Summary

Closes #1785
Part of #1728

UUID stress 테스트 workload를 processor 수와 무관한 고정량으로 만들고 virtual-thread/coroutine 종료를 bounded하게 합니다.

## Background

선행 PR #1775(`#1747`) 검증 중 전체 idgenerators 테스트가 UUID virtual-thread stress 경로의 240초 제한을 넘었습니다. 원인은 production generator와 test harness scheduling을 분리해 확인해야 했습니다.

## What This Solves

- `availableProcessors`에 따라 rounds가 폭증해 상한을 넘는 harness 실패를 제거합니다.
- 10,000회 workload, 8 workers, 30초 timeout으로 uniqueness/format 검증의 실행 경계를 고정합니다.

## Work Done

- Random/name-based/time-based/Base62 UUID stress 테스트의 worker·rounds·timeout을 고정하고 총 생성량을 assert합니다.
- Base62 string을 UUID로 검증하는 기존 assertion을 실제 public decoder 경로로 교정했습니다.

## Validation

- `./gradlew :bluetape4k-idgenerators:test --no-configuration-cache --no-daemon --console=plain --rerun-tasks`: PASS (1155 tests)
- `./gradlew :bluetape4k-idgenerators:test --tests 'io.bluetape4k.idgenerators.uuid.*' --no-configuration-cache --no-daemon --console=plain --rerun-tasks`: PASS (351 tests)
- `JAVA_TOOL_OPTIONS=-XX:ActiveProcessorCount=64 ./gradlew ...RandomUuidGeneratorTest...`: PASS (25 tests)
- `./gradlew :bluetape4k-idgenerators:detekt --no-configuration-cache --no-daemon --console=plain`: PASS; `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: JVM21 직접 실행은 buildSrc가 JVM25 이상을 요구해 local boundary gap으로 기록했습니다.
- Review evidence: processor-count RED/GREEN reproduction, UUID package/full-module tests, Kotlin testing checklist

## Metadata

- Issue: #1785, milestone `2.1.0`, assignee `debop`
- PR: #1791, head `2f7fb7f46052687a8c78d3df6c8fc95e40376b3d`, base `develop`, https://github.com/bluetape4k/bluetape4k-projects/pull/1791
- CI: https://github.com/bluetape4k/bluetape4k-projects/actions/runs/34278295072 — PASS (exact head, terminal success; path-filtered jobs are recorded as skipped)

## DoD Status

Required checks: 14/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01..CG-10 | 기준 문서, UUID caller·stress·테스트·detekt·diff를 확인 | PASS | workflow lane evidence와 exact commit `2f7fb7f4` | 없음 |
| CG-11 | PR 생성 권한과 repo/base/head 확인 | PASS | 사용자 요청, `bluetape4k-projects`, `develop`, `fix/issue-1785-uuid-stress-timeout` | 없음 |
| CG-12 | exact head branch push 및 remote SHA 확인 | PASS | local/remote `2f7fb7f46052687a8c78d3df6c8fc95e40376b3d` 일치 | 없음 |
| CG-12A - Guidance refresh | PR 직전 기준 문서와 linked issue 재확인 | PASS | AGENTS/skill/common-gates/template/issue live readback 및 SHA snapshot | 없음 |
| CG-13 | PR 생성 후 metadata/body live readback | PASS | PR #1791 URL, head SHA, base, labels, assignee, milestone, body heading live readback | 없음 |
| CG-14 | exact-head CI와 review/thread 확인 | PASS | CI run `34278295072` success; reviews 0/comments 0, solo maintainer lane review subgate N/A | 없음 |
| CG-15 | merge-ready 보고 | PENDING | CG-14 이후 | CI/review 수렴 후 보고 |
| CG-16 | fresh merge approval | PENDING | 아직 승인 없음 | exact head 승인 대기 |
| CG-17 | 승인된 merge 실행·검증 | PENDING | merge 미실행 | 승인 후 수행 |
| CG-18 | canonical sync·cleanup | PENDING | merge 전 | merge 후 보존 원칙에 따라 수행 |
| CG-X01 | release/tag/publish | N/A | 이번 PR은 수정 PR이며 release side effect 없음 | 없음 |

Final status: PENDING (merge-ready 보고와 fresh exact-head 승인 대기)

Unchecked required items: CG-14, CG-15, CG-16, CG-17, CG-18
